### PR TITLE
Hide dashboard page before completing Merchant Center setup

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -47,12 +47,12 @@ const SetupFreeListings = () => {
 		try {
 			await fetchSettingsSync();
 
-			getHistory().push(
-				getNewPath(
-					{ guide: 'submission-success' },
-					'/google/product-feed'
-				)
-			);
+			// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
+			const path = `/wp-admin/${ getNewPath(
+				{ guide: 'submission-success' },
+				'/google/product-feed'
+			) }`;
+			window.location.href = path;
 		} catch ( error ) {
 			createNotice(
 				'error',

--- a/js/src/tab-nav/index.js
+++ b/js/src/tab-nav/index.js
@@ -54,19 +54,18 @@ const TabLink = ( { tabId, path, children, selected, ...rest } ) => {
 	);
 };
 
-const marketingMenu = document.querySelector(
-	'#toplevel_page_woocommerce-marketing'
-);
-const dashboardMenu = marketingMenu.querySelector(
-	"a[href='admin.php?page=wc-admin&path=/google/dashboard']"
-).parentElement;
-
 const TabNav = ( props ) => {
 	const { initialName } = props;
 	const activeClass = 'is-active';
 
 	useEffect( () => {
 		// Highlight the wp-admin dashboard menu
+		const marketingMenu = document.querySelector(
+			'#toplevel_page_woocommerce-marketing'
+		);
+		const dashboardMenu = marketingMenu.querySelector(
+			"a[href='admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard']"
+		).parentElement;
 		marketingMenu.classList.add( 'current', 'wp-has-current-submenu' );
 		dashboardMenu.classList.add( 'current' );
 	} );

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -230,6 +230,7 @@ class AccountController extends BaseOptionsController {
 
 			$this->account_state->update( [] );
 			$this->options->delete( OptionsInterface::SITE_VERIFICATION );
+			$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
 
 			return [
 				'status'  => 'success',

--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -51,7 +51,7 @@ class Dashboard implements Service, Registerable, OptionsAwareInterface {
 	protected function add_items( array $items ): array {
 		$items[] = [
 			'id'         => 'google-dashboard',
-			'title'      => __( 'Google (Dashboard)', 'google-listings-and-ads' ),
+			'title'      => __( 'Google', 'google-listings-and-ads' ),
 			'path'       => '/google/dashboard',
 			'capability' => 'manage_woocommerce',
 		];

--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -5,20 +5,27 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\MerchantCenterTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 
 /**
  * Class Dashboard
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu
  */
-class Dashboard implements Service, Registerable {
+class Dashboard implements Service, Registerable, OptionsAwareInterface {
 
 	use MenuFixesTrait;
+	use MerchantCenterTrait;
 
 	/**
 	 * Register a service.
 	 */
 	public function register(): void {
+		if ( ! $this->setup_complete() ) {
+			return;
+		}
+
 		add_filter(
 			'woocommerce_marketing_menu_items',
 			function( $menu_items ) {

--- a/src/Menu/GetStarted.php
+++ b/src/Menu/GetStarted.php
@@ -6,20 +6,27 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\MenuFixesTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\MerchantCenterTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 
 /**
  * Class GetStarted
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu
  */
-class GetStarted implements Service, Registerable {
+class GetStarted implements Service, Registerable, OptionsAwareInterface {
 
 	use MenuFixesTrait;
+	use MerchantCenterTrait;
 
 	/**
 	 * Register a service.
 	 */
 	public function register(): void {
+		if ( $this->setup_complete() ) {
+			return;
+		}
+
 		add_filter(
 			'woocommerce_marketing_menu_items',
 			function( $menu_items ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR will hide the dashboard page until the Merchant Center setup has been completed. It uses the `MerchantCenterTrait->setup_complete` function to check this. I initially wanted to use a Conditional Service, but since `is_needed` is static we can't call the options class directly. We could get around that by using `get_option` but I thought this was a cleaner solution.

### Detailed test instructions:

1. Install the plugin on a new site (or temporarily remove the wp_option `gla_mc_setup_completed_at`)
2. Confirm that only the Google page is shown in Marketing
3. Confirm there are no console errors in the browser
4. Complete Merchant Center setup
5. Confirm that the dashboard page now shows

### Changelog Note:
- Hide dashboard page before completing Merchant Center setup.