### PR TITLE
Make `useDisplayTaxRate` check also store's country

### DIFF
--- a/js/src/components/conditional-section.js
+++ b/js/src/components/conditional-section.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import Section from '.~/wcdl/section';
+import AppSpinner from '.~/components/app-spinner';
+
+/**
+ * Component to conditionally render a section.
+ * If `show` is set to
+ *  - `true` returns given children
+ *  - `false` returns null
+ *  - `null` - unspecified, render section preloader
+ *
+ * @param {Object} props React props
+ * @param {boolean | null} props.show Flag to indicate whether the element should be shown.
+ * @param {Array<JSX.Element>} props.children Content to be rendered.
+ * @return {Array<JSX.Element> | null} Children, preloader section, or null.
+ */
+const ConditionalSection = ( { show, children } ) => {
+	switch ( show ) {
+		case true:
+			return children;
+		case false:
+			return null;
+		default:
+			return (
+				<Section>
+					<AppSpinner />
+				</Section>
+			);
+	}
+};
+
+export default ConditionalSection;

--- a/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
+++ b/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
@@ -1,36 +1,35 @@
 /**
  * Internal dependencies
  */
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
-
-/**
- * Returns a boolean to indicate whether the Tax Rate section should be displayed.
- *
- * The Tax Rate section should be displayed when the country code `'US'` is one of the target audience countries.
- */
-const useDisplayTaxRate = () => {
-	const { data } = useTargetAudienceFinalCountryCodes();
-
-	return shouldDisplayTaxRate( data );
-};
-
-export default useDisplayTaxRate;
+import useStoreCountry from '.~/hooks/useStoreCountry';
 
 /**
  * @typedef {import('.~/data/actions').CountryCode} CountryCode
  */
 
 /**
- * Checks whether the Tax Rate section should be displayed, for given audience.
- * The Tax Rate section should be displayed when there is `'US'` country code in the target audience countries list.
+ * Returns a boolean to indicate whether the Tax Rate section should be displayed for given audience countries.
+ *
+ * The Tax Rate section should be displayed when the store's country code or one of the target audience country codes is `'US'`.
+ *
+ * @param {Array<CountryCode>} [audienceCountries=[]] If no audience countries are given, check only store's one.
+ */
+const useDisplayTaxRate = ( audienceCountries = [] ) => {
+	const { code: storeCountry } = useStoreCountry();
+
+	return shouldDisplayTaxRate( [ ...audienceCountries, storeCountry ] );
+};
+
+export default useDisplayTaxRate;
+
+/**
+ * Checks whether the Tax Rate section should be displayed,
+ * for a given list of involved countries (audience and store's).
+ * The Tax Rate section should be displayed when there is `'US'` country code in the countries list.
  *
  * @param {Array<CountryCode>} countries
  * @return {boolean} `true` if the Tax Rate section should be displayed, `false` otherwise.
  */
 export function shouldDisplayTaxRate( countries ) {
-	if ( ! countries ) {
-		return false;
-	}
-
 	return countries.includes( 'US' );
 }

--- a/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
+++ b/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
@@ -12,24 +12,25 @@ import useStoreCountry from '.~/hooks/useStoreCountry';
  *
  * The Tax Rate section should be displayed when the store's country code or one of the target audience country codes is `'US'`.
  *
- * @param {Array<CountryCode>} [audienceCountries=[]] If no audience countries are given, check only store's one.
+ * @param {Array<CountryCode>} [audienceCountries] If no audience countries are given, check store's one.
+ * @return {boolean | null} `true` if the Tax Rate section should be displayed, `false` if shouldn't, `null` we cannot tell - we still wait for store or audience to be determined.
  */
-const useDisplayTaxRate = ( audienceCountries = [] ) => {
+const useDisplayTaxRate = ( audienceCountries = null ) => {
 	const { code: storeCountry } = useStoreCountry();
 
-	return shouldDisplayTaxRate( [ ...audienceCountries, storeCountry ] );
+	// If any country is US return `true`.
+	if ( storeCountry === 'US' ) {
+		return true;
+	}
+	if ( audienceCountries && audienceCountries.includes( 'US' ) ) {
+		return true;
+	}
+	// If we cannot tell yet, return `null`.
+	if ( storeCountry === null || audienceCountries === null ) {
+		return null;
+	}
+	// Store's and audience countries are available and were checked, none contains `US`.
+	return false;
 };
 
 export default useDisplayTaxRate;
-
-/**
- * Checks whether the Tax Rate section should be displayed,
- * for a given list of involved countries (audience and store's).
- * The Tax Rate section should be displayed when there is `'US'` country code in the countries list.
- *
- * @param {Array<CountryCode>} countries
- * @return {boolean} `true` if the Tax Rate section should be displayed, `false` otherwise.
- */
-export function shouldDisplayTaxRate( countries ) {
-	return countries.includes( 'US' );
-}

--- a/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
+++ b/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
@@ -26,7 +26,7 @@ const useDisplayTaxRate = ( audienceCountries = null ) => {
 		return true;
 	}
 	// If we cannot tell yet, return `null`.
-	if ( storeCountry === null || audienceCountries === null ) {
+	if ( ! storeCountry || audienceCountries === null ) {
 		return null;
 	}
 	// Store's and audience countries are available and were checked, none contains `US`.

--- a/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.test.js
+++ b/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.test.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useDisplayTaxRate from './useDisplayTaxRate';
+
+jest.mock( '.~/hooks/useStoreCountry', () => jest.fn() );
+const useStoreCountry = require( '.~/hooks/useStoreCountry' );
+
+describe( 'useDisplayTaxRate', () => {
+	describe( 'when store country is a non-US country', () => {
+		beforeEach( () => {
+			useStoreCountry.mockReturnValue( { code: 'PL', name: 'Poland' } );
+		} );
+		test( 'should return `null` when called with `null`', () => {
+			const { result } = renderHook( () => useDisplayTaxRate( null ) );
+
+			expect( result.current ).toBe( null );
+		} );
+		test( "should return `true` when called with an array containing `'US'`", () => {
+			const { result } = renderHook( () =>
+				useDisplayTaxRate( [ 'PL', 'US', 'SG' ] )
+			);
+
+			expect( result.current ).toBe( true );
+		} );
+		test( "should return `false` when called with an array not containing `'US'`", () => {
+			const { result } = renderHook( () =>
+				useDisplayTaxRate( [ 'PL', 'TW', 'SG' ] )
+			);
+
+			expect( result.current ).toBe( false );
+		} );
+	} );
+
+	describe( 'when store country is `US`', () => {
+		beforeEach( () => {
+			useStoreCountry.mockReturnValue( {
+				code: 'US',
+				name: 'United States (US)',
+			} );
+		} );
+		test( 'should return `true` when called with `null`', () => {
+			const { result } = renderHook( () => useDisplayTaxRate( null ) );
+
+			expect( result.current ).toBe( true );
+		} );
+		test( "should return `true` when called with an array containing `'US'`", () => {
+			const { result } = renderHook( () =>
+				useDisplayTaxRate( [ 'PL', 'US', 'SG' ] )
+			);
+
+			expect( result.current ).toBe( true );
+		} );
+		test( "should return `true` when called with an array not containing `'US'`", () => {
+			const { result } = renderHook( () =>
+				useDisplayTaxRate( [ 'PL', 'TW', 'SG' ] )
+			);
+
+			expect( result.current ).toBe( true );
+		} );
+	} );
+
+	describe( 'when store country is unresolved (returns falsy `{code}`)', () => {
+		beforeEach( () => {
+			useStoreCountry.mockReturnValue( { code: null } );
+		} );
+		test( 'should return `null` when called with `null`', () => {
+			const { result } = renderHook( () => useDisplayTaxRate( null ) );
+
+			expect( result.current ).toBe( null );
+		} );
+		test( "should return `true` when called with an array containing `'US'`", () => {
+			const { result } = renderHook( () =>
+				useDisplayTaxRate( [ 'PL', 'US', 'SG' ] )
+			);
+
+			expect( result.current ).toBe( true );
+		} );
+		test( "should return `null` when called with an array not containing `'US'`", () => {
+			const { result } = renderHook( () =>
+				useDisplayTaxRate( [ 'PL', 'TW', 'SG' ] )
+			);
+
+			expect( result.current ).toBe( null );
+		} );
+	} );
+} );

--- a/js/src/edit-free-campaign/setup-free-listings/form-content.js
+++ b/js/src/edit-free-campaign/setup-free-listings/form-content.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
 import TaxRate from '.~/components/free-listings/configure-product-listings/tax-rate';
-import { shouldDisplayTaxRate } from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
+import useDisplayTaxRate from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
 import CombinedShipping from '.~/components/free-listings/configure-product-listings/combined-shipping';
 import AppButton from '.~/components/app-button';
 
@@ -35,7 +35,8 @@ const FormContent = ( {
 	submitLabel = __( 'Complete setup', 'google-listings-and-ads' ),
 } ) => {
 	const { errors, handleSubmit } = formProps;
-	const displayTaxRate = shouldDisplayTaxRate( countries );
+
+	const displayTaxRate = useDisplayTaxRate( countries );
 
 	const isCompleteSetupDisabled = Object.keys( errors ).length >= 1;
 

--- a/js/src/edit-free-campaign/setup-free-listings/form-content.js
+++ b/js/src/edit-free-campaign/setup-free-listings/form-content.js
@@ -12,6 +12,7 @@ import TaxRate from '.~/components/free-listings/configure-product-listings/tax-
 import useDisplayTaxRate from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
 import CombinedShipping from '.~/components/free-listings/configure-product-listings/combined-shipping';
 import AppButton from '.~/components/app-button';
+import ConditionalSection from '.~/components/conditional-section';
 
 /**
  * @typedef {import('.~/data/actions').CountryCode} CountryCode
@@ -36,14 +37,17 @@ const FormContent = ( {
 } ) => {
 	const { errors, handleSubmit } = formProps;
 
-	const displayTaxRate = useDisplayTaxRate( countries );
+	const shouldDisplayTaxRate = useDisplayTaxRate( countries );
 
-	const isCompleteSetupDisabled = Object.keys( errors ).length >= 1;
+	const isCompleteSetupDisabled =
+		shouldDisplayTaxRate === null || Object.keys( errors ).length >= 1;
 
 	return (
 		<StepContent>
 			<CombinedShipping formProps={ formProps } countries={ countries } />
-			{ displayTaxRate && <TaxRate formProps={ formProps } /> }
+			<ConditionalSection show={ shouldDisplayTaxRate }>
+				<TaxRate formProps={ formProps } />
+			</ConditionalSection>
 			<StepContentFooter>
 				<AppButton
 					isPrimary

--- a/js/src/get-started-page/unsupported-notices/index.js
+++ b/js/src/get-started-page/unsupported-notices/index.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { Notice, Icon } from '@wordpress/components';
 import { external as externalIcon } from '@wordpress/icons';
 import { Link } from '@woocommerce/components';
@@ -13,21 +11,10 @@ import { createInterpolateElement } from '@wordpress/element';
  * Internal dependencies
  */
 import useTargetAudience from '.~/hooks/useTargetAudience';
+import useStoreCountry from '.~/hooks/useStoreCountry';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import { glaData } from '.~/constants';
 import './index.scss';
-
-const useStoreCountryName = () => {
-	return useSelect( ( select ) => {
-		const { getSetting } = select( SETTINGS_STORE_NAME );
-		const countryNames = getSetting( 'wc_admin', 'countries' );
-		const general = getSetting( 'general', 'general' );
-		const [ countryCode ] = general.woocommerce_default_country.split(
-			':'
-		);
-		return countryNames[ countryCode ];
-	} );
-};
 
 const ExternalIcon = () => (
 	<Icon
@@ -81,7 +68,7 @@ const UnsupportedLanguage = () => {
 };
 
 const UnsupportedCountry = () => {
-	const countryName = useStoreCountryName();
+	const { name: countryName } = useStoreCountry();
 
 	if ( ! countryName ) {
 		return null;

--- a/js/src/hooks/useStoreCountry.js
+++ b/js/src/hooks/useStoreCountry.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+
+/**
+ * Gets the store's country.
+ *
+ * @return {Object} `{ code: CountryCode, name: string }`
+ */
+export default function useStoreCountry() {
+	return useSelect( ( select ) => {
+		const { getSetting } = select( SETTINGS_STORE_NAME );
+		const countryNames = getSetting( 'wc_admin', 'countries' );
+		const general = getSetting( 'general', 'general' );
+		const [ code ] = general.woocommerce_default_country.split( ':' );
+
+		return { code, name: countryNames[ code ] };
+	} );
+}

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/form-content.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/form-content.js
@@ -10,6 +10,7 @@ import PreLaunchChecklist from './pre-launch-checklist';
 import useAutoSaveSettingsEffect from './useAutoSaveSettingsEffect';
 import useDisplayTaxRate from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
+import ConditionalSection from '.~/components/conditional-section';
 
 /**
  * Form to configure free listings.
@@ -22,15 +23,17 @@ const FormContent = ( props ) => {
 	const { formProps, submitButton } = props;
 	const { values } = formProps;
 	const { data: audienceCountries } = useTargetAudienceFinalCountryCodes();
-	const displayTaxRate = useDisplayTaxRate( audienceCountries );
-
+	const shouldDisplayTaxRate = useDisplayTaxRate( audienceCountries );
+	// console.log('FormContent', shouldDisplayTaxRate);
 	useAutoSaveSettingsEffect( values );
 
 	return (
 		<StepContent>
 			<ShippingRate formProps={ formProps } />
 			<ShippingTime formProps={ formProps } />
-			{ displayTaxRate && <TaxRate formProps={ formProps } /> }
+			<ConditionalSection show={ shouldDisplayTaxRate }>
+				<TaxRate formProps={ formProps } />
+			</ConditionalSection>
 			<PreLaunchChecklist formProps={ formProps } />
 			<StepContentFooter>{ submitButton }</StepContentFooter>
 		</StepContent>

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/form-content.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/form-content.js
@@ -9,6 +9,7 @@ import TaxRate from '.~/components/free-listings/configure-product-listings/tax-
 import PreLaunchChecklist from './pre-launch-checklist';
 import useAutoSaveSettingsEffect from './useAutoSaveSettingsEffect';
 import useDisplayTaxRate from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 
 /**
  * Form to configure free listings.
@@ -20,7 +21,8 @@ import useDisplayTaxRate from '.~/components/free-listings/configure-product-lis
 const FormContent = ( props ) => {
 	const { formProps, submitButton } = props;
 	const { values } = formProps;
-	const displayTaxRate = useDisplayTaxRate();
+	const { data: audienceCountries } = useTargetAudienceFinalCountryCodes();
+	const displayTaxRate = useDisplayTaxRate( audienceCountries );
 
 	useAutoSaveSettingsEffect( values );
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/form-content.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/form-content.js
@@ -24,7 +24,7 @@ const FormContent = ( props ) => {
 	const { values } = formProps;
 	const { data: audienceCountries } = useTargetAudienceFinalCountryCodes();
 	const shouldDisplayTaxRate = useDisplayTaxRate( audienceCountries );
-	// console.log('FormContent', shouldDisplayTaxRate);
+
 	useAutoSaveSettingsEffect( values );
 
 	return (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Move `useStoreCountry` hook to the shared folder,
- Make `useDisplayTaxRate` check also store's country, but take audience countries as an argument.
- Stop exporting `shouldDisplayTaxRate` as nothing uses it any longer, YAGNI.

Fixes: https://github.com/woocommerce/google-listings-and-ads/issues/313.


### Screenshots:

![Check store country](https://user-images.githubusercontent.com/17435/114939150-54a30f00-9e40-11eb-9e54-70406fe8f735.gif)

This fix touched the code responsible for showing/hiding unsupported country banner:
![Supported store country](https://user-images.githubusercontent.com/17435/114940070-92546780-9e41-11eb-988e-72c5828ba328.png)

![Unsupported store country](https://user-images.githubusercontent.com/17435/114940079-954f5800-9e41-11eb-8ba8-23ac5b3203d1.png)



### Detailed test instructions:

#### US in the audience or as a store's country in Setup MC 
1. Set store's country to non-US in [Woo settings](https://gla1.test/wp-admin/admin.php?page=wc-settings)
1. (Re-)Start [MC Setup flow](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc)
2. On "Choose your audience" select country/-ies other than the US
3. Continue to the next step
4. Make sure no Tax Rate section is **not** shown
5. Go back to "Choose your audience", select "all" or pick the US from the list.
6. Continue to the next step
7. Make sure no Tax Rate section is shown
8. Change store's country to the US in [Woo settings](https://gla1.test/wp-admin/admin.php?page=wc-settings)
9. open [MC Setup flow](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc)
2. On "Choose your audience" select country/-ies other than the US
3. Continue to the next step
4. Make sure no Tax Rate section is shown
5. Go back to "Choose your audience" select "all" or pick the US from the list.
6. Continue to the next step
7. Make sure no Tax Rate section is shown

#### US in the audience or as a store's country in edit free listings
Do the above by with [Edit free listings page](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fedit-free-campaign&programId=0&pageStep=1) 

#### Regression of unsupported notice
1. With supported store country open [Start page](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart)
2. Make sure no "not supported" banner is shown.
3. Change your country to an unsupported one, or put `return false;` at https://github.com/woocommerce/google-listings-and-ads/blob/fix/313-store-country-tax/src/MerchantCenter/MerchantCenterService.php#L83:L83
2. Make sure the "not supported" banner is shown.



### Changelog Note:

> Check also store location before showing tax settings.

### Additional notes

-I decided to use a data hook [in the middle of the form](https://github.com/woocommerce/google-listings-and-ads/pull/491/commits/05a8b378be52fdf4c13c211d8432838a1aca3702#diff-5f87cc11620c6da6cadd69a3a7a57f4e7337871d3d709f4bcd427f1b8ff1e0afR39), as we are fetching the WC store's configuration, which is unlikely to be variable in our plugin.