### PR TITLE
Rename "Google Shopping Free Listings" and fix "product" typos

### DIFF
--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -69,10 +69,7 @@ const AllProgramsTableCard = ( props ) => {
 	const data = [
 		{
 			id: FREE_LISTINGS_PROGRAM_ID,
-			title: __(
-				'Google Shopping Free Listings',
-				'google-listings-and-ads'
-			),
+			title: __( 'Free listings', 'google-listings-and-ads' ),
 			dailyBudget: __( 'Free', 'google-listings-and-ads' ),
 			country: (
 				<span>

--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -111,9 +111,9 @@ const CompareProductsTableCard = ( props ) => {
 	/**
 	 * Provides a rows configuration, for AppTableCard.
 	 * Maps each data row to respective cell objects ({@link module:app-table-card.Props.rows}):
-	 * checkbox to compere, program title, and available metrics cells.
+	 * checkbox to compere, product title, and available metrics cells.
 	 *
-	 * @param {Array} data Programs data.
+	 * @param {Array} data Products data.
 	 *
 	 * @return {Array<Object>} Rows config {@link module:@woocommerce/components#TableCard.Props.rows}.
 	 */

--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -174,7 +174,7 @@ const CompareProductsTableCard = ( props ) => {
 		<AppTableCard
 			title={
 				<>
-					{ __( 'Programs', 'google-listings-and-ads' ) }
+					{ __( 'Products', 'google-listings-and-ads' ) }
 					<Button
 						isSecondary
 						isSmall

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -35,7 +35,7 @@ const performanceMetrics = [
  * Renders a report page about products sold with GLA.
  */
 const ProductsReport = () => {
-	const reportId = 'reports-programs';
+	const reportId = 'reports-products';
 
 	const metricsData = getMetricsData();
 

--- a/js/src/reports/programs/mocked-programs-data.js
+++ b/js/src/reports/programs/mocked-programs-data.js
@@ -6,7 +6,7 @@ import { getQuery } from '@woocommerce/navigation';
 const freeListings = [
 	{
 		id: 147,
-		title: 'Google Free Listings',
+		title: 'Free Listings',
 		conversions: 89,
 		clicks: 5626,
 		impressions: 23340,

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -35,17 +35,17 @@ All event names are prefixed by `wcadmin_gla_`.
   * `href`: link's URL
 
 * `table_header_toggle` - Toggling display of table columns
-  * `report`: name of the report table (e.g. `"dashboard" | "reports-programs" | "product-feed"`)
+  * `report`: name of the report table (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)
   * `column`: name of the column
   * `status`: (`on`|`off`)
 
 * `gla_table_sort` - Sorting table
-  * `report`: name of the report table (e.g. `"dashboard" | "reports-programs" | "product-feed"`)
+  * `report`: name of the report table (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)
   * `column`: name of the column
   * `direction`: (`asc`|`desc`)
 
 * `datepicker_update` - Changing datepicker
-  * `report`: name of the report (e.g. `"dashboard" | "reports-programs" | "product-feed"`)
+  * `report`: name of the report (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)
   * `compare, period, before, after`: Values selected in [datepicker](https://woocommerce.github.io/woocommerce-admin/#/components/packages/date-range-filter-picker/README?id=props)
 
 * `filter` - Changing products & variations filter


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #449, #480

- Rename "Google * Free Listings" to "Free Listings" for free programs in the program tables (#449)
- Fix title typo of the product table on the Products Report page (#480)
- Fix other "product" typos on the Products Report page. Three tracking events were affected.

### Screenshots:

#### 📷 . Dashboard (#449)

![image](https://user-images.githubusercontent.com/17420811/115206174-e6569900-a12c-11eb-8498-f1ad67cc575c.png)

#### 📷 . Reports - Programs (#449)

![image](https://user-images.githubusercontent.com/17420811/115208981-beb50000-a12f-11eb-96b3-495c59c1dbfc.png)

#### 📷 . Reports - Products (#480)

![image](https://user-images.githubusercontent.com/17420811/115206329-10a85680-a12d-11eb-8ff8-25aebcf96c98.png)

### Detailed test instructions:

1. Open the DevTool console and execute localStorage.setItem( 'debug', 'wc-admin:*' ); to enable tracking debugging mode
2. Go to the Dashboard and Reports pages to see if the naming or title are correct (#449, #480)
3. For testing changed tracking events on the Reports page, make some oper on above UIs, and all the event property **report** should be `reports-products`:
    1. Change date range by date picker
    2. Click on any sortable title in the table header
    3. Toggle on/off of column displaying via the table's option
