### PR TITLE
Avoid two-legged Merchant Center setup for new accounts where possible

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -413,6 +413,10 @@ class AccountController extends BaseOptionsController {
 							$data
 						);
 					}
+				} elseif ( 'link' === $name && 401 === $e->getCode() ) {
+					$state['set_id']['data']['created_timestamp'] = time();
+					$this->account_state->update( $state );
+					return $this->get_time_to_wait_response( MerchantAccountState::MC_DELAY_AFTER_CREATE );
 				}
 
 				$this->account_state->update( $state );
@@ -576,6 +580,26 @@ class AccountController extends BaseOptionsController {
 			$mc_account->setWebsiteUrl( $site_website_url );
 			$this->merchant->update_account( $mc_account );
 		}
+	}
+
+	/**
+	 * Generate a 503 Response with Retry-After header and message.
+	 *
+	 * @param int $time_to_wait The time to indicate
+	 *
+	 * @return Response
+	 */
+	private function get_time_to_wait_response( int $time_to_wait ): Response {
+		return new Response(
+			[
+				'retry_after' => $time_to_wait,
+				'message'     => __( 'Please retry after the indicated number of seconds to complete the account setup process.', 'google-listings-and-ads' ),
+			],
+			503,
+			[
+				'Retry-After' => $time_to_wait,
+			]
+		);
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -329,8 +329,6 @@ class AccountController extends BaseOptionsController {
 	 *
 	 * @return array|Response The newly created (or pre-existing) Merchant ID or the retry delay.
 	 * @throws Exception If an error occurs during any step.
-	 * @todo Check Google Account & Manager Accounts connected correctly before starting.
-	 * @todo Include request+approve account linking process.
 	 */
 	protected function setup_merchant_account() {
 		$state       = $this->account_state->get();

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -429,15 +429,14 @@ class AccountController extends BaseOptionsController {
 	 * 2. Enables the meta tag in the head of the store.
 	 * 3. Instructs the Site Verification API to verify the meta tag.
 	 *
-	 * @return bool True if the site has been (or already was) verified for the connected Google account.
 	 * @throws Exception If any step of the site verification process fails.
 	 */
-	private function verify_site(): bool {
+	private function verify_site(): void {
 		$site_url = apply_filters( 'woocommerce_gla_site_url', site_url() );
 
 		// Inform of previous verification.
 		if ( $this->account_state->is_site_verified() ) {
-			return true;
+			return;
 		}
 
 		// Retrieve the meta tag with verification token.
@@ -467,7 +466,7 @@ class AccountController extends BaseOptionsController {
 				$this->options->update( OptionsInterface::SITE_VERIFICATION, $site_verification_options );
 				do_action( 'gla_site_verify_success', [] );
 
-				return true;
+				return;
 			}
 		} catch ( Exception $e ) {
 			do_action( 'gla_site_verify_failure', [ 'step' => 'meta-tag' ] );
@@ -536,11 +535,10 @@ class AccountController extends BaseOptionsController {
 	 * @param int    $merchant_id      The Merchant Center account to update
 	 * @param string $site_website_url The new website URL
 	 *
-	 * @return bool True if the Merchant Center website URL matches the provided URL (updated or already set).
 	 * @throws Exception If the Merchant Center account can't be retrieved.
 	 * @throws ExceptionWithResponseData If the account website URL doesn't match the given URL.
 	 */
-	private function maybe_add_merchant_center_website_url( int $merchant_id, string $site_website_url ): bool {
+	private function maybe_add_merchant_center_website_url( int $merchant_id, string $site_website_url ): void {
 		/** @var MC_Account $mc_account */
 		$mc_account = $this->merchant->get_account( $merchant_id );
 
@@ -578,8 +576,6 @@ class AccountController extends BaseOptionsController {
 			$mc_account->setWebsiteUrl( $site_website_url );
 			$this->merchant->update_account( $mc_account );
 		}
-
-		return true;
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -327,13 +327,13 @@ class AccountController extends BaseOptionsController {
 	 * Should always resume up at the last pending or unfinished step. If the Merchant Center account
 	 * has already been created, the ID is simply returned.
 	 *
-	 * @todo Check Google Account & Manager Accounts connected correctly before starting.
+	 * @return array|Response The newly created (or pre-existing) Merchant ID or the retry delay.
+	 * @throws Exception If an error occurs during any step.
+	 *@todo Check Google Account & Manager Accounts connected correctly before starting.
 	 * @todo Include request+approve account linking process.
 	 *
-	 * @return array The newly created (or pre-existing) Merchant ID or the retry delay.
-	 * @throws Exception If an error occurs during any step.
 	 */
-	protected function setup_merchant_account(): array {
+	protected function setup_merchant_account() {
 		$state       = $this->account_state->get();
 		$merchant_id = intval( $this->options->get( OptionsInterface::MERCHANT_ID ) );
 

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -329,9 +329,8 @@ class AccountController extends BaseOptionsController {
 	 *
 	 * @return array|Response The newly created (or pre-existing) Merchant ID or the retry delay.
 	 * @throws Exception If an error occurs during any step.
-	 *@todo Check Google Account & Manager Accounts connected correctly before starting.
+	 * @todo Check Google Account & Manager Accounts connected correctly before starting.
 	 * @todo Include request+approve account linking process.
-	 *
 	 */
 	protected function setup_merchant_account() {
 		$state       = $this->account_state->get();
@@ -416,7 +415,7 @@ class AccountController extends BaseOptionsController {
 				} elseif ( 'link' === $name && 401 === $e->getCode() ) {
 					$state['set_id']['data']['created_timestamp'] = time();
 					$this->account_state->update( $state );
-					return $this->get_time_to_wait_response( MerchantAccountState::MC_DELAY_AFTER_CREATE );
+					return $this->get_time_to_wait_response();
 				}
 
 				$this->account_state->update( $state );
@@ -585,19 +584,17 @@ class AccountController extends BaseOptionsController {
 	/**
 	 * Generate a 503 Response with Retry-After header and message.
 	 *
-	 * @param int $time_to_wait The time to indicate
-	 *
 	 * @return Response
 	 */
-	private function get_time_to_wait_response( int $time_to_wait ): Response {
+	private function get_time_to_wait_response(): Response {
 		return new Response(
 			[
-				'retry_after' => $time_to_wait,
+				'retry_after' => MerchantAccountState::MC_DELAY_AFTER_CREATE,
 				'message'     => __( 'Please retry after the indicated number of seconds to complete the account setup process.', 'google-listings-and-ads' ),
 			],
 			503,
 			[
-				'Retry-After' => $time_to_wait,
+				'Retry-After' => MerchantAccountState::MC_DELAY_AFTER_CREATE,
 			]
 		);
 	}

--- a/src/Options/MerchantAccountState.php
+++ b/src/Options/MerchantAccountState.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 class MerchantAccountState extends AccountState {
 
 	/** @var int The number of seconds of delay to enforce between site verification and site claim. */
-	public const MC_DELAY_AFTER_CREATE = 90;
+	public const MC_DELAY_AFTER_CREATE = 10;
 
 	/**
 	 * Return the option name.

--- a/src/Options/MerchantAccountState.php
+++ b/src/Options/MerchantAccountState.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 class MerchantAccountState extends AccountState {
 
 	/** @var int The number of seconds of delay to enforce between site verification and site claim. */
-	public const MC_DELAY_AFTER_CREATE = 10;
+	public const MC_DELAY_AFTER_CREATE = 5;
 
 	/**
 	 * Return the option name.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #472.

Taking advantage of the recent changes on the Google side, which reduce the delay for operating on new sub-accounts, this PR removes the need for a second request to `POST /gla/mc/accounts` to complete the setup process for new sub-accounts, in favor of a `sleep()` before the `link` step.

#### Notes
- This _should_ align the two paths (existing account and new sub-account) of the Merchant Center setup process to requiring just one request.
- The delay is now 5 seconds.
  - It could probably be 0 seconds but a small value is left to allow for any small variations and avoid the need for the second request whenever possible. 
  - Even with the 5 second delay, the process takes under 20s (down from ~100s) and the actual delay is closer to 2s (since the delay is from the creation of the sub-account, and site verification – normally 2-3s – is performed between creation and the `link` step).
- The front end shouldn't need changes at all:
    - A `200` is returned after the first request if all goes well, which is already handled, and
    - There is still a small possibility that the account won't be ready after the 5 seconds, and a `503` will be returned indicating that another request is necessary.


### Detailed test instructions:
1. Disconnect any connected Merchant Center account.
2. Perform step 1 of the Merchant Center onboarding process, creating a new account for the "Google Merchant Center account".
3. Confirm that the basic process (no URL claim overwrite) takes less than 20 seconds.
4. Disconnect using the button on Connection Test (don't delete the MC account in the Google panel), and connect again with another new account to confirm that the claim overwrite process still works as intended.

### Changelog Note:

> Change Merchant Center sub-account creation process to one request instead of two.
