### PR TITLE
Delete all objects before deleting the campaign

### DIFF
--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\PositiveInteger;
 use Google\Ads\GoogleAds\Util\FieldMasks;
 use Google\Ads\GoogleAds\V6\Enums\MerchantCenterLinkStatusEnum\MerchantCenterLinkStatus;
 use Google\Ads\GoogleAds\V6\Resources\MerchantCenterLink;

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -225,6 +225,8 @@ class AdsCampaign implements OptionsAwareInterface {
 			$operation->setRemove( $resource_name );
 			$deleted_campaign = $this->mutate_campaign( $operation );
 
+			$this->ads_campaign_budget->remove_campaign_budget( $campaign_id );
+
 			return $this->parse_campaign_id( $deleted_campaign->getResourceName() );
 		} catch ( ApiException $e ) {
 			do_action( 'gla_ads_client_exception', $e, __METHOD__ );

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -219,13 +219,13 @@ class AdsCampaign implements OptionsAwareInterface {
 		try {
 			$resource_name = ResourceNames::forCampaign( $this->options->get_ads_id(), $campaign_id );
 
-			$this->ads_group->remove_for_campaign( $resource_name );
+			$this->ads_group->delete_for_campaign( $resource_name );
 
 			$operation = new CampaignOperation();
 			$operation->setRemove( $resource_name );
 			$deleted_campaign = $this->mutate_campaign( $operation );
 
-			$this->ads_campaign_budget->remove_campaign_budget( $campaign_id );
+			$this->ads_campaign_budget->delete_campaign_budget( $campaign_id );
 
 			return $this->parse_campaign_id( $deleted_campaign->getResourceName() );
 		} catch ( ApiException $e ) {

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -218,9 +218,13 @@ class AdsCampaign implements OptionsAwareInterface {
 	public function delete_campaign( int $campaign_id ): int {
 		try {
 			$resource_name = ResourceNames::forCampaign( $this->options->get_ads_id(), $campaign_id );
-			$operation     = new CampaignOperation();
+
+			$this->ads_group->remove_for_campaign( $resource_name );
+
+			$operation = new CampaignOperation();
 			$operation->setRemove( $resource_name );
 			$deleted_campaign = $this->mutate_campaign( $operation );
+
 			return $this->parse_campaign_id( $deleted_campaign->getResourceName() );
 		} catch ( ApiException $e ) {
 			do_action( 'gla_ads_client_exception', $e, __METHOD__ );

--- a/src/API/Google/AdsCampaignBudget.php
+++ b/src/API/Google/AdsCampaignBudget.php
@@ -98,10 +98,10 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 	 * @param int $campaign_id
 	 *
 	 * @return array resource names of deleted budgets.
-	 * @throws ApiException If the budget isn't removed.
+	 * @throws ApiException If the budget isn't deleted.
 	 * @throws Exception If no linked budget has been found.
 	 */
-	public function remove_campaign_budget( int $campaign_id ): array {
+	public function delete_campaign_budget( int $campaign_id ): array {
 		$budget_id            = $this->get_budget_from_campaign( $campaign_id );
 		$budget_resource_name = ResourceNames::forCampaignBudget( $this->options->get_ads_id(), $budget_id );
 

--- a/src/API/Google/AdsCampaignBudget.php
+++ b/src/API/Google/AdsCampaignBudget.php
@@ -95,6 +95,23 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 	}
 
 	/**
+	 * @param int $campaign_id
+	 *
+	 * @return array resource names of deleted budgets.
+	 * @throws ApiException If the budget isn't removed.
+	 * @throws Exception If no linked budget has been found.
+	 */
+	public function remove_campaign_budget( int $campaign_id ): array {
+		$budget_id            = $this->get_budget_from_campaign( $campaign_id );
+		$budget_resource_name = ResourceNames::forCampaignBudget( $this->options->get_ads_id(), $budget_id );
+
+		$operation = new CampaignBudgetOperation();
+		$operation->setRemove( $budget_resource_name );
+		$deleted_budget = $this->mutate_budget( $operation );
+		return [ $deleted_budget->getResourceName() ];
+	}
+
+	/**
 	 * Retrieve the linked budget ID from a campaign ID.
 	 *
 	 * @param int $campaign_id Campaign ID.

--- a/src/API/Google/AdsGroup.php
+++ b/src/API/Google/AdsGroup.php
@@ -78,7 +78,7 @@ class AdsGroup implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Remove the additional objects for the specified campaign:
+	 * Delete the additional objects for the specified campaign:
 	 * Ad group
 	 * Ad group ad
 	 * Listing group
@@ -87,12 +87,12 @@ class AdsGroup implements OptionsAwareInterface {
 	 *
 	 * @param string $campaign_resource_name
 	 *
-	 * @throws ApiException|ValidationException If any object isn't removed.
+	 * @throws ApiException|ValidationException If any object isn't deleted.
 	 */
-	public function remove_for_campaign( string $campaign_resource_name ) {
-		$this->remove_shopping_listing_group( $campaign_resource_name );
-		$this->remove_ad_group_ad( $campaign_resource_name );
-		$this->remove_ad_group( $campaign_resource_name );
+	public function delete_for_campaign( string $campaign_resource_name ) {
+		$this->delete_shopping_listing_group( $campaign_resource_name );
+		$this->delete_ad_group_ad( $campaign_resource_name );
+		$this->delete_ad_group( $campaign_resource_name );
 	}
 
 	/**
@@ -124,10 +124,10 @@ class AdsGroup implements OptionsAwareInterface {
 	 * @param string $campaign_resource_name
 	 *
 	 * @return array resource names of deleted ad groups
-	 * @throws ApiException If the ad group isn't removed.
+	 * @throws ApiException If the ad group isn't deleted.
 	 * @throws ValidationException If the ad group query has no results.
 	 */
-	public function remove_ad_group( string $campaign_resource_name ): array {
+	public function delete_ad_group( string $campaign_resource_name ): array {
 		$return   = [];
 		$query    = $this->build_query(
 			[ 'ad_group.resource_name' ],
@@ -189,10 +189,10 @@ class AdsGroup implements OptionsAwareInterface {
 	 * @param string $campaign_resource_name
 	 *
 	 * @return array resource names of deleted ad group ads
-	 * @throws ApiException If the ad group ad isn't removed.
+	 * @throws ApiException If the ad group ad isn't deleted.
 	 * @throws ValidationException If the ad group ad query has no results.
 	 */
-	public function remove_ad_group_ad( string $campaign_resource_name ): array {
+	public function delete_ad_group_ad( string $campaign_resource_name ): array {
 		$return   = [];
 		$query    = $this->build_query(
 			[ 'ad_group_ad.resource_name' ],
@@ -254,10 +254,10 @@ class AdsGroup implements OptionsAwareInterface {
 	 * @param string $campaign_resource_name
 	 *
 	 * @return array resource names of deleted shopping list groups
-	 * @throws ApiException If the ad group criterion isn't removed.
+	 * @throws ApiException If the ad group criterion isn't deleted.
 	 * @throws ValidationException If the ad group criterion query has no results.
 	 */
-	protected function remove_shopping_listing_group( string $campaign_resource_name ): array {
+	protected function delete_shopping_listing_group( string $campaign_resource_name ): array {
 		$return   = [];
 		$query    = $this->build_query(
 			[ 'ad_group_criterion.resource_name' ],

--- a/src/API/Google/AdsGroup.php
+++ b/src/API/Google/AdsGroup.php
@@ -19,10 +19,12 @@ use Google\Ads\GoogleAds\V6\Resources\AdGroupCriterion;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdOperation;
 use Google\Ads\GoogleAds\V6\Services\AdGroupCriterionOperation;
 use Google\Ads\GoogleAds\V6\Services\AdGroupOperation;
+use Google\Ads\GoogleAds\V6\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V6\Services\MutateAdGroupAdResult;
 use Google\Ads\GoogleAds\V6\Services\MutateAdGroupCriterionResult;
 use Google\Ads\GoogleAds\V6\Services\MutateAdGroupResult;
 use Google\ApiCore\ApiException;
+use Google\ApiCore\ValidationException;
 
 /**
  * Class AdsGroup
@@ -35,6 +37,7 @@ use Google\ApiCore\ApiException;
 class AdsGroup implements OptionsAwareInterface {
 
 	use OptionsAwareTrait;
+	use AdsQueryTrait;
 
 	/**
 	 * The Google Ads Client.
@@ -75,6 +78,24 @@ class AdsGroup implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Remove the additional objects for the specified campaign:
+	 * Ad group
+	 * Ad group ad
+	 * Listing group
+	 *
+	 * Should only be called before removing the campaign.
+	 *
+	 * @param string $campaign_resource_name
+	 *
+	 * @throws ApiException|ValidationException If any object isn't removed.
+	 */
+	public function remove_for_campaign( string $campaign_resource_name ) {
+		$this->remove_shopping_listing_group( $campaign_resource_name );
+		$this->remove_ad_group_ad( $campaign_resource_name );
+		$this->remove_ad_group( $campaign_resource_name );
+	}
+
+	/**
 	 * @param string $campaign_resource_name
 	 * @param string $campaign_name
 	 *
@@ -97,6 +118,33 @@ class AdsGroup implements OptionsAwareInterface {
 		$created_ad_group = $this->mutate_ad_group( $operation );
 
 		return $created_ad_group->getResourceName();
+	}
+
+	/**
+	 * @param string $campaign_resource_name
+	 *
+	 * @return array resource names of deleted ad groups
+	 * @throws ApiException If the ad group isn't removed.
+	 * @throws ValidationException If the ad group query has no results.
+	 */
+	public function remove_ad_group( string $campaign_resource_name ): array {
+		$return   = [];
+		$query    = $this->build_query(
+			[ 'ad_group.resource_name' ],
+			'ad_group',
+			'ad_group.campaign = "' . $campaign_resource_name . '"'
+		);
+		$response = $this->query( $query );
+
+		/** @var GoogleAdsRow $row */
+		foreach ( $response->iterateAllElements() as $row ) {
+			$resource_name = $row->getAdGroup()->getResourceName();
+			$operation     = new AdGroupOperation();
+			$operation->setRemove( $resource_name );
+			$deleted_ad_group = $this->mutate_ad_group( $operation );
+			$return[]         = $deleted_ad_group->getResourceName();
+		}
+		return $return;
 	}
 
 	/**
@@ -138,6 +186,33 @@ class AdsGroup implements OptionsAwareInterface {
 	}
 
 	/**
+	 * @param string $campaign_resource_name
+	 *
+	 * @return array resource names of deleted ad group ads
+	 * @throws ApiException If the ad group ad isn't removed.
+	 * @throws ValidationException If the ad group ad query has no results.
+	 */
+	public function remove_ad_group_ad( string $campaign_resource_name ): array {
+		$return   = [];
+		$query    = $this->build_query(
+			[ 'ad_group_ad.resource_name' ],
+			'ad_group_ad',
+			'ad_group.campaign = "' . $campaign_resource_name . '"'
+		);
+		$response = $this->query( $query );
+
+		/** @var GoogleAdsRow $row */
+		foreach ( $response->iterateAllElements() as $row ) {
+			$resource_name = $row->getAdGroupAd()->getResourceName();
+			$operation     = new AdGroupAdOperation();
+			$operation->setRemove( $resource_name );
+			$deleted_ad_group_ad = $this->mutate_ad_group_ad( $operation );
+			$return[]            = $deleted_ad_group_ad->getResourceName();
+		}
+		return $return;
+	}
+
+	/**
 	 * @param AdGroupAdOperation $operation
 	 *
 	 * @return MutateAdGroupAdResult
@@ -170,9 +245,37 @@ class AdsGroup implements OptionsAwareInterface {
 		// Creates an ad group criterion operation.
 		$operation = new AdGroupCriterionOperation();
 		$operation->setCreate( $ad_group_criterion );
-		$created_ad_group_ad = $this->mutate_shopping_listing_group( $operation );
+		$created_ad_group_criterion = $this->mutate_shopping_listing_group( $operation );
 
-		return $created_ad_group_ad->getResourceName();
+		return $created_ad_group_criterion->getResourceName();
+	}
+
+	/**
+	 * @param string $campaign_resource_name
+	 *
+	 * @return array resource names of deleted shopping list groups
+	 * @throws ApiException If the ad group criterion isn't removed.
+	 * @throws ValidationException If the ad group criterion query has no results.
+	 */
+	protected function remove_shopping_listing_group( string $campaign_resource_name ): array {
+		$return   = [];
+		$query    = $this->build_query(
+			[ 'ad_group_criterion.resource_name' ],
+			'ad_group_criterion',
+			'ad_group.campaign = "' . $campaign_resource_name . '"'
+		);
+		$response = $this->query( $query );
+
+		/** @var GoogleAdsRow $row */
+		foreach ( $response->iterateAllElements() as $row ) {
+			$resource_name = $row->getAdGroupCriterion()->getResourceName();
+			$operation     = new AdGroupCriterionOperation();
+			$operation->setRemove( $resource_name );
+			$deleted_ad_group_criterion = $this->mutate_shopping_listing_group( $operation );
+			$return[]                   = $deleted_ad_group_criterion->getResourceName();
+		}
+
+		return $return;
 	}
 
 	/**

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\PositiveInteger;
 use Google_Service_ShoppingContent as ShoppingService;
 use Google_Service_ShoppingContent_Account as MC_Account;
 use Google_Service_ShoppingContent_AccountAdsLink as MC_Account_Ads_Link;

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -10,7 +10,6 @@
 namespace Automattic\WooCommerce\GoogleListingsAndAds;
 
 use Automattic\Jetpack\Connection\Manager;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #390.

This PR removes the objects associated with a campaign that's set to be removed:
![image](https://user-images.githubusercontent.com/228780/113302035-f6364680-92ff-11eb-8001-b3ce38ba6e97.png)

The objects removed are:
- Ad group
- Ad group ad (Ad)
- Ad group criterion (Product group)
- Campaign budget

Using the campaign's `resource_name` and `id`, each type of entity is queried, and any associated objects are removed. Note that they aren't deleted, but set to `REMOVED`, same as the campaign.


### Detailed test instructions:
1. Create a campaign (either with the extension in WordPress or with an API call to `POST /wp-json/wc/gla/ads/campaigns` (with `country`, `amount`, and `name` in the body). 
    - Make a note of the returned campaign `id` (can be found in the Ads panel by clicking on the campaign from the list: `https://ads.google.com/aw/adgroups?campaignId=[CAMPAIGN ID]....`)
2. In the Ads panel, confirm that the campaign has an associated Ad group, Ad, and Product group.
3. Delete the campaign with an API call to
    `DELETE /wp-json/wc/gla/ads/campaigns/[CAMPAIGN ID]`
4. Confirm that the campaign, ad group and ad are all marked as "removed", and the product group is gone.
    - In the Ads panel, a refresh is necessary to see the changes.


### Changelog Note:

> Remove associated ad group objects along with campaign.
