### PR TITLE
Fix incorrect Tooltip position of the close button on the Modal

### DIFF
--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -43,3 +43,24 @@
 .components-input-control__suffix {
 	margin-right: 8px;
 }
+
+// Hack to fix the Tooltip position of the top-right side close button in a Modal component.
+// The follow up can be found here: https://github.com/woocommerce/google-listings-and-ads/issues/203
+.components-modal {
+	&__screen-overlay {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	&__frame {
+		@include break-small() {
+			transform: initial;
+			position: relative;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
+		}
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This issue was found from #193. I open a standalone PR because both Modal and Guide are having this issue.

The root cause is the Popover component calculation could not handle the outside container that positioning by `transform: translate();`. Before the @wordpress/components lib fix, we can temporarily fix it by a workaround.

- Fix incorrect Tooltip position of the close button on the Modal
- More details and follow up: #203 

### Screenshots:

#### Modal
![image](https://user-images.githubusercontent.com/17420811/107189689-b8662180-6a24-11eb-98a1-2eaf30625eb1.png)

#### Guide
![image](https://user-images.githubusercontent.com/17420811/107191032-940b4480-6a26-11eb-91e1-dc4b77250200.png)


### Detailed test instructions:

1. Open with the site URL with this path: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`
1. Click on the *Pause* or *Remove* button on a program item
1. Hover to the close button at the top-right side on the popup Modal
1. A Tooltip should show up and locate at the bottom of the close button
