### PR TITLE
Code refactor with useIsEqualRefValue

### DIFF
--- a/js/src/hooks/useApiFetchEffect.js
+++ b/js/src/hooks/useApiFetchEffect.js
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
-import isEqual from 'lodash/isEqual';
+import { useEffect } from '@wordpress/element';
 import { APIFetchOptions } from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
 
 /**
  * Calls apiFetch as a side effect. This uses useApiFetchCallback in a useEffect hook.
@@ -19,22 +19,19 @@ import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
  * @return {Object} FetchResult from useApiFetchCallback.
  */
 const useApiFetchEffect = ( options ) => {
-	const optionsRef = useRef( options );
-	if ( ! isEqual( optionsRef.current, options ) ) {
-		optionsRef.current = options;
-	}
+	const optionsRefValue = useIsEqualRefValue( options );
 
-	const [ apiFetch, fetchResult ] = useApiFetchCallback( optionsRef.current, {
+	const [ apiFetch, fetchResult ] = useApiFetchCallback( optionsRefValue, {
 		loading: true,
 	} );
 
 	useEffect( () => {
-		if ( ! optionsRef.current ) {
+		if ( ! optionsRefValue ) {
 			return;
 		}
 
 		apiFetch();
-	}, [ apiFetch ] );
+	}, [ apiFetch, optionsRefValue ] );
 
 	return fetchResult;
 };

--- a/js/src/hooks/useAppSelectDispatch.js
+++ b/js/src/hooks/useAppSelectDispatch.js
@@ -2,43 +2,39 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useCallback, useRef } from '@wordpress/element';
-import isEqual from 'lodash/isEqual';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '.~/data/constants';
 import { useAppDispatch } from '.~/data';
+import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
 
 const useAppSelectDispatch = ( selector, ...args ) => {
 	const { invalidateResolution } = useAppDispatch();
-
-	const argsRef = useRef( args );
-	if ( ! isEqual( argsRef.current, args ) ) {
-		argsRef.current = args;
-	}
+	const argsRefValue = useIsEqualRefValue( args );
 
 	const invalidateResolutionCallback = useCallback( () => {
-		invalidateResolution( selector, argsRef.current );
-	}, [ invalidateResolution, selector ] );
+		invalidateResolution( selector, argsRefValue );
+	}, [ invalidateResolution, selector, argsRefValue ] );
 
 	return useSelect(
 		( select ) => {
 			const { hasFinishedResolution } = select( STORE_KEY );
 
-			const data = select( STORE_KEY )[ selector ]( ...argsRef.current );
+			const data = select( STORE_KEY )[ selector ]( ...argsRefValue );
 
 			return {
 				hasFinishedResolution: hasFinishedResolution(
 					selector,
-					argsRef.current
+					argsRefValue
 				),
 				data,
 				invalidateResolution: invalidateResolutionCallback,
 			};
 		},
-		[ invalidateResolutionCallback, selector, argsRef.current ]
+		[ invalidateResolutionCallback, selector, argsRefValue ]
 	);
 };
 

--- a/js/src/hooks/useIsEqualRefValue.js
+++ b/js/src/hooks/useIsEqualRefValue.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import isEqual from 'lodash/isEqual';
+import { useRef } from '@wordpress/element';
+
+/**
+ * Stores value in a ref. In subsequent render, value will be compared with ref.current using `isEqual` comparison.
+ * If it is equal, returns ref.current; else, set ref.current to be value.
+ *
+ * This is useful for objects used in hook dependencies.
+ *
+ * @param {*} value Value to be stored in ref.
+ * @return {*} Value stored in ref.
+ */
+const useIsEqualRefValue = ( value ) => {
+	const optionsRef = useRef( value );
+
+	if ( ! isEqual( optionsRef.current, value ) ) {
+		optionsRef.current = value;
+	}
+
+	return optionsRef.current;
+};
+
+export default useIsEqualRefValue;

--- a/js/src/hooks/useUrlQuery.js
+++ b/js/src/hooks/useUrlQuery.js
@@ -1,9 +1,12 @@
 /**
  * External dependencies
  */
-import isEqual from 'lodash/isEqual';
 import { getQuery } from '@woocommerce/navigation';
-import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
 
 /**
  * Get a memoized URL query object.
@@ -12,11 +15,7 @@ import { useRef } from '@wordpress/element';
  */
 export default function useUrlQuery() {
 	const query = getQuery();
-	const queryRef = useRef( query );
+	const queryRefValue = useIsEqualRefValue( query );
 
-	if ( ! isEqual( queryRef.current, query ) ) {
-		queryRef.current = query;
-	}
-
-	return queryRef.current;
+	return queryRefValue;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces minor code refactoring with a new `useIsEqualRefValue` hook.

### Screenshots:

No changes in UI.

### Detailed test instructions:

Everything should still work the same. Pages impacted: 

- Report and Product Report pages (changes to `useUrlQuery`).
- Budget recommendation in Setup Ads, Create Ads and Edit Ads (changes to `useApiFetchEffect`).
- Product Feed page with Product Statistics and Issues table (changes to `useAppSelectDispatch`).
- MC Setup (changes to `useAppSelectDispatch`).

### Changelog Note:

Code refactor with useIsEqualRefValue.
