### PR TITLE
Product feed API endpoint

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -163,10 +163,14 @@ class ProductFeedController extends BaseController {
 				'sanitize_callback' => 'absint',
 				'validate_callback' => 'rest_validate_request_arg',
 			],
-			'query'    => [
-				'description'       => __( 'Text to search for in product names.', 'google-listings-and-ads' ),
-				'type'              => 'string',
+			'ids'      => [
+				'description'       => __( 'Limit result to items with specified ids (comma-separated).', 'google-listings-and-ads' ),
+				'type'              => 'array',
+				'sanitize_callback' => 'wp_parse_list',
 				'validate_callback' => 'rest_validate_request_arg',
+				'items'             => [
+					'type' => 'integer',
+				],
 			],
 			'orderby'  => [
 				'description'       => __( 'Sort collection by attribute.', 'google-listings-and-ads' ),

--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -163,6 +163,11 @@ class ProductFeedController extends BaseController {
 				'sanitize_callback' => 'absint',
 				'validate_callback' => 'rest_validate_request_arg',
 			],
+			'search'   => [
+				'description'       => __( 'Text to search for in product names.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
 			'ids'      => [
 				'description'       => __( 'Limit result to items with specified ids (comma-separated).', 'google-listings-and-ads' ),
 				'type'              => 'array',

--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -58,7 +58,11 @@ class ProductFeedController extends BaseController {
 	 */
 	protected function get_product_feed_read_callback(): callable {
 		return function( Request $request ) {
-			return [ 'products' => $this->query_helper->get( $request ) ];
+			return [
+				'products' => $this->query_helper->get( $request ),
+				'total'    => $this->query_helper->count( $request ),
+				'page'     => $request['per_page'] > 0 && $request['page'] > 0 ? $request['page'] : 1,
+			];
 		};
 	}
 

--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -1,0 +1,118 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use WP_REST_Request as Request;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ProductFeedController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
+ */
+class ProductFeedController extends BaseOptionsController {
+
+	/**
+	 * @var ProductRepository
+	 */
+	protected $repo;
+
+	/**
+	 * @var ProductMetaHandler
+	 */
+	protected $meta_handler;
+
+	/**
+	 * ProductFeedController constructor.
+	 *
+	 * @param RESTServer         $server
+	 * @param ProductRepository  $repo
+	 * @param ProductMetaHandler $meta_handler
+	 */
+	public function __construct( RESTServer $server, ProductRepository $repo, ProductMetaHandler $meta_handler ) {
+		parent::__construct( $server );
+		$this->repo         = $repo;
+		$this->meta_handler = $meta_handler;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'mc/product-feed',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_product_feed_read_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			],
+		);
+	}
+
+	/**
+	 * Get the callback function for returning the product feed.
+	 *
+	 * @return callable
+	 */
+	protected function get_product_feed_read_callback(): callable {
+		return function( Request $request ) {
+			$products = [];
+
+			$args = [
+				'type' => [ 'simple', 'variable' ],
+			];
+
+			foreach ( $this->repo->find( $args ) as $product ) {
+
+				$id     = $product->get_id();
+				$status = 'not-synced';
+				if ( $this->meta_handler->get_synced_at( $id ) ) {
+					$status = 'synced';
+				} elseif ( empty( $this->meta_handler->get_errors( $id ) ) ) {
+					$status = 'pending';
+				}
+
+				$products[ $id ] = [
+					'id'      => $id,
+					'title'   => $product->get_name(),
+					'visible' => $this->meta_handler->get_visibility( $id ) !== ChannelVisibility::DONT_SYNC_AND_SHOW,
+					'status'  => $status,
+					'errors'  => $this->meta_handler->get_errors( $id ),
+				];
+			}
+			krsort( $products );
+			return [ 'products' => array_values( $products ) ];
+		};
+	}
+
+	/**
+	 * Get the item schema properties for the controller.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'product_feed';
+	}
+}

--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -72,7 +72,54 @@ class ProductFeedController extends BaseController {
 	 * @return array
 	 */
 	protected function get_schema_properties(): array {
-		return [];
+		return [
+			'products' => [
+				'type'        => 'array',
+				'description' => __( 'The store\'s products.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'id'      => [
+							'type'        => 'numeric',
+							'description' => __( 'Product ID.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+						'title'   => [
+							'type'        => 'string',
+							'description' => __( 'Product title.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+						'visible' => [
+							'type'        => 'boolean',
+							'description' => __( 'Whether the product is set to be visible in the Merchant Center', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+						'status'  => [
+							'type'        => 'string',
+							'description' => __( 'The current sync status of the product.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+						'errors'  => [
+							'type'        => 'array',
+							'description' => __( 'Errors preventing the product from being synced to the Merchant Center.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+					],
+				],
+			],
+			'total'    => [
+				'type'     => 'numeric',
+				'context'  => [ 'view' ],
+				'readonly' => true,
+			],
+			'page'     => [
+				'type'     => 'numeric',
+				'context'  => [ 'view' ],
+				'readonly' => true,
+			],
+		];
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -115,4 +115,46 @@ class ProductFeedController extends BaseOptionsController {
 	protected function get_schema_title(): string {
 		return 'product_feed';
 	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params(): array {
+		return [
+			'context'  => $this->get_context_param( [ 'default' => 'view' ] ),
+			'page'     => [
+				'description'       => __( 'Page of data to retrieve.', 'google-listings-and-ads' ),
+				'type'              => 'integer',
+				'default'           => 1,
+				'minimum'           => 1,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'per_page' => [
+				'description'       => __( 'Maximum number of rows to be returned in result data.', 'google-listings-and-ads' ),
+				'type'              => 'integer',
+				'default'           => 0,
+				'minimum'           => 0,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'query'    => [
+				'description'       => __( 'Text to search for in product names.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'order_by' => [
+				'description'       => __( 'Column by which to sort the data.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'order'    => [
+				'description'       => __( 'Direction to sort the data.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+		];
+	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
@@ -14,11 +14,11 @@ use Exception;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class ProductsController
+ * Class ProductStatisticsController
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
-class ProductsController extends BaseOptionsController {
+class ProductStatisticsController extends BaseOptionsController {
 
 	/**
 	 * The ProductStatistics object.
@@ -30,7 +30,7 @@ class ProductsController extends BaseOptionsController {
 
 
 	/**
-	 * ProductsController constructor.
+	 * ProductStatisticsController constructor.
 	 *
 	 * @param RESTServer        $server
 	 * @param ProductStatistics $product_statistics

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -1,0 +1,221 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\DB;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use WP_Query;
+use WP_REST_Request;
+use wpdb;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ProductFeedQueryHelper
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
+ */
+class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
+
+	use ContainerAwareTrait;
+
+	/**
+	 * @var wpdb
+	 */
+	protected $wpdb;
+
+	/**
+	 * @var WP_REST_Request
+	 */
+	protected $request;
+
+	/**
+	 * @var ProductHelper
+	 */
+	protected $product_helper;
+
+	/**
+	 * @var ProductMetaHandler
+	 */
+	protected $meta_handler;
+
+	/**
+	 * ProductFeedQueryHelper constructor.
+	 *
+	 * @param wpdb               $wpdb
+	 * @param ProductHelper      $product_helper
+	 * @param ProductMetaHandler $meta_handler
+	 */
+	public function __construct( wpdb $wpdb, ProductHelper $product_helper, ProductMetaHandler $meta_handler ) {
+		$this->wpdb           = $wpdb;
+		$this->product_helper = $product_helper;
+		$this->meta_handler   = $meta_handler;
+	}
+
+	/**
+	 * @param WP_REST_Request $request
+	 *
+	 * @return array
+	 */
+	public function get( WP_REST_Request $request ) {
+		$this->request          = $request;
+		$products               = [];
+		$args                   = $this->prepare_query_args();
+jplog($args);
+		list( $limit, $offset ) = $this->prepare_query_pagination();
+
+		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );
+		add_filter( 'posts_orderby', [ $this, 'orderby_filter' ], 10, 2 );
+
+		foreach ( $this->container->get( ProductRepository::class )->find( $args, $limit, $offset ) as $product ) {
+			$id              = $product->get_id();
+			$products[ $id ] = [
+				'id'      => $id,
+				'title'   => $product->get_name(),
+				'visible' => $this->product_helper->get_visibility( $product ) !== ChannelVisibility::DONT_SYNC_AND_SHOW,
+				'status'  => $this->product_helper->get_sync_status( $product ),
+				'errors'  => $this->meta_handler->get_errors( $id ),
+			];
+		}
+
+		remove_filter( 'posts_where', [ $this, 'title_filter' ] );
+		remove_filter( 'posts_orderby', [ $this, 'orderby_filter' ] );
+
+		return array_values( $products );
+	}
+
+	/**
+	 * Prepare the args to be used to retrieve the products, namely orderby, meta_query and type.
+	 *
+	 * @return array
+	 */
+	protected function prepare_query_args(): array {
+		$orderby    = [ 'title' => 'ASC' ];
+		$meta_query = [];
+
+		if ( ! empty( $this->request['orderby'] ) ) {
+			$request_orderby = $this->request['orderby'];
+			$order           = $this->get_order();
+
+			if ( $request_orderby === 'title' || $request_orderby === 'name' ) {
+				$orderby['title'] = $order;
+			} elseif ( $request_orderby === 'id' || $request_orderby === 'ID' ) {
+				$orderby = [ 'ID' => $order ] + $orderby;
+			} elseif ( $request_orderby === 'visible' ) {
+				$meta_query = [
+					'relation'            => 'OR',
+					'visibility_clause'   => [
+						'key'   => ProductMetaHandler::KEY_VISIBILITY,
+						'value' => 'sync-and-show',
+					],
+					'visibility_clause_2' => [
+						'key'     => ProductMetaHandler::KEY_VISIBILITY,
+						'compare' => 'NOT EXISTS',
+					],
+					'visibility_clause_3' => [
+						'key'   => ProductMetaHandler::KEY_VISIBILITY,
+						'value' => 'dont-sync-and-show',
+					],
+				];
+				// Orderby treated in orderby_filter
+			} elseif ( $request_orderby === 'status' ) {
+				$meta_query = [
+					'relation'        => 'OR',
+					'synced_clause'   => [
+						'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
+						'compare' => 'EXISTS',
+					],
+					'synced_clause_2' => [
+						'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
+						'compare' => 'NOT EXISTS',
+					],
+				];
+				// Orderby treated in orderby_filter
+			}
+		}
+
+		return [
+			'type'       => [ 'simple', 'variable' ],
+			'orderby'    => $orderby,
+			'meta_query' => $meta_query,
+		];
+	}
+
+	/**
+	 * Convert the per_page and page parameters into limit and offset values.
+	 *
+	 * @return array Containing limit and offset values.
+	 */
+	protected function prepare_query_pagination(): array {
+		$limit  = -1;
+		$offset = 0;
+
+		if ( ! empty( $this->request['per_page'] ) ) {
+			$limit  = intval( $this->request['per_page'] );
+			$page   = max( 1, intval( $this->request['page'] ) );
+			$offset = $limit * ( $page - 1 );
+		}
+		return [ $limit, $offset ];
+	}
+
+
+
+	/**
+	 * Used for the posts_where hook, filters the WHERE clause of the query by
+	 * searching for the 'query' parameter in the product titles (when the parameter is present).
+	 *
+	 * @param string   $where The WHERE clause of the query.
+	 * @param WP_Query $wp_query The WP_Query instance (passed by reference).
+	 *
+	 * @return string The updated WHERE clause.
+	 */
+	public function title_filter( string $where, WP_Query $wp_query ): string {
+		if ( ! empty( $this->request['query'] ) ) {
+			$title_search = '%' . $this->wpdb->esc_like( $this->request['query'] ) . '%';
+			$where       .= $this->wpdb->prepare( " AND `{$this->wpdb->posts}`.`post_title` LIKE %s", $title_search ); // phpcs:ignore WordPress.DB.PreparedSQL
+		}
+		return $where;
+	}
+
+	/**
+	 * Used for the posts_where hook, modifies the ORDER BY clause of the query to
+	 * order the results by visibility or sync status.
+	 *
+	 * @param string   $orderby The ORDER BY clause of the query.
+	 * @param WP_Query $wp_query   The WP_Query instance (passed by reference).
+	 *
+	 * @return string The updated ORDER BY clause.
+	 */
+	public function orderby_filter( string $orderby, WP_Query $wp_query ): string {
+		$order = $this->get_order();
+		switch ( $this->request['orderby'] ) {
+			case 'visible':
+				$new_order = "`{$this->wpdb->postmeta}`.`meta_value` = %s $order, ";
+				$orderby   = $this->wpdb->prepare( $new_order, ChannelVisibility::DONT_SYNC_AND_SHOW ) . $orderby; // phpcs:ignore WordPress.DB.PreparedSQL
+				break;
+			case 'status':
+				$placeholders = implode( ',', array_fill( 0, count( SyncStatus::ALLOWED_VALUES ), '%s' ) );
+				$new_order    = "FIELD( `{$this->wpdb->postmeta}`.`meta_value`, $placeholders ) $order, ";
+				$orderby      = $this->wpdb->prepare( $new_order, SyncStatus::ALLOWED_VALUES ) . $orderby; // phpcs:ignore WordPress.DB.PreparedSQL
+				break;
+		}
+		return $orderby;
+	}
+
+	/**
+	 * Return the ORDER BY order based on the order request parameter value.
+	 *
+	 * @return string
+	 */
+	protected function get_order(): string {
+		return strtoupper( $this->request['order'] ?? '' ) === 'DESC' ? 'DESC' : 'ASC';
+	}
+}
+

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -128,8 +128,11 @@ class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 	 * @throws InvalidValue If the orderby value isn't valid.
 	 */
 	protected function prepare_query_args(): array {
+		$product_types = $this->container->get( ProductRepository::class )->get_supported_product_types();
+		$product_types = array_diff( $product_types, [ 'variation' ] );
+
 		$args = [
-			'type'    => [ 'simple', 'variable' ],
+			'type'    => $product_types,
 			'orderby' => [ 'title' => 'ASC' ],
 		];
 

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -68,7 +68,7 @@ class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 		$this->request          = $request;
 		$products               = [];
 		$args                   = $this->prepare_query_args();
-jplog($args);
+
 		list( $limit, $offset ) = $this->prepare_query_pagination();
 
 		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -25,6 +26,7 @@ defined( 'ABSPATH' ) || exit;
 class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 
 	use ContainerAwareTrait;
+	use PluginHelper;
 
 	/**
 	 * @var wpdb
@@ -151,22 +153,12 @@ class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 				$args['orderby'] = [ 'ID' => $this->get_order() ] + $args['orderby'];
 				break;
 			case 'visible':
-				$args['meta_query'] = [
-					'visibility_clause' => [
-						'key'     => ProductMetaHandler::KEY_VISIBILITY,
-						'compare' => 'EXISTS',
-					],
-				];
-				$args['orderby']    = [ 'visibility_clause' => $this->get_order() ] + $args['orderby'];
+				$args['meta_key'] = $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY );
+				$args['orderby']  = [ 'meta_value' => $this->get_order() ] + $args['orderby'];
 				break;
 			case 'status':
-				$args['meta_query'] = [
-					'synced_clause' => [
-						'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
-						'compare' => 'EXISTS',
-					],
-				];
-				$args['orderby']    = [ 'synced_clause' => $this->get_order() ] + $args['orderby'];
+				$args['meta_key'] = $this->prefix_meta_key( ProductMetaHandler::KEY_SYNC_STATUS );
+				$args['orderby']  = [ 'meta_value' => $this->get_order() ] + $args['orderby'];
 				break;
 			default:
 				throw InvalidValue::not_in_allowed_list( 'orderby', [ 'title', 'id', 'visible', 'status' ] );

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -78,8 +78,9 @@ class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 			$id     = $product->get_id();
 			$errors = $this->meta_handler->get_errors( $id ) ?: [];
 
-			// Combine errors for variations.
-			if ( ! empty( $errors ) && ! isset( $errors[0] ) ) {
+			// Combine errors for variable products, which have a variation-indexed array of errors.
+			$first_key = array_key_first( $errors );
+			if ( ! empty( $errors ) && is_numeric( $first_key ) && 0 !== $first_key ) {
 				$errors = array_unique( array_merge( ...$errors ) );
 			}
 
@@ -88,7 +89,7 @@ class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 				'title'   => $product->get_name(),
 				'visible' => $this->product_helper->get_visibility( $product ) !== ChannelVisibility::DONT_SYNC_AND_SHOW,
 				'status'  => $this->product_helper->get_sync_status( $product ),
-				'errors'  => $errors,
+				'errors'  => array_values( $errors ),
 			];
 		}
 

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -109,7 +109,11 @@ class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 	public function count( WP_REST_Request $request ): int {
 		$this->request = $request;
 		$args          = $this->prepare_query_args();
-		$ids           = $this->container->get( ProductRepository::class )->find_ids( $args );
+
+		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );
+		$ids = $this->container->get( ProductRepository::class )->find_ids( $args );
+		remove_filter( 'posts_where', [ $this, 'title_filter' ] );
+
 		return count( $ids );
 	}
 

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -65,9 +65,9 @@ class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 	 * @return array
 	 */
 	public function get( WP_REST_Request $request ) {
-		$this->request          = $request;
-		$products               = [];
-		$args                   = $this->prepare_query_args();
+		$this->request = $request;
+		$products      = [];
+		$args          = $this->prepare_query_args();
 
 		list( $limit, $offset ) = $this->prepare_query_pagination();
 
@@ -164,8 +164,6 @@ class ProductFeedQueryHelper implements Service, ContainerAwareInterface {
 		}
 		return [ $limit, $offset ];
 	}
-
-
 
 	/**
 	 * Used for the posts_where hook, filters the WHERE clause of the query by

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer as DBInstaller;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
@@ -71,7 +70,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\TracksInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use wpdb;
 
 /**
  * Class CoreServiceProvider
@@ -128,7 +126,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		MerchantIssues::class         => true,
 		TransientsInterface::class    => true,
 		MerchantCenterService::class  => true,
-		ProductFeedQueryHelper::class => true,
 	];
 
 	/**
@@ -245,7 +242,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( Loaded::class );
 		$this->conditionally_share_with_tags( SiteVerificationEvents::class );
 		$this->conditionally_share_with_tags( InstallTimestamp::class );
-		$this->share_with_tags( ProductFeedQueryHelper::class, wpdb::class, ProductHelper::class, ProductMetaHandler::class );
 
 		// The DB Controller has some extra setup required.
 		$db_definition = $this->share_with_tags( DBInstaller::class, 'db_table', OptionsInterface::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer as DBInstaller;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
@@ -126,6 +127,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		MerchantIssues::class         => true,
 		TransientsInterface::class    => true,
 		MerchantCenterService::class  => true,
+		ProductFeedQueryHelper::class => true,
 	];
 
 	/**
@@ -242,6 +244,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( Loaded::class );
 		$this->conditionally_share_with_tags( SiteVerificationEvents::class );
 		$this->conditionally_share_with_tags( InstallTimestamp::class );
+		$this->conditionally_share_with_tags( ProductFeedQueryHelper::class, \wpdb::class, ProductHelper::class, ProductMetaHandler::class );
 
 		// The DB Controller has some extra setup required.
 		$db_definition = $this->share_with_tags( DBInstaller::class, 'db_table', OptionsInterface::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -71,6 +71,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\TracksInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use wpdb;
 
 /**
  * Class CoreServiceProvider
@@ -244,7 +245,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( Loaded::class );
 		$this->conditionally_share_with_tags( SiteVerificationEvents::class );
 		$this->conditionally_share_with_tags( InstallTimestamp::class );
-		$this->conditionally_share_with_tags( ProductFeedQueryHelper::class, \wpdb::class, ProductHelper::class, ProductMetaHandler::class );
+		$this->share_with_tags( ProductFeedQueryHelper::class, wpdb::class, ProductHelper::class, ProductMetaHandler::class );
 
 		// The DB Controller has some extra setup required.
 		$db_definition = $this->share_with_tags( DBInstaller::class, 'db_table', OptionsInterface::class );

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\DefinitionInterface;
 use wpdb;
@@ -75,7 +76,13 @@ class DBServiceProvider extends AbstractServiceProvider {
 		$this->share_table_class( MerchantIssueTable::class );
 		$this->add_query_class( MerchantIssueQuery::class, MerchantIssueTable::class );
 
-		$this->share_with_tags( ProductFeedQueryHelper::class, wpdb::class, ProductHelper::class, ProductMetaHandler::class );
+		$this->share_with_tags(
+			ProductFeedQueryHelper::class,
+			wpdb::class,
+			ProductRepository::class,
+			ProductHelper::class,
+			ProductMetaHandler::class
+		);
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
@@ -11,6 +12,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\BudgetRecommendationTab
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\DefinitionInterface;
 use wpdb;
@@ -40,6 +43,7 @@ class DBServiceProvider extends AbstractServiceProvider {
 		BudgetRecommendationQuery::class => true,
 		MerchantIssueTable::class        => true,
 		MerchantIssueQuery::class        => true,
+		ProductFeedQueryHelper::class    => true,
 	];
 
 	/**
@@ -70,6 +74,8 @@ class DBServiceProvider extends AbstractServiceProvider {
 		$this->add_query_class( ShippingTimeQuery::class, ShippingTimeTable::class );
 		$this->share_table_class( MerchantIssueTable::class );
 		$this->add_query_class( MerchantIssueQuery::class, MerchantIssueTable::class );
+
+		$this->share_with_tags( ProductFeedQueryHelper::class, wpdb::class, ProductHelper::class, ProductMetaHandler::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -20,6 +20,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Jetpack\Acc
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController as MerchantCenterAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\IssuesController as MerchantCenterIssuesController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductStatisticsController as MerchantCenterProductStatsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductFeedController as MerchantCenterProductFeedController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ConnectionController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ReportsController as MerchantCenterReportsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
@@ -33,6 +34,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantIssues;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\ProductStatistics;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
@@ -74,6 +77,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );
 		$this->share( MerchantCenterProductStatsController::class, ProductStatistics::class );
+		$this->share( MerchantCenterProductFeedController::class, ProductRepository::class, ProductMetaHandler::class );
 		$this->share( MerchantCenterIssuesController::class, MerchantIssues::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class );
 		$this->share_with_container( MerchantCenterAccountController::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -19,7 +19,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Google\Site
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Jetpack\AccountController as JetpackAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController as MerchantCenterAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\IssuesController as MerchantCenterIssuesController;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductsController as MerchantCenterProductsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductStatisticsController as MerchantCenterProductStatsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ConnectionController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ReportsController as MerchantCenterReportsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
@@ -73,7 +73,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share_with_container( AdsReportsController::class );
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );
-		$this->share( MerchantCenterProductsController::class, ProductStatistics::class );
+		$this->share( MerchantCenterProductStatsController::class, ProductStatistics::class );
 		$this->share( MerchantCenterIssuesController::class, MerchantIssues::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class );
 		$this->share_with_container( MerchantCenterAccountController::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -31,11 +31,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingTimeController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\TargetAudienceController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SupportedCountriesController;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantIssues;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\ProductStatistics;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
@@ -77,7 +76,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );
 		$this->share( MerchantCenterProductStatsController::class, ProductStatistics::class );
-		$this->share( MerchantCenterProductFeedController::class, ProductRepository::class, ProductMetaHandler::class );
+		$this->share( MerchantCenterProductFeedController::class, ProductFeedQueryHelper::class );
 		$this->share( MerchantCenterIssuesController::class, MerchantIssues::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class );
 		$this->share_with_container( MerchantCenterAccountController::class );

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -36,6 +36,9 @@ defined( 'ABSPATH' ) || exit;
  * @method update_sync_failed_at( int $product_id, int $value )
  * @method delete_sync_failed_at( int $product_id )
  * @method get_sync_failed_at( int $product_id ): int
+ * @method update_sync_status( int $product_id, string $value )
+ * @method delete_sync_status( int $product_id )
+ * @method get_sync_status( int $product_id ): string
  */
 class ProductMetaHandler implements Service, Registerable {
 
@@ -47,6 +50,7 @@ class ProductMetaHandler implements Service, Registerable {
 	public const KEY_ERRORS               = 'errors';
 	public const KEY_FAILED_SYNC_ATTEMPTS = 'failed_sync_attempts';
 	public const KEY_SYNC_FAILED_AT       = 'sync_failed_at';
+	public const KEY_SYNC_STATUS          = 'sync_status';
 
 	protected const TYPES = [
 		self::KEY_SYNCED_AT            => 'int',
@@ -55,6 +59,7 @@ class ProductMetaHandler implements Service, Registerable {
 		self::KEY_ERRORS               => 'array',
 		self::KEY_FAILED_SYNC_ATTEMPTS => 'int',
 		self::KEY_SYNC_FAILED_AT       => 'int',
+		self::KEY_SYNC_STATUS          => 'string',
 	];
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -329,7 +329,7 @@ class ProductRepository implements Service {
 	 *
 	 * @return array
 	 */
-	protected function get_supported_product_types(): array {
+	public function get_supported_product_types(): array {
 		return (array) apply_filters( 'woocommerce_gla_supported_product_types', [ 'simple', 'variable', 'variation' ] );
 	}
 

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -156,6 +156,7 @@ class SyncerHooks implements Service, Registerable, MerchantCenterAwareInterface
 				return;
 			}
 
+			$this->product_helper->mark_as_pending( $product );
 			$this->update_products_job->start( [ $product_ids ] );
 			$this->set_already_scheduled( $product_id );
 		} elseif ( $this->product_helper->is_product_synced( $product ) ) {
@@ -163,6 +164,8 @@ class SyncerHooks implements Service, Registerable, MerchantCenterAwareInterface
 			$request_entries = $this->batch_helper->generate_delete_request_entries( [ $product ] );
 			$this->delete_products_job->start( [ BatchProductIDRequestEntry::convert_to_id_map( $request_entries )->get() ] );
 			$this->set_already_scheduled( $product_id );
+		} else {
+			$this->product_helper->mark_as_unsynced( $product );
 		}
 	}
 

--- a/src/Value/SyncStatus.php
+++ b/src/Value/SyncStatus.php
@@ -22,8 +22,8 @@ class SyncStatus implements ValueInterface {
 	public const ALLOWED_VALUES = [
 		self::SYNCED,
 		self::PENDING,
-		self::NOT_SYNCED,
 		self::HAS_ERRORS,
+		self::NOT_SYNCED,
 	];
 
 	/**

--- a/src/Value/SyncStatus.php
+++ b/src/Value/SyncStatus.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Value
  */
-class SyncStatus implements CastableValueInterface, ValueInterface {
+class SyncStatus implements ValueInterface {
 
 	public const SYNCED     = 'synced';
 	public const NOT_SYNCED = 'not-synced';
@@ -53,19 +53,6 @@ class SyncStatus implements CastableValueInterface, ValueInterface {
 	 */
 	public function get(): string {
 		return $this->status;
-	}
-
-	/**
-	 * Cast a value and return a new instance of the class.
-	 *
-	 * @param string $value Mixed value to cast to class type.
-	 *
-	 * @return SyncStatus
-	 *
-	 * @throws InvalidValue When an invalid visibility type is provided.
-	 */
-	public static function cast( $value ): SyncStatus {
-		return new self( $value );
 	}
 
 	/**

--- a/src/Value/SyncStatus.php
+++ b/src/Value/SyncStatus.php
@@ -1,0 +1,77 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Value;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SyncStatus
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Value
+ */
+class SyncStatus implements CastableValueInterface, ValueInterface {
+
+	public const SYNCED     = 'synced';
+	public const NOT_SYNCED = 'not-synced';
+	public const HAS_ERRORS = 'has-errors';
+	public const PENDING    = 'pending';
+
+	public const ALLOWED_VALUES = [
+		self::SYNCED,
+		self::PENDING,
+		self::NOT_SYNCED,
+		self::HAS_ERRORS,
+	];
+
+	/**
+	 * @var string
+	 */
+	protected $status;
+
+	/**
+	 * SyncStatus constructor.
+	 *
+	 * @param string $status The value.
+	 *
+	 * @throws InvalidValue When an invalid status type is provided.
+	 */
+	public function __construct( string $status ) {
+		if ( ! in_array( $status, self::ALLOWED_VALUES, true ) ) {
+			throw InvalidValue::not_in_allowed_list( $status, self::ALLOWED_VALUES );
+		}
+
+		$this->status = $status;
+	}
+
+	/**
+	 * Get the value of the object.
+	 *
+	 * @return string
+	 */
+	public function get(): string {
+		return $this->status;
+	}
+
+	/**
+	 * Cast a value and return a new instance of the class.
+	 *
+	 * @param string $value Mixed value to cast to class type.
+	 *
+	 * @return SyncStatus
+	 *
+	 * @throws InvalidValue When an invalid visibility type is provided.
+	 */
+	public static function cast( $value ): SyncStatus {
+		return new self( $value );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function __toString(): string {
+		return $this->get();
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #481 .

This PR adds the API endpoint for retrieving the store's product feed.
- Adds the `GET /wp-json/wc/gla/mc/product-feed` endpoint, with a result of:
    ```json
    {
	    "products": [
	        {
	            "id": 24,
	            "title": "Album",
	            "visible": true,
	            "status": "has-errors",
	            "errors": [
	                "[imageLink] This value should not be blank."
	            ]
	        },
	        {
	            "id": 193,
	            "title": "Beanie",
	            "visible": true,
	            "status": "synced",
	            "errors": []
	        },
	        "…"
        ],
        "total": 23,
        "page": "3"
    }
    ```
- `products` is the array of store products with some details for the table:
    - `id` and `title` are product details. `id` can be used to generate the `Edit` link for the product.
    - `visible` is a bool that maps to the Don't/Sync and Show option of the product.
    - `status` is a new meta item for the product (see below) and can be `pending`, `synced`, `not-synced`, or `has-errors`.
    - `errors` is an array of errors found for the product _prior_ to attempting a sync with the Merchant Center. Variable products will show all errors of their variations.
- `total` and `page` for pagination.
- The endpoint also accepts several query parameters:
  - `per_page` and `page` - used to paginate the results.
  - `query` - used to filter by product title.
  - `orderby` and `order` - used to sort the results:
    - `orderby` accepts the values `title` (default), `id`, `visible`, and `status`.
    - `order` accepts the values `asc` and `desc`.
- The endpoint only returns `simple` and `variable` products, but _NOT_ `variations`. So instead of `Sweater - Large`, `Sweater - Medium` and `Sweater - Small`, there's just a `Sweater` item.
  - Variable products without any variations will NOT be displayed.
- The PR adds a `postmeta` item for each product: `_wc_gla_sync_status`, which has the same values as the `status` attribute in the response.
    - The new meta value is updated realtime with the product and reflects the extension's knowledge of the product status. A later PR may add the Merchant Center-reported status as well.
- This PR also modifies the Product update process to fill empty `visibility` values when a product is marked as `synced` or `invalid`, in order to facilitate ordering by `visibility`
- Creates the `DB/ProductFeedQueryHelper` class to handle the query preparation for the product feed
  - ~Specifically, it uses the `posts_where` and `posts_orderby` hooks to enable title filtering and result status ordering.~
  - It also receives `wpdb` as a dependency, which is why it's in the `DB` namespace.

<details>
<summary><em>See full REST response</em></summary>

```json
# Order by status desc
{
    "products": [
        {
            "id": 18,
            "title": "Cap",
            "visible": true,
            "status": "synced",
            "errors": []
        },
        {
            "id": 23,
            "title": "Polo",
            "visible": true,
            "status": "pending",
            "errors": []
        },
        {
            "id": 22,
            "title": "Long Sleeve Tee",
            "visible": false,
            "status": "not-synced",
            "errors": []
        },
        {
            "id": 24,
            "title": "Album",
            "visible": true,
            "status": "has-errors",
            "errors": [
                "[imageLink] This value should not be blank.",   
                "[price] This value should not be null."
            ]
        }
    ],
    "total": 4,
    "page": 1
}
```

</details>

### Detailed test instructions:

1. Create a product or two before activating GLA (so they shouldn't have an GLA-related meta options).
2. Set up a Merchant Center account (using the onboarding wizard).
2. Create some products and sync them (they're queued to sync when created), or sync existing products using the button on _Connection Test_.
3. Send a request to `GET /wp-json/wc/gla/mc/product-feed`
  - Confirm results look correct
  - Test the different query params and confirm they work as expected
  - Modify some products (set to don't sync, remove required values, etc) and see that the changes are reflected in the feed (after giving them time to be synced/checked).

