### PR TITLE
Remove margin-bottom for checkboxes in Table

### DIFF
--- a/js/src/components/app-table-card-div/index.scss
+++ b/js/src/components/app-table-card-div/index.scss
@@ -14,5 +14,14 @@
 				justify-content: flex-start;
 			}
 		}
+
+		&__body {
+			.woocommerce-table__table {
+				.components-base-control__field {
+					// override the default margin-bottom 8px for checkboxes in the table.
+					margin-bottom: 0;
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A simple PR to remove the checkbox's `margin-bottom: 8px` in table.

The implementation is similar to the code that has been removed in PR #545: https://github.com/woocommerce/google-listings-and-ads/pull/545/files#diff-4ed4a3df0d44a1ed00fa6abf2352d8dbda3aefc493d9f94203f2ede47af207dfL20-L26. 

I have added extra line of comment to say what it does, so that it is clearer and we do not accidentally remove it.

### Screenshots:

Before - checkbox has 8px bottom margin:

![image](https://user-images.githubusercontent.com/417342/117487972-62126b80-af9e-11eb-885c-2c3e361a05a9.png)

After - checkbox has no bottom margin:

![image](https://user-images.githubusercontent.com/417342/117487928-4e670500-af9e-11eb-9ac4-5390bb88234a.png)

### Detailed test instructions:

1. Open any page that has a table with checkboxes in it, e.g. https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed
2. The checkboxes should look like the "After" screenshot above, with no bottom margin.

### Changelog Note:

Remove checkbox's bottom margin in table.
