### PR TITLE
Consistent currency format across all summary list usages

### DIFF
--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -3,13 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { SummaryNumber } from '@woocommerce/components';
-import CurrencyFactory from '@woocommerce/currency';
-import { numberFormat } from '@woocommerce/number';
 
 /**
  * Internal dependencies
  */
 import { glaData, REPORT_SOURCE_PAID, REPORT_SOURCE_FREE } from '.~/constants';
+import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
+import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
 import usePerformance from './usePerformance';
 import AppSpinner from '.~/components/app-spinner';
 import SummaryCard from './summary-card';
@@ -21,15 +21,10 @@ const paidPerformanceTitle = __(
 	'google-listings-and-ads'
 );
 
-// Note: Since the `delta` prop of SummaryNumber component wouldn't apply the WC Settings' currency options,
-//       it uses '.' as the decimal separator when transforming to percentage format.
-//       In order to keep the format consistency of number and currency in the same block,
-//       the WC Settings' currency options are not applied in this SummarySection component.
-// ref: https://github.com/woocommerce/woocommerce-admin/blob/v1.6.0/packages/components/src/summary/number.js#L133-L136
-const formatNumber = ( number ) => numberFormat( { precision: 0 }, number );
-const { formatAmount } = CurrencyFactory();
+const numberFormatSetting = { precision: 0 };
 
 const FreePerformanceCard = () => {
+	const formatNumber = useCurrencyFormat( numberFormatSetting );
 	const { data, loaded } = usePerformance( REPORT_SOURCE_FREE );
 
 	return (
@@ -63,6 +58,7 @@ const FreePerformanceCard = () => {
 };
 
 const PaidPerformanceCard = () => {
+	const { formatAmount } = useCurrencyFactory();
 	const { data, loaded } = usePerformance( REPORT_SOURCE_PAID );
 
 	return (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Although the `delta` prop of **SummaryNumber** component wouldn't apply the WC Settings' currency options, all other places that show numbers and prices are using the store currency settings. So this PR intend to apply it to the performance section on the dashboard page to keep overall consistency

- Use store currency setting for the performance section on the dashboard page

ref: https://github.com/woocommerce/woocommerce-admin/blob/v2.1.2/packages/components/src/summary/number.js#L131-L134

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/118441494-d924ce00-b71b-11eb-91a1-47117154e5bf.png)

### Detailed test instructions:

If you want to test with mock random results, please replace the `receiveReport` function with the below code in the [data/actions.js](https://github.com/woocommerce/google-listings-and-ads/blob/a821b15944438b2a3a31c90bd75a98310ed18ed4/js/src/data/actions.js#L620-L626) file.

```js
export function receiveReport( reportKey, data ) {
	data.totals.clicks = Math.random() * 1000000;
	data.totals.impressions = Math.random() * 1000000;
	data.totals.sales = Math.round( Math.random() * 1000000 );
	data.totals.spend = Math.round( Math.random() * 1000000 );
	return {
		type: TYPES.RECEIVE_REPORT,
		reportKey,
		data,
	};
}
```

1. Head to the Dashboard page: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`
2. Except the `delta`, other number and price displayed on the performance section should in the format of store currency setting, which can be viewed/changed at `/wp-admin/admin.php?page=wc-settings`
