### PR TITLE
Add New Paid Ads Campaign

### DIFF
--- a/js/src/apis/createCampaign.js
+++ b/js/src/apis/createCampaign.js
@@ -12,7 +12,7 @@ import apiFetch from '@wordpress/api-fetch';
  * @return {Promise} Result from apiFetch.
  */
 const createCampaign = ( amount, country ) => {
-	const date = formatDate( 'Y-m-d', new Date() );
+	const date = formatDate( 'Y-m-d H:i', new Date() );
 	const options = {
 		path: '/wc/gla/ads/campaigns',
 		method: 'POST',

--- a/js/src/apis/createCampaign.js
+++ b/js/src/apis/createCampaign.js
@@ -17,7 +17,7 @@ const createCampaign = ( amount, country ) => {
 		path: '/wc/gla/ads/campaigns',
 		method: 'POST',
 		data: {
-			name: `Ads Campaign ${ date }`,
+			name: `Campaign ${ date }`,
 			amount: Number( amount ),
 			country,
 		},

--- a/js/src/apis/createCampaign.js
+++ b/js/src/apis/createCampaign.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { format as formatDate } from '@wordpress/date';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Call API to create campaign.
+ *
+ * @param {number} amount Daily average cost of the paid ads campaign.
+ * @param {string} country Country code of the paid ads campaign audience country.
+ * @return {Promise} Result from apiFetch.
+ */
+const createCampaign = ( amount, country ) => {
+	const date = formatDate( 'Y-m-d', new Date() );
+	const options = {
+		path: '/wc/gla/ads/campaigns',
+		method: 'POST',
+		data: {
+			name: `Ads Campaign ${ date }`,
+			amount: Number( amount ),
+			country,
+		},
+	};
+
+	return apiFetch( options );
+};
+
+export default createCampaign;

--- a/js/src/components/paid-ads/add-paid-campaign-button.js
+++ b/js/src/components/paid-ads/add-paid-campaign-button.js
@@ -25,6 +25,11 @@ import recordEvent from '.~/utils/recordEvent';
  *
  * @param {Object} props Props
  * @param {string} [props.eventName='gla_add_paid_campaign_clicked'] eventName to be used when calling `recordEvent`.
+ * @param {Object} [props.eventProps] eventProps to be used when calling `recordEvent`.
+ * @param {string} [props.eventProps.context=''] Context to be used when calling `recordEvent`.
+ * @param {string} [props.eventProps.href] Destination path. This would default to a path with
+ * `'/google/setup-ads'` when users have not completed ads setup, or
+ * `'/google/campaigns/create'` when users have completed ads setup.
  * @return {AppButton} AppButton
  */
 const AddPaidCampaignButton = ( props ) => {

--- a/js/src/components/paid-ads/add-paid-campaign-button.js
+++ b/js/src/components/paid-ads/add-paid-campaign-button.js
@@ -24,7 +24,7 @@ import recordEvent from '.~/utils/recordEvent';
  * You should specify the context where this button is used, e.g. `eventProps={ { context: 'programs-table-card' } }`.
  *
  * @param {Object} props Props
- * @param {string} props.eventName eventName to be used when calling `recordEvent`. Default: `'gla_add_paid_campaign_clicked'`.
+ * @param {string} [props.eventName='gla_add_paid_campaign_clicked'] eventName to be used when calling `recordEvent`.
  * @return {AppButton} AppButton
  */
 const AddPaidCampaignButton = ( props ) => {

--- a/js/src/components/paid-ads/add-paid-campaign-button.js
+++ b/js/src/components/paid-ads/add-paid-campaign-button.js
@@ -36,7 +36,7 @@ const AddPaidCampaignButton = ( props ) => {
 	} = props;
 	const { adsSetupComplete } = glaData;
 	const path = ! adsSetupComplete
-		? '/google/setup-mc'
+		? '/google/setup-ads'
 		: '/google/campaigns/create';
 	const newPath = getNewPath( {}, path, {} );
 	const defaultEventProps = { context: '', href: newPath };

--- a/js/src/components/paid-ads/add-paid-campaign-button.js
+++ b/js/src/components/paid-ads/add-paid-campaign-button.js
@@ -41,13 +41,13 @@ const AddPaidCampaignButton = ( props ) => {
 	const newPath = getNewPath( {}, path, {} );
 	const defaultEventProps = { context: '', href: newPath };
 
-	const handleClick = () => {
+	const handleClick = ( ...args ) => {
 		recordEvent( eventName, {
 			...defaultEventProps,
 			...eventProps,
 		} );
 		getHistory().push( newPath );
-		onClick();
+		onClick( ...args );
 	};
 
 	return (

--- a/js/src/components/paid-ads/add-paid-campaign-button.js
+++ b/js/src/components/paid-ads/add-paid-campaign-button.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { getHistory, getNewPath } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
+import { glaData } from '.~/constants';
+import recordEvent from '.~/utils/recordEvent';
+
+/**
+ * Renders an AppButton with the text "Add Paid Campaign".
+ * Clicking on the button will call `recordEvent` and
+ * redirect to Setup MC or Create New Campaign depending on
+ * whether the users have completed ads setup or not.
+ *
+ * `recordEvent` is called with a default eventName `'gla_add_paid_campaign_clicked'`,
+ * and a default eventProps `{ context: '', href: newPath }`.
+ * You can provide `eventProps` and it will be merged with the default eventProps.
+ *
+ * You should specify the context where this button is used, e.g. `eventProps={ { context: 'programs-table-card' } }`.
+ *
+ * @param {Object} props Props
+ * @param {string} props.eventName eventName to be used when calling `recordEvent`. Default: `'gla_add_paid_campaign_clicked'`.
+ * @return {AppButton} AppButton
+ */
+const AddPaidCampaignButton = ( props ) => {
+	const {
+		eventName = 'gla_add_paid_campaign_clicked',
+		eventProps,
+		onClick = () => {},
+		...rest
+	} = props;
+	const { adsSetupComplete } = glaData;
+	const path = ! adsSetupComplete
+		? '/google/setup-mc'
+		: '/google/campaigns/create';
+	const newPath = getNewPath( {}, path, {} );
+	const defaultEventProps = { context: '', href: newPath };
+
+	const handleClick = () => {
+		recordEvent( eventName, {
+			...defaultEventProps,
+			...eventProps,
+		} );
+		getHistory().push( newPath );
+		onClick();
+	};
+
+	return (
+		<AppButton isSmall isSecondary onClick={ handleClick } { ...rest }>
+			{ __( 'Add paid campaign', 'google-listings-and-ads' ) }
+		</AppButton>
+	);
+};
+
+export default AddPaidCampaignButton;

--- a/js/src/components/paid-ads/create-campaign-form-content.js
+++ b/js/src/components/paid-ads/create-campaign-form-content.js
@@ -10,7 +10,7 @@ import AudienceSection from '.~/components/paid-ads/audience-section';
 import BudgetSection from '.~/components/paid-ads/budget-section';
 import FaqsSection from '.~/components/paid-ads/faqs-section';
 
-const FormContent = ( props ) => {
+const CreateCampaignFormContent = ( props ) => {
 	const { formProps } = props;
 
 	return (
@@ -28,4 +28,4 @@ const FormContent = ( props ) => {
 	);
 };
 
-export default FormContent;
+export default CreateCampaignFormContent;

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { getQuery, getNewPath, onQueryChange } from '@woocommerce/navigation';
-import { Link } from '@woocommerce/components';
-import classnames from 'classnames';
+import { getQuery, onQueryChange } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -21,6 +19,7 @@ import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import AppSpinner from '.~/components/app-spinner';
 import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
+import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
 
 const headers = [
 	{
@@ -104,16 +103,9 @@ const AllProgramsTableCard = ( props ) => {
 			title={
 				<div className="gla-all-programs-table-card__header">
 					{ __( 'Programs', 'google-listings-and-ads' ) }
-					<Link
-						className={ classnames(
-							'components-button',
-							'is-secondary',
-							'is-small'
-						) }
-						href={ getNewPath( {}, '/google/setup-ads' ) }
-					>
-						{ __( 'Add paid campaign', 'google-listings-and-ads' ) }
-					</Link>
+					<AddPaidCampaignButton
+						eventProps={ { context: 'programs-table-card' } }
+					/>
 				</div>
 			}
 			headers={ headers }

--- a/js/src/dashboard/paid-campaign-promotion-card/index.js
+++ b/js/src/dashboard/paid-campaign-promotion-card/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getNewPath } from '@woocommerce/navigation';
 import { Card, CardHeader } from '@wordpress/components';
 import { Spinner } from '@woocommerce/components';
 
@@ -10,11 +9,10 @@ import { Spinner } from '@woocommerce/components';
  * Internal dependencies
  */
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import TrackableLink from '.~/components/trackable-link';
 import './index.scss';
+import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
 
 const PromotionContent = ( { adsAccount } ) => {
-	const href = getNewPath( null, '/google/setup-ads' );
 	const showFreeCredit =
 		adsAccount.sub_account || adsAccount.status === 'disconnected';
 
@@ -31,17 +29,9 @@ const PromotionContent = ( { adsAccount } ) => {
 							'google-listings-and-ads'
 					  ) }
 			</p>
-			<TrackableLink
-				className="components-button is-secondary is-small"
-				eventName="gla_dashboard_link_clicked"
-				eventProps={ {
-					context: 'add-paid-campaign-promotion',
-					href,
-				} }
-				href={ href }
-			>
-				{ __( 'Add paid campaign', 'google-listings-and-ads' ) }
-			</TrackableLink>
+			<AddPaidCampaignButton
+				eventProps={ { context: 'add-paid-campaign-promotion' } }
+			/>
 		</>
 	);
 };

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -14,6 +14,7 @@ import SetupAds from './setup-ads';
 import Dashboard from './dashboard';
 import EditFreeCampaign from './edit-free-campaign';
 import EditPaidAdsCampaign from './pages/edit-paid-ads-campaign';
+import CreatePaidAdsCampaign from './pages/create-paid-ads-campaign';
 import { ProgramsReport, ProductsReport } from './reports';
 import ProductFeed from './product-feed';
 import Settings from './settings';
@@ -98,6 +99,23 @@ addFilter(
 				),
 				container: EditPaidAdsCampaign,
 				path: '/google/campaigns/edit',
+				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
+			},
+			{
+				breadcrumbs: [
+					[ '', wcSettings.woocommerceTranslation ],
+					[
+						'/marketing',
+						__( 'Marketing', 'google-listings-and-ads' ),
+					],
+					__( 'Google Listings & Ads', 'google-listings-and-ads' ),
+				],
+				title: __(
+					'Create your free campaign',
+					'google-listings-and-ads'
+				),
+				container: CreatePaidAdsCampaign,
+				path: '/google/campaigns/create',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 			},
 			{

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -84,7 +84,7 @@ const CreatePaidAdsCampaignForm = () => {
 								{
 									link: (
 										<AppDocumentationLink
-											context="edit-ads"
+											context="create-ads"
 											linkId="see-what-ads-look-like"
 											href="https://support.google.com/google-ads/answer/6275294"
 										/>

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement, useState } from '@wordpress/element';
+import { Form } from '@woocommerce/components';
+import { getNewPath, getHistory } from '@woocommerce/navigation';
+import apiFetch from '@wordpress/api-fetch';
+import { format as formatDate } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import StepContent from '.~/components/stepper/step-content';
+import StepContentHeader from '.~/components/stepper/step-content-header';
+import StepContentFooter from '.~/components/stepper/step-content-footer';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import AppButton from '.~/components/app-button';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import { useAppDispatch } from '.~/data';
+import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
+
+const CreatePaidAdsCampaignForm = () => {
+	const [ loading, setLoading ] = useState( false );
+	const { fetchAdsCampaigns } = useAppDispatch();
+	const { createNotice } = useDispatchCoreNotices();
+
+	const handleValidate = () => {
+		const errors = {};
+
+		// TODO: validation logic.
+
+		return errors;
+	};
+
+	const handleSubmit = async ( values ) => {
+		const { amount, country } = values;
+
+		setLoading( true );
+
+		try {
+			const date = formatDate( 'Y-m-d', new Date() );
+
+			await apiFetch( {
+				path: `/wc/gla/ads/campaigns`,
+				method: 'POST',
+				data: {
+					name: `Ads Campaign ${ date }`,
+					amount: Number( amount ),
+					country: country && country[ 0 ],
+				},
+			} );
+		} catch ( e ) {
+			createNotice(
+				'error',
+				__(
+					'Unable to launch your ads campaign. Please try again later.',
+					'google-listings-and-ads'
+				)
+			);
+			setLoading( false );
+			return;
+		}
+
+		await fetchAdsCampaigns();
+		getHistory().push( getNewPath( {}, '/google/dashboard', {} ) );
+
+		setLoading( false );
+	};
+
+	return (
+		<Form
+			initialValues={ {
+				amount: 0,
+				country: [],
+			} }
+			validate={ handleValidate }
+			onSubmitCallback={ handleSubmit }
+		>
+			{ ( formProps ) => {
+				const { handleSubmit: handleLaunchCampaignClick } = formProps;
+
+				return (
+					<StepContent>
+						<StepContentHeader
+							title={ __(
+								'Create your paid campaign',
+								'google-listings-and-ads'
+							) }
+							description={ createInterpolateElement(
+								__(
+									'Paid Smart Shopping campaigns are automatically optimized for you by Google. <link>See what your ads will look like.</link>',
+									'google-listings-and-ads'
+								),
+								{
+									link: (
+										<AppDocumentationLink
+											context="edit-ads"
+											linkId="see-what-ads-look-like"
+											href="https://support.google.com/google-ads/answer/6275294"
+										/>
+									),
+								}
+							) }
+						/>
+						<CreateCampaignFormContent formProps={ formProps } />
+						<StepContentFooter>
+							<AppButton
+								isPrimary
+								loading={ loading }
+								onClick={ handleLaunchCampaignClick }
+							>
+								{ __(
+									'Launch paid campaign',
+									'google-listings-and-ads'
+								) }
+							</AppButton>
+						</StepContentFooter>
+					</StepContent>
+				);
+			} }
+		</Form>
+	);
+};
+
+export default CreatePaidAdsCampaignForm;

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -39,6 +39,14 @@ const CreatePaidAdsCampaignForm = () => {
 			const { amount, country: countryArr } = values;
 			const country = countryArr && countryArr[ 0 ];
 			await createCampaign( amount, country );
+
+			createNotice(
+				'success',
+				__(
+					'You’ve successfully created a paid campaign!',
+					'google-listings-and-ads'
+				)
+			);
 		} catch ( e ) {
 			createNotice(
 				'error',

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -5,8 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { Form } from '@woocommerce/components';
 import { getNewPath, getHistory } from '@woocommerce/navigation';
-import apiFetch from '@wordpress/api-fetch';
-import { format as formatDate } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -19,6 +17,7 @@ import AppButton from '.~/components/app-button';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import { useAppDispatch } from '.~/data';
 import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
+import createCampaign from '.~/apis/createCampaign';
 
 const CreatePaidAdsCampaignForm = () => {
 	const [ loading, setLoading ] = useState( false );
@@ -34,22 +33,12 @@ const CreatePaidAdsCampaignForm = () => {
 	};
 
 	const handleSubmit = async ( values ) => {
-		const { amount, country } = values;
-
 		setLoading( true );
 
 		try {
-			const date = formatDate( 'Y-m-d', new Date() );
-
-			await apiFetch( {
-				path: `/wc/gla/ads/campaigns`,
-				method: 'POST',
-				data: {
-					name: `Ads Campaign ${ date }`,
-					amount: Number( amount ),
-					country: country && country[ 0 ],
-				},
-			} );
+			const { amount, country: countryArr } = values;
+			const country = countryArr && countryArr[ 0 ];
+			await createCampaign( amount, country );
 		} catch ( e ) {
 			createNotice(
 				'error',

--- a/js/src/pages/create-paid-ads-campaign/index.js
+++ b/js/src/pages/create-paid-ads-campaign/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import FullContainer from '.~/components/full-container';
+
+const CreatePaidAdsCampaign = () => {
+	// TODO: just a dummy render below.
+	return (
+		<FullContainer>
+			<div>Create paid ads campaign</div>
+		</FullContainer>
+	);
+};
+
+export default CreatePaidAdsCampaign;

--- a/js/src/pages/create-paid-ads-campaign/index.js
+++ b/js/src/pages/create-paid-ads-campaign/index.js
@@ -1,13 +1,29 @@
 /**
+ * External dependencies
+ */
+import { getNewPath } from '@woocommerce/navigation';
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import FullContainer from '.~/components/full-container';
+import TopBar from '.~/components/stepper/top-bar';
+import CreatePaidAdsCampaignForm from './create-paid-ads-campaign-form';
+
+const dashboardURL = getNewPath( {}, '/google/dashboard', {} );
 
 const CreatePaidAdsCampaign = () => {
-	// TODO: just a dummy render below.
 	return (
 		<FullContainer>
-			<div>Create paid ads campaign</div>
+			<TopBar
+				title={ __(
+					'Create your paid campaign',
+					'google-listings-and-ads'
+				) }
+				backHref={ dashboardURL }
+			/>
+			<CreatePaidAdsCampaignForm />
 		</FullContainer>
 	);
 };

--- a/js/src/setup-ads/ads-stepper/create-campaign/form-content.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/form-content.js
@@ -6,13 +6,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import StepContentFooter from '.~/components/stepper/step-content-footer';
 import AudienceSection from '.~/components/paid-ads/audience-section';
 import BudgetSection from '.~/components/paid-ads/budget-section';
 import FaqsSection from '.~/components/paid-ads/faqs-section';
 
 const FormContent = ( props ) => {
-	const { formProps, submitButton } = props;
+	const { formProps } = props;
 
 	return (
 		<>
@@ -25,7 +24,6 @@ const FormContent = ( props ) => {
 			/>
 			<BudgetSection formProps={ formProps } />
 			<FaqsSection />
-			<StepContentFooter>{ submitButton }</StepContentFooter>
 		</>
 	);
 };

--- a/js/src/setup-ads/ads-stepper/create-campaign/index.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/index.js
@@ -9,6 +9,7 @@ import { createInterpolateElement } from '@wordpress/element';
  */
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
+import StepContentFooter from '.~/components/stepper/step-content-footer';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import FormContent from './form-content';
 import AppButton from '.~/components/app-button';
@@ -40,14 +41,12 @@ const CreateCampaign = ( props ) => {
 					}
 				) }
 			/>
-			<FormContent
-				formProps={ formProps }
-				submitButton={
-					<AppButton isPrimary onClick={ onContinue }>
-						{ __( 'Continue', 'google-listings-and-ads' ) }
-					</AppButton>
-				}
-			/>
+			<FormContent formProps={ formProps } />
+			<StepContentFooter>
+				<AppButton isPrimary onClick={ onContinue }>
+					{ __( 'Continue', 'google-listings-and-ads' ) }
+				</AppButton>
+			</StepContentFooter>
 		</StepContent>
 	);
 };

--- a/js/src/setup-ads/ads-stepper/create-campaign/index.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/index.js
@@ -11,7 +11,7 @@ import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
 import AppDocumentationLink from '.~/components/app-documentation-link';
-import FormContent from './form-content';
+import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
 import AppButton from '.~/components/app-button';
 
 const CreateCampaign = ( props ) => {
@@ -41,7 +41,7 @@ const CreateCampaign = ( props ) => {
 					}
 				) }
 			/>
-			<FormContent formProps={ formProps } />
+			<CreateCampaignFormContent formProps={ formProps } />
 			<StepContentFooter>
 				<AppButton isPrimary onClick={ onContinue }>
 					{ __( 'Continue', 'google-listings-and-ads' ) }

--- a/js/src/setup-ads/useSetupCompleteCallback.js
+++ b/js/src/setup-ads/useSetupCompleteCallback.js
@@ -3,31 +3,20 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';
-import { format as formatDate } from '@wordpress/date';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import createCampaign from '.~/apis/createCampaign';
 
 export default function useSetupCompleteCallback() {
 	const { createNotice } = useDispatchCoreNotices();
 	const [ loading, setLoading ] = useState( false );
 
-	const createCampaign = useCallback( ( amount, country ) => {
-		const date = formatDate( 'Y-m-d', new Date() );
-		const options = {
-			path: '/wc/gla/ads/campaigns',
-			method: 'POST',
-			data: {
-				name: `Ads Campaign ${ date }`,
-				amount: Number( amount ),
-				country,
-			},
-		};
-
-		return apiFetch( options ).catch( () => {
+	const createCampaignCallback = useCallback( ( amount, country ) => {
+		return createCampaign( amount, country ).catch( () => {
 			return Promise.reject(
 				__(
 					'Unable to launch your ads campaign. Please try again later.',
@@ -55,7 +44,7 @@ export default function useSetupCompleteCallback() {
 	const handleFinishSetup = useCallback(
 		( amount, country, onCompleted ) => {
 			setLoading( true );
-			createCampaign( amount, country )
+			createCampaignCallback( amount, country )
 				.then( completeAdsSetup )
 				.then( onCompleted )
 				.catch( ( errorMessage ) => {
@@ -63,7 +52,7 @@ export default function useSetupCompleteCallback() {
 				} )
 				.then( () => setLoading( false ) );
 		},
-		[ createCampaign, completeAdsSetup, createNotice ]
+		[ createCampaignCallback, completeAdsSetup, createNotice ]
 	);
 
 	return [ handleFinishSetup, loading ];

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -29,6 +29,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupAds;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Dashboard;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\EditFreeCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\EditPaidAdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\CreatePaidAdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Reports\Programs;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Reports\Products;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\ProductFeed;
@@ -88,6 +89,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		Dashboard::class              => true,
 		EditFreeCampaign::class       => true,
 		EditPaidAdsCampaign::class    => true,
+		CreatePaidAdsCampaign::class  => true,
 		EventTracking::class          => true,
 		GetStarted::class             => true,
 		GlobalSiteTag::class          => true,
@@ -176,6 +178,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( Dashboard::class );
 		$this->conditionally_share_with_tags( EditFreeCampaign::class );
 		$this->conditionally_share_with_tags( EditPaidAdsCampaign::class );
+		$this->conditionally_share_with_tags( CreatePaidAdsCampaign::class );
 		$this->conditionally_share_with_tags( Programs::class );
 		$this->conditionally_share_with_tags( Products::class );
 		$this->conditionally_share_with_tags( ProductFeed::class );

--- a/src/Menu/CreatePaidAdsCampaign.php
+++ b/src/Menu/CreatePaidAdsCampaign.php
@@ -1,0 +1,34 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+
+/**
+ * Class CreatePaidAdsCampaign
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu
+ */
+class CreatePaidAdsCampaign implements Service, Registerable {
+
+	/**
+	 * Register a service.
+	 */
+	public function register(): void {
+		add_action(
+			'admin_menu',
+			function() {
+				wc_admin_register_page(
+					[
+						'title'  => __( 'Create your paid campaign', 'google-listings-and-ads' ),
+						'parent' => 'google-dashboard',
+						'path'   => '/google/campaigns/create',
+						'id'     => 'google-create-paid-ads-campaign',
+					]
+				);
+			}
+		);
+	}
+}

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -78,10 +78,6 @@ All event names are prefixed by `wcadmin_gla_`.
   * `context`: indicate which page / module the link is in
   * `link_id`: a unique ID for the link within the page / module
 
-* `dashboard_link_clicked` - Clicking on a link within the dashboard page
-  * `context`: indicate which link is clicked
-  * `href`: link's URL
-
 * `gla_free_campaign_edited` - Saving changes to the free campaign.
 
 * `free_ad_credit_country_click` - Clicking on the link to view free ad credit value by country.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -90,6 +90,10 @@ All event names are prefixed by `wcadmin_gla_`.
 * `disconnected_accounts` - Accounts are disconnected from the Setting page
   * `context`: (`all-accounts`|`ads-account`) - indicate which accounts have been disconnected.
 
+* `add_paid_campaign_clicked` - "Add paid campaign" button is clicked.
+  * `context`: indicate the place where the button is located.
+  * `href`: indicate the destination where the users is directed to, e.g. `'/google/setup-ads'` or `'/google/campaigns/create'`.
+
 <!-- -- >
 ## Developer Info
 All new tracking info should be updated in this readme.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the ability to create new ads campaign.

This PR also temporarily fixes / workaround the issue https://github.com/woocommerce/google-listings-and-ads/issues/408 by using `"Ads Campaign {yyyy-mm-dd hh:mm}"` campaign naming format, which means after creating a new campaign, the users might need to wait at most one minute to create another new campaign.

### Screenshots:

Static screenshot:

![image](https://user-images.githubusercontent.com/417342/113988452-132fc400-9882-11eb-8499-df830126f0d6.png)

Demo video with my voice (https://d.pr/v/LaZDd5):

https://user-images.githubusercontent.com/417342/113989755-58a0c100-9883-11eb-9f5f-c3bc8acc0d75.mp4

### Detailed test instructions:

1. Open the GLA dashboard page: https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard
2. Click on the "Add paid campaign" button.
    - If users have not already completed ads setup, this will bring users to the Setup Ads flow.
    - If users have already completed ads setup, this will bring users to the Create Paid Campaign page.
3. In the Create Paid Campaign page, fill in the country and amount, and click the "Launch paid campaign" button. There should be a loading indicator.
4. Users should be directed back to the dashboard page, and the new campaign should be in the Programs table.

### Changelog Note:

Add the ability to create new paid ads campaign.
