### PR TITLE
Use the google-listings-and-ads WooDNA service

### DIFF
--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -93,7 +93,7 @@ class AccountController extends BaseController {
 			$auth_url = $this->manager->get_authorization_url( null, $redirect );
 
 			// Payments flow allows redirect back to the site without showing plans.
-			$auth_url = add_query_arg( [ 'from' => 'woocommerce-payments' ], $auth_url );
+			$auth_url = add_query_arg( [ 'from' => 'google-listings-and-ads' ], $auth_url );
 
 			return [
 				'url' => $auth_url,

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -546,7 +546,7 @@ class ConnectionTest implements Service, Registerable {
 			$auth_url = $manager->get_authorization_url( null, $redirect );
 
 			// Payments flow allows redirect back to the site without showing plans.
-			$auth_url = add_query_arg( [ 'from' => 'woocommerce-payments' ], $auth_url );
+			$auth_url = add_query_arg( [ 'from' => 'google-listings-and-ads' ], $auth_url );
 
 			error_log( $auth_url );
 


### PR DESCRIPTION
Closes https://github.com/woocommerce/google-listings-and-ads/issues/118

Flips our jetpack connection over to the new Google Listings and Ads WooDNA service instead of the default WooCommerce Payments service.

![Screen Shot 2021-02-17 at 8 23 44 pm](https://user-images.githubusercontent.com/355014/108194391-7e082d00-7166-11eb-82af-50970ca92da4.png)

# How To Test

* Disconnect from Jetpack
* Go to Connection Test Page
* Connect to Jetpack/WordPress
* View new branded flow for GLA
* Complete connection
