### PR TITLE
Proposal/RFC for custom tag names

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -12,6 +12,12 @@
 		"no-duplicate-selectors": null,
 		"rule-empty-line-before": null,
 		"selector-class-pattern": null,
+		"selector-type-no-unknown": [
+      		true,
+      		{
+        		"ignore": ["custom-elements"]
+      		}
+    	],
 		"value-keyword-case": null
 	}
 }

--- a/js/src/components/content-button-layout/index.js
+++ b/js/src/components/content-button-layout/index.js
@@ -3,15 +3,8 @@
  */
 import './index.scss';
 
-const ContentButtonLayout = ( props ) => {
-	const { className, ...rest } = props;
-
-	return (
-		<div
-			className={ `gla-content-button-layout ${ className }` }
-			{ ...rest }
-		/>
-	);
-};
+const ContentButtonLayout = ( props ) => (
+	<woo-gla-content-button-layout { ...props } />
+);
 
 export default ContentButtonLayout;

--- a/js/src/components/content-button-layout/index.scss
+++ b/js/src/components/content-button-layout/index.scss
@@ -1,4 +1,4 @@
-.gla-content-button-layout {
+woo-gla-content-button-layout {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;


### PR DESCRIPTION
This is an example for https://github.com/woocommerce/google-listings-and-ads/issues/84

### Changes proposed in this Pull Request:

Add `ContentButtonLayout` a custom tag name.

To reduce the div-soup, and make use of modern browser features.

I believe such change could be valuable for the components that render a separate wrapping container. Like `<div class="foo">`, as opposed to components that render a document fragment, or to-be-collapsed element. As we render a separate HTML element, why don't we put some sematic into its name, instead of creating 100s of `divs`.

Please note, that this PR does **not** define **a custom element** - it should work in IE8+.
I use a `custom-name` casing, to suppress React warning for `customname`.


### Screenshots:

![Chrom Dev tools highlighting `woo-gla-content-button-layout` element](https://user-images.githubusercontent.com/17435/116815009-de025300-ab5b-11eb-9c1d-9f3421a61b77.png)


### Detailed test instructions:

1. Go to any page that uses `ContentButtonLayout` component, like https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads
2. Open dev tools, highlight the element.

### Pros:

1. Better DevX:
	1. Less blurred picture with 1000s hypnotizing `div`s.
	2. Shorter rendered code `<woo-gla-content-button-layout>` vs `<div class=".woo-gla-content-button-layout">`
	2. Shorter working code [`update/84-custom-name?expand=1`#diff-794cef5df7](https://github.com/woocommerce/google-listings-and-ads/compare/update/84-custom-name?expand=1#diff-794cef5df71654781ea327d6ce357f0b0a19247add18a4df6a420f6c072a4cea)
	3. More semantic/informative HTML tree
	4. Makes it easier to find all instances of the rendered component with: `document.querySelectorAll('my-component-name')`
2. Works even without React. (if it's just a layout component as this one). No dependencies.
3. With the custom tag name, it is easier to relate it with React component, as opposed to reading the class names. See example below.

	  ```js
	  // What we have currently:
	  // it is not immediately clear this is rendered by which React component.
	  <div class="gla-content-button-layout gla-title-button-layout many-more-class-names">
	  
	  // What this PR proposes:
	  // from the custom tag name, you can guess it is coming from ContentButtonLayout component.
	  <woo-gla-content-button-layout class="class-names-here">
	  ```

### Cons:
It's hard for me to find significant ones, please shoot if you have any.

1. It does not follow the existing "make everything a `div`" convention. 
	- This is an argument we could put against any change, and I believe the current conventions do not bring much value themselves.
2. Component names me to collide and result in conflict 
	- The same goes for the existing class name. So, this PR does not introduce any new risk. 
	- The solution for the class names could more as well be adapted for the element name. 
	- If we are about to modernize our HTML even further - go for custom elements, that issue will be solved by Scoped Custom Element Registries.
	- I believe the chances that somebody outside of this project would create a component prefixed with `woo-gla-` and called `content-button-layout` are pretty low.
3. If we would publish this component, and somebody would import it, `<woo-gla-content-…` name is not applicable.
	- Same goes for `.gla-content-…` class name.
