### PR TITLE
Consolidate Site API Information into docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,21 @@
+# API
+
+* [Ads Account Controller](api/ads/account-controller.md)
+* [Ads Campaign Controller](api/ads/campaign-controller.md)
+
+* [Google Account Controller](api/google/account-controller.md)
+* [Site Verification Controller](api/google/site-verification-controller.md)
+
+* [Jetpack Account Controller](api/jetpack/account-controller.md)
+
+* [MC Account Controller](api/merchant-center/account-controller.md)
+* [MC Connection Controller](api/merchant-center/connection-controller.md)
+* [MC Settings Controller](api/merchant-center/settings-controller.md)
+
+* [Shipping Rate Controller](api/merchant-center/shipping-rate-controller.md)
+* [Shipping Rate Batch Controller](api/merchant-center/shipping-rate-batch-controller.md)
+* [Shippinh Time Controller](api/merchant-center/shipping-time-controller.md)
+* [Shippinh Time Batch Controller](api/merchant-center/shipping-time-batch-controller.md)
+
+* [MC Account Controller](api/merchant-center/supported-countries-controller.md)
+* [MC Account Controller](api/merchant-center/target-audience-controller.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,8 +14,8 @@
 
 * [Shipping Rate Controller](api/merchant-center/shipping-rate-controller.md)
 * [Shipping Rate Batch Controller](api/merchant-center/shipping-rate-batch-controller.md)
-* [Shippinh Time Controller](api/merchant-center/shipping-time-controller.md)
-* [Shippinh Time Batch Controller](api/merchant-center/shipping-time-batch-controller.md)
+* [Shipping Time Controller](api/merchant-center/shipping-time-controller.md)
+* [Shipping Time Batch Controller](api/merchant-center/shipping-time-batch-controller.md)
 
-* [MC Account Controller](api/merchant-center/supported-countries-controller.md)
-* [MC Account Controller](api/merchant-center/target-audience-controller.md)
+* [Supported Countries Controller](api/merchant-center/supported-countries-controller.md)
+* [Target Audience Controller](api/merchant-center/target-audience-controller.md)

--- a/docs/api/ads/account-controller.md
+++ b/docs/api/ads/account-controller.md
@@ -1,71 +1,58 @@
 # [API](../../api.md) | GET /ads/accounts/`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint lists a Google users existing ad accounts.
 
 ## Response
 
-The response contains the following fields:
-
-- xyz: <description>
-- xyz: <description>
+The response contains an array of Ads accounts ids.
 
 ## Example Request
 
 ```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
+GET https://domain.test/wp-json/wc/gla/ads/accounts
 ```
 
 ## Example Response
 
 ```javascript
-{
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
-}
+[
+    7897423400,
+    9898373407,
+    7946319897
+]
 ```
 
 ----
 
 # [API](../../api.md) | POST /ads/accounts/`<service>`
 
-This endpoint returns xxx.
+This endpoint creates a new Ads account or links an existing Ads account if there is an "id" in the request body.
+
+Note: Only if the account is not already linked to our manager account will it actually link the account, in both cases the request will respond with the same successful response of the ID number.
+
+For both the create and link account requests, after it is completed the wp_options table should have an entry with the name `gla_ads_id`.
 
 ## Request
 
-The request URL must contain the following path parameters:
+To link an account the request body must contain an id.
 
-- xyz: <description>
+- id: Ads Account ID to be linked.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- id: Ads Account ID that has been created or linked
 
 ## Example Request
 
 ```
-GET /ads/accounts/
+POST https://domain.test/wp-json/wc/gla/ads/accounts
 ```
 
 ```javascript
 {
-	data: 'foo'
+    "id": 5942319812
 }
 ```
 
@@ -73,10 +60,7 @@ GET /ads/accounts/
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "id": 5942319812
 }
 ```
 
@@ -84,41 +68,28 @@ GET /ads/accounts/
 
 # [API](../../api.md) | GET /ads/connection/`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint gets the connected ads account.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- id: The connected ads account id.
+- status: The status of the ads account i.e. "connected"
 
 ## Example Request
 
 ```
-GET /ads/accounts/
+GET https://domain.test/wp-json/wc/gla/ads/connection
 ```
 
-```javascript
-{
-	data: 'foo'
-}
-```
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "id": 1234567890,
+    "status": "connected"
 }
 ```
 
@@ -126,40 +97,26 @@ GET /ads/accounts/
 
 # [API](../../api.md) | DELETE /ads/connection/`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint disconnects the connected ads account.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- status: When the request was successful or not e.g. "success"
+- message: Additional detail about the response e.g. "Successfully disconnected."
 
 ## Example Request
 
 ```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
+POST https://domain.test/wp-json/wc/gla/ads/connection
 ```
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "status": "success",
+    "message": "Successfully disconnected."
 }
 ```

--- a/docs/api/ads/account-controller.md
+++ b/docs/api/ads/account-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /ads/accounts/`<service>`
+# [API](../../api.md) | GET /ads/accounts/
 
 This endpoint lists a Google users existing ad accounts.
 
@@ -24,7 +24,7 @@ GET https://domain.test/wp-json/wc/gla/ads/accounts
 
 ----
 
-# [API](../../api.md) | POST /ads/accounts/`<service>`
+# [API](../../api.md) | POST /ads/accounts/
 
 This endpoint creates a new Ads account or links an existing Ads account if there is an "id" in the request body.
 
@@ -66,7 +66,7 @@ POST https://domain.test/wp-json/wc/gla/ads/accounts
 
 ----
 
-# [API](../../api.md) | GET /ads/connection/`<service>`
+# [API](../../api.md) | GET /ads/connection/
 
 This endpoint gets the connected ads account.
 
@@ -95,7 +95,7 @@ GET https://domain.test/wp-json/wc/gla/ads/connection
 
 ----
 
-# [API](../../api.md) | DELETE /ads/connection/`<service>`
+# [API](../../api.md) | DELETE /ads/connection/
 
 This endpoint disconnects the connected ads account.
 

--- a/docs/api/ads/account-controller.md
+++ b/docs/api/ads/account-controller.md
@@ -1,0 +1,165 @@
+# [API](../../api.md) | GET /ads/accounts/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST /ads/accounts/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | GET /ads/connection/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | DELETE /ads/connection/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/ads/account-controller.md
+++ b/docs/api/ads/account-controller.md
@@ -103,7 +103,7 @@ This endpoint disconnects the connected ads account.
 
 The response contains the following fields:
 
-- status: When the request was successful or not e.g. "success"
+- status: Whether the request was successful or not e.g. "success"
 - message: Additional detail about the response e.g. "Successfully disconnected."
 
 ## Example Request

--- a/docs/api/ads/campaign-controller.md
+++ b/docs/api/ads/campaign-controller.md
@@ -1,0 +1,165 @@
+# [API](../../api.md) | GET /ads/campaigns/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST /ads/campaigns/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST/PUT/PATCH /ads/campaigns/(?P<id>[\d]+)`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | DELETE /ads/campaigns/(?P<id>[\d]+)`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/ads/campaign-controller.md
+++ b/docs/api/ads/campaign-controller.md
@@ -1,71 +1,111 @@
 # [API](../../api.md) | GET /ads/campaigns/`<service>`
 
-This endpoint returns xxx.
+This endpoint returns all campaigns associated with an account.
+
+## Response
+
+The response contains an array of campaigns.
+
+## Example Request
+
+```
+GET https://domain.test/wp-json/wc/gla/ads/campaigns
+```
+
+## Example Response
+
+```javascript
+[
+    {
+        "id": 12124538879,
+        "name": "Ad Campaign 2021-01-20",
+        "status": "enabled",
+        "amount": 10,
+        "country": "US"
+    },
+    {
+        "id": 12134267938,
+        "name": "Paused campaign",
+        "status": "paused",
+        "amount": 3.5,
+        "country": "US"
+    }
+]
+```
+
+----
+
+# [API](../../api.md) | GET /ads/campaigns/<id>`<service>`
+
+This endpoint returns a single campaign.
 
 ## Request
 
 The request URL must contain the following path parameters:
 
-- xyz: <description>
+- id: Campaign ID that is being requested
 
 ## Response
 
-The response contains the following fields:
+The response contains details about the requested campaign such as:
 
-- xyz: <description>
-- xyz: <description>
+- id: Campaign ID
+- name: Campaign name
+- amount: Campaign budget/amount
+- country: Target country
 
 ## Example Request
 
 ```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
+GET https://domain.test/wp-json/wc/gla/ads/campaigns/12134267938
 ```
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "id": 12134267938,
+    "name": "Ad Campaign 2021-01-22",
+    "amount": 10,
+    "country": "US"
 }
 ```
 
 ----
 
+
 # [API](../../api.md) | POST /ads/campaigns/`<service>`
 
-This endpoint returns xxx.
+This endpoint creates a campaign.
 
 ## Request
 
-The request URL must contain the following path parameters:
+The request must contain details about the campaign to be created e.g.
 
-- xyz: <description>
+- name: A name for the campaign
+- amount: Campaign budget/amount
+- country: Target country for the campaign
 
 ## Response
 
-The response contains the following fields:
+The response contains details about the created campaign such as:
 
-- xyz: <description>
-- xyz: <description>
+- id: Campaign ID
+- name: Campaign name
+- amount: Campaign budget/amount
+- country: Target country
 
 ## Example Request
 
 ```
-GET /ads/accounts/
+POST https://domain.test/wp-json/wc/gla/ads/campaigns
 ```
 
 ```javascript
 {
-	data: 'foo'
+    "name": "Ad Campaign 2021-01-21",
+    "amount": 10.00,
+    "country": "US"
 }
 ```
 
@@ -73,10 +113,10 @@ GET /ads/accounts/
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "id": 12134267938,
+    "name": "Ad Campaign 2021-01-22",
+    "amount": 10,
+    "country": "US"
 }
 ```
 
@@ -84,30 +124,25 @@ GET /ads/accounts/
 
 # [API](../../api.md) | POST/PUT/PATCH /ads/campaigns/(?P<id>[\d]+)`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint edits a campaign.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- status: When the request was successful or not e.g. "success"
+- message: Additional detail about the response e.g. "Successfully edited campaign."
+- id: ID of the edited campaign.
 
 ## Example Request
 
 ```
-GET /ads/accounts/
+PATCH https://domain.test/wp-json/wc/gla/ads/campaigns/12134267938
 ```
 
 ```javascript
 {
-	data: 'foo'
+    "amount": 3.50,
 }
 ```
 
@@ -115,10 +150,9 @@ GET /ads/accounts/
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "status": "success",
+    "message": "Successfully edited campaign.",
+    "id": 12134267938
 }
 ```
 
@@ -126,40 +160,28 @@ GET /ads/accounts/
 
 # [API](../../api.md) | DELETE /ads/campaigns/(?P<id>[\d]+)`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint deletes a campaign.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- status: When the request was successful or not e.g. "success"
+- message: Additional detail about the response e.g. "Successfully deleted campaign."
+- id: ID of the deleted campaign.
 
 ## Example Request
 
 ```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
+DELETE https://domain.test/wp-json/wc/gla/ads/campaigns/12134267938
 ```
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "status": "success",
+    "message": "Successfully deleted campaign.",
+    "id": 12134267938
 }
 ```

--- a/docs/api/ads/campaign-controller.md
+++ b/docs/api/ads/campaign-controller.md
@@ -130,7 +130,7 @@ This endpoint edits a campaign.
 
 The response contains the following fields:
 
-- status: When the request was successful or not e.g. "success"
+- status: Whether the request was successful or not e.g. "success"
 - message: Additional detail about the response e.g. "Successfully edited campaign."
 - id: ID of the edited campaign.
 
@@ -166,7 +166,7 @@ This endpoint deletes a campaign.
 
 The response contains the following fields:
 
-- status: When the request was successful or not e.g. "success"
+- status: Whether the request was successful or not e.g. "success"
 - message: Additional detail about the response e.g. "Successfully deleted campaign."
 - id: ID of the deleted campaign.
 

--- a/docs/api/ads/campaign-controller.md
+++ b/docs/api/ads/campaign-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /ads/campaigns/`<service>`
+# [API](../../api.md) | GET /ads/campaigns/
 
 This endpoint returns all campaigns associated with an account.
 
@@ -35,7 +35,7 @@ GET https://domain.test/wp-json/wc/gla/ads/campaigns
 
 ----
 
-# [API](../../api.md) | GET /ads/campaigns/<id>`<service>`
+# [API](../../api.md) | GET /ads/campaigns/`<id>`
 
 This endpoint returns a single campaign.
 
@@ -74,7 +74,7 @@ GET https://domain.test/wp-json/wc/gla/ads/campaigns/12134267938
 ----
 
 
-# [API](../../api.md) | POST /ads/campaigns/`<service>`
+# [API](../../api.md) | POST /ads/campaigns/
 
 This endpoint creates a campaign.
 
@@ -122,7 +122,7 @@ POST https://domain.test/wp-json/wc/gla/ads/campaigns
 
 ----
 
-# [API](../../api.md) | POST/PUT/PATCH /ads/campaigns/(?P<id>[\d]+)`<service>`
+# [API](../../api.md) | POST/PUT/PATCH /ads/campaigns/`<id>`
 
 This endpoint edits a campaign.
 
@@ -158,7 +158,7 @@ PATCH https://domain.test/wp-json/wc/gla/ads/campaigns/12134267938
 
 ----
 
-# [API](../../api.md) | DELETE /ads/campaigns/(?P<id>[\d]+)`<service>`
+# [API](../../api.md) | DELETE /ads/campaigns/`<id>`
 
 This endpoint deletes a campaign.
 

--- a/docs/api/google/account-controller.md
+++ b/docs/api/google/account-controller.md
@@ -1,0 +1,123 @@
+# [API](../../api.md) | GET /google/connect/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | DELETE /google/connect/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | GET /google/connected/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/google/account-controller.md
+++ b/docs/api/google/account-controller.md
@@ -1,40 +1,24 @@
 # [API](../../api.md) | GET /google/connect/`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint returns the URL used to connect to Google.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- url: URL to redirect merchants to to connect to Google.
 
 ## Example Request
 
 ```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
+GET https://domain.test/wp-json/wc/gla/google/connect
 ```
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    url: https://google.com/?somethings
 }
 ```
 
@@ -42,41 +26,27 @@ GET /ads/accounts/
 
 # [API](../../api.md) | DELETE /google/connect/`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint disconnects/revokes the google connection.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- status: Whether the request was successful or not e.g. "success"
+- message: Additional detail about the response e.g. "Successfully disconnected."
 
 ## Example Request
 
 ```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
+DELETE https://domain.test/wp-json/wc/gla/google/connect
 ```
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "status": "success",
+    "message": "Successfully disconnected."
 }
 ```
 
@@ -84,40 +54,27 @@ GET /ads/accounts/
 
 # [API](../../api.md) | GET /google/connected/`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint returns status of the Google account connection indicating when an account is connected or not.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
-
-## Example Request
-
-```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
-```
+- status: Whether the account is connected or disconnected
+- email: Account email address or null if disconnected.
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "status ": "connected",
+    "email": "jason@example.com"
+}
+```
+
+```javascript
+{
+    "status": "disconnected",
+    "email": ""
 }
 ```

--- a/docs/api/google/account-controller.md
+++ b/docs/api/google/account-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /google/connect/`<service>`
+# [API](../../api.md) | GET /google/connect/
 
 This endpoint returns the URL used to connect to Google.
 
@@ -24,7 +24,7 @@ GET https://domain.test/wp-json/wc/gla/google/connect
 
 ----
 
-# [API](../../api.md) | DELETE /google/connect/`<service>`
+# [API](../../api.md) | DELETE /google/connect/
 
 This endpoint disconnects/revokes the google connection.
 
@@ -52,7 +52,7 @@ DELETE https://domain.test/wp-json/wc/gla/google/connect
 
 ----
 
-# [API](../../api.md) | GET /google/connected/`<service>`
+# [API](../../api.md) | GET /google/connected/
 
 This endpoint returns status of the Google account connection indicating when an account is connected or not.
 

--- a/docs/api/google/site-verification-controller.md
+++ b/docs/api/google/site-verification-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /site/verify/`<service>`
+# [API](../../api.md) | GET /site/verify/
 
 This endpoint returns xxx.
 
@@ -40,7 +40,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | POST /site/verify/`<service>`
+# [API](../../api.md) | POST /site/verify/
 
 This endpoint returns xxx.
 

--- a/docs/api/google/site-verification-controller.md
+++ b/docs/api/google/site-verification-controller.md
@@ -1,0 +1,81 @@
+# [API](../../api.md) | GET /site/verify/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST /site/verify/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/jetpack/account-controller.md
+++ b/docs/api/jetpack/account-controller.md
@@ -1,0 +1,123 @@
+# [API](../../api.md) | GET /jetpack/connect/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | DELETE /jetpack/connect/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | GET /jetpack/connected/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/jetpack/account-controller.md
+++ b/docs/api/jetpack/account-controller.md
@@ -1,40 +1,24 @@
 # [API](../../api.md) | GET /jetpack/connect/`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint returns the URL used to connect to Jetpack/WordPress.com.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- url: URL to redirect merchants to to connect to Jetpack/WordPress.com.
 
 ## Example Request
 
 ```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
+GET https://domain.test/wp-json/wc/gla/jetpack/connect
 ```
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    url: https://wordpresscom/?somethings
 }
 ```
 
@@ -42,41 +26,27 @@ GET /ads/accounts/
 
 # [API](../../api.md) | DELETE /jetpack/connect/`<service>`
 
-This endpoint returns xxx.
-
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
+This endpoint disconnects/revokes the jetpack connection.
 
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
+- status: Whether the request was successful or not e.g. "success"
+- message: Additional detail about the response e.g. "Successfully disconnected."
 
 ## Example Request
 
 ```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
+DELETE https://domain.test/wp-json/wc/gla/jetpack/connect
 ```
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "status": "success",
+    "message": "Successfully disconnected."
 }
 ```
 
@@ -86,38 +56,22 @@ GET /ads/accounts/
 
 This endpoint returns xxx.
 
-## Request
-
-The request URL must contain the following path parameters:
-
-- xyz: <description>
-
 ## Response
 
 The response contains the following fields:
 
-- xyz: <description>
-- xyz: <description>
-
-## Example Request
-
-```
-GET /ads/accounts/
-```
-
-```javascript
-{
-	data: 'foo'
-}
-```
+- active: Whether the connection is active
+- owner: Whether the current user is the connection owner (yes or no)
+- displayName: Account display name
+- email: Account email address
 
 ## Example Response
 
 ```javascript
 {
-	offerId: "product123",
-	title: "Lorem Ipsum",
-	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-	...
+    "active": "connected",
+    "owner": "yes",
+    "displayName": "Jason",
+    "email": "jason@example.com"
 }
 ```

--- a/docs/api/jetpack/account-controller.md
+++ b/docs/api/jetpack/account-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /jetpack/connect/`<service>`
+# [API](../../api.md) | GET /jetpack/connect/
 
 This endpoint returns the URL used to connect to Jetpack/WordPress.com.
 
@@ -24,7 +24,7 @@ GET https://domain.test/wp-json/wc/gla/jetpack/connect
 
 ----
 
-# [API](../../api.md) | DELETE /jetpack/connect/`<service>`
+# [API](../../api.md) | DELETE /jetpack/connect/
 
 This endpoint disconnects/revokes the jetpack connection.
 
@@ -52,7 +52,7 @@ DELETE https://domain.test/wp-json/wc/gla/jetpack/connect
 
 ----
 
-# [API](../../api.md) | GET /jetpack/connected/`<service>`
+# [API](../../api.md) | GET /jetpack/connected/
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/account-controller.md
+++ b/docs/api/merchant-center/account-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /mc/accounts/`<service>`
+# [API](../../api.md) | GET /mc/accounts/
 
 This endpoint returns xxx.
 
@@ -40,7 +40,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | POST /mc/accounts/`<service>`
+# [API](../../api.md) | POST /mc/accounts/
 
 This endpoint returns xxx.
 
@@ -82,7 +82,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | POST /mc/accounts/claim-overwrite/`<service>`
+# [API](../../api.md) | POST /mc/accounts/claim-overwrite/
 
 This endpoint returns xxx.
 
@@ -124,7 +124,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | GET /mc/connection/`<service>`
+# [API](../../api.md) | GET /mc/connection/
 
 This endpoint returns xxx.
 
@@ -166,7 +166,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | DELETE /mc/connection/`<service>`
+# [API](../../api.md) | DELETE /mc/connection/
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/account-controller.md
+++ b/docs/api/merchant-center/account-controller.md
@@ -1,0 +1,207 @@
+# [API](../../api.md) | GET /mc/accounts/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST /mc/accounts/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST /mc/accounts/claim-overwrite/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | GET /mc/connection/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | DELETE /mc/connection/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/merchant-center/connection-controller.md
+++ b/docs/api/merchant-center/connection-controller.md
@@ -1,0 +1,39 @@
+# [API](../../api.md) | GET /mc/connect/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/merchant-center/connection-controller.md
+++ b/docs/api/merchant-center/connection-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /mc/connect/`<service>`
+# [API](../../api.md) | GET /mc/connect/
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/settings-controller.md
+++ b/docs/api/merchant-center/settings-controller.md
@@ -1,0 +1,81 @@
+# [API](../../api.md) | GET /mc/settings/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST/PUT/PATCH /mc/settings/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/merchant-center/settings-controller.md
+++ b/docs/api/merchant-center/settings-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /mc/settings/`<service>`
+# [API](../../api.md) | GET /mc/settings/
 
 This endpoint returns xxx.
 
@@ -40,7 +40,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | POST/PUT/PATCH /mc/settings/`<service>`
+# [API](../../api.md) | POST/PUT/PATCH /mc/settings/
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/shipping-rate-batch-controller.md
+++ b/docs/api/merchant-center/shipping-rate-batch-controller.md
@@ -1,0 +1,39 @@
+# [API](../../api.md) | POST /mc/shipping/rates/batch/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/merchant-center/shipping-rate-batch-controller.md
+++ b/docs/api/merchant-center/shipping-rate-batch-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | POST /mc/shipping/rates/batch/`<service>`
+# [API](../../api.md) | POST /mc/shipping/rates/batch/
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/shipping-rate-controller.md
+++ b/docs/api/merchant-center/shipping-rate-controller.md
@@ -1,0 +1,165 @@
+# [API](../../api.md) | GET /mc/shipping/rates/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST /mc/shipping/rates/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | GET /mc/shipping/rates/(?P<country_code>\w{2})`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | DELETE /mc/shipping/rates/(?P<country_code>\w{2})`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/merchant-center/shipping-rate-controller.md
+++ b/docs/api/merchant-center/shipping-rate-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /mc/shipping/rates/`<service>`
+# [API](../../api.md) | GET /mc/shipping/rates/
 
 This endpoint returns xxx.
 
@@ -40,7 +40,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | POST /mc/shipping/rates/`<service>`
+# [API](../../api.md) | POST /mc/shipping/rates/
 
 This endpoint returns xxx.
 
@@ -82,7 +82,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | GET /mc/shipping/rates/(?P<country_code>\w{2})`<service>`
+# [API](../../api.md) | GET /mc/shipping/rates/`<country_code>`
 
 This endpoint returns xxx.
 
@@ -124,7 +124,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | DELETE /mc/shipping/rates/(?P<country_code>\w{2})`<service>`
+# [API](../../api.md) | DELETE /mc/shipping/rates/`<country_code>`
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/shipping-time-batch-controller.md
+++ b/docs/api/merchant-center/shipping-time-batch-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | POST /mc/shipping/times/batch/`<service>`
+# [API](../../api.md) | POST /mc/shipping/times/batch/
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/shipping-time-batch-controller.md
+++ b/docs/api/merchant-center/shipping-time-batch-controller.md
@@ -1,0 +1,39 @@
+# [API](../../api.md) | POST /mc/shipping/times/batch/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/merchant-center/shipping-time-controller.md
+++ b/docs/api/merchant-center/shipping-time-controller.md
@@ -1,0 +1,165 @@
+# [API](../../api.md) | GET /mc/shipping/times/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST /mc/shipping/times/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | GET /mc/shipping/times/(?P<country_code>\w{2})`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | DELETE /mc/shipping/times/(?P<country_code>\w{2})`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/merchant-center/shipping-time-controller.md
+++ b/docs/api/merchant-center/shipping-time-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /mc/shipping/times/`<service>`
+# [API](../../api.md) | GET /mc/shipping/times/
 
 This endpoint returns xxx.
 
@@ -40,7 +40,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | POST /mc/shipping/times/`<service>`
+# [API](../../api.md) | POST /mc/shipping/times/
 
 This endpoint returns xxx.
 
@@ -82,7 +82,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | GET /mc/shipping/times/(?P<country_code>\w{2})`<service>`
+# [API](../../api.md) | GET /mc/shipping/times/`<country_code>`
 
 This endpoint returns xxx.
 
@@ -124,7 +124,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | DELETE /mc/shipping/times/(?P<country_code>\w{2})`<service>`
+# [API](../../api.md) | DELETE /mc/shipping/times/`<country_code>`
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/supported-countries-controller.md
+++ b/docs/api/merchant-center/supported-countries-controller.md
@@ -1,0 +1,39 @@
+# [API](../../api.md) | GET /mc/countries/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```

--- a/docs/api/merchant-center/supported-countries-controller.md
+++ b/docs/api/merchant-center/supported-countries-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /mc/countries/`<service>`
+# [API](../../api.md) | GET /mc/countries/
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/target-audience-controller.md
+++ b/docs/api/merchant-center/target-audience-controller.md
@@ -1,4 +1,4 @@
-# [API](../../api.md) | GET /mc/target_audience/`<service>`
+# [API](../../api.md) | GET /mc/target_audience/
 
 This endpoint returns xxx.
 
@@ -40,7 +40,7 @@ GET /ads/accounts/
 
 ----
 
-# [API](../../api.md) | POST /mc/target_audience/`<service>`
+# [API](../../api.md) | POST /mc/target_audience/
 
 This endpoint returns xxx.
 

--- a/docs/api/merchant-center/target-audience-controller.md
+++ b/docs/api/merchant-center/target-audience-controller.md
@@ -1,0 +1,81 @@
+# [API](../../api.md) | GET /mc/target_audience/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```
+
+----
+
+# [API](../../api.md) | POST /mc/target_audience/`<service>`
+
+This endpoint returns xxx.
+
+## Request
+
+The request URL must contain the following path parameters:
+
+- xyz: <description>
+
+## Response
+
+The response contains the following fields:
+
+- xyz: <description>
+- xyz: <description>
+
+## Example Request
+
+```
+GET /ads/accounts/
+```
+
+```javascript
+{
+	data: 'foo'
+}
+```
+
+## Example Response
+
+```javascript
+{
+	offerId: "product123",
+	title: "Lorem Ipsum",
+	description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	...
+}
+```


### PR DESCRIPTION
I made a start consolidating the local/site API information from the various pull requests.

There is a lot of placeholder information.

If you have a moment to update the info for any endpoints you've worked on, please chip in (don't be shy).

I've tried to just keep format etc. consistent with WCS

* [x] Ads Account Controller
* [x] Ads Campaign Controller
* [x] Google Account Controller
* [ ] Site Verification Controller
* [x] Jetpack Account Controller
* [ ] MC Account Controller
* [ ] MC Connection Controller
* [ ] MC Settings Controller
* [ ] Shipping Rate Controller
* [ ] Shipping Rate Batch Controller
* [ ] Shipping Time Controller
* [ ] Shipping Time Batch Controller
* [ ] Supported Countries Controller
* [ ] Target Audience Controller