### PR TITLE
Fix bouncy shipping times/rates when updating/deleting multiple countries

### DIFF
--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoClearShippingEffect.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoClearShippingEffect.js
@@ -19,12 +19,13 @@ const wait = 500;
 const useAutoClearShippingEffect = ( location, countries ) => {
 	const { data: shippingRates } = useShippingRates();
 	const { data: shippingTimes } = useShippingTimes();
-	const { deleteShippingRate, deleteShippingTime } = useAppDispatch();
+	const { deleteShippingRates, deleteShippingTime } = useAppDispatch();
 
 	const debouncedDelete = useDebouncedCallback( async () => {
-		shippingRates.forEach( ( el ) => {
-			deleteShippingRate( el.countryCode );
-		} );
+		if ( shippingRates.length ) {
+			const countryCodes = shippingRates.map( ( el ) => el.countryCode );
+			deleteShippingRates( countryCodes );
+		}
 
 		shippingTimes.forEach( ( el ) => {
 			deleteShippingTime( el.countryCode );

--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoClearShippingEffect.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoClearShippingEffect.js
@@ -19,7 +19,7 @@ const wait = 500;
 const useAutoClearShippingEffect = ( location, countries ) => {
 	const { data: shippingRates } = useShippingRates();
 	const { data: shippingTimes } = useShippingTimes();
-	const { deleteShippingRates, deleteShippingTime } = useAppDispatch();
+	const { deleteShippingRates, deleteShippingTimes } = useAppDispatch();
 
 	const debouncedDelete = useDebouncedCallback( async () => {
 		if ( shippingRates.length ) {
@@ -27,9 +27,10 @@ const useAutoClearShippingEffect = ( location, countries ) => {
 			deleteShippingRates( countryCodes );
 		}
 
-		shippingTimes.forEach( ( el ) => {
-			deleteShippingTime( el.countryCode );
-		} );
+		if ( shippingTimes.length ) {
+			const countryCodes = shippingTimes.map( ( el ) => el.countryCode );
+			deleteShippingTimes( countryCodes );
+		}
 	}, wait );
 
 	const locationRef = useRef( null );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -18,7 +18,7 @@ import useGetRemainingCountryCodes from './useGetRemainingCountryCodes';
 
 const AddRateModal = ( props ) => {
 	const { onRequestClose } = props;
-	const { upsertShippingRate } = useAppDispatch();
+	const { upsertShippingRates } = useAppDispatch();
 	const { code } = useStoreCurrency();
 	const remainingCountryCodes = useGetRemainingCountryCodes();
 
@@ -33,12 +33,10 @@ const AddRateModal = ( props ) => {
 	const handleSubmitCallback = ( values ) => {
 		const { countryCodes, currency, rate } = values;
 
-		countryCodes.forEach( ( el ) => {
-			upsertShippingRate( {
-				countryCode: el,
-				currency,
-				rate,
-			} );
+		upsertShippingRates( {
+			countryCodes,
+			currency,
+			rate,
 		} );
 
 		onRequestClose();

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
@@ -14,15 +14,14 @@ import CountriesPriceInput from '../countries-price-input';
 const CountriesPriceInputForm = ( props ) => {
 	const { initialValue } = props;
 	const [ value, setValue ] = useState( initialValue );
-	const { upsertShippingRate } = useDispatch( STORE_KEY );
+	const { upsertShippingRates } = useDispatch( STORE_KEY );
 	const debouncedUpsertShippingRate = useDebouncedCallback( ( v ) => {
 		const { countries, currency, price } = v;
-		countries.forEach( async ( el ) => {
-			await upsertShippingRate( {
-				countryCode: el,
-				currency,
-				rate: price,
-			} );
+
+		upsertShippingRates( {
+			countryCodes: countries,
+			currency,
+			rate: price,
 		} );
 	}, 500 );
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -17,12 +17,10 @@ import './index.scss';
 
 const EditRateModal = ( props ) => {
 	const { rate, onRequestClose } = props;
-	const { upsertShippingRate, deleteShippingRate } = useAppDispatch();
+	const { upsertShippingRates, deleteShippingRates } = useAppDispatch();
 
 	const handleDeleteClick = () => {
-		rate.countries.forEach( ( el ) => {
-			deleteShippingRate( el );
-		} );
+		deleteShippingRates( rate.countries );
 
 		onRequestClose();
 	};
@@ -38,20 +36,19 @@ const EditRateModal = ( props ) => {
 	const handleSubmitCallback = ( values ) => {
 		const { countryCodes, currency, price } = values;
 
-		countryCodes.forEach( ( el ) => {
-			upsertShippingRate( {
-				countryCode: el,
-				currency,
-				rate: price,
-			} );
+		upsertShippingRates( {
+			countryCodes,
+			currency,
+			rate: price,
 		} );
 
 		const valuesCountrySet = new Set( values.countryCodes );
-		rate.countries.forEach( ( el ) => {
-			if ( ! valuesCountrySet.has( el ) ) {
-				deleteShippingRate( el );
-			}
-		} );
+		const deletedCountryCodes = rate.countries.filter(
+			( el ) => ! valuesCountrySet.has( el )
+		);
+		if ( deletedCountryCodes.length ) {
+			deleteShippingRates( deletedCountryCodes );
+		}
 
 		onRequestClose();
 	};

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -17,7 +17,7 @@ import useGetRemainingCountryCodes from './useGetRemainingCountryCodes';
 
 const AddTimeModal = ( props ) => {
 	const { onRequestClose } = props;
-	const { upsertShippingTime } = useAppDispatch();
+	const { upsertShippingTimes } = useAppDispatch();
 	const remainingCountryCodes = useGetRemainingCountryCodes();
 
 	const handleValidate = () => {
@@ -29,14 +29,7 @@ const AddTimeModal = ( props ) => {
 	};
 
 	const handleSubmitCallback = ( values ) => {
-		const { countryCodes, time } = values;
-
-		countryCodes.forEach( ( el ) => {
-			upsertShippingTime( {
-				countryCode: el,
-				time,
-			} );
-		} );
+		upsertShippingTimes( values );
 
 		onRequestClose();
 	};

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
@@ -14,15 +14,10 @@ import CountriesTimeInput from '../countries-time-input';
 const CountriesTimeInputForm = ( props ) => {
 	const { initialValue } = props;
 	const [ value, setValue ] = useState( initialValue );
-	const { upsertShippingTime } = useDispatch( STORE_KEY );
+	const { upsertShippingTimes } = useDispatch( STORE_KEY );
 	const debouncedUpsertShippingTime = useDebouncedCallback( ( v ) => {
-		const { countries, time } = v;
-		countries.forEach( async ( el ) => {
-			await upsertShippingTime( {
-				countryCode: el,
-				time,
-			} );
-		} );
+		const { countries: countryCodes, time } = v;
+		upsertShippingTimes( { countryCodes, time } );
 	}, 500 );
 
 	const handleChange = ( v ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -17,12 +17,10 @@ import { useAppDispatch } from '.~/data';
 
 const EditTimeModal = ( props ) => {
 	const { time: groupedTime, onRequestClose } = props;
-	const { upsertShippingTime, deleteShippingTime } = useAppDispatch();
+	const { upsertShippingTimes, deleteShippingTimes } = useAppDispatch();
 
 	const handleDeleteClick = () => {
-		groupedTime.countries.forEach( ( el ) => {
-			deleteShippingTime( el );
-		} );
+		deleteShippingTimes( groupedTime.countries );
 
 		onRequestClose();
 	};
@@ -36,21 +34,15 @@ const EditTimeModal = ( props ) => {
 	};
 
 	const handleSubmitCallback = ( values ) => {
-		const { countryCodes, time } = values;
-
-		countryCodes.forEach( ( el ) => {
-			upsertShippingTime( {
-				countryCode: el,
-				time,
-			} );
-		} );
+		upsertShippingTimes( values );
 
 		const valuesCountrySet = new Set( values.countryCodes );
-		groupedTime.countries.forEach( ( el ) => {
-			if ( ! valuesCountrySet.has( el ) ) {
-				deleteShippingTime( el );
-			}
-		} );
+		const deletedCountryCodes = groupedTime.countries.filter(
+			( el ) => ! valuesCountrySet.has( el )
+		);
+		if ( deletedCountryCodes.length ) {
+			deleteShippingTimes( deletedCountryCodes );
+		}
 
 		onRequestClose();
 	};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #358 .

Migrate the usages of upsert and deletion of shipping rates and times to batch actions.

### Screenshots:

![Kapture 2021-04-01 at 15 39 17](https://user-images.githubusercontent.com/17420811/113260345-bcb20b00-9300-11eb-9f6f-02b0652ec695.gif)

### Detailed test instructions:

1. Head to the MC onboarding flow: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`
2. The upsert/deletion of shipping rates and times should work as before
3. Switch to step 2 and change the **Location** settings, saved shipping rates/times should be removed through batch APIs
4. All relevant upsert/deletion requests should be called to batch APIs
5. The UI bouncy problem should be addressed

### Additional notes

These deprecated actions will be removed separately after all relevant collaborations are completed

https://github.com/woocommerce/google-listings-and-ads/blob/e9d158a41df04fa3455ee22257a318a9c3ffde35/js/src/data/actions.js#L504-L525