### PR TITLE
Make step 2 of free campaign editing use countries defined in step 1.

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/combined-shipping/index.js
+++ b/js/src/components/free-listings/configure-product-listings/combined-shipping/index.js
@@ -12,10 +12,13 @@ import AppRadioContentControl from '.~/components/app-radio-content-control';
 import RadioHelperText from '.~/wcdl/radio-helper-text';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import ShippingRateSetup from '../shipping-rate/shipping-rate-setup';
 import ShippingTimeSetup from '../shipping-time/shipping-time-setup';
 import './index.scss';
+
+/**
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ */
 
 /**
  * Form section to set shipping rate and price per country.
@@ -23,10 +26,10 @@ import './index.scss';
  *
  * @param {Object} props
  * @param {Object} props.formProps
+ * @param {Array<CountryCode>} props.countries List of supported countries.
  */
-const CombinedShipping = ( { formProps } ) => {
+const CombinedShipping = ( { formProps, countries: selectedCountryCodes } ) => {
 	const { getInputProps, values } = formProps;
-	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
 	// Note: since we only use `shipping_rate` to determine how to syncboth shipping rates and times,
 	//       so here also only apply `shipping_rate` to initial form data and sync its manipulation.

--- a/js/src/components/free-listings/configure-product-listings/country-names.js
+++ b/js/src/components/free-listings/configure-product-listings/country-names.js
@@ -7,32 +7,34 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import More from './more';
+
+/**
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ */
 
 /**
  * Accepts an array of country codes and renders a comma-separated string of country names.
  *
- * If the array of country codes is the same as target audience countries, it will render a string `'all countries'`.
+ * If the array's length is same as `total`, it will render a string `'all countries'`.
  *
  * If the country codes is more than `firstN`, it will render the `firstN` country names, and then follow with `'+ <remainingCount> more'`.
  *
  * Usage:
  *
  * ```
- * <CountryNames countries={ ['AU', 'US' ] } />
+ * <CountryNames countries={ ['AU', 'US' ] } total={ 10 }/>
  * ```
  *
  * @param {Object} props
- * @param {Array<string>} props.countries Array of country codes.
- * @param {number} props.firstN Number of country names to be shown before displaying "+ <remainingCount> more".
+ * @param {Array<CountryCode>} props.countries Array of all available country codes.
+ * @param {number} props.total Number of all countries.
+ * @param {number} [props.firstN=5] Number of country names to be shown before displaying "+ <remainingCount> more".
  */
-const CountryNames = ( props ) => {
-	const { countries, firstN = 5 } = props;
-	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
+const CountryNames = ( { countries, firstN = 5, total } ) => {
 	const keyNameMap = useCountryKeyNameMap();
 
-	if ( selectedCountryCodes.length === countries.length ) {
+	if ( countries.length === total ) {
 		return (
 			<strong>
 				{ __( `all countries`, 'google-listings-and-ads' ) }

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -12,7 +12,7 @@ import AppModal from '.~/components/app-modal';
 import AppInputControl from '.~/components/app-input-control';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import AudienceCountrySelect from '.~/components/audience-country-select';
+import AppCountrySelect from '.~/components/app-country-select';
 
 /**
  * Form to add a new rate for selected country(-ies).
@@ -80,7 +80,8 @@ const AddRateModal = ( { countries, onRequestClose, onSubmit } ) => {
 										'google-listings-and-ads'
 									) }
 								</div>
-								<AudienceCountrySelect
+								<AppCountrySelect
+									options={ countries }
 									multiple
 									{ ...getInputProps( 'countries' ) }
 								/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
@@ -13,23 +13,26 @@ import getCountriesPriceArray from './getCountriesPriceArray';
  * @param {Object} props
  * @param {Array<ShippingRateFromServerSide>} props.value Array of individual shipping rates to be used as the initial values of the form.
  * @param {string} props.currencyCode Shop's currency code.
- * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
+ * @param {Array<CountryCode>} props.audienceCountries Array of country codes of all audience countries.
  * @param {(newValue: Object) => void} props.onChange Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChangeCallback}
  */
 export default function ShippingCountriesForm( {
 	value: shippingRates,
 	currencyCode,
-	selectedCountryCodes,
+	audienceCountries,
 	onChange,
 } ) {
 	const actualCountryCount = shippingRates.length;
 	const actualCountries = new Map(
 		shippingRates.map( ( rate ) => [ rate.countryCode, rate ] )
 	);
-	const remainingCountryCodes = selectedCountryCodes.filter(
+	const remainingCountryCodes = audienceCountries.filter(
 		( el ) => ! actualCountries.has( el )
 	);
 	const remainingCount = remainingCountryCodes.length;
+	// We may have shipping rates defined for more than the audience countries.
+	// Therefore, the number of countries we anticipate is what we acutally have + missing audience ones.
+	const totalCountyCount = actualCountryCount + remainingCount;
 
 	// Group countries with the same rate.
 	const countriesPriceArray = getCountriesPriceArray( shippingRates );
@@ -37,7 +40,7 @@ export default function ShippingCountriesForm( {
 	// Prefill to-be-added price.
 	if ( countriesPriceArray.length === 0 ) {
 		countriesPriceArray.push( {
-			countries: selectedCountryCodes,
+			countries: audienceCountries,
 			price: '',
 			currency: currencyCode,
 		} );
@@ -94,7 +97,8 @@ export default function ShippingCountriesForm( {
 						>
 							<CountriesPriceInput
 								value={ el }
-								audienceCountries={ selectedCountryCodes }
+								audienceCountries={ audienceCountries }
+								totalCountyCount={ totalCountyCount }
 								onChange={ handleChange }
 								onDelete={ handleDelete }
 							/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
@@ -94,6 +94,7 @@ export default function ShippingCountriesForm( {
 						>
 							<CountriesPriceInput
 								value={ el }
+								audienceCountries={ selectedCountryCodes }
 								onChange={ handleChange }
 								onDelete={ handleDelete }
 							/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -31,6 +31,11 @@ const EditRateModal = ( {
 	onSubmit,
 	onRequestClose,
 } ) => {
+	// We actually may have rates for more countries than the audience ones.
+	const availableCountries = Array.from(
+		new Set( [ ...rate.countries, ...audienceCountries ] )
+	);
+
 	const handleDeleteClick = () => {
 		onDelete( rate.countries );
 	};
@@ -103,7 +108,7 @@ const EditRateModal = ( {
 									) }
 								</div>
 								<AppCountrySelect
-									options={ audienceCountries }
+									options={ availableCountries }
 									multiple
 									{ ...getInputProps( 'countries' ) }
 								/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -11,19 +11,26 @@ import { Form } from '@woocommerce/components';
 import AppModal from '.~/components/app-modal';
 import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import AudienceCountrySelect from '.~/components/audience-country-select';
+import AppCountrySelect from '.~/components/app-country-select';
 import './index.scss';
 
 /**
- *Form to edit rate for selected country(-ies).
+ * Form to edit rate for selected country(-ies).
  *
  * @param {Object} props
+ * @param {Array<CountryCode>} props.audienceCountries List of all audience countries.
  * @param {AggregatedShippingRate} props.rate
  * @param {(newRate: AggregatedShippingRate, deletedCountries: Array<CountryCode>) => void} props.onSubmit Called once the rate is submitted.
  * @param {(deletedCountries: Array<CountryCode>) => void} props.onDelete Called with list of countries once Delete was requested.
  * @param {Function} props.onRequestClose Called when the form is requested ot be closed.
  */
-const EditRateModal = ( { rate, onDelete, onSubmit, onRequestClose } ) => {
+const EditRateModal = ( {
+	audienceCountries,
+	rate,
+	onDelete,
+	onSubmit,
+	onRequestClose,
+} ) => {
 	const handleDeleteClick = () => {
 		onDelete( rate.countries );
 	};
@@ -95,7 +102,8 @@ const EditRateModal = ( { rate, onDelete, onSubmit, onRequestClose } ) => {
 										'google-listings-and-ads'
 									) }
 								</div>
-								<AudienceCountrySelect
+								<AppCountrySelect
+									options={ audienceCountries }
 									multiple
 									{ ...getInputProps( 'countries' ) }
 								/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/index.js
@@ -16,11 +16,12 @@ import './index.scss';
  * form to edit rate for selected country(-ies).
  *
  * @param {Object} props
+ * @param {Array<CountryCode>} props.audienceCountries List of available audience countries.
  * @param {AggregatedShippingRate} props.rate
  * @param {(newRate: AggregatedShippingRate, deletedCountries: Array<CountryCode>) => void} props.onChange Called once the rate is submitted.
  * @param {(deletedCountries: Array<CountryCode>) => void} props.onDelete Called with list of countries once Delete was requested.
  */
-const EditRateButton = ( { rate, onChange, onDelete } ) => {
+const EditRateButton = ( { audienceCountries, rate, onChange, onDelete } ) => {
 	const [ isOpen, setOpen ] = useState( false );
 
 	const handleClick = () => {
@@ -51,6 +52,7 @@ const EditRateButton = ( { rate, onChange, onDelete } ) => {
 			</Button>
 			{ isOpen && (
 				<EditRateModal
+					audienceCountries={ audienceCountries }
 					rate={ rate }
 					onSubmit={ handleChange }
 					onDelete={ handleDelete }

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
@@ -22,12 +22,14 @@ import '../countries-form';
  * @param {Object} props
  * @param {AggregatedShippingRate} props.value Aggregate, rat: Array object to be used as the initial value.
  * @param {Array<CountryCode>} props.audienceCountries List of all audience countries.
+ * @param {number} props.totalCountyCount Number of all anticipated countries.
  * @param {(newRate: AggregatedShippingRate, deletedCountries: Array<CountryCode>|undefined) => void} props.onChange Called when rate changes.
  * @param {(deletedCountries: Array<CountryCode>) => void} props.onDelete Called with list of countries once Delete was requested.
  */
 const CountriesPriceInput = ( {
 	value,
 	audienceCountries,
+	totalCountyCount,
 	onChange,
 	onDelete,
 } ) => {
@@ -70,7 +72,7 @@ const CountriesPriceInput = ( {
 									countries: (
 										<CountryNames
 											countries={ countries }
-											total={ audienceCountries.length }
+											total={ totalCountyCount }
 										/>
 									),
 								}

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
@@ -10,7 +10,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import AppInputControl from '.~/components/app-input-control';
 import EditRateButton from './edit-rate-button';
 import AppSpinner from '.~/components/app-spinner';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import CountryNames from '.~/components/free-listings/configure-product-listings/country-names';
 import './index.scss';
 import '../countries-form';
@@ -22,14 +21,19 @@ import '../countries-form';
  *
  * @param {Object} props
  * @param {AggregatedShippingRate} props.value Aggregate, rat: Array object to be used as the initial value.
+ * @param {Array<CountryCode>} props.audienceCountries List of all audience countries.
  * @param {(newRate: AggregatedShippingRate, deletedCountries: Array<CountryCode>|undefined) => void} props.onChange Called when rate changes.
  * @param {(deletedCountries: Array<CountryCode>) => void} props.onDelete Called with list of countries once Delete was requested.
  */
-const CountriesPriceInput = ( { value, onChange, onDelete } ) => {
+const CountriesPriceInput = ( {
+	value,
+	audienceCountries,
+	onChange,
+	onDelete,
+} ) => {
 	const { countries, currency, price } = value;
-	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
-	if ( ! selectedCountryCodes ) {
+	if ( ! audienceCountries ) {
 		return <AppSpinner />;
 	}
 
@@ -64,7 +68,10 @@ const CountriesPriceInput = ( { value, onChange, onDelete } ) => {
 								),
 								{
 									countries: (
-										<CountryNames countries={ countries } />
+										<CountryNames
+											countries={ countries }
+											total={ audienceCountries.length }
+										/>
 									),
 								}
 							) }

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
@@ -77,6 +77,7 @@ const CountriesPriceInput = ( {
 							) }
 						</div>
 						<EditRateButton
+							audienceCountries={ audienceCountries }
 							onChange={ onChange }
 							onDelete={ onDelete }
 							rate={ value }

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
@@ -39,7 +39,7 @@ const ShippingRateSetup = ( { formProps, selectedCountryCodes } ) => {
 				<ShippingCountriesForm
 					{ ...getInputProps( 'shipping_country_rates' ) }
 					currencyCode={ currencyCode }
-					selectedCountryCodes={ selectedCountryCodes }
+					audienceCountries={ selectedCountryCodes }
 				/>
 				<CheckboxControl
 					label={ __(

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -11,7 +11,7 @@ import { Form } from '@woocommerce/components';
 import AppModal from '.~/components/app-modal';
 import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import AudienceCountrySelect from '.~/components/audience-country-select';
+import AppCountrySelect from '.~/components/app-country-select';
 
 /**
  * Form to add a new time for selected country(-ies).
@@ -75,7 +75,8 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 										'google-listings-and-ads'
 									) }
 								</div>
-								<AudienceCountrySelect
+								<AppCountrySelect
+									options={ countries }
 									multiple
 									{ ...getInputProps( 'countries' ) }
 								/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -92,6 +92,7 @@ export default function ShippingCountriesForm( {
 						>
 							<CountriesTimeInput
 								value={ el }
+								audienceCountries={ selectedCountryCodes }
 								onChange={ handleChange }
 								onDelete={ handleDelete }
 							/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -34,6 +34,9 @@ export default function ShippingCountriesForm( {
 		( el ) => ! actualCountries.has( el )
 	);
 	const remainingCount = remainingCountryCodes.length;
+	// We may have shipping times defined for more than the audience countries.
+	// Therefore, the number of countries we anticipate is what we acutally have + missing audience ones.
+	const totalCountyCount = actualCountryCount + remainingCount;
 
 	// Group countries with the same time.
 	const countriesTimeArray = getCountriesTimeArray( shippingTimes );
@@ -93,6 +96,7 @@ export default function ShippingCountriesForm( {
 							<CountriesTimeInput
 								value={ el }
 								audienceCountries={ selectedCountryCodes }
+								totalCountyCount={ totalCountyCount }
 								onChange={ handleChange }
 								onDelete={ handleDelete }
 							/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -11,19 +11,26 @@ import { Form } from '@woocommerce/components';
 import AppModal from '.~/components/app-modal';
 import AppInputControl from '.~/components/app-input-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import AudienceCountrySelect from '.~/components/audience-country-select';
+import AppCountrySelect from '.~/components/app-country-select';
 import './index.scss';
 
 /**
  *Form to edit time for selected country(-ies).
  *
  * @param {Object} props
+ * @param {Array<CountryCode>} props.audienceCountries List of all audience countries.
  * @param {AggregatedShippingTime} props.time
  * @param {(newTime: AggregatedShippingTime, deletedCountries: Array<CountryCode>) => void} props.onSubmit Called once the time is submitted.
  * @param {(deletedCountries: Array<CountryCode>) => void} props.onDelete Called with list of countries once Delete was requested.
  * @param {Function} props.onRequestClose Called when the form is requested ot be closed.
  */
-const EditTimeModal = ( { time, onDelete, onSubmit, onRequestClose } ) => {
+const EditTimeModal = ( {
+	audienceCountries,
+	time,
+	onDelete,
+	onSubmit,
+	onRequestClose,
+} ) => {
 	const handleDeleteClick = () => {
 		onDelete( time.countries );
 	};
@@ -94,7 +101,8 @@ const EditTimeModal = ( { time, onDelete, onSubmit, onRequestClose } ) => {
 										'google-listings-and-ads'
 									) }
 								</div>
-								<AudienceCountrySelect
+								<AppCountrySelect
+									options={ audienceCountries }
 									multiple
 									{ ...getInputProps( 'countries' ) }
 								/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -31,6 +31,11 @@ const EditTimeModal = ( {
 	onSubmit,
 	onRequestClose,
 } ) => {
+	// We actually may have times for more countries than the audience ones.
+	const availableCountries = Array.from(
+		new Set( [ ...time.countries, ...audienceCountries ] )
+	);
+
 	const handleDeleteClick = () => {
 		onDelete( time.countries );
 	};
@@ -102,7 +107,7 @@ const EditTimeModal = ( {
 									) }
 								</div>
 								<AppCountrySelect
-									options={ audienceCountries }
+									options={ availableCountries }
 									multiple
 									{ ...getInputProps( 'countries' ) }
 								/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
@@ -16,11 +16,12 @@ import './index.scss';
  * form to edit time for selected country(-ies).
  *
  * @param {Object} props
+ * @param {Array<CountryCode>} props.audienceCountries List of all audience countries.
  * @param {AggregatedShippingTime} props.time
  * @param {(newTime: AggregatedShippingTime, deletedCountries: Array<CountryCode>) => void} props.onChange Called once the time is submitted.
  * @param {(deletedCountries: Array<CountryCode>) => void} props.onDelete Called with list of countries once Delete was requested.
  */
-const EditTimeButton = ( { time, onChange, onDelete } ) => {
+const EditTimeButton = ( { audienceCountries, time, onChange, onDelete } ) => {
 	const [ isOpen, setOpen ] = useState( false );
 
 	const handleClick = () => {
@@ -51,6 +52,7 @@ const EditTimeButton = ( { time, onChange, onDelete } ) => {
 			</Button>
 			{ isOpen && (
 				<EditTimeModal
+					audienceCountries={ audienceCountries }
 					time={ time }
 					onSubmit={ handleChange }
 					onDelete={ handleDelete }

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -75,6 +75,7 @@ const CountriesTimeInput = ( {
 							) }
 						</div>
 						<EditTimeButton
+							audienceCountries={ audienceCountries }
 							onChange={ onChange }
 							onDelete={ onDelete }
 							time={ value }

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -9,7 +9,6 @@ import { createInterpolateElement } from '@wordpress/element';
  */
 import AppInputControl from '.~/components/app-input-control';
 import AppSpinner from '.~/components/app-spinner';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import EditTimeButton from './edit-time-button';
 import './index.scss';
 import CountryNames from '.~/components/free-listings/configure-product-listings/country-names';
@@ -21,14 +20,19 @@ import CountryNames from '.~/components/free-listings/configure-product-listings
  *
  * @param {Object} props
  * @param {AggregatedShippingTime} props.value Aggregate, rat: Array object to be used as the initial value.
+ * @param {Array<CountryCode>} props.audienceCountries List of all audience countries.
  * @param {(newTime: AggregatedShippingTime, deletedCountries: Array<CountryCode>|undefined) => void} props.onChange Called when time changes.
  * @param {(deletedCountries: Array<CountryCode>) => void} props.onDelete Called with list of countries once Delete was requested.
  */
-const CountriesTimeInput = ( { value, onChange, onDelete } ) => {
+const CountriesTimeInput = ( {
+	value,
+	audienceCountries,
+	onChange,
+	onDelete,
+} ) => {
 	const { countries, time } = value;
-	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
-	if ( ! selectedCountryCodes ) {
+	if ( ! audienceCountries ) {
 		return <AppSpinner />;
 	}
 
@@ -62,7 +66,10 @@ const CountriesTimeInput = ( { value, onChange, onDelete } ) => {
 								),
 								{
 									countries: (
-										<CountryNames countries={ countries } />
+										<CountryNames
+											countries={ countries }
+											total={ audienceCountries.length }
+										/>
 									),
 								}
 							) }

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -21,12 +21,14 @@ import CountryNames from '.~/components/free-listings/configure-product-listings
  * @param {Object} props
  * @param {AggregatedShippingTime} props.value Aggregate, rat: Array object to be used as the initial value.
  * @param {Array<CountryCode>} props.audienceCountries List of all audience countries.
+ * @param {number} props.totalCountyCount Number of all anticipated countries.
  * @param {(newTime: AggregatedShippingTime, deletedCountries: Array<CountryCode>|undefined) => void} props.onChange Called when time changes.
  * @param {(deletedCountries: Array<CountryCode>) => void} props.onDelete Called with list of countries once Delete was requested.
  */
 const CountriesTimeInput = ( {
 	value,
 	audienceCountries,
+	totalCountyCount,
 	onChange,
 	onDelete,
 } ) => {
@@ -68,7 +70,7 @@ const CountriesTimeInput = ( {
 									countries: (
 										<CountryNames
 											countries={ countries }
-											total={ audienceCountries.length }
+											total={ totalCountyCount }
 										/>
 									),
 								}

--- a/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
+++ b/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
@@ -11,11 +11,26 @@ import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalC
 const useDisplayTaxRate = () => {
 	const { data } = useTargetAudienceFinalCountryCodes();
 
-	if ( ! data ) {
-		return false;
-	}
-
-	return data.includes( 'US' );
+	return shouldDisplayTaxRate( data );
 };
 
 export default useDisplayTaxRate;
+
+/**
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ */
+
+/**
+ * Checks whether the Tax Rate section should be displayed, for given audience.
+ * The Tax Rate section should be displayed when there is `'US'` country code in the target audience countries list.
+ *
+ * @param {Array<CountryCode>} countries
+ * @return {boolean} `true` if the Tax Rate section should be displayed, `false` otherwise.
+ */
+export function shouldDisplayTaxRate( countries ) {
+	if ( ! countries ) {
+		return false;
+	}
+
+	return countries.includes( 'US' );
+}

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -15,7 +15,7 @@ import { useAppDispatch } from '.~/data';
 import FullContainer from '.~/components/full-container';
 import TopBar from '.~/components/stepper/top-bar';
 import ChooseAudience from '.~/components/free-listings/choose-audience';
-import useTargetAudience from '.~/hooks/useTargetAudience';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import SetupFreeListings from './setup-free-listings';
@@ -83,7 +83,11 @@ function saveShippingData( upsertAction, deleteAction, oldData, newData ) {
  * The displayed step is driven by `pageStep` URL parameter, to make it easier to permalink and navigate back and forth.
  */
 export default function EditFreeCampaign() {
-	const { data: savedTargetAudience } = useTargetAudience();
+	const {
+		targetAudience: savedTargetAudience,
+		getFinalCountries,
+	} = useTargetAudienceFinalCountryCodes();
+
 	const { settings: savedSettings } = useSettings();
 	const {
 		saveTargetAudience,
@@ -249,6 +253,9 @@ export default function EditFreeCampaign() {
 								stepHeader={ __(
 									'STEP TWO',
 									'google-listings-and-ads'
+								) }
+								countries={ getFinalCountries(
+									targetAudience
 								) }
 								settings={ settings }
 								onSettingsChange={ ( change, newSettings ) => {

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -110,14 +110,12 @@ export default function EditFreeCampaign() {
 	const [ shippingRates, updateShippingRates ] = useState(
 		savedShippingRates
 	);
-	// This is a quick and not save workaround for
+	// This is a quick and not safe workaround for
 	// https://github.com/woocommerce/google-listings-and-ads/pull/422#discussion_r607796375
 	// - `<Form>` element ignoring changes to its `initialValues` prop
 	// - default state of shipping* data of `[]`
 	// - resolver not signaling, that data is not ready yet
-	const loadedShippingRates = loadingShippingRates
-		? null
-		: savedShippingRates;
+	const loadedShippingRates = loadingShippingRates ? null : shippingRates;
 
 	const {
 		data: savedShippingTimes,
@@ -126,9 +124,7 @@ export default function EditFreeCampaign() {
 	const [ shippingTimes, updateShippingTimes ] = useState(
 		savedShippingTimes
 	);
-	const loadedShippingTimes = loadingShippingTimes
-		? null
-		: savedShippingTimes;
+	const loadedShippingTimes = loadingShippingTimes ? null : shippingTimes;
 
 	// TODO: Consider making it less repetitive.
 	useEffect( () => updateSettings( savedSettings ), [ savedSettings ] );

--- a/js/src/edit-free-campaign/setup-free-listings/form-content.js
+++ b/js/src/edit-free-campaign/setup-free-listings/form-content.js
@@ -14,14 +14,19 @@ import useDisplayTaxRate from '.~/components/free-listings/configure-product-lis
 import CombinedShipping from '.~/components/free-listings/configure-product-listings/combined-shipping';
 
 /**
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ */
+
+/**
  * Form to configure free listigns.
  * Copied from {@link .~/setup-mc/setup-stepper/setup-free-listings/form-content.js},
  * without auto-save functionality.
  *
- * @param {Object} props
+ * @param {Object} props React props.
+ * @param {Array} props.formProps
+ * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to CombinedShipping.
  */
-const FormContent = ( props ) => {
-	const { formProps } = props;
+const FormContent = ( { formProps, countries } ) => {
 	const { errors, handleSubmit } = formProps;
 	const displayTaxRate = useDisplayTaxRate();
 
@@ -29,7 +34,7 @@ const FormContent = ( props ) => {
 
 	return (
 		<StepContent>
-			<CombinedShipping formProps={ formProps } />
+			<CombinedShipping formProps={ formProps } countries={ countries } />
 			{ displayTaxRate && <TaxRate formProps={ formProps } /> }
 			<StepContentFooter>
 				<Button

--- a/js/src/edit-free-campaign/setup-free-listings/form-content.js
+++ b/js/src/edit-free-campaign/setup-free-listings/form-content.js
@@ -10,7 +10,7 @@ import { Button } from '@wordpress/components';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
 import TaxRate from '.~/components/free-listings/configure-product-listings/tax-rate';
-import useDisplayTaxRate from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
+import { shouldDisplayTaxRate } from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
 import CombinedShipping from '.~/components/free-listings/configure-product-listings/combined-shipping';
 
 /**
@@ -28,7 +28,7 @@ import CombinedShipping from '.~/components/free-listings/configure-product-list
  */
 const FormContent = ( { formProps, countries } ) => {
 	const { errors, handleSubmit } = formProps;
-	const displayTaxRate = useDisplayTaxRate();
+	const displayTaxRate = shouldDisplayTaxRate( countries );
 
 	const isCompleteSetupDisabled = Object.keys( errors ).length >= 1;
 

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -13,6 +13,7 @@ import FormContent from './form-content';
 /**
  * @typedef {import('.~/data/actions').ShippingRate} ShippingRateFromServerSide
  * @typedef {import('.~/data/actions').ShippingTime} ShippingTime
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
  */
 
 /**
@@ -23,6 +24,7 @@ import FormContent from './form-content';
  *
  * @param {Object} props
  * @param {string} props.stepHeader Header text to indicate the step number.
+ * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to FormContent.
  * @param {Object} props.settings Settings data, if not given AppSpinner will be rendered.
  * @param {(change: {name, value}, values: Object) => void} props.onSettingsChange Callback called with new data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback}
  * @param {Array<ShippingRateFromServerSide>} props.shippingRates Shipping rates data, if not given AppSpinner will be rendered.
@@ -33,6 +35,7 @@ import FormContent from './form-content';
  */
 const SetupFreeListings = ( {
 	stepHeader,
+	countries,
 	settings,
 	onSettingsChange = () => {},
 	shippingRates,
@@ -96,7 +99,12 @@ const SetupFreeListings = ( {
 				onSubmitCallback={ onContinue }
 			>
 				{ ( formProps ) => {
-					return <FormContent formProps={ formProps } />;
+					return (
+						<FormContent
+							formProps={ formProps }
+							countries={ countries }
+						/>
+					);
 				} }
 			</Form>
 		</div>

--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.js
@@ -15,7 +15,7 @@ import { STORE_KEY } from '.~/data';
 /**
  * Gets the final country codes from the Target Audience page.
  * This will call the `getTargetAudience` and `getCountries` selectors.
- * Returns `{ loading, data }`.
+ * Returns `{ loading, data, targetAudience, getFinalCountries }`.
  *
  * `loading` is true when both `getTargetAudience` and `getCountries` are still resolving.
  *
@@ -23,6 +23,11 @@ import { STORE_KEY } from '.~/data';
  * - `undefined` when loading is in progress;
  * - an array of all supported country codes when users chose `all` in target audience page;
  * - an array of selected country codes when users chose `selected` in target audience page.
+ *
+ * `targetAudience` is currentyl stored target audience, see `getTargetAudience` selector.
+ *
+ * `getFinalCountries` is a function to resolve given `targetAudience` to final list of countries.
+ *
  */
 const useTargetAudienceFinalCountryCodes = () => {
 	return useSelect( ( select ) => {
@@ -30,7 +35,7 @@ const useTargetAudienceFinalCountryCodes = () => {
 			STORE_KEY
 		);
 
-		const targetAudience = getTargetAudience();
+		const storedTargetAudience = getTargetAudience();
 		const supportedCountries = getCountries();
 
 		const targetAudienceLoading = isResolving( 'getTargetAudience' );
@@ -42,19 +47,35 @@ const useTargetAudienceFinalCountryCodes = () => {
 		 * @type {boolean}
 		 */
 		const loading = targetAudienceLoading || countriesLoading;
+		const allCountries =
+			supportedCountries && Object.keys( supportedCountries );
+
+		/**
+		 * Resolves countries from given targetAudience.
+		 * If `targetAudience.location` is set to `'all'` returns the country codes of all currentyl supported countries.
+		 *
+		 * @param {Object} targetAudience Target audience object to resolve.
+		 * @param {string} targetAudience.location
+		 * @param {string} targetAudience.countries
+		 *
+		 * @return {Array<CountryCode>} `targetAudience.countries` or all supported country codes.
+		 */
+		function getFinalCountries( targetAudience ) {
+			return targetAudience?.location === 'all'
+				? allCountries
+				: targetAudience?.countries;
+		}
+
 		/**
 		 * Final list of country codes.
-		 *
-		 * @type {Array<CountryCode>}
 		 */
-		const data =
-			targetAudience?.location === 'all'
-				? supportedCountries && Object.keys( supportedCountries )
-				: targetAudience?.countries;
+		const data = getFinalCountries( storedTargetAudience );
 
 		return {
 			loading,
 			data,
+			targetAudience: storedTargetAudience,
+			getFinalCountries,
 		};
 	} );
 };

--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.js
@@ -9,6 +9,10 @@ import { useSelect } from '@wordpress/data';
 import { STORE_KEY } from '.~/data';
 
 /**
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ */
+
+/**
  * Gets the final country codes from the Target Audience page.
  * This will call the `getTargetAudience` and `getCountries` selectors.
  * Returns `{ loading, data }`.
@@ -32,7 +36,17 @@ const useTargetAudienceFinalCountryCodes = () => {
 		const targetAudienceLoading = isResolving( 'getTargetAudience' );
 		const countriesLoading = isResolving( 'getCountries' );
 
+		/**
+		 * Flag to indicate that the data is loading.
+		 *
+		 * @type {boolean}
+		 */
 		const loading = targetAudienceLoading || countriesLoading;
+		/**
+		 * Final list of country codes.
+		 *
+		 * @type {Array<CountryCode>}
+		 */
 		const data =
 			targetAudience?.location === 'all'
 				? supportedCountries && Object.keys( supportedCountries )

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
@@ -44,7 +44,12 @@ const CountriesPriceInput = ( props ) => {
 								),
 								{
 									countries: (
-										<CountryNames countries={ countries } />
+										<CountryNames
+											countries={ countries }
+											total={
+												selectedCountryCodes.length
+											}
+										/>
 									),
 								}
 							) }

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -43,7 +43,12 @@ const CountriesTimeInput = ( props ) => {
 								),
 								{
 									countries: (
-										<CountryNames countries={ countries } />
+										<CountryNames
+											countries={ countries }
+											total={
+												selectedCountryCodes.length
+											}
+										/>
 									),
 								}
 							) }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Make step 2 inputs operate on audience countries provided in step 1.
Previously, every component was fetching old, saved state itself, and acting on it.

Also, it fixes the workaround for initial `[]` state (https://github.com/woocommerce/google-listings-and-ads/pull/444/commits/278219a6d6d601fe406cb702db34b7292f61e3bc)

Implements part of #156 


### Screenshots:


https://user-images.githubusercontent.com/17435/114392658-6020dc80-9b99-11eb-8785-aa328a44f9d1.mp4





### Detailed test instructions:

1. Got to [**Marketing > GLA > Dashboard > "Edit" free campaign**](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fedit-free-campaign&programId=0&pageStep=1)
2. Change the "Location" - switch between "all"/"selected", or change the selected list by adding and removing countries.
3. Continue to Step 2
4. Make sure Edit and Add controls operate on the changed list of countries.
5. Make sure Tax Rate section is shown/hidden accordingly to the presence of `US` in the changed audience.
6. (optionally) Go back to Step 1 and repeat points 2-5.
7. Save changes.
8. Check if correct things were saved.

### To be done here:
- [ ] Make "All countries" condition cater for shipping rates/times defined for more countries that target audience.

### Changelog Note:

> Make step 2 of free campaign editing use countries defined in step 1

### Doubts:

1. Shipping Rates & Times set for deleted countries are preserved before and after the save button is clicked. I.e.
	1. Open step 2 with shipping times/rates defined for: `US: 10, PL: 2, SG: 4`.
	2. Go back to step 1, (add `NZ`) remove `PL`.
	3. Continue to step 2. Visible times/rates are: `US: 10, SG: 4` (+ `PL: 2` :question: ).
	4. "Oh! I shouldn't have removed `PL` :facepalm: " Go back to step 1, add `PL`.
	5. Continue to step 2. Visible times/rates are: `US: 10, PL: 2, SG: 4`.
	
	Or even more drastic change:
	
	1. Open step 1 with few countries defined, change to `"all"`.
	1. Open step 2 carefully define rates/times for all 190+ countries, different for every one.
	2. Go back to step 1, switch `Selected countries only: US, SG`.
	3. Continue to step 2. Visible times/rates are: `US: 10, SG: 4`. ( or all countries :question:)
	4. "Oh! I shouldn't have changed that :facepalm: " Go back to step 1, add change to `"all"`.
	5. Continue to step 2. The entire setup is restored.
	
	With save
	
	1. Open step 2 with shipping times/rates defined for: `US: 10, PL: 2, SG: 4`.
	2. Go back to step 1, (add `NZ`) remove `PL`.
	3. Continue to step 2. Visible times/rates are: `US: 10, SG: 4` (+ `PL: 2` :question: ).
	4. Save changes. Navigate away.
	4. "Oh! I shouldn't have removed `PL` :facepalm: " Open edit form again, add `PL`.
	5. Continue to step 2. Visible times/rates are: `US: 10, PL: 2, SG: 4`.
	
	Do we want that behavior? Should we display those preserved shipping rates/times on the second step? @j111q 
	I'd like to confirm it's a feature, not a bug, that we can save and sync rates for the "disabled" audience. @mikkamp 
	
https://user-images.githubusercontent.com/17435/114392816-952d2f00-9b99-11eb-8a46-55fb217ed91b.mp4


### Additional notes

1. :warning: MC setup would need some testing, as I changed shared `CountryNames` which had hardwired the audience data source inside.  [`5628878` (#444)](https://github.com/woocommerce/google-listings-and-ads/pull/444/commits/56288781b9285fe11c25bb519db5c41658778e78)



