### PR TITLE
Dashboard page - UI of paid campaign promotion card

### DIFF
--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -9,14 +9,17 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import { glaData } from '.~/constants';
 import TabNav from '../tab-nav';
 import AppDateRangeFilterPicker from './app-date-range-filter-picker';
 import SummaryCard from './summary-card';
+import PaidCampaignPromotionCard from './paid-campaign-promotion-card';
 import CampaignCreationSuccessGuide from './campaign-creation-success-guide';
 import AllProgramsTableCard from './all-programs-table-card';
 import './index.scss';
 
 const Dashboard = () => {
+	const { adsSetupComplete } = glaData;
 	// TODO: this data should come from backend API.
 	const data = {
 		freeListing: {
@@ -41,6 +44,10 @@ const Dashboard = () => {
 		},
 	};
 	const trackEventReportId = 'dashboard';
+	const paidPerformanceTitle = __(
+		'Performance (Paid Campaigns)',
+		'woocommerce-admin'
+	);
 
 	return (
 		<div className="gla-dashboard">
@@ -71,23 +78,28 @@ const Dashboard = () => {
 						delta={ data.freeListing.totalSpend.delta }
 					/>
 				</SummaryCard>
-				<SummaryCard
-					title={ __(
-						'Performance (Paid Campaigns)',
-						'woocommerce-admin'
-					) }
-				>
-					<SummaryNumber
-						label={ __( 'Net Sales', 'google-listings-and-ads' ) }
-						value={ data.paidCampaigns.netSales.value }
-						delta={ data.paidCampaigns.netSales.delta }
-					/>
-					<SummaryNumber
-						label={ __( 'Total Spend', 'google-listings-and-ads' ) }
-						value={ data.paidCampaigns.totalSpend.value }
-						delta={ data.paidCampaigns.totalSpend.delta }
-					/>
-				</SummaryCard>
+				{ adsSetupComplete ? (
+					<SummaryCard title={ paidPerformanceTitle }>
+						<SummaryNumber
+							label={ __(
+								'Net Sales',
+								'google-listings-and-ads'
+							) }
+							value={ data.paidCampaigns.netSales.value }
+							delta={ data.paidCampaigns.netSales.delta }
+						/>
+						<SummaryNumber
+							label={ __(
+								'Total Spend',
+								'google-listings-and-ads'
+							) }
+							value={ data.paidCampaigns.totalSpend.value }
+							delta={ data.paidCampaigns.totalSpend.delta }
+						/>
+					</SummaryCard>
+				) : (
+					<PaidCampaignPromotionCard title={ paidPerformanceTitle } />
+				) }
 			</div>
 			<div className="gla-dashboard__programs">
 				<CampaignCreationSuccessGuide />

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -21,6 +21,8 @@ import './index.scss';
 const Dashboard = () => {
 	const { adsSetupComplete } = glaData;
 	// TODO: this data should come from backend API.
+	//       And also, reconsider that would it better to encapsulate the `adsSetupComplete` and
+	//       `paidPerformanceTitle` into a new component and conditionally render different content.
 	const data = {
 		freeListing: {
 			netSales: {

--- a/js/src/dashboard/index.scss
+++ b/js/src/dashboard/index.scss
@@ -34,6 +34,8 @@
 		}
 
 		.components-card {
+			display: flex;
+			flex-direction: column;
 			flex: 1;
 		}
 	}

--- a/js/src/dashboard/paid-campaign-promotion-card/index.js
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.js
@@ -20,7 +20,7 @@ const PromotionContent = ( { adsAccount } ) => {
 
 	return (
 		<>
-			<p className="gla-dashboard__performance__promotion-text">
+			<p className="gla-paid-campaign-promotion-card__text">
 				{ showFreeCredit
 					? __(
 							'Create your first campaign and get up to $150* free',
@@ -50,9 +50,9 @@ function PaidCampaignPromotionCard( { title } ) {
 	const { googleAdsAccount } = useGoogleAdsAccount();
 
 	return (
-		<Card>
+		<Card className="gla-paid-campaign-promotion-card">
 			<CardHeader size="medium">{ title }</CardHeader>
-			<div className="gla-dashboard__performance__promotion-container">
+			<div className="gla-paid-campaign-promotion-card__body">
 				{ googleAdsAccount ? (
 					<PromotionContent adsAccount={ googleAdsAccount } />
 				) : (

--- a/js/src/dashboard/paid-campaign-promotion-card/index.js
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.js
@@ -3,11 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getNewPath } from '@woocommerce/navigation';
-import {
-	Card,
-	CardHeader,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardHeader } from '@wordpress/components';
 import { Spinner } from '@woocommerce/components';
 
 /**
@@ -24,7 +20,7 @@ const PromotionContent = ( { adsAccount } ) => {
 
 	return (
 		<>
-			<Text variant="body">
+			<p className="gla-dashboard__performance__promotion-text">
 				{ showFreeCredit
 					? __(
 							'Create your first campaign and get up to $150* free',
@@ -34,7 +30,7 @@ const PromotionContent = ( { adsAccount } ) => {
 							'Create your first campaign',
 							'google-listings-and-ads'
 					  ) }
-			</Text>
+			</p>
 			<TrackableLink
 				className="components-button is-secondary is-small"
 				eventName="gla_dashboard_link_clicked"
@@ -55,9 +51,7 @@ function PaidCampaignPromotionCard( { title } ) {
 
 	return (
 		<Card>
-			<CardHeader size="medium">
-				<Text variant="title.small">{ title }</Text>
-			</CardHeader>
+			<CardHeader size="medium">{ title }</CardHeader>
 			<div className="gla-dashboard__performance__promotion-container">
 				{ googleAdsAccount ? (
 					<PromotionContent adsAccount={ googleAdsAccount } />

--- a/js/src/dashboard/paid-campaign-promotion-card/index.js
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { getNewPath } from '@woocommerce/navigation';
+import {
+	Card,
+	CardHeader,
+	__experimentalText as Text,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import TrackableLink from '.~/components/trackable-link';
+import './index.scss';
+
+function PaidCampaignPromotionCard( { title } ) {
+	const href = getNewPath( null, '/google/setup-ads' );
+
+	return (
+		<Card>
+			<CardHeader size="medium">
+				<Text variant="title.small">{ title }</Text>
+			</CardHeader>
+			<div className="gla-dashboard__performance__promotion-content">
+				<Text variant="body">
+					{ __(
+						'Create your first campaign and get up to $150* free',
+						'google-listings-and-ads'
+					) }
+				</Text>
+				<TrackableLink
+					className="components-button is-secondary is-small"
+					eventName="gla_dashboard_link_clicked"
+					eventProps={ {
+						context: 'add-paid-campaign-promotion',
+						href,
+					} }
+					href={ href }
+				>
+					{ __( 'Add paid campaign', 'google-listings-and-ads' ) }
+				</TrackableLink>
+			</div>
+		</Card>
+	);
+}
+
+export default PaidCampaignPromotionCard;

--- a/js/src/dashboard/paid-campaign-promotion-card/index.js
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.js
@@ -8,39 +8,64 @@ import {
 	CardHeader,
 	__experimentalText as Text,
 } from '@wordpress/components';
+import { Spinner } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import TrackableLink from '.~/components/trackable-link';
 import './index.scss';
 
-function PaidCampaignPromotionCard( { title } ) {
+const PromotionContent = ( { adsAccount } ) => {
 	const href = getNewPath( null, '/google/setup-ads' );
+	const showFreeCredit =
+		adsAccount.sub_account || adsAccount.status === 'disconnected';
+
+	let promoteText = __(
+		'Create your first campaign',
+		'google-listings-and-ads'
+	);
+
+	if ( showFreeCredit ) {
+		promoteText += __(
+			' and get up to $150* free',
+			'google-listings-and-ads'
+		);
+	}
+
+	return (
+		<>
+			<Text variant="body">{ promoteText }</Text>
+			<TrackableLink
+				className="components-button is-secondary is-small"
+				eventName="gla_dashboard_link_clicked"
+				eventProps={ {
+					context: 'add-paid-campaign-promotion',
+					href,
+				} }
+				href={ href }
+			>
+				{ __( 'Add paid campaign', 'google-listings-and-ads' ) }
+			</TrackableLink>
+		</>
+	);
+};
+
+function PaidCampaignPromotionCard( { title } ) {
+	const { googleAdsAccount } = useGoogleAdsAccount();
 
 	return (
 		<Card>
 			<CardHeader size="medium">
 				<Text variant="title.small">{ title }</Text>
 			</CardHeader>
-			<div className="gla-dashboard__performance__promotion-content">
-				<Text variant="body">
-					{ __(
-						'Create your first campaign and get up to $150* free',
-						'google-listings-and-ads'
-					) }
-				</Text>
-				<TrackableLink
-					className="components-button is-secondary is-small"
-					eventName="gla_dashboard_link_clicked"
-					eventProps={ {
-						context: 'add-paid-campaign-promotion',
-						href,
-					} }
-					href={ href }
-				>
-					{ __( 'Add paid campaign', 'google-listings-and-ads' ) }
-				</TrackableLink>
+			<div className="gla-dashboard__performance__promotion-container">
+				{ googleAdsAccount ? (
+					<PromotionContent adsAccount={ googleAdsAccount } />
+				) : (
+					<Spinner />
+				) }
 			</div>
 		</Card>
 	);

--- a/js/src/dashboard/paid-campaign-promotion-card/index.js
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.js
@@ -22,21 +22,19 @@ const PromotionContent = ( { adsAccount } ) => {
 	const showFreeCredit =
 		adsAccount.sub_account || adsAccount.status === 'disconnected';
 
-	let promoteText = __(
-		'Create your first campaign',
-		'google-listings-and-ads'
-	);
-
-	if ( showFreeCredit ) {
-		promoteText += __(
-			' and get up to $150* free',
-			'google-listings-and-ads'
-		);
-	}
-
 	return (
 		<>
-			<Text variant="body">{ promoteText }</Text>
+			<Text variant="body">
+				{ showFreeCredit
+					? __(
+							'Create your first campaign and get up to $150* free',
+							'google-listings-and-ads'
+					  )
+					: __(
+							'Create your first campaign',
+							'google-listings-and-ads'
+					  ) }
+			</Text>
 			<TrackableLink
 				className="components-button is-secondary is-small"
 				eventName="gla_dashboard_link_clicked"

--- a/js/src/dashboard/paid-campaign-promotion-card/index.scss
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.scss
@@ -1,15 +1,12 @@
-.gla-dashboard__performance {
-	.components-card > div:not(.components-card__header) {
-		// Make card contents within a row have the same height
-		flex: 1;
-	}
-
+.gla-paid-campaign-promotion-card {
 	.components-card__header {
 		line-height: 28px;
 		font-size: 20px;
 	}
 
-	&__promotion-container {
+	&__body {
+		// Make card contents within a row have the same height
+		flex: 1;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
@@ -21,7 +18,7 @@
 		color: #757575;
 	}
 
-	&__promotion-text {
+	&__text {
 		margin: 0;
 	}
 

--- a/js/src/dashboard/paid-campaign-promotion-card/index.scss
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.scss
@@ -4,7 +4,7 @@
 		flex: 1;
 	}
 
-	&__promotion-content {
+	&__promotion-container {
 		display: flex;
 		flex-direction: column;
 		justify-content: center;

--- a/js/src/dashboard/paid-campaign-promotion-card/index.scss
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.scss
@@ -1,0 +1,22 @@
+.gla-dashboard__performance {
+	.components-card > div:not(.components-card__header) {
+		// Make card contents within a row have the same height
+		flex: 1;
+	}
+
+	&__promotion-content {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		height: 100%;
+		padding: var(--main-gap);
+		border: 1px solid #e0e0e0;
+		background-color: #f8f9f9;
+		color: #757575;
+	}
+
+	.components-button {
+		margin-top: $grid-unit-20;
+	}
+}

--- a/js/src/dashboard/paid-campaign-promotion-card/index.scss
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.scss
@@ -4,6 +4,11 @@
 		flex: 1;
 	}
 
+	.components-card__header {
+		line-height: 28px;
+		font-size: 20px;
+	}
+
 	&__promotion-container {
 		display: flex;
 		flex-direction: column;
@@ -14,6 +19,10 @@
 		border: 1px solid #e0e0e0;
 		background-color: #f8f9f9;
 		color: #757575;
+	}
+
+	&__promotion-text {
+		margin: 0;
 	}
 
 	.components-button {

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDepen
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminStyleAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsAwareness;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\AdsTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\MerchantCenterTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
@@ -29,6 +30,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 
 	use AdminConditional;
 	use AssetsAwareness;
+	use AdsTrait;
 	use MerchantCenterTrait;
 	use PluginHelper;
 
@@ -91,6 +93,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 				'mcSetupComplete'     => $this->setup_complete(),
 				'mcSupportedCountry'  => $this->is_country_supported(),
 				'mcSupportedLanguage' => $this->is_language_supported(),
+				'adsSetupComplete'    => $this->is_ads_setup_complete(),
 			]
 		);
 

--- a/src/HelperTraits/AdsTrait.php
+++ b/src/HelperTraits/AdsTrait.php
@@ -1,0 +1,28 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait AdsTrait
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits
+ */
+trait AdsTrait {
+
+	use OptionsAwareTrait;
+
+	/**
+	 * Get whether Ads setup is completed.
+	 *
+	 * @return bool
+	 */
+	protected function is_ads_setup_complete(): bool {
+		return boolval( $this->options->get( OptionsInterface::ADS_SETUP_COMPLETED_AT, false ) );
+	}
+}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -34,6 +34,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\CompleteSetup as CompleteSetupNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaign as SetupCampaignNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsSetupCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantSetupCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
@@ -158,6 +159,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( GlobalSiteTag::class, ContainerInterface::class );
 		$this->conditionally_share_with_tags( SiteVerificationMeta::class, ContainerInterface::class );
 		$this->conditionally_share_with_tags( MerchantSetupCompleted::class );
+		$this->conditionally_share_with_tags( AdsSetupCompleted::class );
 
 		// Inbox Notes
 		$this->conditionally_share_with_tags( CompleteSetupNote::class );

--- a/src/Options/AdsSetupCompleted.php
+++ b/src/Options/AdsSetupCompleted.php
@@ -1,0 +1,43 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsSetupCompleted
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Options
+ */
+class AdsSetupCompleted implements OptionsAwareInterface, Registerable, Service {
+
+	use OptionsAwareTrait;
+
+	protected const OPTION = OptionsInterface::ADS_SETUP_COMPLETED_AT;
+
+	/**
+	 * Register a service.
+	 *
+	 * TODO: call `do_action( 'gla_ads_settings_sync' );` when the initial Google Ads account,
+	 *       paid campaign, and billing setup is completed.
+	 */
+	public function register(): void {
+		add_action(
+			'gla_ads_settings_sync',
+			function() {
+				$this->set_completed_timestamp();
+			}
+		);
+	}
+
+	/**
+	 * Set the timestamp when setup was completed.
+	 */
+	protected function set_completed_timestamp() {
+		$this->options->update( self::OPTION, time() );
+	}
+}

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -26,6 +26,7 @@ final class Options implements OptionsInterface, Service {
 		self::ADS_BILLING_URL        => true,
 		self::ADS_ID                 => true,
 		self::ADS_CONVERSION_ACTION  => true,
+		self::ADS_SETUP_COMPLETED_AT => true,
 		self::DB_VERSION             => true,
 		self::FILE_VERSION           => true,
 		self::INSTALL_TIMESTAMP      => true,

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -14,6 +14,7 @@ interface OptionsInterface {
 	public const ADS_BILLING_URL        = 'ads_billing_url';
 	public const ADS_ID                 = 'ads_id';
 	public const ADS_CONVERSION_ACTION  = 'ads_conversion_action';
+	public const ADS_SETUP_COMPLETED_AT = 'ads_setup_completed_at';
 	public const DB_VERSION             = 'db_version';
 	public const FILE_VERSION           = 'file_version';
 	public const INSTALL_TIMESTAMP      = 'install_timestamp';

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -77,6 +77,9 @@ All event names are prefixed by `wcadmin_gla_`.
 * `google_ads_account_link_click` - Clicking on a Google Ads account text link.
   * `context`: indicate which page / module the link is in
   * `link_id`: a unique ID for the link within the page / module
+
+* `dashboard_link_clicked` - Clicking on a link within the dashboard page
+  * `context`: indicate which link is clicked
   * `href`: link's URL
 
 <!-- -- >


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implements part of #7
- Show the paid campaign promotion within the performance card if ads setup isn't completed
- Clicking the call to action will prompt the user to setup ads account and fire an event tracking

### Still not covered here:
- Record the timestamp to the `gla_ads_setup_completed_at` wp_option when the initial Google Ads account, paid campaign, and billing setup is completed.
### Screenshots:

#### Before ads account setup / new ads account
![image](https://user-images.githubusercontent.com/17420811/111263362-b49b6f80-8660-11eb-963c-1aaa35513d2a.png)

#### User uses an existed ads account
![image](https://user-images.githubusercontent.com/17420811/111566910-01a25180-87d9-11eb-99ca-8d2dbab85d92.png)



### Detailed test instructions:

1. Open the DevTool console and execute `localStorage.setItem( 'debug', 'wc-admin:*' );` to enable tracking debugging mode
2. Head to the URL path: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`
3. The paid campaign promotion should show up
4. Click on the "Add paid campaign" button should bring you to ads account setup page, and an event should be logged on the DevTool console
5. The promotion text should not have free credit content "and get up to $150* free" if users use an existed ads account, more details can be found here - https://github.com/woocommerce/google-listings-and-ads/pull/346#issuecomment-801073600
