### PR TITLE
Disable the "create a new MC account" link when an existing account is being connected.

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -92,7 +92,11 @@ const ConnectMCCard = ( props ) => {
 				</ContentButtonLayout>
 			</Section.Card.Body>
 			<Section.Card.Footer>
-				<AppTextButton isSecondary onClick={ onCreateNew }>
+				<AppTextButton
+					disabled={ loading }
+					isSecondary
+					onClick={ onCreateNew }
+				>
 					{ __(
 						'Or, create a new Merchant Center account',
 						'google-listings-and-ads'

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -16,7 +17,6 @@ import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import BetaSwitchUrlCard from '../beta-switch-url-card';
 import BetaReclaimUrlCard from '../beta-reclaim-url-card';
-import AppTextButton from '.~/components/app-text-button';
 
 const ConnectMCCard = ( props ) => {
 	const { onCreateNew = () => {} } = props;
@@ -92,16 +92,12 @@ const ConnectMCCard = ( props ) => {
 				</ContentButtonLayout>
 			</Section.Card.Body>
 			<Section.Card.Footer>
-				<AppTextButton
-					disabled={ loading }
-					isSecondary
-					onClick={ onCreateNew }
-				>
+				<Button disabled={ loading } isLink onClick={ onCreateNew }>
 					{ __(
 						'Or, create a new Merchant Center account',
 						'google-listings-and-ads'
 					) }
-				</AppTextButton>
+				</Button>
 			</Section.Card.Footer>
 		</Section.Card>
 	);


### PR DESCRIPTION
_This is an alternative solution to https://github.com/woocommerce/google-listings-and-ads/pull/478_

### Changes proposed in this Pull Request:

Disable the "create a new MC account" link when an existing account is being connected.
Fixes https://github.com/woocommerce/google-listings-and-ads/issues/360.

### Screenshots:

![Screencast of "create a new MC account" being disabled while one is being connected](https://user-images.githubusercontent.com/17435/114903778-6d4aff00-9e17-11eb-97fb-214556d6af2b.gif)



### Detailed test instructions:

1. Start fresh, or "Disconnect MC" in [Connection Test page](https://gla1.test/wp-admin/admin.php?page=connection-test-admin-page&action=wcs-google-accounts-delete&_wpnonce=78d1a53a89)
2. Go to [MC Setup](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc)
3. Go to Step 1.
4. Choose MC account.
5. Click "Connect"
6. Check if the "create a new MC account" link is disabled while the account is being connected.


### Changelog Note:

> Disable the "create a new MC account" link when an existing account is being connected.
