### PR TITLE
Collections use prepare_response_for_collection

### DIFF
--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -97,7 +97,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 			try {
 				return array_map(
 					function( $campaign ) use ( $request ) {
-						return $this->prepare_item_for_response( $campaign, $request );
+						$data = $this->prepare_item_for_response( $campaign, $request );
+						return $this->prepare_response_for_collection( $data );
 					},
 					$this->ads->get_campaigns()
 				);

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
@@ -80,7 +80,8 @@ class ShippingRateController extends BaseOptionsController implements ISO3166Awa
 			$rates = $this->get_shipping_rates_option();
 			$items = [];
 			foreach ( $rates as $country_code => $details ) {
-				$items[ $country_code ] = $this->prepare_item_for_response( $details, $request );
+				$data                   = $this->prepare_item_for_response( $details, $request );
+				$items[ $country_code ] = $this->prepare_response_for_collection( $data );
 			}
 
 			return $items;

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
@@ -80,7 +80,8 @@ class ShippingTimeController extends BaseOptionsController implements ISO3166Awa
 			$times = $this->get_shipping_times_option();
 			$items = [];
 			foreach ( $times as $country_code => $details ) {
-				$items[ $country_code ] = $this->prepare_item_for_response( $details, $request );
+				$data                   = $this->prepare_item_for_response( $details, $request );
+				$items[ $country_code ] = $this->prepare_response_for_collection( $data );
 			}
 
 			return $items;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When we use the function `prepare_item_for_response` it wraps it in a REST Response object. However when we return a collection of items we don't want each item to be a separate response. WordPress uses the function `prepare_response_for_collection` when adding to the array. This PR changes the collection responses to call this function as well.

Response before changes:
```
{
    "US": {
        "data": {
            "country": "United States of America",
            "country_code": "US",
            "currency": "USD",
            "rate": 10
        },
        "headers": [],
        "status": 200
    }
}
```

Example response after changes:
```
{
    "US": {
        "country": "United States of America",
        "country_code": "US",
        "currency": "USD",
        "rate": 10
    }
}
```
### Detailed test instructions:

1. Request a response which returns a collection, such as shipping rates
2. Confirm that the data isn't wrapped with data, headers, status

### Changelog Note:
- Fix collection responses