### PR TITLE
Save shipping rate & time in edit flow.

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/combined-shipping/index.js
+++ b/js/src/components/free-listings/configure-product-listings/combined-shipping/index.js
@@ -12,6 +12,7 @@ import AppRadioContentControl from '.~/components/app-radio-content-control';
 import RadioHelperText from '.~/wcdl/radio-helper-text';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import ShippingRateSetup from '../shipping-rate/shipping-rate-setup';
 import ShippingTimeSetup from '../shipping-time/shipping-time-setup';
 import './index.scss';
@@ -25,6 +26,7 @@ import './index.scss';
  */
 const CombinedShipping = ( { formProps } ) => {
 	const { getInputProps, values } = formProps;
+	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
 	// Note: since we only use `shipping_rate` to determine how to syncboth shipping rates and times,
 	//       so here also only apply `shipping_rate` to initial form data and sync its manipulation.
@@ -119,7 +121,12 @@ const CombinedShipping = ( { formProps } ) => {
 										'google-listings-and-ads'
 									) }
 								</h3>
-								<ShippingRateSetup formProps={ formProps } />
+								<ShippingRateSetup
+									selectedCountryCodes={
+										selectedCountryCodes
+									}
+									formProps={ formProps }
+								/>
 							</Section.Card.Body>
 						</Section.Card>
 
@@ -134,7 +141,12 @@ const CombinedShipping = ( { formProps } ) => {
 										'google-listings-and-ads'
 									) }
 								</h3>
-								<ShippingTimeSetup formProps={ formProps } />
+								<ShippingTimeSetup
+									selectedCountryCodes={
+										selectedCountryCodes
+									}
+									formProps={ formProps }
+								/>
 							</Section.Card.Body>
 						</Section.Card>
 					</>

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -104,5 +104,5 @@ const AddRateModal = ( { countries, onRequestClose, onSubmit } ) => {
 export default AddRateModal;
 /**
  * @typedef {import("../../countries-form.js").AggregatedShippingRate} AggregatedShippingRate
- * @typedef {import("../../countries-form.js").CountryCode} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
@@ -150,7 +150,5 @@ export default function ShippingCountriesForm( {
  */
 
 /**
- * CountryCode
- *
- * @typedef {string} CountryCode
+ * @typedef { import("./index").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
@@ -43,7 +43,6 @@ export default function ShippingCountriesForm( {
 		} );
 	}
 
-	// TODO: move those handlers up to the ancestors and consider optimizing upserting.
 	// Given the limitations of `<Form>` component we can communicate up only onChange.
 	// Therefore we loose the infromation whether it was add, change, delete.
 	// In autosave/setup MC case, we would have to either re-calculate to deduct that information,

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
@@ -41,6 +41,14 @@ export default function ShippingCountriesForm( {
 	// Group countries with the same rate.
 	const countriesPriceArray = getCountriesPriceArray( shippingRates );
 
+	if ( countriesPriceArray.length === 0 ) {
+		countriesPriceArray.push( {
+			countries: selectedCountryCodes,
+			price: '',
+			currency: currencyCode,
+		} );
+	}
+
 	// TODO: move those handlers up to the ancestors and consider optimizing upserting.
 	function handleDelete( deletedCountries ) {
 		updateShippingRates(
@@ -81,24 +89,10 @@ export default function ShippingCountriesForm( {
 	return (
 		<div className="countries-price">
 			<VerticalGapLayout>
-				{ shippingRates.length === 0 && (
-					<div className="countries-price-input-form">
-						<CountriesPriceInput
-							value={ {
-								countries: selectedCountryCodes,
-								price: '',
-								currency: currencyCode,
-							} }
-							onChange={ handleChange }
-						/>
-					</div>
-				) }
 				{ countriesPriceArray.map( ( el ) => {
 					return (
 						<div
-							key={ `${ el.price }-${ el.countries.join(
-								'-'
-							) }` }
+							key={ el.countries.join( '-' ) }
 							className="countries-price-input-form"
 						>
 							<CountriesPriceInput

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
@@ -117,15 +117,6 @@ export default function ShippingCountriesForm( {
 /**
  * Individual shipping rate.
  *
- * @typedef {Object} ShippingRateFromServerSide
- * @property {CountryCode} countryCode Destination country code.
- * @property {string} currency Currency of the price.
- * @property {number} rate Shipping price.
- */
-
-/**
- * Individual shipping rate.
- *
  * @typedef {Object} ShippingRate
  * @property {CountryCode} countryCode Destination country code.
  * @property {string} currency Currency of the price.
@@ -142,5 +133,6 @@ export default function ShippingCountriesForm( {
  */
 
 /**
- * @typedef { import("./index").CountryCode } CountryCode
+ * @typedef { import(".~/data/actions").ShippingRate } ShippingRateFromServerSide
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -120,5 +120,5 @@ export default EditRateModal;
 
 /**
  * @typedef {import("../../../countries-form.js").AggregatedShippingRate} AggregatedShippingRate
- * @typedef {import("../../../countries-form.js").CountryCode} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/index.js
@@ -64,6 +64,6 @@ const EditRateButton = ( { rate, onChange, onDelete } ) => {
 export default EditRateButton;
 
 /**
- * @typedef {import("../countries-form.js").AggregatedShippingRate} AggregatedShippingRate
- * @typedef {import("../countries-form.js").CountryCode} CountryCode
+ * @typedef {import("../../countries-form.js").AggregatedShippingRate} AggregatedShippingRate
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
-import { useDebouncedCallback } from 'use-debounce';
 
 /**
  * Internal dependencies
@@ -17,16 +16,9 @@ import './index.scss';
 import '../countries-form';
 
 /**
- * The delay between chaning the value an firing onChange callback.
- */
-const debounceDelay = 1000;
-
-/**
  * Input control to edit a shipping rate.
  * Consists of a simple input field to adjust the rate
  * and with a modal with a more advanced form to select countries.
- *
- * The changes made via simple input are debounced, to avoid districting users while typing.
  *
  * @param {Object} props
  * @param {AggregatedShippingRate} props.value Aggregate, rat: Array object to be used as the initial value.
@@ -37,17 +29,27 @@ const CountriesPriceInput = ( { value, onChange, onDelete } ) => {
 	const { countries, currency, price } = value;
 	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
-	const debouncedOnChange = useDebouncedCallback( ( updatedPrice ) => {
-		onChange( {
-			countries,
-			currency,
-			price: updatedPrice,
-		} );
-	}, debounceDelay );
-
 	if ( ! selectedCountryCodes ) {
 		return <AppSpinner />;
 	}
+
+	const handleBlur = ( e ) => {
+		const { value: nextPrice } = e.target;
+
+		if ( nextPrice === price ) {
+			return;
+		}
+
+		if ( nextPrice === '' ) {
+			onDelete( countries );
+		} else {
+			onChange( {
+				countries,
+				currency,
+				price: nextPrice,
+			} );
+		}
+	};
 
 	return (
 		<div className="gla-countries-price-input">
@@ -76,7 +78,7 @@ const CountriesPriceInput = ( { value, onChange, onDelete } ) => {
 				}
 				suffix={ currency }
 				value={ price }
-				onChange={ debouncedOnChange.callback }
+				onBlur={ handleBlur }
 			/>
 		</div>
 	);

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
@@ -88,5 +88,5 @@ export default CountriesPriceInput;
 
 /**
  * @typedef {import("../countries-form.js").AggregatedShippingRate} AggregatedShippingRate
- * @typedef {import("../countries-form.js").CountryCode} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
@@ -12,20 +12,29 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import useShippingRates from '.~/hooks/useShippingRates';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import AppSpinner from '.~/components/app-spinner';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import ShippingCountriesForm from './countries-form';
 import './index.scss';
 
-const ShippingRateSetup = ( props ) => {
-	const {
-		formProps: { getInputProps, values },
-	} = props;
+/**
+ * CountryCode
+ *
+ * @typedef {string} CountryCode
+ */
+
+/**
+ * Form control to edit shipping rate settings.
+ *
+ * @param {Object} props React props.
+ * @param {Object} props.formProps Form props forwarded from `Form` component, containing `offers_free_shipping` and `free_shipping_threshold` properties.
+ * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
+ */
+const ShippingRateSetup = ( { formProps, selectedCountryCodes } ) => {
+	const { getInputProps, values } = formProps;
 	const {
 		loading: loadingShippingRates,
 		data: shippingRates,
 	} = useShippingRates();
 	const { code: currencyCode } = useStoreCurrency();
-	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
 	if ( ! selectedCountryCodes || loadingShippingRates ) {
 		return <AppSpinner />;

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
@@ -15,9 +15,7 @@ import ShippingCountriesForm from './countries-form';
 import './index.scss';
 
 /**
- * CountryCode
- *
- * @typedef {string} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */
 
 /**

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
@@ -9,7 +9,6 @@ import { CheckboxControl } from '@wordpress/components';
  */
 import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import useShippingRates from '.~/hooks/useShippingRates';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import AppSpinner from '.~/components/app-spinner';
 import ShippingCountriesForm from './countries-form';
@@ -30,13 +29,9 @@ import './index.scss';
  */
 const ShippingRateSetup = ( { formProps, selectedCountryCodes } ) => {
 	const { getInputProps, values } = formProps;
-	const {
-		loading: loadingShippingRates,
-		data: shippingRates,
-	} = useShippingRates();
 	const { code: currencyCode } = useStoreCurrency();
 
-	if ( ! selectedCountryCodes || loadingShippingRates ) {
+	if ( ! selectedCountryCodes ) {
 		return <AppSpinner />;
 	}
 
@@ -44,7 +39,7 @@ const ShippingRateSetup = ( { formProps, selectedCountryCodes } ) => {
 		<div className="gla-shipping-rate-setup">
 			<VerticalGapLayout>
 				<ShippingCountriesForm
-					shippingRates={ shippingRates }
+					{ ...getInputProps( 'shipping_country_rates' ) }
 					currencyCode={ currencyCode }
 					selectedCountryCodes={ selectedCountryCodes }
 				/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -103,5 +103,5 @@ export default AddTimeModal;
 
 /**
  * @typedef {import("../../countries-form.js").AggregatedShippingTime} AggregatedShippingTime
- * @typedef {import("../../countries-form.js").CountryCode} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -102,6 +102,6 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 export default AddTimeModal;
 
 /**
- * @typedef {import("../../countries-form.js").AggregatedShippingTime} AggregatedShippingTime
+ * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -134,5 +134,5 @@ export default function ShippingCountriesForm( {
  */
 
 /**
- * @typedef { import("./index").CountryCode } CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -134,7 +134,5 @@ export default function ShippingCountriesForm( {
  */
 
 /**
- * CountryCode
- *
- * @typedef {string} CountryCode
+ * @typedef { import("./index").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -12,14 +12,19 @@ import CountriesTimeInput from './countries-time-input';
 import getCountriesTimeArray from './getCountriesTimeArray';
 
 /**
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import(".~/data/actions").ShippingTime } ShippingTime
+ * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ */
+
+/**
  * Partial form to provide shipping times for individual countries,
  * with an UI, that allows to aggregate countries with the same time.
  *
  * @param {Object} props
- * @param {Array<ShippingTimeFromServerSide>} props.shippingTimes Array of individual shipping times to be used as the initial values of the form.
+ * @param {Array<ShippingTime>} props.shippingTimes Array of individual shipping times to be used as the initial values of the form.
  * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
  */
-
 export default function ShippingCountriesForm( {
 	shippingTimes: savedShippingTimes,
 	selectedCountryCodes,
@@ -108,31 +113,3 @@ export default function ShippingCountriesForm( {
 		</div>
 	);
 }
-
-/**
- * Individual shipping time.
- *
- * @typedef {Object} ShippingTimeFromServerSide
- * @property {CountryCode} countryCode Destination country code.
- * @property {number} time Shipping time.
- */
-
-/**
- * Individual shipping time.
- *
- * @typedef {Object} ShippingTime
- * @property {CountryCode} countryCode Destination country code.
- * @property {number} time Shipping time.
- */
-
-/**
- * Aggregated shipping time.
- *
- * @typedef {Object} AggregatedShippingTime
- * @property {Array<CountryCode>} countries Array of destination country codes.
- * @property {number} time Shipping time.
- */
-
-/**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
- */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -121,6 +121,6 @@ const EditTimeModal = ( { time, onDelete, onSubmit, onRequestClose } ) => {
 export default EditTimeModal;
 
 /**
- * @typedef {import("../../../countries-form.js").AggregatedShippingTime} AggregatedShippingTime
+ * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -122,5 +122,5 @@ export default EditTimeModal;
 
 /**
  * @typedef {import("../../../countries-form.js").AggregatedShippingTime} AggregatedShippingTime
- * @typedef {import("../../../countries-form.js").CountryCode} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
@@ -64,6 +64,6 @@ const EditTimeButton = ( { time, onChange, onDelete } ) => {
 export default EditTimeButton;
 
 /**
- * @typedef {import("../countries-form.js").AggregatedShippingTime} AggregatedShippingTime
+ * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
@@ -65,5 +65,5 @@ export default EditTimeButton;
 
 /**
  * @typedef {import("../countries-form.js").AggregatedShippingTime} AggregatedShippingTime
- * @typedef {import("../countries-form.js").CountryCode} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -85,6 +85,6 @@ const CountriesTimeInput = ( { value, onChange, onDelete } ) => {
 export default CountriesTimeInput;
 
 /**
- * @typedef {import("../countries-form.js").AggregatedShippingTime} AggregatedShippingTime
+ * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -86,5 +86,5 @@ export default CountriesTimeInput;
 
 /**
  * @typedef {import("../countries-form.js").AggregatedShippingTime} AggregatedShippingTime
- * @typedef {import("../countries-form.js").CountryCode} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/getCountriesTimeArray.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/getCountriesTimeArray.js
@@ -34,7 +34,8 @@
  * ]
  * ```
  *
- * @param {Array<Object>} shippingTimes Array of shipping times in the format of `{ countryCode, time }`.
+ * @param {Array<ShippingTime>} shippingTimes Array of individual shipping times in the format of `{ countryCode, time }`.
+ * @return {Array<AggregatedShippingTime>} Array of shipping times grouped by time.
  */
 const getCountriesTimeArray = ( shippingTimes ) => {
 	const timeGroupMap = new Map();
@@ -53,3 +54,8 @@ const getCountriesTimeArray = ( shippingTimes ) => {
 };
 
 export default getCountriesTimeArray;
+
+/**
+ * @typedef { import(".~/data/actions").ShippingTime } ShippingTime
+ * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
@@ -8,7 +8,6 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import useShippingTimes from '.~/hooks/useShippingTimes';
 import AppSpinner from '.~/components/app-spinner';
 import AppDocumentationLink from '.~/components/app-documentation-link';
@@ -16,15 +15,25 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import ShippingCountriesForm from './countries-form';
 import './index.scss';
 
-const ShippingTimeSetup = ( props ) => {
-	const {
-		formProps: { getInputProps },
-	} = props;
+/**
+ * CountryCode
+ *
+ * @typedef {string} CountryCode
+ */
+
+/**
+ * Form control to edit shipping rate settings.
+ *
+ * @param {Object} props React props.
+ * @param {Object} props.formProps Form props forwarded from `Form` component, containing `offers_free_shipping` property.
+ * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
+ */
+const ShippingTimeSetup = ( { formProps, selectedCountryCodes } ) => {
+	const { getInputProps } = formProps;
 	const {
 		loading: loadingShippingTimes,
 		data: shippingTimes,
 	} = useShippingTimes();
-	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
 	if ( ! selectedCountryCodes || loadingShippingTimes ) {
 		return <AppSpinner />;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
@@ -8,7 +8,6 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useShippingTimes from '.~/hooks/useShippingTimes';
 import AppSpinner from '.~/components/app-spinner';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
@@ -28,12 +27,8 @@ import './index.scss';
  */
 const ShippingTimeSetup = ( { formProps, selectedCountryCodes } ) => {
 	const { getInputProps } = formProps;
-	const {
-		loading: loadingShippingTimes,
-		data: shippingTimes,
-	} = useShippingTimes();
 
-	if ( ! selectedCountryCodes || loadingShippingTimes ) {
+	if ( ! selectedCountryCodes ) {
 		return <AppSpinner />;
 	}
 
@@ -41,7 +36,7 @@ const ShippingTimeSetup = ( { formProps, selectedCountryCodes } ) => {
 		<div className="gla-shipping-time-setup">
 			<VerticalGapLayout>
 				<ShippingCountriesForm
-					shippingTimes={ shippingTimes }
+					{ ...getInputProps( 'shipping_country_times' ) }
 					selectedCountryCodes={ selectedCountryCodes }
 				/>
 				<CheckboxControl

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
@@ -16,9 +16,7 @@ import ShippingCountriesForm from './countries-form';
 import './index.scss';
 
 /**
- * CountryCode
- *
- * @typedef {string} CountryCode
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
  */
 
 /**

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -19,6 +19,25 @@ export function handleFetchError( error, message ) {
 	console.log( error );
 }
 
+/**
+ * CountryCode
+ *
+ * @typedef {string} CountryCode
+ */
+
+/**
+ * Individual shipping rate.
+ *
+ * @typedef {Object} ShippingRate
+ * @property {CountryCode} countryCode Destination country code.
+ * @property {string} currency Currency of the price.
+ * @property {number} rate Shipping price.
+ */
+
+/**
+ *
+ * @return {Array<ShippingRate>} Array of individual shipping rates.
+ */
 export function* fetchShippingRates() {
 	try {
 		const response = yield apiFetch( {
@@ -48,6 +67,20 @@ export function* fetchShippingRates() {
 	}
 }
 
+/**
+ * Aggregated shipping rate.
+ *
+ * @typedef {Object} AggregatedShippingRate
+ * @property {Array<CountryCode>} countries Array of destination country codes.
+ * @property {string} currency Currency of the price.
+ * @property {number} rate Shipping price.
+ */
+
+/**
+ * Updates or inserts given aggregated shipping rate.
+ *
+ * @param {AggregatedShippingRate} shippingRate
+ */
 export function* upsertShippingRates( shippingRate ) {
 	const { countryCodes, currency, rate } = shippingRate;
 
@@ -77,6 +110,11 @@ export function* upsertShippingRates( shippingRate ) {
 	}
 }
 
+/**
+ * Deletes shipping rates associated with given country codes.
+ *
+ * @param {Array<CountryCode>} countryCodes
+ */
 export function* deleteShippingRates( countryCodes ) {
 	try {
 		yield apiFetch( {

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -139,7 +139,18 @@ export function* deleteShippingRates( countryCodes ) {
 		);
 	}
 }
+/**
+ * Individual shipping time.
+ *
+ * @typedef {Object} ShippingTime
+ * @property {CountryCode} countryCode Destination country code.
+ * @property {number} time Shipping time.
+ */
 
+/**
+ *
+ * @return {Array<ShippingTime>} Array of individual shipping times.
+ */
 export function* fetchShippingTimes() {
 	try {
 		const response = yield apiFetch( {
@@ -168,6 +179,19 @@ export function* fetchShippingTimes() {
 	}
 }
 
+/**
+ * Aggregated shipping time.
+ *
+ * @typedef {Object} AggregatedShippingTime
+ * @property {Array<CountryCode>} countries Array of destination country codes.
+ * @property {number} time Shipping time.
+ */
+
+/**
+ * Updates or inserts given aggregated shipping rate.
+ *
+ * @param {AggregatedShippingTime} shippingTime
+ */
 export function* upsertShippingTimes( shippingTime ) {
 	const { countryCodes, time } = shippingTime;
 
@@ -196,6 +220,11 @@ export function* upsertShippingTimes( shippingTime ) {
 	}
 }
 
+/**
+ * Deletes shipping times associated with given country codes.
+ *
+ * @param {Array<CountryCode>} countryCodes
+ */
 export function* deleteShippingTimes( countryCodes ) {
 	try {
 		yield apiFetch( {

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -13,8 +13,8 @@ const DEFAULT_STATE = {
 		target_audience: null,
 		countries: null,
 		shipping: {
-			rates: [],
-			times: [],
+			rates: null,
+			times: null,
 		},
 		settings: null,
 		accounts: {

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -90,6 +90,8 @@ export default function EditFreeCampaign() {
 		saveSettings,
 		upsertShippingRate, // We need to use this one, as we serve non-aggregated ShippingRates
 		deleteShippingRates,
+		upsertShippingTime, // We need to use this one, as we serve non-aggregated ShippingTimes
+		deleteShippingTimes,
 	} = useAppDispatch();
 
 	const [ targetAudience, updateTargetAudience ] = useState(
@@ -108,23 +110,14 @@ export default function EditFreeCampaign() {
 	);
 
 	// TODO: Consider making it less repetitive.
-	useEffect( () => {
-		if ( savedTargetAudience ) {
-			updateTargetAudience( savedTargetAudience );
-		}
-		if ( savedSettings ) {
-			updateSettings( savedSettings );
-		}
-		if ( savedShippingRates ) {
-			updateShippingRates( savedShippingRates );
-		}
-		if ( savedShippingTimes ) {
-			updateShippingTimes( savedShippingTimes );
-		}
-	}, [
+	useEffect( () => updateSettings( savedSettings ), [ savedSettings ] );
+	useEffect( () => updateTargetAudience( savedTargetAudience ), [
 		savedTargetAudience,
-		savedSettings,
+	] );
+	useEffect( () => updateShippingRates( savedShippingRates ), [
 		savedShippingRates,
+	] );
+	useEffect( () => updateShippingTimes( savedShippingTimes ), [
 		savedShippingTimes,
 	] );
 
@@ -171,7 +164,12 @@ export default function EditFreeCampaign() {
 				savedShippingRates,
 				shippingRates
 			),
-			// TODO: save batched shipping times
+			...saveShippingData(
+				upsertShippingTime,
+				deleteShippingTimes,
+				savedShippingTimes,
+				shippingTimes
+			),
 		] );
 		// Sync data once our changes are saved, even partially succesfully.
 		await fetchSettingsSync();

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -129,7 +129,13 @@ export default function EditFreeCampaign() {
 	// Check what've changed to show prompt, and send requests only to save changed things.
 	const didAudienceChanged = ! isEqual( targetAudience, savedTargetAudience );
 	const didSettingsChanged = ! isEqual( settings, savedSettings );
-	const didAnythingChanged = didAudienceChanged || didSettingsChanged;
+	const didRatesChanged = ! isEqual( shippingRates, savedShippingRates );
+	const didTimesChanged = ! isEqual( shippingTimes, savedShippingTimes );
+	const didAnythingChanged =
+		didAudienceChanged ||
+		didSettingsChanged ||
+		didRatesChanged ||
+		didTimesChanged;
 
 	// Confirm leaving the page, if there are any changes and the user is navigating away from our stepper.
 	useNavigateAwayPromptEffect(

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -21,6 +21,7 @@ import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import SetupFreeListings from './setup-free-listings';
 import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
 import useShippingRates from '.~/hooks/useShippingRates';
+import useShippingTimes from '.~/hooks/useShippingTimes';
 
 /**
  * Function use to allow the user to navigate between form steps without the prompt.
@@ -97,11 +98,16 @@ export default function EditFreeCampaign() {
 	const [ settings, updateSettings ] = useState( savedSettings );
 
 	const { data: savedShippingRates } = useShippingRates();
-
 	const [ shippingRates, updateShippingRates ] = useState(
 		savedShippingRates
 	);
 
+	const { data: savedShippingTimes } = useShippingTimes();
+	const [ shippingTimes, updateShippingTimes ] = useState(
+		savedShippingTimes
+	);
+
+	// TODO: Consider making it less repetitive.
 	useEffect( () => {
 		if ( savedTargetAudience ) {
 			updateTargetAudience( savedTargetAudience );
@@ -112,7 +118,15 @@ export default function EditFreeCampaign() {
 		if ( savedShippingRates ) {
 			updateShippingRates( savedShippingRates );
 		}
-	}, [ savedTargetAudience, savedSettings, savedShippingRates ] );
+		if ( savedShippingTimes ) {
+			updateShippingTimes( savedShippingTimes );
+		}
+	}, [
+		savedTargetAudience,
+		savedSettings,
+		savedShippingRates,
+		savedShippingTimes,
+	] );
 
 	const [ fetchSettingsSync ] = useApiFetchCallback( {
 		path: `/wc/gla/mc/settings/sync`,
@@ -216,9 +230,11 @@ export default function EditFreeCampaign() {
 									'google-listings-and-ads'
 								) }
 								settings={ settings }
-								shippingRates={ shippingRates }
 								onSettingsChange={ updateSettings }
+								shippingRates={ shippingRates }
 								onShippingRatesChange={ updateShippingRates }
+								shippingTimes={ shippingTimes }
+								onShippingTimesChange={ updateShippingTimes }
 								onContinue={ handleSetupFreeListingsContinue }
 							/>
 						),

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -20,6 +20,7 @@ import useSettings from '.~/components/free-listings/configure-product-listings/
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import SetupFreeListings from './setup-free-listings';
 import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
+import useShippingRates from '.~/hooks/useShippingRates';
 
 /**
  * Function use to allow the user to navigate between form steps without the prompt.
@@ -56,6 +57,12 @@ export default function EditFreeCampaign() {
 	);
 	const [ settings, updateSettings ] = useState( savedSettings );
 
+	const { data: savedShippingRates } = useShippingRates();
+
+	const [ shippingRates, updateShippingRates ] = useState(
+		savedShippingRates
+	);
+
 	useEffect( () => {
 		if ( savedTargetAudience ) {
 			updateTargetAudience( savedTargetAudience );
@@ -63,7 +70,10 @@ export default function EditFreeCampaign() {
 		if ( savedSettings ) {
 			updateSettings( savedSettings );
 		}
-	}, [ savedTargetAudience, savedSettings ] );
+		if ( savedShippingRates ) {
+			updateShippingRates( savedShippingRates );
+		}
+	}, [ savedTargetAudience, savedSettings, savedShippingRates ] );
 
 	const [ fetchSettingsSync ] = useApiFetchCallback( {
 		path: `/wc/gla/mc/settings/sync`,
@@ -161,9 +171,9 @@ export default function EditFreeCampaign() {
 									'google-listings-and-ads'
 								) }
 								settings={ settings }
-								onChange={ ( change, newSettings ) => {
-									updateSettings( newSettings );
-								} }
+								shippingRates={ shippingRates }
+								onSettingsChange={ updateSettings }
+								onShippingRatesChange={ updateShippingRates }
 								onContinue={ handleSetupFreeListingsContinue }
 							/>
 						),

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -12,6 +12,7 @@ import FormContent from './form-content';
 
 /**
  * @typedef {import('.~/data/actions').ShippingRate} ShippingRateFromServerSide
+ * @typedef {import('.~/data/actions').ShippingTime} ShippingTime
  */
 
 /**
@@ -26,17 +27,21 @@ import FormContent from './form-content';
  * @param {(change: {name, value}, values: Object) => void} props.onSettingsChange Callback called with new data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback}
  * @param {Array<ShippingRateFromServerSide>} props.shippingRates Shipping rates data, if not given AppSpinner will be rendered.
  * @param {(newValue: Object) => void} props.onShippingRatesChange Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChangeCallback}
+ * @param {Array<ShippingTime>} props.shippingTimes Shipping times data, if not given AppSpinner will be rendered.
+ * @param {(newValue: Object) => void} props.onShippingTimesChange Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChangeCallback}
  * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked.
  */
 const SetupFreeListings = ( {
 	stepHeader,
 	settings,
-	shippingRates,
 	onSettingsChange = () => {},
+	shippingRates,
 	onShippingRatesChange = () => {},
+	shippingTimes,
+	onShippingTimesChange = () => {},
 	onContinue = () => {},
 } ) => {
-	if ( ! settings || ! shippingRates ) {
+	if ( ! settings || ! shippingRates || ! shippingTimes ) {
 		return <AppSpinner />;
 	}
 
@@ -66,17 +71,22 @@ const SetupFreeListings = ( {
 					contact_info_visible: settings.contact_info_visible,
 					// Glue shipping rates and times together, as the Form does not support nested structures.
 					shipping_country_rates: shippingRates,
+					shipping_country_times: shippingTimes,
 				} }
 				onChangeCallback={ ( change, newVals ) => {
 					// Un-glue form data.
 					const {
 						shipping_country_rates: newShippingRates,
+						shipping_country_times: newShippingTimes,
 						...newSettings
 					} = newVals;
 
 					switch ( change.name ) {
 						case 'shipping_country_rates':
 							onShippingRatesChange( newShippingRates );
+							break;
+						case 'shipping_country_times':
+							onShippingTimesChange( newShippingTimes );
 							break;
 						default:
 							onSettingsChange( change, newSettings );

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -11,7 +11,7 @@ import Hero from '.~/components/free-listings/configure-product-listings/hero';
 import FormContent from './form-content';
 
 /**
- * @typedef {import('.~/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form').ShippingRateFromServerSide} ShippingRateFromServerSide
+ * @typedef {import('.~/data/actions').ShippingRate} ShippingRateFromServerSide
  */
 
 /**


### PR DESCRIPTION
_This PR depends on #412_

### Changes proposed in this Pull Request:

- Save shipping rate & time upon clicking "Save changes".
- Fix old value blinking immediately after leaving the change rate input. (https://github.com/woocommerce/google-listings-and-ads/commit/ffba090dc7b8c5ab0d32a8f5bf32560d5faeaba9)
- Clean up and move some JSDoc type definitions around, to make usage easier, and to surface inconsistencies with used types. (https://github.com/woocommerce/google-listings-and-ads/commit/069e83b5c4d3aeaf6e0081e232ceb686ee1c46b0, https://github.com/woocommerce/google-listings-and-ads/commit/347b89f3e87c532c007ab0b9a7fa0b434a89b20c)
- Move target audience management slightly down. (https://github.com/woocommerce/google-listings-and-ads/commit/e1ab99a8ebba4c58d61c3a8cac71635581c20663) We will eventually need to move it to the main form to be able, but I decided to leave it for a separate PR.

Implements part of https://github.com/woocommerce/google-listings-and-ads/issues/156


### Screenshots:


https://user-images.githubusercontent.com/17435/113459174-e8261a00-9414-11eb-835c-e17f6ed8ed78.mp4




### Detailed test instructions:

1. Go to [**Markeding > GLA > Dashboard > Edit > Step 2**](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fedit-free-campaign&programId=123&pageStep=2)
2. Change some rates and times.
3. Try leaving the form with unsaved changes.
4. Click "Complete setup"

### To be done elsewhere:
- [ ] Change Submit button label.
- [ ] Make step 2 use of (changed) country list from step 1 rather than obtaining it from saved data - server-side.
- [ ] Rendering success / error toasts.
- [ ] DRY Shipping Rate & Time code - many components are very lookalike and different mostly in texts, that could be configurable.
- [ ] We need a new API endpoint for batched rates & times, at least one to accept an array of individual entries in the format returned by GET. Currently, even after #412, we need to make as `2n` requests, `n`- no. countries, as the `batch` API takes only aggregated and only one entry.
- [ ] New API to submit all data altogether would be nice as well.
- [ ] Unify data types. Sometimes we use `{ countries, currency, rate }` sometimes `{ countries, current, price }`. I think we can unify it not to translate things back and forth.

## Additional notes:
- I'm not 100% happy with the way we glue data around the `Form` component, and that we lose the information about add/delete/update when changing, but this comes from the `<Form>` components limitation, which I had no better idea to workaround. Hopefully, someday we could improve `Form` to serve our needs.
- I'm pretty unsure about the change from [`da8f3e0` (#422)](https://github.com/woocommerce/google-listings-and-ads/pull/422/commits/da8f3e04ca2a0e6a27a350da6d39bb1b0b3173e5). I needed it to avoid being stuck with the initial empty array as the form state. I start to wonder, maybe I should use the state from `.~/data` instead of local `useState`, or at least initialize form's one differently?

### Changelog Note:

> Save shipping rates and times in edit flow.
