### PR TITLE
Connected ads account and disconnect endpoints

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -179,6 +179,29 @@ class Proxy {
 	}
 
 	/**
+	 * Get the connected ads account.
+	 *
+	 * @return array
+	 */
+	public function get_connected_ads_account(): array {
+		/** @var Options $options */
+		$options = $this->container->get( OptionsInterface::class );
+		$id      = intval( $options->get( Options::ADS_ID ) );
+
+		return [
+			'id'     => $id,
+			'status' => $id ? 'connected' : 'disconnected',
+		];
+	}
+
+	/**
+	 * Disconnect the connected ads account.
+	 */
+	public function disconnect_ads_account() {
+		$this->update_ads_id( 0 );
+	}
+
+	/**
 	 * Determine whether the TOS have been accepted.
 	 *
 	 * @return TosAccepted

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -60,6 +60,22 @@ class AccountController extends BaseController {
 				'schema' => $this->get_api_response_schema_callback(),
 			]
 		);
+
+		$this->register_route(
+			'ads/connection',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_connected_ads_account_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				[
+					'methods'             => TransportMethods::DELETABLE,
+					'callback'            => $this->disconnect_ads_account_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
 	}
 
 	/**
@@ -94,6 +110,33 @@ class AccountController extends BaseController {
 			} catch ( Exception $e ) {
 				return new WP_REST_Response( [ 'message' => $e->getMessage() ], 400 );
 			}
+		};
+	}
+
+	/**
+	 * Get the callback function for the connected ads account.
+	 *
+	 * @return callable
+	 */
+	protected function get_connected_ads_account_callback(): callable {
+		return function() {
+			return $this->middleware->get_connected_ads_account();
+		};
+	}
+
+	/**
+	 * Get the callback function for disconnecting a merchant.
+	 *
+	 * @return callable
+	 */
+	protected function disconnect_ads_account_callback(): callable {
+		return function() {
+			$this->middleware->disconnect_ads_account();
+
+			return [
+				'status'  => 'success',
+				'message' => __( 'Successfully disconnected.', 'google-listings-and-ads' ),
+			];
 		};
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add similar endpoints for the AdsAccountController as discussed in #179 

The ones that are added here are:
- Get connected ads account GET /ads/connection
- Disconnect the ads account DELETE /ads/connection

### Detailed test instructions:

1\. `GET https://domain.test/wp-json/wc/gla/ads/connection`
Expected response (JSON): Ads ID and status
Example:
```
{
    "id": 1234567890,
    "status": "connected"
}
```

5\. `DELETE https://domain.test/wp-json/wc/gla/ads/connection`
Expected response (JSON): Successful response
Example:
```
{
    "status": "success",
    "message": "Successfully disconnected."
}
```

### Changelog Note:
- Connected ads account and disconnect endpoints