### PR TITLE
Setup Ads - Handle HTTP 428 in front-end and complete ads account setup after approved billing status

### DIFF
--- a/js/src/setup-ads/ads-stepper/setup-billing/setup-card/useAutoCheckBillingStatusEffect.js
+++ b/js/src/setup-ads/ads-stepper/setup-billing/setup-card/useAutoCheckBillingStatusEffect.js
@@ -16,7 +16,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
  * Make API call to complete Google Ads account setup.
  */
 const completeGoogleAdsAccountSetup = async () => {
-	return await apiFetch( {
+	return apiFetch( {
 		path: `/wc/gla/ads/accounts`,
 		method: 'POST',
 	} );

--- a/js/src/setup-ads/ads-stepper/setup-billing/setup-card/useAutoCheckBillingStatusEffect.js
+++ b/js/src/setup-ads/ads-stepper/setup-billing/setup-card/useAutoCheckBillingStatusEffect.js
@@ -15,7 +15,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 /**
  * Make API call to complete Google Ads account setup.
  */
-const completeGoogleAdsAccountSetup = async () => {
+const completeGoogleAdsAccountSetup = () => {
 	return apiFetch( {
 		path: `/wc/gla/ads/accounts`,
 		method: 'POST',

--- a/js/src/setup-ads/ads-stepper/setup-billing/setup-card/useAutoCheckBillingStatusEffect.js
+++ b/js/src/setup-ads/ads-stepper/setup-billing/setup-card/useAutoCheckBillingStatusEffect.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -9,22 +10,51 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import { useAppDispatch } from '.~/data';
 import useWindowFocusCallbackIntervalEffect from '.~/hooks/useWindowFocusCallbackIntervalEffect';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+
+/**
+ * Make API call to complete Google Ads account setup.
+ */
+const completeGoogleAdsAccountSetup = async () => {
+	return await apiFetch( {
+		path: `/wc/gla/ads/accounts`,
+		method: 'POST',
+	} );
+};
 
 const useAutoCheckBillingStatusEffect = ( onStatusApproved = () => {} ) => {
+	const { createNotice } = useDispatchCoreNotices();
 	const { receiveGoogleAdsAccountBillingStatus } = useAppDispatch();
 
-	const checkStatus = useCallback( async () => {
+	const checkStatusAndCompleteSetup = useCallback( async () => {
 		const billingStatus = await apiFetch( {
 			path: '/wc/gla/ads/billing-status',
 		} );
 
-		if ( billingStatus.status === 'approved' ) {
+		if ( billingStatus.status !== 'approved' ) {
+			return;
+		}
+
+		try {
+			await completeGoogleAdsAccountSetup();
 			await onStatusApproved();
 			receiveGoogleAdsAccountBillingStatus( billingStatus );
+		} catch ( e ) {
+			createNotice(
+				'error',
+				__(
+					'Unable to complete your Google Ads account setup. Please try again later.',
+					'google-listings-and-ads'
+				)
+			);
 		}
-	}, [ onStatusApproved, receiveGoogleAdsAccountBillingStatus ] );
+	}, [
+		createNotice,
+		onStatusApproved,
+		receiveGoogleAdsAccountBillingStatus,
+	] );
 
-	useWindowFocusCallbackIntervalEffect( checkStatus, 30 );
+	useWindowFocusCallbackIntervalEffect( checkStatusAndCompleteSetup, 30 );
 };
 
 export default useAutoCheckBillingStatusEffect;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #378 .

This PR does two things: 

1. When users create a new Google Ads account in Setup Ads Step 1, there will be a HTTP 428 response that indicates "Billing setup must be completed". This PR suppresses the HTTP 428 error (doesn't show error notification toast) and allow the users to continue the onboarding flow.
2. In Setup Ads Step 3, when the billing status polling returns `status: 'approved'`, this PR proceed with another call to `POST /wc/gla/ads/accounts` to complete the ads account setup.

### Screenshots:

No UI change screenshot as this is data flow and API calls related changes.

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads
2. Open your browser dev tools > network panel.
2. Create a new Google Ads account. There should be no error notification toast.
3. Proceed through Step 2 and Step 3.
4. In Step 3, click on the "Setup billing" button and complete the Google Ads billing setup in the new tab. When you are done, close the Google Ads tab.
5. The GLA Setup Ads tab should automatically check for billing status, complete account setup, and display the GLA Dashboard page with a campaign creation success modal.

### Changelog Note:

Handle HTTP 428 in Setup Ads and complete account setup after billing status becomes approved.
