### PR TITLE
Show selected "Free Listings" filter / Handle URL param id `0` as valid in `getIdsFromQuery`

### DIFF
--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -4,11 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 import { CheckboxControl, Button } from '@wordpress/components';
-import { getIdsFromQuery, onQueryChange } from '@woocommerce/navigation';
+import { onQueryChange } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import { getIdsFromQuery } from '../utils';
 import useUrlQuery from '.~/hooks/useUrlQuery';
 import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
 import useCurrencyFactory from '.~/hooks/useCurrencyFactory';

--- a/js/src/reports/programs/filter-config.js
+++ b/js/src/reports/programs/filter-config.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getIdsFromQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import { getIdsFromQuery } from '../utils';
 import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
 
 export const programsFilterConfig = ( adsCampaigns ) => {

--- a/js/src/reports/utils.js
+++ b/js/src/reports/utils.js
@@ -1,0 +1,18 @@
+/**
+ * Get an array of unique IDs from a comma-separated query parameter.
+ * We cannot use '@woocommerce/navigation.getIdsFromQuery' as it does not support `0` as an Id
+ * https://github.com/woocommerce/woocommerce-admin/issues/6980
+ *
+ * @param {string} [queryString=''] string value extracted from URL.
+ * @return {Array} List of IDs converted to numbers.
+ */
+export function getIdsFromQuery( queryString = '' ) {
+	return [
+		...new Set( // Return only unique ids.
+			queryString
+				.split( ',' )
+				.map( ( id ) => parseInt( id, 10 ) )
+				.filter( ( id ) => ! isNaN( id ) )
+		),
+	];
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Workaround https://github.com/woocommerce/woocommerce-admin/issues/6980.
Cover only affected programs report cases. In the long-term, we should use fixed `@woocommerce/navigation`.
Change is introduced also to `CompareProductsTableCard`, as its code may be extracted as a shared component between programs and reports.


### Screenshots:


![Screencast showing Free Listings label being displayed](https://user-images.githubusercontent.com/17435/118180646-11d05900-b437-11eb-8575-172f64bd3c6e.gif)


### Detailed test instructions:

1. Got to Programs Report page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms)
2. Use program filter: `Single program -> "Free Listings"`
3. You should see the selected program label

4. Reload the page or visit the[ URL with already selected `programs=0` (Free Listings)](https://gla1.test/wp-admin/admin.php?page=wc-admin&filter=single_program&programs=0&path=%2Fgoogle%2Freports%2Fprograms)
5. You should see the selected program label



### Changelog Note:

> Fixed rendering label for Free Listings program filter.

### Additional notes:

This util is also used in https://github.com/woocommerce/google-listings-and-ads/pull/602.
Whichever PR gets merged first, I'll update the other to share the code. 
I thought this one is just easier to test and review.