### PR TITLE
Register our activation and deactivation hooks

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -32,6 +32,14 @@ if ( ! Autoloader::init() ) {
 	return;
 }
 
+// Register activation hook
+register_activation_hook(
+	__FILE__,
+	function () {
+		PluginFactory::instance()->activate();
+	},
+);
+
 // Hook much of our plugin after WooCommerce is loaded.
 add_action(
 	'woocommerce_loaded',
@@ -39,6 +47,14 @@ add_action(
 		PluginFactory::instance()->register();
 	},
 	1
+);
+
+// Register deactivation hook
+register_deactivation_hook(
+	__FILE__,
+	function () {
+		PluginFactory::instance()->deactivate();
+	},
 );
 
 /**


### PR DESCRIPTION
# Changes

Registers the activation and deactivation hooks so that the Activateable and Deactivateable interfaces work.

# Detailed test instructions

1. Clone, composer install etc.
2. Setup  a service which uses the Activateable & Deactivateable interfaces (quick example below)
3. Activate and Deactivate the plugin
4. Check logs etc. if you put anything in place

```
<?php
declare( strict_types=1 );

namespace Automattic\WooCommerce\GoogleListingsAndAds;

use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Activateable;
use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
use Psr\Container\ContainerInterface;

/**
 * Class Example
 *
 * @package Automattic\WooCommerce\GoogleListingsAndAds\Example
 */
class Example implements Activateable, Deactivateable, Service, Registerable {

	/**
	 * CompleteSetup constructor.
	 *
	 * @param ContainerInterface $container The container object.
	 */
	public function __construct( ContainerInterface $container ) {
		///
	}

	/**
	 * Register a service.
	 */
	public function register(): void {
		error_log( var_export('register', true ));
	}

	/**
	 * Activate the service.
	 *
	 * @return void
	 */
	public function activate(): void {
		error_log( var_export('activate', true ));
	}

	/**
	 * Deactivate the service.
	 *
	 * @return void
	 */
	public function deactivate(): void {
		error_log( var_export('deactivate', true ));
	}
}
```
