### PR TITLE
Use shared `SummarySection` in Programs Report page.

### DIFF
--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -132,4 +132,5 @@ export function mapReportFieldsToPerformance( primary, secondary ) {
  * @property {number} value Value of the current period.
  * @property {number} prevValue Value of the previous period.
  * @property {number} delta The delta of the current value compared to the previous value.
+ * @property {boolean} [missingFreeListingsData] Flag indicating whether the data miss entries from Free Listings.
  */

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -29,11 +29,7 @@ const numberFormatSetting = { precision: 0 };
  * @param {boolean} [props.selected] Whether show a highlight style on this metric.
  * @param {boolean} [props.isCurrency=false] Display `data.value` and `data.prevValue` as price format if true.
  *                                           Otherwise, display as number format.
- * @param {Object} props.data Data as get from API.
- * @param {number} props.data.value
- * @param {number} props.data.prevValue
- * @param {string} props.data.delta
- * @param {boolean} props.data.missingFreeListingsData Flag indicating whether the data miss entries from Free Listings.
+ * @param {import('.~/data/utils').PerformanceMetrics} props.data Data as get from API.
  *
  * @return {SummaryNumber} Filled SummaryNumber.
  */

--- a/js/src/reports/programs/compare-programs-table-card.js
+++ b/js/src/reports/programs/compare-programs-table-card.js
@@ -20,13 +20,8 @@ import { mockedListingsData, availableMetrics } from './mocked-programs-data'; /
  */
 const metricsHeaders = [
 	{
-		key: 'netSales',
+		key: 'sales',
 		label: __( 'Net Sales', 'google-listings-and-ads' ),
-		isSortable: true,
-	},
-	{
-		key: 'itemsSold',
-		label: __( 'Items Sold', 'google-listings-and-ads' ),
 		isSortable: true,
 	},
 	{

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { SummaryList, Chart } from '@woocommerce/components';
+import { Chart } from '@woocommerce/components';
 import { getQuery } from '@woocommerce/navigation';
 
 /**
@@ -11,28 +11,44 @@ import { getQuery } from '@woocommerce/navigation';
 import TabNav from '../../tab-nav';
 import SubNav from '../sub-nav';
 import ProgramsReportFilters from './programs-report-filters';
+import SummarySection from '../summary-section';
 import CompareProgramsTableCard from './compare-programs-table-card';
-import MetricNumber from '../metric-number';
 import '../../dashboard/index.scss';
 import metricsData from './mocked-metrics-data'; // Mocked data
 
 /**
  * Available metrics and their human-readable labels.
  *
- * @type {Map<string, string>}
+ * @type {Array<import('../index.js').Metric>}
  */
 const performanceMetrics = [
-	[ 'netSales', __( 'Net Sales', 'google-listings-and-ads' ), true ],
-	[ 'itemsSold', __( 'Items Sold', 'google-listings-and-ads' ) ],
-	[ 'conversions', __( 'Conversions', 'google-listings-and-ads' ) ],
-	[ 'clicks', __( 'Clicks', 'google-listings-and-ads' ) ],
-	[ 'impressions', __( 'Impressions', 'google-listings-and-ads' ) ],
-	[ 'totalSpend', __( 'Total Spend', 'google-listings-and-ads' ), true ],
+	{
+		key: 'sales',
+		label: __( 'Net Sales', 'google-listings-and-ads' ),
+		isCurrency: true,
+	},
+	{
+		key: 'conversions',
+		label: __( 'Conversions', 'google-listings-and-ads' ),
+	},
+	{
+		key: 'clicks',
+		label: __( 'Clicks', 'google-listings-and-ads' ),
+	},
+	{
+		key: 'impressions',
+		label: __( 'Impressions', 'google-listings-and-ads' ),
+	},
+	{
+		key: 'spend',
+		label: __( 'Total Spend', 'google-listings-and-ads' ),
+		isCurrency: true,
+	},
 ];
 
 const ProgramsReport = () => {
 	// TODO: this data should come from backend API.
-	const data = metricsData();
+	const totals = metricsData();
 
 	const chartData = [
 		{
@@ -89,7 +105,7 @@ const ProgramsReport = () => {
 	// Show only available data.
 	// Until ~Q4 2021, free listings, may not have all metrics.
 	const availableMetrics = performanceMetrics.filter(
-		( [ key ] ) => data[ key ]
+		( { key } ) => totals[ key ]
 	);
 
 	const reportId = 'reports-programs';
@@ -101,20 +117,10 @@ const ProgramsReport = () => {
 
 			<ProgramsReportFilters query={ getQuery() } report={ reportId } />
 			<div className="gla-reports__performance">
-				<SummaryList>
-					{ () =>
-						availableMetrics.map(
-							( [ key, label, isCurrency ] ) => (
-								<MetricNumber
-									key={ key }
-									label={ label }
-									isCurrency={ isCurrency }
-									data={ data[ key ] }
-								/>
-							)
-						)
-					}
-				</SummaryList>
+				<SummarySection
+					metrics={ availableMetrics }
+					report={ { loaded: true, data: { totals } } }
+				/>
 				<Chart
 					data={ chartData }
 					title="Conversions"

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -119,7 +119,8 @@ const ProgramsReport = () => {
 			<div className="gla-reports__performance">
 				<SummarySection
 					metrics={ availableMetrics }
-					report={ { loaded: true, data: { totals } } }
+					loaded={ true }
+					totals={ totals }
 				/>
 				<Chart
 					data={ chartData }

--- a/js/src/reports/programs/mocked-metrics-data.js
+++ b/js/src/reports/programs/mocked-metrics-data.js
@@ -9,6 +9,8 @@ import { getQuery } from '@woocommerce/navigation';
  * not set or "" - mark all metrics as not missing data.
  * "true" or any truthy value - mark some metrics as missing data from free listings.
  * "na" - not applicable, do not provide metrics that would miss data.
+ *
+ * @return {Array<import('..').TotalsData>} Mocked performance metrics.
  */
 export default function () {
 	const { missingFreeListingsData = false } = getQuery();
@@ -17,36 +19,43 @@ export default function () {
 		clicks: {
 			value: 14135,
 			delta: 0,
+			prevValue: 14135,
 			label: 'Clicks',
 		},
 		impressions: {
 			value: 383512,
 			delta: 1.28,
+			prevValue: 378665,
 			label: 'Impressions',
-		},
-		totalSpend: {
-			value: 600,
-			delta: -1.97,
-			label: 'Total Spend',
 		},
 	};
 	const conditionalData = {
 		itemsSold: {
 			value: 6928,
 			delta: 0.35,
+			prevValue: 6903.84,
 			label: 'itemsSold',
 			missingFreeListingsData,
 		},
 		conversions: {
 			value: 4102,
 			delta: -2.21,
+			prevValue: 4195,
 			label: 'Conversions',
 			missingFreeListingsData,
 		},
-		netSales: {
+		sales: {
 			value: 10802.93,
 			delta: 5.35,
+			prevValue: 10254.32,
 			label: 'Net Sales',
+			missingFreeListingsData,
+		},
+		spend: {
+			value: 600,
+			delta: -1.97,
+			prevValue: 612.05,
+			label: 'Total Spend',
 			missingFreeListingsData,
 		},
 	};

--- a/js/src/reports/programs/mocked-programs-data.js
+++ b/js/src/reports/programs/mocked-programs-data.js
@@ -5,14 +5,13 @@ import { getQuery } from '@woocommerce/navigation';
 
 const freeListings = [
 	{
-		id: 147,
+		id: 0,
 		title: 'Free Listings',
 		conversions: 89,
 		clicks: 5626,
 		impressions: 23340,
-		itemsSold: 120,
-		netSales: '$96.73',
-		spend: '$0',
+		sales: 96.73,
+		spend: 0,
 		compare: false,
 	},
 ];
@@ -20,8 +19,8 @@ const freeListingsMissingData = freeListings.map( ( program ) => {
 	return {
 		...program,
 		conversions: null,
-		itemsSold: null,
-		netSales: null,
+		sales: null,
+		spend: null,
 	};
 } );
 
@@ -32,9 +31,8 @@ const paidPrograms = [
 		conversions: 540,
 		clicks: 4152,
 		impressions: 14339,
-		itemsSold: 1033,
-		netSales: '$2,527.91',
-		spend: '$300',
+		sales: 2527.91,
+		spend: 300,
 		compare: false,
 	},
 	{
@@ -43,9 +41,8 @@ const paidPrograms = [
 		conversions: 357,
 		clicks: 1374,
 		impressions: 43359,
-		itemsSold: 456,
-		netSales: '$6,204.16',
-		spend: '$200',
+		sales: 6204.16,
+		spend: 200,
 		compare: false,
 	},
 	{
@@ -54,9 +51,8 @@ const paidPrograms = [
 		conversions: 426,
 		clicks: 3536,
 		impressions: 92771,
-		itemsSold: 877,
-		netSales: '$2,091.05',
-		spend: '$100',
+		sales: 2091.05,
+		spend: 100,
 		compare: false,
 	},
 ];
@@ -94,7 +90,7 @@ export function availableMetrics() {
 	const { missingFreeListingsData = false } = getQuery();
 
 	const stableMetrics = [ 'clicks', 'impressions', 'spend' ];
-	const conditionalMetrics = [ 'netSales', 'itemsSold', 'conversions' ];
+	const conditionalMetrics = [ 'sales', 'conversions' ];
 
 	if ( missingFreeListingsData === 'na' ) {
 		return stableMetrics;


### PR DESCRIPTION
_This PR is based on #569 to reduce the conflict with shared summary section_

### Changes proposed in this Pull Request:

Use shared `SummarySection` on the Programs Report page.
Update mocked metrics data to match the API schema.
Update mocked programs data to use correct metric names.

Implements part of #242 

This is a baby step to make the programs report page follow products one.


### Screenshots:

All programs / `missingFreeListingsData=true`
![Summary section on Programs Report Page for all programs](https://user-images.githubusercontent.com/17435/117726615-19012800-b1e7-11eb-93ce-da5e2e69dd76.gif)

Free listings only / `missingFreeListingsData=na`
![Summary section on Programs Report Page for Free Listings only](https://user-images.githubusercontent.com/17435/117726916-94fb7000-b1e7-11eb-9913-adaaf59979d1.gif)


Paid campaigns only / `missingFreeListingsData`
![Summary section on Programs Report Page for Paid Campaigns only](https://user-images.githubusercontent.com/17435/117726905-90cf5280-b1e7-11eb-8d1b-af4e58a36eca.gif)




### Detailed test instructions:

1. Open Programs report page https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms
2. The currency format displayed on the summary section should align with store's currency setting
3. The default selected summary metric should be the first metric
4. Click on summary metrics, the selected metric and table's order column should be changed respectively.

:warning: Metrics are still using mocked data, so switching program filter will make no effect. However, to test different scenarios you can use `missingFreeListingsData` URL param:

1. [none](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms) - when only paid programs are filtered (or we are somewhere in a far future when free listings also have all metrics) 
2. [`missingFreeListingsData=na`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms&orderby=totalSpend&missingFreeListingsData=na) - when only free listings are chosen
3. [`missingFreeListingsData=true`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms&orderby=totalSpend&missingFreeListingsData=true) - when free listings and paid campaigns are chosen together.
