### PR TITLE
Fix breadcrumb text for setup-mc and setup-ads

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -39,13 +39,7 @@ addFilter(
 			{
 				breadcrumbs: [
 					[ '', wcSettings.woocommerceTranslation ],
-					[
-						'/google/setup-mc',
-						__(
-							'Setup Merchant Center',
-							'google-listings-and-ads'
-						),
-					],
+					__( 'Setup Merchant Center', 'google-listings-and-ads' ),
 				],
 				container: SetupMC,
 				path: '/google/setup-mc',
@@ -53,10 +47,7 @@ addFilter(
 			{
 				breadcrumbs: [
 					[ '', wcSettings.woocommerceTranslation ],
-					[
-						'/google/setup-ads',
-						__( 'Setup Google Ads', 'google-listings-and-ads' ),
-					],
+					__( 'Setup Google Ads', 'google-listings-and-ads' ),
 				],
 				container: SetupAds,
 				path: '/google/setup-ads',


### PR DESCRIPTION
Just a really tiny fix for something I noticed. 

The final item in the breadcrumbs doesn't need a path because its not a link

Before:

![Screen Shot 2020-11-30 at 11 31 51 am](https://user-images.githubusercontent.com/355014/100558829-f5fd4e80-32ff-11eb-8edf-fe8b294d5f63.png)

After:

![Screen Shot 2020-11-30 at 11 32 11 am](https://user-images.githubusercontent.com/355014/100558831-f8f83f00-32ff-11eb-881d-8e05d30cd321.png)

These pages are going to have a full screen/page look soon but figured I'd just clean it up
