### PR TITLE
Adjust report data interfaces and structures in the wp.data

### DIFF
--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -30,7 +30,7 @@ const formatNumber = ( number ) => numberFormat( { precision: 0 }, number );
 const { formatAmount } = CurrencyFactory();
 
 const FreePerformanceCard = () => {
-	const { data, loading } = usePerformance( 'free' );
+	const { data, loaded } = usePerformance( 'free' );
 
 	return (
 		<SummaryCard
@@ -39,9 +39,7 @@ const FreePerformanceCard = () => {
 				'google-listings-and-ads'
 			) }
 		>
-			{ loading ? (
-				<AppSpinner />
-			) : (
+			{ loaded ? (
 				[
 					<SummaryNumber
 						key="1"
@@ -57,19 +55,19 @@ const FreePerformanceCard = () => {
 						delta={ null }
 					/>,
 				]
+			) : (
+				<AppSpinner />
 			) }
 		</SummaryCard>
 	);
 };
 
 const PaidPerformanceCard = () => {
-	const { data, loading } = usePerformance( 'paid' );
+	const { data, loaded } = usePerformance( 'paid' );
 
 	return (
 		<SummaryCard title={ paidPerformanceTitle }>
-			{ loading ? (
-				<AppSpinner />
-			) : (
+			{ loaded ? (
 				[
 					<SummaryNumber
 						key="1"
@@ -86,6 +84,8 @@ const PaidPerformanceCard = () => {
 						delta={ data.spend.delta }
 					/>,
 				]
+			) : (
+				<AppSpinner />
 			) }
 		</SummaryCard>
 	);

--- a/js/src/dashboard/summary-section/usePerformance.js
+++ b/js/src/dashboard/summary-section/usePerformance.js
@@ -85,7 +85,6 @@ export default function usePerformance( type ) {
  * @property {PerformanceMetrics} clicks Clicks performance.
  * @property {PerformanceMetrics} impressions Impressions performance.
  * @property {PerformanceMetrics} [sales] Sales performance. Available for paid type.
- * @property {PerformanceMetrics} [solds] Solds performance. Available for paid type.
  * @property {PerformanceMetrics} [conversions] Conversions performance. Available for paid type.
  * @property {PerformanceMetrics} [spend] Spend performance. Available for paid type.
  */

--- a/js/src/dashboard/summary-section/usePerformance.js
+++ b/js/src/dashboard/summary-section/usePerformance.js
@@ -9,25 +9,7 @@ import { getCurrentDates } from '@woocommerce/date';
  * Internal dependencies
  */
 import { STORE_KEY } from '.~/data/constants';
-import round from '.~/utils/round';
-
-const mapToData = ( primary, secondary ) => {
-	return Object.keys( primary ).reduce( ( acc, key ) => {
-		const value = primary[ key ];
-		const base = secondary[ key ];
-		let delta = 0;
-
-		if ( value !== base ) {
-			const percent = ( ( value - base ) / base ) * 100;
-			delta = Number.isFinite( percent ) ? round( percent ) : null;
-		}
-
-		return {
-			...acc,
-			[ key ]: { value, delta, prevValue: base },
-		};
-	}, {} );
-};
+import { mapReportFieldsToPerformance } from '.~/data/utils';
 
 /**
  * Get performance results by program type.
@@ -58,7 +40,7 @@ export default function usePerformance( type ) {
 			isResolving( 'getDashboardPerformance', secondaryArgs );
 
 		if ( primary && secondary ) {
-			data = mapToData( primary, secondary );
+			data = mapReportFieldsToPerformance( primary, secondary );
 		} else {
 			loading = true;
 		}
@@ -79,21 +61,5 @@ export default function usePerformance( type ) {
  */
 
 /**
- * Performance data of each metric.
- *
- * @typedef {Object} PerformanceData
- * @property {PerformanceMetrics} clicks Clicks performance.
- * @property {PerformanceMetrics} impressions Impressions performance.
- * @property {PerformanceMetrics} [sales] Sales performance. Available for paid type.
- * @property {PerformanceMetrics} [conversions] Conversions performance. Available for paid type.
- * @property {PerformanceMetrics} [spend] Spend performance. Available for paid type.
- */
-
-/**
- * Performance metrics.
- *
- * @typedef {Object} PerformanceMetrics
- * @property {number} value Value of the current period.
- * @property {number} prevValue Value of the previous period.
- * @property {number} delta The delta of the current value compared to the previous value.
+ * @typedef { import(".~/data/utils").PerformanceData } PerformanceData
  */

--- a/js/src/dashboard/summary-section/usePerformance.js
+++ b/js/src/dashboard/summary-section/usePerformance.js
@@ -82,10 +82,12 @@ export default function usePerformance( type ) {
  * Performance data of each metric.
  *
  * @typedef {Object} PerformanceData
- * @property {PerformanceMetrics} sales Sales performance.
  * @property {PerformanceMetrics} clicks Clicks performance.
- * @property {PerformanceMetrics} spend Spend performance.
  * @property {PerformanceMetrics} impressions Impressions performance.
+ * @property {PerformanceMetrics} [sales] Sales performance. Available for paid type.
+ * @property {PerformanceMetrics} [solds] Solds performance. Available for paid type.
+ * @property {PerformanceMetrics} [conversions] Conversions performance. Available for paid type.
+ * @property {PerformanceMetrics} [spend] Spend performance. Available for paid type.
  */
 
 /**

--- a/js/src/dashboard/summary-section/usePerformance.js
+++ b/js/src/dashboard/summary-section/usePerformance.js
@@ -28,25 +28,19 @@ export default function usePerformance( type ) {
 	];
 
 	return useSelect( ( select ) => {
-		const { getDashboardPerformance, isResolving } = select( STORE_KEY );
-		const primaryArgs = [ type, query, 'primary' ];
-		const secondaryArgs = [ type, query, 'secondary' ];
-		const primary = getDashboardPerformance( ...primaryArgs );
-		const secondary = getDashboardPerformance( ...secondaryArgs );
+		const { getDashboardPerformance } = select( STORE_KEY );
+		const primary = getDashboardPerformance( type, query, 'primary' );
+		const secondary = getDashboardPerformance( type, query, 'secondary' );
 
 		let data = {};
-		let loading =
-			isResolving( 'getDashboardPerformance', primaryArgs ) ||
-			isResolving( 'getDashboardPerformance', secondaryArgs );
+		const loaded = primary.loaded && secondary.loaded;
 
-		if ( primary && secondary ) {
-			data = mapReportFieldsToPerformance( primary, secondary );
-		} else {
-			loading = true;
+		if ( loaded ) {
+			data = mapReportFieldsToPerformance( primary.data, secondary.data );
 		}
 
 		return {
-			loading,
+			loaded,
 			data,
 		};
 	}, deps );
@@ -56,7 +50,7 @@ export default function usePerformance( type ) {
  * Performance schema of the `usePerformance` hook
  *
  * @typedef {Object} PerformanceSchema
- * @property {boolean} loading Whether the data is loading.
+ * @property {boolean} loaded Whether the data have been loaded.
  * @property {PerformanceData} data Fetched performance data.
  */
 

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import TYPES from './action-types';
 import { API_NAMESPACE } from './constants';
-import { getReportQuery, getReportKey } from './utils';
+import { getReportKey } from './utils';
 
 import {
 	handleFetchError,
@@ -134,8 +134,7 @@ const reportTypeMap = new Map( [
 	[ 'paid', 'ads' ],
 ] );
 
-export function* getReport( category, type, query, dateReference ) {
-	const reportQuery = getReportQuery( query, dateReference );
+export function* getReportByApiQuery( category, type, reportQuery ) {
 	const reportType = reportTypeMap.get( type );
 	const url = `${ API_NAMESPACE }/${ reportType }/reports/${ category }`;
 	const path = addQueryArgs( url, reportQuery );

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -2,14 +2,13 @@
  * External dependencies
  */
 import { createRegistrySelector } from '@wordpress/data';
-import { getDateParamsFromQuery } from '@woocommerce/date';
 import createSelector from 'rememo';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from './constants';
-import { getReportQuery, getReportKey } from './utils';
+import { getReportKey, getPerformanceQuery } from './utils';
 
 export const getShippingRates = ( state ) => {
 	return state.mc.shipping.rates;
@@ -96,18 +95,19 @@ export const getMCIssues = createSelector(
 );
 
 /**
- * Select report data according to parameters.
+ * Select report data according to parameters and report API query.
  *
  * @param  {Object} state The current store state will be injected by `wp.data`.
  * @param  {string} category Category of report, 'programs' or 'products'.
  * @param  {string} type Type of report, 'free' or 'paid'.
- * @param  {Object} query Query parameters in the URL.
- * @param  {string} dateReference Which date range to use, 'primary' or 'secondary'.
+ * @param  {Object} reportQuery Query options of report API.
+ * @param  {string} reportQuery.after Start date in 'YYYY-MM-DD' format.
+ * @param  {string} reportQuery.before End date in 'YYYY-MM-DD' format.
+ * @param  {Array<string>} reportQuery.fields An array of performance metrics field to retrieve.
  *
  * @return {Object|null} The report data of specified parameters. It would return `null` before the data is fetched.
  */
-export const getReport = ( state, category, type, query, dateReference ) => {
-	const reportQuery = getReportQuery( query, dateReference );
+export const getReportByApiQuery = ( state, category, type, reportQuery ) => {
 	const reportKey = getReportKey( category, type, reportQuery );
 	return state.report[ reportKey ] || null;
 };
@@ -124,11 +124,10 @@ export const getReport = ( state, category, type, query, dateReference ) => {
  */
 export const getDashboardPerformance = createRegistrySelector(
 	( select ) => ( state, type, query, dateReference ) => {
-		const report = select( STORE_KEY ).getReport(
+		const report = select( STORE_KEY ).getReportByApiQuery(
 			'programs',
 			type,
-			getDateParamsFromQuery( query ),
-			dateReference
+			getPerformanceQuery( type, query, dateReference )
 		);
 
 		if ( report ) {

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -8,7 +8,7 @@ import createSelector from 'rememo';
  * Internal dependencies
  */
 import { STORE_KEY } from './constants';
-import { getReportKey, getPerformanceQuery } from './utils';
+import { getReportQuery, getReportKey, getPerformanceQuery } from './utils';
 
 export const getShippingRates = ( state ) => {
 	return state.mc.shipping.rates;
@@ -104,6 +104,12 @@ export const getMCIssues = createSelector(
  * @param  {string} reportQuery.after Start date in 'YYYY-MM-DD' format.
  * @param  {string} reportQuery.before End date in 'YYYY-MM-DD' format.
  * @param  {Array<string>} reportQuery.fields An array of performance metrics field to retrieve.
+ * @param  {string} [reportQuery.ids] Filter product or campaign by a comma separated list of IDs.
+ * @param  {string} [reportQuery.orderby] Column to order the results by, this must be one of the fields in requesting.
+ * @param  {string} [reportQuery.order] Results order, 'desc' or 'asc'.
+ * @param  {string} [reportQuery.interval] How to segment the data. Note that the 'free' type data only supports segmenting by day,
+ *                                         but the 'paid' type report allows any of the following values:
+ *                                         'day', 'week', 'month', 'quarter', 'year'
  *
  * @return {Object|null} The report data of specified parameters. It would return `null` before the data is fetched.
  */
@@ -111,6 +117,27 @@ export const getReportByApiQuery = ( state, category, type, reportQuery ) => {
 	const reportKey = getReportKey( category, type, reportQuery );
 	return state.report[ reportKey ] || null;
 };
+
+/**
+ * Select report data according to parameters and URL query.
+ *
+ * @param  {Object} state The current store state will be injected by `wp.data`.
+ * @param  {string} category Category of report, 'programs' or 'products'.
+ * @param  {string} type Type of report, 'free' or 'paid'.
+ * @param  {Object} query Query parameters in the URL.
+ * @param  {string} dateReference Which date range to use, 'primary' or 'secondary'.
+ *
+ * @return {Object|null} The report data of specified parameters. It would return `null` before the data is fetched.
+ */
+export const getReport = createRegistrySelector(
+	( select ) => ( state, category, type, query, dateReference ) => {
+		return select( STORE_KEY ).getReportByApiQuery(
+			category,
+			type,
+			getReportQuery( category, type, query, dateReference )
+		);
+	}
+);
 
 /**
  * Select programs performace data according to parameters.

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -119,6 +119,11 @@ export const getReportByApiQuery = ( state, category, type, reportQuery ) => {
 };
 
 /**
+ * @typedef {Object} ReportData
+ * @property {boolean} loaded Whether the data have been loaded.
+ * @property {Object|null} data The report data of specified parameters. It would return `null` before the data is fetched.
+ */
+/**
  * Select report data according to parameters and URL query.
  *
  * @param  {Object} state The current store state will be injected by `wp.data`.
@@ -127,18 +132,32 @@ export const getReportByApiQuery = ( state, category, type, reportQuery ) => {
  * @param  {Object} query Query parameters in the URL.
  * @param  {string} dateReference Which date range to use, 'primary' or 'secondary'.
  *
- * @return {Object|null} The report data of specified parameters. It would return `null` before the data is fetched.
+ * @return {ReportData} Report data.
  */
 export const getReport = createRegistrySelector(
 	( select ) => ( state, category, type, query, dateReference ) => {
-		return select( STORE_KEY ).getReportByApiQuery(
+		const selector = select( STORE_KEY );
+		const args = [
 			category,
 			type,
-			getReportQuery( category, type, query, dateReference )
-		);
+			getReportQuery( category, type, query, dateReference ),
+		];
+
+		return {
+			data: selector.getReportByApiQuery( ...args ),
+			loaded: selector.hasFinishedResolution(
+				'getReportByApiQuery',
+				args
+			),
+		};
 	}
 );
 
+/**
+ * @typedef {Object} PerformaceData
+ * @property {boolean} loaded Whether the data have been loaded.
+ * @property {Object|null} data The programs performace data of specified parameters. It would return `null` before the data is fetched.
+ */
 /**
  * Select programs performace data according to parameters.
  *
@@ -147,19 +166,24 @@ export const getReport = createRegistrySelector(
  * @param  {Object} query Query parameters in the URL.
  * @param  {string} dateReference Which date range to use, 'primary' or 'secondary'.
  *
- * @return {Object|null} The programs performace data of specified parameters. It would return `null` before the data is fetched.
+ * @return {PerformaceData} Performace data.
  */
 export const getDashboardPerformance = createRegistrySelector(
 	( select ) => ( state, type, query, dateReference ) => {
-		const report = select( STORE_KEY ).getReportByApiQuery(
+		const selector = select( STORE_KEY );
+		const args = [
 			'programs',
 			type,
-			getPerformanceQuery( type, query, dateReference )
-		);
+			getPerformanceQuery( type, query, dateReference ),
+		];
+		const report = selector.getReportByApiQuery( ...args );
 
-		if ( report ) {
-			return report.totals;
-		}
-		return report;
+		return {
+			data: report ? report.totals : null,
+			loaded: selector.hasFinishedResolution(
+				'getReportByApiQuery',
+				args
+			),
+		};
 	}
 );

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -5,24 +5,28 @@
 import { format } from '@wordpress/date';
 import { getCurrentDates } from '@woocommerce/date';
 
+const freeFields = [ 'clicks', 'impressions' ];
+const paidFields = [ 'sales', 'solds', 'conversions', 'spend', ...freeFields ];
+
 /**
- * Get report query for fetching API data.
+ * Get report query for fetching performance data from API.
  *
+ * @param  {string} type Type of report, 'free' or 'paid'.
  * @param  {Object} query Query parameters in the URL.
  * @param  {string} dateReference Which date range to use, 'primary' or 'secondary'.
  *
- * @return {Object} The report query for fetching API data.
+ * @return {Object} The report query for fetching performance data from API.
  */
-export function getReportQuery( query, dateReference ) {
-	// TODO: add more query parameters when implementing the report page.
-	// ref: https://github.com/woocommerce/google-listings-and-ads/pull/251
+export function getPerformanceQuery( type, query, dateReference ) {
 	const datesQuery = getCurrentDates( query );
 	const after = format( 'Y-m-d', datesQuery[ dateReference ].after );
 	const before = format( 'Y-m-d', datesQuery[ dateReference ].before );
+	const fields = type === 'free' ? freeFields : paidFields;
+
 	return {
 		after,
 		before,
-		fields: [ 'sales', 'spend', 'clicks', 'impressions' ],
+		fields,
 	};
 }
 

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -31,6 +31,36 @@ export function getPerformanceQuery( type, query, dateReference ) {
 }
 
 /**
+ * Get report query for fetching report data from API.
+ *
+ * @param  {string} category Category of report, 'programs' or 'products'.
+ * @param  {string} type Type of report, 'free' or 'paid'.
+ * @param  {Object} query Query parameters in the URL.
+ * @param  {string} dateReference Which date range to use, 'primary' or 'secondary'.
+ *
+ * @return {Object} The report query for fetching report data from API.
+ */
+export function getReportQuery( category, type, query, dateReference ) {
+	const baseQuery = getPerformanceQuery( type, query, dateReference );
+	const { orderby = baseQuery.fields[ 0 ], order = 'desc' } = query;
+
+	const reportQuery = {
+		...baseQuery,
+		interval: 'day',
+		orderby,
+		order,
+	};
+
+	if ( category === 'programs' ) {
+		// TODO: append `ids` for filtering by programs
+	} else if ( category === 'products' && query.products ) {
+		reportQuery.ids = query.products.replace( /\d+/g, 'gla_$&' );
+	}
+
+	return reportQuery;
+}
+
+/**
  * Get a key for accessing report data from store state.
  *
  * @param  {string} category Category of report, 'programs' or 'products'.

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -6,7 +6,7 @@ import { format } from '@wordpress/date';
 import { getCurrentDates } from '@woocommerce/date';
 
 const freeFields = [ 'clicks', 'impressions' ];
-const paidFields = [ 'sales', 'solds', 'conversions', 'spend', ...freeFields ];
+const paidFields = [ 'sales', 'conversions', 'spend', ...freeFields ];
 
 /**
  * Get report query for fetching performance data from API.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It a pre-tuning PR for #242 and #244.

- Adjusted the `getDashboardPerformance` selector to move the API query parameter from `getReport` to `getDashboardPerformance` since the Report page uses more parameters than Dashboard and needs to bring in some default queries automatically.
- Add a selector for the Program and Products Reporting pages.
- Add a function `getReportQuery` to create the report API query parameters.
- Move `mapToData` function out from `usePerformance` hook for reuse.
- Get loaded status from `getReport` and `getDashboardPerformance selectors`. Looks like `isResolving` and `hasFinishedResolution` did not work for selectors without a relevant resolver.

~❗ Consider that the `useReport` would need more time to tweak, I will open another PR once it's ready.~
💡 . The PR of `useProductsReport` hook is ready - #540

### Detailed test instructions:

1. The performance section on the Dashboard page should work well as before.
