### PR TITLE
Proposal/RFC scoped styles

### DIFF
--- a/js/src/components/content-button-layout/index.js
+++ b/js/src/components/content-button-layout/index.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { useRef } from 'react';
-/**
  * Internal dependencies
  */
 import useShadowStyles from '.~/hooks/useShadowStyles';
@@ -14,15 +10,8 @@ const styles = /* css */ `:host {
 	gap: calc(var(--main-gap) / 2);
 }`;
 
-const ContentButtonLayout = ( props ) => {
-	const shadowHost = useRef( null );
-	useShadowStyles( shadowHost, styles );
-
-	return (
-		<div ref={ shadowHost } { ...props }>
-			{ props.children }
-		</div>
-	);
-};
+const ContentButtonLayout = ( props ) => (
+	<div ref={ useShadowStyles( styles ) } { ...props } />
+);
 
 export default ContentButtonLayout;

--- a/js/src/components/content-button-layout/index.js
+++ b/js/src/components/content-button-layout/index.js
@@ -1,16 +1,27 @@
 /**
+ * External dependencies
+ */
+import { useRef } from 'react';
+/**
  * Internal dependencies
  */
-import './index.scss';
+import useShadowStyles from '.~/hooks/useShadowStyles';
+
+const styles = /* css */ `:host {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: calc(var(--main-gap) / 2);
+}`;
 
 const ContentButtonLayout = ( props ) => {
-	const { className, ...rest } = props;
+	const shadowHost = useRef( null );
+	useShadowStyles( shadowHost, styles );
 
 	return (
-		<div
-			className={ `gla-content-button-layout ${ className }` }
-			{ ...rest }
-		/>
+		<div ref={ shadowHost } { ...props }>
+			{ props.children }
+		</div>
 	);
 };
 

--- a/js/src/components/content-button-layout/index.scss
+++ b/js/src/components/content-button-layout/index.scss
@@ -1,6 +1,0 @@
-.gla-content-button-layout {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	gap: calc(var(--main-gap) / 2);
-}

--- a/js/src/hooks/useShadowStyles.js
+++ b/js/src/hooks/useShadowStyles.js
@@ -1,21 +1,21 @@
 /**
  * External dependencies
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 /**
  * Adds encapsulated styles to a given element.
  * Adds given inline CSS or array of constructed stylesheets to element's shadow root.
  *
- * @param {HTMLElement} shadowHost Reference to HTMLElement to be styled.
  * @param {string} inlineStyles Styles to be addes inline.
  * @param {Array<CSSStyleSheet> | null} styleSheets Array of (constructed) style sheets to be adopted.
+ * @return {Object} React ref for a HTMLElement to be styled.
  */
 export default function useShadowStyles(
-	shadowHost,
 	inlineStyles = '',
 	styleSheets = null
 ) {
+	const shadowHost = useRef( null );
 	useEffect( () => {
 		if ( shadowHost.current ) {
 			if ( ! shadowHost.current.shadowRoot ) {
@@ -29,4 +29,6 @@ export default function useShadowStyles(
 			}
 		}
 	}, [ shadowHost, inlineStyles, styleSheets ] );
+
+	return shadowHost;
 }

--- a/js/src/hooks/useShadowStyles.js
+++ b/js/src/hooks/useShadowStyles.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+
+/**
+ * Adds encapsulated styles to a given element.
+ * Adds given inline CSS or array of constructed stylesheets to element's shadow root.
+ *
+ * @param {HTMLElement} shadowHost Reference to HTMLElement to be styled.
+ * @param {string} inlineStyles Styles to be addes inline.
+ * @param {Array<CSSStyleSheet> | null} styleSheets Array of (constructed) style sheets to be adopted.
+ */
+export default function useShadowStyles(
+	shadowHost,
+	inlineStyles = '',
+	styleSheets = null
+) {
+	useEffect( () => {
+		if ( shadowHost.current ) {
+			if ( ! shadowHost.current.shadowRoot ) {
+				const shadowRoot = shadowHost.current.attachShadow( {
+					mode: 'open',
+				} );
+				shadowRoot.innerHTML = `<style>${ inlineStyles }</style><slot></slot>`;
+				if ( styleSheets && styleSheets.length > 0 ) {
+					shadowRoot.adoptedStyleSheets = styleSheets;
+				}
+			}
+		}
+	}, [ shadowHost, inlineStyles, styleSheets ] );
+}


### PR DESCRIPTION
This is an experiment/proposal/RFC for a style scoping solution to address https://github.com/woocommerce/google-listings-and-ads/issues/65
- leaking & conflicting styles,
- class names conflicts
- CSS-in-JS ergonomics

(Could be considered a native alternative to libraries like styled-components / emotion https://github.com/woocommerce/google-listings-and-ads/pull/71)

This change plays well with https://github.com/woocommerce/google-listings-and-ads/pull/538, but could be totally separated.

### Live demo

https://codesandbox.io/s/scoped-shadow-styles-for-react-82wrh?file=/src/components/QuoteCard.js


### Changes proposed in this Pull Request:

Encapsulate `ContentButtonLayout`'s styles.
Move them as inline styles to element's shadow root.

Add `useShadowStyles` hook,  to separate style encapsulation logic.


I'm using inline styles here to simplify the PR, we can use `CSSStyleSheets` but making them work in all browsers https://caniuse.com/mdn-api_cssstylesheet_replacesync would require a little bit more code that could blur the picture. I guess with our heavy cannon of webpack, generating stylesheet objects, adding css imports, adding them as chunked styles, should be a big deal.

See styleSheet version at [fix/65-encapsulated-stylesheets](https://github.com/woocommerce/google-listings-and-ads/compare/fix/65-encapsulated-stylesheets)

Please note, that components `children` are still rendered in the light DOM, so are accessible for external use, styling, and manipulation as there were before.

### Screenshots:

![Screenshot of devtools showing `:host` styles for `ContentButtonLayout`](https://user-images.githubusercontent.com/17435/116822197-ca67e400-ab7d-11eb-83ba-632ff9b1b869.png)


### Detailed test instructions:

1. Go to any page that uses `ContentButtonLayout` component, like https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads
2. Open dev tools, highlight the element.


### Pros:

1. Styles do not leak. No other element would be styled with them, no matter what.
2. Element could be still easily styled/themed/specialized, with regular light DOM styles.
3. There is no class name to collide with something else.
4. Better DevX:
	1. Clear distinction, which styles pertains to the class which are instance-specific
		Shadow, `:host ...` selector styles are the class ones - applies to all instances.
		`.gla-some-class` indicates a special subset of instances to be selected.
	2. You don't have to think about the hardest thing in programming - a new class name.
	3. You can use CSS-in-JS to build, import, etc. your CSS string, or `CSSStyleSheet` object
	4. We can have single-file components (CSS and JS together), as well as the distributed cases.
	5. It's a native Web platform feature - any browser tooling will work to support it.
5. Forever backward-compatibility (native Web Feature)
6. No dependencies.

### Cons:

1. IE and older browsers are not supported, at least without polyfill. https://caniuse.com/shadowdomv1

### Fields for improvements / further exploration
1. I'm not a React expert, but I guess we could add some sugar on top, not to have to hardwire `ref` manually.
2. I don't know how React serializes markup for SSR. This should be fully serializable for Chromium with Declarative Shadow DOM. For other browsers, we could probably shim it with some selectors. Probably we will have to add few lines that dump `shadowRoot` styles back to HTML.
3. We need to take care of the fact that shadow host styles have lower origin importance than light dom ones. That's basically what we want, but we need to be aware, that it means we are slightly easier to be overwritten than overwrite.
4. We could consider adding more content to the shadow root, to be able to have encapsulated styles for more than `:host` and `::slotted( foo )`