### PR TITLE
Indicate saving state of the edit free listings form, update submit button label.

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -262,6 +262,10 @@ export default function EditFreeCampaign() {
 								shippingTimes={ loadedShippingTimes }
 								onShippingTimesChange={ updateShippingTimes }
 								onContinue={ handleSetupFreeListingsContinue }
+								submitLabel={ __(
+									'Save changes',
+									'google-listings-and-ads'
+								) }
 							/>
 						),
 						onClick: handleStepClick,

--- a/js/src/edit-free-campaign/setup-free-listings/form-content.js
+++ b/js/src/edit-free-campaign/setup-free-listings/form-content.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,6 +11,7 @@ import StepContentFooter from '.~/components/stepper/step-content-footer';
 import TaxRate from '.~/components/free-listings/configure-product-listings/tax-rate';
 import { shouldDisplayTaxRate } from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
 import CombinedShipping from '.~/components/free-listings/configure-product-listings/combined-shipping';
+import AppButton from '.~/components/app-button';
 
 /**
  * @typedef {import('.~/data/actions').CountryCode} CountryCode
@@ -23,10 +23,11 @@ import CombinedShipping from '.~/components/free-listings/configure-product-list
  * without auto-save functionality.
  *
  * @param {Object} props React props.
- * @param {Array} props.formProps
  * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to CombinedShipping.
+ * @param {Object} props.formProps Form props forwarded from `Form` component, containing free listings settings.
+ * @param {boolean} [props.saving=false] Is the form currently beign saved?
  */
-const FormContent = ( { formProps, countries } ) => {
+const FormContent = ( { countries, formProps, saving = false } ) => {
 	const { errors, handleSubmit } = formProps;
 	const displayTaxRate = shouldDisplayTaxRate( countries );
 
@@ -37,13 +38,14 @@ const FormContent = ( { formProps, countries } ) => {
 			<CombinedShipping formProps={ formProps } countries={ countries } />
 			{ displayTaxRate && <TaxRate formProps={ formProps } /> }
 			<StepContentFooter>
-				<Button
+				<AppButton
 					isPrimary
 					disabled={ isCompleteSetupDisabled }
+					loading={ saving }
 					onClick={ handleSubmit }
 				>
 					{ __( 'Complete setup', 'google-listings-and-ads' ) }
-				</Button>
+				</AppButton>
 			</StepContentFooter>
 		</StepContent>
 	);

--- a/js/src/edit-free-campaign/setup-free-listings/form-content.js
+++ b/js/src/edit-free-campaign/setup-free-listings/form-content.js
@@ -26,8 +26,14 @@ import AppButton from '.~/components/app-button';
  * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to CombinedShipping.
  * @param {Object} props.formProps Form props forwarded from `Form` component, containing free listings settings.
  * @param {boolean} [props.saving=false] Is the form currently beign saved?
+ * @param {string} [props.submitLabel="Complete setup"] Submit button label.
  */
-const FormContent = ( { countries, formProps, saving = false } ) => {
+const FormContent = ( {
+	countries,
+	formProps,
+	saving = false,
+	submitLabel = __( 'Complete setup', 'google-listings-and-ads' ),
+} ) => {
 	const { errors, handleSubmit } = formProps;
 	const displayTaxRate = shouldDisplayTaxRate( countries );
 
@@ -44,7 +50,7 @@ const FormContent = ( { countries, formProps, saving = false } ) => {
 					loading={ saving }
 					onClick={ handleSubmit }
 				>
-					{ __( 'Complete setup', 'google-listings-and-ads' ) }
+					{ submitLabel }
 				</AppButton>
 			</StepContentFooter>
 		</StepContent>

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -33,6 +33,7 @@ import FormContent from './form-content';
  * @param {Array<ShippingTime>} props.shippingTimes Shipping times data, if not given AppSpinner will be rendered.
  * @param {(newValue: Object) => void} props.onShippingTimesChange Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChangeCallback}
  * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked. Could be async. While it's being resolved the form would turn into a saving state.
+ * @param {string} [props.submitLabel] Submit button label, to be forwarded to `FormContent`.
  */
 const SetupFreeListings = ( {
 	stepHeader,
@@ -44,6 +45,7 @@ const SetupFreeListings = ( {
 	shippingTimes,
 	onShippingTimesChange = () => {},
 	onContinue = () => {},
+	submitLabel,
 } ) => {
 	const [ saving, setSaving ] = useState( false );
 
@@ -112,6 +114,7 @@ const SetupFreeListings = ( {
 						<FormContent
 							formProps={ formProps }
 							countries={ countries }
+							submitLabel={ submitLabel }
 							saving={ saving }
 						/>
 					);

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Form } from '@woocommerce/components';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ import FormContent from './form-content';
  * @param {(newValue: Object) => void} props.onShippingRatesChange Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChangeCallback}
  * @param {Array<ShippingTime>} props.shippingTimes Shipping times data, if not given AppSpinner will be rendered.
  * @param {(newValue: Object) => void} props.onShippingTimesChange Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChangeCallback}
- * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked.
+ * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked. Could be async. While it's being resolved the form would turn into a saving state.
  */
 const SetupFreeListings = ( {
 	stepHeader,
@@ -44,6 +45,8 @@ const SetupFreeListings = ( {
 	onShippingTimesChange = () => {},
 	onContinue = () => {},
 } ) => {
+	const [ saving, setSaving ] = useState( false );
+
 	if ( ! settings || ! shippingRates || ! shippingTimes ) {
 		return <AppSpinner />;
 	}
@@ -54,6 +57,12 @@ const SetupFreeListings = ( {
 		// TODO: validation logic.
 
 		return errors;
+	};
+
+	const handleSubmit = async () => {
+		setSaving( true );
+		await onContinue();
+		setSaving( false );
 	};
 
 	return (
@@ -96,13 +105,14 @@ const SetupFreeListings = ( {
 					}
 				} }
 				validate={ handleValidate }
-				onSubmitCallback={ onContinue }
+				onSubmitCallback={ handleSubmit }
 			>
 				{ ( formProps ) => {
 					return (
 						<FormContent
 							formProps={ formProps }
 							countries={ countries }
+							saving={ saving }
 						/>
 					);
 				} }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Indicate the saving state of the edit free listings form. (7f70bb3)
	Set saving state on submit button while (async) `onContinue` callback is being resolved.
	Change submit `Button` to `AppButton` to make use of its API and deliver a consistent experience.
- Change submit button label in the edit free listings form. (855aed1) - Fixes #434

Implements part of #156.

### Screenshots:

Regular state
![Screenshot with a "Save changes" button in a regular state](https://user-images.githubusercontent.com/17435/114623743-f9421700-9caf-11eb-9749-1b888fccf5c1.png)

Saving state
![Screenshot with a "Save changes" button in a loading state with a spinner inside](https://user-images.githubusercontent.com/17435/114623785-0828c980-9cb0-11eb-8815-3477dbd4c85d.png)


### Detailed test instructions:

1. Go to [**Marketing > GLA > Dashboard > Edit free listing > Step 2**](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fedit-free-campaign&programId=0&pageStep=2).
2. Check the label on submit button at the bottom.
3. Click to save changes.
4. Check the saving state.
5. Check if it's disabled while saving.


### Changelog Note:

> Updated label and the saving state of the edit free listings submit button.