### PR TITLE
Update Product Feed status labels

### DIFF
--- a/js/src/product-feed/product-feed-table-card/statusLabelMap.js
+++ b/js/src/product-feed/product-feed-table-card/statusLabelMap.js
@@ -4,10 +4,12 @@
 import { __ } from '@wordpress/i18n';
 
 const statusLabelMap = {
+	approved: __( 'Approved', 'google-listings-and-ads' ),
+	partially_approved: __( 'Partially approved', 'google-listings-and-ads' ),
+	expiring: __( 'Expiring', 'google-listings-and-ads' ),
 	pending: __( 'Pending', 'google-listings-and-ads' ),
-	synced: __( 'Synced', 'google-listings-and-ads' ),
-	'not-synced': __( 'Not synced', 'google-listings-and-ads' ),
-	'has-errors': __( 'Has errors', 'google-listings-and-ads' ),
+	disapproved: __( 'Disapproved', 'google-listings-and-ads' ),
+	not_synced: __( 'Not synced', 'google-listings-and-ads' ),
 };
 
 export default statusLabelMap;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #599 .

This PR updates the `statusLabelMap` used in the Product Feed page. This is needed in conjunction with the API changes done in PR #562.

### Screenshots:

![image](https://user-images.githubusercontent.com/417342/118115017-f35c6480-b41a-11eb-9b39-19c7564924f2.png)

### Detailed test instructions:

1. Connect MC using onboarding wizard.
2. Sync products.
3. Navigate to Product Feed page, https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed
4. The product feed should show their status in the table.

### Changelog Note:

Update Product Feed status labels.
