### PR TITLE
CSS to fix add paid campaign button position.

### DIFF
--- a/js/src/dashboard/all-programs-table-card/index.scss
+++ b/js/src/dashboard/all-programs-table-card/index.scss
@@ -1,4 +1,11 @@
 .gla-all-programs-table-card {
+	// fix to position the Add Paid Campaign button correctly
+	// after the recent CSS change in WooCommerce TableCard component
+	// which uses grid-template-columns: auto 1fr auto.
+	.components-card__header {
+		grid-template-columns: 1fr auto auto;
+	}
+
 	.gla-all-programs-table-card__header {
 		display: flex;
 		justify-content: space-between;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #320 .

This PR fixes the Add Paid Campaign button position issue by using CSS override.

### Screenshots:

Before:

![image](https://user-images.githubusercontent.com/417342/113335681-dcc0e900-9357-11eb-8e0b-baeb94e191ea.png)

After:

![image](https://user-images.githubusercontent.com/417342/113335610-c3b83800-9357-11eb-9bd2-fe149973a796.png)

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard
2. The Add Paid Campaign button should be on the right hand side as per the "After" screenshot above.

### Changelog Note:

Fix Add Paid Campaign button position.
