### PR TITLE
Replacement polyfills for mbstring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     "wp-cli/i18n-command": "^2.2",
     "wp-coding-standards/wpcs": "^2.3"
   },
+  "replace": {
+    "symfony/polyfill-mbstring": "*"
+  },
   "license": "GPL-3.0",
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18e9f0efce101c7100d240f76146c746",
+    "content-hash": "d3fdc4a5830cbb783afc499d80dcecde",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -2115,86 +2115,6 @@
             "time": "2021-01-07T16:49:33+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.22-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-01-22T09:19:47+00:00"
-        },
-        {
             "name": "symfony/polyfill-php73",
             "version": "v1.22.1",
             "source": {
@@ -2436,16 +2356,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v5.2.5",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "456a3d95947e99c4c70e64c09833eed56095086c"
+                "reference": "b0be0360bfbf15059308d815da7f4151bd448b37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/456a3d95947e99c4c70e64c09833eed56095086c",
-                "reference": "456a3d95947e99c4c70e64c09833eed56095086c",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/b0be0360bfbf15059308d815da7f4151bd448b37",
+                "reference": "b0be0360bfbf15059308d815da7f4151bd448b37",
                 "shasum": ""
             },
             "require": {
@@ -2488,8 +2408,6 @@
                 "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
-                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
-                "doctrine/cache": "For using the default cached annotation reader.",
                 "egulias/email-validator": "Strict (RFC compliant) email validation",
                 "psr/cache-implementation": "For using the mapping cache.",
                 "symfony/config": "",
@@ -2526,9 +2444,6 @@
             ],
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/validator/tree/v5.2.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2543,7 +2458,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-08T13:20:18+00:00"
+            "time": "2021-04-14T13:12:03+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -99,6 +99,8 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 				}
 			}
 		);
+
+		require_once dirname( __DIR__ ) . '/Polyfills/bootstrap.php';
 	}
 
 	/**

--- a/src/Polyfills/MBString.php
+++ b/src/Polyfills/MBString.php
@@ -1,0 +1,209 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Polyfills;
+
+/**
+ * Class Multi Byte String
+ * Based off of: https://github.com/symfony/polyfill-mbstring
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Polyfills
+ */
+final class MBString {
+	/**
+	 * Default list of supported encodings.
+	 *
+	 * @var array
+	 */
+	private static $encoding_list = [ 'ASCII', 'UTF-8' ];
+
+	/**
+	 * Default encoding type.
+	 *
+	 * @var string
+	 */
+	private static $internal_encoding = 'UTF-8';
+
+	/**
+	 * Convert encoding.
+	 *
+	 * @param array|string      $string
+	 * @param string            $to_encoding
+	 * @param array|string|null $from_encoding
+	 */
+	public static function mb_convert_encoding( $string, $to_encoding, $from_encoding = null ) {
+		if ( \is_array( $from_encoding ) || false !== strpos( $from_encoding, ',' ) ) {
+			$from_encoding = self::mb_detect_encoding( $string, $from_encoding );
+		} else {
+			$from_encoding = self::get_encoding( $from_encoding );
+		}
+
+		$to_encoding = self::get_encoding( $to_encoding );
+
+		if ( 'BASE64' === $from_encoding ) {
+			$string        = base64_decode( $string );
+			$from_encoding = $to_encoding;
+		}
+
+		if ( 'BASE64' === $to_encoding ) {
+			return base64_encode( $string );
+		}
+
+		if ( 'HTML-ENTITIES' === $to_encoding || 'HTML' === $to_encoding ) {
+			if ( 'HTML-ENTITIES' === $from_encoding || 'HTML' === $from_encoding ) {
+				$from_encoding = 'Windows-1252';
+			}
+			if ( 'UTF-8' !== $from_encoding ) {
+				$string = \iconv( $from_encoding, 'UTF-8//IGNORE', $string );
+			}
+
+			return preg_replace_callback( '/[\x80-\xFF]+/', [ __CLASS__, 'html_encoding_callback' ], $string );
+		}
+
+		if ( 'HTML-ENTITIES' === $from_encoding ) {
+			$string        = html_entity_decode( $string, \ENT_COMPAT, 'UTF-8' );
+			$from_encoding = 'UTF-8';
+		}
+
+		return \iconv( $from_encoding, $to_encoding . '//IGNORE', $string );
+	}
+
+	/**
+	 * Check if strings are valid for the specified encoding.
+	 *
+	 * @param array|string|null $value
+	 * @param string|null       $encoding
+	 */
+	public static function mb_check_encoding( $value = null, $encoding = null ) {
+		if ( null === $encoding ) {
+			if ( null === $value ) {
+				return false;
+			}
+			$encoding = self::$internal_encoding;
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		return self::mb_detect_encoding( $value, [ $encoding ] ) || false !== @\iconv( $encoding, $encoding, $value );
+	}
+
+	/**
+	 * Detect character encoding.
+	 *
+	 * @param string            $string
+	 * @param array|string|null $encoding_list
+	 * @param boolean           $strict
+	 *
+	 * @return string|false
+	 */
+	public static function mb_detect_encoding( $string, $encoding_list = null, $strict = false ) {
+		if ( null === $encoding_list ) {
+			$encoding_list = self::$encoding_list;
+		} else {
+			if ( ! \is_array( $encoding_list ) ) {
+				$encoding_list = array_map( 'trim', explode( ',', $encoding_list ) );
+			}
+			$encoding_list = array_map( 'strtoupper', $encoding_list );
+		}
+
+		foreach ( $encoding_list as $enc ) {
+			switch ( $enc ) {
+				case 'ASCII':
+					if ( ! preg_match( '/[\x80-\xFF]/', $string ) ) {
+						return $enc;
+					}
+					break;
+
+				case 'UTF8':
+				case 'UTF-8':
+					if ( preg_match( '//u', $string ) ) {
+						return 'UTF-8';
+					}
+					break;
+
+				default:
+					if ( 0 === strncmp( $enc, 'ISO-8859-', 9 ) ) {
+						return $enc;
+					}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get string length.
+	 *
+	 * @param string      $string
+	 * @param string|null $encoding
+	 * @return int
+	 */
+	public static function mb_strlen( $string, $encoding = null ): int {
+		$encoding = self::get_encoding( $encoding );
+		if ( 'CP850' === $encoding || 'ASCII' === $encoding ) {
+			return \strlen( $string );
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		return @\iconv_strlen( $string, $encoding );
+	}
+
+	/**
+	 * Encode HTML entities.
+	 *
+	 * @param array $m
+	 *
+	 * @return string
+	 */
+	private static function html_encoding_callback( array $m ) {
+		$i        = 1;
+		$entities = '';
+		$m        = unpack( 'C*', htmlentities( $m[0], \ENT_COMPAT, 'UTF-8' ) );
+
+		while ( isset( $m[ $i ] ) ) {
+			if ( 0x80 > $m[ $i ] ) {
+				$entities .= \chr( $m[ $i++ ] );
+				continue;
+			}
+			if ( 0xF0 <= $m[ $i ] ) {
+				$c = ( ( $m[ $i++ ] - 0xF0 ) << 18 ) + ( ( $m[ $i++ ] - 0x80 ) << 12 ) + ( ( $m[ $i++ ] - 0x80 ) << 6 ) + $m[ $i++ ] - 0x80;
+			} elseif ( 0xE0 <= $m[ $i ] ) {
+				$c = ( ( $m[ $i++ ] - 0xE0 ) << 12 ) + ( ( $m[ $i++ ] - 0x80 ) << 6 ) + $m[ $i++ ] - 0x80;
+			} else {
+				$c = ( ( $m[ $i++ ] - 0xC0 ) << 6 ) + $m[ $i++ ] - 0x80;
+			}
+
+			$entities .= '&#' . $c . ';';
+		}
+
+		return $entities;
+	}
+
+	/**
+	 * Return formatted encoding string.
+	 *
+	 * @param string $encoding
+	 *
+	 * @return string
+	 */
+	private static function get_encoding( $encoding ) {
+		if ( null === $encoding ) {
+			return self::$internal_encoding;
+		}
+
+		if ( 'UTF-8' === $encoding ) {
+			return 'UTF-8';
+		}
+
+		$encoding = strtoupper( $encoding );
+
+		if ( '8BIT' === $encoding || 'BINARY' === $encoding ) {
+			return 'CP850';
+		}
+
+		if ( 'UTF8' === $encoding ) {
+			return 'UTF-8';
+		}
+
+		return $encoding;
+	}
+}

--- a/src/Polyfills/MBString.php
+++ b/src/Polyfills/MBString.php
@@ -5,7 +5,11 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Polyfills;
 
 /**
  * Class Multi Byte String
+ *
  * Based off of: https://github.com/symfony/polyfill-mbstring
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * https://github.com/symfony/polyfill-mbstring/blob/v1.22.1/LICENSE
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Polyfills
  */

--- a/src/Polyfills/bootstrap.php
+++ b/src/Polyfills/bootstrap.php
@@ -1,0 +1,42 @@
+<?php
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Polyfills\MBString;
+
+if ( ! function_exists( 'mb_convert_encoding' ) ) {
+	/**
+	 * Convert encoding.
+	 *
+	 * @param array|string      $string
+	 * @param string            $to_encoding
+	 * @param array|string|null $from_encoding
+	 */
+	function mb_convert_encoding( $string, $to_encoding, $from_encoding = null ) {
+		return MBString::mb_convert_encoding( $string, $to_encoding, $from_encoding );
+	}
+}
+
+if ( ! function_exists( 'mb_check_encoding' ) ) {
+	/**
+	 * Check if strings are valid for the specified encoding.
+	 *
+	 * @param array|string|null $value
+	 * @param string|null       $encoding
+	 */
+	function mb_check_encoding( $value = null, $encoding = null ) {
+		return MBString::mb_check_encoding( $value, $encoding );
+	}
+}
+
+if ( ! function_exists( 'mb_strlen' ) ) {
+	/**
+	 * Get string length.
+	 *
+	 * @param string      $string
+	 * @param string|null $encoding
+	 * @return int
+	 */
+	function mb_strlen( $string, $encoding = null ): int {
+		return MBString::mb_strlen( $string, $encoding );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To validate products before they sync to the Merchant Center API, we use the `symfony/validator` library. This in turn installs `polyfill-mbstring` as a fallback for sites that do not have the `mbstring` extension enabled.

The polyfill works fine but it produces an error when submitting to WordPress.org. To get around this, we provide our own polyfill so the symfony one is no longer needed.

Closes #331

### Detailed test instructions:

1. Configure PHP to skip loading of the mbstring extension `extension=mbstring.so`
2. Remove the vendor folder and run `composer install --no-dev` to make sure the `polyfill-mbstring` package is no longer loaded (dev dependencies require the mbstring PHP extension)
3. Tools > Health Check will confirm if the mbstring extension is missing (make sure the GLA plugin is not active as it provides an alternative)
![image](https://user-images.githubusercontent.com/11388669/117839751-6aef8f80-b273-11eb-9b7c-ffc1de3a13ee.png)
4. Edit one of the products and set one of the MPN numbers (this will trigger a string length validation when syncing)
5. Sync all the products on the connection test page
6. Confirm there are no fatal errors or warnings

### Changelog Note:
- Fix - Replacement polyfills for mbstring.