### PR TITLE
Call ads setup completion API when it's able to continue the final step

### DIFF
--- a/js/src/setup-ads/setup-ads-form-content.js
+++ b/js/src/setup-ads/setup-ads-form-content.js
@@ -12,7 +12,7 @@ import SetupAdsTopBar from './top-bar';
 
 const SetupAdsFormContent = ( props ) => {
 	const { formProps } = props;
-	// FIX: the form dirty checking should return `true`` after successful creating the campaign,
+	// FIX: the form dirty checking should return `true` after successful creating the campaign,
 	//      or it would be triggered when exiting the Google ads setup page
 	const shouldPreventClose = isFormDirty( formProps );
 

--- a/js/src/setup-ads/setup-ads-form-content.js
+++ b/js/src/setup-ads/setup-ads-form-content.js
@@ -12,6 +12,8 @@ import SetupAdsTopBar from './top-bar';
 
 const SetupAdsFormContent = ( props ) => {
 	const { formProps } = props;
+	// FIX: the form dirty checking should return `true`` after successful creating the campaign,
+	//      or it would be triggered when exiting the Google ads setup page
 	const shouldPreventClose = isFormDirty( formProps );
 
 	useEffect( () => {


### PR DESCRIPTION
This is a follow-on PR to call the setup complete API provided by #397, so it depends on the `feature/onboarding_timestamp` branch currently.

### Changes proposed in this Pull Request:

Closes #365 .
- Call ads setup completion API when it's able to continue the final step

### Screenshots:


https://user-images.githubusercontent.com/17420811/113115254-d25efc00-923e-11eb-926b-51a28f94d799.mp4



### Detailed test instructions:

If you want to skip the billing part, you can add a line under the `return <AppSpinner />` condition in [this file](https://github.com/woocommerce/google-listings-and-ads/blob/284997d6a1d712a7b92acfafc081f67b5c1c86fc/js/src/setup-ads/ads-stepper/setup-billing/index.js#L99-L101). For example:
```js
	if ( ! billingStatus ) {
		return <AppSpinner />;
	}

	billingStatus.status = 'approved';
```

1. Delete the `gla_ads_setup_completed_at` wp option from your database if it exist
    `delete from wp_options where option_name = 'gla_ads_setup_completed_at';`
2. Head to the Dashboard page: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`
3. A promotion content should show up in the "Performance (Paid Campaigns)" area before completing ads setup
4. Go to the paid campaign setup page by clicking on the "Add Paid Campaign" button
5. Finish the setup and then you should be redirected back to the Dashboard page
6. The  "Performance (Paid Campaigns)" area should display performance data instead of promotion content.

### Additional notes

- Before the redirection happened at the 6th step of test instructions, an unsaved change prompt will pop up. It's an out-of-scope issue needs to be addressed by another PR, and there is also an ongoing RP #393 related to it.
- You may encounter an error due to a campaign with this name already exists, then you need to delete that campaign from [Google Ads console](https://ads.google.com/)
