### PR TITLE
Get report parameter defaults using a helper function

### DIFF
--- a/src/API/Site/Controllers/BaseReportsController.php
+++ b/src/API/Site/Controllers/BaseReportsController.php
@@ -121,11 +121,29 @@ abstract class BaseReportsController extends BaseController {
 	 */
 	protected function prepare_query_arguments( Request $request ): array {
 		$params   = $this->get_collection_params();
-		$defaults = array_column( $params, 'default' );
+		$defaults = $this->get_defaults( $params );
 		$args     = wp_parse_args( array_intersect_key( $request->get_query_params(), $params ), $defaults );
 
 		$this->normalize_timezones( $args );
 		return $args;
+	}
+
+	/**
+	 * Get paramater defaults.
+	 *
+	 * @param array $params List of parameters.
+	 *
+	 * @return array
+	 */
+	protected function get_defaults( array $params ): array {
+		$defaults = [];
+		foreach ( $params as $key => $param ) {
+			if ( isset( $param['default'] ) ) {
+				$defaults[ $key ] = $param['default'];
+			}
+		}
+
+		return $defaults;
 	}
 
 	/**

--- a/src/API/Site/Controllers/BaseReportsController.php
+++ b/src/API/Site/Controllers/BaseReportsController.php
@@ -129,7 +129,7 @@ abstract class BaseReportsController extends BaseController {
 	}
 
 	/**
-	 * Get paramater defaults.
+	 * Get parameter defaults.
 	 *
 	 * @param array $params List of parameters.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The code for getting the defaults was refactored several times, which resulted in a bug in how they are combined with the actual parameters we send.

`array_column` returns array index with a numeric array. We want it to be indexed by the parameter slug so it can be combined by index. Both `array_column` and `wp_list_pluck` have a third parameter, but since the slug of the parameter isn't included in the array we can't use this. We end up with an array something like this:

```php
[
  0 => 'default',
  1 => 'asc',
  'per_page' => 200,
  'order' => 'desc',
]
```

### Detailed test instructions:

1. Change the default `per_page` to 5
2. Send an API request to retrieve report data `GET https://domain.test/wp-json/wc/gla/ads/reports/products?after=2021-03-01&before=2021-03-14&interval=day&fields[0]=sales`
3. Confirm that we aren't retrieving all the results

### Changelog Note:
* Fix - Report parameter defaults.