### PR TITLE
Add batch delete APIs for shipping rates and times

### DIFF
--- a/src/API/Site/Controllers/BatchSchemaTrait.php
+++ b/src/API/Site/Controllers/BatchSchemaTrait.php
@@ -3,6 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
 
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -46,5 +49,49 @@ trait BatchSchemaTrait {
 		];
 
 		return $schema;
+	}
+
+	/**
+	 * Get the schema for a batch DELETE request.
+	 *
+	 * @return array
+	 */
+	public function get_item_delete_schema(): array {
+		$schema = $this->get_item_schema();
+		unset( $schema['rate'], $schema['currency'] );
+
+		return $schema;
+	}
+
+	/**
+	 * Get the callback for deleting shipping items via batch.
+	 *
+	 * @return callable
+	 */
+	public function get_batch_delete_shipping_callback(): callable {
+		return function( Request $request ) {
+			$country_codes = $request->get_param( 'country_codes' );
+
+			$responses = [];
+			$errors    = [];
+			foreach ( $country_codes as $country_code ) {
+				$route          = "/{$this->get_namespace()}/{$this->route_base}/{$country_code}";
+				$delete_request = new Request( 'DELETE', $route );
+
+				$response = $this->server->dispatch_request( $delete_request );
+				if ( 200 !== $response->get_status() ) {
+					$errors[] = $response->get_data();
+				} else {
+					$responses[] = $response->get_data();
+				}
+			}
+
+			return new Response(
+				[
+					'errors'  => $errors,
+					'success' => $responses,
+				],
+			);
+		};
 	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
@@ -32,6 +32,12 @@ class ShippingRateBatchController extends ShippingRateController {
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_item_schema(),
 				],
+				[
+					'methods'             => TransportMethods::DELETABLE,
+					'callback'            => $this->get_batch_delete_shipping_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_item_delete_schema(),
+				],
 				'schema' => $this->get_api_response_schema_callback(),
 			]
 		);

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeBatchController.php
@@ -32,6 +32,12 @@ class ShippingTimeBatchController extends ShippingTimeController {
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_item_schema(),
 				],
+				[
+					'methods'             => TransportMethods::DELETABLE,
+					'callback'            => $this->get_batch_delete_shipping_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_item_delete_schema(),
+				],
 				'schema' => $this->get_api_response_schema_callback(),
 			]
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add batch delete API to resolve the bouncy (#358) or too many connections problem when deleting shipping rates/times.

1. A new `DELETE /wc/gla/mc/shipping/rates/batch` endpoint to allow for deleting multiple shipping **rates** at once. A request to this endpoint would look like this:

```json
{
	"country_codes": [
		"JP",
		"US"
	],
}
```

1. A new `DELETE /wc/gla/mc/shipping/times/batch` endpoint to allow for deleting multiple shipping **times** at once. A request to this endpoint would look like this:

```json
{
	"country_codes": [
		"JP",
		"US"
	],
}
```

### Screenshots:

Problems to be solved: too many connections

![oops](https://user-images.githubusercontent.com/17420811/113247101-e2cdb000-92ec-11eb-9066-475ca93a1cad.png)


### Detailed test instructions:

Apologies, I can't find how to write the API related test steps at the moment. ~~I will open another PR with client-side changes based on this branch to provide a more comprehensive test.~~

If you want to test this PR with client-side changes, please refer to PR #412. 🙏 

### Doubt

❓  Since the batch deletion operation of shipping rates and times is exactly the same, I'm not sure if it's a correct practice to put the shared method at **BatchSchemaTrait.php**.

https://github.com/woocommerce/google-listings-and-ads/blob/5fdb9ec6924ce380623b9c09905a196730e5b63f/src/API/Site/Controllers/BatchSchemaTrait.php#L66-L96