### PR TITLE
DEMO: Export SCSS to JS

### DIFF
--- a/js/src/export.scss
+++ b/js/src/export.scss
@@ -1,0 +1,14 @@
+// Import Gutenberg variables
+@import "node_modules/@wordpress/base-styles/colors";
+@import "node_modules/@wordpress/base-styles/variables";
+@import "node_modules/@wordpress/base-styles/mixins";
+@import "node_modules/@wordpress/base-styles/breakpoints";
+@import "node_modules/@wordpress/base-styles/animations";
+@import "node_modules/@wordpress/base-styles/z-index";
+@import "node_modules/@wordpress/base-styles/default-custom-properties";
+
+:export {
+	black: $black;
+	alertyellow: $alert-yellow;
+	gridunit60: $grid-unit-60;
+}

--- a/js/src/get-started-page/index.js
+++ b/js/src/get-started-page/index.js
@@ -4,12 +4,24 @@
 import './index.scss';
 import Faqs from './faqs';
 import GetStartedCard from './get-started-card';
+import exp from '../export.scss';
 
 const GetStartedPage = () => {
+	console.log( 'exp: ', exp );
+
 	return (
 		<div className="woocommerce-marketing-google-get-started-page">
 			<GetStartedCard />
 			<Faqs></Faqs>
+			<div
+				style={ {
+					color: exp.alertyellow,
+					backgroundColor: exp.black,
+					width: exp.gridunit60,
+				} }
+			>
+				hello
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is just a demo PR for discussion, not meant to be merged.

Some online source: 

- https://www.bluematador.com/blog/how-to-share-variables-between-js-and-sass
- https://css-tricks.com/getting-javascript-to-talk-to-css-and-sass/

Apparently we can only export SCSS variables (the ones with `$` prefix). There isn't a way to export mixins.

This video shows manually creating JavaScript mixin function to replace SCSS mixin: https://egghead.io/lessons/scss-use-javascript-functions-as-mixin-directives-for-css-in-js-style-declarations

### Screenshots:

![image](https://user-images.githubusercontent.com/417342/100374219-e2738e80-3046-11eb-9b28-0eca7276a4fb.png)

### Detailed test instructions:

1. Go to http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart
2. Notice the small output at the bottom of the screen as per screenshot.
3. In the console, you can see the exported object.
