### PR TITLE
Delete MC shipping settings on disconnect

### DIFF
--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -35,7 +35,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `applicable_countries` text NOT NULL,
     `created_at` datetime NOT NULL,
     PRIMARY KEY `id` (`id`),
-    UNIQUE `product_issue` (`product_id`, `issue`)
+    UNIQUE KEY `product_issue` (`product_id`, `issue`)
 ) {$this->get_collation()};
 SQL;
 	}

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -25,7 +25,7 @@ class MerchantIssueTable extends Table {
 	protected function get_install_query(): string {
 		return <<< SQL
 CREATE TABLE `{$this->get_sql_safe_name()}` (
-    `id` bigint(20) NOT NULL  AUTO_INCREMENT,
+    `id` bigint(20) NOT NULL AUTO_INCREMENT,
     `product_id` bigint(20) NOT NULL,
     `issue` varchar(200) NOT NULL,
     `code` varchar(100) NOT NULL,

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -57,8 +57,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks as TracksProxy;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\TaskList\CompleteSetup;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\Loaded;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteVerificationEvents;

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -153,14 +153,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			->invokeMethod( 'set_options_object', [ OptionsInterface::class ] );
 
 		// Set up MerchantCenter service, and inflect classes that need it.
-		$this->share_with_tags(
-			MerchantCenterService::class,
-			WC::class,
-			WP::class,
-			TransientsInterface::class,
-			MerchantAccountState::class,
-			MerchantIssues::class
-		);
+		$this->share_with_tags( MerchantCenterService::class );
 		$this->getLeagueContainer()
 			->inflector( MerchantCenterAwareInterface::class )
 			->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -18,58 +20,22 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class MerchantCenterService
  *
+ * ContainerAware used to access:
+ * - MerchantAccountState
+ * - MerchantIssues
+ * - ShippingRateTable
+ * - ShippingTimeTable
+ * - TransientsInterface
+ * - WC
+ * - WP
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter
  */
-class MerchantCenterService implements OptionsAwareInterface, Service {
+class MerchantCenterService implements OptionsAwareInterface, ContainerAwareInterface, Service {
 
 	use GoogleHelper;
 	use OptionsAwareTrait;
-
-	/**
-	 * WooCommerce proxy service
-	 *
-	 * @var WC
-	 */
-	protected $wc;
-
-	/**
-	 * WordPress proxy service
-	 *
-	 * @var WP
-	 */
-	protected $wp;
-
-	/**
-	 * @var TransientsInterface
-	 */
-	protected $transients;
-
-	/**
-	 * @var MerchantAccountState
-	 */
-	protected $account_state;
-
-	/**
-	 * @var MerchantIssues
-	 */
-	protected $issues;
-
-	/**
-	 * MerchantCenterService constructor.
-	 *
-	 * @param WC                   $wc
-	 * @param WP                   $wp
-	 * @param TransientsInterface  $transients
-	 * @param MerchantAccountState $account_state
-	 * @param MerchantIssues       $issues
-	 */
-	public function __construct( WC $wc, WP $wp, TransientsInterface $transients, MerchantAccountState $account_state, MerchantIssues $issues ) {
-		$this->wc            = $wc;
-		$this->wp            = $wp;
-		$this->transients    = $transients;
-		$this->account_state = $account_state;
-		$this->issues        = $issues;
-	}
+	use ContainerAwareTrait;
 
 	/**
 	 * Get whether Merchant Center setup is completed.
@@ -89,7 +55,7 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 	public function is_country_supported( string $country = '' ): bool {
 		// Default to WooCommerce store country
 		if ( empty( $country ) ) {
-			$country = $this->wc->get_base_country();
+			$country = $this->container->get( WC::class )->get_base_country();
 		}
 
 		return array_key_exists(
@@ -107,7 +73,7 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 	public function is_language_supported( string $language = '' ): bool {
 		// Default to base site language
 		if ( empty( $language ) ) {
-			$language = substr( $this->wp->get_locale(), 0, 2 );
+			$language = substr( $this->container->get( WP::class )->get_locale(), 0, 2 );
 		}
 
 		return array_key_exists(
@@ -120,7 +86,7 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 	 * @return string[] List of target countries specified in options. Defaults to WooCommerce store base country.
 	 */
 	public function get_target_countries(): array {
-		$target_countries = [ $this->wc->get_base_country() ];
+		$target_countries = [ $this->container->get( WC::class )->get_base_country() ];
 
 		$target_audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE );
 		if ( empty( $target_audience['location'] ) && empty( $target_audience['countries'] ) ) {
@@ -149,7 +115,7 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 			'status' => $id ? 'connected' : 'disconnected',
 		];
 
-		$incomplete = $this->account_state->last_incomplete_step();
+		$incomplete = $this->container->get( MerchantAccountState::class )->last_incomplete_step();
 		if ( ! empty( $incomplete ) ) {
 			$status['status'] = 'incomplete';
 			$status['step']   = $incomplete;
@@ -194,9 +160,8 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 		$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
 
-		$this->transients->delete( TransientsInterface::MC_PRODUCT_STATISTICS );
-
-		$this->issues->delete();
+		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_PRODUCT_STATISTICS );
+		$this->container->get( MerchantIssues::class )->delete();
 	}
 
 	/**
@@ -206,7 +171,7 @@ class MerchantCenterService implements OptionsAwareInterface, Service {
 	 */
 	protected function connected_account(): bool {
 		$id = $this->options->get_merchant_id();
-		return $id && ! $this->account_state->last_incomplete_step();
+		return $id && ! $this->container->get( MerchantAccountState::class )->last_incomplete_step();
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter
  */
-class MerchantCenterService implements OptionsAwareInterface, ContainerAwareInterface, Service {
+class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInterface, Service {
 
 	use GoogleHelper;
 	use OptionsAwareTrait;

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
@@ -162,6 +164,9 @@ class MerchantCenterService implements OptionsAwareInterface, ContainerAwareInte
 
 		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_PRODUCT_STATISTICS );
 		$this->container->get( MerchantIssues::class )->delete();
+
+		$this->container->get( ShippingRateTable::class )->truncate();
+		$this->container->get( ShippingTimeTable::class )->truncate();
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantIssues.php
+++ b/src/MerchantCenter/MerchantIssues.php
@@ -19,6 +19,11 @@ use Exception;
 /**
  * Class MerchantIssues
  *
+ * ContainerAware used to access:
+ * - MerchantIssueTable
+ * - OptionsInterface
+ * - ProductHelper
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Options
  */
 class MerchantIssues implements Service, ContainerAwareInterface {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #453.

This PR adds steps to truncate `wp_gla_shipping_rates` and `wp_gla_shipping_settings` when the Merchant Center account is disconnected.

Additionally
- Add a missing "`KEY`" to the `wp_gla_merchant_issues` table creation query that caused DB upgrade issues.
- Refactor `MerchantCenterService` to use `ContainerAware` for all dependencies.
- Clarify the ContainerAware dependencies loaded in `MerchantCenterService` and `MerchantIssues`.

### Detailed test instructions:

1. Set up the Merchant Center account with a handful of countries (two, for example). Set the same shipping time and rate for both countries (for example, `3.00` and `2`).
1. Check in the database that the values for Shipping Time and Rate have been stored for the selected countries:
    ```sql
    SELECT * FROM `wp_gla_shipping_rates`
    # and
    SELECT * FROM `wp_gla_shipping_times`
    ```
1. Disconnect from the Merchant Center using the button on Connection Test.
1. Check in the database that the tables for Shipping Time and Rate have been emptied:
    ```sql
    SELECT * FROM `wp_gla_shipping_rates`
    # and
    SELECT * FROM `wp_gla_shipping_times`
    ```
1. Begin the Merchant Center setup process again, this time choose `All Countries` for the Audience.
1. Click on the `I have a fairly simple shipping setup and I can estimate flat shipping rates.` radio button for Shipping Rates
1. Confirm that the countries from the first Merchant Center connection no longer appear by default.

### Changelog Note:

> Reset shipping times and rates when disconnecting the Merchant Center account.
