### PR TITLE
Hide the "create a new MC account" link when an existing account is being connected.

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -91,14 +91,16 @@ const ConnectMCCard = ( props ) => {
 					</AppButton>
 				</ContentButtonLayout>
 			</Section.Card.Body>
-			<Section.Card.Footer>
-				<AppTextButton isSecondary onClick={ onCreateNew }>
-					{ __(
-						'Or, create a new Merchant Center account',
-						'google-listings-and-ads'
-					) }
-				</AppTextButton>
-			</Section.Card.Footer>
+			{ ! loading && (
+				<Section.Card.Footer>
+					<AppTextButton isSecondary onClick={ onCreateNew }>
+						{ __(
+							'Or, create a new Merchant Center account',
+							'google-listings-and-ads'
+						) }
+					</AppTextButton>
+				</Section.Card.Footer>
+			) }
 		</Section.Card>
 	);
 };


### PR DESCRIPTION
_alternative solution available at https://github.com/woocommerce/google-listings-and-ads/pull/479_
### Changes proposed in this Pull Request:

Hide the "create a new MC account" link when an existing account is being connected.
Fixes https://github.com/woocommerce/google-listings-and-ads/issues/360.

### Screenshots:
![Animation of "create a new MC account" being hidden while one is connected](https://user-images.githubusercontent.com/17435/114788807-658d4b00-9d82-11eb-80b6-c3234cb932d9.gif)



### Detailed test instructions:

1. Start fresh, or "Disconnect MC" in [Connection Test page](https://gla1.test/wp-admin/admin.php?page=connection-test-admin-page&action=wcs-google-accounts-delete&_wpnonce=78d1a53a89)
2. Go to [MC Setup](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc)
3. Go to Step 1.
4. Choose MC account.
5. Click "Connect"
6. Check if the "create a new MC account" link is hidden while the account is being connected.


### Changelog Note:

> Hide the "create a new MC account" link when an existing account is being connected.
