### PR TITLE
Clean up TODO comments

### DIFF
--- a/js/src/components/free-listings/choose-audience/form-content.js
+++ b/js/src/components/free-listings/choose-audience/form-content.js
@@ -59,11 +59,10 @@ const FormContent = ( props ) => {
 									),
 									{
 										link: (
-											// TODO: check URL and track event is correct.
 											<AppDocumentationLink
 												context="setup-mc-audience"
 												linkId="site-language"
-												href="https://support.google.com/merchants/answer/160491"
+												href="https://support.google.com/merchants/answer/160637"
 											/>
 										),
 									}

--- a/js/src/components/free-listings/configure-product-listings/combined-shipping/index.js
+++ b/js/src/components/free-listings/configure-product-listings/combined-shipping/index.js
@@ -55,11 +55,10 @@ const CombinedShipping = ( { formProps, countries: selectedCountryCodes } ) => {
 						) }
 					</p>
 					<p>
-						{ /* TODO: Link to read more on shipping rate. */ }
 						<AppDocumentationLink
 							context="setup-mc-shipping-rate"
 							linkId="shipping-rate-read-more"
-							href="https://docs.woocommerce.com/"
+							href="https://support.google.com/merchants/answer/7050921"
 						>
 							{ __( 'Read more', 'google-listings-and-ads' ) }
 						</AppDocumentationLink>

--- a/js/src/components/free-listings/configure-product-listings/tax-rate.js
+++ b/js/src/components/free-listings/configure-product-listings/tax-rate.js
@@ -33,11 +33,10 @@ const TaxRate = ( props ) => {
 						) }
 					</p>
 					<p>
-						{ /* TODO: Link to read more on shipping rate. */ }
 						<AppDocumentationLink
 							context="setup-mc-tax-rate"
 							linkId="tax-rate-read-more"
-							href="https://docs.woocommerce.com/"
+							href="https://support.google.com/merchants/answer/160162"
 						>
 							{ __( 'Read more', 'google-listings-and-ads' ) }
 						</AppDocumentationLink>

--- a/js/src/components/stepper/top-bar/index.js
+++ b/js/src/components/stepper/top-bar/index.js
@@ -40,7 +40,6 @@ const TopBar = ( {
 			</Link>
 			<span className="title">{ title }</span>
 			<div className="actions">
-				{ /* TODO: click and navigate to where? */ }
 				<AppIconButton
 					icon={ <GridiconHelpOutline /> }
 					text={ __( 'Help', 'google-listings-and-ads' ) }

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -64,8 +64,6 @@ const AllProgramsTableCard = ( props ) => {
 		return <AppSpinner />;
 	}
 
-	// TODO: data from backend API.
-	// using the above query (e.g. orderby, order and page) as parameter.
 	const data = [
 		{
 			id: FREE_LISTINGS_PROGRAM_ID,

--- a/js/src/setup-ads/ads-stepper/index.js
+++ b/js/src/setup-ads/ads-stepper/index.js
@@ -15,13 +15,10 @@ import './index.scss';
 
 const AdsStepper = ( props ) => {
 	const { formProps } = props;
-
-	// TODO: call API and check if users have already done the account setup,
-	// we can straight away bring them to step 2.
 	const [ step, setStep ] = useState( '1' );
 
-	// TOOD: figure out when to allow and not to allow step click.
-	// Right now we just allow them to go backward, not forward.
+	// Allow the users to go backward only, not forward.
+	// Users can only go forward by clicking on the Continue button.
 	const handleStepClick = ( value ) => {
 		if ( value < step ) {
 			setStep( value );

--- a/js/src/setup-ads/top-bar/index.js
+++ b/js/src/setup-ads/top-bar/index.js
@@ -20,8 +20,6 @@ const SetupAdsTopBar = () => {
 
 	const handleHelpButtonClick = () => {
 		recordSetupAdsEvent( 'help' );
-
-		// TODO: navigate to where upon clicking help link?
 	};
 
 	return (

--- a/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
@@ -62,11 +62,10 @@ const FormContent = ( props ) => {
 									),
 									{
 										link: (
-											// TODO: check URL and track event is correct.
 											<AppDocumentationLink
 												context="setup-mc-audience"
 												linkId="site-language"
-												href="https://support.google.com/merchants/answer/160491"
+												href="https://support.google.com/merchants/answer/160637"
 											/>
 										),
 									}

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/pre-launch-checklist/index.js
@@ -35,11 +35,10 @@ const PreLaunchChecklist = ( props ) => {
 							) }
 						</p>
 						<p>
-							{ /* TODO: Link to read more on Google Merchant requirements. */ }
 							<AppDocumentationLink
 								context="setup-mc-checklist"
 								linkId="checklist-requirements"
-								href="https://www.google.com/"
+								href="https://support.google.com/merchants/answer/6363310"
 							>
 								{ __(
 									'Read Google Merchant requirements',
@@ -91,7 +90,6 @@ const PreLaunchChecklist = ( props ) => {
 												) }
 											</p>
 											<p>
-												{ /* TODO: link URL. */ }
 												{ createInterpolateElement(
 													__(
 														'Payment and transaction processing, as well as collection of any sensitive and financial personal information from the user, must be conducted over a secure processing server (SSL-protected, with a valid SSL certificate - https://). <link>Read more</link>',
@@ -102,7 +100,7 @@ const PreLaunchChecklist = ( props ) => {
 															<AppDocumentationLink
 																context="setup-mc-checklist"
 																linkId="check-checkout-process"
-																href="https://www.google.com/retail/solutions/merchant-center/"
+																href="https://support.google.com/merchants/answer/2704221#wycd-unsafe-collection-or-use-of-personal-information"
 															/>
 														),
 													}

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/index.js
@@ -37,11 +37,10 @@ const ShippingRate = ( props ) => {
 						) }
 					</p>
 					<p>
-						{ /* TODO: Link to read more on shipping rate. */ }
 						<AppDocumentationLink
 							context="setup-mc-shipping-rate"
 							linkId="shipping-rate-read-more"
-							href="https://docs.woocommerce.com/"
+							href="https://support.google.com/merchants/answer/6069284"
 						>
 							{ __( 'Read more', 'google-listings-and-ads' ) }
 						</AppDocumentationLink>

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/index.js
@@ -37,11 +37,10 @@ const ShippingTime = ( props ) => {
 						) }
 					</p>
 					<p>
-						{ /* TODO: Link to read more on shipping rate. */ }
 						<AppDocumentationLink
 							context="setup-mc-shipping-time"
 							linkId="shipping-time-read-more"
-							href="https://docs.woocommerce.com/"
+							href="https://support.google.com/merchants/answer/7409926"
 						>
 							{ __( 'Read more', 'google-listings-and-ads' ) }
 						</AppDocumentationLink>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fix links to Google documentations and removed the associated TODO comments. The links are based on what I found based on Google Search, and I used my best judgement to select the closest possible ones.
- Removed some unneeded TODO comments because they are obsolete or not applicable.

While I was going through the TODO comments in our JS code base, I also created a few issues for those TODO:

- Help Button: action upon click? #550
- Edit Free Listings: Validation logic #551
- Shipping rates and shipping times: Add and edit modals - validation logic #552
- Remove Beta Testing UI for production release #553

When the above issues are done, this would further reduce down the number of TODO comments in our JS code base.

Note that since Reports (`js/src/reports/*`) are still being actively worked on, I did not touch any TODO within that directory to prevent work conflict.

### Screenshots:

Nil.

### Detailed test instructions:

This is mainly technical code clean up, we probably don't need to test anything specific on this.

One thing we can test is to test on the changed documentation links and make sure that a correct sensible documentation page shows up.

### Changelog Note:

Fix links to documentations; code clean up.
