### PR TITLE
Specify `argsRef.current` as dependency in `useAppSelectDispatch`

### DIFF
--- a/js/src/hooks/useAppSelectDispatch.js
+++ b/js/src/hooks/useAppSelectDispatch.js
@@ -38,7 +38,7 @@ const useAppSelectDispatch = ( selector, ...args ) => {
 				invalidateResolution: invalidateResolutionCallback,
 			};
 		},
-		[ invalidateResolutionCallback, selector ]
+		[ invalidateResolutionCallback, selector, argsRef.current ]
 	);
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #542 .

This PR specifies `argsRef.current` as dependency in `useSelect` in `useAppSelectDispatch`, so that the `mapSelect` function runs when `argsRef.current` is changed.

### Screenshots:

Demo video for fixing #542 (https://d.pr/v/Cel2ij):

https://user-images.githubusercontent.com/417342/117011244-384c1100-ad20-11eb-9781-9c63c4d45e94.mp4

### Detailed test instructions:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed
2. In the "Issues to resolve" table, click on the right and left pagination arrow. The data should load and display correctly.

### Changelog Note:

Fix: specify `argsRef.current` as dependency in `useSelect` in `useAppSelectDispatch`, so that the `mapSelect` function runs when `argsRef.current` is changed.
