### PR TITLE
Better JS Import with alias

### DIFF
--- a/js/src/jsconfig.json
+++ b/js/src/jsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "root/*": ["./*"]
+      ".~/*": ["./*"]
     }
   },
 }

--- a/js/src/setup-mc/index.js
+++ b/js/src/setup-mc/index.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import FullScreen from 'root/components/full-screen';
-
-/**
  * Internal dependencies
  */
+import FullScreen from '.~/components/full-screen';
 import TopBar from './top-bar';
 import SetupStepper from './setup-stepper';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ const webpackConfig = {
 	...defaultConfig,
 	resolve: {
 		alias: {
-			root: path.resolve( process.cwd(), 'js/src/' ),
+			'.~': path.resolve( process.cwd(), 'js/src/' ),
 		},
 	},
 	plugins: [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR provides better JS import. Instead of doing relative import like `import CompA from '../../../path/to/CompA`, you can now do `.~/path/to/CompA`. `.~` points to the `js/src` directory.

Note that when you use the alias import, it falls under internal dependencies: 

```js
/**
 * Internal dependencies
 */
import FullScreen from '.~/components/full-screen';
```

### Detailed test instructions:

1. Checkout the branch.
2. Make sure it can build.
3. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc and make sure it works OK.
4. Open `js/src/setup-mc/index.js` in VS Code editor, right click on the keyword `FullScreen` and click on "Go to Definition". VS Code should show you the `js/src/components/full-screen/index.js` file and briefly highlight the `FullScreen` function.

### Changelog Note:

Better JS import with alias.
