### PR TITLE
Update the shipping api, including an intial version of batch rates

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
@@ -59,7 +59,7 @@ class ShippingRateController extends BaseOptionsController {
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_rate_schema(),
 				],
-				'schema' => $this->get_item_schema(),
+				'schema' => $this->get_item_schema_callback(),
 			]
 		);
 
@@ -72,7 +72,7 @@ class ShippingRateController extends BaseOptionsController {
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_batch_schema(),
 				],
-				'schema' => $this->get_batch_item_schema(),
+				'schema' => $this->get_batch_item_schema_callback(),
 			]
 		);
 
@@ -90,6 +90,7 @@ class ShippingRateController extends BaseOptionsController {
 					'callback'            => $this->get_delete_rate_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 				],
+				'schema' => $this->get_item_schema_callback(),
 			]
 		);
 	}
@@ -255,6 +256,28 @@ class ShippingRateController extends BaseOptionsController {
 	}
 
 	/**
+	 * Get the callback to obtain the item schema.
+	 *
+	 * @return callable
+	 */
+	protected function get_item_schema_callback(): callable {
+		return function() {
+			return $this->get_item_schema();
+		};
+	}
+
+	/**
+	 * Get the callback to obtain the batch item schema.
+	 *
+	 * @return callable
+	 */
+	protected function get_batch_item_schema_callback(): callable {
+		return function() {
+			return $this->get_batch_item_schema();
+		};
+	}
+
+	/**
 	 * @return array
 	 */
 	protected function get_rate_schema(): array {
@@ -298,6 +321,11 @@ class ShippingRateController extends BaseOptionsController {
 	protected function get_batch_schema(): array {
 		$schema = $this->get_rate_schema();
 		unset( $schema['country'], $schema['country_code'] );
+
+		// Context is always edit for batches.
+		foreach ( $schema as $key => &$value ) {
+			$value['context'] = [ 'edit' ];
+		}
 
 		$schema['country_codes'] = [
 			'type'              => 'array',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Changes to the shipping Rates API to better suit the React app needs.

**Schema changes**

The country code in ISO 3166-1 alpha-2 format is now used exclusively rather than the country name. There are two main reasons for this:

1. This is a better standard to avoid issues with i18n (thanks @ecgan)
2. This allows for proper l10n of the country name

As a result, the endpoint is now `/wp/gla/mc/settings/shipping/{country_code}`.

**Additional endpoints**

There is now a `DELETE /wp/gla/mc/settings/shipping/{country_code}` endpoint to allow for deletion of individual code rates.

There is also a new `POST /wp/gla/mc/settings/shipping/batch` endpoint to allow for creating a single rate for multiple countries at once. A request to this endpoint would look like this:

```json
{
	"country_codes": [
		"gb",
		"US"
	],
	"currency": "USD",
	"rate": 12
}
```

Note here that the country codes are **case insensitive** for all scenarios. The API will properly convert lowercase codes to uppercase.

With all of these API endpoints, you can also send an `OPTIONS` request to obtain data about the request. For example, here's the response for `OPTIONS /wp/gla/mc/settings/shipping/batch`:

```json
{
    "namespace": "wc\/gla",
    "methods": [
        "POST"
    ],
    "endpoints": [
        {
            "methods": [
                "POST"
            ],
            "args": {
                "currency": {
                    "type": "string",
                    "description": "The currency to use for the shipping rate.",
                    "default": "USD",
                    "required": false
                },
                "rate": {
                    "type": "integer",
                    "description": "The shipping rate.",
                    "required": true
                },
                "country_codes": {
                    "type": "array",
                    "description": "Array of country codes in ISO 3166-1 alpha-2 format.",
                    "minItems": 1,
                    "uniqueItems": true,
                    "items": {
                        "type": "string"
                    },
                    "required": true
                }
            }
        }
    ],
    "schema": {
        "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
        "title": "batch_shipping_rates",
        "type": "object",
        "additionalProperties": false,
        "properties": {
            "currency": {
                "type": "string",
                "description": "The currency to use for the shipping rate.",
                "context": [
                    "edit"
                ]
            },
            "rate": {
                "type": "integer",
                "description": "The shipping rate.",
                "context": [
                    "edit"
                ],
                "required": true
            },
            "country_codes": {
                "type": "array",
                "description": "Array of country codes in ISO 3166-1 alpha-2 format.",
                "context": [
                    "edit"
                ],
                "minItems": 1,
                "required": true,
                "uniqueItems": true
            }
        }
    },
    "_links": {
        "self": [
            {
                "href": "https:\/\/a8c.test\/wp-json\/wc\/gla\/mc\/settings\/shipping\/batch"
            }
        ]
    }
}
```