### PR TITLE
Use js root alias `.~/`,

### DIFF
--- a/js/src/components/app-table-card/index.js
+++ b/js/src/components/app-table-card/index.js
@@ -7,7 +7,7 @@ import { TableCard } from '@woocommerce/components';
  * Internal dependencies
  */
 import recordColumnToggleEvent from './recordColumnToggleEvent';
-import { recordTableSortEvent } from '../../utils/recordEvent';
+import { recordTableSortEvent } from '.~/utils/recordEvent';
 import './index.scss';
 
 /**

--- a/js/src/components/app-table-card/recordColumnToggleEvent.js
+++ b/js/src/components/app-table-card/recordColumnToggleEvent.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { recordTableHeaderToggleEvent } from '../../utils/recordEvent';
+import { recordTableHeaderToggleEvent } from '.~/utils/recordEvent';
 
 const recordColumnToggleEvent = ( trackEventReportId, shown, toggled ) => {
 	const status = shown.includes( toggled ) ? 'on' : 'off';

--- a/js/src/components/trackable-link/index.js
+++ b/js/src/components/trackable-link/index.js
@@ -6,7 +6,7 @@ import { Link } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import recordEvent from '../../utils/recordEvent';
+import recordEvent from '.~/utils/recordEvent';
 
 /**
  * A {@link module:@woocommerce/components~Link} component that will call `recordEvent` with `eventName` and `eventProps` parameters upon click.

--- a/js/src/dashboard/all-programs-table-card/edit-program-link/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-link/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import TrackableLink from '../../../components/trackable-link';
+import TrackableLink from '.~/components/trackable-link';
 
 /**
  * Internal dependencies

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -8,7 +8,7 @@ import { getQuery, onQueryChange } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppTableCard from '../../components/app-table-card';
+import AppTableCard from '.~/components/app-table-card';
 import RemoveProgramButton from './remove-program-button';
 import EditProgramLink from './edit-program-link';
 import PauseProgramButton from './pause-program-button';

--- a/js/src/dashboard/all-programs-table-card/pause-program-button/pause-program-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/pause-program-button/pause-program-modal/index.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppModal from '../../../../components/app-modal';
+import AppModal from '.~/components/app-modal';
 import './index.scss';
 
 /**

--- a/js/src/dashboard/all-programs-table-card/remove-program-button/remove-program-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/remove-program-button/remove-program-modal/index.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppModal from '../../../../components/app-modal';
+import AppModal from '.~/components/app-modal';
 import './index.scss';
 
 /**

--- a/js/src/dashboard/app-date-range-filter-picker/index.js
+++ b/js/src/dashboard/app-date-range-filter-picker/index.js
@@ -8,7 +8,7 @@ import { updateQueryString } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import getDateQuery from './getDateQuery';
-import { recordDatepickerUpdateEvent } from '../../utils/recordEvent';
+import { recordDatepickerUpdateEvent } from '.~/utils/recordEvent';
 
 const isoDateFormat = 'YYYY-MM-DD';
 

--- a/js/src/get-started-page/faqs.js
+++ b/js/src/get-started-page/faqs.js
@@ -9,7 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '../components/app-documentation-link';
+import AppDocumentationLink from '.~/components/app-documentation-link';
 
 const recordToggleEvent = ( id, isOpened ) => {
 	recordEvent( 'gla_get_started_faq', {

--- a/js/src/get-started-page/get-started-card/index.js
+++ b/js/src/get-started-page/get-started-card/index.js
@@ -18,7 +18,7 @@ import { getNewPath } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import AppDocumentationLink from '.~/components/app-documentation-link';
-import { recordSetupMCEvent } from '../../utils/recordEvent';
+import { recordSetupMCEvent } from '.~/utils/recordEvent';
 import { ReactComponent as GoogleShoppingImage } from './image.svg';
 import './index.scss';
 

--- a/js/src/hooks/useGetCountries.js
+++ b/js/src/hooks/useGetCountries.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '../data';
+import { STORE_KEY } from '.~/data';
 
 /**
  * Get the supported countries from API. Returns `{ loading, data }`.

--- a/js/src/hooks/useTargetAudience.js
+++ b/js/src/hooks/useTargetAudience.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '../data';
+import { STORE_KEY } from '.~/data';
 
 const useTargetAudience = () => {
 	return useSelect( ( select ) => {

--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '../data';
+import { STORE_KEY } from '.~/data';
 
 /**
  * Gets the final country codes from the Target Audience page.

--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -7,11 +7,11 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import EditProductLink from '../../components/edit-product-link';
-import HelpPopover from '../../components/help-popover';
-import AppTableCard from '../../components/app-table-card';
-import WarningIcon from '../../components/warning-icon';
-import AppDocumentationLink from '../../components/app-documentation-link';
+import EditProductLink from '.~/components/edit-product-link';
+import HelpPopover from '.~/components/help-popover';
+import AppTableCard from '.~/components/app-table-card';
+import WarningIcon from '.~/components/warning-icon';
+import AppDocumentationLink from '.~/components/app-documentation-link';
 
 const headers = [
 	{

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -9,8 +9,8 @@ import { getQuery, onQueryChange } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import EditProductLink from '../../components/edit-product-link';
-import AppTableCard from '../../components/app-table-card';
+import EditProductLink from '.~/components/edit-product-link';
+import AppTableCard from '.~/components/app-table-card';
 
 /**
  * All programs table, with compare feature.

--- a/js/src/product-feed/product-status-help-popover/index.js
+++ b/js/src/product-feed/product-status-help-popover/index.js
@@ -7,8 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '../../components/app-documentation-link';
-import HelpPopover from '../../components/help-popover';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import HelpPopover from '.~/components/help-popover';
 import './index.scss';
 
 const ProductStatusHelpPopover = () => {

--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -9,7 +9,7 @@ import { getQuery, onQueryChange } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppTableCard from '../../components/app-table-card';
+import AppTableCard from '.~/components/app-table-card';
 import { mockedListingsData, availableMetrics } from './mocked-products-data'; // Mocked API calls
 
 /**

--- a/js/src/reports/products/products-report-filters.js
+++ b/js/src/reports/products/products-report-filters.js
@@ -18,7 +18,7 @@ import { ITEMS_STORE_NAME } from '@woocommerce/data';
 import {
 	recordDatepickerUpdateEvent,
 	recordFilterEvent,
-} from '../../utils/recordEvent';
+} from '.~/utils/recordEvent';
 import { productsFilter, advancedFilters } from './filter-config';
 
 // TODO: Consider importing it from something like '@woocommerce/wc-admin-settings'.

--- a/js/src/reports/programs/compare-programs-table-card.js
+++ b/js/src/reports/programs/compare-programs-table-card.js
@@ -9,7 +9,7 @@ import { getQuery, onQueryChange } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppTableCard from '../../components/app-table-card';
+import AppTableCard from '.~/components/app-table-card';
 import { mockedListingsData, availableMetrics } from './mocked-programs-data'; // Mocked API calls
 
 /**

--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import AppSpinner from '../../components/app-spinner';
-import useGetOption from '../../hooks/useGetOption';
+import AppSpinner from '.~/components/app-spinner';
+import useGetOption from '.~/hooks/useGetOption';
 import SavedSetupStepper from './saved-setup-stepper';
 import './index.scss';
 

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { recordSetupMCEvent } from '../../utils/recordEvent';
+import { recordSetupMCEvent } from '.~/utils/recordEvent';
 import SetupAccounts from './setup-accounts';
 import SetupFreeListings from './setup-free-listings';
 import ChooseAudience from './choose-audience';

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-account/index.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Section from '../../../../wcdl/section';
-import DisabledDiv from '../../../../components/disabled-div';
+import Section from '.~/wcdl/section';
+import DisabledDiv from '.~/components/disabled-div';
 import CardContent from './card-content';
 
 const GoogleAccount = ( props ) => {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/disabled-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/disabled-card/index.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Section from '../../../../../wcdl/section';
+import Section from '.~/wcdl/section';
 import TitleButtonLayout from '../../title-button-layout';
 
 const DisabledCard = () => {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/title-button-layout/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/title-button-layout/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import Subsection from '../../../../wcdl/subsection';
+import Subsection from '.~/wcdl/subsection';
 import ContentButtonLayout from '../content-button-layout';
 import './index.scss';
 

--- a/js/src/setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Section from '../../../../wcdl/section';
+import Section from '.~/wcdl/section';
 import CardContent from './card-content';
 
 const WordPressDotComAccount = () => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -6,7 +6,7 @@ import { Form } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppSpinner from '../../../components/app-spinner';
+import AppSpinner from '.~/components/app-spinner';
 import Hero from './hero';
 import useSettings from './useSettings';
 import FormContent from './form-content';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/pre-launch-checklist/index.js
@@ -9,9 +9,9 @@ import { CheckboxControl } from '@wordpress/components';
  * Internal dependencies
  */
 
-import HelpPopover from '../../../../components/help-popover';
-import AppDocumentationLink from '../../../../components/app-documentation-link';
-import Section from '../../../../wcdl/section';
+import HelpPopover from '.~/components/help-popover';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import Section from '.~/wcdl/section';
 import VerticalGapLayout from '../components/vertical-gap-layout';
 import './index.scss';
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/index.js
@@ -7,10 +7,10 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Section from '../../../../wcdl/section';
-import AppRadioContentControl from '../../../../components/app-radio-content-control';
-import RadioHelperText from '../../../../wcdl/radio-helper-text';
-import AppDocumentationLink from '../../../../components/app-documentation-link';
+import Section from '.~/wcdl/section';
+import AppRadioContentControl from '.~/components/app-radio-content-control';
+import RadioHelperText from '.~/wcdl/radio-helper-text';
+import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '../components/vertical-gap-layout';
 import ShippingRateSetup from './shipping-rate-setup';
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -9,12 +9,12 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '../../../../../../../data';
-import AppModal from '../../../../../../../components/app-modal';
-import AppInputControl from '../../../../../../../components/app-input-control';
+import { STORE_KEY } from '.~/data';
+import AppModal from '.~/components/app-modal';
+import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '../../../../components/vertical-gap-layout';
 import AudienceCountrySelect from '../../../../components/audience-country-select';
-import useStoreCurrency from '../../../../../../../hooks/useStoreCurrency';
+import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import useGetRemainingCountryCodes from './useGetRemainingCountryCodes';
 
 const AddRateModal = ( props ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
@@ -8,7 +8,7 @@ import { useDebouncedCallback } from 'use-debounce';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '../../../../../../data';
+import { STORE_KEY } from '.~/data';
 import CountriesPriceInput from '../countries-price-input';
 
 const CountriesPriceInputForm = ( props ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -9,9 +9,9 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '../../../../../../../../data';
-import AppModal from '../../../../../../../../components/app-modal';
-import AppInputControl from '../../../../../../../../components/app-input-control';
+import { STORE_KEY } from '.~/data';
+import AppModal from '.~/components/app-modal';
+import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '../../../../../components/vertical-gap-layout';
 import AudienceCountrySelect from '../../../../../components/audience-country-select';
 import './index.scss';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
@@ -7,8 +7,8 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useCountryKeyNameMap from '../../../../../../hooks/useCountryKeyNameMap';
-import AppInputControl from '../../../../../../components/app-input-control';
+import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
+import AppInputControl from '.~/components/app-input-control';
 import More from '../../../components/more';
 import EditRateButton from './edit-rate-button';
 import AppSpinner from '.~/components/app-spinner';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
@@ -8,12 +8,12 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import AppInputControl from '../../../../../components/app-input-control';
+import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '../../components/vertical-gap-layout';
 import AddRateButton from './add-rate-button';
-import { STORE_KEY } from '../../../../../data';
+import { STORE_KEY } from '.~/data';
 import CountriesPriceInputForm from './countries-price-input-form';
-import useStoreCurrency from '../../../../../hooks/useStoreCurrency';
+import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import getCountriesPriceArray from './getCountriesPriceArray';
 import AppSpinner from '.~/components/app-spinner';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/index.js
@@ -7,10 +7,10 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Section from '../../../../wcdl/section';
-import RadioHelperText from '../../../../wcdl/radio-helper-text';
-import AppRadioContentControl from '../../../../components/app-radio-content-control';
-import AppDocumentationLink from '../../../../components/app-documentation-link';
+import Section from '.~/wcdl/section';
+import RadioHelperText from '.~/wcdl/radio-helper-text';
+import AppRadioContentControl from '.~/components/app-radio-content-control';
+import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '../components/vertical-gap-layout';
 import ShippingTimeSetup from './shipping-time-setup';
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -8,8 +8,8 @@ import { Form } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppModal from '../../../../../../../components/app-modal';
-import AppInputControl from '../../../../../../../components/app-input-control';
+import AppModal from '.~/components/app-modal';
+import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '../../../../components/vertical-gap-layout';
 import AudienceCountrySelect from '../../../../components/audience-country-select';
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -8,8 +8,8 @@ import { Form } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppModal from '../../../../../../../../components/app-modal';
-import AppInputControl from '../../../../../../../../components/app-input-control';
+import AppModal from '.~/components/app-modal';
+import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '../../../../../components/vertical-gap-layout';
 import AudienceCountrySelect from '../../../../../components/audience-country-select';
 import './index.scss';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -7,7 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppInputControl from '../../../../../../components/app-input-control';
+import AppInputControl from '.~/components/app-input-control';
 import More from '../../../components/more';
 import EditTimeButton from './edit-time-button';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
@@ -8,7 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '../../../../../components/app-documentation-link';
+import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '../../components/vertical-gap-layout';
 import AddTimeButton from './add-time-button';
 import CountriesTimeInput from './countries-time-input';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/tax-rate/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/tax-rate/index.js
@@ -7,10 +7,10 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Section from '../../../../wcdl/section';
-import RadioHelperText from '../../../../wcdl/radio-helper-text';
-import AppRadioContentControl from '../../../../components/app-radio-content-control';
-import AppDocumentationLink from '../../../../components/app-documentation-link';
+import Section from '.~/wcdl/section';
+import RadioHelperText from '.~/wcdl/radio-helper-text';
+import AppRadioContentControl from '.~/components/app-radio-content-control';
+import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '../components/vertical-gap-layout';
 
 const TaxRate = ( props ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/useSettings.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/useSettings.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '../../../data';
+import { STORE_KEY } from '.~/data';
 
 /**
  * Returns an object `{ settings }` to be used in the Setup Free Listing page.

--- a/js/src/setup-mc/setup-stepper/usePageStep.js
+++ b/js/src/setup-mc/setup-stepper/usePageStep.js
@@ -6,7 +6,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useDispatchOptions from '../../hooks/useDispatchOptions';
+import useDispatchOptions from '.~/hooks/useDispatchOptions';
 
 /**
  * @typedef {Object} UsePageStepResult

--- a/js/src/setup-mc/top-bar/index.js
+++ b/js/src/setup-mc/top-bar/index.js
@@ -10,8 +10,8 @@ import GridiconHelpOutline from 'gridicons/dist/help-outline';
 /**
  * Internal dependencies
  */
-import AppIconButton from '../../components/app-icon-button';
-import { recordSetupMCEvent } from '../../utils/recordEvent';
+import AppIconButton from '.~/components/app-icon-button';
+import { recordSetupMCEvent } from '.~/utils/recordEvent';
 import './index.scss';
 
 const TopBar = () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use js root alias `.~/` (https://github.com/woocommerce/google-listings-and-ads/pull/192),

for
- `.~/components`
- `.~/hooks`
- `.~/utils`
- `.~/wcdl`
to remove hard to read "morse code": `../../..`, make the code less conflict prone.


I think it's beneficial to have it done once for good:
- to have our code cleaner from day 1 ;)
- not to pollute other PRs with updating paths bay-the-way
- to make it easier to shuffle files, like for https://github.com/woocommerce/google-listings-and-ads/issues/195, https://github.com/woocommerce/google-listings-and-ads/issues/156
- to make the code less conflict-prone

The cost:
Lots of pages to check for regression at once.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Look at the diff to see how many characters are gone
2. Let your eyes appreciate nystagmus fading away :dancers: :eyes: ;)  when you trying to compare [`feature/use-root-alias?expand=1`#diff-f5aaf9cefa](https://github.com/woocommerce/google-listings-and-ads/compare/feature/use-root-alias?expand=1#diff-f5aaf9cefa40769e92344bd2904de3d3ad679400807b0d83a170bf409d78c2f9)L14-L15
3. Check briefly that none of the affected pages is broken :/ 


### Changelog Note:

 none