### PR TITLE
Don't enable Continue button when MC account is not connected

### DIFF
--- a/js/src/hooks/useGoogleAccount.js
+++ b/js/src/hooks/useGoogleAccount.js
@@ -10,13 +10,14 @@ import { STORE_KEY } from '.~/data/constants';
 import useJetpackAccount from './useJetpackAccount';
 
 const useGoogleAccount = () => {
-	const { jetpack, isResolving } = useJetpackAccount();
+	const { jetpack, isResolving, hasFinishedResolution } = useJetpackAccount();
 
 	return useSelect( ( select ) => {
 		if ( ! jetpack || jetpack.active === 'no' ) {
 			return {
 				google: undefined,
 				isResolving,
+				hasFinishedResolution,
 			};
 		}
 
@@ -24,8 +25,15 @@ const useGoogleAccount = () => {
 		const isResolvingGoogle = select( STORE_KEY ).isResolving(
 			'getGoogleAccount'
 		);
+		const hasFinishedResolutionGoogle = select(
+			STORE_KEY
+		).hasFinishedResolution( 'getGoogleAccount' );
 
-		return { google: acc, isResolving: isResolvingGoogle };
+		return {
+			google: acc,
+			isResolving: isResolvingGoogle,
+			hasFinishedResolution: hasFinishedResolutionGoogle,
+		};
 	} );
 };
 

--- a/js/src/hooks/useGoogleAccount.js
+++ b/js/src/hooks/useGoogleAccount.js
@@ -10,31 +10,38 @@ import { STORE_KEY } from '.~/data/constants';
 import useJetpackAccount from './useJetpackAccount';
 
 const useGoogleAccount = () => {
-	const { jetpack, isResolving, hasFinishedResolution } = useJetpackAccount();
+	const {
+		jetpack,
+		isResolving: isResolvingJetpack,
+		hasFinishedResolution: hasFinishedResolutionJetpack,
+	} = useJetpackAccount();
 
-	return useSelect( ( select ) => {
-		if ( ! jetpack || jetpack.active === 'no' ) {
-			return {
-				google: undefined,
+	return useSelect(
+		( select ) => {
+			if ( ! jetpack || jetpack.active === 'no' ) {
+				return {
+					google: undefined,
+					isResolving: isResolvingJetpack,
+					hasFinishedResolution: hasFinishedResolutionJetpack,
+				};
+			}
+
+			const {
+				getGoogleAccount,
 				isResolving,
 				hasFinishedResolution,
+			} = select( STORE_KEY );
+
+			return {
+				google: getGoogleAccount(),
+				isResolving: isResolving( 'getGoogleAccount' ),
+				hasFinishedResolution: hasFinishedResolution(
+					'getGoogleAccount'
+				),
 			};
-		}
-
-		const acc = select( STORE_KEY ).getGoogleAccount();
-		const isResolvingGoogle = select( STORE_KEY ).isResolving(
-			'getGoogleAccount'
-		);
-		const hasFinishedResolutionGoogle = select(
-			STORE_KEY
-		).hasFinishedResolution( 'getGoogleAccount' );
-
-		return {
-			google: acc,
-			isResolving: isResolvingGoogle,
-			hasFinishedResolution: hasFinishedResolutionGoogle,
-		};
-	} );
+		},
+		[ jetpack, isResolvingJetpack, hasFinishedResolutionJetpack ]
+	);
 };
 
 export default useGoogleAccount;

--- a/js/src/hooks/useGoogleMCAccount.js
+++ b/js/src/hooks/useGoogleMCAccount.js
@@ -10,31 +10,38 @@ import { STORE_KEY } from '.~/data/constants';
 import useGoogleAccount from './useGoogleAccount';
 
 const useGoogleMCAccount = () => {
-	const { google, isResolving, hasFinishedResolution } = useGoogleAccount();
+	const {
+		google,
+		isResolving: isResolvingGoogle,
+		hasFinishedResolution: hasFinishedResolutionGoogle,
+	} = useGoogleAccount();
 
-	return useSelect( ( select ) => {
-		if ( ! google || google.active === 'no' ) {
-			return {
-				googleMCAccount: undefined,
+	return useSelect(
+		( select ) => {
+			if ( ! google || google.active === 'no' ) {
+				return {
+					googleMCAccount: undefined,
+					isResolving: isResolvingGoogle,
+					hasFinishedResolution: hasFinishedResolutionGoogle,
+				};
+			}
+
+			const {
+				getGoogleMCAccount,
 				isResolving,
 				hasFinishedResolution,
+			} = select( STORE_KEY );
+
+			return {
+				googleMCAccount: getGoogleMCAccount(),
+				isResolving: isResolving( 'getGoogleMCAccount' ),
+				hasFinishedResolution: hasFinishedResolution(
+					'getGoogleMCAccount'
+				),
 			};
-		}
-
-		const acc = select( STORE_KEY ).getGoogleMCAccount();
-		const isResolvingGoogleMCAccount = select( STORE_KEY ).isResolving(
-			'getGoogleMCAccount'
-		);
-		const hasFinishedResolutionGoogleMCAccount = select(
-			STORE_KEY
-		).hasFinishedResolution( 'getGoogleMCAccount' );
-
-		return {
-			googleMCAccount: acc,
-			isResolving: isResolvingGoogleMCAccount,
-			hasFinishedResolution: hasFinishedResolutionGoogleMCAccount,
-		};
-	} );
+		},
+		[ google, isResolvingGoogle, hasFinishedResolutionGoogle ]
+	);
 };
 
 export default useGoogleMCAccount;

--- a/js/src/hooks/useGoogleMCAccount.js
+++ b/js/src/hooks/useGoogleMCAccount.js
@@ -10,13 +10,14 @@ import { STORE_KEY } from '.~/data/constants';
 import useGoogleAccount from './useGoogleAccount';
 
 const useGoogleMCAccount = () => {
-	const { google, isResolving } = useGoogleAccount();
+	const { google, isResolving, hasFinishedResolution } = useGoogleAccount();
 
 	return useSelect( ( select ) => {
 		if ( ! google || google.active === 'no' ) {
 			return {
 				googleMCAccount: undefined,
 				isResolving,
+				hasFinishedResolution,
 			};
 		}
 
@@ -24,10 +25,14 @@ const useGoogleMCAccount = () => {
 		const isResolvingGoogleMCAccount = select( STORE_KEY ).isResolving(
 			'getGoogleMCAccount'
 		);
+		const hasFinishedResolutionGoogleMCAccount = select(
+			STORE_KEY
+		).hasFinishedResolution( 'getGoogleMCAccount' );
 
 		return {
 			googleMCAccount: acc,
 			isResolving: isResolvingGoogleMCAccount,
+			hasFinishedResolution: hasFinishedResolutionGoogleMCAccount,
 		};
 	} );
 };

--- a/js/src/hooks/useJetpackAccount.js
+++ b/js/src/hooks/useJetpackAccount.js
@@ -19,7 +19,7 @@ const useJetpackAccount = () => {
 		);
 
 		return { jetpack, isResolving, hasFinishedResolution };
-	} );
+	}, [] );
 };
 
 export default useJetpackAccount;

--- a/js/src/hooks/useJetpackAccount.js
+++ b/js/src/hooks/useJetpackAccount.js
@@ -14,8 +14,11 @@ const useJetpackAccount = () => {
 		const isResolving = select( STORE_KEY ).isResolving(
 			'getJetpackAccount'
 		);
+		const hasFinishedResolution = select( STORE_KEY ).hasFinishedResolution(
+			'getJetpackAccount'
+		);
 
-		return { jetpack, isResolving };
+		return { jetpack, isResolving, hasFinishedResolution };
 	} );
 };
 

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -29,15 +29,15 @@ const ConnectMCCard = ( props ) => {
 		method: 'POST',
 		data: { id: value },
 	} );
-	const { receiveMCAccount } = useAppDispatch();
+	const { invalidateResolution } = useAppDispatch();
 
 	const handleConnectClick = async () => {
 		if ( ! value ) {
 			return;
 		}
 
-		const data = await fetchMCAccounts();
-		receiveMCAccount( data );
+		await fetchMCAccounts();
+		invalidateResolution( 'getGoogleMCAccount', [] );
 	};
 
 	const handleSelectAnotherAccount = () => {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
@@ -16,7 +16,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 const CreateAccount = ( props ) => {
 	const { allowShowExisting, onShowExisting } = props;
 	const { createNotice } = useDispatchCoreNotices();
-	const { receiveMCAccount } = useAppDispatch();
+	const { invalidateResolution } = useAppDispatch();
 	const [
 		fetchCreateMCAccount,
 		{ loading, error, response },
@@ -27,9 +27,8 @@ const CreateAccount = ( props ) => {
 
 	const handleCreateAccount = async () => {
 		try {
-			const res = await fetchCreateMCAccount( { parse: false } );
-			const data = await res.json();
-			receiveMCAccount( data );
+			await fetchCreateMCAccount( { parse: false } );
+			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {
 			if ( e.status === 406 ) {
 				const body = await e.json();

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -25,7 +25,7 @@ import ReclaimUrlFailCard from './reclaim-url-fail-card';
 const ReclaimUrlCard = ( props ) => {
 	const { websiteUrl } = props;
 	const { createNotice } = useDispatchCoreNotices();
-	const { receiveMCAccount } = useAppDispatch();
+	const { invalidateResolution } = useAppDispatch();
 	const [
 		fetchClaimOverwrite,
 		{ loading, response, reset },
@@ -36,9 +36,8 @@ const ReclaimUrlCard = ( props ) => {
 
 	const handleReclaimClick = async () => {
 		try {
-			const res = await fetchClaimOverwrite( { parse: false } );
-			const data = await res.json();
-			receiveMCAccount( data );
+			await fetchClaimOverwrite( { parse: false } );
+			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {
 			if ( e.status !== 406 ) {
 				createNotice(

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/section-content.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/section-content.js
@@ -19,9 +19,7 @@ const SectionContent = ( props ) => {
 		return <SpinnerCard />;
 	}
 
-	const { id } = googleMCAccount;
-
-	if ( id === 0 ) {
+	if ( googleMCAccount.id === 0 || googleMCAccount.status !== 'connected' ) {
 		return <NonConnected />;
 	}
 

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/section-content.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/section-content.js
@@ -9,13 +9,13 @@ import SpinnerCard from '.~/components/spinner-card';
 
 const SectionContent = ( props ) => {
 	const { disabled } = props;
-	const { googleMCAccount } = useGoogleMCAccount();
+	const { hasFinishedResolution, googleMCAccount } = useGoogleMCAccount();
 
 	if ( disabled ) {
 		return <DisabledCard />;
 	}
 
-	if ( ! googleMCAccount ) {
+	if ( ! hasFinishedResolution ) {
 		return <SpinnerCard />;
 	}
 

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
@@ -30,7 +30,7 @@ const SwitchUrlCard = ( props ) => {
 		newUrl,
 		onSelectAnotherAccount = () => {},
 	} = props;
-	const { receiveMCAccount } = useAppDispatch();
+	const { invalidateResolution } = useAppDispatch();
 	const [ fetchMCAccountSwitchUrl, { loading } ] = useApiFetchCallback( {
 		path: `/wc/gla/mc/accounts/switch-url`,
 		method: 'POST',
@@ -38,8 +38,8 @@ const SwitchUrlCard = ( props ) => {
 	} );
 
 	const handleSwitch = async () => {
-		const account = await fetchMCAccountSwitchUrl();
-		receiveMCAccount( account );
+		await fetchMCAccountSwitchUrl();
+		invalidateResolution( 'getGoogleMCAccount', [] );
 	};
 
 	const handleUseDifferentMCClick = () => {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -32,10 +32,9 @@ const SetupAccounts = ( props ) => {
 		return <AppSpinner />;
 	}
 
-	const isGoogleAccountDisabled = jetpack.active === 'no';
-	const isGoogleMCAccountDisabled = ! google || google.active === 'no';
-	const isContinueButtonDisabled =
-		! googleMCAccount || googleMCAccount.status === 'disconnected';
+	const isGoogleAccountDisabled = ! jetpack?.active === 'yes';
+	const isGoogleMCAccountDisabled = ! google?.active === 'yes';
+	const isContinueButtonDisabled = ! googleMCAccount?.status === 'connected';
 
 	return (
 		<StepContent>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -32,9 +32,9 @@ const SetupAccounts = ( props ) => {
 		return <AppSpinner />;
 	}
 
-	const isGoogleAccountDisabled = ! jetpack?.active === 'yes';
-	const isGoogleMCAccountDisabled = ! google?.active === 'yes';
-	const isContinueButtonDisabled = ! googleMCAccount?.status === 'connected';
+	const isGoogleAccountDisabled = jetpack?.active !== 'yes';
+	const isGoogleMCAccountDisabled = google?.active !== 'yes';
+	const isContinueButtonDisabled = googleMCAccount?.status !== 'connected';
 
 	return (
 		<StepContent>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #414 .

This PR checks for the Google MC account status. If the status is not `connected`, the UI will allow the user to connect an account and disable the Continue button at the bottom of the page. 

### Screenshots:

UI remains the same, only logic changes. 

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc
2. In Step 1, the Continue button should only be enabled when all the accounts are connected.
3. After connecting Google MC account, in the database modify the `gla_merchant_account_state` option and set `claim` and `link` to unfinished:
    ```sql
    UPDATE `wp_options` 
    SET `option_value` = 'a:4:{s:6:"set_id";a:3:{s:6:"status";i:1;s:7:"message";s:0:"";s:4:"data";a:1:{s:8:"from_mca";b:0;}}s:6:"verify";a:3:{s:6:"status";i:1;s:7:"message";s:0:"";s:4:"data";a:0:{}}s:4:"link";a:3:{s:6:"status";i:-1;s:7:"message";s:61:"Error linking merchant to MCA: Refresh token is not available";s:4:"data";a:0:{}}s:5:"claim";a:3:{s:6:"status";i:0;s:7:"message";s:0:"";s:4:"data";a:0:{}}}' 
    WHERE `option_name` = 'gla_merchant_account_state'
    ```
    This represents the state if the link step fails.
4. Reload the setup page and confirm that the `/mc/connection` request indicates that the setup is `incomplete`, and the "Continue" button should be disabled.

### Changelog Note:

Don't enable Continue button when MC account is not connected.
