### PR TITLE
Fix useTargetAudienceFinalCountryCodes hook: data should not be false

### DIFF
--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.js
@@ -15,8 +15,10 @@ import { STORE_KEY } from '.~/data';
  *
  * `loading` is true when both `getTargetAudience` and `getCountries` are still resolving.
  *
- * `data` is an array of all supported country codes when users selected `all` in target audience page;
- * else, an array of selected country codes in target audience page.
+ * `data` is:
+ * - `undefined` when loading is in progress;
+ * - an array of all supported country codes when users chose `all` in target audience page;
+ * - an array of selected country codes when users chose `selected` in target audience page.
  */
 const useTargetAudienceFinalCountryCodes = () => {
 	return useSelect( ( select ) => {
@@ -38,7 +40,7 @@ const useTargetAudienceFinalCountryCodes = () => {
 
 		return {
 			loading,
-			data: ! loading && data,
+			data,
 		};
 	} );
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow up to https://github.com/woocommerce/google-listings-and-ads/pull/264#discussion_r585255019.

When `loading` is true, `data` will be `false`, which is not right.

`data` should be: 

- `undefined` when loading is in progress;
- an array of all supported country codes when users chose `all` in target audience page;
- an array of selected country codes when users chose `selected` in target audience page.
 
### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc
2. In step 2, select "all countries".
3. In step 3, click on the shipping rate edit button. All the countries should appear in the edit modal.
4. Go back to step 2, choose "selected countries only", and select a few countries.
5. Go to step 3, click on the shipping rate edit button. The selected countries should appear in the edit modal.
