### PR TITLE
Set default destinations for Google products submission

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -36,6 +36,9 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 
 	public const CHANNEL_ONLINE = 'online';
 
+	public const DESTINATION_SHOPPING_ADS  = 'Shopping ads';
+	public const DESTINATION_FREE_LISTINGS = 'Free listings';
+
 	/**
 	 * @var WC_Product WooCommerce product object
 	 */
@@ -93,6 +96,8 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 
 		$content_language = empty( get_locale() ) ? 'en' : strtolower( substr( get_locale(), 0, 2 ) ); // ISO 639-1.
 		$this->setContentLanguage( $content_language );
+
+		$this->setIncludedDestinations( [ self::DESTINATION_SHOPPING_ADS, self::DESTINATION_FREE_LISTINGS ] );
 
 		$this->map_wc_general_attributes()
 			 ->map_wc_product_image( self::IMAGE_SIZE_FULL )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #215.

This PR sets the `included_destination` field to a set of default constant values for all products: `Shopping ads` and `Free listings`.

**Question:** I got a validation error from Google while submitting these two destinations. It's probably because I don't have the `Shopping ads` destination set in my product feed. But I can't set it anyways because there's no option but `Free listings` there. Not sure what configuration should I make to include that destination.

### Detailed test instructions:

1. Sync all products or one product from the Connection Test page
2. Check your Merchant Center after a few minutes and open the newly submitted product
3. Check under the "Raw feed attributes" and make sure that both destinations are included
