### PR TITLE
Retrieve merchant ID directly from options

### DIFF
--- a/src/Google/GoogleProductService.php
+++ b/src/Google/GoogleProductService.php
@@ -3,10 +3,11 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Google;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Google\Exception as GoogleException;
 use Google_Service_ShoppingContent as GoogleShoppingService;
 use Google_Service_ShoppingContent_Product as GoogleProduct;
@@ -22,8 +23,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Google
  */
-class GoogleProductService implements Service {
+class GoogleProductService implements OptionsAwareInterface, Service {
 
+	use OptionsAwareTrait;
 	use ValidateInterface;
 
 	public const INTERNAL_ERROR_REASON = 'internalError';
@@ -45,19 +47,12 @@ class GoogleProductService implements Service {
 	protected $shopping_service;
 
 	/**
-	 * @var Merchant
-	 */
-	protected $merchant;
-
-	/**
 	 * GoogleProductService constructor.
 	 *
 	 * @param GoogleShoppingService $shopping_service
-	 * @param Merchant              $merchant
 	 */
-	public function __construct( GoogleShoppingService $shopping_service, Merchant $merchant ) {
+	public function __construct( GoogleShoppingService $shopping_service ) {
 		$this->shopping_service = $shopping_service;
-		$this->merchant         = $merchant;
 	}
 
 	/**
@@ -68,7 +63,7 @@ class GoogleProductService implements Service {
 	 * @throws GoogleException If there are any Google API errors.
 	 */
 	public function get( string $product_id ): GoogleProduct {
-		$merchant_id = $this->merchant->get_id();
+		$merchant_id = $this->options->get_merchant_id();
 
 		return $this->shopping_service->products->get( $merchant_id, $product_id );
 	}
@@ -81,7 +76,7 @@ class GoogleProductService implements Service {
 	 * @throws GoogleException If there are any Google API errors.
 	 */
 	public function insert( GoogleProduct $product ): GoogleProduct {
-		$merchant_id = $this->merchant->get_id();
+		$merchant_id = $this->options->get_merchant_id();
 
 		return $this->shopping_service->products->insert( $merchant_id, $product );
 	}
@@ -92,7 +87,7 @@ class GoogleProductService implements Service {
 	 * @throws GoogleException If there are any Google API errors.
 	 */
 	public function delete( string $product_id ) {
-		$merchant_id = $this->merchant->get_id();
+		$merchant_id = $this->options->get_merchant_id();
 
 		$this->shopping_service->products->delete( $merchant_id, $product_id );
 	}
@@ -152,7 +147,7 @@ class GoogleProductService implements Service {
 	 * @throws GoogleException If there are any Google API errors.
 	 */
 	protected function custom_batch( array $products, string $method ): BatchProductResponse {
-		$merchant_id     = $this->merchant->get_id();
+		$merchant_id     = $this->options->get_merchant_id();
 		$request_entries = [];
 
 		// An array of WooCommerce product IDs mapped to each batch ID. Used to parse Google's batch response.

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -158,8 +158,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		);
 		$this->share(
 			GoogleProductService::class,
-			Google_Service_ShoppingContent::class,
-			Merchant::class
+			Google_Service_ShoppingContent::class
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes the issue where the `get_id()` function of the Merchant class was still being called by the ProductSyncer. The ID's should be retrieved directly from the options class instead.

Closes #425 

### Detailed test instructions:

1. Sync all products on the connection test (non-async)
2. Confirm that the fatal error no longer appears and the products are synced successfully

### Changelog Note:
- Retrieve merchant ID directly from options in the product syncer.