### PR TITLE
Revert accidental doc change

### DIFF
--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -60,7 +60,7 @@ trait PluginHelper {
 	}
 
 	/**
-	 * Get the plugin slug.
+	 * Get the plugin version.
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION
Reverts [an accidental change](https://github.com/woocommerce/google-listings-and-ads/commit/c2ca70231a1c639146798e799d6e019895b5977a#commitcomment-44081606) in a method's doc.