### PR TITLE
Opens documentation in new tab upon clicking Help button

### DIFF
--- a/js/src/components/app-icon-button/index.js
+++ b/js/src/components/app-icon-button/index.js
@@ -1,21 +1,17 @@
 /**
- * External dependencies
- */
-import { Button } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import './index.scss';
 
 const AppIconButton = ( props ) => {
 	const { icon, text, className = '', ...rest } = props;
 
 	return (
-		<Button className={ `app-icon-button ${ className }` } { ...rest }>
+		<AppButton className={ `app-icon-button ${ className }` } { ...rest }>
 			<div>{ icon }</div>
 			{ text }
-		</Button>
+		</AppButton>
 	);
 };
 

--- a/js/src/components/help-icon-button.js
+++ b/js/src/components/help-icon-button.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import GridiconHelpOutline from 'gridicons/dist/help-outline';
+
+/**
+ * Internal dependencies
+ */
+import AppIconButton from '.~/components/app-icon-button';
+
+/**
+ * An AppIconButton that renders GridiconHelpOutline icon and "Help" text.
+ * Upon click, it will open documentation page in a new tab,
+ * and call `gla_help_click` track event.
+ *
+ * @param {Object} props Props
+ * @param {string} props.eventContext Context to be used in `gla_help_click` track event.
+ * @return {import(".~/components/app-icon-button")} The button.
+ */
+const HelpIconButton = ( props ) => {
+	const { eventContext, ...rest } = props;
+
+	return (
+		<AppIconButton
+			icon={ <GridiconHelpOutline /> }
+			text={ __( 'Help', 'google-listings-and-ads' ) }
+			href="https://docs.woocommerce.com/document/google-listings-and-ads/"
+			target="_blank"
+			eventName="gla_help_click"
+			eventProps={ {
+				context: eventContext,
+			} }
+			{ ...rest }
+		/>
+	);
+};
+
+export default HelpIconButton;

--- a/js/src/components/stepper/top-bar/index.js
+++ b/js/src/components/stepper/top-bar/index.js
@@ -2,14 +2,11 @@
  * External dependencies
  */
 import { Link } from '@woocommerce/components';
-import { __ } from '@wordpress/i18n';
 import GridiconChevronLeft from 'gridicons/dist/chevron-left';
-import GridiconHelpOutline from 'gridicons/dist/help-outline';
 
 /**
  * Internal dependencies
  */
-import AppIconButton from '.~/components/app-icon-button';
 import './index.scss';
 
 /**
@@ -18,16 +15,11 @@ import './index.scss';
  *
  * @param {Object} props
  * @param {string} props.title Title to indicate where the user is at.
+ * @param {import(".~/components/app-button")} props.helpButton Help button
  * @param {string} props.backHref Href for the back button.
  * @param {Function} props.onBackButtonClick
- * @param {Function} props.onHelpButtonClick
  */
-const TopBar = ( {
-	title,
-	backHref,
-	onBackButtonClick,
-	onHelpButtonClick,
-} ) => {
+const TopBar = ( { title, backHref, helpButton, onBackButtonClick } ) => {
 	return (
 		<div className="gla-stepper-top-bar">
 			<Link
@@ -39,13 +31,7 @@ const TopBar = ( {
 				<GridiconChevronLeft />
 			</Link>
 			<span className="title">{ title }</span>
-			<div className="actions">
-				<AppIconButton
-					icon={ <GridiconHelpOutline /> }
-					text={ __( 'Help', 'google-listings-and-ads' ) }
-					onClick={ onHelpButtonClick }
-				/>
-			</div>
+			<div className="actions">{ helpButton }</div>
 		</div>
 	);
 };

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -23,6 +23,7 @@ import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
 import useShippingRates from '.~/hooks/useShippingRates';
 import useShippingTimes from '.~/hooks/useShippingTimes';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import HelpIconButton from '.~/components/help-icon-button';
 
 /**
  * Function use to allow the user to navigate between form steps without the prompt.
@@ -228,6 +229,9 @@ export default function EditFreeCampaign() {
 		<FullContainer>
 			<TopBar
 				title={ __( 'Edit free listings', 'google-listings-and-ads' ) }
+				helpButton={
+					<HelpIconButton eventContext="edit-free-listings" />
+				}
 				backHref={ dashboardURL }
 			/>
 			<Stepper

--- a/js/src/pages/create-paid-ads-campaign/index.js
+++ b/js/src/pages/create-paid-ads-campaign/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import FullContainer from '.~/components/full-container';
 import TopBar from '.~/components/stepper/top-bar';
+import HelpIconButton from '.~/components/help-icon-button';
 import CreatePaidAdsCampaignForm from './create-paid-ads-campaign-form';
 
 const dashboardURL = getNewPath( {}, '/google/dashboard', {} );
@@ -21,6 +22,7 @@ const CreatePaidAdsCampaign = () => {
 					'Create your paid campaign',
 					'google-listings-and-ads'
 				) }
+				helpButton={ <HelpIconButton eventContext="create-ads" /> }
 				backHref={ dashboardURL }
 			/>
 			<CreatePaidAdsCampaignForm />

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -12,8 +12,10 @@ import TopBar from '.~/components/stepper/top-bar';
 import useApiFetchEffect from '.~/hooks/useApiFetchEffect';
 import AppSpinner from '.~/components/app-spinner';
 import EditPaidAdsCampaignForm from './edit-paid-ads-campaign-form';
+import HelpIconButton from '.~/components/help-icon-button';
 
 const dashboardURL = getNewPath( {}, '/google/dashboard', {} );
+const helpButton = <HelpIconButton eventContext="edit-ads" />;
 
 const EditPaidAdsCampaign = () => {
 	const { programId } = getQuery();
@@ -26,6 +28,7 @@ const EditPaidAdsCampaign = () => {
 			<FullContainer>
 				<TopBar
 					title={ __( 'Loading…', 'google-listings-and-ads' ) }
+					helpButton={ helpButton }
 					backHref={ dashboardURL }
 				/>
 				<AppSpinner />
@@ -38,6 +41,7 @@ const EditPaidAdsCampaign = () => {
 			<FullContainer>
 				<TopBar
 					title={ __( 'Edit Campaign', 'google-listings-and-ads' ) }
+					helpButton={ helpButton }
 					backHref={ dashboardURL }
 				/>
 				<div>
@@ -58,6 +62,7 @@ const EditPaidAdsCampaign = () => {
 					__( 'Edit %s', 'google-listings-and-ads' ),
 					campaignData.name
 				) }
+				helpButton={ helpButton }
 				backHref={ dashboardURL }
 			/>
 			<EditPaidAdsCampaignForm campaign={ campaignData } />

--- a/js/src/setup-ads/top-bar/index.js
+++ b/js/src/setup-ads/top-bar/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { recordSetupAdsEvent } from '.~/utils/recordEvent';
 import TopBar from '.~/components/stepper/top-bar';
+import HelpIconButton from '.~/components/help-icon-button';
 
 const SetupAdsTopBar = () => {
 	// We record the intent to go back or to help - clicking buttons.
@@ -18,16 +19,12 @@ const SetupAdsTopBar = () => {
 		recordSetupAdsEvent( 'back' );
 	};
 
-	const handleHelpButtonClick = () => {
-		recordSetupAdsEvent( 'help' );
-	};
-
 	return (
 		<TopBar
 			title={ __( 'Set up paid campaign', 'google-listings-and-ads' ) }
+			helpButton={ <HelpIconButton eventContext="setup-ads" /> }
 			backHref={ getNewPath( {}, '/google/dashboard' ) }
 			onBackButtonClick={ handleBackButtonClick }
-			onHelpButtonClick={ handleHelpButtonClick }
 		/>
 	);
 };

--- a/js/src/setup-mc/top-bar/index.js
+++ b/js/src/setup-mc/top-bar/index.js
@@ -9,14 +9,11 @@ import { getNewPath } from '@woocommerce/navigation';
  */
 import TopBar from '.~/components/stepper/top-bar';
 import { recordSetupMCEvent } from '.~/utils/recordEvent';
+import HelpIconButton from '.~/components/help-icon-button';
 
 const SetupMCTopBar = () => {
 	const handleBackButtonClick = () => {
 		recordSetupMCEvent( 'back' );
-	};
-
-	const handleHelpButtonClick = () => {
-		recordSetupMCEvent( 'help' );
 	};
 
 	return (
@@ -25,9 +22,9 @@ const SetupMCTopBar = () => {
 				'Get started with Google Listings & Ads',
 				'google-listings-and-ads'
 			) }
+			helpButton={ <HelpIconButton eventContext="setup-mc" /> }
 			backHref={ getNewPath( {}, '/google/start' ) }
 			onBackButtonClick={ handleBackButtonClick }
-			onHelpButtonClick={ handleHelpButtonClick }
 		/>
 	);
 };

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -95,6 +95,9 @@ All event names are prefixed by `wcadmin_gla_`.
   * `link_id`: a unique ID for the button within the context, e.g. `set-up-billing`.
   * `href`: indicate the destination where the users is directed to.
 
+* `help_click` - "Help" button is clicked.
+  * `context`: indicate the place where the button is located, e.g. `setup-ads`.
+
 <!-- -- >
 ## Developer Info
 All new tracking info should be updated in this readme.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #550 .

With this PR, clicking the "Help" button will open the documentation page https://docs.woocommerce.com/document/google-listings-and-ads/ in a new tab. It will also call a new track event with the event name `gla_help_click` and event props `{ context }` where `context` indicate the page the button is located. 

The help button is present in the following five pages: 

- Setup MC
- Edit free listing
- Setup Ads
- Create Ads
- Edit Ads

### Screenshots:

![](https://user-images.githubusercontent.com/417342/117181782-2f366f00-ae08-11eb-914b-dce318406135.png)

### Detailed test instructions:

1. Open the pages mentioned above.
2. Click on the Help button at the top right corner. It should open the documentation page (https://docs.woocommerce.com/document/google-listings-and-ads/) in a new tab.
3. Go back to the GLA tab. The track event should be called with the event name `gla_help_click` and with appropriate context value in the event props `{ context }`

### Changelog Note:

Opens documentation in new tab upon clicking Help button.
