### PR TITLE
Make `getReport` ignore unsupported orderby query params.

### DIFF
--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -10,7 +10,7 @@ import { getCurrentDates } from '@woocommerce/date';
 import round from '.~/utils/round';
 
 export const freeFields = [ 'clicks', 'impressions' ];
-const paidFields = [ 'sales', 'conversions', 'spend', ...freeFields ];
+export const paidFields = [ 'sales', 'conversions', 'spend', ...freeFields ];
 
 /**
  * Get report query for fetching performance data from API.
@@ -46,7 +46,12 @@ export function getPerformanceQuery( type, query, dateReference ) {
  */
 export function getReportQuery( category, type, query, dateReference ) {
 	const baseQuery = getPerformanceQuery( type, query, dateReference );
-	const { orderby = baseQuery.fields[ 0 ], order = 'desc' } = query;
+	const { order = 'desc' } = query;
+	let { orderby } = query;
+	// Ignore orderby's not supported by fields.
+	if ( ! orderby || ! baseQuery.fields.includes( orderby ) ) {
+		orderby = baseQuery.fields[ 0 ];
+	}
 
 	const reportQuery = {
 		...baseQuery,

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -1,0 +1,86 @@
+/**
+ * Internal dependencies
+ */
+import { getReportQuery, freeFields, paidFields } from './utils';
+
+// Needed as wc-admin breaks tests
+// https://github.com/woocommerce/woocommerce-admin/issues/6483
+jest.mock( '@woocommerce/date', () => ( {
+	getCurrentDates: jest
+		.fn()
+		.mockName( 'getCurrentDates' )
+		.mockReturnValue( {
+			primary: {
+				before: new Date(),
+				after: new Date(),
+			},
+			secondary: {
+				before: new Date(),
+				after: new Date(),
+			},
+		} ),
+} ) );
+
+/**
+ * Calls given function with all combinations of possible categories and dataReferences.
+ *
+ * @param {(category: string, dateReference: string) => void} callback Function to be called with all combinations.
+ */
+function forAnyCategoryAndDateReference( callback ) {
+	for ( const category of [ 'products', 'programs' ] ) {
+		for ( const dateReference of [ 'primary', 'secondary' ] ) {
+			callback( category, dateReference );
+		}
+	}
+}
+
+describe( 'getReportQuery', () => {
+	test( "should foward the `orderby` query parameter if it's one of supported fields for given type", () => {
+		forAnyCategoryAndDateReference( ( category, dateReference ) => {
+			for ( const orderby of freeFields ) {
+				expect(
+					getReportQuery(
+						category,
+						'free',
+						{ orderby },
+						dateReference
+					)
+				).toHaveProperty( 'orderby', orderby );
+			}
+			for ( const orderby of paidFields ) {
+				expect(
+					getReportQuery(
+						category,
+						'paid',
+						{ orderby },
+						dateReference
+					)
+				).toHaveProperty( 'orderby', orderby );
+			}
+		} );
+	} );
+	test( 'should set the `orderby` property to the first supported field if provided `query.orderby` is not supported', () => {
+		forAnyCategoryAndDateReference( ( category, dateReference ) => {
+			// Some key that's totally off.
+			const unsupported = 'unsupported_foo';
+			const query = {
+				orderby: unsupported,
+			};
+			expect(
+				getReportQuery( category, 'free', query, dateReference )
+			).toHaveProperty( 'orderby', freeFields[ 0 ] );
+			expect(
+				getReportQuery( category, 'paid', query, dateReference )
+			).toHaveProperty( 'orderby', paidFields[ 0 ] );
+			// Supported for paid, but not for free.
+			expect(
+				getReportQuery(
+					category,
+					'free',
+					{ orderby: paidFields[ 0 ] },
+					dateReference
+				)
+			).toHaveProperty( 'orderby', freeFields[ 0 ] );
+		} );
+	} );
+} );

--- a/js/src/reports/products/filter-config.js
+++ b/js/src/reports/products/filter-config.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { getQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -14,7 +13,6 @@ import {
 	REPORT_SOURCE_FREE,
 	REPORT_SOURCE_DEFAULT,
 } from '.~/constants';
-import { freeFields } from '.~/data/utils';
 import { getProductLabels, getVariationLabels } from './async-requests';
 
 // XXX: Should we register those filters somewhere?
@@ -22,26 +20,6 @@ import { getProductLabels, getVariationLabels } from './async-requests';
 const PRODUCTS_REPORT_FILTERS_FILTER = 'gla_products_report_filters';
 const PRODUCTS_REPORT_ADVANCED_FILTERS_FILTER =
 	'gla_products_report_advanced_filters';
-
-/**
- * Gets the field name from the given URL query parameter.
- * Returns `undefined` when the selected field doesn't exist in the free fields list.
- * This lets the other components fall back to the default value instead.
- *
- * @see https://github.com/woocommerce/woocommerce-admin/blob/v2.1.2/packages/components/src/filter-picker/index.js#L192
- * @see https://github.com/woocommerce/woocommerce-admin/blob/v2.1.2/packages/components/src/filter-picker/index.js#L140
- *
- * @param  {string} paramName The parameter name to check if needs fallback.
- * @return {string|undefined} Returns the selected free field, or
- *                            `undefined` if the value is not a free field.
- */
-function getFreeFieldFromQuery( paramName ) {
-	const field = getQuery()[ paramName ];
-	if ( freeFields.includes( field ) ) {
-		return field;
-	}
-	return undefined;
-}
 
 const productsFilterConfig = {
 	label: __( 'Show', 'google-listings-and-ads' ),
@@ -126,6 +104,8 @@ const variationsConfig = {
 		'filter',
 		'products',
 		'chartType',
+		'orderby',
+		'order',
 		'paged',
 		'per_page',
 		'selectedMetric',
@@ -196,32 +176,23 @@ const variationsConfig = {
 const reportSourceConfig = {
 	label: __( 'Show data from', 'google-listings-and-ads' ),
 	param: REPORT_SOURCE_PARAM,
-	staticParams: [ 'filter', 'products', 'order', 'chartType' ],
+	staticParams: [
+		'filter',
+		'products',
+		'orderby',
+		'order',
+		'chartType',
+		'selectedMetric',
+	],
 	defaultValue: REPORT_SOURCE_DEFAULT,
 	filters: [
 		{
 			value: REPORT_SOURCE_PAID,
 			label: __( 'Paid campaigns', 'google-listings-and-ads' ),
-			query: {
-				get orderby() {
-					return getQuery().orderby;
-				},
-				get selectedMetric() {
-					return getQuery().selectedMetric;
-				},
-			},
 		},
 		{
 			value: REPORT_SOURCE_FREE,
 			label: __( 'Free listings', 'google-listings-and-ads' ),
-			query: {
-				get orderby() {
-					return getFreeFieldFromQuery( 'orderby' );
-				},
-				get selectedMetric() {
-					return getFreeFieldFromQuery( 'selectedMetric' );
-				},
-			},
 		},
 	],
 	showFilters: ( { hasPaidSource } ) => hasPaidSource,


### PR DESCRIPTION
_this is a followup from https://github.com/woocommerce/google-listings-and-ads/pull/602#issuecomment-841286431_
### Changes proposed in this Pull Request:

- Respect and preserve the user's selection of `selectedMetric` or `orderby` for Products page. Let individual components fall back to their defaults if an unsupported field is given. Make it behave consistently with Programs page.
	- Make `getReport` ignore unsupported `orderby` query params. (c5c62ae)
		If an unsupported (for a selected type) field is given in order by, fall back to the default one - first from the supported list.
	- Remove query overwriting workaround from product source filter. (ed5bf16)



### Screenshots:

<!--- Optional --->


### Detailed test instructions:

0. Make sure you have some report data, or mock it with 
	  ```php
	  add_filter(
		  'gla_prepared_response_ads-reports-products',
		  function( $response ) {
			  return json_decode( file_get_contents( __DIR__ . '/tests/mocks/ads/reports/products.json' ), true ) ?: [];
		  },
	  );
	  add_filter(
		  'gla_prepared_response_mc-reports-products',
		  function( $response ) {
			  return json_decode( file_get_contents( __DIR__ . '/tests/mocks/mc/reports/products.json' ), true ) ?: [];
		  },
	  );
	  ```

##### `selectedMetric`

1. Go to Products report page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fproducts`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fproducts)
2. In the Performance section select a tile with a metric that's supported for paid but not for free programs.
4. Switch from "Paid campaigns" to "Free Listings"
	You should see 
	- `summaryMetric` you selected for paid ones, still in the URL,
	- no metric visually selected
	- Chart rendering default metric - clicks
6. Switch back to "Paid campaigns"
	You should see the metric you selected highlighted and the chart rendered for it

![Screencast showing the selected metric being preserved](https://user-images.githubusercontent.com/17435/118545366-c7ace780-b756-11eb-87b3-43981ed7c4b8.gif)


##### `orderby`

1. Go to Products report page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fproducts`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fproducts)
2. In the Products table select a column with a metric that's supported for paid but not for free programs.
3. Open dev tools on network tab
4. Switch from "Paid campaigns" to "Free Listings"
	You should see 
	- `orderby` you selected for paid ones, still in the URL,
	- no column visually selected
	- The `/wp-json/wc/gla/mc/reports/products` requests should have `orderby=clicks`
6. Switch back to "Paid campaigns"
	You should see 
	- Table ordered by the metric you selected

![Screencast showing orderby being preserved](https://user-images.githubusercontent.com/17435/118545348-c380ca00-b756-11eb-8ade-e199a088c2b4.gif)



### Changelog Note:

> Preserve `orderby` and `selectedMetric` selection, when the user switches from paid to free, when it may be not supported, and back.