### PR TITLE
Change reliance on Locale and the intl extension

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php
+++ b/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php
@@ -208,7 +208,7 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 
 		// Default to using the Locale class if it is available.
 		if ( class_exists( Locale::class ) ) {
-			return function() use ( $locale ) {
+			return function() use ( $locale ): string {
 				return Locale::getDisplayLanguage( $locale, $locale );
 			};
 		}
@@ -216,7 +216,7 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 		return function() use ( $locale ): string {
 			// en_US isn't provided by the translations API.
 			if ( 'en_US' === $locale ) {
-				return 'English (United States)';
+				return 'English';
 			}
 
 			require_once ABSPATH . 'wp-admin/includes/translation-install.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This will use the `intl` extension if available, but will fall back to the WordPress Translations API if that extension isn't available.

Fixes #266.

### Detailed test instructions:

1. Ensure that the `intl` PHP extension is not running 
2. Make a request to the [Target Audience endpoint](https://github.com/woocommerce/google-listings-and-ads/pull/142)
3. You should get a valid response (`200` status) instead of a fatal error (`500` status) with correct locale information based on your site settings.