### PR TITLE
Log acceptance of WP.com TOS

### DIFF
--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -124,6 +124,6 @@ class Connection {
 	 * @return string
 	 */
 	protected function get_connection_url(): string {
-		return "{$this->container->get( 'connect_server_root' )}connection/google-mc";
+		return "{$this->container->get( 'connect_server_root' )}google/connection/google-mc";
 	}
 }

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -455,7 +455,7 @@ class Proxy implements OptionsAwareInterface {
 	 * @return string
 	 */
 	protected function get_manager_url( string $name = '' ): string {
-		$url = $this->container->get( 'connect_server_root' ) . 'manager';
+		$url = $this->container->get( 'connect_server_root' ) . 'google/manager';
 		return $name ? trailingslashit( $url ) . $name : $url;
 	}
 

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -87,7 +87,7 @@ class AccountController extends BaseOptionsController {
 			$this->manager->enable_plugin();
 
 			// Register the site to wp.com.
-			if ( ! $this->manager->is_registered() ) {
+			if ( ! $this->manager->is_connected() ) {
 				$result = $this->manager->register();
 
 				if ( is_wp_error( $result ) ) {

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -197,7 +197,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function log_wp_tos_accepted() {
 		$user = wp_get_current_user();
-		$tos  = $this->middleware->mark_tos_accepted( 'wp-com', $user->user_email );
+		$this->middleware->mark_tos_accepted( 'wp-com', $user->user_email );
 		$this->options->update( OptionsInterface::WP_TOS_ACCEPTED, true );
 	}
 

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -144,8 +144,8 @@ class AccountController extends BaseOptionsController {
 
 			$user_data = $this->get_jetpack_user_data();
 			return [
-				'active'      => $this->is_jetpack_connected(),
-				'owner'       => $this->is_jetpack_connection_owner(),
+				'active'      => $this->display_boolean( $this->is_jetpack_connected() ),
+				'owner'       => $this->display_boolean( $this->is_jetpack_connection_owner() ),
 				'displayName' => $user_data['display_name'] ?? '',
 				'email'       => $user_data['email'] ?? '',
 			];
@@ -155,19 +155,30 @@ class AccountController extends BaseOptionsController {
 	/**
 	 * Determine whether Jetpack is connected.
 	 *
-	 * @return string
+	 * @return bool
 	 */
-	protected function is_jetpack_connected(): string {
-		return $this->manager->is_active() ? 'yes' : 'no';
+	protected function is_jetpack_connected(): bool {
+		return $this->manager->is_active();
 	}
 
 	/**
 	 * Determine whether user is the current Jetpack connection owner.
 	 *
+	 * @return bool
+	 */
+	protected function is_jetpack_connection_owner(): bool {
+		return $this->manager->is_connection_owner();
+	}
+
+	/**
+	 * Format boolean for display.
+	 *
+	 * @param bool $value
+	 *
 	 * @return string
 	 */
-	protected function is_jetpack_connection_owner(): string {
-		return $this->manager->is_connection_owner() ? 'yes' : 'no';
+	protected function display_boolean( bool $value ): string {
+		return $value ? 'yes' : 'no';
 	}
 
 	/**

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -603,7 +603,7 @@ class ConnectionTest implements Service, Registerable {
 			$manager->enable_plugin(); // Mark the plugin connection as enabled, in case it was disabled earlier.
 
 			// Register the site to wp.com.
-			if ( ! $manager->is_registered() ) {
+			if ( ! $manager->is_connected() ) {
 				$result = $manager->register();
 
 				if ( is_wp_error( $result ) ) {

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -151,12 +151,12 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->add(
 			Google_Service_ShoppingContent::class,
 			Client::class,
-			$this->get_connect_server_url_root( 'google-mc' )
+			$this->get_connect_server_url_root( 'google/google-mc' )
 		);
 		$this->add(
 			Google_Service_SiteVerification::class,
 			Client::class,
-			$this->get_connect_server_url_root( 'google-sv' )
+			$this->get_connect_server_url_root( 'google/google-sv' )
 		);
 		$this->share(
 			GoogleProductService::class,
@@ -252,7 +252,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 		$path = '/' . trim( $path, '/' );
 
-		return new RawArgument( "{$url}/google${path}" );
+		return new RawArgument( "{$url}{$path}" );
 	}
 
 	/**
@@ -261,7 +261,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @return string
 	 */
 	protected function get_connect_server_endpoint(): string {
-		$parts = wp_parse_url( $this->get_connect_server_url_root( 'google-ads' )->getValue() );
+		$parts = wp_parse_url( $this->get_connect_server_url_root( 'google/google-ads' )->getValue() );
 		$port  = empty( $parts['port'] ) ? 443 : $parts['port'];
 		return sprintf( '%s:%d%s', $parts['host'], $port, $parts['path'] );
 	}

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\SetupCompleteController;
@@ -71,7 +72,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share_with_container( AdsCampaignController::class );
 		$this->share_with_container( AdsReportsController::class );
 		$this->share( GoogleAccountController::class, Connection::class );
-		$this->share( JetpackAccountController::class, Manager::class );
+		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );
 		$this->share( MerchantCenterProductsController::class, ProductStatistics::class );
 		$this->share( MerchantCenterIssuesController::class, MerchantIssues::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class );

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -39,6 +39,7 @@ final class Options implements OptionsInterface, Service {
 		self::SHIPPING_TIMES         => true,
 		self::SITE_VERIFICATION      => true,
 		self::TARGET_AUDIENCE        => true,
+		self::WP_TOS_ACCEPTED        => true,
 	];
 
 	private const OPTION_TYPES = [

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -26,6 +26,7 @@ interface OptionsInterface {
 	public const SHIPPING_TIMES         = 'shipping_times';
 	public const SITE_VERIFICATION      = 'site_verification';
 	public const TARGET_AUDIENCE        = 'target_audience';
+	public const WP_TOS_ACCEPTED        = 'wp_tos_accepted';
 
 	/**
 	 * Get an option.


### PR DESCRIPTION
### Changes proposed in this Pull Request:
We show the TOS on the getting started page:
![image](https://user-images.githubusercontent.com/11388669/114547778-c586d300-9c56-11eb-9be2-de8f8f045508.png)

So the user automatically accepts the WP TOS when getting started. However we aren't able to add a handler right after the connection is made, because they could have connected in different ways. If the user has already connected through Jetpack, or the payments or shipping extensions we reuse the connection. So instead we log the TOS acceptance when we check the connection status. We use the option `gla_wp_tos_accepted` to prevent it from being logged multiple times (this option will be cleared on disconnect).

This PR addresses the following points:
- Only add the middleware prefix `google` when sending requests to the Google endpoints. TOS acceptance is [generic and no longer tied to Google services](https://github.com/Automattic/woocommerce-connect-server/pull/1774)
- Log TOS acceptance for WordPress.com connection

Closes #172

### Detailed test instructions:

1. Setup a local copy of WCS with PR: https://github.com/Automattic/woocommerce-connect-server/pull/1774
2. Disconnect WordPress.com account
3. Go through the get started screen and connect WordPress.com account
4. Confirm that a request got logged in your local copy of WCS `POST /tos/wp-com`
5. Check the options table for `gla_wp_tos_accepted` and confirm it's set to 1
6. Revisit the setup screen and confirm that the request does not get logged a second time

### Changelog Note:
- Log acceptance of WP.com TOS