### PR TITLE
South Korea is only supported for currency KRW

### DIFF
--- a/src/GoogleHelper.php
+++ b/src/GoogleHelper.php
@@ -110,7 +110,6 @@ trait GoogleHelper {
 			'SG' => 'SGD', // Singapore
 			'SK' => 'EUR', // Slovakia
 			'ZA' => 'ZAR', // South Africa
-			'KR' => 'KRW', // South Korea
 			'ES' => 'EUR', // Spain
 			'SE' => 'SEK', // Sweden
 			'CH' => 'CHF', // Switzerland
@@ -123,7 +122,14 @@ trait GoogleHelper {
 			'UZ' => 'UZS', // Uzbekistan
 		];
 
-		return $include_beta ? array_merge( $supported_countries, $beta_countries ) : $supported_countries;
+		$supported = $include_beta ? array_merge( $supported_countries, $beta_countries ) : $supported_countries;
+
+		// Currency conversion is unavailable in South Korea: https://support.google.com/merchants/answer/7055540
+		if ( 'KRW' === get_woocommerce_currency() ) {
+			$supported['KR'] = 'KRW'; // South Korea
+		}
+
+		return $supported;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currency conversion is unavailable in South Korea, see: https://support.google.com/merchants/answer/7055540
To get around this we remove South Korea from the list of countries unless the currency is set to `KRW`.

Patch for #530

### Detailed test instructions:

1. Select US / USD in WooCommerce settings
2. Go through MC onboarding and select 'All Countries' in step 2
3. In step 3 confirm that "South Korea" is not included in list of countries and that we can complete setup
4. Set country to South Korea but leave at USD
5. Go back through setup and confirm the warning is there:
![image](https://user-images.githubusercontent.com/11388669/116561029-d3e11a00-a8f9-11eb-839e-38e7bbbc16cd.png)
6. Set currency to South Korean Won
7. Go back through setup and confirm we can complete setup

### Notes:

The warning notice displays the country is not supported, when the currency is not correct. That should be more flexible to prompt them to check both.

### Changelog Note:
- South Korea is only supported for currency KRW