### PR TITLE
Fix conversion tracking requests

### DIFF
--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -596,8 +596,7 @@ class Ads {
 			// Create the conversion.
 			$response = $client->getConversionActionServiceClient()->mutateConversionActions(
 				$this->get_id(),
-				[ $conversion_action_operation ],
-				$this->get_args()
+				[ $conversion_action_operation ]
 			);
 
 			/** @var MutateConversionActionResult $added_conversion_action */
@@ -633,7 +632,7 @@ class Ads {
 
 			/** @var ConversionActionServiceClient $ca_client */
 			$ca_client         = $this->container->get( GoogleAdsClient::class )->getConversionActionServiceClient();
-			$conversion_action = $ca_client->getConversionAction( $resource_name, $this->get_args() );
+			$conversion_action = $ca_client->getConversionAction( $resource_name );
 
 			return $this->convert_conversion_action( $conversion_action );
 		} catch ( Exception $e ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the conversion tracking requests. After #323 we no longer need to pass the authentication header to each request, so the `get_args` function was removed.

Followup to: #322 

### Detailed test instructions:

1. Try linking an existing ad account and confirm we don't get a fatal error at the conversion_action step.

### Changelog Note:
- Fix conversion tracking requests