### PR TITLE
Add REST endpoint to mark Ads Setup Complete

### DIFF
--- a/src/API/Site/Controllers/Ads/SetupCompleteController.php
+++ b/src/API/Site/Controllers/Ads/SetupCompleteController.php
@@ -1,0 +1,67 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SetupCompleteController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
+ */
+class SetupCompleteController extends BaseController {
+
+	use EmptySchemaPropertiesTrait;
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+		$this->register_route(
+			'ads/setup/complete',
+			[
+				[
+					'methods'             => TransportMethods::CREATABLE,
+					'callback'            => $this->get_setup_complete_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the callback function for marking setup complete.
+	 *
+	 * @return callable
+	 */
+	protected function get_setup_complete_callback(): callable {
+		return function( Request $request ) {
+			do_action( 'gla_ads_setup_completed' );
+
+			return new Response(
+				[
+					'status'  => 'success',
+					'message' => __( 'Successfully marked Ads setup as completed.', 'google-listings-and-ads' ),
+				]
+			);
+		};
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'ads_setup_complete';
+	}
+}

--- a/src/API/Site/Controllers/DisconnectController.php
+++ b/src/API/Site/Controllers/DisconnectController.php
@@ -16,6 +16,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class DisconnectController extends BaseController {
 
+	use EmptySchemaPropertiesTrait;
+
 	/**
 	 * Register rest routes with WordPress.
 	 */
@@ -78,15 +80,6 @@ class DisconnectController extends BaseController {
 		$path = ltrim( $path, '/' );
 
 		return $this->server->dispatch_request( new Request( 'DELETE', "/{$this->get_namespace()}/{$path}" ) );
-	}
-
-	/**
-	 * Get the item schema properties for the controller.
-	 *
-	 * @return array
-	 */
-	protected function get_schema_properties(): array {
-		return [];
 	}
 
 	/**

--- a/src/API/Site/Controllers/EmptySchemaPropertiesTrait.php
+++ b/src/API/Site/Controllers/EmptySchemaPropertiesTrait.php
@@ -1,0 +1,21 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
+
+/**
+ * Trait EmptySchemaPropertiesTrait
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers
+ */
+trait EmptySchemaPropertiesTrait {
+
+	/**
+	 * Get the item schema properties for the controller.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [];
+	}
+}

--- a/src/API/Site/Controllers/Google/SiteVerificationController.php
+++ b/src/API/Site/Controllers/Google/SiteVerificationController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Googl
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
@@ -18,6 +19,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Onboarding
  */
 class SiteVerificationController extends BaseOptionsController {
+
+	use EmptySchemaPropertiesTrait;
 
 	/**
 	 * @var SiteVerification
@@ -177,15 +180,6 @@ class SiteVerificationController extends BaseOptionsController {
 					'message'  => $verified ? __( 'Site already verified.', 'google-listings-and-ads' ) : __( 'Site not verified.', 'google-listings-and-ads' ),
 				];
 			};
-	}
-
-	/**
-	 * Get the item schema for the controller.
-	 *
-	 * @return array
-	 */
-	protected function get_schema_properties(): array {
-		return [];
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\WPErrorTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
@@ -21,6 +22,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class SettingsSyncController extends BaseController {
 
+	use EmptySchemaPropertiesTrait;
 	use WPErrorTrait;
 
 	/** @var Settings */
@@ -96,15 +98,6 @@ class SettingsSyncController extends BaseController {
 				);
 			}
 		};
-	}
-
-	/**
-	 * Get the item schema properties for the controller.
-	 *
-	 * @return array
-	 */
-	protected function get_schema_properties(): array {
-		return [];
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/SupportedCountriesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SupportedCountriesController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
@@ -20,6 +21,7 @@ defined( 'ABSPATH' ) || exit;
 class SupportedCountriesController extends BaseController {
 
 	use CountryCodeTrait;
+	use EmptySchemaPropertiesTrait;
 	use GoogleHelper;
 
 	/**
@@ -89,15 +91,6 @@ class SupportedCountriesController extends BaseController {
 		}
 
 		return $supported;
-	}
-
-	/**
-	 * Get the item schema properties for the controller.
-	 *
-	 * @return array
-	 */
-	protected function get_schema_properties(): array {
-		return [];
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -7,6 +7,7 @@ use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\SetupCompleteController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\DisconnectController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Google\AccountController as GoogleAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController as AdsAccountController;
@@ -78,6 +79,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( SupportedCountriesController::class, WC::class );
 		$this->share( SettingsSyncController::class, Settings::class );
 		$this->share( DisconnectController::class );
+		$this->share( SetupCompleteController::class );
 	}
 
 	/**

--- a/src/Options/AdsSetupCompleted.php
+++ b/src/Options/AdsSetupCompleted.php
@@ -27,7 +27,7 @@ class AdsSetupCompleted implements OptionsAwareInterface, Registerable, Service 
 	 */
 	public function register(): void {
 		add_action(
-			'gla_ads_settings_sync',
+			'gla_ads_setup_completed',
 			function() {
 				$this->set_completed_timestamp();
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #365.

This renames the `gla_ads_settings_sync` hook to `gla_ads_setup_completed`, which more accurately describes its purpose.

This PR also adds a new REST endpoint:

```
POST /wp-json/wc/gla/ads/setup/complete
```

Sending a request to this endpoint will trigger the `gla_ads_setup_completed` hook to fire, which will in turn allow the `AdsSetupCompleted` class to update the option.

### Detailed test instructions:

1. Send a `POST` request to the `/wp-jsonWc/gla/ads/setup/complete` endpoint
2. Check the `options` table in the database to see the `gla_ads_setup_completed_at` option has been set to the current timestamp

