### PR TITLE
Sync by default if no visibility option is set

### DIFF
--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -132,7 +132,7 @@ class SyncerHooks implements Service, Registerable, OptionsAwareInterface {
 			return;
 		}
 
-		if ( ChannelVisibility::SYNC_AND_SHOW === $this->product_helper->get_visibility( $product ) ) {
+		if ( ChannelVisibility::DONT_SYNC_AND_SHOW !== $this->product_helper->get_visibility( $product ) ) {
 			// schedule an update job if product sync is enabled.
 			$this->update_products_job->start( [ $product_id ] );
 			$this->set_already_scheduled( $product_id );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #14.

This PR fixes an issue with the product syncer hooks where it did not sync a product if it had no `visibility` options set. This issue appeared in the Quick Edit feature because, unlike the normal edit product page, it did not send a `visibility` parameter along with other product parameters.

### Detailed test instructions:

1. Use the quick edit to edit a product
2. If it has no `_wc_gla_visibility` meta or if it's set to `sync-and-show` in the `wp_postmeta` table, an `update_products` job should be scheduled with the mentioned product ID as its argument
3. Use the normal product edit page to set the `Channel visibility` to `Don't sync and show`
4. Make sure a `delete_products` job is queued for this product to remove it from Google Merchant Center
5. Use the quick edit feature again to edit the same product
6. This time, no update job should be queued for this product
