### PR TITLE
Add Jetpack user data to connected endpoint

### DIFF
--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -131,8 +131,8 @@ class AccountController extends BaseController {
 			return [
 				'active'      => $this->is_jetpack_connected(),
 				'owner'       => $this->is_jetpack_connection_owner(),
-				'displayName' => $user_data['display_name'],
-				'email'       => $user_data['email'],
+				'displayName' => array_key_exists( 'display_name', $user_data, ) ? $user_data['display_name'] : '',
+				'email'       => array_key_exists( 'email', $user_data, ) ? $user_data['email'] : '',
 			];
 		};
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add 3 additional properties to the jetpack connected endpoint

'owner'  - whether the connected user is the owner
'displayName' - their wpcom display name
'email' - their wpcom email address

### Detailed test instructions:

Setup the extension and make sure it's connected to a WCS as described in pb0Spc-1hC-p2

1. Clone, Install, Build
2. Connect jetpack 
3. GET https://domain.test/wp-json/wc/gla/jetpack/connected

If you are the owner, the expected results should look like:

```
{"active":"yes","owner":"yes","displayName":"Jason","email":"jason@test.com"}
```

If you are not the owner, the expected results should look like:

```
{"active":"yes","owner":"no","displayName":"Jason","email":"jason@test.com"}
```

If you disconnect Jetpack and try the endpoint, the results should look like:

```
{"active":"no","owner":"no","displayName":"","email":""}
```

I knocked this up pretty quick, feel free to commit any small tweaks and merge if it is blocking