### PR TITLE
Tab clean up items

### DIFF
--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -1,4 +1,3 @@
 // Import Gutenberg components that aren't already imported in the lowest WC Admin version we support
 @import "node_modules/@wordpress/components/src/panel/style";
 @import 'node_modules/@wordpress/components/src/button/style'; // required for tab-panel
-@import "node_modules/@wordpress/components/src/tab-panel/style";

--- a/js/src/tab-nav/index.js
+++ b/js/src/tab-nav/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { NavigableMenu } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 import classnames from 'classnames';
@@ -53,22 +54,35 @@ const TabLink = ( { tabId, path, children, selected, ...rest } ) => {
 	);
 };
 
+const marketingMenu = document.querySelector(
+	'#toplevel_page_woocommerce-marketing'
+);
+const dashboardMenu = marketingMenu.querySelector(
+	"a[href='admin.php?page=wc-admin&path=/google/dashboard']"
+).parentElement;
+
 const TabNav = ( props ) => {
 	const { initialName } = props;
 	const activeClass = 'is-active';
 
+	useEffect( () => {
+		// Highlight the wp-admin dashboard menu
+		marketingMenu.classList.add( 'current', 'wp-has-current-submenu' );
+		dashboardMenu.classList.add( 'current' );
+	} );
+
 	return (
-		<div className="gla-page-tabs-component">
+		<div className="gla-tab-nav">
 			<NavigableMenu
 				role="tablist"
 				orientation="horizontal"
-				className="components-tab-panel__tabs"
+				className="gla-tab-nav__tabs"
 			>
 				{ tabs.map( ( tab ) => (
 					<TabLink
 						className={ classnames(
 							'components-button',
-							'components-tab-panel__tabs-item',
+							'gla-tab-nav__tabs-item',
 							tab.className,
 							{
 								[ activeClass ]: tab.name === initialName,

--- a/js/src/tab-nav/index.scss
+++ b/js/src/tab-nav/index.scss
@@ -1,11 +1,61 @@
-.gla-page-tabs-component {
-	.components-tab-panel__tabs {
-		box-shadow: inset 0px -1px 0px #CCCCCC;
-		margin: 7px -20px 18px;
-		padding: 0 20px;
-	}
+.gla-tab-nav__tabs {
+	display: flex;
+	align-items: stretch;
+	box-shadow: inset 0px -1px 0px #CCCCCC;
+	margin-bottom: var(--main-gap);
 
-	.components-tab-panel__tabs-item {
-		font-size: 14px;
+	.gla-tab-nav__tabs-item {
+		background: transparent;
+		border: none;
+		box-shadow: none;
+		border-radius: 0;
+		cursor: pointer;
+		height: $grid-unit-60;
+		padding: 3px $grid-unit-20; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
+		margin-left: 0;
+		font-weight: 500;
+		//transition: box-shadow 0.1s linear;
+		box-sizing: border-box;
+
+		// This pseudo-element "duplicates" the tab label and sets the text to bold.
+		// This ensures that the tab doesn't change width when selected.
+		// See: https://github.com/WordPress/gutenberg/pull/9793
+		&::after {
+			content: attr(data-label);
+			display: block;
+			height: 0;
+			overflow: hidden;
+			speak: none;
+			visibility: hidden;
+		}
+
+		&:focus:not(:disabled) {
+			box-shadow: inset 0 $border-width-focus var(--wp-admin-theme-color);
+		}
+
+		&.is-active {
+			// The transparent shadow ensures no jumpiness when focus animates on an active tab.
+			box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+			position: relative;
+
+			// This border appears in Windows High Contrast mode instead of the box-shadow.
+			&::before {
+				content: "";
+				position: absolute;
+				top: 0;
+				bottom: 1px;
+				right: 0;
+				left: 0;
+				border-bottom: $border-width-tab solid transparent;
+			}
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		}
+
+		&.is-active:focus {
+			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		}
 	}
 }


### PR DESCRIPTION
Some cleanups from tinkering over the weekend - I can spin it out to separate PRs or ignore - just pushing for visibility.

The primary fix we'll need is highlighting the correct dashboard sidebar menu items when viewing a tab. WP doesn't handle tabs nicely so we need to hack it.

Other items here for 👀 
* I removed the TabPanel import and copied relevant styles to our internal stylesheet
* I adjusted padding around the main `gla-tab-nav__tabs` container - it should line up a little nicer now

![Screen Shot 2020-11-30 at 12 20 16 pm](https://user-images.githubusercontent.com/355014/100560687-7e7eed80-3306-11eb-8d93-7f3c3f68f82b.png)


