### PR TITLE
Consistent i18n domain name

### DIFF
--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -34,7 +34,10 @@ const FreePerformanceCard = () => {
 
 	return (
 		<SummaryCard
-			title={ __( 'Performance (Free Listing)', 'google-listings-and-ads' ) }
+			title={ __(
+				'Performance (Free Listing)',
+				'google-listings-and-ads'
+			) }
 		>
 			{ loading ? (
 				<AppSpinner />

--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -18,7 +18,7 @@ import './index.scss';
 
 const paidPerformanceTitle = __(
 	'Performance (Paid Campaigns)',
-	'woocommerce-admin'
+	'google-listings-and-ads'
 );
 
 // Note: Since the `delta` prop of SummaryNumber component wouldn't apply the WC Settings' currency options,
@@ -34,7 +34,7 @@ const FreePerformanceCard = () => {
 
 	return (
 		<SummaryCard
-			title={ __( 'Performance (Free Listing)', 'woocommerce-admin' ) }
+			title={ __( 'Performance (Free Listing)', 'google-listings-and-ads' ) }
 		>
 			{ loading ? (
 				<AppSpinner />

--- a/js/src/reports/products/filter-config.js
+++ b/js/src/reports/products/filter-config.js
@@ -21,7 +21,10 @@ const productsFilterConfig = {
 	param: 'filter',
 	showFilters: () => true,
 	filters: [
-		{ label: __( 'All Products', 'google-listings-and-ads' ), value: 'all' },
+		{
+			label: __( 'All Products', 'google-listings-and-ads' ),
+			value: 'all',
+		},
 		{
 			label: __( 'Single Product', 'google-listings-and-ads' ),
 			value: 'select_product',
@@ -43,7 +46,10 @@ const productsFilterConfig = {
 								'Type to search for a product',
 								'google-listings-and-ads'
 							),
-							button: __( 'Single Product', 'google-listings-and-ads' ),
+							button: __(
+								'Single Product',
+								'google-listings-and-ads'
+							),
 						},
 					},
 				},
@@ -133,7 +139,10 @@ const variationsConfig = {
 						'Search for variations to compare',
 						'google-listings-and-ads'
 					),
-					title: __( 'Compare Variations', 'google-listings-and-ads' ),
+					title: __(
+						'Compare Variations',
+						'google-listings-and-ads'
+					),
 					update: __( 'Compare', 'google-listings-and-ads' ),
 				},
 			},

--- a/js/src/reports/products/filter-config.js
+++ b/js/src/reports/products/filter-config.js
@@ -16,14 +16,14 @@ const PRODUCTS_REPORT_ADVANCED_FILTERS_FILTER =
 	'gla_products_report_advanced_filters';
 
 const productsFilterConfig = {
-	label: __( 'Show', 'woocommerce-admin' ),
+	label: __( 'Show', 'google-listings-and-ads' ),
 	staticParams: [ 'chartType', 'paged', 'per_page' ],
 	param: 'filter',
 	showFilters: () => true,
 	filters: [
-		{ label: __( 'All Products', 'woocommerce-admin' ), value: 'all' },
+		{ label: __( 'All Products', 'google-listings-and-ads' ), value: 'all' },
 		{
-			label: __( 'Single Product', 'woocommerce-admin' ),
+			label: __( 'Single Product', 'google-listings-and-ads' ),
 			value: 'select_product',
 			chartMode: 'item-comparison',
 			subFilters: [
@@ -41,16 +41,16 @@ const productsFilterConfig = {
 						labels: {
 							placeholder: __(
 								'Type to search for a product',
-								'woocommerce-admin'
+								'google-listings-and-ads'
 							),
-							button: __( 'Single Product', 'woocommerce-admin' ),
+							button: __( 'Single Product', 'google-listings-and-ads' ),
 						},
 					},
 				},
 			],
 		},
 		{
-			label: __( 'Comparison', 'woocommerce-admin' ),
+			label: __( 'Comparison', 'google-listings-and-ads' ),
 			value: 'compare-products',
 			chartMode: 'item-comparison',
 			settings: {
@@ -60,14 +60,14 @@ const productsFilterConfig = {
 				labels: {
 					helpText: __(
 						'Check at least two products below to compare',
-						'woocommerce-admin'
+						'google-listings-and-ads'
 					),
 					placeholder: __(
 						'Search for products to compare',
-						'woocommerce-admin'
+						'google-listings-and-ads'
 					),
-					title: __( 'Compare Products', 'woocommerce-admin' ),
-					update: __( 'Compare', 'woocommerce-admin' ),
+					title: __( 'Compare Products', 'google-listings-and-ads' ),
+					update: __( 'Compare', 'google-listings-and-ads' ),
 				},
 			},
 		},
@@ -84,12 +84,12 @@ const variationsConfig = {
 	param: 'filter-variations',
 	filters: [
 		{
-			label: __( 'All Variations', 'woocommerce-admin' ),
+			label: __( 'All Variations', 'google-listings-and-ads' ),
 			chartMode: 'item-comparison',
 			value: 'all',
 		},
 		{
-			label: __( 'Single Variation', 'woocommerce-admin' ),
+			label: __( 'Single Variation', 'google-listings-and-ads' ),
 			value: 'select_variation',
 			subFilters: [
 				{
@@ -105,11 +105,11 @@ const variationsConfig = {
 						labels: {
 							placeholder: __(
 								'Type to search for a variation',
-								'woocommerce-admin'
+								'google-listings-and-ads'
 							),
 							button: __(
 								'Single Variation',
-								'woocommerce-admin'
+								'google-listings-and-ads'
 							),
 						},
 					},
@@ -117,7 +117,7 @@ const variationsConfig = {
 			],
 		},
 		{
-			label: __( 'Comparison', 'woocommerce-admin' ),
+			label: __( 'Comparison', 'google-listings-and-ads' ),
 			chartMode: 'item-comparison',
 			value: 'compare-variations',
 			settings: {
@@ -127,14 +127,14 @@ const variationsConfig = {
 				labels: {
 					helpText: __(
 						'Check at least two variations below to compare',
-						'woocommerce-admin'
+						'google-listings-and-ads'
 					),
 					placeholder: __(
 						'Search for variations to compare',
-						'woocommerce-admin'
+						'google-listings-and-ads'
 					),
-					title: __( 'Compare Variations', 'woocommerce-admin' ),
-					update: __( 'Compare', 'woocommerce-admin' ),
+					title: __( 'Compare Variations', 'google-listings-and-ads' ),
+					update: __( 'Compare', 'google-listings-and-ads' ),
 				},
 			},
 		},

--- a/js/src/reports/programs/filter-config.js
+++ b/js/src/reports/programs/filter-config.js
@@ -36,7 +36,10 @@ export const programsFilterConfig = {
 								'Type to search for a program',
 								'google-listings-and-ads'
 							),
-							button: __( 'Single Program', 'google-listings-and-ads' ),
+							button: __(
+								'Single Program',
+								'google-listings-and-ads'
+							),
 						},
 						autocompleter: {
 							name: 'fruit',

--- a/js/src/reports/programs/filter-config.js
+++ b/js/src/reports/programs/filter-config.js
@@ -34,9 +34,9 @@ export const programsFilterConfig = {
 						labels: {
 							placeholder: __(
 								'Type to search for a program',
-								'woocommerce-admin'
+								'google-listings-and-ads'
 							),
-							button: __( 'Single Program', 'woocommerce-admin' ),
+							button: __( 'Single Program', 'google-listings-and-ads' ),
 						},
 						autocompleter: {
 							name: 'fruit',


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Use the domain name `google-listings-and-ads` consistently so we can translate all our strings.

Closes #499

### Detailed test instructions:

1. `npm run i18n`
2. Install the Loco Translate plugin
3. Change the language of your site, ex: English (UK)
4. Generate a translation file using Loco Translate for the language you set (use the system folder)
5. Translate some strings like: `Performance (Free Listing)`
6. Confirm that we see the string translated on the site (GLA Dashboar)

### Changelog Note:
- Consistent i18n domain name.