### PR TITLE
Hook up `is_xx_supported` MC helper methods

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -13,8 +13,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\ViewFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\BuiltScriptDependencyArray;
@@ -25,7 +25,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Pages
  */
-class Admin implements Service, Registerable, Conditional, OptionsAwareInterface {
+class Admin implements Service, Registerable, Conditional, OptionsAwareInterface, ContainerAwareInterface {
 
 	use AdminConditional;
 	use AssetsAwareness;

--- a/src/GoogleHelper.php
+++ b/src/GoogleHelper.php
@@ -125,4 +125,50 @@ trait GoogleHelper {
 
 		return $include_beta ? array_merge( $supported_countries, $beta_countries ) : $supported_countries;
 	}
+
+	/**
+	 * Get an array of Google Merchant Center supported languages (ISO 639-1).
+	 *
+	 * WooCommerce Languages -> https://translate.wordpress.org/projects/wp-plugins/woocommerce/
+	 * Google Supported Languages -> https://support.google.com/merchants/answer/160637?hl=en
+	 * ISO 639-1 -> https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+	 *
+	 * @return array
+	 */
+	protected function get_mc_supported_languages(): array {
+		// Repeated values removed:
+		// 'pt', // Brazilian Portuguese
+		// 'zh', // Simplified Chinese*
+
+		return [
+			'ar', // Arabic
+			'cs', // Czech
+			'da', // Danish
+			'nl', // Dutch
+			'en', // English
+			'fi', // Finnish
+			'fr', // French
+			'de', // German
+			'he', // Hebrew
+			'hu', // Hungarian
+			'id', // Indonesian
+			'it', // Italian
+			'ja', // Japanese
+			'ko', // Korean
+			'el', // Modern Greek
+			'no', // Norwegian
+			'pl', // Polish
+			'pt', // Portuguese
+			'ro', // Romanian
+			'ru', // Russian
+			'sk', // Slovak
+			'es', // Spanish
+			'sv', // Swedish
+			'th', // Thai
+			'zh', // Traditional Chinese
+			'tr', // Turkish
+			'uk', // Ukrainian
+			'vi', // Vietnamese
+		];
+	}
 }

--- a/src/GoogleHelper.php
+++ b/src/GoogleHelper.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds;
 trait GoogleHelper {
 
 	/**
-	 * Get an array of merchant center supported countries and currencies.
+	 * Get an array of Google Merchant Center supported countries and currencies.
 	 *
 	 * Note - Other currencies may be supported using currency conversion.
 	 *

--- a/src/GoogleHelper.php
+++ b/src/GoogleHelper.php
@@ -18,8 +18,6 @@ trait GoogleHelper {
 	 * WooCommerce Countries -> https://github.com/woocommerce/woocommerce/blob/master/i18n/countries.php
 	 * Google Supported Countries -> https://support.google.com/merchants/answer/160637?hl=en
 	 *
-	 * Commented out countries are "listed" as beta countries.
-	 *
 	 * @param bool $include_beta Whether to include countries supported in Beta by Google.
 	 *
 	 * @return array

--- a/src/HelperTraits/MerchantCenterTrait.php
+++ b/src/HelperTraits/MerchantCenterTrait.php
@@ -59,6 +59,10 @@ trait MerchantCenterTrait {
 			$language = substr( get_locale(), 0, 2 );
 		}
 
-		return in_array( $language, $this->get_mc_supported_languages(), true );
+		return in_array(
+			strtolower( $language ),
+			$this->get_mc_supported_languages(),
+			true
+		);
 	}
 }

--- a/src/HelperTraits/MerchantCenterTrait.php
+++ b/src/HelperTraits/MerchantCenterTrait.php
@@ -46,12 +46,10 @@ trait MerchantCenterTrait {
 	}
 
 	/**
-	 * Get whether the language is supported by the Merchant Center
+	 * Get whether the language is supported by the Merchant Center.
 	 *
-	 * TODO: actually determine if supported
-	 *
-	 * @param  string $language
-	 * @return bool
+	 * @param  string $language Optional - to check a language other than the site language.
+	 * @return bool True if the language is in the list of MC-supported languages.
 	 */
 	protected function is_language_supported( string $language = '' ): bool {
 		// Default to base site language

--- a/src/HelperTraits/MerchantCenterTrait.php
+++ b/src/HelperTraits/MerchantCenterTrait.php
@@ -4,9 +4,11 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use WC_Countries;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -19,6 +21,7 @@ trait MerchantCenterTrait {
 
 	use OptionsAwareTrait;
 	use GoogleHelper;
+	use ContainerAwareTrait;
 
 	/**
 	 * Get whether Merchant Center setup is completed.
@@ -26,7 +29,7 @@ trait MerchantCenterTrait {
 	 * @return bool
 	 */
 	protected function setup_complete(): bool {
-		return boolval( $this->options->get( OptionsInterface::MC_SETUP_COMPLETED_AT, false ) );
+		return boolval( $this->options->get( Options::MC_SETUP_COMPLETED_AT, false ) );
 	}
 
 	/**
@@ -38,8 +41,7 @@ trait MerchantCenterTrait {
 	protected function is_country_supported( string $country = '' ): bool {
 		// Default to WooCommerce store country
 		if ( empty( $country ) ) {
-			$wc_countries = WC()->countries ?? new WC_Countries();
-			$country      = $wc_countries->get_base_country();
+			$country = $this->container->get( WC::class )->get_base_country();
 		}
 
 		return array_key_exists(
@@ -57,7 +59,7 @@ trait MerchantCenterTrait {
 	protected function is_language_supported( string $language = '' ): bool {
 		// Default to base site language
 		if ( empty( $language ) ) {
-			$language = substr( get_locale(), 0, 2 );
+			$language = substr( $this->container->get( WP::class )->get_locale(), 0, 2 );
 		}
 
 		return in_array(

--- a/src/HelperTraits/MerchantCenterTrait.php
+++ b/src/HelperTraits/MerchantCenterTrait.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 
@@ -16,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
 trait MerchantCenterTrait {
 
 	use OptionsAwareTrait;
+	use GoogleHelper;
 
 	/**
 	 * Get whether Merchant Center setup is completed.
@@ -54,9 +56,9 @@ trait MerchantCenterTrait {
 	protected function is_language_supported( string $language = '' ): bool {
 		// Default to base site language
 		if ( empty( $language ) ) {
-			$language = '';
+			$language = substr( get_locale(), 0, 2 );
 		}
 
-		return true;
+		return in_array( $language, $this->get_mc_supported_languages(), true );
 	}
 }

--- a/src/HelperTraits/MerchantCenterTrait.php
+++ b/src/HelperTraits/MerchantCenterTrait.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use WC_Countries;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -29,20 +30,22 @@ trait MerchantCenterTrait {
 	}
 
 	/**
-	 * Get whether the country is supported by the Merchant Center
+	 * Get whether the country is supported by the Merchant Center.
 	 *
-	 * TODO: actually determine if supported
-	 *
-	 * @param  string $country
-	 * @return bool
+	 * @param  string $country Optional - to check a country other than the site country.
+	 * @return bool True if the country is in the list of MC-supported countries.
 	 */
 	protected function is_country_supported( string $country = '' ): bool {
 		// Default to WooCommerce store country
 		if ( empty( $country ) ) {
-			$country = '';
+			$wc_countries = WC()->countries ?? new WC_Countries();
+			$country      = $wc_countries->get_base_country();
 		}
 
-		return true;
+		return array_key_exists(
+			strtoupper( $country ),
+			$this->get_mc_supported_countries()
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #268 and also closes #269.

Performs a live check of the WordPress language and WooCommerce store location against the Google Merchant Center supported values for each. As a result, real values are generated for the `is_country_supported` and is_language_supported` methods used to populate the `glaData` JS variable:
https://github.com/woocommerce/google-listings-and-ads/blob/3bd296baf9aca8d888fe20461287647e1622a65a/src/Admin/Admin.php#L89-L94

(Previously both values were just `true`).

**Notes**
- Currently "Beta Countries" are not included in the list of MC-supported countries that are used. 
- Confirmed fixed by #350. ~❗  I get an error when  the "Unsupported Country" notice is displayed: `Cannot read property 'name' of undefined` (implemented in #289). I think this is because the `countryNames` array only contain the MC-supported countries (L22), so when a non-supported country is used as an index (L33), it throws an [error]( https://github.com/woocommerce/google-listings-and-ads/blob/e6f1ebb1cbf2aa7f2744d7b6a1b5a58dbde5214d/js/src/get-started-page/unsupported-notices/index.js#L21-L35). Maybe @eason9487 can confirm?~

### Detailed test instructions:

**Supported Languages**
1. Navigate to the WordPress General Settings `/wp-admin/options-general.php` and update the `Site Language` to something that's not supported by the Google Merchant Center (for example, `Esperanto`).
2. Visit the GLA start page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart` and confirm that the red "Language Not Supported" notice appears:
    ![image](https://user-images.githubusercontent.com/228780/111498866-a6258480-8742-11eb-9eb7-512f855723b0.png)
    And the "Get Started" button is disabled.
3. Look at the page source code and confirm that the `mcSupportedLanguage` attribute of the `glaData` JavaScript object has a value of `false`.
3. Change the site language to something supported (for example, `Italiano`).
4. Visit the GLA start page and confirm that the "Language Not Supported" notice **does not** appear.
5. Change the site language to a child locale of a supported language (for example, `Português do Brasil`).
6. Visit the GLA start page and confirm that the "Language Not Supported" notice **does not** appear.

**Supported Countries**
1. Navigate to the WooCommerce General Settings page `/wp-admin/admin.php?page=wc-settings` and update the Store Address `Country/State` to a country that's not supported by the Google Merchant Center (for example, `Vatican`).
2. Visit the GLA start page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart` and confirm that the yellow "Country Not Supported" notice appears :
    ![image](https://user-images.githubusercontent.com/228780/111602125-5511a100-87d3-11eb-8547-f734ae6d2a33.png)
3. Look at the page source code and confirm that the `mcSupportedCountry` attribute of the `glaData` JavaScript object has a value of `false`.
1. Navigate to the WooCommerce General Settings page and update the Store Address `Country/State` to a country that **is** supported by the Google Merchant Center (for example, `Portugal`).
4. Visit the GLA start page and confirm that the "Country Not Supported" notice **does not** appear.
1. Navigate to the WooCommerce General Settings page and update the Store Address `Country/State` to a country *and state** that is supported by the Google Merchant Center (for example, `Hong Kong - Kowloon`).
4. Visit the GLA start page and confirm that the "Country Not Supported" notice **does not** appear.
1. Navigate to the WooCommerce General Settings page and update the Store Address `Country/State` to a country that is only **beta** supported by the Google Merchant Center (for example, `Madagascar`).
4. Visit the GLA start page and confirm that the "Country Not Supported" notice **does** appear.

**Bonus**
1. Double whammy - set the WooCommerce Store Count to an unsupported value (like `Iraq`) and the WordPress Site Language to an unsupported value (like `Cebuano`)
2. Confirm that both "Unsupported" notices are displayed on the GLA start page, and the "Get Started" button is disabled.