### PR TITLE
Generate optimized autoload for final archive

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"build": "NODE_ENV=production wp-scripts build && npm run i18n",
 		"postbuild": "npm run archive",
 		"dev": "NODE_ENV=development wp-scripts build",
-		"prearchive": "rm -rf vendor && composer install --no-dev",
+		"prearchive": "rm -rf vendor && composer install --no-dev && composer dump-autoload -o",
 		"archive": "composer archive --file=$npm_package_name --format=zip",
 		"postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
 		"i18n": "php -d memory_limit=1024M `which wp` i18n make-pot ./ languages/$npm_package_name.pot --slug=$npm_package_name --domain=$npm_package_name --exclude=bin,data,js/src,node_modules,tests,vendor",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

My initial intent was to decrease the size of the classmap used by the autoloader (for #314). The reason why this was large was because it gets generated before the `post-install-cmd` hook. Which means we have a large amount of Google Service classes which get included, because they haven't been cleaned up.

Running `composer dump-autoload` again just before generating the zip file causes the `vendor/composer` size to go from 3.2MB to 264k, which is a massive drop. However this is still not optimized for speed. For the release it's better to take [advantage of speed](https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-1-class-map-generation). Which means we need to run it with the `-o` flag. Doing so increases the `vendor/composer` size back up to 3.1MB. Still a small win, because if we would have optimized the class map with all the unused classes we would have reached 14MB.

Note: If we want to sacrifice a bit of speed (not slower then it was) and win 3MB space we can remove the `-o` option.

### Detailed test instructions:

1. `wr build https://github.com/woocommerce/google-listings-and-ads/tree/fix/optimized-autoload`
2. Check the built zip file and confirm size of the vendor/composer directory
3. Confirm the file `vendor/composer/jetpack_autoload_psr4.php` is not present

### Changelog Note:
- Generate optimized autoload map