### PR TITLE
Suppress some generate_auth_header errors

### DIFF
--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -195,7 +195,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 *
 	 * @return string Empty if no access token is available.
 	 *
-	 * @throws WPError If the authorization token isn't found and errors aren't suppressed.
+	 * @throws WPError If the authorization token isn't found.
 	 */
 	protected function generate_auth_header(): string {
 		/** @var Manager $manager */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a `$suppress_errors` parameter in the `GoogleServiceProvider::get_auth_header()` method 
 to avoid fatal errors when loading the plugin without a Jetpack connection.

Currently, the auth header is loaded directly into the container:
https://github.com/woocommerce/google-listings-and-ads/blob/5eb7f93832ae5a0a290140c20b8e0c4cb1283739/src/Internal/DependencyManagement/GoogleServiceProvider.php#L97
This causes an error to be thrown on every WC-admin enabled page load until Jetpack is connected (or until the auth tokens are available). Since it's not a breaking error until API calls have to be made, errors on that initial container load can suppressed.

Further, when the Guzzle client is actually instantiated, the error _is_ important, so it's logged and then a new, more generalized error is thrown.

Closes #181.

### Detailed test instructions:

1. With `trunk` and a clean install, go to WooCommerce → Home to see the fatal error.
2. With this PR, do the same thing and confirm that the page loads and no log entry is created (WooCommerce → Status → Logs)
3. With this PR, make an authenticated GET request to `/wp-json/wc/gla/mc/accounts` and confirm the "Jetpack authorization header error" `400` message, and the accompanying WC log entry.
4. Connect Jetpack and confirm that neither of the actions in (2) and (3) result in error messages or log entries.

