### PR TITLE
Admin Notes 2 to 4

### DIFF
--- a/src/Ads/AdsAwareInterface.php
+++ b/src/Ads/AdsAwareInterface.php
@@ -1,0 +1,19 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Ads;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface AdsAwareInterface
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Ads
+ */
+interface AdsAwareInterface {
+
+	/**
+	 * @param AdsService $ads_service
+	 */
+	public function set_ads_object( AdsService $ads_service ): void;
+}

--- a/src/Ads/AdsAwareTrait.php
+++ b/src/Ads/AdsAwareTrait.php
@@ -1,0 +1,28 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Ads;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait AdsAwareTrait
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Ads
+ */
+trait AdsAwareTrait {
+
+	/**
+	 * The AdsService object.
+	 *
+	 * @var AdsService
+	 */
+	protected $ads_service;
+
+	/**
+	 * @param AdsService $ads_service
+	 */
+	public function set_ads_object( AdsService $ads_service ): void {
+		$this->ads_service = $ads_service;
+	}
+}

--- a/src/Ads/AdsService.php
+++ b/src/Ads/AdsService.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -13,21 +15,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Ads
  */
-class AdsService implements Service {
+class AdsService implements OptionsAwareInterface, Service {
 
-	/**
-	 * @var OptionsInterface
-	 */
-	protected $options;
-
-	/**
-	 * MerchantCenterService constructor.
-	 *
-	 * @param OptionsInterface $options
-	 */
-	public function __construct( OptionsInterface $options ) {
-		$this->options = $options;
-	}
+	use OptionsAwareTrait;
 
 	/**
 	 * Get whether Ads setup is completed.

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -42,6 +42,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterSer
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\CompleteSetup as CompleteSetupNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaign as SetupCampaignNote;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaignTwoWeeks as SetupCampaign2Note;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsSetupCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
@@ -107,6 +108,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		SetupAds::class               => true,
 		SetupMerchantCenter::class    => true,
 		SetupCampaignNote::class      => true,
+		SetupCampaign2Note::class     => true,
 		TrackerSnapshot::class        => true,
 		Tracks::class                 => true,
 		TracksInterface::class        => true,
@@ -207,6 +209,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Inbox Notes
 		$this->conditionally_share_with_tags( CompleteSetupNote::class );
 		$this->conditionally_share_with_tags( SetupCampaignNote::class );
+		$this->conditionally_share_with_tags( SetupCampaign2Note::class );
 
 		// Product attributes
 		$this->conditionally_share_with_tags( AttributeManager::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -160,7 +160,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			->inflector( MerchantCenterAwareInterface::class )
 			->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );
 
-		$this->share_with_tags( AdsService::class, OptionsInterface::class );
+		$this->share_with_tags( AdsService::class );
 
 		// Set up the installer.
 		$installer_definition = $this->share_with_tags( Installer::class, InstallableInterface::class, FirstInstallInterface::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTab;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\VariationsAttributes;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer as DBInstaller;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;
@@ -160,7 +161,11 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			->inflector( MerchantCenterAwareInterface::class )
 			->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );
 
+		// Set up Ads service, and inflect classes that need it.
 		$this->share_with_tags( AdsService::class );
+		$this->getLeagueContainer()
+			->inflector( AdsAwareInterface::class )
+			->invokeMethod( 'set_ads_object', [ AdsService::class ] );
 
 		// Set up the installer.
 		$installer_definition = $this->share_with_tags( Installer::class, InstallableInterface::class, FirstInstallInterface::class );

--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -43,8 +43,6 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 
 	/**
 	 * Possibly add the note
-	 *
-	 * @return void
 	 */
 	public function possibly_add_note(): void {
 		if ( ! $this->can_add_note() ) {
@@ -76,7 +74,7 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 	 * Check if it is > 3 days ago from DATE OF START OF SETUP (installation date)
 	 * Send notification
 	 *
-	 * @return Note
+	 * @return bool
 	 */
 	public function can_add_note(): bool {
 		if ( ! class_exists( '\WC_Data_Store' ) ) {

--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -27,7 +27,7 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 	use PluginHelper;
 	use Utilities;
 
-	public const NOTE_NAME = 'gla-complete-setup-2021-02';
+	public const NOTE_NAME = 'gla-complete-setup';
 
 	/**
 	 * Register a service.
@@ -52,8 +52,8 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Drive traffic and sales with Google', 'google-listings-and-ads' ) );
-		$note->set_content( __( 'Reach online shoppers to drive traffic and sales for your store by showcasing products across Google, for free or with ads.', 'google-listings-and-ads' ) );
+		$note->set_title( __( 'Complete your setup on Google', 'google-listings-and-ads' ) );
+		$note->set_content( __( 'Finish setting up Google Listings & Ads to list your products on Google for free and promote them with paid ads.', 'google-listings-and-ads' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_layout( 'plain' );
@@ -62,7 +62,7 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 		$note->set_source( $this->get_slug() );
 		$note->add_action(
 			'complete-setup',
-			__( 'Get started', 'google-listings-and-ads' ),
+			__( 'Finish setup', 'google-listings-and-ads' ),
 			$this->get_start_url()
 		);
 		$note->save();
@@ -91,10 +91,6 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 		}
 
 		if ( $this->merchant_center->is_setup_complete() ) {
-			return false;
-		}
-
-		if ( ! $this->gla_active_for( 3 * DAY_IN_SECONDS ) ) {
 			return false;
 		}
 

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -6,12 +6,12 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 use Automattic\WooCommerce\Admin\Notes\DataStore;
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use WC_Data_Store;
@@ -21,13 +21,13 @@ use WC_Data_Store;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwareInterface, MerchantCenterAwareInterface {
+class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwareInterface, AdsAwareInterface {
 
-	use MerchantCenterAwareTrait;
+	use AdsAwareTrait;
 	use PluginHelper;
 	use Utilities;
 
-	public const NOTE_NAME = 'gla-setup-campaign-2021-02';
+	public const NOTE_NAME = 'gla-setup-campaign';
 
 	/**
 	 * Register a service.
@@ -52,7 +52,7 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Boost store sales with Google Ads', 'google-listings-and-ads' ) );
+		$note->set_title( __( 'Create your first campaign to boost sales', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'Leverage the power of paid ads to list products on Google Search, Shopping, YouTube, Gmail and the Display Network and drive sales.', 'google-listings-and-ads' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
@@ -63,7 +63,7 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 		$note->add_action(
 			'setup-campaign',
 			__( 'Get started', 'google-listings-and-ads' ),
-			$this->get_start_url() // TODO: update to ads/campgaign flow
+			$this->get_setup_ads_url()
 		);
 		$note->save();
 	}
@@ -71,8 +71,7 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 	/**
 	 * Checks if a note can and should be added.
 	 *
-	 * Check if a stores done 5 sales
-	 * Check if setup IS complete
+	 * Check if ads setup IS NOT complete
 	 * Check if it is > 3 days ago from DATE OF SETUP COMPLETION
 	 * Send notification
 	 *
@@ -91,15 +90,11 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 			return false;
 		}
 
-		if ( ! $this->merchant_center->is_setup_complete() ) {
+		if ( $this->ads_service->is_setup_complete() ) {
 			return false;
 		}
 
 		if ( ! $this->gla_setup_for( 3 * DAY_IN_SECONDS ) ) {
-			return false;
-		}
-
-		if ( ! $this->has_orders( 5 ) ) {
 			return false;
 		}
 

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -43,8 +43,6 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 
 	/**
 	 * Possibly add the note
-	 *
-	 * @return Note
 	 */
 	public function possibly_add_note(): void {
 		if ( ! $this->can_add_note() ) {
@@ -75,7 +73,7 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 	 * Check if it is > 3 days ago from DATE OF SETUP COMPLETION
 	 * Send notification
 	 *
-	 * @return Note
+	 * @return bool
 	 */
 	public function can_add_note(): bool {
 		if ( ! class_exists( WC_Data_Store::class ) ) {

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -1,0 +1,116 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
+
+use Automattic\WooCommerce\Admin\Notes\DataStore;
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use WC_Data_Store;
+
+/**
+ * Class SetupCampaignTwoWeeks
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
+ */
+class SetupCampaignTwoWeeks implements Deactivateable, Service, Registerable, OptionsAwareInterface, AdsAwareInterface {
+
+	use AdsAwareTrait;
+	use PluginHelper;
+	use Utilities;
+
+	public const NOTE_NAME = 'gla-setup-campaign-two-weeks';
+
+	/**
+	 * Register a service.
+	 */
+	public function register(): void {
+		add_action(
+			'admin_init',
+			function() {
+				$this->possibly_add_note();
+			}
+		);
+	}
+
+	/**
+	 * Possibly add the note
+	 *
+	 * @return Note
+	 */
+	public function possibly_add_note(): void {
+		if ( ! $this->can_add_note() ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Launch your first ad in a few steps', 'google-listings-and-ads' ) );
+		$note->set_content( __( 'You’re just a few steps away from reaching new shoppers across Google. Create your first paid ad campaign today.', 'google-listings-and-ads' ) );
+		$note->set_content_data( (object) [] );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_layout( 'plain' );
+		$note->set_image( '' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( $this->get_slug() );
+		$note->add_action(
+			'setup-campaign',
+			__( 'Get started', 'google-listings-and-ads' ),
+			$this->get_setup_ads_url()
+		);
+		$note->save();
+	}
+
+	/**
+	 * Checks if a note can and should be added.
+	 *
+	 * Check if ads setup IS NOT complete
+	 * Check if it is > 14 days ago from DATE OF SETUP COMPLETION
+	 * Send notification
+	 *
+	 * @return Note
+	 */
+	public function can_add_note(): bool {
+		if ( ! class_exists( WC_Data_Store::class ) ) {
+			return false;
+		}
+
+		/** @var DataStore $data_store */
+		$data_store = WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+
+		if ( ! empty( $note_ids ) ) {
+			return false;
+		}
+
+		if ( $this->ads_service->is_setup_complete() ) {
+			return false;
+		}
+
+		if ( ! $this->gla_setup_for( 14 * DAY_IN_SECONDS ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Deactivate the service.
+	 *
+	 * @return void
+	 */
+	public function deactivate(): void {
+		if ( ! class_exists( Notes::class ) ) {
+			return;
+		}
+
+		Notes::delete_notes_with_name( self::NOTE_NAME );
+	}
+}

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -43,8 +43,6 @@ class SetupCampaignTwoWeeks implements Deactivateable, Service, Registerable, Op
 
 	/**
 	 * Possibly add the note
-	 *
-	 * @return Note
 	 */
 	public function possibly_add_note(): void {
 		if ( ! $this->can_add_note() ) {
@@ -75,7 +73,7 @@ class SetupCampaignTwoWeeks implements Deactivateable, Service, Registerable, Op
 	 * Check if it is > 14 days ago from DATE OF SETUP COMPLETION
 	 * Send notification
 	 *
-	 * @return Note
+	 * @return bool
 	 */
 	public function can_add_note(): bool {
 		if ( ! class_exists( WC_Data_Store::class ) ) {

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -109,6 +109,15 @@ trait PluginHelper {
 	}
 
 	/**
+	 * Get the URL to connect an Ads account
+	 *
+	 * @return string
+	 */
+	protected function get_setup_ads_url(): string {
+		return admin_url( 'admin.php?page=wc-admin&path=/google/setup-ads' );
+	}
+
+	/**
 	 * Get the plugin settings URL
 	 *
 	 * @return string


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolves part of #546 
For note 1 we will need to use a remote inbox note which needs to be added to the [json feed](https://github.com/Automattic/woocommerce.com/blob/trunk/plugins/wccom-plugins/inbox-notifications/includes/notifications.json.php).

### Test Note 2:
1. Delete the option `gla_mc_setup_completed_at` in the DB
2. Make sure the site has at least 5 "completed" orders
3. Confirm that the note appears in WooCommerce > Home

![image](https://user-images.githubusercontent.com/11388669/118135424-e9c30480-b3fa-11eb-9dd7-c3c99ae01087.png)

### Test Note 3:
1. Disconnect the ads account on the settings page
2. Make sure the option `gla_mc_setup_completed_at` has a timestamp of at least 3 days ago
3. Confirm that the note appears in WooCommerce > Home

![image](https://user-images.githubusercontent.com/11388669/118135438-efb8e580-b3fa-11eb-815f-15e14c1e5497.png)

### Test Note 4:
1. Disconnect the ads account on the settings page
2. Make sure the option `gla_mc_setup_completed_at` has a timestamp of at least 14 days ago
3. Confirm that the note appears in WooCommerce > Home

![image](https://user-images.githubusercontent.com/11388669/118135451-f5aec680-b3fa-11eb-8fba-df222eb0a040.png)

_Note: To reset notes we can remove them from the `wp_wc_admin_notes` table._

### Changelog Note:
* Update - Change admin notes text and prompt to setup ads after two weeks.
