### PR TITLE
WIP: Switch back to non-beta versions of `SwitchUrlCard` & `ReclaimUrlCard`.

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -15,8 +15,8 @@ import Subsection from '.~/wcdl/subsection';
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
-import BetaSwitchUrlCard from '../beta-switch-url-card';
-import BetaReclaimUrlCard from '../beta-reclaim-url-card';
+import SwitchUrlCard from '../switch-url-card';
+import ReclaimUrlCard from '../reclaim-url-card';
 
 const ConnectMCCard = ( props ) => {
 	const { onCreateNew = () => {} } = props;
@@ -46,10 +46,9 @@ const ConnectMCCard = ( props ) => {
 
 	if ( response && response.status === 409 ) {
 		return (
-			// TODO: Use the BetaSwitchUrlCard for beta testing purpose only.
-			// To switch back to SwitchUrlCard for production roll out.
-			// <SwitchUrlCard
-			<BetaSwitchUrlCard
+			// Switch to BetaSwitchUrlCard for beta testing.
+			// <BetaSwitchUrlCard
+			<SwitchUrlCard
 				id={ error.id }
 				message={ error.message }
 				claimedUrl={ error.claimed_url }
@@ -60,10 +59,9 @@ const ConnectMCCard = ( props ) => {
 	}
 
 	if ( response && response.status === 403 ) {
-		// TODO: Use the BetaReclaimUrlCard for beta testing purpose only.
-		// To switch back to ReclaimUrlCard for production roll out.
-		// return <ReclaimUrlCard websiteUrl={ error.website_url } />;
-		return <BetaReclaimUrlCard websiteUrl={ error.website_url } />;
+		// Switch to BetaReclaimUrlCard for beta testing.
+		// return <BetaReclaimUrlCard websiteUrl={ error.website_url } />;
+		return <ReclaimUrlCard websiteUrl={ error.website_url } />;
 	}
 
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -18,8 +18,6 @@ import ContentButtonLayout from '.~/components/content-button-layout';
 import ReclaimUrlFailCard from './reclaim-url-fail-card';
 
 /**
- * Temporarily unused for beta testing period. This should be used in production later.
- *
  * @param {Object} props Props.
  */
 const ReclaimUrlCard = ( props ) => {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
@@ -18,8 +18,6 @@ import ContentButtonLayout from '.~/components/content-button-layout';
 import './index.scss';
 
 /**
- * Temporarily unused for beta testing period. This should be used in production later.
- *
  * @param {Object} props Props.
  */
 const SwitchUrlCard = ( props ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Switch back to non-beta versions of SwitchUrlCard & ReclaimUrlCard.

Fixes: https://github.com/woocommerce/google-listings-and-ads/issues/553.


### Screenshots:



### Detailed test instructions:

1. 
2. 
3. 


### Changelog Note:

> Switch back to non-beta versions of `SwitchUrlCard` & `ReclaimUrlCard`.
