### PR TITLE
Use admin URL from WC settings instead of hardcoded URL

### DIFF
--- a/js/src/settings/disconnect-accounts/index.js
+++ b/js/src/settings/disconnect-accounts/index.js
@@ -11,6 +11,7 @@ import { getNewPath } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import toAccountText from '.~/utils/toAccountText';
+import useAdminUrl from '.~/hooks/useAdminUrl';
 import useJetpackAccount from '.~/hooks/useJetpackAccount';
 import useGoogleAccount from '.~/hooks/useGoogleAccount';
 import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
@@ -22,6 +23,7 @@ import DisconnectModal from './disconnect-modal';
 import { ALL_ACCOUNTS, ADS_ACCOUNT } from './constants';
 
 export default function DisconnectAccounts() {
+	const adminUrl = useAdminUrl();
 	const { jetpack } = useJetpackAccount();
 	const { google } = useGoogleAccount();
 	const { googleMCAccount } = useGoogleMCAccount();
@@ -54,8 +56,8 @@ export default function DisconnectAccounts() {
 			queueRecordEvent( ...eventArgs );
 
 			// Force reload WC admin page to initiate the Get Started page.
-			const path = `/wp-admin/${ getNewPath( null, '/google/start' ) }`;
-			window.location.href = path;
+			const path = getNewPath( null, '/google/start' );
+			window.location.href = adminUrl + path;
 		} else {
 			recordEvent( ...eventArgs );
 		}

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -12,6 +12,7 @@ import AppSpinner from '.~/components/app-spinner';
 import Hero from '.~/components/free-listings/configure-product-listings/hero';
 import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
 import FormContent from './form-content';
+import useAdminUrl from '.~/hooks/useAdminUrl';
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import AppButton from '.~/components/app-button';
@@ -30,6 +31,7 @@ const SetupFreeListings = () => {
 		path: `/wc/gla/mc/settings/sync`,
 		method: 'POST',
 	} );
+	const adminUrl = useAdminUrl();
 
 	if ( ! settings ) {
 		return <AppSpinner />;
@@ -48,11 +50,11 @@ const SetupFreeListings = () => {
 			await fetchSettingsSync();
 
 			// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
-			const path = `/wp-admin/${ getNewPath(
+			const path = getNewPath(
 				{ guide: 'submission-success' },
 				'/google/product-feed'
-			) }`;
-			window.location.href = path;
+			);
+			window.location.href = adminUrl + path;
 		} catch ( error ) {
 			createNotice(
 				'error',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR tends to fix a potential problem raised from https://github.com/woocommerce/google-listings-and-ads/pull/416#discussion_r607531059

https://github.com/woocommerce/google-listings-and-ads/blob/5dfa00b3db4fad4a790b2c2177d6ec23465cf0ea/js/src/setup-ads/setup-ads-form.js#L40-L44

> I'm wondering if this will break for subdirectory installs of Wordpress. E.g if the site is hosted at https://example.com/my-store/ and the admin URL is https://example.com/my-store/wp-admin/

The issue has been fixed in that PR, and there are two other places with the same issue that will be fixed in this PR.
1. [The onboarding flow](https://github.com/woocommerce/google-listings-and-ads/blob/a0d9d5598dcd05aca8b1e24eb3f44b4e7be41ecd/js/src/setup-mc/setup-stepper/setup-free-listings/index.js#L51-L55)
2. [The accounts disconnection in the Setting page](https://github.com/woocommerce/google-listings-and-ads/blob/a0d9d5598dcd05aca8b1e24eb3f44b4e7be41ecd/js/src/settings/disconnect-accounts/index.js#L57-L58)

### Detailed test instructions:

1. Head to the Setting page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`
2. After disconnecting all accounts, it should redirect to the Get Started page
3. Continue to the onboarding flow from the Get Started page
4. After setting up onboarding flow, it should redirect to the Product Feed page
