### PR TITLE
Fix supported countries check in `create_ads_account`

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -285,7 +285,7 @@ class Proxy implements OptionsAwareInterface {
 		try {
 			$country   = WC()->countries->get_base_country();
 			$countries = $this->get_mc_supported_countries();
-			if ( ! array_key_exists( $country, $countries ) ) {
+			if ( ! in_array( $country, $countries ) ) {
 				throw new Exception( __( 'Store country is not supported', 'google-listings-and-ads' ) );
 			}
 

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -285,7 +285,7 @@ class Proxy implements OptionsAwareInterface {
 		try {
 			$country   = WC()->countries->get_base_country();
 			$countries = $this->get_mc_supported_countries();
-			if ( ! in_array( $country, $countries ) ) {
+			if ( ! in_array( $country, $countries, true ) ) {
 				throw new Exception( __( 'Store country is not supported', 'google-listings-and-ads' ) );
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use `in_array` instead of `array_key_exists` for the object returned from `get_mc_supported_countries`,
to use the new structure introduced in 1657f75.


Before that fix, you could not create a new ads account, as your country was always considered not supported.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Checkout this branch
2. Got to [**Connection Test** page](https://gla1.test/wp-admin/admin.php?page=connection-test-admin-page)
2. Make sure you have your Google and MC accounts set up.
3. Try creating a new ads account with the "Setup an existing account or create a new one" button (leaving the input field empty)


### Changelog Note:

> Fixed Google Ads account creation, do not reject supported countries.

//cc @mikkamp as the author of this solution