### PR TITLE
WIP Add website claim REST endpoint

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -3,9 +3,13 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Google\Service\Exception as GoogleException;
+use Exception;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\PositiveInteger;
 use Google_Service_ShoppingContent as ShoppingService;
 use Google_Service_ShoppingContent_Product as Product;
+use Google_Service_ShoppingContent_AccountsClaimWebsiteResponse as ClaimWebsiteResponse;
 use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -16,6 +20,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
 class Merchant {
+
+	use PluginHelper;
 
 	/**
 	 * The container object.
@@ -74,5 +80,22 @@ class Merchant {
 		}
 
 		return $return;
+	}
+
+	/**
+	 * @return bool
+	 * @throws Exception If the website claim fails.
+	 */
+	public function claimwebsite(): bool {
+		/** @var ShoppingService $service */
+		$service = $this->container->get( ShoppingService::class );
+
+		try {
+			$response = $service->accounts->claimwebsite( $this->get_id(), $this->get_id() );
+		} catch ( GoogleException $e ) {
+			do_action( $this->get_slug() . '_claimwebsite_exception', $e, __METHOD__ );
+			throw new Exception( __( 'Unable to claim website.', 'google-listings-and-ads' ), $e->getCode() );
+		}
+		return true;
 	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/ClaimWebsiteController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ClaimWebsiteController.php
@@ -1,0 +1,78 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Psr\Container\ContainerInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ClaimWebsiteController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
+ */
+class ClaimWebsiteController extends BaseController {
+
+	/** @var ContainerInterface $container */
+	protected $container;
+
+	/**
+	 * BaseController constructor.
+	 *
+	 * @param ContainerInterface $container
+	 */
+	public function __construct( ContainerInterface $container ) {
+		parent::__construct( $container->get( RESTServer::class ) );
+		$this->container = $container;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	protected function register_routes(): void {
+		$this->register_route(
+			'mc/claimwebsite',
+			[
+				[
+					'methods'             => TransportMethods::CREATABLE,
+					'callback'            => $this->get_claimwebsite_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the callback function for the connection request.
+	 *
+	 * @return callable
+	 */
+	protected function get_claimwebsite_callback(): callable {
+		return function () {
+			try {
+				$this->container->get( Merchant::class )->claimwebsite();
+			} catch ( \Exception $e ) {
+				do_action( $this->get_slug() . '_claimwebsite_failure', [] );
+
+				return new \WP_REST_Response(
+					[
+						'status'  => 'failure',
+						'message' => __( 'Unable to claim website.', 'google-listings-and-ads' ),
+					],
+					$e->getCode()
+				);
+			}
+
+			return [
+				'status'  => 'success',
+				'message' => __( 'Successfully claimed website.', 'google-listings-and-ads' ),
+			];
+		};
+	}
+}

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -210,12 +210,23 @@ class ConnectionTest implements Service, Registerable {
 					</form>
 				</div>
 
+
+				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET" style="display:inline">
 				<p>
-					<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'wcs-accept-tos' ), $url ), 'wcs-accept-tos' ) ); ?>">Accept ToS for Google</a>
+				<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'wcs-accept-tos' ), $url ), 'wcs-accept-tos' ) ); ?>">Accept ToS for Google</a>
 					<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'wcs-check-tos' ), $url ), 'wcs-check-tos' ) ); ?>">Get latest ToS for Google</a>
 					<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'wcs-google-sv-token' ), $url ), 'wcs-google-sv-token' ) ); ?>">Perform Site Verification</a>
 					<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'wcs-google-sv-check' ), $url ), 'wcs-google-sv-check' ) ); ?>">Check Site Verification</a>
+					<br/>
+					<?php wp_nonce_field( 'wcs-google-mc-claim' ); ?>
+					<input name="page" value="connection-test-admin-page" type="hidden" />
+					<input name="action" value="wcs-google-mc-claim" type="hidden" />
+					<label>
+						Merchant ID <input name="merchant_id" type="text" value="<?php echo ! empty( $_GET['merchant_id'] ) ? intval( $_GET['merchant_id'] ) : ''; ?>" />
+					</label>
+					<button class="button">Claim website</button>
 				</p>
+				</form>
 
 				<div>
 					<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
@@ -452,6 +463,12 @@ class ConnectionTest implements Service, Registerable {
 			$data = $server->response_to_data( $response, false );
 			$json = wp_json_encode( $data );
 			$this->response = $json;
+		}
+		if ( 'wcs-google-mc-claim' === $_GET['action'] && check_admin_referer( 'wcs-google-mc-claim' ) ) {
+			/** @var Merchant $merchant */
+			$merchant = $this->container->get( Merchant::class );
+			$claim = $merchant->claim_website();
+//			$this->response = print_r( $merchant, true );
 		}
 
 		if ( 'wcs-google-mc-status' === $_GET['action'] && check_admin_referer( 'wcs-google-mc-status' ) ) {

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Google\Acco
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController as AdsAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\CampaignController as AdsCampaignController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Jetpack\AccountController as JetpackAccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ClaimWebsiteController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ConnectionController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingRateBatchController;
@@ -60,6 +61,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share_with_container( ShippingTimeBatchController::class );
 		$this->share_with_container( ShippingTimeController::class );
 		$this->share_with_container( SiteVerificationController::class );
+		$this->share_with_container( ClaimWebsiteController::class );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

#### DRAFT

Closes #10.

Enables a WP REST API endpoint for website claiming.

### Detailed test instructions:

1. TBD

