### PR TITLE
Helper function for getting the WCS URL

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -34,6 +34,8 @@ use WP_REST_Request as Request;
  */
 class ConnectionTest implements Service, Registerable {
 
+	use PluginHelper;
+
 	/**
 	 * @var ContainerInterface
 	 */
@@ -52,10 +54,6 @@ class ConnectionTest implements Service, Registerable {
 	 * Register a service.
 	 */
 	public function register(): void {
-		if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_URL' ) ) {
-			define( 'WOOCOMMERCE_CONNECT_SERVER_URL', 'https://api-vipgo.woocommerce.com' );
-		}
-
 		add_action(
 			'admin_menu',
 			function() {
@@ -635,7 +633,7 @@ class ConnectionTest implements Service, Registerable {
 		}
 
 		if ( 'wcs-test' === $_GET['action'] && check_admin_referer( 'wcs-test' ) ) {
-			$url            = WOOCOMMERCE_CONNECT_SERVER_URL;
+			$url            = $this->get_connect_server_url();
 			$this->response = 'GET ' . $url . "\n";
 
 			$response = wp_remote_get( $url );
@@ -648,7 +646,7 @@ class ConnectionTest implements Service, Registerable {
 		}
 
 		if ( 'wcs-auth-test' === $_GET['action'] && check_admin_referer( 'wcs-auth-test' ) ) {
-			$url  = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL ) . 'connection/test';
+			$url  = trailingslashit( $this->get_connect_server_url() ) . 'connection/test';
 			$args = [
 				'headers' => [ 'Authorization' => $this->get_auth_header() ],
 			];
@@ -671,7 +669,7 @@ class ConnectionTest implements Service, Registerable {
 			}
 
 			$id   = absint( $_GET['manager_id'] );
-			$url  = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL ) . 'google/connection/google-manager';
+			$url  = trailingslashit( $this->get_connect_server_url() ) . 'google/connection/google-manager';
 			$args = [
 				'headers' => [ 'Authorization' => $this->get_auth_header() ],
 				'body'    => [
@@ -812,7 +810,7 @@ class ConnectionTest implements Service, Registerable {
 		}
 
 		if ( 'wcs-google-mc-status' === $_GET['action'] && check_admin_referer( 'wcs-google-mc-status' ) ) {
-			$url  = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL ) . 'google/connection/google-mc';
+			$url  = trailingslashit( $this->get_connect_server_url() ) . 'google/connection/google-mc';
 			$args = [
 				'headers' => [ 'Authorization' => $this->get_auth_header() ],
 				'method'  => 'GET',

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -20,6 +20,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\WPError;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\WPErrorTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Argument\RawArgument;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\Definition;
 use Exception;
@@ -42,6 +43,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class GoogleServiceProvider extends AbstractServiceProvider {
 
+	use PluginHelper;
 	use WPErrorTrait;
 
 	/**
@@ -244,13 +246,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @return RawArgument
 	 */
 	protected function get_connect_server_url_root( string $path = '' ): RawArgument {
-		if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_URL' ) ) {
-			define( 'WOOCOMMERCE_CONNECT_SERVER_URL', 'https://api.woocommerce.com/' );
-		}
-		$url = WOOCOMMERCE_CONNECT_SERVER_URL;
-		$url = rtrim( $url, '/' );
-
-		$path = '/' . trim( $path, '/' );
+		$url  = trailingslashit( $this->get_connect_server_url() );
+		$path = trim( $path, '/' );
 
 		return new RawArgument( "{$url}{$path}" );
 	}

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -134,4 +134,18 @@ trait PluginHelper {
 	protected function is_debug_mode(): bool {
 		return defined( 'WP_DEBUG' ) && WP_DEBUG;
 	}
+
+	/**
+	 * Get the WooCommerce Connect Server URL
+	 *
+	 * @return string
+	 */
+	protected function get_connect_server_url(): string {
+		if ( defined( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL' ) ) {
+			return apply_filters( 'woocommerce_gla_wcs_url', WOOCOMMERCE_GLA_CONNECT_SERVER_URL );
+		}
+
+		// TODO: Change to api.woocommerce.com when we are no longer in test fase.
+		return apply_filters( 'woocommerce_gla_wcs_url', 'https://api-vipgo.woocommerce.com' );
+	}
 }

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -145,7 +145,7 @@ trait PluginHelper {
 			return apply_filters( 'woocommerce_gla_wcs_url', WOOCOMMERCE_GLA_CONNECT_SERVER_URL );
 		}
 
-		// TODO: Change to api.woocommerce.com when we are no longer in test fase.
+		// TODO: Change to api.woocommerce.com when we are no longer in test phase.
 		return apply_filters( 'woocommerce_gla_wcs_url', 'https://api-vipgo.woocommerce.com' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Our plugin had two methods of retrieving the WCS URL. One in ConnectionTest and the other in GoogleServiceProvider. Both of these were based off of the environment variable `WOOCOMMERCE_CONNECT_SERVER_URL`. The problem with this solution is that the WooCommerce Shipping & Tax extension uses the same variable. However until we are out of the testing phase we can't use the same server URL. This PR resolves that so the two plugins can be used without any conflicts.

Shipping & Tax > api.woocommerce.com
GLA > api-vipgo.woocommerce.com

Closes #514 

### Notes:
After this PR merges by default all requests will go to the api-vipgo.woocommerce.com, if we want to override it for a local server, we can use a code snippet like this:

```
define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://localhost:5000' );
```

### Detailed test instructions:

1. Start with a default plugin install
2. Connection test page should show: `https://api-vipgo.woocommerce.com/`
3. Define `WOOCOMMERCE_CONNECT_SERVER_URL` in a code snippet
4. Connection test page should still show: `https://api-vipgo.woocommerce.com/`
5. Define `WOOCOMMERCE_GLA_CONNECT_SERVER_URL` in a code snippet
6. Connection test page should show the URL you set in the code snippet
7. Override the URL with a filter using `woocommerce_gla_wcs_url`
8. Connection test page should show the URL you set in the code snippet
9. Test some regular requests to the MC and Ads API's
10. Confirm that they are sent to the right server
11. Install the [WooCommerce Shipping & Tax extension](https://wordpress.org/plugins/woocommerce-services/)
12. Confirm that we are still able to send requests without them being redirected to api.woocommerce.com

### Changelog Note:
- Helper function for getting the WCS URL.