### PR TITLE
Display prompt when editing program

### DIFF
--- a/js/src/components/app-button-modal-trigger.js
+++ b/js/src/components/app-button-modal-trigger.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState , cloneElement} from '@wordpress/element';
+import { useState, cloneElement } from '@wordpress/element';
 
 /**
  * A convenience component to glue button and modal together.
@@ -13,7 +13,7 @@ import { useState , cloneElement} from '@wordpress/element';
  * ## Usage
  *
  * ```js
- * <AppModalButton
+ * <AppButtonModalTrigger
 		button={
 			<AppTextButton>
 				Click to open MySuperModal
@@ -27,7 +27,7 @@ import { useState , cloneElement} from '@wordpress/element';
  * @param {Object} props.button Button component.
  * @param {Object} props.modal Modal component.
  */
-const AppModalButton = ( props ) => {
+const AppButtonModalTrigger = ( props ) => {
 	const { button, modal } = props;
 	const { onClick = () => {} } = button.props;
 	const { onRequestClose = () => {} } = modal.props;
@@ -45,10 +45,13 @@ const AppModalButton = ( props ) => {
 
 	return (
 		<>
-			{ cloneElement(button, { onClick: handleButtonClick }) }
-			{ isOpen && cloneElement(modal, { onRequestClose: handleModalRequestClose }) }
+			{ cloneElement( button, { onClick: handleButtonClick } ) }
+			{ isOpen &&
+				cloneElement( modal, {
+					onRequestClose: handleModalRequestClose,
+				} ) }
 		</>
 	);
 };
 
-export default AppModalButton;
+export default AppButtonModalTrigger;

--- a/js/src/components/app-modal-button.js
+++ b/js/src/components/app-modal-button.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState , cloneElement} from '@wordpress/element';
 
 /**
  * A convenience component to glue button and modal together.
@@ -43,20 +43,10 @@ const AppModalButton = ( props ) => {
 		onRequestClose( ...args );
 	};
 
-	button.props = {
-		...button.props,
-		onClick: handleButtonClick,
-	};
-
-	modal.props = {
-		...modal.props,
-		onRequestClose: handleModalRequestClose,
-	};
-
 	return (
 		<>
-			{ button }
-			{ isOpen && modal }
+			{ cloneElement(button, { onClick: handleButtonClick }) }
+			{ isOpen && cloneElement(modal, { onRequestClose: handleModalRequestClose }) }
 		</>
 	);
 };

--- a/js/src/components/app-modal-button.js
+++ b/js/src/components/app-modal-button.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * A convenience component to glue button and modal together.
+ *
+ * Upon button click, this component will open the modal automatically.
+ *
+ * Upon modal's onRequestClose, this component will close the modal automatically.
+ *
+ * ## Usage
+ *
+ * ```js
+ * <AppModalButton
+		button={
+			<AppTextButton>
+				Click to open MySuperModal
+			</AppTextButton>
+		}
+		modal={ <MySuperModal /> }
+	/>
+ * ```
+ *
+ * @param {Object} props Props.
+ * @param {Object} props.button Button component.
+ * @param {Object} props.modal Modal component.
+ */
+const AppModalButton = ( props ) => {
+	const { button, modal } = props;
+	const { onClick = () => {} } = button.props;
+	const { onRequestClose = () => {} } = modal.props;
+	const [ isOpen, setOpen ] = useState( false );
+
+	const handleButtonClick = ( ...args ) => {
+		setOpen( true );
+		onClick( ...args );
+	};
+
+	const handleModalRequestClose = ( ...args ) => {
+		setOpen( false );
+		onRequestClose( ...args );
+	};
+
+	button.props = {
+		...button.props,
+		onClick: handleButtonClick,
+	};
+
+	modal.props = {
+		...modal.props,
+		onRequestClose: handleModalRequestClose,
+	};
+
+	return (
+		<>
+			{ button }
+			{ isOpen && modal }
+		</>
+	);
+};
+
+export default AppModalButton;

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { getHistory, getNewPath } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
+import AppModal from '.~/components/app-modal';
+import recordEvent from '.~/utils/recordEvent';
+import './index.scss';
+
+const EditProgramPromptModal = ( props ) => {
+	const { programId, onRequestClose } = props;
+
+	const handleDontEditClick = () => {
+		onRequestClose();
+	};
+
+	const handleContinueEditClick = () => {
+		const url =
+			programId === FREE_LISTINGS_PROGRAM_ID
+				? getNewPath( { programId }, '/google/edit-free-campaign' )
+				: getNewPath( { programId }, '/google/campaigns/edit' );
+
+		getHistory().push( url );
+
+		recordEvent( 'gla_dashboard_edit_program_click', {
+			programId,
+			url,
+		} );
+	};
+
+	return (
+		<AppModal
+			className="gla-edit-program-prompt-modal"
+			title={ __( 'Before you edit…', 'google-listings-and-ads' ) }
+			buttons={ [
+				<Button key="no" isSecondary onClick={ handleDontEditClick }>
+					{ __( `Don't edit`, 'google-listings-and-ads' ) }
+				</Button>,
+				<Button key="yes" isPrimary onClick={ handleContinueEditClick }>
+					{ __( 'Continue to edit', 'google-listings-and-ads' ) }
+				</Button>,
+			] }
+			onRequestClose={ onRequestClose }
+		>
+			<p>
+				{ __(
+					'Results typically improve with time with Google’s Free Listing and Smart Shopping campaigns.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Editing will result in the loss of any optimisations learned over time.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ __(
+					'We recommend allowing your programs to run for at least 14 days after set up, without pausing or editing, for optimal performance.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		</AppModal>
+	);
+};
+
+export default EditProgramPromptModal;

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.scss
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.scss
@@ -1,0 +1,5 @@
+.gla-edit-program-prompt-modal {
+	@include break-small() {
+		max-width: 360px;
+	}
+}

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
@@ -8,13 +8,13 @@ import { __ } from '@wordpress/i18n';
  */
 import AppTextButton from '.~/components/app-text-button';
 import EditProgramPromptModal from './edit-program-prompt-modal';
-import AppModalButton from '.~/components/app-modal-button';
+import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
 
 const EditProgramButton = ( props ) => {
 	const { programId } = props;
 
 	return (
-		<AppModalButton
+		<AppButtonModalTrigger
 			button={
 				<AppTextButton isSecondary>
 					{ __( 'Edit', 'google-listings-and-ads' ) }

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import AppTextButton from '.~/components/app-text-button';
+import EditProgramPromptModal from './edit-program-prompt-modal';
+
+const EditProgramButton = ( props ) => {
+	const { programId } = props;
+	const [ isOpen, setOpen ] = useState( false );
+
+	const handleClick = () => {
+		setOpen( true );
+	};
+
+	const handleModalRequestClose = () => {
+		setOpen( false );
+	};
+
+	return (
+		<>
+			<AppTextButton isSecondary onClick={ handleClick }>
+				{ __( 'Edit', 'google-listings-and-ads' ) }
+			</AppTextButton>
+			{ isOpen && (
+				<EditProgramPromptModal
+					programId={ programId }
+					onRequestClose={ handleModalRequestClose }
+				/>
+			) }
+		</>
+	);
+};
+
+export default EditProgramButton;

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
@@ -2,38 +2,26 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import AppTextButton from '.~/components/app-text-button';
 import EditProgramPromptModal from './edit-program-prompt-modal';
+import AppModalButton from '.~/components/app-modal-button';
 
 const EditProgramButton = ( props ) => {
 	const { programId } = props;
-	const [ isOpen, setOpen ] = useState( false );
-
-	const handleClick = () => {
-		setOpen( true );
-	};
-
-	const handleModalRequestClose = () => {
-		setOpen( false );
-	};
 
 	return (
-		<>
-			<AppTextButton isSecondary onClick={ handleClick }>
-				{ __( 'Edit', 'google-listings-and-ads' ) }
-			</AppTextButton>
-			{ isOpen && (
-				<EditProgramPromptModal
-					programId={ programId }
-					onRequestClose={ handleModalRequestClose }
-				/>
-			) }
-		</>
+		<AppModalButton
+			button={
+				<AppTextButton isSecondary>
+					{ __( 'Edit', 'google-listings-and-ads' ) }
+				</AppTextButton>
+			}
+			modal={ <EditProgramPromptModal programId={ programId } /> }
+		/>
 	);
 };
 

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -9,7 +9,7 @@ import { getQuery, onQueryChange } from '@woocommerce/navigation';
  */
 import AppTableCard from '.~/components/app-table-card';
 import RemoveProgramButton from './remove-program-button';
-import EditProgramLink from './edit-program-link';
+import EditProgramButton from './edit-program-button';
 import './index.scss';
 import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
 import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
@@ -125,7 +125,7 @@ const AllProgramsTableCard = ( props ) => {
 					{
 						display: (
 							<div className="program-actions">
-								<EditProgramLink programId={ el.id } />
+								<EditProgramButton programId={ el.id } />
 								{ el.id !== FREE_LISTINGS_PROGRAM_ID && (
 									<RemoveProgramButton programId={ el.id } />
 								) }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR will display a prompt modal when users click on the edit program button in the Programs table in the Dashboard page.

Figma link: https://www.figma.com/file/jZUpa8eTrnrK1Lwt2ry7zk/Native-Google-Integration?node-id=4298%3A78366

![image](https://user-images.githubusercontent.com/417342/114756761-a6d72800-9d8d-11eb-8ec0-3f1c720a4bfd.png)

### Screenshots:

Demo video with my voice (https://d.pr/v/qa4Kdq):

https://user-images.githubusercontent.com/417342/114757279-37ae0380-9d8e-11eb-98da-d7b5574d9da3.mov

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard
2. Click on the edit button for Free Listings in the Programs table. You should see a prompt modal.
    - Click on "Don't edit" to cancel the modal.
    - Click on "Continue to edit" to go to the edit listings page.
3. Click on the edit button for an ads campaign in the Programs table. You should see a prompt modal.
    - Click on "Don't edit" to cancel the modal.
    - Click on "Continue to edit" to go to the edit campaign page.

### Changelog Note:

Display prompt modal when users click on the edit program button in the Programs table in the Dashboard page.
