### PR TITLE
Conflict resolution in Merchant Center account connection process

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -72,7 +72,9 @@ const ConnectMCCard = ( props ) => {
 	}
 
 	if ( response && response.status === 403 ) {
-		return <ReclaimUrlCard websiteUrl={ error.website_url } />;
+		return (
+			<ReclaimUrlCard id={ error.id } websiteUrl={ error.website_url } />
+		);
 	}
 
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
@@ -55,7 +55,9 @@ const CreateAccount = ( props ) => {
 	}
 
 	if ( response && response.status === 403 ) {
-		return <ReclaimUrlCard websiteUrl={ error.website_url } />;
+		return (
+			<ReclaimUrlCard id={ error.id } websiteUrl={ error.website_url } />
+		);
 	}
 
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
@@ -27,7 +27,10 @@ const CreateAccount = ( props ) => {
 
 	const handleCreateAccount = async () => {
 		try {
-			await fetchCreateMCAccount( { parse: false } );
+			await fetchCreateMCAccount( {
+				data: error?.id && { id: error.id },
+				parse: false,
+			} );
 			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {
 			if ( ! [ 403, 503 ].includes( e.status ) ) {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
@@ -30,17 +30,15 @@ const CreateAccount = ( props ) => {
 			await fetchCreateMCAccount( { parse: false } );
 			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {
-			if ( e.status === 406 ) {
+			if ( ! [ 403, 503 ].includes( e.status ) ) {
 				const body = await e.json();
-				createNotice( 'error', body.message );
-			} else if ( ! [ 403, 503 ].includes( e.status ) ) {
-				createNotice(
-					'error',
+				const message =
+					body.message ||
 					__(
 						'Unable to create Merchant Center account. Please try again later.',
 						'google-listings-and-ads'
-					)
-				);
+					);
+				createNotice( 'error', message );
 			}
 		}
 	};

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -7,6 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import toAccountText from '.~/utils/toAccountText';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import AppButton from '.~/components/app-button';
 import Section from '.~/wcdl/section';
@@ -18,7 +19,7 @@ import ContentButtonLayout from '.~/components/content-button-layout';
 import ReclaimUrlFailCard from './reclaim-url-fail-card';
 
 const ReclaimUrlCard = ( props ) => {
-	const { websiteUrl } = props;
+	const { id, websiteUrl } = props;
 	const { createNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
 	const [
@@ -27,6 +28,7 @@ const ReclaimUrlCard = ( props ) => {
 	] = useApiFetchCallback( {
 		path: `/wc/gla/mc/accounts/claim-overwrite`,
 		method: 'POST',
+		data: { id },
 	} );
 
 	const handleReclaimClick = async () => {
@@ -57,6 +59,9 @@ const ReclaimUrlCard = ( props ) => {
 	return (
 		<Section.Card>
 			<Section.Card.Body>
+				<ContentButtonLayout>
+					<Subsection.Title>{ toAccountText( id ) }</Subsection.Title>
+				</ContentButtonLayout>
 				<ContentButtonLayout>
 					<div>
 						<Subsection.Title>

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -502,7 +502,7 @@ class AccountController extends BaseOptionsController {
 			throw new Exception(
 				sprintf(
 					/* translators: 1: is a numeric account ID */
-					__( 'Merchant Center sub-account %1$d already created.', 'google-listings-and-ads' ),
+					__( 'Merchant Center connection already in process with account %1$d.', 'google-listings-and-ads' ),
 					$merchant_id
 				)
 			);

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -310,6 +310,19 @@ class AccountController extends BaseOptionsController {
 
 			// Reset the process if the provided ID isn't the same as the one "on file" in `options`.
 			if ( $merchant_id && $merchant_id !== $account_id ) {
+				// Can't do it if the MC connection is active and complete.
+				if ( $this->mc_service->is_connected() ) {
+					return $this->prepare_error_response(
+						[
+							'message' => sprintf(
+								/* translators: 1: is a numeric account ID */
+								__( 'Merchant Center account already connected: %d', 'google-listings-and-ads' ),
+								$merchant_id
+							),
+						]
+					);
+				}
+
 				$this->mc_service->disconnect();
 			}
 
@@ -403,7 +416,7 @@ class AccountController extends BaseOptionsController {
 					default:
 						throw new Exception(
 							sprintf(
-							/* translators: 1: is a string representing an unknown step name */
+								/* translators: 1: is a string representing an unknown step name */
 								__( 'Unknown merchant account creation step %1$s', 'google-listings-and-ads' ),
 								$name
 							)
@@ -522,6 +535,7 @@ class AccountController extends BaseOptionsController {
 	 *
 	 * @param int $account_id The merchant ID to use.
 	 *
+	 * @throws Exception If the merchant IDs of the connected account can't be retrieved.
 	 * @throws ExceptionWithResponseData If there's a website URL conflict.
 	 */
 	private function use_existing_account_id( int $account_id ): void {

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -353,7 +353,7 @@ class AccountController extends BaseOptionsController {
 	protected function prepare_error_response( array $data, int $code = null ): Response {
 		$merchant_id = $this->options->get_merchant_id();
 		if ( $merchant_id ) {
-			$data['merchant_id'] = $merchant_id;
+			$data['id'] = $merchant_id;
 		}
 		return new Response( $data, $code ?: 400 );
 
@@ -432,7 +432,7 @@ class AccountController extends BaseOptionsController {
 				// URL already claimed.
 				if ( 'claim' === $name && 403 === $e->getCode() ) {
 					$data = [
-						'merchant_id' => $merchant_id,
+						'id'          => $merchant_id,
 						'website_url' => $this->strip_url_protocol(
 							esc_url_raw( apply_filters( 'woocommerce_gla_site_url', site_url() ) )
 						),

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -310,8 +310,8 @@ class AccountController extends BaseOptionsController {
 
 			// Reset the process if the provided ID isn't the same as the one "on file" in `options`.
 			if ( $merchant_id && $merchant_id !== $account_id ) {
-				// Can't do it if the MC connection is active and complete.
-				if ( $this->mc_service->is_connected() ) {
+				// Can't do it if the MC connection process has been completed previously.
+				if ( $this->mc_service->is_setup_complete() ) {
 					return $this->prepare_error_response(
 						[
 							'message' => sprintf(

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -354,7 +354,7 @@ class ConnectionTest implements Service, Registerable {
 										add_query_arg(
 											[
 												'action' => 'wcs-google-mc-claim-overwrite',
-												'account_id' => ($_GET['account_id'] ?? false) || $merchant_id,
+												'account_id' => ($_GET['account_id'] ?? false) ?: $merchant_id,
 											],
 											$url
 										),
@@ -373,7 +373,7 @@ class ConnectionTest implements Service, Registerable {
 												[
 													'action' => 'wcs-google-mc-switch-url',
 													'site_url' => $_GET['site_url'] ?? apply_filters( 'woocommerce_gla_site_url', site_url(), $url ),
-													'account_id' => ($_GET['account_id'] ?? false) || $merchant_id,
+													'account_id' => ($_GET['account_id'] ?? false) ?: $merchant_id,
 												]
 											),
 											'wcs-google-mc-switch-url'

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -555,7 +555,7 @@ class ConnectionTest implements Service, Registerable {
 							<td>
 								<p>
 						<label>
-							Product ID <input name="product_id" type="text" value="<?php echo ! empty( $_GET['product_id'] ) ? intval( $_GET['product_id'] ) : ''; ?>" /></label>
+							Product ID <input name="product_id" type="text" value="<?php echo ! empty( $_GET['product_id'] ) ? intval( $_GET['product_id'] ) : ''; ?>" />
 						</label>
 						<label for="async-sync-product">Async?</label>
 						<input id="async-sync-product" name="async" value=1 type="checkbox" <?php echo ! empty( $_GET['async'] ) ? 'checked' : ''; ?> />

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -304,10 +304,12 @@ class ConnectionTest implements Service, Registerable {
 
 								<?php
 									$mc_account_state = $this->container->get( MerchantAccountState::class )->get( false );
+									$merchant_id = $this->container->get( OptionsInterface::class )->get_merchant_id();
 									if ( ! empty( $mc_account_state ) ) :
 								?>
 									<p class="description" style="font-style: italic">
-										( Merchant Center account status -- ID: <?php echo $this->container->get( OptionsInterface::class )->get( OptionsInterface::MERCHANT_ID ); ?> ||
+										( Merchant Center account status -- ID: <?php
+										echo $merchant_id; ?> ||
 										<?php foreach ( $mc_account_state as $name => $step ) : ?>
 											<?php echo $name . ':' . $step['status']; ?>
 										<?php endforeach; ?>
@@ -344,15 +346,25 @@ class ConnectionTest implements Service, Registerable {
 							</td>
 						</tr>
 						<tr>
-							<th><a name="overwrite"></a>Claim Overwrite:</th>
+							<th><a id="overwrite"></a>Claim Overwrite:</th>
 							<td>
 								<p>
-									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'wcs-google-mc-claim-overwrite' ], $url ), 'wcs-google-mc-claim-overwrite' ) ); ?>">Claim Overwrite</a>
+									<a class="button" href="<?php
+									echo esc_url( wp_nonce_url(
+										add_query_arg(
+											[
+												'action' => 'wcs-google-mc-claim-overwrite',
+												'account_id' => ($_GET['account_id'] ?? false) || $merchant_id,
+											],
+											$url
+										),
+										'wcs-google-mc-claim-overwrite' )
+									); ?>" <?php echo ( ($_GET['account_id'] ?? false) || $merchant_id ) ? '' : 'disabled="disabled" title="Missing account ID"' ?>>Claim Overwrite</a>
 								</p>
 							</td>
 						</tr>
 						<tr>
-							<th><a name="overwrite"></a>Switch URL:</th>
+							<th><a id="switch"></a>Switch URL:</th>
 							<td>
 								<p>
 									<a class="button" href="<?php
@@ -361,11 +373,11 @@ class ConnectionTest implements Service, Registerable {
 												[
 													'action' => 'wcs-google-mc-switch-url',
 													'site_url' => $_GET['site_url'] ?? apply_filters( 'woocommerce_gla_site_url', site_url(), $url ),
-													'account_id' => $_GET['account_id'] ?? ''
+													'account_id' => ($_GET['account_id'] ?? false) || $merchant_id,
 												]
 											),
 											'wcs-google-mc-switch-url'
-										) ); ?>" <?php echo ( $_GET['account_id'] ?? false ) ? '' : 'disabled="disabled" title="Missing account ID"' ?>>Switch URL</a>
+										) ); ?>" <?php echo ( ($_GET['account_id'] ?? false) || $merchant_id ) ? '' : 'disabled="disabled" title="Missing account ID"' ?>>Switch URL</a>
 								</p>
 							</td>
 						</tr>
@@ -785,6 +797,9 @@ class ConnectionTest implements Service, Registerable {
 
 		if ( 'wcs-google-mc-claim-overwrite' === $_GET['action'] && check_admin_referer( 'wcs-google-mc-claim-overwrite' ) ) {
 			$request = new Request( 'POST', '/wc/gla/mc/accounts/claim-overwrite' );
+			if ( is_numeric( $_GET['account_id'] ?? false ) ) {
+				$request->set_body_params( [ 'id' => $_GET['account_id'] ] );
+			}
 			$this->send_rest_request( $request );
 		}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -68,7 +68,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * @var array Statuses for each product ID.
 	 */
-	protected $product_statuses;
+	protected $product_statuses = [];
 
 	/**
 	 * MerchantStatuses constructor.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -66,9 +66,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	protected $mc_statuses;
 
 	/**
-	 * @var array Statuses for each product ID.
+	 * @var array Statuses for each product id and parent id.
 	 */
-	protected $product_statuses = [];
+	protected $product_statuses = [
+		'products' => [],
+		'parents'  => [],
+	];
 
 	/**
 	 * MerchantStatuses constructor.
@@ -341,15 +344,15 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			if ( is_null( $status ) ) {
 				continue;
 			}
-			// Simple is used later for global product status statistics.
-			$this->product_statuses['simple'][ $wc_product_id ][ $status ] = 1 + ( $this->product_statuses['simple'][ $wc_product_id ][ $status ] ?? 0 );
+			// Products is used later for global product status statistics.
+			$this->product_statuses['products'][ $wc_product_id ][ $status ] = 1 + ( $this->product_statuses['products'][ $wc_product_id ][ $status ] ?? 0 );
 
 			// Aggregate parent statuses for mc_status postmeta.
 			$wc_parent_id = $product_helper->maybe_swap_for_parent_id( $wc_product_id );
 			if ( $wc_parent_id === $wc_product_id ) {
 				continue;
 			}
-			$this->product_statuses['parent'][ $wc_parent_id ][ $status ] = 1 + ( $this->product_statuses['parent'][ $wc_parent_id ][ $status ] ?? 0 );
+			$this->product_statuses['parents'][ $wc_parent_id ][ $status ] = 1 + ( $this->product_statuses['parents'][ $wc_parent_id ][ $status ] ?? 0 );
 		}
 	}
 
@@ -366,7 +369,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			MCSTATUS::NOT_SYNCED         => 0,
 		];
 
-		foreach ( $this->product_statuses['simple'] as $statuses ) {
+		foreach ( $this->product_statuses['products'] as $statuses ) {
 			foreach ( $statuses as $status => $num_products ) {
 				$product_statistics[ $status ] += $num_products;
 			}
@@ -394,30 +397,30 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 */
 	protected function update_product_mc_statuses() {
 		// Generate a product_id=>mc_status array.
-		$product_statuses = [];
-		foreach ( $this->product_statuses as $products ) {
-			foreach ( $products as $product_id => $statuses ) {
+		$all_product_statuses = [];
+		foreach ( $this->product_statuses as $types ) {
+			foreach ( $types as $product_id => $statuses ) {
 				if ( isset( $statuses[ MCStatus::PENDING ] ) ) {
-					$product_statuses[ $product_id ] = MCStatus::PENDING;
+					$all_product_statuses[ $product_id ] = MCStatus::PENDING;
 				} elseif ( isset( $statuses[ MCStatus::EXPIRING ] ) ) {
-					$product_statuses[ $product_id ] = MCStatus::EXPIRING;
+					$all_product_statuses[ $product_id ] = MCStatus::EXPIRING;
 				} elseif ( isset( $statuses[ MCStatus::APPROVED ] ) ) {
 					if ( count( $statuses ) > 1 ) {
-						$product_statuses[ $product_id ] = MCStatus::PARTIALLY_APPROVED;
+						$all_product_statuses[ $product_id ] = MCStatus::PARTIALLY_APPROVED;
 					} else {
-						$product_statuses[ $product_id ] = MCStatus::APPROVED;
+						$all_product_statuses[ $product_id ] = MCStatus::APPROVED;
 					}
 				} else {
-					$product_statuses[ $product_id ] = array_key_first( $statuses );
+					$all_product_statuses[ $product_id ] = array_key_first( $statuses );
 				}
 			}
 		}
-		ksort( $product_statuses );
+		ksort( $all_product_statuses );
 
 		/** @var ProductMetaHandler $product_meta */
 		$product_meta = $this->container->get( ProductMetaHandler::class );
 		foreach ( $this->container->get( ProductRepository::class )->find_ids() as $product_id ) {
-			$product_meta->update_mc_status( $product_id, $product_statuses[ $product_id ] ?? MCStatus::NOT_SYNCED );
+			$product_meta->update_mc_status( $product_id, $all_product_statuses[ $product_id ] ?? MCStatus::NOT_SYNCED );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #604.

After some issues (described in issue #604), this PR modifies the Merchant Center account connection endpoint to simplify the process slightly:

- When the MC account connection process is started, the Merchant ID (either of an existing account, or of a newly-created sub-account) is stored in `options`. This doesn't change
    - Previously, if the process didn't complete (error, url switch required, claim overwrite required), it could be restarted with an empty POST request, and the saved Merchant ID would be used to attempt to complete the process.
    - Now, the Merchant ID **must always be passed explicitly** in every request (as `id`) in order to continue. Requests without an `id` value will be treated as "Create sub-account" connection requests, and any existing process will be reset in favor of a new create connection.

To summarize the new logic, from the issue:
> - If an account ID is provided and none is stored, start the connection process with the specified account.
> - If an account ID is provided and matches the one that’s stored, resume the setup process with the provided account.
> - If an account ID is provided and *doesn’t* match the one that’s stored, reset the state/process and start the connection process with the specified account.
> - If no account ID is provided, always begin the process of creating and connecting a sub-account from scratch.

- Additionally, now the Merchant ID being connected is always returned by the endpoint (as `id`), whether it's an error response or a success response. This provides the value that the requester (front end) should use when sending requests to resume/complete the process.


### Detailed test instructions:

1. Try all the paths in the Merchant Center account connection process to confirm they work, and that the Merchant ID `id` is always returned and the process works as expected:
  - Create account
    - With and without the need to overwrite a claim.
  - Existing account
    - Needs to switch URL (already has a different claimed URL)
    - Needs to overwrite claim (unresolvable error).
2. Confirm the new logic works:
  - Start the connection process with an account that will need to overwrite a claim.
  - Instead of overwriting the claim, start the connection process again
    - With a different account
    - With a "create account"
3. Same as #1, but using the MC onboarding wizard.


### Changelog Note:

> Fix - simplify Merchant Center connection process.
