### PR TITLE
Add GoogleHelper trait

### DIFF
--- a/src/GoogleHelper.php
+++ b/src/GoogleHelper.php
@@ -23,6 +23,7 @@ trait GoogleHelper {
 	 * @return array
 	 */
 	protected function get_mc_supported_countries() {
+		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
 		return [
 			// 'DZ' => 'DZD', // Algeria
 			// 'AO' => 'AOA', // Angola
@@ -119,5 +120,6 @@ trait GoogleHelper {
 			// 'ZM' => 'ZMW', // Zambia
 			// 'ZW' => 'USD', // Zimbabwe
 		];
+		// phpcs:enable
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I've added a function to get merchant center supported countries as an array (along with supported currency).

[MC Supported Countries documentation](https://support.google.com/merchants/answer/160637?hl=en) - I've commented out Beta countries for now.

[WooCommerce Countries](https://github.com/woocommerce/woocommerce/blob/master/i18n/countries.php)

I'm guessing this will likely be moved - Jeremy just mentioned it would be useful info and to dump it in a trait for now.

### Detailed test instructions:

1. Clone
2. Add the trait to a new or existing service
3. Call `get_mc_supported_countries()`
