### PR TITLE
Add created data with ads account status

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -383,11 +383,14 @@ class Proxy implements OptionsAwareInterface {
 			'status' => $id ? 'connected' : 'disconnected',
 		];
 
-		$incomplete = $this->container->get( AdsAccountState::class )->last_incomplete_step();
+		$state      = $this->container->get( AdsAccountState::class );
+		$incomplete = $state->last_incomplete_step();
 		if ( ! empty( $incomplete ) ) {
 			$status['status'] = 'incomplete';
 			$status['step']   = $incomplete;
 		}
+
+		$status += $state->get_step_data( 'set_id' );
 
 		return $status;
 	}

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -288,6 +288,9 @@ class AccountController extends BaseOptionsController {
 							break;
 						}
 						$account = $this->middleware->create_ads_account();
+
+						$step['data']['sub_account']       = true;
+						$step['data']['created_timestamp'] = time();
 						break;
 
 					case 'billing':

--- a/src/Options/AccountState.php
+++ b/src/Options/AccountState.php
@@ -100,4 +100,14 @@ abstract class AccountState implements Service, OptionsAwareInterface {
 
 		return $incomplete;
 	}
+
+	/**
+	 * Returns any data from a specific step.
+	 *
+	 * @param string $step Step name.
+	 * @return array
+	 */
+	public function get_step_data( string $step ): array {
+		return $this->get( false )[ $step ]['data'] ?? [];
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR will add additional data such as the created_timestamp and a boolean stating it's a sub_account when querying the endpoint `GET /gla/ads/connection`

The data is only added when we create the account, since when we are linking we can't confirm whether it's a `sub_account` or not. So returning it as `false` might not be correct. If a user creates a `sub_account` and then disconnects and then relinks the same `sub_account` we will lose the `created_timestamp` and the boolean `sub_account`. We are accepting this as a limitation in v1.

The credit notice should only be shown if `sub_account` is true and `created_timestamp` is less than 30 days ago.

Closes #315 

### Detailed test instructions:

1\. Disconnect ads account > create ads account > check status
```
Request:  GET /wc/gla/ads/connection
Status:   200
Response: {
    "id": 6111390429,
    "status": "connected",
    "sub_account": true,
    "created_timestamp": 1615468994
}
```

2\. Disconnect ads account > link existing ads account > check status
```
Request:  GET /wc/gla/ads/connection
Status:   200
Response: {
    "id": 343085949,
    "status": "connected"
}
```

### Changelog Note:
- Add created data with ads account status