### PR TITLE
Display loading indicator when creating new Google Ads account in Setup Ads Step 1

### DIFF
--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account-button.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account-button.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
@@ -9,6 +8,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import TermsModal from './terms-modal';
+import AppButton from '.~/components/app-button';
 
 const CreateAccountButton = ( props ) => {
 	const { onCreateAccount, ...rest } = props;
@@ -24,9 +24,9 @@ const CreateAccountButton = ( props ) => {
 
 	return (
 		<>
-			<Button { ...rest } onClick={ handleButtonClick }>
+			<AppButton { ...rest } onClick={ handleButtonClick }>
 				{ __( 'Create Account', 'google-listings-and-ads' ) }
-			</Button>
+			</AppButton>
 			{ isOpen && (
 				<TermsModal
 					onCreateAccount={ onCreateAccount }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A follow-up from https://github.com/woocommerce/google-listings-and-ads/pull/377#issuecomment-808906004.

When we click on Create Account in the Google Ads section in Setup Ads Step 1, there is no loading indicator. This PR fixes that.

Thanks to @eason9487 for catching that bug.

### Screenshots:

![Create account button loading indicator](https://user-images.githubusercontent.com/417342/112756553-52574d00-9018-11eb-867c-d74370b66fb4.gif)

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads
2. You might want to throttle the network speed in your browser dev tools network panel, to see the loading indicator.
2. Create a new Google Ads account. Accept the terms. You should see loading indicator in the Create account button.

### Changelog Note:

Fix loading indicator not display in Create Account button in Setup Ads Step 1.