### PR TITLE
Add FAQ for "What if I already have free listings set up for my store?"

### DIFF
--- a/js/src/get-started-page/faqs.js
+++ b/js/src/get-started-page/faqs.js
@@ -31,6 +31,46 @@ const faqItems = [
 		),
 	},
 	{
+		trackId: 'what-if-i-already-have-free-listings',
+		question: __(
+			'What if I already have free listings set up for my store?',
+			'google-listings-and-ads'
+		),
+		answer: (
+			<>
+				<p>
+					{ __(
+						'If there is an existing claim on your store URL, this WooCommerce integration will reclaim your store URL. This will cause any existing product listings or ads to stop running, and the other verified account will be notified that they have lost their claim.',
+						'google-listings-and-ads'
+					) }
+				</p>
+				<p>
+					{ createInterpolateElement(
+						__(
+							'Learn more about claiming URLs <link>here</link>.',
+							'google-listings-and-ads'
+						),
+						{
+							link: (
+								<AppDocumentationLink
+									context="faqs"
+									linkId="claiming-urls"
+									href="https://support.google.com/merchants/answer/7527436"
+								/>
+							),
+						}
+					) }
+				</p>
+				<p>
+					{ __(
+						'If you have an existing Content API feed, it will not be changed, overwritten or deleted by this WooCommerce integration. Instead, products will be added to your existing Content API feed.',
+						'google-listings-and-ads'
+					) }
+				</p>
+			</>
+		),
+	},
+	{
 		trackId: 'which-countries-are-available',
 		question: __(
 			'Which countries are available for Google Listings & Ads?',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #376 .

This PR adds a new FAQ item for the question "What if I already have free listings set up for my store?". In the FAQ, when users click on the "here" link, a new tab will open with the URL https://support.google.com/merchants/answer/7527436.

Track event for panel open, panel close and link click would work similar to other FAQ items.

### Screenshots:

![image](https://user-images.githubusercontent.com/417342/115446324-a0432780-a249-11eb-9445-ec4a2277803d.png)

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart
2. Scroll down to the FAQs. There should be an FAQ item for "What if I already have free listings set up for my store?".
3. Click on the "here" link. A new tab should open with the URL https://support.google.com/merchants/answer/7527436.
4. Track event for panel open, panel close and link click should work similar to other FAQ items.

### Changelog Note:

Add FAQ for "What if I already have free listings set up for my store?".
