### PR TITLE
Conditionally hide Reports tab and show a coming soon notice on Product Feed tab.

### DIFF
--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -13,10 +13,19 @@ import AppDateRangeFilterPicker from './app-date-range-filter-picker';
 import SummarySection from './summary-section';
 import CampaignCreationSuccessGuide from './campaign-creation-success-guide';
 import AllProgramsTableCard from './all-programs-table-card';
+import { glaData } from '.~/constants';
 import './index.scss';
 
 const Dashboard = () => {
 	const trackEventReportId = 'dashboard';
+	const { enableReports } = glaData;
+	const ReportsLink = () => {
+		return (
+			<Link href={ getNewPath( null, '/google/reports/programs' ) }>
+				<Button isPrimary>View Reports</Button>
+			</Link>
+		);
+	};
 
 	return (
 		<div className="gla-dashboard">
@@ -25,9 +34,7 @@ const Dashboard = () => {
 				<AppDateRangeFilterPicker
 					trackEventReportId={ trackEventReportId }
 				/>
-				<Link href={ getNewPath( null, '/google/reports/programs' ) }>
-					<Button isPrimary>View Reports</Button>
-				</Link>
+				{ enableReports && <ReportsLink /> }
 			</div>
 			<div className="gla-dashboard__performance">
 				<SummarySection />

--- a/js/src/product-feed/coming-soon-notice/index.js
+++ b/js/src/product-feed/coming-soon-notice/index.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice, Icon } from '@wordpress/components';
+import { external as externalIcon } from '@wordpress/icons';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import './index.scss';
+
+const ExternalIcon = () => (
+	<Icon
+		className="gla-coming-soon-notice__icon"
+		icon={ externalIcon }
+		size={ 18 }
+	/>
+);
+
+const ComingSoonNotice = () => {
+	return (
+		<Notice
+			className="gla-coming-soon-notice"
+			status="warning"
+			isDismissible={ false }
+		>
+			{ createInterpolateElement(
+				__(
+					'Your products will be listed in the Product Feed section soon! We’re working on improvements to this plugin. Our estimated full-featured release is in June 2021. In the mean time, manage your synced product feed directly in <googleMerchantCenterLink>Google Merchant Center</googleMerchantCenterLink>. Optionally, <feedbackLink>give us some feedback</feedbackLink>.',
+					'google-listings-and-ads'
+				),
+				{
+					feedbackLink: (
+						<AppDocumentationLink
+							className="gla-coming-soon-notice__link"
+							href="https://forms.gle/aA9BpfEwceAe3eBA9"
+							eventName="get_coming_soon_link_click"
+							context="coming-soon"
+							linkId="feedback-form"
+						/>
+					),
+					googleMerchantCenterLink: (
+						<AppDocumentationLink
+							className="gla-coming-soon-notice__link"
+							href="https://merchants.google.com/mc/"
+							eventName="get_coming_soon_link_click"
+							context="coming-soon"
+							linkId="google-merchant-center"
+						/>
+					),
+				}
+			) }
+			<ExternalIcon />
+		</Notice>
+	);
+};
+
+export default ComingSoonNotice;

--- a/js/src/product-feed/coming-soon-notice/index.scss
+++ b/js/src/product-feed/coming-soon-notice/index.scss
@@ -1,10 +1,6 @@
 .gla-coming-soon-notice {
 	margin: 0 0 $grid-unit-40;
 
-	&.is-error {
-		background-color: #ffcbcb;
-	}
-
 	&.is-warning {
 		background-color: #ffeec1;
 	}

--- a/js/src/product-feed/coming-soon-notice/index.scss
+++ b/js/src/product-feed/coming-soon-notice/index.scss
@@ -1,0 +1,24 @@
+.gla-coming-soon-notice {
+	margin: 0 0 $grid-unit-40;
+
+	&.is-error {
+		background-color: #ffcbcb;
+	}
+
+	&.is-warning {
+		background-color: #ffeec1;
+	}
+
+	.components-notice__content {
+		margin-left: $grid-unit-20;
+	}
+
+	&__link {
+		color: currentColor;
+	}
+
+	&__icon {
+		margin-left: 0.2em;
+		vertical-align: middle;
+	}
+}

--- a/js/src/product-feed/index.js
+++ b/js/src/product-feed/index.js
@@ -12,6 +12,7 @@ import IssuesTableCard from './issues-table-card';
 import ProductStatusHelpPopover from './product-status-help-popover';
 import ProductFeedTableCard from './product-feed-table-card';
 import SubmissionSuccessGuide from './submission-success-guide';
+import ComingSoonNotice from './coming-soon-notice';
 import './index.scss';
 
 /* TODO: The last updated date and time need to come from backend API. */
@@ -22,6 +23,7 @@ const ProductFeed = () => {
 		<div className="gla-product-feed">
 			<TabNav initialName="product-feed" />
 			<SubmissionSuccessGuide />
+			<ComingSoonNotice />
 			<div className="gla-product-feed__last-updated">
 				Last updated:{ ' ' }
 				{ formatDate( 'Y-m-d H:i:s', lastUpdatedDateTime ) }

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -9,7 +9,6 @@ import { getQuery, onQueryChange } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import EditProductLink from '.~/components/edit-product-link';
 import AppTableCard from '.~/components/app-table-card';
 
 /**
@@ -26,20 +25,7 @@ const ProductFeedTableCard = ( props ) => {
 	// TODO: data should be coming from backend API,
 	// using the above query (e.g. orderby, order and page) as parameter.
 	// Also, i18n for the display labels too.
-	const data = [
-		{
-			id: 123,
-			title: 'Pink marble tee',
-			visibility: 'Sync and show',
-			status: 'Not synced',
-		},
-		{
-			id: 456,
-			title: 'Brown socks',
-			visibility: 'Sync and show',
-			status: 'Not synced',
-		},
-	];
+	const data = [];
 
 	// TODO: total should be coming from API response above.
 	const total = data.length;
@@ -141,7 +127,7 @@ const ProductFeedTableCard = ( props ) => {
 							display: el.status,
 						},
 						{
-							display: <EditProductLink productId={ el.id } />,
+							display: '',
 						},
 					];
 				} ) }

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -9,6 +9,7 @@ import { getQuery, onQueryChange } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import EditProductLink from '.~/components/edit-product-link';
 import AppTableCard from '.~/components/app-table-card';
 
 /**
@@ -127,7 +128,7 @@ const ProductFeedTableCard = ( props ) => {
 							display: el.status,
 						},
 						{
-							display: '',
+							display: <EditProductLink productId={ el.id } />,
 						},
 					];
 				} ) }

--- a/js/src/tab-nav/index.js
+++ b/js/src/tab-nav/index.js
@@ -13,7 +13,7 @@ import classnames from 'classnames';
 import { glaData } from '.~/constants';
 import './index.scss';
 
-const tabs = [
+let tabs = [
 	{
 		name: 'dashboard',
 		title: __( 'Dashboard', 'google-listings-and-ads' ),
@@ -39,6 +39,10 @@ const tabs = [
 		path: '%2Fgoogle%2Fsettings',
 	},
 ];
+// Hide reports tab.
+if ( ! glaData.enableReports ) {
+	tabs = tabs.filter( ( { name } ) => name === 'reports' );
+}
 
 const TabLink = ( { tabId, path, children, selected, ...rest } ) => {
 	return (
@@ -58,7 +62,6 @@ const TabLink = ( { tabId, path, children, selected, ...rest } ) => {
 const TabNav = ( props ) => {
 	const { initialName } = props;
 	const activeClass = 'is-active';
-	const { enableReports } = glaData;
 
 	useEffect( () => {
 		// Highlight the wp-admin dashboard menu
@@ -82,30 +85,25 @@ const TabNav = ( props ) => {
 				orientation="horizontal"
 				className="gla-tab-nav__tabs"
 			>
-				{ tabs.map( ( tab ) => {
-					if ( ! enableReports && tab.name === 'reports' ) {
-						return '';
-					}
-					return (
-						<TabLink
-							className={ classnames(
-								'components-button',
-								'gla-tab-nav__tabs-item',
-								tab.className,
-								{
-									[ activeClass ]: tab.name === initialName,
-								}
-							) }
-							tabId={ `${ tab.name }` }
-							aria-controls={ `${ tab.name }-view` }
-							selected={ tab.name === initialName }
-							key={ tab.name }
-							path={ tab.path }
-						>
-							{ tab.title }
-						</TabLink>
-					);
-				} ) }
+				{ tabs.map( ( tab ) => (
+					<TabLink
+						className={ classnames(
+							'components-button',
+							'gla-tab-nav__tabs-item',
+							tab.className,
+							{
+								[ activeClass ]: tab.name === initialName,
+							}
+						) }
+						tabId={ `${ tab.name }` }
+						aria-controls={ `${ tab.name }-view` }
+						selected={ tab.name === initialName }
+						key={ tab.name }
+						path={ tab.path }
+					>
+						{ tab.title }
+					</TabLink>
+				) ) }
 			</NavigableMenu>
 		</div>
 	);

--- a/js/src/tab-nav/index.js
+++ b/js/src/tab-nav/index.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { glaData } from '.~/constants';
 import './index.scss';
 
 const tabs = [
@@ -57,6 +58,7 @@ const TabLink = ( { tabId, path, children, selected, ...rest } ) => {
 const TabNav = ( props ) => {
 	const { initialName } = props;
 	const activeClass = 'is-active';
+	const { enableReports } = glaData;
 
 	useEffect( () => {
 		// Highlight the wp-admin dashboard menu
@@ -80,25 +82,30 @@ const TabNav = ( props ) => {
 				orientation="horizontal"
 				className="gla-tab-nav__tabs"
 			>
-				{ tabs.map( ( tab ) => (
-					<TabLink
-						className={ classnames(
-							'components-button',
-							'gla-tab-nav__tabs-item',
-							tab.className,
-							{
-								[ activeClass ]: tab.name === initialName,
-							}
-						) }
-						tabId={ `${ tab.name }` }
-						aria-controls={ `${ tab.name }-view` }
-						selected={ tab.name === initialName }
-						key={ tab.name }
-						path={ tab.path }
-					>
-						{ tab.title }
-					</TabLink>
-				) ) }
+				{ tabs.map( ( tab ) => {
+					if ( ! enableReports && tab.name === 'reports' ) {
+						return '';
+					}
+					return (
+						<TabLink
+							className={ classnames(
+								'components-button',
+								'gla-tab-nav__tabs-item',
+								tab.className,
+								{
+									[ activeClass ]: tab.name === initialName,
+								}
+							) }
+							tabId={ `${ tab.name }` }
+							aria-controls={ `${ tab.name }-view` }
+							selected={ tab.name === initialName }
+							key={ tab.name }
+							path={ tab.path }
+						>
+							{ tab.title }
+						</TabLink>
+					);
+				} ) }
 			</NavigableMenu>
 		</div>
 	);

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -104,6 +104,7 @@ class Admin implements Service, Registerable, Conditional {
 				'mcSupportedCountry'  => $this->merchant_center->is_country_supported(),
 				'mcSupportedLanguage' => $this->merchant_center->is_language_supported(),
 				'adsSetupComplete'    => $this->ads->is_setup_complete(),
+				'enableReports'       => $this->enableReports(),
 			]
 		);
 
@@ -186,5 +187,14 @@ class Admin implements Service, Registerable, Conditional {
 	 */
 	protected static function get_view_path( string $view ): string {
 		return path_join( 'src/Admin/views', $view );
+	}
+
+	/**
+	 * Only show reports if we enable it through a snippet.
+	 *
+	 * @return bool Whether reports should be enabled .
+	 */
+	protected function enableReports(): bool {
+		return apply_filters( 'gla_enable_reports', false );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes some adjustments to avoid confusion about in-progress functionality ahead of release to WPORG and tranche 4 testing.

Specifically...

**Adds a coming soon notice to the Product Feed tab.**

<img width="806" alt="Screen Shot 2021-04-30 at 1 38 40 pm" src="https://user-images.githubusercontent.com/355014/116652756-fb50e900-a9c4-11eb-9db0-d92014f480e2.png">

note - Can be removed once the product feed table is working.

**Removes dummy content from the Product Feed table**

<img width="838" alt="Screen Shot 2021-04-30 at 3 02 18 pm" src="https://user-images.githubusercontent.com/355014/116689206-f2790b00-a9f6-11eb-8d0a-6a313b225f73.png">

note - Will be populated once product feed table is connected properly

The other sections on this product feed page have current PRs in for review and will hopefully be ready for tranche 4 testing and can be pushed to WPORG once finalised.

https://github.com/woocommerce/google-listings-and-ads/pull/518
https://github.com/woocommerce/google-listings-and-ads/pull/512

**Hides the Reports tab and "View reports" button by default**

Before...

<img width="879" alt="Screen Shot 2021-04-30 at 2 57 47 pm" src="https://user-images.githubusercontent.com/355014/116652899-47039280-a9c5-11eb-8cdb-61a23d4da3ff.png">

After...

<img width="881" alt="Screen Shot 2021-04-30 at 2 58 27 pm" src="https://user-images.githubusercontent.com/355014/116652883-40751b00-a9c5-11eb-9d05-c05892fdfa9e.png">

This can be controlled with a new `gla_enable_reports` filter.

Reports pages themselves should still be accessible if you know the URLs eg.

wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms
wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fproducts

### Detailed test instructions:

1.  View Product Feed back and confirm notice is displayed and links work and the product feed table is empty.
2.  Build the extension and confirm by default the reports tab and view reports button (on the main dashboard page) are not displayed
3. Add a filter to `gla_enable_reports` to set to "true" and confirm the reports tab is now visible and so is the button.


