### PR TITLE
Merchant setup status endpoint

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -134,15 +134,6 @@ class Proxy implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Disconnect the connected merchant account.
-	 */
-	public function disconnect_merchant() {
-		$this->update_merchant_id( 0 );
-
-		// TODO: Cancel any active campaigns and remove product feeds when disconnecting.
-	}
-
-	/**
 	 * Link Merchant Center account to MCA.
 	 *
 	 * @return bool

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -132,27 +131,6 @@ class Proxy implements OptionsAwareInterface {
 		$this->update_merchant_id( $id );
 
 		return $id;
-	}
-
-	/**
-	 * Get the connected merchant account.
-	 *
-	 * @return array
-	 */
-	public function get_connected_merchant(): array {
-		$id     = $this->options->get( OptionsInterface::MERCHANT_ID );
-		$status = [
-			'id'     => $id,
-			'status' => $id ? 'connected' : 'disconnected',
-		];
-
-		$incomplete = $this->container->get( MerchantAccountState::class )->last_incomplete_step();
-		if ( ! empty( $incomplete ) ) {
-			$status['status'] = 'incomplete';
-			$status['step']   = $incomplete;
-		}
-
-		return $status;
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -233,7 +233,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function get_connected_merchant_callback(): callable {
 		return function() {
-			return $this->middleware->get_connected_merchant();
+			return $this->mc_service->get_connected_status();
 		};
 	}
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -147,7 +147,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Set up MerchantCenter service, and inflect classes that need it.
 		$this->share_with_tags(
 			MerchantCenterService::class,
-			OptionsInterface::class,
 			WC::class,
 			WP::class,
 			TransientsInterface::class,

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -145,7 +145,14 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			->invokeMethod( 'set_options_object', [ OptionsInterface::class ] );
 
 		// Set up MerchantCenter service, and inflect classes that need it.
-		$this->share_with_tags( MerchantCenterService::class, OptionsInterface::class, WC::class, WP::class, TransientsInterface::class );
+		$this->share_with_tags(
+			MerchantCenterService::class,
+			OptionsInterface::class,
+			WC::class,
+			WP::class,
+			TransientsInterface::class,
+			MerchantAccountState::class
+		);
 		$this->getLeagueContainer()
 			->inflector( MerchantCenterAwareInterface::class )
 			->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -6,6 +6,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -18,13 +20,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter
  */
-class MerchantCenterService implements Service {
-	use GoogleHelper;
+class MerchantCenterService implements OptionsAwareInterface, Service {
 
-	/**
-	 * @var OptionsInterface
-	 */
-	protected $options;
+	use GoogleHelper;
+	use OptionsAwareTrait;
 
 	/**
 	 * WooCommerce proxy service
@@ -53,14 +52,12 @@ class MerchantCenterService implements Service {
 	/**
 	 * MerchantCenterService constructor.
 	 *
-	 * @param OptionsInterface     $options
 	 * @param WC                   $wc
 	 * @param WP                   $wp
 	 * @param TransientsInterface  $transients
 	 * @param MerchantAccountState $account_state
 	 */
-	public function __construct( OptionsInterface $options, WC $wc, WP $wp, TransientsInterface $transients, MerchantAccountState $account_state ) {
-		$this->options       = $options;
+	public function __construct( WC $wc, WP $wp, TransientsInterface $transients, MerchantAccountState $account_state ) {
 		$this->wc            = $wc;
 		$this->wp            = $wp;
 		$this->transients    = $transients;

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -201,11 +201,18 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 	}
 
 	/**
-	 * Check if target audience has been saved.
+	 * Check if target audience has been saved (with a valid selection of countries).
 	 *
 	 * @return bool
 	 */
 	protected function saved_target_audience(): bool {
-		return ! empty( $this->options->get( OptionsInterface::TARGET_AUDIENCE ) );
+		$audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE );
+
+		if ( empty( $audience ) || ! isset( $audience['location'] ) ) {
+			return false;
+		}
+
+		$empty_selection = 'selected' === $audience['location'] && empty( $audience['countries'] );
+		return ! $empty_selection;
 	}
 }

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -186,7 +186,6 @@ class MerchantCenterService implements Service {
 	 */
 	public function disconnect() {
 		$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
-		$this->options->delete( OptionsInterface::MC_SETUP_SAVED_STEP );
 		$this->options->delete( OptionsInterface::MERCHANT_ACCOUNT_STATE );
 		$this->options->delete( OptionsInterface::MERCHANT_CENTER );
 		$this->options->delete( OptionsInterface::SITE_VERIFICATION );

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -167,7 +167,7 @@ class MerchantCenterService implements Service {
 			return [ 'status' => 'complete' ];
 		}
 
-		if ( ! $this->account_state->last_incomplete_step() ) {
+		if ( $this->connected_account() ) {
 			$step = 'target_audience';
 
 			if ( $this->saved_target_audience() ) {
@@ -193,6 +193,16 @@ class MerchantCenterService implements Service {
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
 
 		$this->transients->delete( TransientsInterface::MC_PRODUCT_STATISTICS );
+	}
+
+	/**
+	 * Check if account has been connected.
+	 *
+	 * @return bool
+	 */
+	protected function connected_account(): bool {
+		$id = $this->options->get_merchant_id();
+		return $id && ! $this->account_state->last_incomplete_step();
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -160,13 +160,11 @@ class MerchantCenterService implements Service {
 	 * @return array
 	 */
 	public function get_setup_status(): array {
-		$complete = $this->is_setup_complete();
-		$step     = 'accounts';
-
-		if ( $complete ) {
+		if ( $this->is_setup_complete() ) {
 			return [ 'status' => 'complete' ];
 		}
 
+		$step = 'accounts';
 		if ( $this->connected_account() ) {
 			$step = 'target_audience';
 

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -32,7 +32,6 @@ final class Options implements OptionsInterface, Service {
 		self::FILE_VERSION           => true,
 		self::INSTALL_TIMESTAMP      => true,
 		self::MC_SETUP_COMPLETED_AT  => true,
-		self::MC_SETUP_SAVED_STEP    => true,
 		self::MERCHANT_ACCOUNT_STATE => true,
 		self::MERCHANT_CENTER        => true,
 		self::MERCHANT_ID            => true,

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -19,7 +19,6 @@ interface OptionsInterface {
 	public const FILE_VERSION           = 'file_version';
 	public const INSTALL_TIMESTAMP      = 'install_timestamp';
 	public const MC_SETUP_COMPLETED_AT  = 'mc_setup_completed_at';
-	public const MC_SETUP_SAVED_STEP    = 'setup_mc_saved_step';
 	public const MERCHANT_ACCOUNT_STATE = 'merchant_account_state';
 	public const MERCHANT_CENTER        = 'merchant_center';
 	public const MERCHANT_ID            = 'merchant_id';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR covers the following changes:
- Add an endpoint to retrieve the merchant center setup status
- Move the connection status function to the MerchantService class
- Remove references to MC_SETUP_SAVED_STEP

As a followup to this PR the UI will need to be changed to no longer retrieve the step from `gla_setup_mc_saved_step` but from the `mc/setup` endpoint instead.

`GET https://domain.test/wp-json/wc/gla/mc/setup` will return the status:
- complete (all done)
- incomplete (step parameter will show what step we are setting up)

Values for step:
- accounts (setting up accounts - step 1)
- target_audience (setting up the target countries - step 2)
- shipping_and_taxes (setting up shipping settings - step 3)

Example response:
```
{
	"status": "incomplete",
	"step": "shipping_and_taxes"
}
```

Closes #369 

### Detailed test instructions:

1. Disconnect the merchant account, manually delete `gla_setup_mc_saved_step` from options since we no longer manage this
2. Reconnect a merchant account in the UI
3. At each setup step, send a request to `GET https://domain.test/wp-json/wc/gla/mc/setup` and confirm it returns the expected results

### Changelog Note:
Endpoint for retrieving the Merchant Center account setup status