### PR TITLE
Move ads disconnect steps into a common function

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -407,7 +407,6 @@ class Proxy implements OptionsAwareInterface {
 	 */
 	public function disconnect_ads_account() {
 		$this->update_ads_id( 0 );
-		$this->options->update( OptionsInterface::ADS_BILLING_URL, '' );
 	}
 
 	/**

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BillingSetupStatus;
@@ -173,9 +174,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function disconnect_ads_account_callback(): callable {
 		return function() {
-			$this->middleware->disconnect_ads_account();
-			$this->account_state->update( [] );
-			$this->options->update( OptionsInterface::ADS_CONVERSION_ACTION, [] );
+			$this->container->get( AdsService::class )->disconnect();
 
 			return [
 				'status'  => 'success',

--- a/src/Ads/AdsService.php
+++ b/src/Ads/AdsService.php
@@ -38,4 +38,14 @@ class AdsService implements Service {
 		return boolval( $this->options->get( OptionsInterface::ADS_SETUP_COMPLETED_AT, false ) );
 	}
 
+	/**
+	 * Disconnect Ads account
+	 */
+	public function disconnect() {
+		$this->options->delete( OptionsInterface::ADS_ACCOUNT_STATE );
+		$this->options->delete( OptionsInterface::ADS_BILLING_URL );
+		$this->options->delete( OptionsInterface::ADS_CONVERSION_ACTION );
+		$this->options->delete( OptionsInterface::ADS_ID );
+		$this->options->delete( OptionsInterface::ADS_SETUP_COMPLETED_AT );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR takes advantage of the AdsService and moves all the disconnect options into one function, so it isn't spread out over several. This pattern is copied from the way we disconnect a Merchant account.

Closes #415 

### Detailed test instructions:

1. Connect an ads account
2. Disconnect ads account
3. Confirm all options are now removed `SELECT * FROM wp_options WHERE option_name LIKE 'gla_ads%'`

### Changelog Note:
- Move ads disconnect steps into a common function