### PR TITLE
Add more props and formatting to the shared summary component for report pages

### DIFF
--- a/js/src/hooks/useCurrencyFactory.js
+++ b/js/src/hooks/useCurrencyFactory.js
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { useMemo } from '@wordpress/element';
 import CurrencyFactory from '@woocommerce/currency';
+
+/**
+ * Internal dependencies
+ */
+import useStoreCurrency from './useStoreCurrency';
 
 /**
  * Gets the CurrencyFactory to format string based on the store's currency settings.
  */
 const useCurrencyFactory = () => {
-	const currencySetting = useSelect( ( select ) => {
-		return select( SETTINGS_STORE_NAME ).getSetting(
-			'wc_admin',
-			'currency'
-		);
-	} );
-
-	return CurrencyFactory( currencySetting );
+	const currencySetting = useStoreCurrency();
+	return useMemo( () => CurrencyFactory( currencySetting ), [
+		currencySetting,
+	] );
 };
 
 export default useCurrencyFactory;

--- a/js/src/hooks/useCurrencyFormat.js
+++ b/js/src/hooks/useCurrencyFormat.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useMemo } from '@wordpress/element';
 import { numberFormat } from '@woocommerce/number';
 
 /**
@@ -12,13 +13,18 @@ import useStoreCurrency from './useStoreCurrency';
  * Gets a formatter function to format a number based on the store's currency settings.
  *
  * The formatted string does not contain currency code or symbol.
+ *
+ * @param {Object} [overrideSetting] Currency setting to override store's.
  */
-const useCurrencyFormat = () => {
+const useCurrencyFormat = ( overrideSetting ) => {
 	const currencySetting = useStoreCurrency();
-
-	return ( number ) => {
-		return numberFormat( currencySetting, number );
-	};
+	return useMemo( () => {
+		const mergedSetting = {
+			...currencySetting,
+			...overrideSetting,
+		};
+		return ( number ) => numberFormat( mergedSetting, number );
+	}, [ currencySetting, overrideSetting ] );
 };
 
 export default useCurrencyFormat;

--- a/js/src/hooks/useStoreCurrency.js
+++ b/js/src/hooks/useStoreCurrency.js
@@ -22,7 +22,7 @@ const useStoreCurrency = () => {
 			'wc_admin',
 			'currency'
 		);
-	} );
+	}, [] );
 };
 
 export default useStoreCurrency;

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -20,8 +20,11 @@ import AppTooltip from '.~/components/app-tooltip';
  *
  * @param {Object} props
  * @param {string} props.label Metric label.
+ * @param {string} [props.href] An internal link to the report focused on this metric.
+ * @param {boolean} [props.selected] Whether show a highlight style on this metric.
  * @param {Object} props.data Data as get from API.
- * @param {string} props.data.value
+ * @param {number} props.data.value
+ * @param {number} props.data.prevValue
  * @param {string} props.data.delta
  * @param {boolean} props.data.missingFreeListingsData Flag indicating whether the data miss entries from Free Listings.
  *
@@ -29,7 +32,9 @@ import AppTooltip from '.~/components/app-tooltip';
  */
 const MetricNumber = ( {
 	label,
-	data: { value, delta, missingFreeListingsData },
+	href,
+	selected,
+	data: { value, prevValue, delta, missingFreeListingsData },
 } ) => {
 	let markedLabel = label;
 
@@ -54,7 +59,14 @@ const MetricNumber = ( {
 		);
 	}
 	return (
-		<SummaryNumber label={ markedLabel } value={ value } delta={ delta } />
+		<SummaryNumber
+			label={ markedLabel }
+			href={ href }
+			selected={ selected }
+			value={ value }
+			prevValue={ prevValue }
+			delta={ delta }
+		/>
 	);
 };
 

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 import { SummaryNumber } from '@woocommerce/components';
 import GridiconInfoOutline from 'gridicons/dist/info-outline';
 
@@ -10,6 +11,10 @@ import GridiconInfoOutline from 'gridicons/dist/info-outline';
  */
 import './metric-number.scss';
 import AppTooltip from '.~/components/app-tooltip';
+import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
+import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
+
+const numberFormatSetting = { precision: 0 };
 
 /**
  * SummeryNumber annotated about missing data.
@@ -22,6 +27,8 @@ import AppTooltip from '.~/components/app-tooltip';
  * @param {string} props.label Metric label.
  * @param {string} [props.href] An internal link to the report focused on this metric.
  * @param {boolean} [props.selected] Whether show a highlight style on this metric.
+ * @param {boolean} [props.isCurrency=false] Display `data.value` and `data.prevValue` as price format if true.
+ *                                           Otherwise, display as number format.
  * @param {Object} props.data Data as get from API.
  * @param {number} props.data.value
  * @param {number} props.data.prevValue
@@ -34,8 +41,20 @@ const MetricNumber = ( {
 	label,
 	href,
 	selected,
+	isCurrency = false,
 	data: { value, prevValue, delta, missingFreeListingsData },
 } ) => {
+	const formatNumber = useCurrencyFormat( numberFormatSetting );
+	const { formatAmount } = useCurrencyFactory();
+	const valueProps = useMemo( () => {
+		const formatFn = isCurrency ? formatAmount : formatNumber;
+
+		return {
+			value: formatFn( value ),
+			prevValue: formatFn( prevValue ),
+		};
+	}, [ isCurrency, value, prevValue, formatNumber, formatAmount ] );
+
 	let markedLabel = label;
 
 	// Until ~Q4 2021, metrics for all programs, may lack data for free listings.
@@ -63,9 +82,8 @@ const MetricNumber = ( {
 			label={ markedLabel }
 			href={ href }
 			selected={ selected }
-			value={ value }
-			prevValue={ prevValue }
 			delta={ delta }
+			{ ...valueProps }
 		/>
 	);
 };

--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -26,7 +26,7 @@ const compareParam = 'filter';
  * @see AppTableCard
  *
  * @param {Object} props React props.
- * @param {[[string, string]]} props.metrics Metrics array of each metric tuple [key, label].
+ * @param {Array<Metric>} props.metrics Metrics to display.
  * @param {Object} [props.restProps] Properties to be forwarded to AppTableCard.
  */
 const CompareProductsTableCard = ( { metrics, ...restProps } ) => {
@@ -36,9 +36,8 @@ const CompareProductsTableCard = ( { metrics, ...restProps } ) => {
 	} );
 
 	const availableMetricHeaders = useMemo( () => {
-		const headers = metrics.map( ( [ key, label ] ) => ( {
-			key,
-			label,
+		const headers = metrics.map( ( metric ) => ( {
+			...metric,
 			isSortable: true,
 		} ) );
 		headers[ 0 ].defaultSort = true;
@@ -189,3 +188,7 @@ const CompareProductsTableCard = ( { metrics, ...restProps } ) => {
 };
 
 export default CompareProductsTableCard;
+
+/**
+ * @typedef {import("./index.js").Metric} Metric
+ */

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getQuery } from '@woocommerce/navigation';
-import { SummaryList, Chart } from '@woocommerce/components';
+import { Chart } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -14,16 +14,16 @@ import {
 	REPORT_SOURCE_PAID,
 	REPORT_SOURCE_DEFAULT,
 } from '.~/constants';
+import useProductsReport from './useProductsReport';
 import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
 import AppSpinner from '.~/components/app-spinner';
 import TabNav from '../../tab-nav';
 import ProductsReportFilters from './products-report-filters';
-import MetricNumber from '../metric-number';
+import SummarySection from './summary-section';
 import CompareProductsTableCard from './compare-products-table-card';
 
 import chartData from './mocked-chart-data';
 import SubNav from '../sub-nav';
-import getMetricsData from './mocked-metrics-data'; // Mocked data
 
 /**
  * Available metrics and their human-readable labels.
@@ -35,7 +35,7 @@ const freeMetrics = [
 	[ 'impressions', __( 'Impressions', 'google-listings-and-ads' ) ],
 ];
 const paidMetrics = [
-	[ 'sales', __( 'Total Sales', 'google-listings-and-ads' ) ],
+	[ 'sales', __( 'Total Sales', 'google-listings-and-ads' ), true ],
 	[ 'conversions', __( 'Conversions', 'google-listings-and-ads' ) ],
 	...freeMetrics,
 ];
@@ -49,7 +49,6 @@ const paidMetrics = [
 const ProductsReport = ( { hasPaidSource } ) => {
 	const reportId = 'reports-products';
 	const query = getQuery();
-	const metricsData = getMetricsData();
 
 	const type = hasPaidSource
 		? query[ REPORT_SOURCE_PARAM ] || REPORT_SOURCE_DEFAULT
@@ -66,17 +65,7 @@ const ProductsReport = ( { hasPaidSource } ) => {
 				query={ query }
 				report={ reportId }
 			/>
-			<SummaryList>
-				{ () =>
-					metrics.map( ( [ key, label ] ) => (
-						<MetricNumber
-							key={ key }
-							label={ label }
-							data={ metricsData[ key ] }
-						/>
-					) )
-				}
-			</SummaryList>
+			<SummarySection metrics={ metrics } />
 			<Chart
 				data={ chartData }
 				title="Conversions"

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -27,15 +27,28 @@ import SubNav from '../sub-nav';
 /**
  * Available metrics and their human-readable labels.
  *
- * @type {Array<Array<string>>}
+ * @type {Array<Metric>}
  */
 const freeMetrics = [
-	[ 'clicks', __( 'Clicks', 'google-listings-and-ads' ) ],
-	[ 'impressions', __( 'Impressions', 'google-listings-and-ads' ) ],
+	{
+		key: 'clicks',
+		label: __( 'Clicks', 'google-listings-and-ads' ),
+	},
+	{
+		key: 'impressions',
+		label: __( 'Impressions', 'google-listings-and-ads' ),
+	},
 ];
 const paidMetrics = [
-	[ 'sales', __( 'Total Sales', 'google-listings-and-ads' ), true ],
-	[ 'conversions', __( 'Conversions', 'google-listings-and-ads' ) ],
+	{
+		key: 'sales',
+		label: __( 'Total Sales', 'google-listings-and-ads' ),
+		isCurrency: true,
+	},
+	{
+		key: 'conversions',
+		label: __( 'Conversions', 'google-listings-and-ads' ),
+	},
 	...freeMetrics,
 ];
 
@@ -102,3 +115,10 @@ const ProductsReportPage = () => {
 };
 
 export default ProductsReportPage;
+
+/**
+ * @typedef {Object} Metric Metric item structure for disaplying label and its currency type.
+ * @property {string} key Metric key.
+ * @property {string} label Metric label to display.
+ * @property {boolean} [isCurrency] Metric is a currency if true.
+ */

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -14,7 +14,6 @@ import {
 	REPORT_SOURCE_PAID,
 	REPORT_SOURCE_DEFAULT,
 } from '.~/constants';
-import useProductsReport from './useProductsReport';
 import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
 import AppSpinner from '.~/components/app-spinner';
 import TabNav from '../../tab-nav';

--- a/js/src/reports/products/mocked-metrics-data.js
+++ b/js/src/reports/products/mocked-metrics-data.js
@@ -15,31 +15,25 @@ export default function () {
 
 	const data = {
 		clicks: {
-			value: '14,135',
+			value: 14135,
 			delta: 0,
 			label: 'Clicks',
 		},
 		impressions: {
-			value: '383,512',
+			value: 383512,
 			delta: 1.28,
 			label: 'Impressions',
 		},
 	};
 	const conditionalData = {
-		itemsSold: {
-			value: '6,928',
-			delta: 0.35,
-			label: 'itemsSold',
-			missingFreeListingsData,
-		},
 		conversions: {
-			value: '4,102',
+			value: 4102,
 			delta: -2.21,
 			label: 'Conversions',
 			missingFreeListingsData,
 		},
 		sales: {
-			value: '$10,802.93',
+			value: 10802.93,
 			delta: 5.35,
 			label: 'Net Sales',
 			missingFreeListingsData,

--- a/js/src/reports/products/summary-section.js
+++ b/js/src/reports/products/summary-section.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { SummaryList } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import MetricNumber from '../metric-number';
+import getMetricsData from './mocked-metrics-data';
+
+/**
+ * Renders a section composed with SummaryList and MetricNumber.
+ *
+ * @param {Object} props React props.
+ * @param {[[string, string, boolean]]} props.metrics Metrics array of each metric tuple [key, label, isCurrency=false].
+ */
+export default function SummarySection( { metrics } ) {
+	const metricsData = getMetricsData();
+
+	return (
+		<SummaryList>
+			{ () =>
+				metrics.map( ( [ key, label, isCurrency = false ] ) => {
+					return (
+						<MetricNumber
+							key={ key }
+							label={ label }
+							isCurrency={ isCurrency }
+							data={ metricsData[ key ] }
+						/>
+					);
+				} )
+			}
+		</SummaryList>
+	);
+}

--- a/js/src/reports/products/summary-section.js
+++ b/js/src/reports/products/summary-section.js
@@ -15,17 +15,17 @@ import getMetricsData from './mocked-metrics-data';
  * Renders a section composed with SummaryList and MetricNumber.
  *
  * @param {Object} props React props.
- * @param {[[string, string, boolean]]} props.metrics Metrics array of each metric tuple [key, label, isCurrency=false].
+ * @param {Array<Metric>} props.metrics Metrics to display.
  */
 export default function SummarySection( { metrics } ) {
 	const query = useUrlQuery();
 	const metricsData = getMetricsData();
-	const { orderby = metrics[ 0 ][ 0 ] } = query;
+	const { orderby = metrics[ 0 ].key } = query;
 
 	return (
 		<SummaryList>
 			{ () =>
-				metrics.map( ( [ key, label, isCurrency = false ] ) => {
+				metrics.map( ( { key, label, isCurrency = false } ) => {
 					const selected = orderby === key;
 					const href = getNewPath( { orderby: key } );
 					return (
@@ -43,3 +43,7 @@ export default function SummarySection( { metrics } ) {
 		</SummaryList>
 	);
 }
+
+/**
+ * @typedef {import("./index.js").Metric} Metric
+ */

--- a/js/src/reports/products/summary-section.js
+++ b/js/src/reports/products/summary-section.js
@@ -2,10 +2,12 @@
  * External dependencies
  */
 import { SummaryList } from '@woocommerce/components';
+import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import useUrlQuery from '.~/hooks/useUrlQuery';
 import MetricNumber from '../metric-number';
 import getMetricsData from './mocked-metrics-data';
 
@@ -16,16 +18,22 @@ import getMetricsData from './mocked-metrics-data';
  * @param {[[string, string, boolean]]} props.metrics Metrics array of each metric tuple [key, label, isCurrency=false].
  */
 export default function SummarySection( { metrics } ) {
+	const query = useUrlQuery();
 	const metricsData = getMetricsData();
+	const { orderby = metrics[ 0 ][ 0 ] } = query;
 
 	return (
 		<SummaryList>
 			{ () =>
 				metrics.map( ( [ key, label, isCurrency = false ] ) => {
+					const selected = orderby === key;
+					const href = getNewPath( { orderby: key } );
 					return (
 						<MetricNumber
 							key={ key }
 							label={ label }
+							href={ href }
+							selected={ selected }
 							isCurrency={ isCurrency }
 							data={ metricsData[ key ] }
 						/>

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -22,12 +22,12 @@ import metricsData from './mocked-metrics-data'; // Mocked data
  * @type {Map<string, string>}
  */
 const performanceMetrics = [
-	[ 'netSales', __( 'Net Sales', 'google-listings-and-ads' ) ],
+	[ 'netSales', __( 'Net Sales', 'google-listings-and-ads' ), true ],
 	[ 'itemsSold', __( 'Items Sold', 'google-listings-and-ads' ) ],
 	[ 'conversions', __( 'Conversions', 'google-listings-and-ads' ) ],
 	[ 'clicks', __( 'Clicks', 'google-listings-and-ads' ) ],
 	[ 'impressions', __( 'Impressions', 'google-listings-and-ads' ) ],
-	[ 'totalSpend', __( 'Total Spend', 'google-listings-and-ads' ) ],
+	[ 'totalSpend', __( 'Total Spend', 'google-listings-and-ads' ), true ],
 ];
 
 const ProgramsReport = () => {
@@ -103,13 +103,16 @@ const ProgramsReport = () => {
 			<div className="gla-reports__performance">
 				<SummaryList>
 					{ () =>
-						availableMetrics.map( ( [ key, label ] ) => (
-							<MetricNumber
-								key={ key }
-								label={ label }
-								data={ data[ key ] }
-							/>
-						) )
+						availableMetrics.map(
+							( [ key, label, isCurrency ] ) => (
+								<MetricNumber
+									key={ key }
+									label={ label }
+									isCurrency={ isCurrency }
+									data={ data[ key ] }
+								/>
+							)
+						)
 					}
 				</SummaryList>
 				<Chart

--- a/js/src/reports/programs/mocked-metrics-data.js
+++ b/js/src/reports/programs/mocked-metrics-data.js
@@ -15,36 +15,36 @@ export default function () {
 
 	const data = {
 		clicks: {
-			value: '14,135',
+			value: 14135,
 			delta: 0,
 			label: 'Clicks',
 		},
 		impressions: {
-			value: '383,512',
+			value: 383512,
 			delta: 1.28,
 			label: 'Impressions',
 		},
 		totalSpend: {
-			value: '$600.00',
+			value: 600,
 			delta: -1.97,
 			label: 'Total Spend',
 		},
 	};
 	const conditionalData = {
 		itemsSold: {
-			value: '6,928',
+			value: 6928,
 			delta: 0.35,
 			label: 'itemsSold',
 			missingFreeListingsData,
 		},
 		conversions: {
-			value: '4,102',
+			value: 4102,
 			delta: -2.21,
 			label: 'Conversions',
 			missingFreeListingsData,
 		},
 		netSales: {
-			value: '$10,802.93',
+			value: 10802.93,
 			delta: 5.35,
 			label: 'Net Sales',
 			missingFreeListingsData,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Parts of #242, #244. Some adjustments of shared component **MetricNumber** used in both report pages.

- Forward **MetricNumber** props of `href`, `selected`, and `prevValue` to **SummaryNumber**
- Format `value` and `prevValue` within the **MetricNumber**
- Change selected metric and display selected style when clicking on **SummarySection** metrics for the Products Report page

### Screenshots:

![Kapture 2021-05-07 at 17 20 09](https://user-images.githubusercontent.com/17420811/117428282-821f3c00-af58-11eb-8136-20de85646dc7.gif)

### Detailed test instructions:

1. Head to the Products Report page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fproducts`
2. The currency format displayed on the summary section should align with store's currency setting
3. The default selected summary metric should be the first metric
4. Click on summary metrics, the selected metric and table's order column should be changed respectively. And vice versa, clicking on product table headers should change the selected metric as well
