### PR TITLE
Run async jobs only when Google is connected

### DIFF
--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -3,6 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Exception;
 use GuzzleHttp\Client;
 use Psr\Container\ContainerInterface;
@@ -15,9 +18,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
-class Connection {
+class Connection implements OptionsAwareInterface {
 
 	use ApiExceptionTrait;
+	use OptionsAwareTrait;
 
 	/**
 	 * @var ContainerInterface
@@ -104,6 +108,9 @@ class Connection {
 			$response = json_decode( $result->getBody()->getContents(), true );
 
 			if ( 200 === $result->getStatusCode() ) {
+				$connected = isset( $response['status'] ) && 'connected' === $response['status'];
+				$this->options->update( OptionsInterface::GOOGLE_CONNECTED, $connected );
+
 				return $response;
 			}
 

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -58,6 +58,8 @@ class Connection implements OptionsAwareInterface {
 
 			$response = json_decode( $result->getBody()->getContents(), true );
 			if ( 200 === $result->getStatusCode() && ! empty( $response['oauthUrl'] ) ) {
+				$this->options->update( OptionsInterface::GOOGLE_CONNECTED, true );
+
 				return $response['oauthUrl'];
 			}
 
@@ -81,6 +83,8 @@ class Connection implements OptionsAwareInterface {
 			/** @var Client $client */
 			$client = $this->container->get( Client::class );
 			$result = $client->delete( $this->get_connection_url() );
+
+			$this->options->update( OptionsInterface::GOOGLE_CONNECTED, false );
 
 			return $result->getBody()->getContents();
 		} catch ( ClientExceptionInterface $e ) {

--- a/src/Ads/AdsService.php
+++ b/src/Ads/AdsService.php
@@ -39,6 +39,16 @@ class AdsService implements Service {
 	}
 
 	/**
+	 * Get whether Ads is connected.
+	 *
+	 * @return bool
+	 */
+	public function is_connected(): bool {
+		$google_connected = boolval( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) );
+		return $google_connected && $this->is_setup_complete();
+	}
+
+	/**
 	 * Disconnect Ads account
 	 */
 	public function disconnect() {

--- a/src/Jobs/AbstractProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractProductSyncerBatchedJob.php
@@ -58,12 +58,12 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	}
 
 	/**
-	 * Get whether Merchant Center setup is completed.
+	 * Get whether Merchant Center is connected.
 	 *
 	 * @return bool
 	 */
-	public function is_mc_setup(): bool {
-		return $this->merchant_center->is_setup_complete();
+	public function is_mc_connected(): bool {
+		return $this->merchant_center->is_connected();
 	}
 
 	/**
@@ -74,6 +74,6 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	 * @return bool Returns true if the job can start.
 	 */
 	public function can_start( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->is_mc_setup();
+		return ! $this->is_running( $args ) && $this->is_mc_connected();
 	}
 }

--- a/src/Jobs/AbstractProductSyncerJob.php
+++ b/src/Jobs/AbstractProductSyncerJob.php
@@ -49,12 +49,12 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob imple
 	}
 
 	/**
-	 * Get whether Merchant Center setup is completed.
+	 * Get whether Merchant Center is connected.
 	 *
 	 * @return bool
 	 */
-	public function is_mc_setup(): bool {
-		return $this->merchant_center->is_setup_complete();
+	public function is_mc_connected(): bool {
+		return $this->merchant_center->is_connected();
 	}
 
 	/**
@@ -65,6 +65,6 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob imple
 	 * @return bool Returns true if the job can start.
 	 */
 	public function can_start( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->is_mc_setup();
+		return ! $this->is_running( $args ) && $this->is_mc_connected();
 	}
 }

--- a/src/Jobs/ProductSyncerJobInterface.php
+++ b/src/Jobs/ProductSyncerJobInterface.php
@@ -15,10 +15,10 @@ defined( 'ABSPATH' ) || exit;
 interface ProductSyncerJobInterface extends MerchantCenterAwareInterface {
 
 	/**
-	 * Get whether Merchant Center setup is completed.
+	 * Get whether Merchant Center setup is connected.
 	 *
 	 * @return bool
 	 */
-	public function is_mc_setup(): bool;
+	public function is_mc_connected(): bool;
 
 }

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -49,6 +49,16 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	}
 
 	/**
+	 * Get whether Merchant Center is connected.
+	 *
+	 * @return bool
+	 */
+	public function is_connected(): bool {
+		$google_connected = boolval( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) );
+		return $google_connected && $this->is_setup_complete();
+	}
+
+	/**
 	 * Get whether the country is supported by the Merchant Center.
 	 *
 	 * @param  string $country Optional - to check a country other than the site country.

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -30,6 +30,7 @@ final class Options implements OptionsInterface, Service {
 		self::ADS_SETUP_COMPLETED_AT => true,
 		self::DB_VERSION             => true,
 		self::FILE_VERSION           => true,
+		self::GOOGLE_CONNECTED       => true,
 		self::INSTALL_TIMESTAMP      => true,
 		self::MC_SETUP_COMPLETED_AT  => true,
 		self::MERCHANT_ACCOUNT_STATE => true,

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -17,6 +17,7 @@ interface OptionsInterface {
 	public const ADS_SETUP_COMPLETED_AT = 'ads_setup_completed_at';
 	public const DB_VERSION             = 'db_version';
 	public const FILE_VERSION           = 'file_version';
+	public const GOOGLE_CONNECTED       = 'google_connected';
 	public const INSTALL_TIMESTAMP      = 'install_timestamp';
 	public const MC_SETUP_COMPLETED_AT  = 'mc_setup_completed_at';
 	public const MERCHANT_ACCOUNT_STATE = 'merchant_account_state';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In some circumstances it's possible for the Google account to get disconnected, even though the Merchant Account is still considered setup. Since async actions only require the MC account to be setup it could repeatedly run scheduled jobs even though they fail each time.

This PR maintains a Google Connected status which is updated when we connect / disconnect the account. It also relies on a 401 response, which will mark the status as disconnected. This status will also be useful for handling https://github.com/woocommerce/google-listings-and-ads/issues/486

Closes #521 

### Detailed test instructions:

To be tested in combination with: https://github.com/Automattic/woocommerce-connect-server/pull/1782

1. On the connection test page send a request to sync all products (with the async option checked)
2. In WooCommerce > Status > Scheduled Actions confirm that we see the actions being completed `gla/jobs/update_all_products/process_item`
3. In the database table for the local WCS temporarily remove the refresh token and set the expires date to something expired
4. Send a proxied request or check the settings page `wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`
5. Confirm that the option `gla_google_connected` is not set to true (1)
6. Reschedule the same async job and confirm that this time there aren't any actions being completed

### Changelog Note:
- Fix - Run async jobs only when Google is connected.
