### PR TITLE
Set default paid campaign name on server-side.

### DIFF
--- a/js/src/apis/createCampaign.js
+++ b/js/src/apis/createCampaign.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { format as formatDate } from '@wordpress/date';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -12,12 +11,10 @@ import apiFetch from '@wordpress/api-fetch';
  * @return {Promise} Result from apiFetch.
  */
 const createCampaign = ( amount, country ) => {
-	const date = formatDate( 'Y-m-d H:i', new Date() );
 	const options = {
 		path: '/wc/gla/ads/campaigns',
 		method: 'POST',
 		data: {
-			name: `Campaign ${ date }`,
 			amount: Number( amount ),
 			country,
 		},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Set default paid campaign name on server-side.
Run it through i18n. Add seconds for a granular specificity.
Fixes https://github.com/woocommerce/google-listings-and-ads/issues/408.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Go to [ads setup](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads) or [add paid campaign](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcampaigns%2Fcreate) page
2. Create a new campaign
3. Repeat the step 1-2 in less than a minute.

Alternatively, you can open two browser tabs with the create campaign pages, then click "Launch paid campaign" on both 

### Changelog Note:

> Set default paid capaign name on server-side, as `Campaign ${date('Y-m-d H:i:s')}`

### Additional notes:

- I was not able to test it locally, as saving campaigns fails for me even on `trunk`, see Slack conv: p1618589128385500-slack-C01E9LB4X61
- Also, as discussed at https://github.com/woocommerce/google-listings-and-ads/issues/408#issuecomment-821297694 this PR might be overkill, for a rare edge case.