### PR TITLE
Script for cleaning up some vendor files

### DIFF
--- a/bin/cleanup-vendor-files.sh
+++ b/bin/cleanup-vendor-files.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo Removing unused vendor files to reduce space
+rm vendor/google/grpc-gcp/cloudprober/bins/opt/grpc_php_plugin
+rm vendor/symfony/validator/Resources/translations/*.xlf

--- a/bin/cleanup-vendor-files.sh
+++ b/bin/cleanup-vendor-files.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo Removing unused vendor files to reduce space
-rm vendor/google/grpc-gcp/cloudprober/bins/opt/grpc_php_plugin
-rm vendor/symfony/validator/Resources/translations/*.xlf
+rm vendor/google/grpc-gcp/cloudprober/bins/opt/grpc_php_plugin || true
+rm vendor/symfony/validator/Resources/translations/*.xlf || true

--- a/composer.json
+++ b/composer.json
@@ -43,16 +43,14 @@
     "sort-packages": true
   },
   "scripts": {
-    "post-install-cmd": [
+    "install-scripts": [
       "Google\\Task\\Composer::cleanup",
       "php ./bin/prefix-vendor-namespace.php",
-      "bash ./bin/googleads-remove-older-versions.sh"
+      "bash ./bin/googleads-remove-older-versions.sh",
+      "bash ./bin/cleanup-vendor-files.sh"
     ],
-    "post-update-cmd": [
-      "Google\\Task\\Composer::cleanup",
-      "php ./bin/prefix-vendor-namespace.php",
-      "bash ./bin/googleads-remove-older-versions.sh"
-    ]
+    "post-install-cmd": [ "@install-scripts" ],
+    "post-update-cmd": [ "@install-scripts" ]
   },
   "archive": {
     "exclude": [


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR adds a script to cleanup some unused files in the vendor directory, which reduces the folder by @ 3MB. 

The final zip is now down to 9.7MB

Also reduces the duplicate code for update and install by [referencing install scripts](https://getcomposer.org/doc/articles/scripts.md#referencing-scripts).

Improves #314

### Detailed test instructions:
1. `wr build https://github.com/woocommerce/google-listings-and-ads/tree/cleanup-vendor-files`
2. Confirm that the final zip file is around 9.7MB
3. Confirm the zip file doesn't contain `vendor/google/grpc-gcp/cloudprober/bins/opt/grpc_php_plugin`

### Changelog Note:
- Cleanup unused files in vendor directory