### PR TITLE
Setup MC: display error message when Google MC Account API call failed

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
@@ -13,6 +13,7 @@ import AppTextButton from '.~/components/app-text-button';
 import Section from '.~/wcdl/section';
 import Subsection from '.~/wcdl/subsection';
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import './index.scss';
@@ -25,6 +26,7 @@ const SwitchUrlCard = ( props ) => {
 		newUrl,
 		onSelectAnotherAccount = () => {},
 	} = props;
+	const { createNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
 	const [ fetchMCAccountSwitchUrl, { loading } ] = useApiFetchCallback( {
 		path: `/wc/gla/mc/accounts/switch-url`,
@@ -33,8 +35,18 @@ const SwitchUrlCard = ( props ) => {
 	} );
 
 	const handleSwitch = async () => {
-		await fetchMCAccountSwitchUrl();
-		invalidateResolution( 'getGoogleMCAccount', [] );
+		try {
+			await fetchMCAccountSwitchUrl();
+			invalidateResolution( 'getGoogleMCAccount', [] );
+		} catch ( e ) {
+			const errorMessage =
+				e.message ||
+				__(
+					'Unable to switch to your new URL. Please try again later.',
+					'google-listings-and-ads'
+				);
+			createNotice( 'error', errorMessage );
+		}
 	};
 
 	const handleUseDifferentMCClick = () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #582 .

Prior to this PR, in the Setup MC flow, when there is an API error in the following two actions, there are no error message displayed in the UI:

1. Connecting an existing MC account. (`POST /wc/gla/mc/accounts` with `id`)
2. Switch URL. (`POST /wc/gla/mc/accounts/switch-url`)

This PR adds better error handling for the above two actions and displays the error message in a notice toast.

Note: Other Google MC Account API calls (i.e. create account with `POST /wc/gla/mc/accounts` with empty body, and claim overwrite with `POST /wc/gla/mc/accounts/claim-overwrite`) already has error handling and displays error notice toast.

### Screenshots:

Demo video with my voice (https://d.pr/v/VRGDNT):

https://user-images.githubusercontent.com/417342/117866298-8e452980-b2c9-11eb-8361-be565d540749.mov

### Detailed test instructions:

Test Setup: You can open `src/API/Site/Controllers/MerchantCenter/AccountController.php` file and add the following line to `set_account_id` function to simulate error in connecting Google MC Account:

```php
	protected function set_account_id( Request $request ) {
		return new Response( [ 'message' => 'error message here' ], 400 ); // For testing error handling: add this line.

		try {
```

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc
2. Connect Google MC account
3. If there is an error in the API call, you should see an error message displayed in a notice toast.

### Changelog Note:

Setup MC: display error message when Google MC Account API call failed.
