### PR TITLE
Fix issues of shipping rate/time components for MC onboarding flow

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/index.js
@@ -12,7 +12,6 @@ import EditRateButton from './edit-rate-button';
 import AppSpinner from '.~/components/app-spinner';
 import CountryNames from '.~/components/free-listings/configure-product-listings/country-names';
 import './index.scss';
-import '../countries-form';
 
 /**
  * Input control to edit a shipping rate.

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
@@ -1,20 +1,24 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 import { useDebouncedCallback } from 'use-debounce';
 
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data';
+import { useAppDispatch } from '.~/data';
 import CountriesPriceInput from '../countries-price-input';
 
 const CountriesPriceInputForm = ( props ) => {
-	const { initialValue } = props;
-	const [ value, setValue ] = useState( initialValue );
-	const { upsertShippingRates } = useDispatch( STORE_KEY );
+	const { savedValue } = props;
+	const [ value, setValue ] = useState( savedValue );
+	const { upsertShippingRates } = useAppDispatch();
+
+	useEffect( () => {
+		setValue( savedValue );
+	}, [ savedValue ] );
+
 	const debouncedUpsertShippingRate = useDebouncedCallback( ( v ) => {
 		const { countries, currency, price } = v;
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/getCountriesPriceArray.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/getCountriesPriceArray.js
@@ -47,13 +47,14 @@ const getCountriesPriceArray = ( shippingRates ) => {
 
 	shippingRates.forEach( ( shippingRate ) => {
 		const { countryCode, rate } = shippingRate;
-		const group = rateGroupMap.get( rate ) || {
+		const price = Number( rate );
+		const group = rateGroupMap.get( price ) || {
 			countries: [],
-			price: rate,
+			price,
 			currency,
 		};
 		group.countries.push( countryCode );
-		rateGroupMap.set( rate, group );
+		rateGroupMap.set( price, group );
 	} );
 
 	return Array.from( rateGroupMap.values() );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
@@ -39,32 +39,28 @@ const ShippingRateSetup = ( props ) => {
 
 	const countriesPriceArray = getCountriesPriceArray( shippingRates );
 
+	// Prefill to-be-added price.
+	if ( countriesPriceArray.length === 0 ) {
+		countriesPriceArray.push( {
+			countries: selectedCountryCodes,
+			price: '',
+			currency: currencyCode,
+		} );
+	}
+
 	return (
 		<div className="gla-shipping-rate-setup">
 			<VerticalGapLayout>
 				<div className="countries-price">
 					<VerticalGapLayout>
-						{ shippingRates.length === 0 && (
-							<div className="countries-price-input-form">
-								<CountriesPriceInputForm
-									initialValue={ {
-										countries: selectedCountryCodes,
-										price: '',
-										currency: currencyCode,
-									} }
-								/>
-							</div>
-						) }
 						{ countriesPriceArray.map( ( el ) => {
 							return (
 								<div
-									key={ `${ el.price }-${ el.countries.join(
-										'-'
-									) }` }
+									key={ el.countries.join( '-' ) }
 									className="countries-price-input-form"
 								>
 									<CountriesPriceInputForm
-										initialValue={ el }
+										savedValue={ el }
 									/>
 								</div>
 							);

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
@@ -13,7 +13,7 @@ import CountriesTimeInput from '../countries-time-input';
 const CountriesTimeInputForm = ( props ) => {
 	const { savedValue } = props;
 	const [ value, setValue ] = useState( savedValue );
-	const { upsertShippingTimes } = useAppDispatch();
+	const { upsertShippingTimes, deleteShippingTimes } = useAppDispatch();
 
 	useEffect( () => {
 		setValue( savedValue );
@@ -21,7 +21,9 @@ const CountriesTimeInputForm = ( props ) => {
 
 	const debouncedUpsertShippingTime = useDebouncedCallback( ( v ) => {
 		const { countries: countryCodes, time } = v;
-		upsertShippingTimes( { countryCodes, time } );
+		if ( time ) {
+			upsertShippingTimes( { countryCodes, time } );
+		}
 	}, 500 );
 
 	const handleChange = ( v ) => {
@@ -29,7 +31,19 @@ const CountriesTimeInputForm = ( props ) => {
 		debouncedUpsertShippingTime.callback( v );
 	};
 
-	return <CountriesTimeInput value={ value } onChange={ handleChange } />;
+	const handleBlur = () => {
+		if ( value.time === '' ) {
+			deleteShippingTimes( value.countries );
+		}
+	};
+
+	return (
+		<CountriesTimeInput
+			value={ value }
+			onChange={ handleChange }
+			onBlur={ handleBlur }
+		/>
+	);
 };
 
 export default CountriesTimeInputForm;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
@@ -1,20 +1,24 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 import { useDebouncedCallback } from 'use-debounce';
 
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data';
+import { useAppDispatch } from '.~/data';
 import CountriesTimeInput from '../countries-time-input';
 
 const CountriesTimeInputForm = ( props ) => {
-	const { initialValue } = props;
-	const [ value, setValue ] = useState( initialValue );
-	const { upsertShippingTimes } = useDispatch( STORE_KEY );
+	const { savedValue } = props;
+	const [ value, setValue ] = useState( savedValue );
+	const { upsertShippingTimes } = useAppDispatch();
+
+	useEffect( () => {
+		setValue( savedValue );
+	}, [ savedValue ] );
+
 	const debouncedUpsertShippingTime = useDebouncedCallback( ( v ) => {
 		const { countries: countryCodes, time } = v;
 		upsertShippingTimes( { countryCodes, time } );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -15,7 +15,7 @@ import './index.scss';
 import CountryNames from '.~/components/free-listings/configure-product-listings/country-names';
 
 const CountriesTimeInput = ( props ) => {
-	const { value, onChange } = props;
+	const { value, onChange, onBlur } = props;
 	const { countries, time } = value;
 	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
@@ -59,6 +59,7 @@ const CountriesTimeInput = ( props ) => {
 				suffix={ __( 'days', 'google-listings-and-ads' ) }
 				value={ time }
 				onChange={ handleChange }
+				onBlur={ onBlur }
 			/>
 		</div>
 	);

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
@@ -38,32 +38,26 @@ const ShippingTimeSetup = ( props ) => {
 
 	const countriesTimeArray = getCountriesTimeArray( shippingTimes );
 
+	// Prefill to-be-added price.
+	if ( countriesTimeArray.length === 0 ) {
+		countriesTimeArray.push( {
+			countries: selectedCountryCodes,
+			time: '',
+		} );
+	}
+
 	return (
 		<div className="gla-shipping-time-setup">
 			<VerticalGapLayout>
 				<div className="countries-time">
 					<VerticalGapLayout>
-						{ shippingTimes.length === 0 && (
-							<div className="countries-time-input-form">
-								<CountriesTimeInputForm
-									initialValue={ {
-										countries: selectedCountryCodes,
-										time: '',
-									} }
-								/>
-							</div>
-						) }
 						{ countriesTimeArray.map( ( el ) => {
 							return (
 								<div
-									key={ `${ el.time }-${ el.countries.join(
-										'-'
-									) }` }
+									key={ el.countries.join( '-' ) }
 									className="countries-time-input-form"
 								>
-									<CountriesTimeInputForm
-										initialValue={ el }
-									/>
+									<CountriesTimeInputForm savedValue={ el } />
 								</div>
 							);
 						} ) }

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
@@ -38,7 +38,7 @@ const ShippingTimeSetup = ( props ) => {
 
 	const countriesTimeArray = getCountriesTimeArray( shippingTimes );
 
-	// Prefill to-be-added price.
+	// Prefill to-be-added time.
 	if ( countriesTimeArray.length === 0 ) {
 		countriesTimeArray.push( {
 			countries: selectedCountryCodes,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

❗ Since issue #427 is pending, but it will address these issues eventually, this PR tends to fix problems in a smaller scope and effort first.

Closes #374 .

1. Fix the losing focus problems when typing on shipping rate/time inputs
2. Fix that upsert shipping time with `""` value will cause API error
3. Fix the problem of the same shipping rates didn't merge together 
4. Remove a leftover import

### Screenshots:

![Kapture 2021-04-20 at 11 38 44](https://user-images.githubusercontent.com/17420811/115333893-00e04f00-a1cd-11eb-9a19-21067ea6c90c.gif)

### Detailed test instructions:

All testing can be done on the MC onboarding flow: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`

#### 1. Losing focus

1. Update any shipping rate/time group by inputs
2. Shouldn't lose the focused cursor when typing on the input

#### 2. Upsert shipping time with `""` value

1. Delete input value from any shipping time group (not in the pop-up modal)
2. Should call the delete API instead of upsert API and API error should not occur

#### 3. The same shipping rates didn't merge together

1. Select at least two countries at step 2
2. Set shipping rate for one country
3. Refresh the current page
4. Set shipping rate for another country with the same value as the first country
5. The second country should merge with the first one