### PR TITLE
Additional testing flags

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -80,15 +80,28 @@ class ConnectionTest implements Service, Registerable {
 	 * Add menu entries
 	 */
 	protected function register_admin_menu() {
-		add_menu_page(
-			'Connection Test',
-			'Connection Test',
-			'manage_options',
-			'connection-test-admin-page',
-			function() {
-				$this->render_admin_page();
-			}
-		);
+		if ( apply_filters( 'gla_enable_connection_test', false ) ) {
+			add_menu_page(
+				'Connection Test',
+				'Connection Test',
+				'manage_options',
+				'connection-test-admin-page',
+				function() {
+					$this->render_admin_page();
+				}
+			);
+		} else {
+			add_submenu_page(
+				'',
+				'Connection Test',
+				'Connection Test',
+				'manage_options',
+				'connection-test-admin-page',
+				function() {
+					$this->render_admin_page();
+				}
+			);
+		}
 	}
 
 	/**

--- a/src/Logging/DebugLogger.php
+++ b/src/Logging/DebugLogger.php
@@ -24,12 +24,12 @@ class DebugLogger implements Service, Registerable, Conditional {
 	private $logger = null;
 
 	/**
-	 * Only needed if we enable it through a snippet.
+	 * Check if debug logging should be enabled.
 	 *
-	 * @return bool Whether the object is needed.
+	 * @return bool Whether the service is needed.
 	 */
 	public static function is_needed(): bool {
-		return apply_filters( 'gla_enable_debug_logging', false );
+		return apply_filters( 'gla_enable_debug_logging', true );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In line with the `gla_enable_reports` I've added another one to enable the Connection Test page `gla_enable_connection_test`.
I've also changed the default of enabling the debug logger to true (we want to be able to get as much feedback from testing).

I've added an initial WIKI page here describing the filters: https://github.com/woocommerce/google-listings-and-ads/wiki/Hooks-and-Filters
This also allows us to simplify some of the steps in the [release WIKI](https://github.com/woocommerce/google-listings-and-ads/wiki/Release-Process), since we no longer need to customize the code.


### Detailed test instructions:

1. Confirm the Connection Test page does not show in the menu by default
2. Add the snippet `add_filter( 'gla_enable_connection_test', '__return_true' );`
3. Confirm that the Connection Test page shows in the menu

### Changelog Note:
- Conditional flags for testing