### PR TITLE
Return error response when Jetpack fails

### DIFF
--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -7,6 +7,7 @@ use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -81,10 +82,13 @@ class AccountController extends BaseController {
 				$result = $this->manager->register();
 
 				if ( is_wp_error( $result ) ) {
-					return [
-						'status'  => 'error',
-						'message' => $result->get_error_message(),
-					];
+					return new Response(
+						[
+							'status'  => 'error',
+							'message' => $result->get_error_message(),
+						],
+						400
+					);
 				}
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR returns a `WP_REST_Response` with an error code set when we encounter a Jetpack connection error.

Closes #248 

### Detailed test instructions:
I wasn't able to trigger the exact error in the issue but I replicated it returning a different error.

1. Disconnect Jetpack and clear any entries in `wp_options` with the key `jetpack_options`
2. Send a connection request to `https://site.test/wp-json/wc/gla/jetpack/connect` using a local test site
3. Check the response and confirm that it now has the error code 400 returned

```
400 Bad Request
{
	"status": "error",
	"message": "Your site host \"woo-google.test\" is on a private network. Jetpack can only connect to public sites."
}
```

_Note: until #259 is resolved, you'll hit into a fatal error when disconnecting Jetpack. As a temporary workaround the following line can be commented out:_ `google-listings-and-ads/src/Internal/DependencyManagement/GoogleServiceProvider.php` 124
```
//throw new Exception( __( 'Jetpack authorization header error.', 'google-listings-and-ads' ), $error->getCode() );
```

### Changelog Note:
- Return error response when Jetpack fails