### PR TITLE
Generate the auth header when request sent instead of on instatiation

### DIFF
--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -180,7 +180,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 				try {
 					$request = $request->withHeader( 'Authorization', $this->generate_auth_header() );
 				} catch ( WPError $error ) {
-					do_action( 'gla_guzzle_client_exception', $error, __METHOD__ . ' in register_guzzle()' );
+					do_action( 'gla_guzzle_client_exception', $error, __METHOD__ . ' in add_auth_header()' );
 					throw new Exception( __( 'Jetpack authorization header error.', 'google-listings-and-ads' ), $error->getCode() );
 				}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #259.

This PR moves the `generate_auth_header()` call from client instantiation to request, so it doesn't throw an exception when loaded without a valid Jetpack connection. (p1614676679095400-slack-C01E9LB4X61)

### Detailed test instructions:

1. Load a fresh install of WP+WC+GLA. Confirm that no fatal error is thrown.
2. Connect Jetpack and make some requests to the WCS from the Connection test page. Confirm that the requests work (i.e., the auth header is being used correctly).


