### PR TITLE
Dedicated Merchant Center issues table

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -69,11 +69,10 @@ class IssuesController extends BaseOptionsController {
 			$page        = max( 1, intval( $request['page'] ) );
 
 			try {
-				$total = $this->mc_issues->count( $type_filter );
 				return $this->prepare_item_for_response(
 					[
 						'issues' => $this->mc_issues->get( $type_filter, $per_page, $page ),
-						'total'  => $total,
+						'total'  => $this->mc_issues->count( $type_filter ),
 						'page'   => $page,
 					],
 					$request

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -128,14 +128,9 @@ class IssuesController extends BaseOptionsController {
 							'description' => __( 'Descriptive text of action to take.', 'google-listings-and-ads' ),
 							'context'     => [ 'view' ],
 						],
-						'action_link'          => [
+						'action_url'           => [
 							'type'        => 'string',
 							'description' => __( 'Documentation URL for issue and/or action.', 'google-listings-and-ads' ),
-							'context'     => [ 'view' ],
-						],
-						'edit_link'            => [
-							'type'        => 'string',
-							'description' => __( 'Link to affected product edit page.', 'google-listings-and-ads' ),
 							'context'     => [ 'view' ],
 						],
 						'applicable_countries' => [

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -69,10 +69,11 @@ class IssuesController extends BaseOptionsController {
 			$page        = max( 1, intval( $request['page'] ) );
 
 			try {
+				$issues = $this->mc_issues->get( $type_filter, $per_page, $page );
 				return $this->prepare_item_for_response(
 					[
-						'issues' => $this->mc_issues->get( $type_filter, $per_page, $page ),
-						'total'  => $this->mc_issues->count( $type_filter ),
+						'issues' => $issues['results'],
+						'total'  => $issues['count'],
 						'page'   => $page,
 					],
 					$request

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantIssues;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantIssues;
 use WP_REST_Response as Response;
 use WP_REST_Request as Request;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -440,11 +440,17 @@ abstract class Query implements QueryInterface {
 			$all_values       = [];
 			$all_placeholders = [];
 			foreach ( array_slice( $records, $i, $chunk_size ) as $issue ) {
+				if ( array_keys( $issue ) !== $columns ) {
+					throw new InvalidQuery( 'Not all records contain the same columns' );
+				}
 				$all_placeholders[] = $single_placeholder;
 				array_push( $all_values, ...array_values( $issue ) );
 			}
 
-			$query  = 'INSERT INTO ' . $this->table->get_sql_safe_name() . ' (`' . implode( '`, `', $columns ) . '`) VALUES ';
+			$table_name   = $this->wpdb->_escape( $this->table->get_name() );
+			$column_names = '(`' . implode( '`, `', $columns ) . '`)';
+
+			$query  = "INSERT INTO `{$table_name}` $column_names VALUES ";
 			$query .= implode( ', ', $all_placeholders );
 			$query .= ' ON DUPLICATE KEY UPDATE ' . implode( ', ', $update_values );
 

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -435,7 +435,7 @@ abstract class Query implements QueryInterface {
 	 *
 	 * @throws InvalidQuery If an invalid column name is provided.
 	 */
-	public function update_or_insert( array $records ) {
+	public function update_or_insert( array $records ): void {
 		if ( empty( $records ) ) {
 			return;
 		}

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -40,7 +40,7 @@ abstract class Query implements QueryInterface {
 	 *
 	 * @var int
 	 */
-	protected $num_rows = null;
+	protected $count = null;
 
 	/** @var TableInterface */
 	protected $table;
@@ -169,11 +169,11 @@ abstract class Query implements QueryInterface {
 	 * @return int
 	 */
 	public function get_count(): int {
-		if ( null === $this->num_rows ) {
+		if ( null === $this->count ) {
 			$this->count_results(); // phpcs:ignore WordPress.DB.PreparedSQL
 		}
 
-		return $this->num_rows;
+		return $this->count;
 	}
 
 	/**
@@ -206,7 +206,7 @@ abstract class Query implements QueryInterface {
 	 * Count the results and save the result.
 	 */
 	protected function count_results() {
-		$this->num_rows = (int) $this->wpdb->get_var( $this->build_query( true ) ); // phpcs:ignore WordPress.DB.PreparedSQL
+		$this->count = (int) $this->wpdb->get_var( $this->build_query( true ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 
 	/**

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -273,24 +273,25 @@ abstract class Query implements QueryInterface {
 	 * @return string
 	 */
 	protected function build_query( bool $get_count = false ): string {
-		$pieces = [ 'SELECT ' . ( $get_count ? 'COUNT(*)' : '*' ) . " FROM {$this->table->get_name()}" ];
+		$columns = $get_count ? 'COUNT(*)' : '*';
+		$pieces  = [ "SELECT {$columns} FROM {$this->table->get_name()}" ];
 
 		$pieces = array_merge( $pieces, $this->generate_where_pieces() );
 
 		if ( ! $get_count ) {
 			$pieces[] = "GROUP BY {$this->table->get_name()}.{$this->table->get_primary_column()}";
-		}
 
-		if ( $this->orderby ) {
-			$pieces[] = "ORDER BY {$this->orderby} {$this->order}";
-		}
+			if ( $this->orderby ) {
+				$pieces[] = "ORDER BY {$this->orderby} {$this->order}";
+			}
 
-		if ( $this->limit ) {
-			$pieces[] = "LIMIT {$this->limit}";
-		}
+			if ( $this->limit ) {
+				$pieces[] = "LIMIT {$this->limit}";
+			}
 
-		if ( $this->offset ) {
-			$pieces[] = "OFFSET {$this->offset}";
+			if ( $this->offset ) {
+				$pieces[] = "OFFSET {$this->offset}";
+			}
 		}
 
 		return join( "\n", $pieces );

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -288,12 +288,12 @@ abstract class Query implements QueryInterface {
 	 */
 	protected function build_query( bool $get_count = false ): string {
 		$columns = $get_count ? 'COUNT(*)' : '*';
-		$pieces  = [ "SELECT {$columns} FROM {$this->table->get_name()}" ];
+		$pieces  = [ "SELECT {$columns} FROM `{$this->table->get_name()}`" ];
 
 		$pieces = array_merge( $pieces, $this->generate_where_pieces() );
 
 		if ( ! $get_count ) {
-			$pieces[] = "GROUP BY {$this->table->get_name()}.{$this->table->get_primary_column()}";
+			$pieces[] = "GROUP BY `{$this->table->get_name()}`.`{$this->table->get_primary_column()}`";
 
 			if ( $this->orderby ) {
 				$pieces[] = "ORDER BY {$this->orderby} {$this->order}";

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -163,11 +163,7 @@ abstract class Query implements QueryInterface {
 	 */
 	public function get_count(): int {
 		if ( null === $this->results ) {
-			$count = $this->wpdb->get_results(
-				$this->build_query( true ), // phpcs:ignore WordPress.DB.PreparedSQL
-				ARRAY_N
-			);
-			return intval( $count[0][0] ?? 0 );
+			return intval( $this->wpdb->get_var( $this->build_query( true ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 		}
 
 		return count( $this->results );

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -35,6 +35,13 @@ abstract class Query implements QueryInterface {
 	 */
 	protected $results = null;
 
+	/**
+	 * The number of rows returned by the query.
+	 *
+	 * @var int
+	 */
+	protected $num_rows = null;
+
 	/** @var TableInterface */
 	protected $table;
 
@@ -162,11 +169,11 @@ abstract class Query implements QueryInterface {
 	 * @return int
 	 */
 	public function get_count(): int {
-		if ( null === $this->results ) {
-			return intval( $this->wpdb->get_var( $this->build_query( true ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
+		if ( null === $this->num_rows ) {
+			$this->count_results(); // phpcs:ignore WordPress.DB.PreparedSQL
 		}
 
-		return count( $this->results );
+		return $this->num_rows;
 	}
 
 	/**
@@ -193,6 +200,13 @@ abstract class Query implements QueryInterface {
 			$this->build_query(), // phpcs:ignore WordPress.DB.PreparedSQL
 			ARRAY_A
 		);
+	}
+
+	/**
+	 * Count the results and save the result.
+	 */
+	protected function count_results() {
+		$this->num_rows = (int) $this->wpdb->get_var( $this->build_query( true ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 
 	/**

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -461,10 +461,9 @@ abstract class Query implements QueryInterface {
 				array_push( $all_values, ...array_values( $issue ) );
 			}
 
-			$table_name   = $this->wpdb->_escape( $this->table->get_name() );
 			$column_names = '(`' . implode( '`, `', $columns ) . '`)';
 
-			$query  = "INSERT INTO `{$table_name}` $column_names VALUES ";
+			$query  = "INSERT INTO `{$this->table->get_name()}` $column_names VALUES ";
 			$query .= implode( ', ', $all_placeholders );
 			$query .= ' ON DUPLICATE KEY UPDATE ' . implode( ', ', $update_values );
 

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -170,7 +170,7 @@ abstract class Query implements QueryInterface {
 	 */
 	public function get_count(): int {
 		if ( null === $this->count ) {
-			$this->count_results(); // phpcs:ignore WordPress.DB.PreparedSQL
+			$this->count_results();
 		}
 
 		return $this->count;

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -37,4 +37,35 @@ class MerchantIssueQuery extends Query {
 	protected function sanitize_value( string $column, $value ) {
 		return $value;
 	}
+
+	/**
+	 * Batch update or insert a set of merchant issues.
+	 *
+	 * @param array $issues The issues to be updated or inserted.
+	 */
+	public function update_or_insert( array $issues ) {
+		if ( empty( $issues ) ) {
+			return;
+		}
+
+		$update_values = [];
+		$columns       = array_keys( $issues[0] );
+		foreach ( $columns as $c ) {
+			$update_values[] = "`$c`=VALUES(`$c`)";
+		}
+		$single_placeholder = '(' . implode( ',', array_fill( 0, count( $columns ), "'%s'" ) ) . ')';
+
+		$all_values       = [];
+		$all_placeholders = [];
+		foreach ( $issues as $i ) {
+			$all_placeholders[] = $single_placeholder;
+			array_push( $all_values, ...array_values( $i ) );
+		}
+
+		$query  = 'INSERT INTO ' . $this->table->get_sql_safe_name() . ' (`' . implode( '`, `', $columns ) . '`) VALUES ';
+		$query .= implode( ', ', $all_placeholders );
+		$query .= ' ON DUPLICATE KEY UPDATE ' . implode( ', ', $update_values );
+
+		$this->wpdb->query( $this->wpdb->prepare( $query, $all_values ) ); // phpcs:ignore WordPress.DB.PreparedSQL
+	}
 }

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -5,8 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
-use DateTime;
 use wpdb;
 
 defined( 'ABSPATH' ) || exit;
@@ -38,15 +36,5 @@ class MerchantIssueQuery extends Query {
 	 */
 	protected function sanitize_value( string $column, $value ) {
 		return $value;
-	}
-
-	/**
-	 * Delete stale issue records.
-	 *
-	 * @param DateTime $created_before Delete all records created before this.
-	 */
-	public function delete_stale( DateTime $created_before ) {
-		$query = 'DELETE FROM ' . $this->table->get_sql_safe_name() . ' WHERE `created_at` < \'%s\'';
-		$this->wpdb->query( $this->wpdb->prepare( $query, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 }

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
+use DateTime;
 use wpdb;
 
 defined( 'ABSPATH' ) || exit;
@@ -67,5 +68,15 @@ class MerchantIssueQuery extends Query {
 		$query .= ' ON DUPLICATE KEY UPDATE ' . implode( ', ', $update_values );
 
 		$this->wpdb->query( $this->wpdb->prepare( $query, $all_values ) ); // phpcs:ignore WordPress.DB.PreparedSQL
+	}
+
+	/**
+	 * Delete stale issue records.
+	 *
+	 * @param DateTime $created_before Delete all records created before this.
+	 */
+	public function delete_stale( DateTime $created_before ) {
+		$query = 'DELETE FROM ' . $this->table->get_sql_safe_name() . ' WHERE `created_at` < \'%s\'';
+		$this->wpdb->query( $this->wpdb->prepare( $query, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 }

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -58,20 +58,24 @@ class MerchantIssueQuery extends Query {
 			$this->validate_column( $c );
 			$update_values[] = "`$c`=VALUES(`$c`)";
 		}
+
 		$single_placeholder = '(' . implode( ',', array_fill( 0, count( $columns ), "'%s'" ) ) . ')';
+		$chunk_size         = 200;
+		$num_issues         = count( $issues );
+		for ( $i = 0; $i < $num_issues; $i += $chunk_size ) {
+			$all_values       = [];
+			$all_placeholders = [];
+			foreach ( array_slice( $issues, $i, $chunk_size ) as $issue ) {
+				$all_placeholders[] = $single_placeholder;
+				array_push( $all_values, ...array_values( $issue ) );
+			}
 
-		$all_values       = [];
-		$all_placeholders = [];
-		foreach ( $issues as $i ) {
-			$all_placeholders[] = $single_placeholder;
-			array_push( $all_values, ...array_values( $i ) );
+			$query  = 'INSERT INTO ' . $this->table->get_sql_safe_name() . ' (`' . implode( '`, `', $columns ) . '`) VALUES ';
+			$query .= implode( ', ', $all_placeholders );
+			$query .= ' ON DUPLICATE KEY UPDATE ' . implode( ', ', $update_values );
+
+			$this->wpdb->query( $this->wpdb->prepare( $query, $all_values ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 		}
-
-		$query  = 'INSERT INTO ' . $this->table->get_sql_safe_name() . ' (`' . implode( '`, `', $columns ) . '`) VALUES ';
-		$query .= implode( ', ', $all_placeholders );
-		$query .= ' ON DUPLICATE KEY UPDATE ' . implode( ', ', $update_values );
-
-		$this->wpdb->query( $this->wpdb->prepare( $query, $all_values ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 
 	/**

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -50,7 +50,7 @@ class MerchantIssueQuery extends Query {
 		}
 
 		$update_values = [];
-		$columns       = array_keys( $issues[0] );
+		$columns       = array_keys( reset( $issues ) );
 		foreach ( $columns as $c ) {
 			$update_values[] = "`$c`=VALUES(`$c`)";
 		}

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
 use DateTime;
 use wpdb;
 
@@ -43,6 +44,8 @@ class MerchantIssueQuery extends Query {
 	 * Batch update or insert a set of merchant issues.
 	 *
 	 * @param array $issues The issues to be updated or inserted.
+	 *
+	 * @throws InvalidQuery If an invalid column name is provided.
 	 */
 	public function update_or_insert( array $issues ) {
 		if ( empty( $issues ) ) {
@@ -52,6 +55,7 @@ class MerchantIssueQuery extends Query {
 		$update_values = [];
 		$columns       = array_keys( reset( $issues ) );
 		foreach ( $columns as $c ) {
+			$this->validate_column( $c );
 			$update_values[] = "`$c`=VALUES(`$c`)";
 		}
 		$single_placeholder = '(' . implode( ',', array_fill( 0, count( $columns ), "'%s'" ) ) . ')';

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -1,0 +1,46 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
+use wpdb;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MerchantIssueQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\DB\Query
+ */
+class MerchantIssueQuery extends Query {
+
+	/**
+	 * Query constructor.
+	 *
+	 * @param wpdb                      $wpdb
+	 * @param MerchantIssueTable $table
+	 */
+	public function __construct( wpdb $wpdb, MerchantIssueTable $table ) {
+		parent::__construct( $wpdb, $table );
+	}
+
+	/**
+	 * Sanitize a value for a given column before inserting it into the DB.
+	 *
+	 * @param string $column The column name.
+	 * @param mixed  $value  The value to sanitize.
+	 *
+	 * @return mixed The sanitized value.
+	 * @throws InvalidQuery When the code tries to set the ID column.
+	 */
+	protected function sanitize_value( string $column, $value ) {
+		if ( 'id' === $column ) {
+			throw InvalidQuery::cant_set_id( MerchantIssueTable::class );
+		}
+
+		return $value;
+	}
+}

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
 use wpdb;
 
 defined( 'ABSPATH' ) || exit;
@@ -20,7 +19,7 @@ class MerchantIssueQuery extends Query {
 	/**
 	 * Query constructor.
 	 *
-	 * @param wpdb                      $wpdb
+	 * @param wpdb               $wpdb
 	 * @param MerchantIssueTable $table
 	 */
 	public function __construct( wpdb $wpdb, MerchantIssueTable $table ) {
@@ -34,13 +33,8 @@ class MerchantIssueQuery extends Query {
 	 * @param mixed  $value  The value to sanitize.
 	 *
 	 * @return mixed The sanitized value.
-	 * @throws InvalidQuery When the code tries to set the ID column.
 	 */
 	protected function sanitize_value( string $column, $value ) {
-		if ( 'id' === $column ) {
-			throw InvalidQuery::cant_set_id( MerchantIssueTable::class );
-		}
-
 		return $value;
 	}
 }

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -41,44 +41,6 @@ class MerchantIssueQuery extends Query {
 	}
 
 	/**
-	 * Batch update or insert a set of merchant issues.
-	 *
-	 * @param array $issues The issues to be updated or inserted.
-	 *
-	 * @throws InvalidQuery If an invalid column name is provided.
-	 */
-	public function update_or_insert( array $issues ) {
-		if ( empty( $issues ) ) {
-			return;
-		}
-
-		$update_values = [];
-		$columns       = array_keys( reset( $issues ) );
-		foreach ( $columns as $c ) {
-			$this->validate_column( $c );
-			$update_values[] = "`$c`=VALUES(`$c`)";
-		}
-
-		$single_placeholder = '(' . implode( ',', array_fill( 0, count( $columns ), "'%s'" ) ) . ')';
-		$chunk_size         = 200;
-		$num_issues         = count( $issues );
-		for ( $i = 0; $i < $num_issues; $i += $chunk_size ) {
-			$all_values       = [];
-			$all_placeholders = [];
-			foreach ( array_slice( $issues, $i, $chunk_size ) as $issue ) {
-				$all_placeholders[] = $single_placeholder;
-				array_push( $all_values, ...array_values( $issue ) );
-			}
-
-			$query  = 'INSERT INTO ' . $this->table->get_sql_safe_name() . ' (`' . implode( '`, `', $columns ) . '`) VALUES ';
-			$query .= implode( ', ', $all_placeholders );
-			$query .= ' ON DUPLICATE KEY UPDATE ' . implode( ', ', $update_values );
-
-			$this->wpdb->query( $this->wpdb->prepare( $query, $all_values ) ); // phpcs:ignore WordPress.DB.PreparedSQL
-		}
-	}
-
-	/**
 	 * Delete stale issue records.
 	 *
 	 * @param DateTime $created_before Delete all records created before this.

--- a/src/DB/QueryInterface.php
+++ b/src/DB/QueryInterface.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\DB;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -22,6 +24,15 @@ interface QueryInterface {
 	 * @return $this
 	 */
 	public function where( string $column, $value, string $compare = '=' ): QueryInterface;
+
+	/**
+	 * Set the where relation for the query.
+	 *
+	 * @param string $relation
+	 *
+	 * @return QueryInterface
+	 */
+	public function set_where_relation( string $relation ): QueryInterface;
 
 	/**
 	 * @param string $column
@@ -55,4 +66,58 @@ interface QueryInterface {
 	 * @return mixed
 	 */
 	public function get_results();
+
+	/**
+	 * Get the number of results returned by the query.
+	 *
+	 * @return int
+	 */
+	public function get_count(): int;
+
+	/**
+	 * Gets the first result of the query.
+	 *
+	 * @return array
+	 */
+	public function get_row(): array;
+
+	/**
+	 * Insert a row of data into the table.
+	 *
+	 * @param array $data
+	 *
+	 * @return int
+	 * @throws InvalidQuery When there is an error inserting the data.
+	 */
+	public function insert( array $data ): int;
+
+	/**
+	 * Delete rows from the database.
+	 *
+	 * @param string $where_column Column to use when looking for values to delete.
+	 * @param mixed  $value        Value to use when determining what rows to delete.
+	 *
+	 * @return int The number of rows deleted.
+	 * @throws InvalidQuery When there is an error deleting data.
+	 */
+	public function delete( string $where_column, $value ): int;
+
+	/**
+	 * Update data in the database.
+	 *
+	 * @param array $data  Array of columns and their values.
+	 * @param array $where Array of where conditions for updating values.
+	 *
+	 * @return int
+	 * @throws InvalidQuery When there is an error updating data, or when an empty where array is provided.
+	 */
+	public function update( array $data, array $where ): int;
+	/**
+	 * Batch update or insert a set of records.
+	 *
+	 * @param array $records Array of records to be updated or inserted.
+	 *
+	 * @throws InvalidQuery If an invalid column name is provided.
+	 */
+	public function update_or_insert( array $records ): void;
 }

--- a/src/DB/Table.php
+++ b/src/DB/Table.php
@@ -62,9 +62,6 @@ abstract class Table implements TableInterface {
 		$this->wpdb->query( "DROP TABLE `{$this->get_sql_safe_name()}`" ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 
-
-
-
 	/**
 	 * Truncate the Database table.
 	 */

--- a/src/DB/Table.php
+++ b/src/DB/Table.php
@@ -74,7 +74,7 @@ abstract class Table implements TableInterface {
 	 *
 	 * @return string
 	 */
-	protected function get_sql_safe_name(): string {
+	public function get_sql_safe_name(): string {
 		return $this->wpdb->_escape( $this->get_name() );
 	}
 

--- a/src/DB/Table.php
+++ b/src/DB/Table.php
@@ -74,7 +74,7 @@ abstract class Table implements TableInterface {
 	 *
 	 * @return string
 	 */
-	public function get_sql_safe_name(): string {
+	protected function get_sql_safe_name(): string {
 		return $this->wpdb->_escape( $this->get_name() );
 	}
 

--- a/src/DB/Table.php
+++ b/src/DB/Table.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\DB;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use wpdb;
@@ -60,6 +61,16 @@ abstract class Table implements TableInterface {
 	 */
 	public function delete(): void {
 		$this->wpdb->query( "DROP TABLE `{$this->get_sql_safe_name()}`" ); // phpcs:ignore WordPress.DB.PreparedSQL
+	}
+
+
+
+
+	/**
+	 * Truncate the Database table.
+	 */
+	public function truncate(): void {
+		$this->wpdb->query( "TRUNCATE TABLE `{$this->get_sql_safe_name()}`" ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 
 	/**

--- a/src/DB/Table.php
+++ b/src/DB/Table.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\DB;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use wpdb;

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -32,7 +32,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `action` varchar(100) NOT NULL,
     `action_url` varchar(100) NOT NULL,
     `applicable_countries` text NOT NULL,
-    `created_at` TIMESTAMP on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `created_at` datetime on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY `id` (`id`),
     UNIQUE `product_issue` (`product_id`, `issue`)
 ) {$this->get_collation()};

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -24,12 +24,15 @@ class MerchantIssueTable extends Table {
 	protected function get_install_query(): string {
 		return <<< SQL
 CREATE TABLE `{$this->get_sql_safe_name()}` (
-    `product_id` bigint(20) NOT NULL AUTO_INCREMENT,
-    `code` varchar(100) NOT NULL,
+    `id` bigint(20) NOT NULL  AUTO_INCREMENT,
+    `product_id` bigint(20) NOT NULL,
     `issue` varchar(200) NOT NULL,
+    `code` varchar(100) NOT NULL,
     `details` text NOT NULL,
     `applicable_countries` text NOT NULL,
-    KEY `product_id` (`product_id`)
+    PRIMARY KEY `id` (`id`),
+    KEY `product_id` (`product_id`),
+    UNIQUE `product_issue` (`product_id`, `issue`)
 ) {$this->get_collation()};
 SQL;
 	}

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Table;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table;
+use DateTime;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,6 +47,16 @@ SQL;
 	 */
 	protected function get_raw_name(): string {
 		return 'merchant_issues';
+	}
+
+	/**
+	 * Delete stale issue records.
+	 *
+	 * @param DateTime $created_before Delete all records created before this.
+	 */
+	public function delete_stale( DateTime $created_before ) {
+		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` < '%s'";
+		$this->wpdb->query( $this->wpdb->prepare( $query, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 
 	/**

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -32,7 +32,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `action` varchar(100) NOT NULL,
     `action_url` varchar(100) NOT NULL,
     `applicable_countries` text NOT NULL,
-     `created_at` TIMESTAMP on update CURRENT_TIMESTAMP NOT NULL,
+    `created_at` TIMESTAMP on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY `id` (`id`),
     UNIQUE `product_issue` (`product_id`, `issue`)
 ) {$this->get_collation()};
@@ -59,7 +59,9 @@ SQL;
 			'product_id'           => true,
 			'code'                 => true,
 			'issue'                => true,
-			'details'              => true,
+			'product'              => true,
+			'action'              => true,
+			'action_url'              => true,
 			'applicable_countries' => true,
 		];
 	}

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -1,0 +1,60 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Table;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MerchantIssueTable
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\DB\Tables
+ */
+class MerchantIssueTable extends Table {
+
+	/**
+	 * Get the schema for the DB.
+	 *
+	 * This should be a SQL string for creating the DB table.
+	 *
+	 * @return string
+	 */
+	protected function get_install_query(): string {
+		return <<< SQL
+CREATE TABLE `{$this->get_sql_safe_name()}` (
+    `product_id` bigint(20) NOT NULL AUTO_INCREMENT,
+    `code` varchar(100) NOT NULL,
+    `issue` varchar(200) NOT NULL,
+    `details` text NOT NULL,
+    `applicable_countries` text NOT NULL,
+    KEY `product_id` (`product_id`)
+) {$this->get_collation()};
+SQL;
+	}
+
+	/**
+	 * Get the un-prefixed (raw) table name.
+	 *
+	 * @return string
+	 */
+	protected function get_raw_name(): string {
+		return 'merchant_issues';
+	}
+
+	/**
+	 * Get the columns for the table.
+	 *
+	 * @return array
+	 */
+	public function get_columns(): array {
+		return [
+			'product_id'           => true,
+			'code'                 => true,
+			'issue'                => true,
+			'details'              => true,
+			'applicable_countries' => true,
+		];
+	}
+}

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -28,10 +28,12 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `product_id` bigint(20) NOT NULL,
     `issue` varchar(200) NOT NULL,
     `code` varchar(100) NOT NULL,
-    `details` text NOT NULL,
+    `product` varchar(100) NOT NULL,
+    `action` varchar(100) NOT NULL,
+    `action_url` varchar(100) NOT NULL,
     `applicable_countries` text NOT NULL,
+     `created_at` TIMESTAMP on update CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY `id` (`id`),
-    KEY `product_id` (`product_id`),
     UNIQUE `product_issue` (`product_id`, `issue`)
 ) {$this->get_collation()};
 SQL;

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -32,7 +32,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `action` varchar(100) NOT NULL,
     `action_url` varchar(100) NOT NULL,
     `applicable_countries` text NOT NULL,
-    `created_at` datetime on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `created_at` datetime NOT NULL,
     PRIMARY KEY `id` (`id`),
     UNIQUE `product_issue` (`product_id`, `issue`)
 ) {$this->get_collation()};
@@ -60,9 +60,10 @@ SQL;
 			'code'                 => true,
 			'issue'                => true,
 			'product'              => true,
-			'action'              => true,
-			'action_url'              => true,
+			'action'               => true,
+			'action_url'           => true,
 			'applicable_countries' => true,
+			'created_at'           => true,
 		];
 	}
 }

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -53,6 +53,7 @@ SQL;
 	 */
 	public function get_columns(): array {
 		return [
+			'id'                   => true,
 			'product_id'           => true,
 			'code'                 => true,
 			'issue'                => true,

--- a/src/DB/TableInterface.php
+++ b/src/DB/TableInterface.php
@@ -30,6 +30,11 @@ interface TableInterface {
 	public function delete(): void;
 
 	/**
+	 * Truncate the Database table.
+	 */
+	public function truncate(): void;
+
+	/**
 	 * Get the name of the Database table.
 	 *
 	 * @return string

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -4,7 +4,10 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer as DBInstaller;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityMetaBox;
@@ -208,7 +211,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( AdsAccountState::class );
 		$this->share_with_tags( MerchantAccountState::class );
 		$this->share_with_tags( ProductStatistics::class );
-		$this->share_with_tags( MerchantIssues::class );
+		$this->share_with_tags( MerchantIssues::class, TransientsInterface::class, Merchant::class, MerchantIssueQuery::class );
 		$this->share_with_tags( ProductMetaHandler::class );
 		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class );
 		$this->share( ProductHelper::class, ProductMetaHandler::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -44,7 +44,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaign as SetupCamp
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsSetupCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantIssues;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantIssues;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantSetupCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer as DBInstaller;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -158,7 +158,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			WC::class,
 			WP::class,
 			TransientsInterface::class,
-			MerchantAccountState::class
+			MerchantAccountState::class,
+			MerchantIssues::class
 		);
 		$this->getLeagueContainer()
 			->inflector( MerchantCenterAwareInterface::class )

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -4,9 +4,11 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\BudgetRecommendationTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
@@ -36,6 +38,8 @@ class DBServiceProvider extends AbstractServiceProvider {
 		ShippingTimeQuery::class         => true,
 		BudgetRecommendationTable::class => true,
 		BudgetRecommendationQuery::class => true,
+		MerchantIssueTable::class        => true,
+		MerchantIssueQuery::class        => true,
 	];
 
 	/**
@@ -64,6 +68,8 @@ class DBServiceProvider extends AbstractServiceProvider {
 		$this->add_query_class( ShippingRateQuery::class, ShippingRateTable::class );
 		$this->share_table_class( ShippingTimeTable::class );
 		$this->add_query_class( ShippingTimeQuery::class, ShippingTimeTable::class );
+		$this->share_table_class( MerchantIssueTable::class );
+		$this->add_query_class( MerchantIssueQuery::class, MerchantIssueTable::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -31,7 +31,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\TargetAudienceController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SupportedCountriesController;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantIssues;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantIssues;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\ProductStatistics;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -50,18 +50,25 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 	protected $account_state;
 
 	/**
+	 * @var MerchantIssues
+	 */
+	protected $issues;
+
+	/**
 	 * MerchantCenterService constructor.
 	 *
 	 * @param WC                   $wc
 	 * @param WP                   $wp
 	 * @param TransientsInterface  $transients
 	 * @param MerchantAccountState $account_state
+	 * @param MerchantIssues       $issues
 	 */
-	public function __construct( WC $wc, WP $wp, TransientsInterface $transients, MerchantAccountState $account_state ) {
+	public function __construct( WC $wc, WP $wp, TransientsInterface $transients, MerchantAccountState $account_state, MerchantIssues $issues ) {
 		$this->wc            = $wc;
 		$this->wp            = $wp;
 		$this->transients    = $transients;
 		$this->account_state = $account_state;
+		$this->issues        = $issues;
 	}
 
 	/**
@@ -188,6 +195,8 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
 
 		$this->transients->delete( TransientsInterface::MC_PRODUCT_STATISTICS );
+
+		$this->issues->delete();
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -125,6 +125,9 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	 * @return array|null
 	 */
 	protected function fetch_cached_issues( string $type = null, int $per_page = 0, int $page = 1 ): array {
+		// Ensure account issues are shown first.
+		$this->issue_query->set_order( 'product_id' );
+
 		// Filter by type.
 		if ( $this->is_valid_type( $type ) ) {
 			$this->issue_query->where(

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -152,15 +152,14 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 
 		$issues = [];
 		foreach ( $this->issue_query->get_results() as $row ) {
-			$details = json_decode( $row['details'], true );
-			$issue   = [
+			$issue = [
 				'type'        => $row['product_id'] ? self::TYPE_PRODUCT : self::TYPE_ACCOUNT,
 				'product_id'  => intval( $row['product_id'] ),
-				'product'     => $details['product'],
+				'product'     => $row['product'],
 				'issue'       => $row['issue'],
 				'code'        => $row['code'],
-				'action'      => $details['action'],
-				'action_link' => $details['action_link'],
+				'action'      => $row['action'],
+				'action_url' => $row['action_url'],
 			];
 			if ( $issue['product_id'] ) {
 				$issue['applicable_countries'] = json_decode( $row['applicable_countries'], true );
@@ -208,7 +207,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 				'code'        => $issue->getId(),
 				'issue'       => $issue->getTitle(),
 				'action'      => __( 'Read more about this account issue', 'google-listings-and-ads' ),
-				'action_link' => $issue->getDocumentation(),
+				'action_url' => $issue->getDocumentation(),
 			];
 		}
 		return $account_issues;
@@ -253,7 +252,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 						'code'                 => $item_level_issue->getCode(),
 						'issue'                => $item_level_issue->getDescription(),
 						'action'               => $item_level_issue->getDetail(),
-						'action_link'          => $item_level_issue->getDocumentation(),
+						'action_url'          => $item_level_issue->getDocumentation(),
 						'applicable_countries' => $item_level_issue->getApplicableCountries(),
 					];
 				}
@@ -287,14 +286,10 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 					'product_id'           => $i['product_id'] ?? 0,
 					'code'                 => $i['code'],
 					'issue'                => $i['issue'],
+					'product'              => $i['product'],
+					'action'               => $i['action'],
+					'action_url'          => $i['action_url'],
 					'applicable_countries' => isset( $i['applicable_countries'] ) ? json_encode( $i['applicable_countries'] ) : '',
-					'details'              => json_encode(
-						[
-							'product'     => $i['product'],
-							'action'      => $i['action'],
-							'action_link' => $i['action_link'],
-						]
-					),
 				]
 			);
 		}

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use DateTime;
 use Exception;
 
 /**
@@ -52,6 +53,11 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	protected $issue_query;
 
 	/**
+	 * @var DateTime $current_time For cache age operations.
+	 */
+	protected $current_time;
+
+	/**
 	 * MerchantIssues constructor.
 	 *
 	 * @param TransientsInterface $transients
@@ -59,9 +65,10 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	 * @param MerchantIssueQuery  $issue_query
 	 */
 	public function __construct( TransientsInterface $transients, Merchant $merchant, MerchantIssueQuery $issue_query ) {
-		$this->transients  = $transients;
-		$this->merchant    = $merchant;
-		$this->issue_query = $issue_query;
+		$this->transients   = $transients;
+		$this->merchant     = $merchant;
+		$this->issue_query  = $issue_query;
+		$this->current_time = new DateTime();
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -72,9 +72,10 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	}
 
 	/**
-	 * Retrieve the Merchant Center issues. Refresh if the cache issues have gone stale.
+	 * Retrieve the Merchant Center issues and total count. Refresh if the cache issues have gone stale.
 	 * Issue details are reduced, and for products, grouped by type.
 	 * Issues can be filtered by type, searched by name or ID (if product type) and paginated.
+	 * Count takes into account the type filter, but not the pagination.
 	 *
 	 * @param string|null $type To filter by issue type if desired.
 	 * @param int         $per_page The number of issues to return (0 for no limit).

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -153,12 +153,12 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 		$issues = [];
 		foreach ( $this->issue_query->get_results() as $row ) {
 			$issue = [
-				'type'        => $row['product_id'] ? self::TYPE_PRODUCT : self::TYPE_ACCOUNT,
-				'product_id'  => intval( $row['product_id'] ),
-				'product'     => $row['product'],
-				'issue'       => $row['issue'],
-				'code'        => $row['code'],
-				'action'      => $row['action'],
+				'type'       => $row['product_id'] ? self::TYPE_PRODUCT : self::TYPE_ACCOUNT,
+				'product_id' => intval( $row['product_id'] ),
+				'product'    => $row['product'],
+				'issue'      => $row['issue'],
+				'code'       => $row['code'],
+				'action'     => $row['action'],
 				'action_url' => $row['action_url'],
 			];
 			if ( $issue['product_id'] ) {
@@ -202,11 +202,11 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 		$account_issues = [];
 		foreach ( $this->merchant->get_accountstatus()->getAccountLevelIssues() as $issue ) {
 			$account_issues[] = [
-				'type'        => self::TYPE_ACCOUNT,
-				'product'     => __( 'All products', 'google-listings-and-ads' ),
-				'code'        => $issue->getId(),
-				'issue'       => $issue->getTitle(),
-				'action'      => __( 'Read more about this account issue', 'google-listings-and-ads' ),
+				'type'       => self::TYPE_ACCOUNT,
+				'product'    => __( 'All products', 'google-listings-and-ads' ),
+				'code'       => $issue->getId(),
+				'issue'      => $issue->getTitle(),
+				'action'     => __( 'Read more about this account issue', 'google-listings-and-ads' ),
 				'action_url' => $issue->getDocumentation(),
 			];
 		}
@@ -252,7 +252,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 						'code'                 => $item_level_issue->getCode(),
 						'issue'                => $item_level_issue->getDescription(),
 						'action'               => $item_level_issue->getDetail(),
-						'action_url'          => $item_level_issue->getDocumentation(),
+						'action_url'           => $item_level_issue->getDocumentation(),
 						'applicable_countries' => $item_level_issue->getApplicableCountries(),
 					];
 				}
@@ -288,7 +288,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 					'issue'                => $i['issue'],
 					'product'              => $i['product'],
 					'action'               => $i['action'],
-					'action_url'          => $i['action_url'],
+					'action_url'           => $i['action_url'],
 					'applicable_countries' => isset( $i['applicable_countries'] ) ? json_encode( $i['applicable_countries'] ) : '',
 				]
 			);

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -181,7 +181,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 
 		$delete_before = clone $this->current_time;
 		$delete_before->modify( '-' . $this->get_issues_lifetime() . ' seconds' );
-		$this->issue_query->delete_stale( $delete_before );
+		$this->container->get( MerchantIssueTable::class )->delete_stale( $delete_before );
 
 		$this->transients->set(
 			TransientsInterface::MC_ISSUES_CREATED_AT,

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -206,7 +206,6 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 				'action'     => __( 'Read more about this account issue', 'google-listings-and-ads' ),
 				'action_url' => $issue->getDocumentation(),
 				'created_at' => $this->current_time->format( 'Y-m-d H:i:s' ),
-
 			];
 		}
 

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types=1 );
 
-namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
@@ -9,6 +9,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Exception;
@@ -295,7 +297,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	 * @return array|null
 	 */
 	protected function fetch_cached_issues( string $type = null, int $per_page = 0, int $page = 1 ): ?array {
-		if ( null === $this->transients->get( TransientsInterface::MC_ISSUES_CREATED_AT, null ) ) {
+		if ( null === $this->transients->get( TransientsInterface::MC_ISSUES_CREATED_AT ) ) {
 			return null;
 		}
 

--- a/src/Options/MerchantIssues.php
+++ b/src/Options/MerchantIssues.php
@@ -121,6 +121,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	 */
 	public function delete(): void {
 		$this->container->get( TransientsInterface::class )->delete( Transients::MC_ISSUES_CREATED_AT );
+		$this->container->get( MerchantIssueTable::class )->truncate();
 	}
 
 	/**

--- a/src/Options/MerchantIssues.php
+++ b/src/Options/MerchantIssues.php
@@ -60,7 +60,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 
 			// Filter by issue type.
 			if ( $type ) {
-				if ( ! in_array( $type, $this->get_issue_types(), true ) ) {
+				if ( ! $this->is_valid_type( $type ) ) {
 					throw new Exception( 'Unknown filter type ' . $type );
 				}
 				$issues = array_filter(
@@ -142,6 +142,15 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 			self::TYPE_ACCOUNT,
 			self::TYPE_PRODUCT,
 		];
+	}
+
+	/**
+	 * @param string $type
+	 *
+	 * @return bool
+	 */
+	public function is_valid_type( string $type ): bool {
+		return in_array( $type, $this->get_issue_types(), true );
 	}
 
 	/**
@@ -282,7 +291,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 
 		// Filter in query.
-		if ( in_array( $type, $this->get_issue_types(), true ) ) {
+		if ( $this->is_valid_type( $type ) ) {
 			$issue_query->where(
 				'product_id',
 				0,

--- a/src/Options/MerchantIssues.php
+++ b/src/Options/MerchantIssues.php
@@ -112,7 +112,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 
 		// Refresh the cache and the validation transient.
 		$this->cache_issues( $issues );
-		$this->container->get( TransientsInterface::class )->set( Transients::MC_ISSUES, time(), $this->get_issues_lifetime() );
+		$this->container->get( TransientsInterface::class )->set( Transients::MC_ISSUES_CREATED_AT, time(), $this->get_issues_lifetime() );
 		return $issues;
 	}
 
@@ -120,7 +120,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	 * Delete the cached statistics.
 	 */
 	public function delete(): void {
-		$this->container->get( TransientsInterface::class )->delete( Transients::MC_ISSUES );
+		$this->container->get( TransientsInterface::class )->delete( Transients::MC_ISSUES_CREATED_AT );
 	}
 
 	/**
@@ -283,7 +283,7 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	 * @return array|null
 	 */
 	protected function fetch_cached_issues( string $type = null, int $per_page = 0, int $page = 1 ): ?array {
-		if ( null === $this->container->get( TransientsInterface::class )->get( Transients::MC_ISSUES, null ) ) {
+		if ( null === $this->container->get( TransientsInterface::class )->get( Transients::MC_ISSUES_CREATED_AT, null ) ) {
 			return null;
 		}
 

--- a/src/Options/MerchantIssues.php
+++ b/src/Options/MerchantIssues.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Exception;
 
 /**
@@ -34,11 +33,6 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 	 */
 	public const TYPE_ACCOUNT = 'account';
 	public const TYPE_PRODUCT = 'product';
-
-	/**
-	 * @var WP $wp The WP proxy object.
-	 */
-	protected $wp;
 
 	/**
 	 * Retrieve or initialize the mc_issues transient. Refresh if the issues have gone stale.
@@ -189,10 +183,6 @@ class MerchantIssues implements Service, ContainerAwareInterface {
 
 		/** @var ProductHelper $product_helper */
 		$product_helper = $this->container->get( ProductHelper::class );
-
-		if ( empty( $this->wp ) ) {
-			$this->wp = $this->container->get( WP::class );
-		}
 
 		$product_issues = [];
 		foreach ( $merchant->get_productstatuses() as $product ) {

--- a/src/Options/Transients.php
+++ b/src/Options/Transients.php
@@ -21,7 +21,7 @@ final class Transients implements TransientsInterface, Service {
 
 	private const VALID_OPTIONS = [
 		self::MC_PRODUCT_STATISTICS => true,
-		self::MC_ISSUES             => true,
+		self::MC_ISSUES_CREATED_AT  => true,
 	];
 
 	/**

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
 interface TransientsInterface {
 
 	public const MC_PRODUCT_STATISTICS = 'mc_product_statistics';
-	public const MC_ISSUES             = 'mc_issues';
+	public const MC_ISSUES_CREATED_AT  = 'mc_issues_created_at';
 
 	/**
 	 * Get a transient.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #421 

Create the `wp_gla_merchant_issues` table, and cache all account- and product-level issues there instead of in a transient. The transient is maintained as a "CREATED_AT" timestamp used to determine whether the issues table data is stale.

*Notes*
- The combination of `product_id` and `issue` is the unique key, and multi-country product-level issues are grouped on that key.
- Account-level issues have a `product_id` of 0 and an empty `applicable_countries`
- Issues are cached using batched `INSERT … ON DUPLICATE KEY` requests.
- Unsure whether to completely remove `ContainerAware`-ness and directly inject the final few dependencies (`OptionsInterface`, `MerchantIssueTable` and `ProductHelper`).
 - Also cleans up the issues and related transient when Merchant Center account is disconnected

### Detailed test instructions:

1. Update the extension version in `google-listings-and-ads.php` and confirm the table `wp_gla_merchant_issues` is created when `/wp-admin/` is loaded.
2. Same test instructions as  #421 

### Changelog Note:

> Move the account- and product-level issues to an independent database table
