### PR TITLE
Adjust chart to fit with API schema and visual design, and extract as a shared component for report pages

### DIFF
--- a/js/src/reports/chart-section.js
+++ b/js/src/reports/chart-section.js
@@ -1,13 +1,20 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { Chart } from '@woocommerce/components';
+import { getChartTypeForQuery } from '@woocommerce/date';
 
 /**
  * Internal dependencies
  */
 import useUrlQuery from '.~/hooks/useUrlQuery';
+
+const emptyMessage = __(
+	'No data for the selected date range',
+	'google-listings-and-ads'
+);
 
 /**
  * Renders a report chart.
@@ -22,6 +29,8 @@ export default function ChartSection( { metrics, report } ) {
 	const { key, label } = orderby
 		? metrics.find( ( metric ) => metric.key === orderby )
 		: metrics[ 0 ];
+
+	const chartType = getChartTypeForQuery( query );
 
 	const {
 		loaded,
@@ -49,10 +58,12 @@ export default function ChartSection( { metrics, report } ) {
 			data={ chartData }
 			title={ label }
 			query={ query }
+			chartType={ chartType }
 			isRequesting={ ! loaded }
+			emptyMessage={ emptyMessage }
 			layout="time-comparison"
-			interactiveLegend="false"
-			showHeaderControls="false"
+			// 'hidden' is NOT a valid `legendPosition` value, but it can hack to hide the legend.
+			legendPosition="hidden"
 		/>
 	);
 }

--- a/js/src/reports/chart-section.js
+++ b/js/src/reports/chart-section.js
@@ -1,16 +1,63 @@
 /**
  * External dependencies
  */
+import { useMemo } from '@wordpress/element';
 import { Chart } from '@woocommerce/components';
 
-export default function ChartSection( { chartData } ) {
+/**
+ * Internal dependencies
+ */
+import useUrlQuery from '.~/hooks/useUrlQuery';
+
+/**
+ * Renders a report chart.
+ *
+ * @param {Object} props React props.
+ * @param {Array<Metric>} props.metrics Metrics to display.
+ * @param {ProductsReportSchema} props.report Report data and its status.
+ */
+export default function ChartSection( { metrics, report } ) {
+	const query = useUrlQuery();
+	const { orderby } = query;
+	const { key, label } = orderby
+		? metrics.find( ( metric ) => metric.key === orderby )
+		: metrics[ 0 ];
+
+	const {
+		loaded,
+		data: { intervals },
+	} = report;
+
+	const chartData = useMemo( () => {
+		if ( ! loaded ) {
+			return [];
+		}
+
+		return intervals.map( ( { interval, subtotals } ) => {
+			return {
+				date: interval,
+				[ label ]: {
+					value: subtotals[ key ],
+					label,
+				},
+			};
+		} );
+	}, [ key, label, loaded, intervals ] );
+
 	return (
 		<Chart
 			data={ chartData }
-			title="Conversions"
+			title={ label }
+			query={ query }
+			isRequesting={ ! loaded }
 			layout="time-comparison"
 			interactiveLegend="false"
 			showHeaderControls="false"
 		/>
 	);
 }
+
+/**
+ * @typedef {import("./index.js").Metric} Metric
+ * @typedef {import("./index.js").ProductsReportSchema} ProductsReportSchema
+ */

--- a/js/src/reports/chart-section.js
+++ b/js/src/reports/chart-section.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { Chart } from '@woocommerce/components';
+
+export default function ChartSection( { chartData } ) {
+	return (
+		<Chart
+			data={ chartData }
+			title="Conversions"
+			layout="time-comparison"
+			interactiveLegend="false"
+			showHeaderControls="false"
+		/>
+	);
+}

--- a/js/src/reports/chart-section.js
+++ b/js/src/reports/chart-section.js
@@ -10,6 +10,8 @@ import { getChartTypeForQuery } from '@woocommerce/date';
  * Internal dependencies
  */
 import useUrlQuery from '.~/hooks/useUrlQuery';
+import useStoreCurrency from '.~/hooks/useStoreCurrency';
+import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
 
 const emptyMessage = __(
 	'No data for the selected date range',
@@ -25,12 +27,17 @@ const emptyMessage = __(
  */
 export default function ChartSection( { metrics, report } ) {
 	const query = useUrlQuery();
+	const currency = useStoreCurrency();
+	const { formatAmount } = useCurrencyFactory();
+
 	const { orderby } = query;
-	const { key, label } = orderby
+	const { key, label, isCurrency = false } = orderby
 		? metrics.find( ( metric ) => metric.key === orderby )
 		: metrics[ 0 ];
 
 	const chartType = getChartTypeForQuery( query );
+	const valueType = isCurrency ? 'currency' : 'number';
+	const tooltipValueFormat = isCurrency ? formatAmount : ',';
 
 	const {
 		loaded,
@@ -58,7 +65,10 @@ export default function ChartSection( { metrics, report } ) {
 			data={ chartData }
 			title={ label }
 			query={ query }
+			currency={ currency }
 			chartType={ chartType }
+			valueType={ valueType }
+			tooltipValueFormat={ tooltipValueFormat }
 			isRequesting={ ! loaded }
 			emptyMessage={ emptyMessage }
 			layout="time-comparison"

--- a/js/src/reports/index.js
+++ b/js/src/reports/index.js
@@ -3,3 +3,40 @@
  */
 export { default as ProgramsReport } from './programs';
 export { default as ProductsReport } from './products';
+
+/**
+ * @typedef {Object} Metric Metric item structure for disaplying label and its currency type.
+ * @property {string} key Metric key.
+ * @property {string} label Metric label to display.
+ * @property {boolean} [isCurrency] Metric is a currency if true.
+ */
+
+/**
+ * @typedef {Object} ProductsReportSchema
+ * @property {boolean} loaded Whether the data have been loaded.
+ * @property {ProductsReportData} data Fetched products report data.
+ */
+
+/**
+ * @typedef {Object} ProductsReportData
+ * @property {Array<ProductsData>} products Products data.
+ * @property {Array<IntervalsData>} intervals Intervals data.
+ * @property {PerformanceData} totals Performance data.
+ */
+
+/**
+ * @typedef {Object} ProductsData
+ * @property {number} id Product ID.
+ * @property {TotalsData} subtotals Performance data.
+ */
+
+/**
+ * @typedef {Object} IntervalsData
+ * @property {string} interval ID of this report segment.
+ * @property {TotalsData} subtotals Performance data.
+ */
+
+/**
+ * @typedef { import(".~/data/utils").ReportFieldsSchema } TotalsData
+ * @typedef { import(".~/data/utils").PerformanceData } PerformanceData
+ */

--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -190,5 +190,5 @@ const CompareProductsTableCard = ( { metrics, ...restProps } ) => {
 export default CompareProductsTableCard;
 
 /**
- * @typedef {import("./index.js").Metric} Metric
+ * @typedef {import("../index.js").Metric} Metric
  */

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getQuery } from '@woocommerce/navigation';
-import { Chart } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -19,6 +18,7 @@ import AppSpinner from '.~/components/app-spinner';
 import TabNav from '../../tab-nav';
 import ProductsReportFilters from './products-report-filters';
 import SummarySection from './summary-section';
+import ChartSection from '../chart-section';
 import CompareProductsTableCard from './compare-products-table-card';
 
 import chartData from './mocked-chart-data';
@@ -78,13 +78,7 @@ const ProductsReport = ( { hasPaidSource } ) => {
 				report={ reportId }
 			/>
 			<SummarySection metrics={ metrics } />
-			<Chart
-				data={ chartData }
-				title="Conversions"
-				layout="time-comparison"
-				interactiveLegend="false"
-				showHeaderControls="false"
-			/>
+			<ChartSection chartData={ chartData } />
 			<CompareProductsTableCard
 				trackEventReportId={ reportId }
 				metrics={ metrics }

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -70,6 +70,12 @@ const ProductsReport = ( { hasPaidSource } ) => {
 	// Until ~Q4 2021, free listings, may not have all metrics.
 	const metrics = type === REPORT_SOURCE_PAID ? paidMetrics : freeMetrics;
 
+	// Mocked report data for the chart.
+	const report = {
+		loaded: true,
+		data: { intervals: chartData },
+	};
+
 	return (
 		<>
 			<ProductsReportFilters
@@ -78,7 +84,7 @@ const ProductsReport = ( { hasPaidSource } ) => {
 				report={ reportId }
 			/>
 			<SummarySection metrics={ metrics } />
-			<ChartSection chartData={ chartData } />
+			<ChartSection metrics={ metrics } report={ report } />
 			<CompareProductsTableCard
 				trackEventReportId={ reportId }
 				metrics={ metrics }

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -117,8 +117,5 @@ const ProductsReportPage = () => {
 export default ProductsReportPage;
 
 /**
- * @typedef {Object} Metric Metric item structure for disaplying label and its currency type.
- * @property {string} key Metric key.
- * @property {string} label Metric label to display.
- * @property {boolean} [isCurrency] Metric is a currency if true.
+ * @typedef {import("../index.js").Metric} Metric
  */

--- a/js/src/reports/products/mocked-chart-data.js
+++ b/js/src/reports/products/mocked-chart-data.js
@@ -1,51 +1,65 @@
 export default [
 	{
-		date: '2018-05-30T00:00:00',
-		Conversions: {
-			label: 'Conversions',
-			value: 14205,
+		interval: '2021-04-01',
+		subtotals: {
+			sales: 975.4519,
+			conversions: 84258,
+			clicks: 9799,
+			impressions: 6152,
 		},
 	},
 	{
-		date: '2018-05-31T00:00:00',
-		Conversions: {
-			label: 'Conversions',
-			value: 10581,
+		interval: '2021-04-02',
+		subtotals: {
+			sales: 537.77512,
+			conversions: 89094,
+			clicks: 7603,
+			impressions: 9620,
 		},
 	},
 	{
-		date: '2018-06-01T00:00:00',
-		Conversions: {
-			label: 'Conversions',
-			value: 16307,
+		interval: '2021-04-03',
+		subtotals: {
+			sales: 1206.0219,
+			conversions: 82129,
+			clicks: 9107,
+			impressions: 9063,
 		},
 	},
 	{
-		date: '2018-06-02T00:00:00',
-		Conversions: {
-			label: 'Conversions',
-			value: 13481,
+		interval: '2021-04-04',
+		subtotals: {
+			sales: 1035.76,
+			conversions: 95745,
+			clicks: 6829,
+			impressions: 6532,
 		},
 	},
 	{
-		date: '2018-06-03T00:00:00',
-		Conversions: {
-			label: 'Conversions',
-			value: 10581,
+		interval: '2021-04-05',
+		subtotals: {
+			sales: 627.435,
+			conversions: 61148,
+			clicks: 9530,
+			impressions: 6149,
 		},
 	},
 	{
-		date: '2018-06-04T00:00:00',
-		Conversions: {
-			label: 'Conversions',
-			value: 19874,
+		interval: '2021-04-06',
+		subtotals: {
+			sales: 697.4789,
+			conversions: 69968,
+			clicks: 6736,
+			impressions: 6619,
 		},
 	},
 	{
-		date: '2018-06-05T00:00:00',
-		Conversions: {
-			label: 'Conversions',
-			value: 20593,
+		interval: '2021-04-07',
+		subtotals: {
+			sales: 520.5314,
+			conversions: 86649,
+			clicks: 8812,
+			impressions: 7358,
 		},
 	},
 ];

--- a/js/src/reports/products/summary-section.js
+++ b/js/src/reports/products/summary-section.js
@@ -45,5 +45,5 @@ export default function SummarySection( { metrics } ) {
 }
 
 /**
- * @typedef {import("./index.js").Metric} Metric
+ * @typedef {import("../index.js").Metric} Metric
  */

--- a/js/src/reports/products/useProductsReport.js
+++ b/js/src/reports/products/useProductsReport.js
@@ -55,33 +55,5 @@ export default function useProductsReport( type ) {
 }
 
 /**
- * Schema of the `useProductsReport` hook
- *
- * @typedef {Object} ProductsReportSchema
- * @property {boolean} loaded Whether the data have been loaded.
- * @property {ProductsReportData} data Fetched products report data.
- */
-
-/**
- * @typedef {Object} ProductsReportData
- * @property {Array<ProductsData>} products Products data.
- * @property {Array<IntervalsData>} intervals Intervals data.
- * @property {PerformanceData} totals Performance data.
- */
-
-/**
- * @typedef {Object} ProductsData
- * @property {number} id Product ID.
- * @property {TotalsData} subtotals Performance data.
- */
-
-/**
- * @typedef {Object} IntervalsData
- * @property {string} interval ID of this report segment.
- * @property {TotalsData} subtotals Performance data.
- */
-
-/**
- * @typedef { import(".~/data/utils").ReportFieldsSchema } TotalsData
- * @typedef { import(".~/data/utils").PerformanceData } PerformanceData
+ * @typedef { import("../index.js").ProductsReportSchema } ProductsReportSchema
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Parts of #242, #244. Adjust chart to fit with API schema and visual design, and extract as a shared component **ChartSection** for both report pages.

- Add a shared component **ChartSection** under `.~/report`
- Align to the data schema of report API and display selected metric
- Apply store's currency setting to format values
- Enable chart type switching
- Tweak chart props to fit with visual design

### Screenshots:

#### 🎥 . Switch metrics and chart types

![Kapture 2021-05-10 at 12 11 18](https://user-images.githubusercontent.com/17420811/117604801-e45e8380-b188-11eb-9f2c-96f4bf5d3960.gif)

#### 🖼️ . Loading status

![image](https://user-images.githubusercontent.com/17420811/117604845-fb9d7100-b188-11eb-8c7c-a2ebd0a43082.png)

#### 🖼️ . No data

![image](https://user-images.githubusercontent.com/17420811/117604880-0eb04100-b189-11eb-9637-559635bbf587.png)

### Detailed test instructions:

1. Head to the Products Report page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fproducts`
2. The currency format displayed on the chart section should align with store's currency setting
3. Click on summary metrics or product table headers to change selected metric, the chart section should display selected data
4. Click on the **Bar** or **Line** chart type icons on the right side, and then the chart should display data by corresponding chart types
