### PR TITLE
Make unit-tests run with `woocommerce/components` dependency.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,11 @@
+// Import WP-scripts presets to extend them,
+// see https://developer.wordpress.org/block-editor/packages/packages-scripts/#advanced-information-11.
+const defaultConfig = require( '@wordpress/scripts/config/jest-unit.config' );
+
 module.exports = {
+	...defaultConfig,
 	moduleNameMapper: {
-        "\\.~/(.*)$": "<rootDir>/js/src/$1",
+		// Transform our `.~/` alias.
+		'\\.~/(.*)$': '<rootDir>/js/src/$1',
 	},
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	moduleNameMapper: {
+        "\\.~/(.*)$": "<rootDir>/js/src/$1",
+	},
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ const defaultConfig = require( '@wordpress/scripts/config/jest-unit.config' );
 
 module.exports = {
 	...defaultConfig,
+	transformIgnorePatterns: [ 'node_modules/(?!@woocommerce)' ],
 	moduleNameMapper: {
 		// Transform our `.~/` alias.
 		'\\.~/(.*)$': '<rootDir>/js/src/$1',

--- a/js/src/setup-mc/test/index.js
+++ b/js/src/setup-mc/test/index.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { SetupMC } from '../';
+describe( 'SetupMC', () => {
+	test( 'should render empty message when there are no rows', () => {
+		const { container } = render( <SetupMC /> );
+
+		expect( container ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Maps `.~/` alias. Closes https://github.com/woocommerce/google-listings-and-ads/issues/233. ([`a15dd13 - 03ad4bc`](https://github.com/woocommerce/google-listings-and-ads/pull/234/files/03ad4bcc84d61165099f397d456bff816b6e7c78))
Marks `@woocommerce/components` for transpiling (https://github.com/woocommerce/google-listings-and-ads/pull/234/commits/d16db1099be8af2c3a36a8d0424e9980a950d092), to fix 
```
 SyntaxError: Cannot use import statement outside a module

      2 |  * External dependencies
      3 |  */
    > 4 | import { Link } from '@woocommerce/components';
```



Resolves the original issue, but there is still a problem to run our tests, as it fails due to other reasons

```
 FAIL  js/src/setup-mc/test/index.js
  ● Test suite failed to run

    TypeError: Cannot read property 'add' of undefined

      at setupWPTimezone (node_modules/@woocommerce/components/node_modules/@wordpress/date/build/@wordpress/date/src/index.js:141:15)
      at Object.<anonymous> (node_modules/@woocommerce/components/node_modules/@wordpress/date/build/@wordpress/date/src/index.js:527:1)
      at Object.<anonymous> (../../../../Users/psealock/vagrant-local/www/tangaroa/public_html/wp-content/plugins/wc-admin/packages/components/src/date/index.js:5:1)
      at Object.<anonymous> (../../../../Users/psealock/vagrant-local/www/tangaroa/public_html/wp-content/plugins/wc-admin/packages/components/src/index.js:14:1)
      at Object.<anonymous> (js/src/setup-mc/top-bar/index.js:4:1)
      at Object.<anonymous> (js/src/setup-mc/index.js:5:1)
      at Object.<anonymous> (js/src/setup-mc/test/index.js:9:1)
```


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Checkout and build this branch `git co issue/tests-w-alias && npm install`
2. Run JS tests `npm run test-unit`


### Changelog Note:

none

### Additional comments. 

The fact we need to transpile `woocommerce/components` looks suspicious to me.

Also, the tests are being built quite long (~15sec on my machine), 
 - I'm not sure whether it's something I miss in this PR.
 - React is lagging behind ES Modules support and needs to transpile everything back and forth.
 - Some of our dependencies are lagging.
