### PR TITLE
Add initial Google menu item

### DIFF
--- a/google-for-woocommerce.php
+++ b/google-for-woocommerce.php
@@ -25,11 +25,12 @@ defined( 'ABSPATH' ) || exit;
  * Register the JS.
  */
 function add_extension_register_script() {
-
-	/* This if statement will need to be adjusted later. Simply disabled for now
+	/*
+	This if statement will need to be adjusted later. Simply disabled for now
 	if ( ! class_exists( Loader::class ) || ! Loader::is_admin_page() ) {
 		return;
-	}*/
+	}
+	*/
 
 	$script_path       = '/js/build/index.js';
 	$script_asset_path = dirname( __FILE__ ) . '/js/build/index.asset.php';
@@ -68,3 +69,44 @@ function add_extension_register_script() {
 }
 
 add_action( 'admin_enqueue_scripts', 'add_extension_register_script' );
+
+/**
+ * Add Google Menu item under Marketing
+ *
+ * @param array $items
+ *
+ * @return array
+ */
+function add_menu_items( $items ) {
+	$items[] = array(
+		'id'         => 'google-connect',
+		'title'      => __( 'Google', 'google-for-woocommerce' ),
+		'path'       => '/google/connect',
+		'capability' => 'manage_woocommerce',
+	);
+
+	return $items;
+}
+
+add_filter( 'woocommerce_marketing_menu_items', 'add_menu_items' );
+
+/**
+ * Fix sub-menu paths. wc_admin_register_page() gets it wrong.
+ */
+function fix_menu_paths() {
+
+	global $submenu;
+
+	if ( ! isset( $submenu['woocommerce-marketing'] ) ) {
+		return;
+	}
+
+	foreach ( $submenu['woocommerce-marketing'] as &$item ) {
+		// The "slug" (aka the path) is the third item in the array.
+		if ( 0 === strpos( $item[2], 'wc-admin' ) ) {
+			$item[2] = 'admin.php?page=' . $item[2];
+		}
+	}
+}
+
+add_action( 'admin_menu', 'fix_menu_paths' );

--- a/js/src/connect-account-page/index.js
+++ b/js/src/connect-account-page/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
+
+const ConnectAccountPage = ( { query } ) => {
+
+	return (
+		<div>
+			Hello World!
+		</div>
+	);
+};
+
+export default ConnectAccountPage;

--- a/js/src/connect-account-page/index.scss
+++ b/js/src/connect-account-page/index.scss
@@ -1,0 +1,1 @@
+// Add styles here.

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,6 +1,31 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import './index.scss';
+import ConnectAccountPage from './connect-account-page';
 
-console.log('hello from the Woogle plugin');
+addFilter(
+	'woocommerce_admin_pages_list',
+	'woocommerce-marketing',
+	( pages ) => {
+		return [
+			...pages,
+			{
+				breadcrumbs: [
+					[ '', wcSettings.woocommerceTranslation ],
+					['/marketing', __( 'Marketing', 'google-for-woocommerce' ) ],
+					__( 'Connect', 'google-for-woocommerce' ) ],
+				title: __( 'Connect', 'google-for-woocommerce' ),
+				container: ConnectAccountPage,
+				path: '/google/connect',
+				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
+			},
+		];
+	},
+);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #25 
Closes #26 

Adds an initial Google menu item to help with get basic plugin scaffolding in place.

wc-admin connected pages get the inbox notification bar free.

### Screenshots:

<img width="1562" alt="Screen Shot 2020-10-29 at 9 57 41 am" src="https://user-images.githubusercontent.com/355014/97507535-4ade3a00-19cd-11eb-8eb4-9007b7e0d83d.png">
