### PR TITLE
For Beta Testing: block reclaim URL and switch URL

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/beta-reclaim-url-card.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/beta-reclaim-url-card.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import Section from '.~/wcdl/section';
+import Subsection from '.~/wcdl/subsection';
+import ContentButtonLayout from '.~/components/content-button-layout';
+import betaExistingProductListingsStatement from './betaExistingProductListingsStatement';
+
+/**
+ * This is used temporarily for beta testing purpose. For production roll out, we should remove this and use the above ReclaimUrlCard instead.
+ *
+ * @param {Object} props Props.
+ */
+const BetaReclaimUrlCard = ( props ) => {
+	const { websiteUrl } = props;
+
+	return (
+		<Section.Card>
+			<Section.Card.Body>
+				<ContentButtonLayout>
+					<div>
+						<Subsection.Title>
+							{ createInterpolateElement(
+								__(
+									'Your URL, <url />, is currently claimed by another Merchant Center account. ',
+									'google-listings-and-ads'
+								),
+								{
+									url: <span>{ websiteUrl }</span>,
+								}
+							) }
+						</Subsection.Title>
+						<Subsection.HelperText>
+							{ betaExistingProductListingsStatement }
+						</Subsection.HelperText>
+					</div>
+				</ContentButtonLayout>
+			</Section.Card.Body>
+			<Section.Card.Footer>
+				<AppDocumentationLink
+					context="setup-mc"
+					linkId="claim-url"
+					href="https://support.google.com/merchants/answer/176793"
+				>
+					{ __(
+						'Read more about claiming URLs',
+						'google-listings-and-ads'
+					) }
+				</AppDocumentationLink>
+			</Section.Card.Footer>
+		</Section.Card>
+	);
+};
+
+export default BetaReclaimUrlCard;

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/beta-switch-url-card.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/beta-switch-url-card.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import toAccountText from '.~/utils/toAccountText';
+import AppTextButton from '.~/components/app-text-button';
+import Section from '.~/wcdl/section';
+import Subsection from '.~/wcdl/subsection';
+import ContentButtonLayout from '.~/components/content-button-layout';
+import betaExistingProductListingsStatement from './betaExistingProductListingsStatement';
+
+/**
+ * This is used temporarily for beta testing purpose. For production roll out, we should remove this and use the above SwitchUrlCard instead.
+ *
+ * @param {Object} props Props.
+ */
+const BetaSwitchUrlCard = ( props ) => {
+	const { id, message, onSelectAnotherAccount = () => {} } = props;
+
+	const handleUseDifferentMCClick = () => {
+		onSelectAnotherAccount();
+	};
+
+	return (
+		<Section.Card className="gla-switch-url-card">
+			<Section.Card.Body>
+				<ContentButtonLayout>
+					<Subsection.Title>{ toAccountText( id ) }</Subsection.Title>
+				</ContentButtonLayout>
+				<ContentButtonLayout>
+					<div>
+						<Subsection.Title>{ message }</Subsection.Title>
+						<Subsection.HelperText>
+							{ betaExistingProductListingsStatement }
+						</Subsection.HelperText>
+					</div>
+				</ContentButtonLayout>
+			</Section.Card.Body>
+			<Section.Card.Footer>
+				<AppTextButton
+					isSecondary
+					onClick={ handleUseDifferentMCClick }
+				>
+					{ __(
+						'Or, use a different Merchant Center account',
+						'google-listings-and-ads'
+					) }
+				</AppTextButton>
+			</Section.Card.Footer>
+		</Section.Card>
+	);
+};
+
+export default BetaSwitchUrlCard;

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/betaExistingProductListingsStatement.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/betaExistingProductListingsStatement.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Only used temporarily for beta testing purpose. For production roll out, this should be not needed.
+ */
+const betaExistingProductListingsStatement = __(
+	`We've detected that your store may have some existing product listings in Google. Because this extension is still in beta, we don't want to disrupt any active listings, so you cannot continue to setup this extension at this point. Thanks for participating in our beta test!`,
+	'google-listings-and-ads'
+);
+
+export default betaExistingProductListingsStatement;

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -14,7 +14,7 @@ import Subsection from '.~/wcdl/subsection';
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
-import SwitchUrlCard from '../switch-url-card';
+import BetaSwitchUrlCard from '../beta-switch-url-card';
 import BetaReclaimUrlCard from '../beta-reclaim-url-card';
 import AppTextButton from '.~/components/app-text-button';
 
@@ -47,7 +47,10 @@ const ConnectMCCard = ( props ) => {
 
 	if ( response && response.status === 409 ) {
 		return (
-			<SwitchUrlCard
+			// TODO: Use the BetaSwitchUrlCard for beta testing purpose only.
+			// To switch back to SwitchUrlCard for production roll out.
+			// <SwitchUrlCard
+			<BetaSwitchUrlCard
 				id={ error.id }
 				message={ error.message }
 				claimedUrl={ error.claimed_url }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -15,7 +15,7 @@ import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import SwitchUrlCard from '../switch-url-card';
-import ReclaimUrlCard from '../reclaim-url-card';
+import BetaReclaimUrlCard from '../beta-reclaim-url-card';
 import AppTextButton from '.~/components/app-text-button';
 
 const ConnectMCCard = ( props ) => {
@@ -58,7 +58,10 @@ const ConnectMCCard = ( props ) => {
 	}
 
 	if ( response && response.status === 403 ) {
-		return <ReclaimUrlCard websiteUrl={ error.website_url } />;
+		// TODO: Use the BetaReclaimUrlCard for beta testing purpose only.
+		// To switch back to ReclaimUrlCard for production roll out.
+		// return <ReclaimUrlCard websiteUrl={ error.website_url } />;
+		return <BetaReclaimUrlCard websiteUrl={ error.website_url } />;
 	}
 
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
@@ -10,7 +10,7 @@ import { useAppDispatch } from '.~/data';
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import CreateAccountCard from './create-account-card';
 import CreatingCard from './creating-card';
-import ReclaimUrlCard from '../reclaim-url-card';
+import BetaReclaimUrlCard from '../beta-reclaim-url-card';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 
 const CreateAccount = ( props ) => {
@@ -57,7 +57,10 @@ const CreateAccount = ( props ) => {
 	}
 
 	if ( response && response.status === 403 ) {
-		return <ReclaimUrlCard websiteUrl={ error.website_url } />;
+		// TODO: Use the BetaReclaimUrlCard for beta testing purpose only.
+		// To switch back to ReclaimUrlCard for production roll out.
+		// return <ReclaimUrlCard websiteUrl={ error.website_url } />;
+		return <BetaReclaimUrlCard websiteUrl={ error.website_url } />;
 	}
 
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -17,6 +17,11 @@ import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import ReclaimUrlFailCard from './reclaim-url-fail-card';
 
+/**
+ * Temporarily unused for beta testing period. This should be used in production later.
+ *
+ * @param {Object} props Props.
+ */
 const ReclaimUrlCard = ( props ) => {
 	const { websiteUrl } = props;
 	const { createNotice } = useDispatchCoreNotices();

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -17,6 +17,12 @@ import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import ReclaimUrlFailCard from './reclaim-url-fail-card';
 
+/**
+ * Temporarily unused for beta testing period. This should be used in production later.
+ *
+ * @param {Object} props Props.
+ * * @param {string} props.websiteUrl Website URL.
+ */
 const ReclaimUrlCard = ( props ) => {
 	const { websiteUrl } = props;
 	const { createNotice } = useDispatchCoreNotices();
@@ -104,4 +110,54 @@ const ReclaimUrlCard = ( props ) => {
 	);
 };
 
-export default ReclaimUrlCard;
+/**
+ * This is used temporarily for beta testing purpose. For production roll out, we should remove this and use the above ReclaimUrlCard instead.
+ *
+ * @param {Object} props Props.
+ */
+const BetaReclaimUrlCard = ( props ) => {
+	const { websiteUrl } = props;
+
+	return (
+		<Section.Card>
+			<Section.Card.Body>
+				<ContentButtonLayout>
+					<div>
+						<Subsection.Title>
+							{ createInterpolateElement(
+								__(
+									'Your URL, <url />, is currently claimed by another Merchant Center account. ',
+									'google-listings-and-ads'
+								),
+								{
+									url: <span>{ websiteUrl }</span>,
+								}
+							) }
+						</Subsection.Title>
+						<Subsection.HelperText>
+							{ __(
+								`We've detected that your store may have some existing product listings in Google. Because this extension is still in beta, we don't want to disrupt any active listings, so you cannot continue to setup this extension at this point. Thanks for participating in our beta test!`,
+								'google-listings-and-ads'
+							) }
+						</Subsection.HelperText>
+					</div>
+				</ContentButtonLayout>
+			</Section.Card.Body>
+			<Section.Card.Footer>
+				<AppDocumentationLink
+					context="setup-mc"
+					linkId="claim-url"
+					href="https://support.google.com/merchants/answer/176793"
+				>
+					{ __(
+						'Read more about claiming URLs',
+						'google-listings-and-ads'
+					) }
+				</AppDocumentationLink>
+			</Section.Card.Footer>
+		</Section.Card>
+	);
+};
+
+// export default ReclaimUrlCard;
+export default BetaReclaimUrlCard;

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -16,6 +16,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import ReclaimUrlFailCard from './reclaim-url-fail-card';
+import betaExistingProductListingsStatement from '../betaExistingProductListingsStatement';
 
 /**
  * Temporarily unused for beta testing period. This should be used in production later.
@@ -135,10 +136,7 @@ const BetaReclaimUrlCard = ( props ) => {
 							) }
 						</Subsection.Title>
 						<Subsection.HelperText>
-							{ __(
-								`We've detected that your store may have some existing product listings in Google. Because this extension is still in beta, we don't want to disrupt any active listings, so you cannot continue to setup this extension at this point. Thanks for participating in our beta test!`,
-								'google-listings-and-ads'
-							) }
+							{ betaExistingProductListingsStatement }
 						</Subsection.HelperText>
 					</div>
 				</ContentButtonLayout>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -16,14 +16,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import ReclaimUrlFailCard from './reclaim-url-fail-card';
-import betaExistingProductListingsStatement from '../betaExistingProductListingsStatement';
 
-/**
- * Temporarily unused for beta testing period. This should be used in production later.
- *
- * @param {Object} props Props.
- * * @param {string} props.websiteUrl Website URL.
- */
 const ReclaimUrlCard = ( props ) => {
 	const { websiteUrl } = props;
 	const { createNotice } = useDispatchCoreNotices();
@@ -111,51 +104,4 @@ const ReclaimUrlCard = ( props ) => {
 	);
 };
 
-/**
- * This is used temporarily for beta testing purpose. For production roll out, we should remove this and use the above ReclaimUrlCard instead.
- *
- * @param {Object} props Props.
- */
-const BetaReclaimUrlCard = ( props ) => {
-	const { websiteUrl } = props;
-
-	return (
-		<Section.Card>
-			<Section.Card.Body>
-				<ContentButtonLayout>
-					<div>
-						<Subsection.Title>
-							{ createInterpolateElement(
-								__(
-									'Your URL, <url />, is currently claimed by another Merchant Center account. ',
-									'google-listings-and-ads'
-								),
-								{
-									url: <span>{ websiteUrl }</span>,
-								}
-							) }
-						</Subsection.Title>
-						<Subsection.HelperText>
-							{ betaExistingProductListingsStatement }
-						</Subsection.HelperText>
-					</div>
-				</ContentButtonLayout>
-			</Section.Card.Body>
-			<Section.Card.Footer>
-				<AppDocumentationLink
-					context="setup-mc"
-					linkId="claim-url"
-					href="https://support.google.com/merchants/answer/176793"
-				>
-					{ __(
-						'Read more about claiming URLs',
-						'google-listings-and-ads'
-					) }
-				</AppDocumentationLink>
-			</Section.Card.Footer>
-		</Section.Card>
-	);
-};
-
-// export default ReclaimUrlCard;
-export default BetaReclaimUrlCard;
+export default ReclaimUrlCard;

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
@@ -16,7 +16,6 @@ import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import './index.scss';
-import betaExistingProductListingsStatement from '../betaExistingProductListingsStatement';
 
 /**
  * Temporarily unused for beta testing period. This should be used in production later.
@@ -99,47 +98,4 @@ const SwitchUrlCard = ( props ) => {
 	);
 };
 
-/**
- * This is used temporarily for beta testing purpose. For production roll out, we should remove this and use the above SwitchUrlCard instead.
- *
- * @param {Object} props Props.
- */
-const BetaSwitchUrlCard = ( props ) => {
-	const { id, message, onSelectAnotherAccount = () => {} } = props;
-
-	const handleUseDifferentMCClick = () => {
-		onSelectAnotherAccount();
-	};
-
-	return (
-		<Section.Card className="gla-switch-url-card">
-			<Section.Card.Body>
-				<ContentButtonLayout>
-					<Subsection.Title>{ toAccountText( id ) }</Subsection.Title>
-				</ContentButtonLayout>
-				<ContentButtonLayout>
-					<div>
-						<Subsection.Title>{ message }</Subsection.Title>
-						<Subsection.HelperText>
-							{ betaExistingProductListingsStatement }
-						</Subsection.HelperText>
-					</div>
-				</ContentButtonLayout>
-			</Section.Card.Body>
-			<Section.Card.Footer>
-				<AppTextButton
-					isSecondary
-					onClick={ handleUseDifferentMCClick }
-				>
-					{ __(
-						'Or, use a different Merchant Center account',
-						'google-listings-and-ads'
-					) }
-				</AppTextButton>
-			</Section.Card.Footer>
-		</Section.Card>
-	);
-};
-
-// export default SwitchUrlCard;
-export default BetaSwitchUrlCard;
+export default SwitchUrlCard;

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
@@ -16,6 +16,7 @@ import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import './index.scss';
+import betaExistingProductListingsStatement from '../betaExistingProductListingsStatement';
 
 /**
  * Temporarily unused for beta testing period. This should be used in production later.
@@ -120,10 +121,7 @@ const BetaSwitchUrlCard = ( props ) => {
 					<div>
 						<Subsection.Title>{ message }</Subsection.Title>
 						<Subsection.HelperText>
-							{ __(
-								`We've detected that your store may have some existing product listings in Google. Because this extension is still in beta, we don't want to disrupt any active listings, so you cannot continue to setup this extension at this point. Thanks for participating in our beta test!`,
-								'google-listings-and-ads'
-							) }
+							{ betaExistingProductListingsStatement }
 						</Subsection.HelperText>
 					</div>
 				</ContentButtonLayout>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
@@ -17,6 +17,11 @@ import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import './index.scss';
 
+/**
+ * Temporarily unused for beta testing period. This should be used in production later.
+ *
+ * @param {Object} props Props.
+ */
 const SwitchUrlCard = ( props ) => {
 	const {
 		id,
@@ -93,4 +98,50 @@ const SwitchUrlCard = ( props ) => {
 	);
 };
 
-export default SwitchUrlCard;
+/**
+ * This is used temporarily for beta testing purpose. For production roll out, we should remove this and use the above SwitchUrlCard instead.
+ *
+ * @param {Object} props Props.
+ */
+const BetaSwitchUrlCard = ( props ) => {
+	const { id, message, onSelectAnotherAccount = () => {} } = props;
+
+	const handleUseDifferentMCClick = () => {
+		onSelectAnotherAccount();
+	};
+
+	return (
+		<Section.Card className="gla-switch-url-card">
+			<Section.Card.Body>
+				<ContentButtonLayout>
+					<Subsection.Title>{ toAccountText( id ) }</Subsection.Title>
+				</ContentButtonLayout>
+				<ContentButtonLayout>
+					<div>
+						<Subsection.Title>{ message }</Subsection.Title>
+						<Subsection.HelperText>
+							{ __(
+								`We've detected that your store may have some existing product listings in Google. Because this extension is still in beta, we don't want to disrupt any active listings, so you cannot continue to setup this extension at this point. Thanks for participating in our beta test!`,
+								'google-listings-and-ads'
+							) }
+						</Subsection.HelperText>
+					</div>
+				</ContentButtonLayout>
+			</Section.Card.Body>
+			<Section.Card.Footer>
+				<AppTextButton
+					isSecondary
+					onClick={ handleUseDifferentMCClick }
+				>
+					{ __(
+						'Or, use a different Merchant Center account',
+						'google-listings-and-ads'
+					) }
+				</AppTextButton>
+			</Section.Card.Footer>
+		</Section.Card>
+	);
+};
+
+// export default SwitchUrlCard;
+export default BetaSwitchUrlCard;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #459 .

This PR provides a temporary beta testing measure to not allow users to reclaim URL and switch to new URL, so that we do not disrupt users' active listings during this beta testing.

MC Account Setup Flow chart: https://docs.google.com/presentation/d/1MqkxuWsDEmfTFDwi1Shkh_mOX30VdJ25dHCQDW4vg0Y/edit#slide=id.p

### Screenshots:

Blocked Reclaim URL:

![image](https://user-images.githubusercontent.com/417342/114431330-f41e9280-9bf1-11eb-96b3-eb9629c42b9e.png)

Blocked switch to new URL:

![image](https://user-images.githubusercontent.com/417342/114431347-fa147380-9bf1-11eb-900b-66d1db397b6b.png)

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc
2. Use a Google account and Google MC account that would require reclaiming URL and switching to new URL.
3. Reclaim URL and switch to new URL should display the UI as per the above screenshots.

### Changelog Note:

For beta testing: block users from reclaiming URL and switching to new URL to avoid disrupting active listings.
