### PR TITLE
Use fallback billing url when billingStatus.billing_url is null.

### DIFF
--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -7,12 +7,15 @@ import { Spinner } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
+import recordEvent from '.~/utils/recordEvent';
 import './index.scss';
 
 /**
  * Renders a Button component with extra props.
  *
  * Set `loading` to `true` and it will render a disabled Button with a loading spinner indicator.
+ *
+ * Set `eventName` and upon `onClick` it will call `recordEvent` with provided `eventName` and `eventProps`.
  *
  * ## Usage
  *
@@ -26,12 +29,30 @@ import './index.scss';
  * @param {boolean} [props.loading] If true, the button will be disabled and will display a loading spinner indicator beside the button text.
  */
 const AppButton = ( props ) => {
-	const { className = '', disabled, loading, children, ...rest } = props;
+	const {
+		className = '',
+		disabled,
+		loading,
+		eventName,
+		eventProps,
+		children,
+		onClick = () => {},
+		...rest
+	} = props;
+
+	const handleClick = ( ...args ) => {
+		if ( eventName ) {
+			recordEvent( eventName, eventProps );
+		}
+
+		onClick( ...args );
+	};
 
 	return (
 		<Button
 			className={ `app-button ${ className }` }
 			disabled={ disabled || loading }
+			onClick={ handleClick }
 			{ ...rest }
 		>
 			{ loading && <Spinner /> }

--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { Spinner } from '@woocommerce/components';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -30,7 +31,7 @@ import './index.scss';
  */
 const AppButton = ( props ) => {
 	const {
-		className = '',
+		className,
 		disabled,
 		loading,
 		eventName,
@@ -50,7 +51,7 @@ const AppButton = ( props ) => {
 
 	return (
 		<Button
-			className={ `app-button ${ className }` }
+			className={ classnames( 'app-button', className ) }
 			disabled={ disabled || loading }
 			onClick={ handleClick }
 			{ ...rest }

--- a/js/src/setup-ads/ads-stepper/setup-billing/fallbackBillingUrl.js
+++ b/js/src/setup-ads/ads-stepper/setup-billing/fallbackBillingUrl.js
@@ -1,0 +1,16 @@
+/**
+ * `fallbackBillingUrl` is the billing URL used when `billingStatus.billing_url` is null.
+ *
+ * `billingStatus.billing_url` can be null when merchants connect an existing ads account.
+ *
+ * An example scenario:
+ *
+ * 1. Merchants create a new account, they will get the billing url.
+ * 2. For some reasons, they did not complete billing, and they decided to disconnect everything and maybe even uninstall GLA plugin.
+ * 3. Then they use GLA again, and they connect the old ads account, the billing url would be null.
+ * 4. When the billing url is null, we should use this fallback billing url, so that they can continue billing setup manually.
+ */
+const fallbackBillingUrl =
+	'https://support.google.com/google-ads/answer/2375375';
+
+export default fallbackBillingUrl;

--- a/js/src/setup-ads/ads-stepper/setup-billing/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-billing/index.js
@@ -15,6 +15,7 @@ import SetupCard from './setup-card';
 import BillingSavedCard from './billing-saved-card';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
 import AppButton from '.~/components/app-button';
+import fallbackBillingUrl from './fallbackBillingUrl';
 
 const SetupBilling = ( props ) => {
 	const {
@@ -54,7 +55,9 @@ const SetupBilling = ( props ) => {
 					<BillingSavedCard />
 				) : (
 					<SetupCard
-						billingUrl={ billingStatus.billing_url }
+						billingUrl={
+							billingStatus.billing_url || fallbackBillingUrl
+						}
 						onSetupComplete={ handleSubmit }
 					/>
 				) }

--- a/js/src/setup-ads/ads-stepper/setup-billing/setup-card/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-billing/setup-card/index.js
@@ -24,10 +24,6 @@ const SetupCard = ( props ) => {
 		return <AppSpinner />;
 	}
 
-	const handleSetupBillingClick = () => {
-		window.open( billingUrl, '_blank' );
-	};
-
 	return (
 		<div className="gla-google-ads-billing-setup-card">
 			<Section.Card>
@@ -38,7 +34,7 @@ const SetupCard = ( props ) => {
 						/>
 					</div>
 					<div className="gla-google-ads-billing-setup-card__description">
-						<div>
+						<div className="gla-google-ads-billing-setup-card__description__text">
 							{ __(
 								'You do not have billing information set up in your Google Ads account. Once you have completed your billing setup, your campaign will launch automatically.',
 								'google-listings-and-ads'
@@ -46,7 +42,14 @@ const SetupCard = ( props ) => {
 						</div>
 						<AppButton
 							isSecondary
-							onClick={ handleSetupBillingClick }
+							href={ billingUrl }
+							target="_blank"
+							eventName="gla_ads_set_up_billing_click"
+							eventProps={ {
+								context: 'setup-ads',
+								link_id: 'set-up-billing',
+								href: billingUrl,
+							} }
 						>
 							{ __(
 								'Set up billing',

--- a/js/src/setup-ads/ads-stepper/setup-billing/setup-card/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-billing/setup-card/index.js
@@ -44,7 +44,7 @@ const SetupCard = ( props ) => {
 							isSecondary
 							href={ billingUrl }
 							target="_blank"
-							eventName="gla_ads_set_up_billing_click"
+							eventName="ads_set_up_billing_click"
 							eventProps={ {
 								context: 'setup-ads',
 								link_id: 'set-up-billing',

--- a/js/src/setup-ads/ads-stepper/setup-billing/setup-card/index.scss
+++ b/js/src/setup-ads/ads-stepper/setup-billing/setup-card/index.scss
@@ -6,6 +6,9 @@
 	&__description {
 		display: flex;
 		gap: calc(var(--main-gap) * 2);
-		font-style: italic;
+
+		&__text {
+			font-style: italic;
+		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3368,6 +3368,11 @@
 						"lodash": "^4.17.15"
 					}
 				},
+				"classnames": {
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+					"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+				},
 				"core-js": {
 					"version": "3.6.5",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -7002,9 +7007,9 @@
 			}
 		},
 		"classnames": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"clean-stack": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"@wordpress/date": "^3.12.0",
 		"@wordpress/element": "^2.18.0",
 		"@wordpress/icons": "^2.8.0",
+		"classnames": "^2.3.1",
 		"gridicons": "^3.3.1",
 		"lodash": "^4.17.20",
 		"use-debounce": "^5.2.0"

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -90,6 +90,11 @@ All event names are prefixed by `wcadmin_gla_`.
   * `context`: indicate the place where the button is located.
   * `href`: indicate the destination where the users is directed to, e.g. `'/google/setup-ads'` or `'/google/campaigns/create'`.
 
+* `ads_set_up_billing_click` - "Set up billing" button for Google Ads account is clicked.
+  * `context`: indicate the place where the button is located, e.g. `setup-ads`.
+  * `link_id`: a unique ID for the button within the context, e.g. `set-up-billing`.
+  * `href`: indicate the destination where the users is directed to.
+
 <!-- -- >
 ## Developer Info
 All new tracking info should be updated in this readme.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #447 .

This PR will redirect the users to the fallback billing URL (https://support.google.com/google-ads/answer/2375375) when the `billingStatus.billing_url` is `null` in Setup Ads Step 3.

`billingStatus.billing_url` can be null when merchants connect an existing ads account.
 
An example scenario:
 
1. Merchants create a new account, they will get the billing url.
2. For some reasons, they did not complete billing, and they decided to disconnect everything and maybe even uninstall GLA plugin.
3. Then they use GLA again, and they connect the old ads account, the billing url would be null.
4. When the billing url is null, we should use this fallback billing url, so that they can continue billing setup manually.

Other technical notes:

- I made the `AppButton` support `eventName` and `eventProps` props (similar to `TrackableLink` component) so that upon click, it will automatically call `recordEvent`. This should come in handy in many places.
- I noticed we are using `classnames` package but it was not specified as dependency in `package.json`. I added it as dependency in this PR.

### Screenshots:

Demo video with my voice (https://d.pr/v/egXCwc):

https://user-images.githubusercontent.com/417342/115431852-59006b00-a238-11eb-8b9e-1eb692ee3ecc.mov

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads
2. In Step 1, connect an existing ads account that does not have billing setup yet.
3. Proceed through Step 2 and Step 3. 
4. In Step 3, click on the "Set up billing" button. A new tab should open with the URL `https://support.google.com/google-ads/answer/2375375`.


### Changelog Note:

Redirect users to the fallback billing URL (https://support.google.com/google-ads/answer/2375375) when the `billingStatus.billing_url` is `null` in Setup Ads Step 3.
