### PR TITLE
Add a custom hook to get calculated data and its status for the Products Reporting page

### DIFF
--- a/js/src/hooks/useUrlQuery.js
+++ b/js/src/hooks/useUrlQuery.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import isEqual from 'lodash/isEqual';
+import { getQuery } from '@woocommerce/navigation';
+import { useRef } from '@wordpress/element';
+
+/**
+ * Get a memoized URL query object.
+ *
+ * @return {Object}  Current query object, defaults to empty object.
+ */
+export default function useUrlQuery() {
+	const query = getQuery();
+	const queryRef = useRef( query );
+
+	if ( ! isEqual( queryRef.current, query ) ) {
+		queryRef.current = query;
+	}
+
+	return queryRef.current;
+}

--- a/js/src/reports/products/useProductsReport.js
+++ b/js/src/reports/products/useProductsReport.js
@@ -3,19 +3,31 @@
  */
 import { useSelect } from '@wordpress/data';
 import { getQuery } from '@woocommerce/navigation';
-import { getCurrentDates } from '@woocommerce/date';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '.~/data/constants';
-import { mapReportFieldsToPerformance } from '.~/data/utils';
+import {
+	getReportQuery,
+	getReportKey,
+	mapReportFieldsToPerformance,
+} from '.~/data/utils';
 
+const category = 'products';
 const emptyData = {
 	products: [],
 	intervals: [],
 	totals: {},
 };
+
+function getDependencyString( type, query, dateReference ) {
+	return getReportKey(
+		category,
+		type,
+		getReportQuery( category, type, query, dateReference )
+	);
+}
 
 /**
  * Get products report data by source of program type.
@@ -26,21 +38,16 @@ const emptyData = {
  */
 export default function useProductsReport( type ) {
 	const query = getQuery();
-	const currentDate = getCurrentDates( query );
 	const deps = [
-		type,
-		currentDate.primary.range,
-		currentDate.secondary.range,
-		query.products,
-		query.orderby,
-		query.order,
+		getDependencyString( type, query, 'primary' ),
+		getDependencyString( type, query, 'secondary' ),
 	];
 
 	return useSelect( ( select ) => {
 		const { getReport } = select( STORE_KEY );
 
-		const primary = getReport( 'products', type, query, 'primary' );
-		const secondary = getReport( 'products', type, query, 'secondary' );
+		const primary = getReport( category, type, query, 'primary' );
+		const secondary = getReport( category, type, query, 'secondary' );
 		const loaded = primary.loaded && secondary.loaded;
 
 		let data = emptyData;

--- a/js/src/reports/products/useProductsReport.js
+++ b/js/src/reports/products/useProductsReport.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { getQuery } from '@woocommerce/navigation';
+import { getCurrentDates } from '@woocommerce/date';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '.~/data/constants';
+import { mapReportFieldsToPerformance } from '.~/data/utils';
+
+const emptyData = {
+	products: [],
+	intervals: [],
+	totals: {},
+};
+
+/**
+ * Get products report data by source of program type.
+ * Query parameters will be parsed from the URL by this hook.
+ *
+ * @param  {string} type Data source of program type, 'free' or 'paid'.
+ * @return {ProductsReportSchema} The fetched products report data and its status.
+ */
+export default function useProductsReport( type ) {
+	const query = getQuery();
+	const currentDate = getCurrentDates( query );
+	const deps = [
+		type,
+		currentDate.primary.range,
+		currentDate.secondary.range,
+		query.products,
+		query.orderby,
+		query.order,
+	];
+
+	return useSelect( ( select ) => {
+		const { getReport } = select( STORE_KEY );
+
+		const primary = getReport( 'products', type, query, 'primary' );
+		const secondary = getReport( 'products', type, query, 'secondary' );
+		const loaded = primary.loaded && secondary.loaded;
+
+		let data = emptyData;
+
+		if ( loaded ) {
+			data = {
+				products: primary.data.products || emptyData.products,
+				intervals: primary.data.intervals || emptyData.intervals,
+				totals: mapReportFieldsToPerformance(
+					primary.data.totals,
+					secondary.data.totals
+				),
+			};
+		}
+
+		return { data, loaded };
+	}, deps );
+}
+
+/**
+ * Schema of the `useProductsReport` hook
+ *
+ * @typedef {Object} ProductsReportSchema
+ * @property {boolean} loaded Whether the data have been loaded.
+ * @property {ProductsReportData} data Fetched products report data.
+ */
+
+/**
+ * @typedef {Object} ProductsReportData
+ * @property {Array<ProductsData>} products Products data.
+ * @property {Array<IntervalsData>} intervals Intervals data.
+ * @property {PerformanceData} totals Performance data.
+ */
+
+/**
+ * @typedef {Object} ProductsData
+ * @property {number} id Product ID.
+ * @property {TotalsData} subtotals Performance data.
+ */
+
+/**
+ * @typedef {Object} IntervalsData
+ * @property {string} interval ID of this report segment.
+ * @property {TotalsData} subtotals Performance data.
+ */
+
+/**
+ * @typedef { import(".~/data/utils").ReportFieldsSchema } TotalsData
+ * @typedef { import(".~/data/utils").PerformanceData } PerformanceData
+ */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It a pre-tuning PR for #244 and also a follow-up development of #524.
- Add a custom hook to get calculated data and its status for the Products Reporting page

### Detailed test instructions:

💡. For easier mock testing, I pushed another branch `feature/244-products-report-hook-mock-local` with some mock code, which located at:
- Trigger data fetching and print log
    https://github.com/woocommerce/google-listings-and-ads/blob/aaeed073d6ed22c41e992fb1bb2559003a65df8d/js/src/reports/products/index.js#L49-L51
- Mock paid data
    https://github.com/woocommerce/google-listings-and-ads/blob/aaeed073d6ed22c41e992fb1bb2559003a65df8d/src/API/Site/Controllers/Ads/ReportsController.php#L84-L94
- Mock free data
    https://github.com/woocommerce/google-listings-and-ads/blob/aaeed073d6ed22c41e992fb1bb2559003a65df8d/src/API/Site/Controllers/MerchantCenter/ReportsController.php#L83-L90

🩺 . Test with the UIs
1. Checkout `feature/244-products-report-hook-mock-local` branch
2. Head to the Products Reporting page: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fproducts`
3. Data aren't connected to the UI yet, please open browser DevTool to view the fetched data from the Console panel
4. Made some change on **Date Range** or **Show** UIs, it should reflect with query change and then triggering relevant data fetching, but duplicate query would not re-trigger unnecessary request.
    ![image](https://user-images.githubusercontent.com/17420811/116854209-eb860e80-ac29-11eb-80ce-f60d87f1d3b7.png)
