### PR TITLE
Conflict resolution in Merchant Center account connection process - client side

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -72,7 +72,9 @@ const ConnectMCCard = ( props ) => {
 	}
 
 	if ( response && response.status === 403 ) {
-		return <ReclaimUrlCard websiteUrl={ error.website_url } />;
+		return (
+			<ReclaimUrlCard id={ error.id } websiteUrl={ error.website_url } />
+		);
 	}
 
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
@@ -55,7 +55,9 @@ const CreateAccount = ( props ) => {
 	}
 
 	if ( response && response.status === 403 ) {
-		return <ReclaimUrlCard websiteUrl={ error.website_url } />;
+		return (
+			<ReclaimUrlCard id={ error.id } websiteUrl={ error.website_url } />
+		);
 	}
 
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
@@ -27,7 +27,10 @@ const CreateAccount = ( props ) => {
 
 	const handleCreateAccount = async () => {
 		try {
-			await fetchCreateMCAccount( { parse: false } );
+			await fetchCreateMCAccount( {
+				data: error?.id && { id: error.id },
+				parse: false,
+			} );
 			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {
 			if ( ! [ 403, 503 ].includes( e.status ) ) {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account/index.js
@@ -30,17 +30,15 @@ const CreateAccount = ( props ) => {
 			await fetchCreateMCAccount( { parse: false } );
 			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {
-			if ( e.status === 406 ) {
+			if ( ! [ 403, 503 ].includes( e.status ) ) {
 				const body = await e.json();
-				createNotice( 'error', body.message );
-			} else if ( ! [ 403, 503 ].includes( e.status ) ) {
-				createNotice(
-					'error',
+				const message =
+					body.message ||
 					__(
 						'Unable to create Merchant Center account. Please try again later.',
 						'google-listings-and-ads'
-					)
-				);
+					);
+				createNotice( 'error', message );
 			}
 		}
 	};

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -7,6 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import toAccountText from '.~/utils/toAccountText';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import AppButton from '.~/components/app-button';
 import Section from '.~/wcdl/section';
@@ -18,7 +19,7 @@ import ContentButtonLayout from '.~/components/content-button-layout';
 import ReclaimUrlFailCard from './reclaim-url-fail-card';
 
 const ReclaimUrlCard = ( props ) => {
-	const { websiteUrl } = props;
+	const { id, websiteUrl } = props;
 	const { createNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
 	const [
@@ -27,6 +28,7 @@ const ReclaimUrlCard = ( props ) => {
 	] = useApiFetchCallback( {
 		path: `/wc/gla/mc/accounts/claim-overwrite`,
 		method: 'POST',
+		data: { id },
 	} );
 
 	const handleReclaimClick = async () => {
@@ -57,6 +59,9 @@ const ReclaimUrlCard = ( props ) => {
 	return (
 		<Section.Card>
 			<Section.Card.Body>
+				<ContentButtonLayout>
+					<Subsection.Title>{ toAccountText( id ) }</Subsection.Title>
+				</ContentButtonLayout>
 				<ContentButtonLayout>
 					<div>
 						<Subsection.Title>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #604 , works in conjunction with the API changes in PR https://github.com/woocommerce/google-listings-and-ads/pull/609.

In the Setup MC flow, when there is an error in connecting or creating MC account, the account ID would be available in the API error response. This PR reads the account ID in the API error response, and then use it in the subsequent flow, i.e.: 

- Reclaim URL.
- Retry request to Link MCA.

Note: existing code for Switch URL already pass account ID in its request.

### Screenshots:

No UI changes. 

### Detailed test instructions:

The test instruction is the similar to the one in https://github.com/woocommerce/google-listings-and-ads/pull/609:

1. Try all the paths in the Setup MC flow to confirm they work, and that the Merchant ID `id` is always returned and the process works as expected:
    - Create account 
        - With and without the need to overwrite a claim.
    - Existing account
        - Needs to switch URL (already has a different claimed URL)
        - Needs to overwrite claim (unresolvable error).
2. Confirm the new logic works:
    - Start the connection process with an account that will need to overwrite a claim.
    - Instead of overwriting the claim, start the connection process again
        - With a different account
        - With a "create account"

### Changelog Note:

Client side changes for conflict resolution in Merchant Center account connection process.
