### PR TITLE
Hide `SupportedCountrySelect` if `location` is not `selected`.

### DIFF
--- a/js/src/components/free-listings/choose-audience/form-content.js
+++ b/js/src/components/free-listings/choose-audience/form-content.js
@@ -107,6 +107,7 @@ const FormContent = ( props ) => {
 								</AppRadioContentControl>
 								<AppRadioContentControl
 									{ ...getInputProps( 'location' ) }
+									collapsible="true"
 									label={ __(
 										'Selected countries only',
 										'google-listings-and-ads'

--- a/js/src/components/free-listings/choose-audience/form-content.js
+++ b/js/src/components/free-listings/choose-audience/form-content.js
@@ -107,7 +107,7 @@ const FormContent = ( props ) => {
 								</AppRadioContentControl>
 								<AppRadioContentControl
 									{ ...getInputProps( 'location' ) }
-									collapsible="true"
+									collapsible={ true }
 									label={ __(
 										'Selected countries only',
 										'google-listings-and-ads'

--- a/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
@@ -110,6 +110,7 @@ const FormContent = ( props ) => {
 								</AppRadioContentControl>
 								<AppRadioContentControl
 									{ ...getInputProps( 'location' ) }
+									collapsible="true"
 									label={ __(
 										'Selected countries only',
 										'google-listings-and-ads'

--- a/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
@@ -110,7 +110,7 @@ const FormContent = ( props ) => {
 								</AppRadioContentControl>
 								<AppRadioContentControl
 									{ ...getInputProps( 'location' ) }
-									collapsible="true"
+									collapsible={ true }
 									label={ __(
 										'Selected countries only',
 										'google-listings-and-ads'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Hide `SupportedCountrySelect` if `location` is not `selected`.

So users won't try to choose countries before setting any `location` value, which would result in a 400 error.

Fixes: https://github.com/woocommerce/google-listings-and-ads/issues/359.

A user still can choose 'selected' provide countries list, then change to 'all'. Choose countries are saved and preserved in case they want to switch back without a need to re-configure the list of countries.


### Screenshots:

#### MC Setup
![Screencast of collapsible audience in MC setup flow](https://user-images.githubusercontent.com/17435/114778870-b3e81d00-9d75-11eb-9c4f-c0dbdcd29467.gif)

#### Edit flow
![Screencast of collapsible audience in edit flow](https://user-images.githubusercontent.com/17435/114778965-ca8e7400-9d75-11eb-94b4-b37a918fcc92.gif)



### Detailed test instructions:

#### MC Setup
1. Visit [MC Setup step 2](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc) preferably for the first time (with clear setup)
2. Check that country select control is not visible,
	and you cannot use the UI to change specific audience countries before selecting the "Selected countries only" radio button.

#### Edit flow
1. Visit [Edit free listings step 1](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fedit-free-campaign&programId=0&pageStep=1).
2. Check that country select control is not visible,
	and you cannot use the UI to change specific audience countries before selecting the "Selected countries only" radio button.


### Changelog Note:

> Hide `SupportedCountrySelect` if `location` is not `selected`.
