### PR TITLE
Replace cloneDeep by getNextStateForShipping for the rest shipping actions in reducer

### DIFF
--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -45,7 +45,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 	switch ( action.type ) {
 		case TYPES.RECEIVE_SHIPPING_RATES: {
 			const { shippingRates } = action;
-			const newState = cloneDeep( state );
+			const newState = getNextStateForShipping( state );
 			newState.mc.shipping.rates = shippingRates;
 			return newState;
 		}
@@ -85,7 +85,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 
 		case TYPES.RECEIVE_SHIPPING_TIMES: {
 			const { shippingTimes } = action;
-			const newState = cloneDeep( state );
+			const newState = getNextStateForShipping( state );
 			newState.mc.shipping.times = shippingTimes;
 			return newState;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

It's raised from https://github.com/woocommerce/google-listings-and-ads/pull/411#discussion_r605503786 and relates to #270

- Replace cloneDeep by getNextStateForShipping for the rest shipping actions in reducer

Please note that it's only a quick and interim solution to keep the problem from spreading. Further solutions still need to be discussed in #270.

### Detailed test instructions:

1. Head to the MC onboarding flow or the free campaign edit page
2. Check if the previously saved shipping rates and times are displayed correctly
