### PR TITLE
Dashboard page - fix unsupported country notice

### DIFF
--- a/js/src/get-started-page/unsupported-notices/index.js
+++ b/js/src/get-started-page/unsupported-notices/index.js
@@ -13,25 +13,20 @@ import { createInterpolateElement } from '@wordpress/element';
  * Internal dependencies
  */
 import useTargetAudience from '.~/hooks/useTargetAudience';
-import useGetCountries from '.~/hooks/useGetCountries';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import { glaData } from '.~/constants';
 import './index.scss';
 
-const useStoreCountry = () => {
-	const { data: countryNames } = useGetCountries();
-	const { woocommerce_default_country: country } = useSelect( ( select ) =>
-		select( SETTINGS_STORE_NAME ).getSetting( 'general', 'general' )
-	);
-
-	if ( ! countryNames ) {
-		return {};
-	}
-
-	const [ countryCode ] = country.split( ':' );
-	return {
-		countryName: countryNames[ countryCode ].name,
-	};
+const useStoreCountryName = () => {
+	return useSelect( ( select ) => {
+		const { getSetting } = select( SETTINGS_STORE_NAME );
+		const countryNames = getSetting( 'wc_admin', 'countries' );
+		const general = getSetting( 'general', 'general' );
+		const [ countryCode ] = general.woocommerce_default_country.split(
+			':'
+		);
+		return countryNames[ countryCode ];
+	} );
 };
 
 const ExternalIcon = () => (
@@ -86,7 +81,7 @@ const UnsupportedLanguage = () => {
 };
 
 const UnsupportedCountry = () => {
-	const { countryName } = useStoreCountry();
+	const countryName = useStoreCountryName();
 
 	if ( ! countryName ) {
 		return null;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The bug was found in #349 

> ❗  I get an error when the "Unsupported Country" notice is displayed: `Cannot read property 'name' of undefined` (implemented in #289). I think this is because the `countryNames` array only contain the MC-supported countries (L22), so when a non-supported country is used as an index (L33), it throws an error:
    https://github.com/woocommerce/google-listings-and-ads/blob/e6f1ebb1cbf2aa7f2744d7b6a1b5a58dbde5214d/js/src/get-started-page/unsupported-notices/index.js#L21-L35

### Root cause

The API `wc/gla/mc/countries` returns MC supported countries. It will run into an error if users' store is not on the MC supported country list.

### Solution

Use the full country name list provided by `@woocommerce/data` instead.

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/111574131-da528100-87e6-11eb-960b-bda7751e49bd.png)

### Detailed test instructions:

1. Head to the settings page `/wp-admin/admin.php?page=wc-settings` and update the Store Address Country/State to a country that's not supported by the Google Merchant Center (for example, Vatican).
2. Open the MerchantCenterTrait.php file and change `return true` to `return false` - https://github.com/woocommerce/google-listings-and-ads/blob/feature/7-promote-paid-campaign/src/HelperTraits/MerchantCenterTrait.php#L43
3. Head to the URL path: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart`, the unsupported country notice should appear with relevant country name.

