### PR TITLE
Check for adsSetupComplete before getting campaigns

### DIFF
--- a/js/src/hooks/useAdsCampaigns.js
+++ b/js/src/hooks/useAdsCampaigns.js
@@ -7,9 +7,22 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { STORE_KEY } from '.~/data';
+import { glaData } from '.~/constants';
 
 const useAdsCampaigns = () => {
 	return useSelect( ( select ) => {
+		// TODO: ideally adsSetupComplete should be retrieved from API endpoint
+		// and then put into wp-data.
+		// With that in place, then we don't need to depend on glaData
+		// which requires force reload using window.location.href.
+		const { adsSetupComplete } = glaData;
+		if ( ! adsSetupComplete ) {
+			return {
+				loading: false,
+				data: [],
+			};
+		}
+
 		const { getAdsCampaigns, isResolving } = select( STORE_KEY );
 
 		const data = getAdsCampaigns();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #446 .

This PR checks for `gla.adsSetupComplete` before getting campaigns to prevent getting error response when ads setup is not completed yet.

I think ideally we should retrieve `adsSetupComplete` from an API endpoint and then put it into wp-data store. With that in place, we don't need to depend on the global `glaData` which requires force reload using `window.location.href`.

### Detailed test instructions:

1. Don't complete ads setup. Open your browser dev tools network panel.
2. Open dashboard page at https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard
3. Make sure there are no requests to `/ads/campaigns` API endpoint.
4. Complete ads setup. You should be directed to dashboard page again.
5. Make sure there is a request to `/ads/campaigns` API endpoint.

### Changelog Note:

Check for adsSetupComplete before getting campaigns.
