### PR TITLE
Update composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ cache:
 
 # Test supported versions of PHP, WP and WC and the WC master branch.
 php:
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
 
 env:
   global:
@@ -38,7 +37,7 @@ matrix:
   fast_finish: true
   include:
     - name: "Coding standard check"
-      php: 7.3
+      php: 7.4
       env: WP_VERSION="${WP_LATEST}" WC_VERSION=master WP_TRAVISCI=cs WP_MULTISITE=0
 
 before_script:
@@ -50,7 +49,7 @@ before_script:
       echo "xdebug.ini does not exist"
     fi
   - nvm install 10
-  - composer update
+  - composer install
 #  - bash tests/install/install-wp-tests.sh
 
 script:

--- a/bin/googleads-remove-older-versions.sh
+++ b/bin/googleads-remove-older-versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-echo Removing googleads lib versions 3,4,5
-rm -rf vendor/googleads/google-ads-php/metadata/Google/Ads/GoogleAds/V{3,4,5}
-rm -rf vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/V{3,4,5}
-rm -rf vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/Util/V{3,4,5}
-rm -rf vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/Lib/V{3,4,5}
+echo Removing googleads lib versions 4,5
+rm -rf vendor/googleads/google-ads-php/metadata/Google/Ads/GoogleAds/V{4,5}
+rm -rf vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/V{4,5}
+rm -rf vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/Util/V{4,5}
+rm -rf vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/Lib/V{4,5}

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
   },
   "archive": {
     "exclude": [
-        "!/js/build"
+      "!/js/build",
+      "!/vendor/*"
     ]
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,18 @@
 {
   "name": "woocommerce/google-listings-and-ads",
   "type": "wordpress-plugin",
+  "description": "Native integration with Google that allows merchants to easily display their products across Google’s network.",
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.3",
     "automattic/jetpack-autoloader": "^2.4",
     "automattic/jetpack-config": "^1.4",
     "automattic/jetpack-connection": "^1.20",
     "google/apiclient": "^2.7",
     "googleads/google-ads-php": "^6.1",
     "league/container": "^3.3",
-    "league/iso3166": "^2.1",
+    "league/iso3166": "^3.0",
     "symfony/validator": "^5.2",
     "ext-json": "*"
   },
@@ -35,7 +36,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.2.34"
+      "php": "7.3.27"
     },
     "sort-packages": true
   },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "google/apiclient": "^2.7",
     "googleads/google-ads-php": "^6.1",
     "league/container": "^3.3",
-    "league/iso3166": "^3.0",
+    "league/iso3166": "^2.1",
     "symfony/validator": "^5.2",
     "ext-json": "*"
   },
@@ -35,7 +35,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.4"
+      "php": "7.2.34"
     },
     "sort-packages": true
   },

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "automattic/jetpack-connection": "^1.20",
     "google/apiclient": "^2.7",
     "googleads/google-ads-php": "^7.0",
+    "grpc/grpc": "~1.35.0",
     "league/container": "^3.3",
     "league/iso3166": "^3.0",
     "psr/container": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "automattic/jetpack-config": "^1.4",
     "automattic/jetpack-connection": "^1.20",
     "google/apiclient": "^2.7",
-    "googleads/google-ads-php": "^6.1",
+    "googleads/google-ads-php": "^7.0",
     "league/container": "^3.3",
     "league/iso3166": "^3.0",
     "psr/container": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "googleads/google-ads-php": "^6.1",
     "league/container": "^3.3",
     "league/iso3166": "^3.0",
+    "psr/container": "^1.0",
     "symfony/validator": "^5.2",
     "ext-json": "*"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4fb934f5225ac6eee150f954a959c12",
+    "content-hash": "ba07eafe86acb1c10aeaa16144cf2880",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -945,16 +945,16 @@
         },
         {
             "name": "grpc/grpc",
-            "version": "1.36.0",
+            "version": "1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grpc/grpc-php.git",
-                "reference": "6145dd917d340b579f0b663940b17cc93172b79a"
+                "reference": "cf75367acfcf154331f97d1525f9f46383b7891d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/6145dd917d340b579f0b663940b17cc93172b79a",
-                "reference": "6145dd917d340b579f0b663940b17cc93172b79a",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/cf75367acfcf154331f97d1525f9f46383b7891d",
+                "reference": "cf75367acfcf154331f97d1525f9f46383b7891d",
                 "shasum": ""
             },
             "require": {
@@ -983,9 +983,9 @@
                 "rpc"
             ],
             "support": {
-                "source": "https://github.com/grpc/grpc-php/tree/v1.36.0"
+                "source": "https://github.com/grpc/grpc-php/tree/v1.35.0"
             },
-            "time": "2021-03-01T21:52:11+00:00"
+            "time": "2021-01-20T20:15:34+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd6cc7cb3a13881c04e794ad2fc00f65",
+    "content-hash": "0ddfa81df3e1a977ccd0c3334a46ef38",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -604,16 +604,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.163.0",
+            "version": "v0.164.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "8e326f378a1f505064912fddd19fd93bbdcc80fb"
+                "reference": "266557af3f595681eb9199853641f334a913d1bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/8e326f378a1f505064912fddd19fd93bbdcc80fb",
-                "reference": "8e326f378a1f505064912fddd19fd93bbdcc80fb",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/266557af3f595681eb9199853641f334a913d1bf",
+                "reference": "266557af3f595681eb9199853641f334a913d1bf",
                 "shasum": ""
             },
             "require": {
@@ -639,9 +639,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.163.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.164.0"
             },
-            "time": "2021-03-06T12:20:02+00:00"
+            "time": "2021-03-13T12:20:04+00:00"
         },
         {
             "name": "google/auth",
@@ -843,16 +843,16 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v3.15.5",
+            "version": "v3.15.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "c4a8128a7df155fce4faba3087b27dcdfe3ece2e"
+                "reference": "3237975660b8fd3ed51cf34312a1a166572d2463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/c4a8128a7df155fce4faba3087b27dcdfe3ece2e",
-                "reference": "c4a8128a7df155fce4faba3087b27dcdfe3ece2e",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/3237975660b8fd3ed51cf34312a1a166572d2463",
+                "reference": "3237975660b8fd3ed51cf34312a1a166572d2463",
                 "shasum": ""
             },
             "require": {
@@ -882,9 +882,9 @@
             ],
             "support": {
                 "issues": "https://github.com/protocolbuffers/protobuf-php/issues",
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.15.5"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.15.6"
             },
-            "time": "2021-03-05T01:43:13+00:00"
+            "time": "2021-03-11T20:45:02+00:00"
         },
         {
             "name": "googleads/google-ads-php",
@@ -1301,23 +1301,24 @@
         },
         {
             "name": "league/iso3166",
-            "version": "3.0.0",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/iso3166.git",
-                "reference": "9976d382f270ad3f3df8a68719beb7a7179ffa1e"
+                "reference": "aed3b32fc293afdf2c6c6a322c2408eb5d20804a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/iso3166/zipball/9976d382f270ad3f3df8a68719beb7a7179ffa1e",
-                "reference": "9976d382f270ad3f3df8a68719beb7a7179ffa1e",
+                "url": "https://api.github.com/repos/thephpleague/iso3166/zipball/aed3b32fc293afdf2c6c6a322c2408eb5d20804a",
+                "reference": "aed3b32fc293afdf2c6c6a322c2408eb5d20804a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3|^8.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "friendsofphp/php-cs-fixer": "^2.12",
+                "phpunit/phpunit": "^5.7.11 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
@@ -1354,7 +1355,7 @@
                 "issues": "https://github.com/thephpleague/iso3166/issues",
                 "source": "https://github.com/thephpleague/iso3166"
             },
-            "time": "2020-12-05T06:50:42+00:00"
+            "time": "2020-01-29T07:08:12+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1571,16 +1572,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "7c751ea006577e4c2e83326d90c8b1e8c11b8ede"
+                "reference": "906a5fafabe5e6ba51ef3dc65b2722a677908837"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7c751ea006577e4c2e83326d90c8b1e8c11b8ede",
-                "reference": "7c751ea006577e4c2e83326d90c8b1e8c11b8ede",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/906a5fafabe5e6ba51ef3dc65b2722a677908837",
+                "reference": "906a5fafabe5e6ba51ef3dc65b2722a677908837",
                 "shasum": ""
             },
             "require": {
@@ -1662,7 +1663,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.5"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.6"
             },
             "funding": [
                 {
@@ -1678,7 +1679,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-12T16:18:16+00:00"
+            "time": "2021-03-10T13:58:31+00:00"
         },
         {
             "name": "psr/cache",
@@ -4407,7 +4408,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4"
+        "php": "7.2.34"
     },
     "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e033a4120d064ca4388e5c257b03f631",
+    "content-hash": "c4fb934f5225ac6eee150f954a959c12",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -888,35 +888,34 @@
         },
         {
             "name": "googleads/google-ads-php",
-            "version": "v6.1.0",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleads/google-ads-php.git",
-                "reference": "aae0d03b6221d8420d5ab46aa3709a2b018deba1"
+                "reference": "3ac94411427b1b1ab19ee95fadc6e7780f49d595"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleads/google-ads-php/zipball/aae0d03b6221d8420d5ab46aa3709a2b018deba1",
-                "reference": "aae0d03b6221d8420d5ab46aa3709a2b018deba1",
+                "url": "https://api.github.com/repos/googleads/google-ads-php/zipball/3ac94411427b1b1ab19ee95fadc6e7780f49d595",
+                "reference": "3ac94411427b1b1ab19ee95fadc6e7780f49d595",
                 "shasum": ""
             },
             "require": {
                 "google/gax": "^1.5.0",
                 "google/protobuf": "^3.14.0",
-                "monolog/monolog": "^1.23.0 || ^2.0",
-                "php": ">=7.2",
+                "monolog/monolog": "^2.0",
+                "php": ">=7.3",
                 "ulrichsg/getopt-php": "^3.4"
             },
             "require-dev": {
                 "ext-bcmath": "*",
-                "phpunit/phpunit": "^7.5 || ^9.3",
-                "react/http": "^0.8.3",
+                "phpunit/phpunit": "^9.5",
+                "react/http": "^1.2.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "suggest": {
                 "ext-protobuf": "For better performance, use the C implementation of Protobuf",
                 "google/protobuf": "In case the C implementation of Protobuf is not suitable, use the PHP one",
-                "php-64bit": ">=7.2",
                 "react/http": "To run the AuthenticateInWebApplication.php example"
             },
             "type": "library",
@@ -940,9 +939,9 @@
             "description": "Google Ads API client for PHP",
             "support": {
                 "issues": "https://github.com/googleads/google-ads-php/issues",
-                "source": "https://github.com/googleads/google-ads-php/tree/v6.1.0"
+                "source": "https://github.com/googleads/google-ads-php/tree/v7.0.0"
             },
-            "time": "2020-12-11T05:37:03+00:00"
+            "time": "2021-02-19T03:40:23+00:00"
         },
         {
             "name": "grpc/grpc",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e414ae986b0c345e5f03e9632e30b9c",
+    "content-hash": "e033a4120d064ca4388e5c257b03f631",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1731,27 +1731,22 @@
         },
         {
             "name": "psr/container",
-            "version": "2.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "68f5200c33f18c018db17eb869d4b0f97da17cad"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/68f5200c33f18c018db17eb869d4b0f97da17cad",
-                "reference": "68f5200c33f18c018db17eb869d4b0f97da17cad",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -1778,9 +1773,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.0"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2021-03-05T16:02:18+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "psr/http-client",
@@ -3077,16 +3072,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -3138,9 +3133,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,29 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f0d35139f572a500bed02d7fffbf4bd",
+    "content-hash": "cd6cc7cb3a13881c04e794ad2fc00f65",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
-            "version": "v1.2.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-a8c-mc-stats.git",
-                "reference": "9daa7d933679f7c3c38f1a2a1eaeaa87d7b43e37"
+                "reference": "b2f6b20aa3046848391593e6a18f87ae3797e888"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/9daa7d933679f7c3c38f1a2a1eaeaa87d7b43e37",
-                "reference": "9daa7d933679f7c3c38f1a2a1eaeaa87d7b43e37",
+                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/b2f6b20aa3046848391593e6a18f87ae3797e888",
+                "reference": "b2f6b20aa3046848391593e6a18f87ae3797e888",
                 "shasum": ""
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-a8c-mc-stats"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -35,22 +38,62 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/v1.2.0"
+                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/1.4.1"
             },
-            "time": "2020-09-17T18:20:50+00:00"
+            "time": "2021-02-05T19:06:50+00:00"
         },
         {
-            "name": "automattic/jetpack-autoloader",
-            "version": "v2.7.1",
+            "name": "automattic/jetpack-assets",
+            "version": "v1.11.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "5437697a56aefbdf707849b9833e1b36093d7a73"
+                "url": "https://github.com/Automattic/jetpack-assets.git",
+                "reference": "833a6840b5f39ef05b2a65def8a1e61dc7c45a7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/5437697a56aefbdf707849b9833e1b36093d7a73",
-                "reference": "5437697a56aefbdf707849b9833e1b36093d7a73",
+                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/833a6840b5f39ef05b2a65def8a1e61dc7c45a7a",
+                "reference": "833a6840b5f39ef05b2a65def8a1e61dc7c45a7a",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "1.6.2"
+            },
+            "require-dev": {
+                "brain/monkey": "2.6.0",
+                "yoast/phpunit-polyfills": "0.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-assets"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Asset management utilities for Jetpack ecosystem packages",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-assets/tree/v1.11.2"
+            },
+            "time": "2021-02-23T14:58:20+00:00"
+        },
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "v2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "6409c42b32ed82aff50869fd0a6a2e5c7a96fbd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/6409c42b32ed82aff50869fd0a6a2e5c7a96fbd6",
+                "reference": "6409c42b32ed82aff50869fd0a6a2e5c7a96fbd6",
                 "shasum": ""
             },
             "require": {
@@ -61,7 +104,8 @@
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+                "mirror-repo": "Automattic/jetpack-autoloader"
             },
             "autoload": {
                 "classmap": [
@@ -77,25 +121,28 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.7.1"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.10.0"
             },
-            "time": "2020-12-18T22:33:59+00:00"
+            "time": "2021-02-09T18:24:48+00:00"
         },
         {
             "name": "automattic/jetpack-config",
-            "version": "v1.4.2",
+            "version": "v1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-config.git",
-                "reference": "0f4b1f66f276cc2352d5fa0c29f98566df8efdd3"
+                "reference": "6bc77aa73d90510c9488e2d8fdaad4b056d3a066"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/0f4b1f66f276cc2352d5fa0c29f98566df8efdd3",
-                "reference": "0f4b1f66f276cc2352d5fa0c29f98566df8efdd3",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/6bc77aa73d90510c9488e2d8fdaad4b056d3a066",
+                "reference": "6bc77aa73d90510c9488e2d8fdaad4b056d3a066",
                 "shasum": ""
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-config"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -107,38 +154,41 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-config/tree/v1.4.2"
+                "source": "https://github.com/Automattic/jetpack-config/tree/v1.4.3"
             },
-            "time": "2020-10-28T19:00:23+00:00"
+            "time": "2021-01-19T14:25:05+00:00"
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "v1.21.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "d44cc99636389cff1f7ca0e1a2aee630b9d1673f"
+                "reference": "5ffc22ecc7210cb229ab4a9833e2ba1def817ff8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/d44cc99636389cff1f7ca0e1a2aee630b9d1673f",
-                "reference": "d44cc99636389cff1f7ca0e1a2aee630b9d1673f",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/5ffc22ecc7210cb229ab4a9833e2ba1def817ff8",
+                "reference": "5ffc22ecc7210cb229ab4a9833e2ba1def817ff8",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-constants": "1.5.1",
-                "automattic/jetpack-heartbeat": "1.2.2",
-                "automattic/jetpack-options": "1.9.1",
-                "automattic/jetpack-roles": "1.3.1",
-                "automattic/jetpack-status": "1.6.0",
-                "automattic/jetpack-tracking": "1.11.1"
+                "automattic/jetpack-constants": "1.6.2",
+                "automattic/jetpack-heartbeat": "1.3.3",
+                "automattic/jetpack-options": "1.11.2",
+                "automattic/jetpack-roles": "1.4.2",
+                "automattic/jetpack-status": "1.7.2",
+                "automattic/jetpack-tracking": "1.13.2"
             },
             "require-dev": {
                 "automattic/wordbless": "@dev",
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "brain/monkey": "^2.6",
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-connection"
+            },
             "autoload": {
                 "files": [
                     "legacy/load-ixr.php"
@@ -154,29 +204,32 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-connection/tree/v1.21.1"
+                "source": "https://github.com/Automattic/jetpack-connection/tree/v1.24.0"
             },
-            "time": "2020-11-24T17:50:38+00:00"
+            "time": "2021-02-23T15:05:16+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "v1.5.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "18f772daddc8be5df76c9f4a92e017a3c2569a5b"
+                "reference": "84c8f09c5a6467104094243912fdcfe8eaed945b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/18f772daddc8be5df76c9f4a92e017a3c2569a5b",
-                "reference": "18f772daddc8be5df76c9f4a92e017a3c2569a5b",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/84c8f09c5a6467104094243912fdcfe8eaed945b",
+                "reference": "84c8f09c5a6467104094243912fdcfe8eaed945b",
                 "shasum": ""
             },
             "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "brain/monkey": "2.6.0",
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-constants"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -188,32 +241,32 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.5.1"
+                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.6.2"
             },
-            "time": "2020-10-28T19:00:31+00:00"
+            "time": "2021-02-05T19:07:24+00:00"
         },
         {
             "name": "automattic/jetpack-heartbeat",
-            "version": "v1.2.2",
+            "version": "v1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-heartbeat.git",
-                "reference": "22bfefe0477978a1aca5410f406b020bf5a6920e"
+                "reference": "d6e906c15a539bee5f52957126ba1b43d11e63da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-heartbeat/zipball/22bfefe0477978a1aca5410f406b020bf5a6920e",
-                "reference": "22bfefe0477978a1aca5410f406b020bf5a6920e",
+                "url": "https://api.github.com/repos/Automattic/jetpack-heartbeat/zipball/d6e906c15a539bee5f52957126ba1b43d11e63da",
+                "reference": "d6e906c15a539bee5f52957126ba1b43d11e63da",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-a8c-mc-stats": "1.2.0",
-                "automattic/jetpack-options": "1.9.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "automattic/jetpack-a8c-mc-stats": "1.4.1",
+                "automattic/jetpack-options": "1.11.2"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-heartbeat"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -225,32 +278,34 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-heartbeat/tree/v1.2.2"
+                "source": "https://github.com/Automattic/jetpack-heartbeat/tree/v1.3.3"
             },
-            "time": "2020-11-24T17:50:38+00:00"
+            "time": "2021-02-23T15:01:22+00:00"
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "v1.9.1",
+            "version": "v1.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-options.git",
-                "reference": "59c630e3d88f878195f2076971e7d5e2a72941ee"
+                "reference": "1889f3648782b5ceaac255f2a5ee96c1de8cca1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/59c630e3d88f878195f2076971e7d5e2a72941ee",
-                "reference": "59c630e3d88f878195f2076971e7d5e2a72941ee",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/1889f3648782b5ceaac255f2a5ee96c1de8cca1e",
+                "reference": "1889f3648782b5ceaac255f2a5ee96c1de8cca1e",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-constants": "1.5.1"
+                "automattic/jetpack-constants": "1.6.2"
             },
             "require-dev": {
-                "10up/wp_mock": "0.4.2",
-                "phpunit/phpunit": "7.*.*"
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-options"
+            },
             "autoload": {
                 "classmap": [
                     "legacy"
@@ -262,29 +317,32 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-options/tree/v1.9.1"
+                "source": "https://github.com/Automattic/jetpack-options/tree/v1.11.2"
             },
-            "time": "2020-11-24T17:47:49+00:00"
+            "time": "2021-02-23T15:00:26+00:00"
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "v1.3.1",
+            "version": "v1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-roles.git",
-                "reference": "10234f39a2294d7c2598e7492477031470f5a01b"
+                "reference": "ad4e0c4483945b24db10c09696558a2f381236ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/10234f39a2294d7c2598e7492477031470f5a01b",
-                "reference": "10234f39a2294d7c2598e7492477031470f5a01b",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/ad4e0c4483945b24db10c09696558a2f381236ee",
+                "reference": "ad4e0c4483945b24db10c09696558a2f381236ee",
                 "shasum": ""
             },
             "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "brain/monkey": "2.6.0",
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-roles"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -296,30 +354,32 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-roles/tree/v1.3.1"
+                "source": "https://github.com/Automattic/jetpack-roles/tree/v1.4.2"
             },
-            "time": "2020-10-28T19:01:03+00:00"
+            "time": "2021-02-05T19:07:59+00:00"
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "v1.6.0",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-status.git",
-                "reference": "5ae34fcc1b5c48594778dbdb2783910109746d45"
+                "reference": "a0f1f7450f045afc2669135ba576632ca0889506"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/5ae34fcc1b5c48594778dbdb2783910109746d45",
-                "reference": "5ae34fcc1b5c48594778dbdb2783910109746d45",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/a0f1f7450f045afc2669135ba576632ca0889506",
+                "reference": "a0f1f7450f045afc2669135ba576632ca0889506",
                 "shasum": ""
             },
             "require-dev": {
-                "brain/monkey": "2.5.0",
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "brain/monkey": "2.6.0",
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-status"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -331,33 +391,36 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-status/tree/v1.6.0"
+                "source": "https://github.com/Automattic/jetpack-status/tree/v1.7.2"
             },
-            "time": "2020-11-23T17:14:22+00:00"
+            "time": "2021-02-05T19:08:03+00:00"
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "v1.8.2",
+            "version": "v1.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
-                "reference": "25bbbdee520eb17f9a30e899255494583a2bbb64"
+                "reference": "f8435228d918a5bd32912339b1124d35911efde1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/25bbbdee520eb17f9a30e899255494583a2bbb64",
-                "reference": "25bbbdee520eb17f9a30e899255494583a2bbb64",
+                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/f8435228d918a5bd32912339b1124d35911efde1",
+                "reference": "f8435228d918a5bd32912339b1124d35911efde1",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-options": "1.9.1",
-                "automattic/jetpack-status": "1.6.0"
+                "automattic/jetpack-options": "1.11.2",
+                "automattic/jetpack-status": "1.7.2"
             },
             "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "brain/monkey": "2.6.0",
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-terms-of-service"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -369,34 +432,37 @@
             ],
             "description": "Everything need to manage the terms of service state",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-terms-of-service/tree/v1.8.2"
+                "source": "https://github.com/Automattic/jetpack-terms-of-service/tree/v1.9.3"
             },
-            "time": "2020-11-24T17:50:38+00:00"
+            "time": "2021-02-23T15:02:14+00:00"
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "v1.11.1",
+            "version": "v1.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-tracking.git",
-                "reference": "982936c59852e8fd3768a8e33121db63928fba76"
+                "reference": "b2dc6688098798111e21bd7d5d052fb828fa0932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/982936c59852e8fd3768a8e33121db63928fba76",
-                "reference": "982936c59852e8fd3768a8e33121db63928fba76",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/b2dc6688098798111e21bd7d5d052fb828fa0932",
+                "reference": "b2dc6688098798111e21bd7d5d052fb828fa0932",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-options": "1.9.1",
-                "automattic/jetpack-status": "1.6.0",
-                "automattic/jetpack-terms-of-service": "1.8.2"
+                "automattic/jetpack-assets": "1.11.2",
+                "automattic/jetpack-options": "1.11.2",
+                "automattic/jetpack-status": "1.7.2",
+                "automattic/jetpack-terms-of-service": "1.9.3"
             },
             "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-tracking"
+            },
             "autoload": {
                 "classmap": [
                     "legacy",
@@ -409,22 +475,22 @@
             ],
             "description": "Tracking for Jetpack",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-tracking/tree/v1.11.1"
+                "source": "https://github.com/Automattic/jetpack-tracking/tree/v1.13.2"
             },
-            "time": "2020-11-24T17:51:57+00:00"
+            "time": "2021-02-23T15:03:25+00:00"
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v5.2.0",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "feb0e820b8436873675fd3aca04f3728eb2185cb"
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/feb0e820b8436873675fd3aca04f3728eb2185cb",
-                "reference": "feb0e820b8436873675fd3aca04f3728eb2185cb",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
                 "shasum": ""
             },
             "require": {
@@ -463,40 +529,40 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/master"
+                "source": "https://github.com/firebase/php-jwt/tree/v5.2.1"
             },
-            "time": "2020-03-25T18:49:23+00:00"
+            "time": "2021-02-12T00:02:00+00:00"
         },
         {
             "name": "google/apiclient",
-            "version": "v2.8.3",
+            "version": "v2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "81696e6206322e38c643cfcc96c4494ccfef8a32"
+                "reference": "2fb6e702aca5d68203fa737f89f6f774022494c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/81696e6206322e38c643cfcc96c4494ccfef8a32",
-                "reference": "81696e6206322e38c643cfcc96c4494ccfef8a32",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/2fb6e702aca5d68203fa737f89f6f774022494c6",
+                "reference": "2fb6e702aca5d68203fa737f89f6f774022494c6",
                 "shasum": ""
             },
             "require": {
                 "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
                 "google/apiclient-services": "~0.13",
                 "google/auth": "^1.10",
-                "guzzlehttp/guzzle": "~5.3.1||~6.0||~7.0",
+                "guzzlehttp/guzzle": "~5.3.3||~6.0||~7.0",
                 "guzzlehttp/psr7": "^1.2",
                 "monolog/monolog": "^1.17|^2.0",
-                "php": ">=5.4",
-                "phpseclib/phpseclib": "~0.3.10||~2.0"
+                "php": "^5.6|^7.0|^8.0",
+                "phpseclib/phpseclib": "~2.0||^3.0.2"
             },
             "require-dev": {
-                "cache/filesystem-adapter": "^0.3.2",
+                "cache/filesystem-adapter": "^0.3.2|^1.1",
                 "composer/composer": "^1.10",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "phpcompatibility/php-compatibility": "^9.2",
-                "phpunit/phpunit": "^4.8.36|^5.0",
+                "phpunit/phpunit": "^5.7||^8.5.13",
                 "squizlabs/php_codesniffer": "~2.3",
                 "symfony/css-selector": "~2.1",
                 "symfony/dom-crawler": "~2.1"
@@ -532,22 +598,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.8.3"
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.9.1"
             },
-            "time": "2020-11-17T17:33:35+00:00"
+            "time": "2021-01-19T17:48:59+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.156",
+            "version": "v0.163.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "2f5e54fdef034f856208328126bddd8376dae4b3"
+                "reference": "8e326f378a1f505064912fddd19fd93bbdcc80fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/2f5e54fdef034f856208328126bddd8376dae4b3",
-                "reference": "2f5e54fdef034f856208328126bddd8376dae4b3",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/8e326f378a1f505064912fddd19fd93bbdcc80fb",
+                "reference": "8e326f378a1f505064912fddd19fd93bbdcc80fb",
                 "shasum": ""
             },
             "require": {
@@ -573,22 +639,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.156"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.163.0"
             },
-            "time": "2020-11-30T20:03:55+00:00"
+            "time": "2021-03-06T12:20:02+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.14.3",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "c1503299c779af0cbc99b43788f75930988852cf"
+                "reference": "b346c07de6613e26443d7b4830e5e1933b830dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/c1503299c779af0cbc99b43788f75930988852cf",
-                "reference": "c1503299c779af0cbc99b43788f75930988852cf",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/b346c07de6613e26443d7b4830e5e1933b830dc4",
+                "reference": "b346c07de6613e26443d7b4830e5e1933b830dc4",
                 "shasum": ""
             },
             "require": {
@@ -601,7 +667,7 @@
             },
             "require-dev": {
                 "guzzlehttp/promises": "0.1.1|^1.3",
-                "kelvinmo/simplejwt": "^0.2.5",
+                "kelvinmo/simplejwt": "^0.2.5|^0.5.1",
                 "phpseclib/phpseclib": "^2",
                 "phpunit/phpunit": "^4.8.36|^5.7",
                 "sebastian/comparator": ">=1.2.3",
@@ -630,9 +696,9 @@
             "support": {
                 "docs": "https://googleapis.github.io/google-auth-library-php/master/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.14.3"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.15.0"
             },
-            "time": "2020-10-16T21:33:48+00:00"
+            "time": "2021-02-05T20:50:04+00:00"
         },
         {
             "name": "google/common-protos",
@@ -679,16 +745,16 @@
         },
         {
             "name": "google/gax",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/gax-php.git",
-                "reference": "dbf534f579f14148c046c4065b98b7bc377c194a"
+                "reference": "a2d48062b0ac0433da463a1f7c77ab672bbbfa08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/dbf534f579f14148c046c4065b98b7bc377c194a",
-                "reference": "dbf534f579f14148c046c4065b98b7bc377c194a",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/a2d48062b0ac0433da463a1f7c77ab672bbbfa08",
+                "reference": "a2d48062b0ac0433da463a1f7c77ab672bbbfa08",
                 "shasum": ""
             },
             "require": {
@@ -726,9 +792,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/gax-php/issues",
-                "source": "https://github.com/googleapis/gax-php/tree/1.6.1"
+                "source": "https://github.com/googleapis/gax-php/tree/1.7.0"
             },
-            "time": "2020-12-15T22:49:17+00:00"
+            "time": "2021-01-06T16:47:47+00:00"
         },
         {
             "name": "google/grpc-gcp",
@@ -777,16 +843,16 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v3.14.0",
+            "version": "v3.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "03f132a66f09f96064309e81c5fac8d35b7474e1"
+                "reference": "c4a8128a7df155fce4faba3087b27dcdfe3ece2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/03f132a66f09f96064309e81c5fac8d35b7474e1",
-                "reference": "03f132a66f09f96064309e81c5fac8d35b7474e1",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/c4a8128a7df155fce4faba3087b27dcdfe3ece2e",
+                "reference": "c4a8128a7df155fce4faba3087b27dcdfe3ece2e",
                 "shasum": ""
             },
             "require": {
@@ -816,9 +882,9 @@
             ],
             "support": {
                 "issues": "https://github.com/protocolbuffers/protobuf-php/issues",
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.14.0"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.15.5"
             },
-            "time": "2020-11-13T23:41:35+00:00"
+            "time": "2021-03-05T01:43:13+00:00"
         },
         {
             "name": "googleads/google-ads-php",
@@ -880,16 +946,16 @@
         },
         {
             "name": "grpc/grpc",
-            "version": "1.34.0",
+            "version": "1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grpc/grpc-php.git",
-                "reference": "f84e39861fd9f48ce6cc671688a05df13c7cd7e8"
+                "reference": "6145dd917d340b579f0b663940b17cc93172b79a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/f84e39861fd9f48ce6cc671688a05df13c7cd7e8",
-                "reference": "f84e39861fd9f48ce6cc671688a05df13c7cd7e8",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/6145dd917d340b579f0b663940b17cc93172b79a",
+                "reference": "6145dd917d340b579f0b663940b17cc93172b79a",
                 "shasum": ""
             },
             "require": {
@@ -918,9 +984,9 @@
                 "rpc"
             ],
             "support": {
-                "source": "https://github.com/grpc/grpc-php/tree/v1.34.0"
+                "source": "https://github.com/grpc/grpc-php/tree/v1.36.0"
             },
-            "time": "2020-12-02T22:47:45+00:00"
+            "time": "2021-03-01T21:52:11+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1026,16 +1092,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631"
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/60d379c243457e073cff02bc323a2a86cb355631",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
                 "shasum": ""
             },
             "require": {
@@ -1075,9 +1141,9 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.4.0"
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
             },
-            "time": "2020-09-30T07:37:28+00:00"
+            "time": "2021-03-07T09:25:29+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1156,16 +1222,16 @@
         },
         {
             "name": "league/container",
-            "version": "3.3.3",
+            "version": "3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/container.git",
-                "reference": "7dc67bdf89efc338e674863c0ea70a63efe4de05"
+                "reference": "40aed0f11d16bc23f9d04a27acc3549cd1bb42ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/container/zipball/7dc67bdf89efc338e674863c0ea70a63efe4de05",
-                "reference": "7dc67bdf89efc338e674863c0ea70a63efe4de05",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/40aed0f11d16bc23f9d04a27acc3549cd1bb42ab",
+                "reference": "40aed0f11d16bc23f9d04a27acc3549cd1bb42ab",
                 "shasum": ""
             },
             "require": {
@@ -1180,11 +1246,14 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0",
-                "squizlabs/php_codesniffer": "^3.3"
+                "roave/security-advisories": "dev-master",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
+                    "dev-master": "3.x-dev",
                     "dev-3.x": "3.x-dev",
                     "dev-2.x": "2.x-dev",
                     "dev-1.x": "1.x-dev"
@@ -1220,7 +1289,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/container/issues",
-                "source": "https://github.com/thephpleague/container/tree/3.3.3"
+                "source": "https://github.com/thephpleague/container/tree/3.3.4"
             },
             "funding": [
                 {
@@ -1228,7 +1297,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T13:38:44+00:00"
+            "time": "2021-02-22T10:35:05+00:00"
         },
         {
             "name": "league/iso3166",
@@ -1384,25 +1453,144 @@
             "time": "2020-12-14T13:15:25+00:00"
         },
         {
-            "name": "phpseclib/phpseclib",
-            "version": "2.0.30",
+            "name": "paragonie/constant_time_encoding",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "136b9ca7eebef78be14abf90d65c5e57b6bc5d36"
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/136b9ca7eebef78be14abf90d65c5e57b6bc5d36",
-                "reference": "136b9ca7eebef78be14abf90d65c5e57b6bc5d36",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
+                "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6|^7|^8|^9",
+                "vimeo/psalm": "^1|^2|^3|^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2020-12-06T15:14:20+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "7c751ea006577e4c2e83326d90c8b1e8c11b8ede"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7c751ea006577e4c2e83326d90c8b1e8c11b8ede",
+                "reference": "7c751ea006577e4c2e83326d90c8b1e8c11b8ede",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
             },
             "require-dev": {
                 "phing/phing": "~2.7",
-                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
+                "phpunit/phpunit": "^5.7|^6.0|^9.4",
                 "squizlabs/php_codesniffer": "~2.0"
             },
             "suggest": {
@@ -1417,7 +1605,7 @@
                     "phpseclib/bootstrap.php"
                 ],
                 "psr-4": {
-                    "phpseclib\\": "phpseclib/"
+                    "phpseclib3\\": "phpseclib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1474,7 +1662,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.30"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.5"
             },
             "funding": [
                 {
@@ -1490,7 +1678,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-17T05:42:04+00:00"
+            "time": "2021-02-12T16:18:16+00:00"
         },
         {
             "name": "psr/cache",
@@ -1543,27 +1731,22 @@
         },
         {
             "name": "psr/container",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -1576,7 +1759,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -1590,9 +1773,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "psr/http-client",
@@ -1862,16 +2045,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
@@ -1883,7 +2066,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1921,7 +2104,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -1937,20 +2120,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13"
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
                 "shasum": ""
             },
             "require": {
@@ -2001,7 +2184,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -2017,11 +2200,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -2080,7 +2263,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -2100,7 +2283,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -2163,7 +2346,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -2261,16 +2444,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v5.2.1",
+            "version": "v5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "312d36715799ca1d195ee8dbf258b31d1a3cbf7b"
+                "reference": "456a3d95947e99c4c70e64c09833eed56095086c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/312d36715799ca1d195ee8dbf258b31d1a3cbf7b",
-                "reference": "312d36715799ca1d195ee8dbf258b31d1a3cbf7b",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/456a3d95947e99c4c70e64c09833eed56095086c",
+                "reference": "456a3d95947e99c4c70e64c09833eed56095086c",
                 "shasum": ""
             },
             "require": {
@@ -2293,9 +2476,9 @@
                 "symfony/yaml": "<4.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.7",
+                "doctrine/annotations": "^1.10.4",
                 "doctrine/cache": "~1.0",
-                "egulias/email-validator": "^2.1.10",
+                "egulias/email-validator": "^2.1.10|^3",
                 "symfony/cache": "^4.4|^5.0",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/console": "^4.4|^5.0",
@@ -2349,10 +2532,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Validator Component",
+            "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v5.2.1"
+                "source": "https://github.com/symfony/validator/tree/v5.2.5"
             },
             "funding": [
                 {
@@ -2368,7 +2551,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-18T07:32:35+00:00"
+            "time": "2021-03-08T13:20:18+00:00"
         },
         {
             "name": "ulrichsg/getopt-php",
@@ -4105,30 +4288,35 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -4151,10 +4339,10 @@
                 "validate"
             ],
             "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -4214,7 +4402,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ddfa81df3e1a977ccd0c3334a46ef38",
+    "content-hash": "1e414ae986b0c345e5f03e9632e30b9c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1222,21 +1222,21 @@
         },
         {
             "name": "league/container",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/container.git",
-                "reference": "40aed0f11d16bc23f9d04a27acc3549cd1bb42ab"
+                "reference": "048ab87810f508dbedbcb7ae941b606eb8ee353b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/container/zipball/40aed0f11d16bc23f9d04a27acc3549cd1bb42ab",
-                "reference": "40aed0f11d16bc23f9d04a27acc3549cd1bb42ab",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/048ab87810f508dbedbcb7ae941b606eb8ee353b",
+                "reference": "048ab87810f508dbedbcb7ae941b606eb8ee353b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/container": "^1.0"
+                "psr/container": "^1.0.0 || ^2.0.0"
             },
             "provide": {
                 "psr/container-implementation": "^1.0"
@@ -1289,7 +1289,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/container/issues",
-                "source": "https://github.com/thephpleague/container/tree/3.3.4"
+                "source": "https://github.com/thephpleague/container/tree/3.3.5"
             },
             "funding": [
                 {
@@ -1297,28 +1297,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-22T10:35:05+00:00"
+            "time": "2021-03-16T09:42:56+00:00"
         },
         {
             "name": "league/iso3166",
-            "version": "2.1.5",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/iso3166.git",
-                "reference": "aed3b32fc293afdf2c6c6a322c2408eb5d20804a"
+                "reference": "9976d382f270ad3f3df8a68719beb7a7179ffa1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/iso3166/zipball/aed3b32fc293afdf2c6c6a322c2408eb5d20804a",
-                "reference": "aed3b32fc293afdf2c6c6a322c2408eb5d20804a",
+                "url": "https://api.github.com/repos/thephpleague/iso3166/zipball/9976d382f270ad3f3df8a68719beb7a7179ffa1e",
+                "reference": "9976d382f270ad3f3df8a68719beb7a7179ffa1e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3|^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.12",
-                "phpunit/phpunit": "^5.7.11 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
@@ -1355,7 +1354,7 @@
                 "issues": "https://github.com/thephpleague/iso3166/issues",
                 "source": "https://github.com/thephpleague/iso3166"
             },
-            "time": "2020-01-29T07:08:12+00:00"
+            "time": "2020-12-05T06:50:42+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1732,22 +1731,27 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "68f5200c33f18c018db17eb869d4b0f97da17cad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/68f5200c33f18c018db17eb869d4b0f97da17cad",
+                "reference": "68f5200c33f18c018db17eb869d4b0f97da17cad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -1774,9 +1778,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/2.0.0"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-03-05T16:02:18+00:00"
         },
         {
             "name": "psr/http-client",
@@ -4403,12 +4407,12 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1",
+        "php": ">=7.3",
         "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.34"
+        "php": "7.3.27"
     },
     "plugin-api-version": "2.0.0"
 }

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
  * Requires at least: 5.3
- * Requires PHP: 7.1
+ * Requires PHP: 7.3
  *
  * WC requires at least: 4.5
  * WC tested up to: 4.8
@@ -21,6 +21,7 @@ use Automattic\Jetpack\Config;
 use Automattic\WooCommerce\GoogleListingsAndAds\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Autoloader;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginFactory;
+use Automattic\WooCommerce\GoogleListingsAndAds\VersionValidator;
 use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -30,6 +31,11 @@ define( 'GLA_VERSION', '0.2.2' ); // WRCS: DEFINED_VERSION.
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';
 if ( ! Autoloader::init() ) {
+	return;
+}
+
+// Validate the versions of everything our plugin depends on.
+if ( ! ( new VersionValidator() )->validate() ) {
 	return;
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"prebuild": "rm -rf vendor",
 		"build": "composer install --no-dev && NODE_ENV=production wp-scripts build",
 		"postbuild": "npm run archive",
-		"dev": "composer install && NODE_ENV=development wp-scripts build",
+		"dev": "NODE_ENV=development wp-scripts build",
 		"archive": "composer archive --file=$npm_package_name --format=zip",
 		"postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
 		"check-engines": "wp-scripts check-engines",

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -47,8 +47,8 @@ class Autoloader {
 	 */
 	protected static function missing_autoloader() {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			error_log(  // phpcs:ignore
-				esc_html__( 'Your installation of Google for WooCommerce is incomplete. If you installed WooCommerce from GitHub, please refer to this document to set up your development environment: https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment', 'google-listings-and-ads' )
+			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions
+				esc_html__( 'Your installation of Google Listings and Ads is incomplete. If you installed from GitHub, please refer to this document to set up your development environment: https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment', 'google-listings-and-ads' )
 			);
 		}
 		add_action(
@@ -60,7 +60,7 @@ class Autoloader {
 						<?php
 						printf(
 							/* translators: 1: is a link to a support document. 2: closing link */
-							esc_html__( 'Your installation of WooCommerce is incomplete. If you installed WooCommerce from GitHub, %1$splease refer to this document%2$s to set up your development environment.', 'google-listings-and-ads' ),
+							esc_html__( 'Your installation of Google Listings and Ads is incomplete. If you installed from GitHub, %1$splease refer to this document%2$s to set up your development environment.', 'google-listings-and-ads' ),
 							'<a href="' . esc_url( 'https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment' ) . '" target="_blank" rel="noopener noreferrer">',
 							'</a>'
 						);

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -14,7 +14,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
@@ -100,8 +99,8 @@ class ConnectionTest implements Service, Registerable {
 	protected function render_admin_page() {
 		/** @var Manager $manager */
 		$manager    = $this->container->get( Manager::class );
-		$blog_token = $manager->get_access_token();
-		$user_token = $manager->get_access_token( get_current_user_id() );
+		$blog_token = $manager->get_tokens()->get_access_token();
+		$user_token = $manager->get_tokens()->get_access_token( get_current_user_id() );
 		$user_data  = $manager->get_connected_user_data( get_current_user_id() );
 		$url        = admin_url( 'admin.php?page=connection-test-admin-page' );
 
@@ -1042,7 +1041,7 @@ class ConnectionTest implements Service, Registerable {
 	private function get_auth_header(): string {
 		/** @var Manager $manager */
 		$manager = $this->container->get( Manager::class );
-		$token   = $manager->get_access_token();
+		$token   = $manager->get_tokens()->get_access_token();
 
 		[ $token_key, $token_secret ] = explode( '.', $token->secret );
 

--- a/src/Exception/InvalidVersion.php
+++ b/src/Exception/InvalidVersion.php
@@ -1,0 +1,38 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
+
+use RuntimeException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class InvalidVersion
+ *
+ * Error messages generated in this class should be translated, as they are intended to be displayed
+ * to end users.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
+ */
+class InvalidVersion extends RuntimeException implements GoogleListingsAndAdsException {
+
+	/**
+	 * Create a new instance of the exception when an invalid PHP version is detected.
+	 *
+	 * @param string $found_version
+	 * @param string $minimum_version
+	 *
+	 * @return static
+	 */
+	public static function from_php_version( string $found_version, string $minimum_version ): InvalidVersion {
+		return new static(
+			sprintf(
+				/* translators: 1 is the minimum required PHP version, 2 is the version in use on the site */
+				__( 'Google Listings and Ads requires PHP version %1$s or higher. You are using version %2$s.', 'google-listings-and-ads' ),
+				$minimum_version,
+				$found_version
+			)
+		);
+	}
+}

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -197,7 +197,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	protected function generate_auth_header(): string {
 		/** @var Manager $manager */
 		$manager = $this->getLeagueContainer()->get( Manager::class );
-		$token   = $manager->get_access_token( false, false, false );
+		$token   = $manager->get_tokens()->get_access_token( false, false, false );
 		$this->check_for_wp_error( $token );
 
 		[ $key, $secret ] = explode( '.', $token->secret );

--- a/src/VersionValidator.php
+++ b/src/VersionValidator.php
@@ -1,0 +1,62 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidVersion;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class VersionValidator
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds
+ */
+class VersionValidator {
+
+	/**
+	 * Validate all versions that we require for the plugin to function properly.
+	 *
+	 * @return bool
+	 */
+	public function validate(): bool {
+		try {
+			$this->validate_php_version();
+
+			return true;
+		} catch ( InvalidVersion $e ) {
+			add_action(
+				'admin_notices',
+				function() use ( $e ) {
+					$this->admin_notice( $e->getMessage() );
+				}
+			);
+
+			return false;
+		}
+	}
+
+	/**
+	 * Validate the PHP version being used.
+	 *
+	 * @throws InvalidVersion When the PHP version does not meet the minimum version.
+	 */
+	protected function validate_php_version() {
+		if ( ! version_compare( PHP_VERSION, '7.3', '>=' ) ) {
+			throw InvalidVersion::from_php_version( PHP_VERSION, '7.3' );
+		}
+	}
+
+	/**
+	 * Display an admin notice with the provided message.
+	 *
+	 * @param string $message
+	 */
+	protected function admin_notice( string $message ) {
+		?>
+		<div class="notice notice-error">
+			<p><?php echo esc_html( $message ); ?></p>
+		</div>
+		<?php
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I noticed that `trunk` displays this message when running `composer install`:

```
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
```

This PR runs `composer update` to bring our lock file up to date. These are the packages that were updated:

```
Loading composer repositories with package information
Updating dependencies
Lock file operations: 3 installs, 28 updates, 0 removals
  - Upgrading automattic/jetpack-a8c-mc-stats (v1.2.0 => 1.4.1)
  - Locking automattic/jetpack-assets (v1.11.2)
  - Upgrading automattic/jetpack-autoloader (v2.7.1 => v2.10.0)
  - Upgrading automattic/jetpack-config (v1.4.2 => v1.4.3)
  - Upgrading automattic/jetpack-connection (v1.21.1 => v1.24.0)
  - Upgrading automattic/jetpack-constants (v1.5.1 => v1.6.2)
  - Upgrading automattic/jetpack-heartbeat (v1.2.2 => v1.3.3)
  - Upgrading automattic/jetpack-options (v1.9.1 => v1.11.2)
  - Upgrading automattic/jetpack-roles (v1.3.1 => v1.4.2)
  - Upgrading automattic/jetpack-status (v1.6.0 => v1.7.2)
  - Upgrading automattic/jetpack-terms-of-service (v1.8.2 => v1.9.3)
  - Upgrading automattic/jetpack-tracking (v1.11.1 => v1.13.2)
  - Upgrading firebase/php-jwt (v5.2.0 => v5.2.1)
  - Upgrading google/apiclient (v2.8.3 => v2.9.1)
  - Upgrading google/apiclient-services (v0.156 => v0.163.0)
  - Upgrading google/auth (v1.14.3 => v1.15.0)
  - Upgrading google/gax (1.6.1 => 1.7.0)
  - Upgrading google/protobuf (v3.14.0 => v3.15.5)
  - Upgrading grpc/grpc (1.34.0 => 1.36.0)
  - Upgrading guzzlehttp/promises (1.4.0 => 1.4.1)
  - Upgrading league/container (3.3.3 => 3.3.4)
  - Locking paragonie/constant_time_encoding (v2.4.0)
  - Locking paragonie/random_compat (v9.99.100)
  - Upgrading phpseclib/phpseclib (2.0.30 => 3.0.5)
  - Upgrading psr/container (1.0.0 => 1.1.1)
  - Upgrading symfony/polyfill-ctype (v1.20.0 => v1.22.1)
  - Upgrading symfony/polyfill-mbstring (v1.22.0 => v1.22.1)
  - Upgrading symfony/polyfill-php73 (v1.22.0 => v1.22.1)
  - Upgrading symfony/polyfill-php80 (v1.22.0 => v1.22.1)
  - Upgrading symfony/validator (v5.2.1 => v5.2.5)
  - Upgrading webmozart/assert (1.9.1 => 1.10.0)
```


### Detailed test instructions:

1. Run `composer install`
2. You should **not** receive a warning about the lock file being out of date