### PR TITLE
Complete Merchant Center disconnect

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -231,7 +231,7 @@ class AccountController extends BaseOptionsController {
 			$this->middleware->disconnect_merchant();
 
 			$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
-			$this->options->delete( OptionsInterface::MC_SETUP_SAVED_SETUP );
+			$this->options->delete( OptionsInterface::MC_SETUP_SAVED_STEP );
 			$this->options->delete( OptionsInterface::MERCHANT_ACCOUNT_STATE );
 			$this->options->delete( OptionsInterface::MERCHANT_CENTER );
 			$this->options->delete( OptionsInterface::SITE_VERIFICATION );

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ProductStatistics;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Google_Service_ShoppingContent_Account as MC_Account;
@@ -228,13 +230,18 @@ class AccountController extends BaseOptionsController {
 		return function() {
 			$this->middleware->disconnect_merchant();
 
-			$this->account_state->update( [] );
-			$this->options->delete( OptionsInterface::SITE_VERIFICATION );
 			$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
+			$this->options->delete( OptionsInterface::MC_SETUP_SAVED_SETUP );
+			$this->options->delete( OptionsInterface::MERCHANT_ACCOUNT_STATE );
+			$this->options->delete( OptionsInterface::MERCHANT_CENTER );
+			$this->options->delete( OptionsInterface::MERCHANT_ID );
+			$this->options->delete( OptionsInterface::SITE_VERIFICATION );
+			$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
+			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_PRODUCT_STATISTICS );
 
 			return [
 				'status'  => 'success',
-				'message' => __( 'Successfully disconnected.', 'google-listings-and-ads' ),
+				'message' => __( 'Merchant Center account successfully disconnected.', 'google-listings-and-ads' ),
 			];
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -234,9 +234,9 @@ class AccountController extends BaseOptionsController {
 			$this->options->delete( OptionsInterface::MC_SETUP_SAVED_SETUP );
 			$this->options->delete( OptionsInterface::MERCHANT_ACCOUNT_STATE );
 			$this->options->delete( OptionsInterface::MERCHANT_CENTER );
-			$this->options->delete( OptionsInterface::MERCHANT_ID );
 			$this->options->delete( OptionsInterface::SITE_VERIFICATION );
 			$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
+
 			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_PRODUCT_STATISTICS );
 
 			return [

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -31,7 +31,7 @@ final class Options implements OptionsInterface, Service {
 		self::FILE_VERSION           => true,
 		self::INSTALL_TIMESTAMP      => true,
 		self::MC_SETUP_COMPLETED_AT  => true,
-		self::MC_SETUP_SAVED_SETUP   => true,
+		self::MC_SETUP_SAVED_STEP    => true,
 		self::MERCHANT_ACCOUNT_STATE => true,
 		self::MERCHANT_CENTER        => true,
 		self::MERCHANT_ID            => true,

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -31,6 +31,7 @@ final class Options implements OptionsInterface, Service {
 		self::FILE_VERSION           => true,
 		self::INSTALL_TIMESTAMP      => true,
 		self::MC_SETUP_COMPLETED_AT  => true,
+		self::MC_SETUP_SAVED_SETUP   => true,
 		self::MERCHANT_ACCOUNT_STATE => true,
 		self::MERCHANT_CENTER        => true,
 		self::MERCHANT_ID            => true,

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -19,6 +19,7 @@ interface OptionsInterface {
 	public const FILE_VERSION           = 'file_version';
 	public const INSTALL_TIMESTAMP      = 'install_timestamp';
 	public const MC_SETUP_COMPLETED_AT  = 'mc_setup_completed_at';
+	public const MC_SETUP_SAVED_SETUP   = 'setup_mc_saved_step';
 	public const MERCHANT_ACCOUNT_STATE = 'merchant_account_state';
 	public const MERCHANT_CENTER        = 'merchant_center';
 	public const MERCHANT_ID            = 'merchant_id';

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -19,7 +19,7 @@ interface OptionsInterface {
 	public const FILE_VERSION           = 'file_version';
 	public const INSTALL_TIMESTAMP      = 'install_timestamp';
 	public const MC_SETUP_COMPLETED_AT  = 'mc_setup_completed_at';
-	public const MC_SETUP_SAVED_SETUP   = 'setup_mc_saved_step';
+	public const MC_SETUP_SAVED_STEP    = 'setup_mc_saved_step';
 	public const MERCHANT_ACCOUNT_STATE = 'merchant_account_state';
 	public const MERCHANT_CENTER        = 'merchant_center';
 	public const MERCHANT_ID            = 'merchant_id';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #362 .

This makes sure all traces of the connected Merchant Center account are removed from the options table (`Options` and `Transients`).

It also adds a constant in `OptionsInterface` for the Merchant Center setup saved step option (currently manipulated independently from the client side).

The options cleared during disconnect are 
```
MC_SETUP_COMPLETED_AT  -> 'mc_setup_completed_at'
MC_SETUP_SAVED_SETUP   -> 'setup_mc_saved_step'
MERCHANT_ACCOUNT_STATE -> 'merchant_account_state'
MERCHANT_CENTER        -> 'merchant_center'
MERCHANT_ID            -> 'merchant_id'
SITE_VERIFICATION      -> 'site_verification'
TARGET_AUDIENCE        -> 'target_audience'
MC_PRODUCT_STATISTICS  -> 'mc_product_statistics'
```
**Note**
This process should probably be move to the `MerchantCenterService` once #367 is merged.

### Detailed test instructions:

1. Go through the full Merchant Center account setup process using the onboarding wizard
    - All three steps, `Set up your accounts`, `Choose your audience` and `Configure your product listings` 
2. Retrieve the product statistics for the Merchant Center with 
    `GET /wp-json/wc/gla/mc/product-statistics`
3. Confirm that all of the above options and transients are present in the database options table with 
    ```sql
    SELECT * FROM `wp_options` WHERE `option_name` LIKE '%gla_%'
    ```
4. Disconnect the Merchant Center account (using the `MC Disconnect` button on Connection Test page, or with 
    `DELETE /wc/gla/mc/connection`
5. Confirm that the listed options and transients  are all removed.

**Bonus**
- Restart the onboarding wizard and confirm that it starts on Step 1 instead of Step 3 (because the option is now deleted.
