### PR TITLE
Setup Ads Step 2: format money value based on store's currency settings

### DIFF
--- a/js/src/hooks/useCurrencyFactory.js
+++ b/js/src/hooks/useCurrencyFactory.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import CurrencyFactory from '@woocommerce/currency';
+
+/**
+ * Gets the CurrencyFactory to format string based on the store's currency settings.
+ */
+const useCurrencyFactory = () => {
+	const currencySetting = useSelect( ( select ) => {
+		return select( SETTINGS_STORE_NAME ).getSetting(
+			'wc_admin',
+			'currency'
+		);
+	} );
+
+	return CurrencyFactory( currencySetting );
+};
+
+export default useCurrencyFactory;

--- a/js/src/setup-ads/ads-stepper/create-campaign/budget-section/index.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/budget-section/index.js
@@ -14,6 +14,7 @@ import './index.scss';
 import FreeAdCredit from './free-ad-credit';
 import BudgetRecommendation from './budget-recommendation';
 import useFreeAdCredit from '.~/hooks/useFreeAdCredit';
+import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
 
 const BudgetSection = ( props ) => {
 	const {
@@ -24,9 +25,22 @@ const BudgetSection = ( props ) => {
 		amount,
 	} = values;
 	const { code: currencyCode } = useStoreCurrency();
+	const { formatDecimalString } = useCurrencyFactory();
 	const hasFreeAdCredit = useFreeAdCredit();
 
 	const monthlyMaxEstimated = getMonthlyMaxEstimated( values.amount );
+
+	// format the amount input on blur.
+	const handleAmountBlur = () => {
+		const { value, onChange, onBlur } = getInputProps( 'amount' );
+		const newValue = formatDecimalString( value );
+
+		if ( newValue !== value ) {
+			onChange( newValue );
+		}
+
+		onBlur();
+	};
 
 	return (
 		<div className="gla-budget-section">
@@ -51,6 +65,7 @@ const BudgetSection = ( props ) => {
 								) }
 								suffix={ currencyCode }
 								{ ...getInputProps( 'amount' ) }
+								onBlur={ handleAmountBlur }
 							/>
 							<AppInputControl
 								disabled
@@ -59,7 +74,9 @@ const BudgetSection = ( props ) => {
 									'google-listings-and-ads'
 								) }
 								suffix={ currencyCode }
-								value={ monthlyMaxEstimated }
+								value={ formatDecimalString(
+									monthlyMaxEstimated
+								) }
 							/>
 						</div>
 						{ selectedCountryCode && (

--- a/js/src/setup-ads/ads-stepper/create-campaign/getMonthlyMaxEstimated.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/getMonthlyMaxEstimated.js
@@ -11,8 +11,6 @@
  * @param {number} dailyAverageCost The daily average cost provided by user.
  */
 const getMonthlyMaxEstimated = ( dailyAverageCost ) => {
-	// TODO: format the result based on the store currency settings.
-	// might need to use https://www.npmjs.com/package/@woocommerce/number.
 	return dailyAverageCost * 30.4;
 };
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 	},
 	"dependencies": {
 		"@woocommerce/components": "^5.1.2",
+		"@woocommerce/currency": "^3.0.0",
 		"@woocommerce/data": "^1.1.1",
 		"@woocommerce/date": "^2.1.0",
 		"@woocommerce/navigation": "^5.2.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #372 .

This PR formats the daily average cost and monthly max values based on the store's currency settings. It uses the [@woocommerce/currency package](https://www.npmjs.com/package/@woocommerce/currency) and format the values during the input field's `onChange` and `onBlur` events.

### Screenshots:

![Format money values based on store's currency settings](https://user-images.githubusercontent.com/417342/112802334-a3148780-90a4-11eb-86ba-82c0acc981f2.gif)

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads.
2. Proceed to Step 2.
3. Key in a value for the daily average cost. The monthly max result should be formatted based on the store's currency settings.
4. Click outside the daily average cost field (essentially triggering the input field's `blur` event). The daily average cost and monthly max values would be formatted based on the store's currency settings.

### Changelog Note:

Format the money values based on the store's currency settings in Setup Ads Step 2.
