### PR TITLE
Separate batch delete shipping callback to a standalone trait

### DIFF
--- a/src/API/Site/Controllers/BatchSchemaTrait.php
+++ b/src/API/Site/Controllers/BatchSchemaTrait.php
@@ -3,9 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
 
-use WP_REST_Request as Request;
-use WP_REST_Response as Response;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -61,37 +58,5 @@ trait BatchSchemaTrait {
 		unset( $schema['rate'], $schema['currency'] );
 
 		return $schema;
-	}
-
-	/**
-	 * Get the callback for deleting shipping items via batch.
-	 *
-	 * @return callable
-	 */
-	public function get_batch_delete_shipping_callback(): callable {
-		return function( Request $request ) {
-			$country_codes = $request->get_param( 'country_codes' );
-
-			$responses = [];
-			$errors    = [];
-			foreach ( $country_codes as $country_code ) {
-				$route          = "/{$this->get_namespace()}/{$this->route_base}/{$country_code}";
-				$delete_request = new Request( 'DELETE', $route );
-
-				$response = $this->server->dispatch_request( $delete_request );
-				if ( 200 !== $response->get_status() ) {
-					$errors[] = $response->get_data();
-				} else {
-					$responses[] = $response->get_data();
-				}
-			}
-
-			return new Response(
-				[
-					'errors'  => $errors,
-					'success' => $responses,
-				],
-			);
-		};
 	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/BatchShippingTrait.php
+++ b/src/API/Site/Controllers/MerchantCenter/BatchShippingTrait.php
@@ -1,0 +1,48 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
+
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait BatchShippingTrait
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
+ */
+trait BatchShippingTrait {
+	/**
+	 * Get the callback for deleting shipping items via batch.
+	 *
+	 * @return callable
+	 */
+	protected function get_batch_delete_shipping_callback(): callable {
+		return function( Request $request ) {
+			$country_codes = $request->get_param( 'country_codes' );
+
+			$responses = [];
+			$errors    = [];
+			foreach ( $country_codes as $country_code ) {
+				$route          = "/{$this->get_namespace()}/{$this->route_base}/{$country_code}";
+				$delete_request = new Request( 'DELETE', $route );
+
+				$response = $this->server->dispatch_request( $delete_request );
+				if ( 200 !== $response->get_status() ) {
+					$errors[] = $response->get_data();
+				} else {
+					$responses[] = $response->get_data();
+				}
+			}
+
+			return new Response(
+				[
+					'errors'  => $errors,
+					'success' => $responses,
+				],
+			);
+		};
+	}
+}

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
 class ShippingRateBatchController extends ShippingRateController {
 
 	use BatchSchemaTrait;
+	use BatchShippingTrait;
 
 	/**
 	 * Register rest routes with WordPress.

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeBatchController.php
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
 class ShippingTimeBatchController extends ShippingTimeController {
 
 	use BatchSchemaTrait;
+	use BatchShippingTrait;
 
 	/**
 	 * Register rest routes with WordPress.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up PR separated from https://github.com/woocommerce/google-listings-and-ads/pull/410#issuecomment-814078616

> I'd say the easy way around it would be to either create a new trait with a descriptive name that can be shared between the two controllers. Or rename the `BatchSchemaTrait` to indicate that it's shared batch functionality and not just for schema functions. Although for re-usability, I think I'd prefer to create an abstract class `BaseBatchController`

The `ShippingRateBatchController` and `ShippingTimeBatchController` had extended corresponding `Shipping*Controller`, so looks like it could not extend another abstract class. Therefore, I create a new trait for the shared batch callback method.

### Detailed test instructions:

1. Head to the MC onboarding flow: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`
2. The upsert/deletion of shipping rates and times should work well as before

❗ Please note that PR #419 had changed the stored data type of shipping `rate` from **string** to **number**. Therefore, when you use the previously saved data and change one country's shipping rate to be the same as another country, you will find that the countries with the same shipping rate are not combined in the UI. This is due to the data type change. After deleting the saved data, this problem will not occur.
