### PR TITLE
Minor tweaks to readme and menu item labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,11 @@
 
 A native integration with Google offering free listings and Smart Shopping ads to WooCommerce merchants.
 
-## Prerequisites (TBC)
+## Prerequisites
 
  - WordPress 5.3+
  - WooCommerce 4.5+
- - PHP 7.0+
-
-Current considerations...
- - PHP 7.2 is recommended but [Woo still supports 7.0](https://docs.woocommerce.com/document/update-php-wordpress/)
- - We're using new 7.1+ syntax - will assess closer to launch whether we revert to 7.0 compatibility syntax
- - We're building using React UI elements (available in WP 5.3) which was only bumped to be the minimum for WC 4.5
+ - PHP 7.3+
 
 ## Development
 

--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -51,7 +51,7 @@ class Dashboard implements Service, Registerable, OptionsAwareInterface {
 	protected function add_items( array $items ): array {
 		$items[] = [
 			'id'         => 'google-dashboard',
-			'title'      => __( 'Google', 'google-listings-and-ads' ),
+			'title'      => __( 'Google Listings & Ads', 'google-listings-and-ads' ),
 			'path'       => '/google/dashboard',
 			'capability' => 'manage_woocommerce',
 		];

--- a/src/Menu/GetStarted.php
+++ b/src/Menu/GetStarted.php
@@ -52,7 +52,7 @@ class GetStarted implements Service, Registerable, OptionsAwareInterface {
 	protected function add_items( array $items ): array {
 		$items[] = [
 			'id'         => 'google-start',
-			'title'      => __( 'Google', 'google-listings-and-ads' ),
+			'title'      => __( 'Google Listings & Ads', 'google-listings-and-ads' ),
 			'path'       => '/google/start',
 			'capability' => 'manage_woocommerce',
 		];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* Updates the readme.me prequisites
* Updates the Get Started and Dashboard menu items to be "Google Listings & Ads"

### Screenshots:

<img width="222" alt="Screen Shot 2021-03-19 at 3 40 36 pm" src="https://user-images.githubusercontent.com/355014/111734348-e2cfb800-88c9-11eb-8ba6-d3743d7535f0.png">

### Detailed test instructions:

1. Check Readme
2. Clone, composer install and build
3. Open WP dashboard and check the menu items labels are "Google Listings & Ads" (when onboarding) and also after

### Changelog Note:

> Update Google menu item labels to be "Google Listings & Ads"
