### PR TITLE
Add spend column to product reports

### DIFF
--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -48,6 +48,11 @@ const paidMetrics = [
 		key: 'conversions',
 		label: __( 'Conversions', 'google-listings-and-ads' ),
 	},
+	{
+		key: 'spend',
+		label: __( 'Spend', 'google-listings-and-ads' ),
+		isCurrency: true,
+	},
 	...freeMetrics,
 ];
 

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -48,12 +48,12 @@ const paidMetrics = [
 		key: 'conversions',
 		label: __( 'Conversions', 'google-listings-and-ads' ),
 	},
+	...freeMetrics,
 	{
 		key: 'spend',
 		label: __( 'Spend', 'google-listings-and-ads' ),
 		isCurrency: true,
 	},
-	...freeMetrics,
 ];
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds the spend column in the product reports as suggested here: https://github.com/woocommerce/google-listings-and-ads/pull/569#issuecomment-839693623

### Screenshots:
![image](https://user-images.githubusercontent.com/11388669/117974360-6388be80-b325-11eb-850e-e411d11b5138.png)

### Detailed test instructions:

1. View the product reports page with either live data or test data
2. Confirm that the spend column is present in the graph and the product table below


### Changelog Note:
- Fix - Show spend column in product reports
