### PR TITLE
Make unit-tests run with `woocommerce/date` (~`/components`~) dependency.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,10 +6,6 @@ module.exports = {
 	...defaultConfig,
 	// Workaround https://github.com/woocommerce/woocommerce-admin/issues/6483.
 	transformIgnorePatterns: [ 'node_modules/(?!@woocommerce/date/build)' ],
-	transform: {
-		...( defaultConfig.transform || [] ),
-		'node_modules/@woocommerce/date/build/index.js': 'babel-jest',
-	},
 	moduleNameMapper: {
 		// Transform our `.~/` alias.
 		'\\.~/(.*)$': '<rootDir>/js/src/$1',

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,12 @@ const defaultConfig = require( '@wordpress/scripts/config/jest-unit.config' );
 
 module.exports = {
 	...defaultConfig,
+	// Workaround https://github.com/woocommerce/woocommerce-admin/issues/6483.
+	transformIgnorePatterns: [ 'node_modules/(?!@woocommerce/date/build)' ],
+	transform: {
+		...( defaultConfig.transform || [] ),
+		'node_modules/@woocommerce/date/build/index.js': 'babel-jest',
+	},
 	moduleNameMapper: {
 		// Transform our `.~/` alias.
 		'\\.~/(.*)$': '<rootDir>/js/src/$1',

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -3,24 +3,6 @@
  */
 import { getReportQuery, freeFields, paidFields } from './utils';
 
-// Needed as wc-admin breaks tests
-// https://github.com/woocommerce/woocommerce-admin/issues/6483
-jest.mock( '@woocommerce/date', () => ( {
-	getCurrentDates: jest
-		.fn()
-		.mockName( 'getCurrentDates' )
-		.mockReturnValue( {
-			primary: {
-				before: new Date(),
-				after: new Date(),
-			},
-			secondary: {
-				before: new Date(),
-				after: new Date(),
-			},
-		} ),
-} ) );
-
 /**
  * Calls given function with all combinations of possible categories and dataReferences.
  *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Transform `@woocommerce/data` build for jest,
	  To make our tests run with `@woocommerce/date` ~or `@woocommerce/components`~ dependencies.
	  Fixes **part of** https://github.com/woocommerce/google-listings-and-ads/pull/234.
	  Works around **part of**  https://github.com/woocommerce/woocommerce-admin/issues/6483.
- Removes no longer needed `woocommerce/date` mock.


### Screenshots:

![Screenshot from test run results](https://user-images.githubusercontent.com/17435/118597605-3026b380-b7ad-11eb-9829-0366582afd06.png)


### Detailed test instructions:
```
git co fix/234-wc-admin-tests
npm install
npm run test-unit
```

Make sure tests run without complaining about `@woocommerce/date` dependency, like:
```
 SyntaxError: Cannot use import statement outside a module

      2 |  * External dependencies
      3 |  */
    > 4 | import { getCurrentDates } from '@woocommerce/date';
```

### Changelog Note:

> Workaround `@woocommerce/date` breaking tests.


### Additional notes:

Shall we remove the incomplete e2e test and enable `npm test-unit` to run in travis?