### PR TITLE
Provide site url with claim conflict error response

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -372,12 +372,21 @@ class AccountController extends BaseOptionsController {
 				$step['message'] = $e->getMessage();
 
 				if ( 'claim' === $name && 403 === $e->getCode() ) {
+					$data = [
+						'website_url' => $this->strip_url_protocol(
+							apply_filters( 'woocommerce_gla_site_url', site_url() )
+						),
+					];
+
 					if ( $state['set_id']['data']['from_mca'] ?? true ) {
 						$step['data']['overwrite_required'] = true;
+						$e                                  = new ExceptionWithResponseData( $e->getMessage(), $e->getCode(), null, $data );
 					} else {
-						throw new Exception(
+						throw new ExceptionWithResponseData(
 							__( 'Unable to claim website URL with this Merchant Center Account.', 'google-listings-and-ads' ),
-							406
+							406,
+							null,
+							$data
 						);
 					}
 				} elseif ( 'link' === $name && 401 === $e->getCode() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Return the current site URL with the error response (`403` or `406`) so it can be displayed to the user.

Examples:
```json
# Claim overwrite necessary (for sub-accounts)
403
{ 
  "message":"Website already claimed, use overwrite to complete the process.",
  "website_url":"woo.store.url"
}

# No claim possible (because it's a standalone account)
406
{
  "message":"Unable to claim website URL with this Merchant Center Account.",
  "website_url":"woo.store.url"
}
```

### Detailed test instructions:

1. Attempt to claim a site that's already claimed (with an existing standalone account, or with an existing or new sub-account).
2. Confirm that the `40x` error response includes the correct `website_url` attribute.


### Changelog Note:

> Return the `website_url` attribute with website claim conflict responses.
