### PR TITLE
Better conversion action duplicate name error message

### DIFF
--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -575,10 +575,13 @@ class Ads {
 			$conversion_action_operation->setCreate(
 				new ConversionAction(
 					[
-						'name'           => sprintf(
+						'name'           => apply_filters(
+							'woocommerce_gla_conversion_action_name',
+							sprintf(
 							/* translators: %1 is a random 4-digit string */
-							__( '[%1$s] Google Listings and Ads purchase action', 'google-listings-and-ads' ),
-							$unique
+								__( '[%1$s] Google Listings and Ads purchase action', 'google-listings-and-ads' ),
+								$unique
+							)
 						),
 						'category'       => ConversionActionCategory::PURCHASE,
 						'type'           => ConversionActionType::WEBPAGE,

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -578,7 +578,7 @@ class Ads {
 						'name'           => apply_filters(
 							'woocommerce_gla_conversion_action_name',
 							sprintf(
-							/* translators: %1 is a random 4-digit string */
+								/* translators: %1 is a random 4-digit string */
 								__( '[%1$s] Google Listings and Ads purchase action', 'google-listings-and-ads' ),
 								$unique
 							)

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -607,7 +607,12 @@ class Ads {
 			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
 			$message = $e->getMessage();
 			if ( $e instanceof ApiException ) {
-				$message = $e->getBasicMessage();
+
+				if ( $this->has_api_exception_error( $e, 'DUPLICATE_NAME' ) ) {
+					$message = __( 'A conversion action with this name already exists', 'google-listings-and-ads' );
+				} else {
+					$message = $e->getBasicMessage();
+				}
 			}
 
 			/* translators: %s Error message */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the vein of #344, this PR clarifies one of the errors from the conversion action creation process, by checking the error received from the Ads API when the conversion action step of the Ads onboarding fails, and clarifying the cause if it is due to a duplicate name.

Currently, the `400` response body is simply
```json
{ "message": "Error creating conversion action: Request contains an invalid argument." }
```

This changes it to a more illustrative
```json
{ "message": "Error creating conversion action: A conversion action with this name already exists" }
```

### Detailed test instructions:

1.  Use this snippet to always set the same conversion action name:
    ```php
    add_filter( 'woocommerce_gla_conversion_action_name', function($name) { return 'Test Conversion Action Name'; });
    ```
2. Connect an existing Ads account. 
    - Confirm that the process completes successfully.
    - Confirm that the Conversion Action was created. (<https://ads.google.com/aw/conversions> with the account used).
3. Disconnect and reconnect the same existing Ads account.
    - Confirm that you receive the new error message shown above.
4. Remove the `add_filter` snippet and reconnect the same existing Ads account.
    - Confirm that the setup process completes successfully .
    - Confirm that the new conversion action is created with a unique name.
