### PR TITLE
Use Order ID instead of transaction ID

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -151,7 +151,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			'send_to': '<?php echo esc_js( $ads_conversion_id ); ?>/<?php echo esc_js( $ads_conversion_label ); ?>',
 			'value': '<?php echo esc_js( $order->get_total() ); ?>',
 			'currency': '<?php echo esc_js( $order->get_currency() ); ?>',
-			'transaction_id': '<?php echo esc_js( $order->get_transaction_id() ); ?>'
+			'transaction_id': '<?php echo esc_js( $order->get_id() ); ?>'
 		});
 	</script>
 			<?php


### PR DESCRIPTION
Use `$order->get_id()` instead of `$order->get_transaction_id()` to line conversions up with the WooCommerce order number.

Small change to #322 