### PR TITLE
Move TopBar to `.~/components/stepper/`,

### DIFF
--- a/js/src/components/stepper/top-bar/index.js
+++ b/js/src/components/stepper/top-bar/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { Link } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
+import GridiconChevronLeft from 'gridicons/dist/chevron-left';
+import GridiconHelpOutline from 'gridicons/dist/help-outline';
+
+/**
+ * Internal dependencies
+ */
+import AppIconButton from '.~/components/app-icon-button';
+import './index.scss';
+
+/**
+ * Simple top bar with back button and title,
+ * to be used when configuring a campaign during oboarding and later.
+ *
+ * @param {Object} props
+ * @param {string} props.backHref Href for the back button.
+ * @param {Function} props.onBackButtonClick
+ * @param {Function} props.onHelpButtonClick
+ */
+const TopBar = ( { backHref, onBackButtonClick, onHelpButtonClick } ) => {
+	return (
+		<div className="gla-stepper-top-bar">
+			<Link
+				className="back-button"
+				href={ backHref }
+				type="wc-admin"
+				onClick={ onBackButtonClick }
+			>
+				<GridiconChevronLeft />
+			</Link>
+			<span className="title">
+				{ __(
+					'Get started with Google Listings & Ads',
+					'google-listings-and-ads'
+				) }
+			</span>
+			<div className="actions">
+				{ /* TODO: click and navigate to where? */ }
+				<AppIconButton
+					icon={ <GridiconHelpOutline /> }
+					text={ __( 'Help', 'google-listings-and-ads' ) }
+					onClick={ onHelpButtonClick }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default TopBar;

--- a/js/src/components/stepper/top-bar/index.scss
+++ b/js/src/components/stepper/top-bar/index.scss
@@ -1,4 +1,4 @@
-.gla-setup-mc-top-bar {
+.gla-stepper-top-bar {
 	display: flex;
 	align-items: stretch;
 	min-height: 64px;

--- a/js/src/setup-mc/index.js
+++ b/js/src/setup-mc/index.js
@@ -2,13 +2,13 @@
  * Internal dependencies
  */
 import FullScreen from '.~/components/full-screen';
-import TopBar from './top-bar';
+import SetupMCTopBar from './top-bar';
 import SetupStepper from './setup-stepper';
 
 const SetupMC = () => {
 	return (
 		<FullScreen>
-			<TopBar />
+			<SetupMCTopBar />
 			<SetupStepper />
 		</FullScreen>
 	);

--- a/js/src/setup-mc/top-bar/index.js
+++ b/js/src/setup-mc/top-bar/index.js
@@ -1,20 +1,15 @@
 /**
  * External dependencies
  */
-import { Link } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
-import { __ } from '@wordpress/i18n';
-import GridiconChevronLeft from 'gridicons/dist/chevron-left';
-import GridiconHelpOutline from 'gridicons/dist/help-outline';
 
 /**
  * Internal dependencies
  */
-import AppIconButton from '.~/components/app-icon-button';
+import TopBar from '.~/components/stepper/top-bar';
 import { recordSetupMCEvent } from '.~/utils/recordEvent';
-import './index.scss';
 
-const TopBar = () => {
+const SetupMCTopBar = () => {
 	const handleBackButtonClick = () => {
 		recordSetupMCEvent( 'back' );
 	};
@@ -24,31 +19,12 @@ const TopBar = () => {
 	};
 
 	return (
-		<div className="gla-setup-mc-top-bar">
-			<Link
-				className="back-button"
-				href={ getNewPath( {}, '/google/start' ) }
-				type="wc-admin"
-				onClick={ handleBackButtonClick }
-			>
-				<GridiconChevronLeft />
-			</Link>
-			<span className="title">
-				{ __(
-					'Get started with Google Listings & Ads',
-					'google-listings-and-ads'
-				) }
-			</span>
-			<div className="actions">
-				{ /* TODO: click and navigate to where? */ }
-				<AppIconButton
-					icon={ <GridiconHelpOutline /> }
-					text={ __( 'Help', 'google-listings-and-ads' ) }
-					onClick={ handleHelpButtonClick }
-				/>
-			</div>
-		</div>
+		<TopBar
+			backHref={ getNewPath( {}, '/google/start' ) }
+			onBackButtonClick={ handleBackButtonClick }
+			onHelpButtonClick={ handleHelpButtonClick }
+		/>
 	);
 };
 
-export default TopBar;
+export default SetupMCTopBar;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Move TopBar to `.~/components/stepper/`,to reuse it between pages.

Code was copied from /js/src/setup-mc/top-bar/index.js and stripped from SetupMC-specific tracking events.

(cherry picked and redone from commit  da49c29c24ddd0956353b9c4a1f4caad861f875e)

This is a smaller PR, that does the common part of https://github.com/woocommerce/google-listings-and-ads/pull/293 and https://github.com/woocommerce/google-listings-and-ads/pull/290
as agreed at https://github.com/woocommerce/google-listings-and-ads/pull/292#issuecomment-791431195


### Screenshots:

<!--- Optional --->
![image](https://user-images.githubusercontent.com/17435/110151157-6aa0c700-7de0-11eb-8664-a716b1f9846c.png)



### Detailed test instructions:

0. `git checkout update/move-top-bar && npm install && npm run build`
1. Visit MC setup https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc
2. Make sure the TopBar's layout looks like it did
3. and tracking events are recorded as they were.


### Comments

It also addresses @eason9487 comments from the other PR review https://github.com/woocommerce/google-listings-and-ads/pull/292#pullrequestreview-604981154