### PR TITLE
Paid ads campaign form validation

### DIFF
--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -18,18 +18,15 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import { useAppDispatch } from '.~/data';
 import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
 import createCampaign from '.~/apis/createCampaign';
+import validateForm from '.~/utils/paid-ads/validateForm';
 
 const CreatePaidAdsCampaignForm = () => {
 	const [ loading, setLoading ] = useState( false );
 	const { fetchAdsCampaigns } = useAppDispatch();
 	const { createNotice } = useDispatchCoreNotices();
 
-	const handleValidate = () => {
-		const errors = {};
-
-		// TODO: validation logic.
-
-		return errors;
+	const handleValidate = ( values ) => {
+		return validateForm( values );
 	};
 
 	const handleSubmit = async ( values ) => {
@@ -75,7 +72,10 @@ const CreatePaidAdsCampaignForm = () => {
 			onSubmitCallback={ handleSubmit }
 		>
 			{ ( formProps ) => {
-				const { handleSubmit: handleLaunchCampaignClick } = formProps;
+				const {
+					isValidForm,
+					handleSubmit: handleLaunchCampaignClick,
+				} = formProps;
 
 				return (
 					<StepContent>
@@ -104,6 +104,7 @@ const CreatePaidAdsCampaignForm = () => {
 						<StepContentFooter>
 							<AppButton
 								isPrimary
+								disabled={ ! isValidForm }
 								loading={ loading }
 								onClick={ handleLaunchCampaignClick }
 							>

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -18,6 +18,7 @@ import EditPaidAdsCampaignFormContent from './edit-paid-ads-campaign-form-conten
 import AppButton from '.~/components/app-button';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import { useAppDispatch } from '.~/data';
+import validateForm from '.~/utils/paid-ads/validateForm';
 
 const EditPaidAdsCampaignForm = ( props ) => {
 	const { campaign } = props;
@@ -25,12 +26,8 @@ const EditPaidAdsCampaignForm = ( props ) => {
 	const { fetchAdsCampaigns } = useAppDispatch();
 	const { createNotice } = useDispatchCoreNotices();
 
-	const handleValidate = () => {
-		const errors = {};
-
-		// TODO: validation logic.
-
-		return errors;
+	const handleValidate = ( values ) => {
+		return validateForm( values );
 	};
 
 	const handleSubmit = async ( values ) => {
@@ -73,7 +70,10 @@ const EditPaidAdsCampaignForm = ( props ) => {
 			onSubmitCallback={ handleSubmit }
 		>
 			{ ( formProps ) => {
-				const { handleSubmit: handleSaveChangesClick } = formProps;
+				const {
+					isValidForm,
+					handleSubmit: handleSaveChangesClick,
+				} = formProps;
 
 				return (
 					<StepContent>
@@ -104,6 +104,7 @@ const EditPaidAdsCampaignForm = ( props ) => {
 						<StepContentFooter>
 							<AppButton
 								isPrimary
+								disabled={ ! isValidForm }
 								loading={ loading }
 								onClick={ handleSaveChangesClick }
 							>

--- a/js/src/setup-ads/ads-stepper/create-campaign/index.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/index.js
@@ -16,6 +16,7 @@ import AppButton from '.~/components/app-button';
 
 const CreateCampaign = ( props ) => {
 	const { formProps, onContinue = () => {} } = props;
+	const { isValidForm } = formProps;
 
 	return (
 		<StepContent>
@@ -43,7 +44,11 @@ const CreateCampaign = ( props ) => {
 			/>
 			<CreateCampaignFormContent formProps={ formProps } />
 			<StepContentFooter>
-				<AppButton isPrimary onClick={ onContinue }>
+				<AppButton
+					isPrimary
+					disabled={ ! isValidForm }
+					onClick={ onContinue }
+				>
 					{ __( 'Continue', 'google-listings-and-ads' ) }
 				</AppButton>
 			</StepContentFooter>

--- a/js/src/setup-ads/ads-stepper/index.js
+++ b/js/src/setup-ads/ads-stepper/index.js
@@ -21,8 +21,11 @@ const AdsStepper = ( props ) => {
 	const [ step, setStep ] = useState( '1' );
 
 	// TOOD: figure out when to allow and not to allow step click.
+	// Right now we just allow them to go backward, not forward.
 	const handleStepClick = ( value ) => {
-		setStep( value );
+		if ( value < step ) {
+			setStep( value );
+		}
 	};
 
 	const handleSetupAccountsContinue = () => {

--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.js
@@ -25,8 +25,7 @@ const SetupAccounts = ( props ) => {
 		return <AppSpinner />;
 	}
 
-	// TODO: call backend API to check and set the following to true/false.
-	const isContinueButtonDisabled = false;
+	const isContinueButtonDisabled = ! googleAdsAccount.id;
 
 	return (
 		<StepContent>

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -14,6 +14,7 @@ import useAdminUrl from '.~/hooks/useAdminUrl';
 import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
 import SetupAdsFormContent from './setup-ads-form-content';
 import useSetupCompleteCallback from './useSetupCompleteCallback';
+import validateForm from '.~/utils/paid-ads/validateForm';
 
 // when amount is null or undefined in an onChange callback,
 // it will cause runtime error with the Form component.
@@ -29,23 +30,7 @@ const SetupAdsForm = () => {
 	const adminUrl = useAdminUrl();
 
 	const handleValidate = ( values ) => {
-		const errors = {};
-
-		if ( values.country.length === 0 ) {
-			errors.country = __(
-				'Please select a country for your ads campaign.',
-				'google-listings-and-ads'
-			);
-		}
-
-		if ( values.amount <= 0 ) {
-			errors.amount = __(
-				'Please make sure daily average cost is greater than 0.',
-				'google-listings-and-ads'
-			);
-		}
-
-		return errors;
+		return validateForm( values );
 	};
 
 	useEffect( () => {

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -28,10 +28,22 @@ const SetupAdsForm = () => {
 	const [ handleSetupComplete, isSubmitting ] = useSetupCompleteCallback();
 	const adminUrl = useAdminUrl();
 
-	const handleValidate = () => {
+	const handleValidate = ( values ) => {
 		const errors = {};
 
-		// TODO: validation logic.
+		if ( values.country.length === 0 ) {
+			errors.country = __(
+				'Please select a country for your ads campaign.',
+				'google-listings-and-ads'
+			);
+		}
+
+		if ( values.amount <= 0 ) {
+			errors.amount = __(
+				'Please make sure daily average cost is greater than 0.',
+				'google-listings-and-ads'
+			);
+		}
 
 		return errors;
 	};

--- a/js/src/utils/paid-ads/validateForm.js
+++ b/js/src/utils/paid-ads/validateForm.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const validateForm = ( values ) => {
+	const errors = {};
+
+	if ( values.country.length === 0 ) {
+		errors.country = __(
+			'Please select a country for your ads campaign.',
+			'google-listings-and-ads'
+		);
+	}
+
+	if ( values.amount <= 0 ) {
+		errors.amount = __(
+			'Please make sure daily average cost is greater than 0.',
+			'google-listings-and-ads'
+		);
+	}
+
+	return errors;
+};
+
+export default validateForm;

--- a/js/src/utils/paid-ads/validateForm.js
+++ b/js/src/utils/paid-ads/validateForm.js
@@ -3,6 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Validate paid ads form. Accepts the form values object and returns errors object.
+ *
+ * @param {Object} values Form values.
+ * @param {Array<string>} values.country Selected country for the paid ads campaign.
+ * @param {number} values.amount The daily average cost amount.
+ * @return {Object} errors.
+ */
 const validateForm = ( values ) => {
 	const errors = {};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #433 .

This PR adds form validation and disable main primary action buttons in the following forms:

- Setup Ads flow.
- Edit paid ads form.
- Create new paid ads form.

### Screenshots:

Demo video with my voice (https://d.pr/v/pVmuUM):

https://user-images.githubusercontent.com/417342/115598776-5b80c480-a30d-11eb-92cf-6b74e3a92c56.mov

### Detailed test instructions:

Setup Ads flow: 

1. Open https://gla1.loca.lt/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads
2. In Step 1, the Continue button is disabled if you do not have a connected Google Ads account.
3. In Step 2, the Continue button is disabled if there are no country selected or if the daily average cost is less than or equal to 0.

Edit paid ads campaign: 

1.  Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcampaigns%2Fedit&programId={YOUR_CAMPAIGN_ID}
2. The "Save changes" button is disabled if the daily average cost is less than or equal to 0.

Create paid ads campaign: 

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcampaigns%2Fcreate
2. The "Launch paid campaign" button is disabled if there are no country selected or if the daily average cost is less than or equal to 0.

### Changelog Note:

Validate paid ads campaign forms and disable primary action button if the form is not valid.
