### PR TITLE
Fix flash of error message in Google Account section in Setup Ads.

### DIFF
--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.js
@@ -12,9 +12,18 @@ import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
 import GoogleAccount from '.~/components/google-account';
 import GoogleAdsAccountSection from './google-ads-account-section';
+import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
+import useGoogleAccount from '.~/hooks/useGoogleAccount';
+import AppSpinner from '.~/components/app-spinner';
 
 const SetupAccounts = ( props ) => {
 	const { onContinue = () => {} } = props;
+	const { google } = useGoogleAccount();
+	const { googleAdsAccount } = useGoogleAdsAccount();
+
+	if ( ! google || ( google.active === 'yes' && ! googleAdsAccount ) ) {
+		return <AppSpinner />;
+	}
 
 	// TODO: call backend API to check and set the following to true/false.
 	const isContinueButtonDisabled = false;


### PR DESCRIPTION
This is done by checking for Google Account connection status and Google Ads connection status in the parent level and show AppSpinner accordingly.

### Changes proposed in this Pull Request:

Closes #318.

This PR fixes the flash of error message in Google Account section in Setup Ads. This is done by checking for Google Account connection status and Google Ads connection status in the parent level and show AppSpinner accordingly, similar to the one in Setup MC flow.

### Screenshots:

![fix flash of error message](https://user-images.githubusercontent.com/417342/110656707-27d55980-81fb-11eb-959c-a2cfbc61e63f.gif)

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads
2. The page should load and then show the Google Account section and Google Ads account section correctly, there should be no flash of error message.
