### PR TITLE
Change SetupFreeListings step title

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -66,7 +66,7 @@ export default function EditFreeCampaign() {
 					{
 						key: '2',
 						label: __(
-							'Configure your free listings',
+							'Configure your product listings',
 							'google-listings-and-ads'
 						),
 						content: (

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -68,7 +68,7 @@ const SavedSetupStepper = ( props ) => {
 				{
 					key: '3',
 					label: __(
-						'Configure your free listings',
+						'Configure your product listings',
 						'google-listings-and-ads'
 					),
 					content: <SetupFreeListings />,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Change SetupFreeListings step title.

from 'Configure your free listings' to 'Configure your product listings'.
For SavedSetupStepper and EditFreeCampaign.

Addresses https://github.com/woocommerce/google-listings-and-ads/pull/292#issuecomment-791123423.


### Screenshots:

![Screenshot of edit listing view](https://user-images.githubusercontent.com/17435/110250759-6bbb2b00-7f7d-11eb-9784-684f7afdb419.png)

![Screenshot of onboarding](https://user-images.githubusercontent.com/17435/110250778-842b4580-7f7d-11eb-8521-73cb67812bd9.png)



### Detailed test instructions:

1. Visit https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc and **Marketing > [Dashboard](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard) > ["Edit"](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fedit-free-campaign&programId=123)
2. Make sure "Configure your product listings" step title looks as in [Figma](https://www.figma.com/file/jZUpa8eTrnrK1Lwt2ry7zk/Native-Google-Integration?node-id=4162%3A0)


