### PR TITLE
Change eslint jsdoc syntax to typescript,

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,8 @@
 {
-  "extends": [ "plugin:@woocommerce/eslint-plugin/recommended" ]
+  "extends": [ "plugin:@woocommerce/eslint-plugin/recommended" ],
+  "settings": {
+    "jsdoc": {
+	  "mode": "typescript"
+    }
+  }
 }

--- a/js/src/dashboard/app-date-range-filter-picker/index.js
+++ b/js/src/dashboard/app-date-range-filter-picker/index.js
@@ -20,7 +20,7 @@ const isoDateFormat = 'YYYY-MM-DD';
  * @param {string} [props.trackEventReportId] An id to be used as `report` propert in fired events.
  * 												If not given, no track event will be fired.
  *
- * @return {module:woocommerce/components~DateRangeFilterPicker} Customized DateRangeFilterPicker.
+ * @return {import('@woocommerce/components').DateRangeFilterPicker} Customized DateRangeFilterPicker.
  */
 const AppDateRangeFilterPicker = ( props ) => {
 	const { trackEventReportId } = props;

--- a/js/src/hooks/useApiFetchCallback.js
+++ b/js/src/hooks/useApiFetchCallback.js
@@ -105,7 +105,7 @@ const shouldReturnResponseBody = ( options ) => {
  * )
  * ```
  *
- * @param {module:wordpress/api-fetch.APIFetchOptions} [options] options to be forwarded to `apiFetch`.
+ * @param {import('@wordpress/api-fetch').APIFetchOptions} [options] options to be forwarded to `apiFetch`.
  *
  * @return {Array} `[ apiFetchCallback, fetchResult ]`
  * 		- `apiFetchCallback` is the function to be called to trigger `apiFetch`.

--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -16,7 +16,7 @@ import { mockedListingsData, availableMetrics } from './mocked-products-data'; /
  * All posible metric headers.
  * Sorted in the order we wish to render them.
  *
- * @type {module:app-table-card.Props.headers}
+ * @type {import('.~/components/app-table-card').Props.headers}
  */
 const metricsHeaders = [
 	{
@@ -66,7 +66,7 @@ const CompareProductsTableCard = ( props ) => {
 	 *
 	 * @param {Array} data
 	 *
-	 * @return {module:app-table-card.Props.headers} All headers.
+	 * @return {import('.~/components/app-table-card').Props.headers} All headers.
 	 */
 	const getHeaders = ( data ) => [
 		{

--- a/js/src/reports/programs/compare-programs-table-card.js
+++ b/js/src/reports/programs/compare-programs-table-card.js
@@ -16,7 +16,7 @@ import { mockedListingsData, availableMetrics } from './mocked-programs-data'; /
  * All posible metric headers.
  * Sorted in the order we wish to render them.
  *
- * @type {module:app-table-card.Props.headers}
+ * @type {import('.~/components/app-table-card').Props.headers}
  */
 const metricsHeaders = [
 	{
@@ -76,7 +76,7 @@ const CompareProgramsTableCard = ( props ) => {
 	 *
 	 * @param {Array} data
 	 *
-	 * @return {module:app-table-card.Props.headers} All headers.
+	 * @return {import('.~/components/app-table-card').Props.headers} All headers.
 	 */
 	const getHeaders = ( data ) => [
 		{


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Change eslint jsdoc syntax to typescript,

to get better integration with VSCode's hints
in regards to importing types.

It also allows us to use TS function type syntax, which is in my opinion much more informative and readable at the same time:

```js
/**
 * @param {(countries: Array<CountryCode>, price: number) => boolean} [onSomething] My callback's description.
 */
```

### Screenshots:
![Screenshot from 2021-03-11 01-01-51](https://user-images.githubusercontent.com/17435/110820907-d7f4a200-828f-11eb-90c7-a6da4c64af0a.png)

![Screenshot from 2021-03-11 17-11-56](https://user-images.githubusercontent.com/17435/110820894-d32fee00-828f-11eb-9e4c-a888ba0e335e.png)



### Detailed test instructions:

1. Check that linters passes `npm run lint:js`
2. Open a file, like https://github.com/woocommerce/google-listings-and-ads/blob/1ad8d09ce8bb9173608e34217c2486c040c035a0/js/src/dashboard/app-date-range-filter-picker/index.js  in VSCode see hints for imported types.

