### PR TITLE
Some README and contributor documentation updates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+-   Using welcoming and inclusive language
+-   Being respectful of differing viewpoints and experiences
+-   Gracefully accepting constructive criticism
+-   Focusing on what is best for the community
+-   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+-   The use of sexualized language or imagery and unwelcome sexual attention or advances
+-   Trolling, insulting/derogatory comments, and personal or political attacks
+-   Public or private harassment
+-   Publishing others' private information, such as a physical or electronic address, without explicit permission
+-   Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project email address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Thanks for your interest in contributing to Google Listings and Ads!
+
+## Guidelines
+
+Like the WooCommerce project, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Reporting Security Issues
+
+Please see [SECURITY.md](./SECURITY.md).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting Security Issues
+
+The WooCommerce team take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To disclose a security issue to our team, [please submit a report via HackerOne here](https://hackerone.com/automattic/).

--- a/README.md
+++ b/README.md
@@ -89,8 +89,3 @@ What is considered private?
 * Internal Automattic links. Default to summarizing the information instead. If you must it’s OK to use shorthand (e.g., 1234-wpcom) but please try to summarize.
 * References to filenames in proprietary codebases. E.g. or a reference to a private repository.
 * Images that show private user data… or any of the above.
-
-## Project Management
-
- - [Project Board](https://github.com/woocommerce/google-listings-and-ads/projects/1)
- - [Issue breakdown by integration area project board](https://github.com/woocommerce/google-listings-and-ads/projects/2)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A native integration with Google offering free listings and Smart Shopping ads to WooCommerce merchants.
 
+- [WooCommerce.com product page](https://woocommerce.com/products/google-listings-and-ads/)
+- [WordPress.org plugin page](https://wordpress.org/plugins/google-listings-and-ads/)
+- [User documentation](https://docs.woocommerce.com/document/google-listings-and-ads/)
+- [Ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=403986)
+
+## Support
+
+This repository is not suitable for support. Please don't use our issue tracker for support requests.
+
+For self help, start with our [user documentation](https://docs.woocommerce.com/document/google-listings-and-ads/).
+
+The best place to get support is the [WordPress.org Google Listings and Ads forum](https://wordpress.org/support/plugin/google-listings-and-ads/).
+
+If you have a WooCommerce.com account, you can [start a chat or open a ticket on WooCommerce.com](https://woocommerce.com/my-account/create-a-ticket/).
+
 ## Prerequisites
 
  - WordPress 5.3+
@@ -76,16 +91,8 @@ To delete the Docker container (this will **delete everything** in the WordPress
 
 * [Usage Tracking](./src/Tracking/README.md)
 
-## Please treat this repo as public
-
-* Avoid posting any private or sensitive information
-* Avoid posting anything that could be misunderstood by community contributors or that is heavily Automattic-centric
-* Default to open and keep as much conversation in Github as possible. In cases where private conversation happens on a P2 or in Slack, post a brief summary to GitHub instead of simply adding a private link.
-
-What is considered private?
-
-* Personally identifiable information (PII). Usernames, emails, user IDs, blog names, blog urls, blog IDs, credit card details. It’s best not to include our own usernames, emails, user IDs, etc. Better to use test data with a test user on a test blog.
-* Passwords, tokens, private keys, etc.
-* Internal Automattic links. Default to summarizing the information instead. If you must it’s OK to use shorthand (e.g., 1234-wpcom) but please try to summarize.
-* References to filenames in proprietary codebases. E.g. or a reference to a private repository.
-* Images that show private user data… or any of the above.
+<p align="center">
+	<br/><br/>
+	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
+	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
+</p>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* Updates README.md with links to product pages, docs, and ideas board
* Adds initial SECURITY.md (borrowed from core + blocks)
* Adds initial CODE_OF_CONDUCT.md (borrowed from blocks)
* Adds initial CONTRIBUTOR.md

The initial.md files are used by github
* [Adding a security policy](https://docs.github.com/en/code-security/security-advisories/adding-a-security-policy-to-your-repository)
* [Adding a code of conduct](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project)
* [Setting guidelines for contributors](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)
