### PR TITLE
Run unit tests on TravisCI,

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,17 @@ env:
 matrix:
   fast_finish: true
   include:
+    - name: "JS unit tests"
+      language: node_js # Takes version from `.nvmrc`, runs `npm ci` automatically.
+      env: WP_VERSION="${WP_LATEST}" WC_VERSION=master WP_TRAVISCI=jest WP_MULTISITE=0
+      script: npm run test-unit
     - name: "Coding standard check"
       php: 7.4
       env: WP_VERSION="${WP_LATEST}" WC_VERSION=master WP_TRAVISCI=cs WP_MULTISITE=0
+      script: npm ci && npm run lint
+
+before_install:
+  - if [[ "${WP_TRAVISCI}" != "jest" ]]; then composer self-update --1; fi
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
@@ -49,13 +57,8 @@ before_script:
       echo "xdebug.ini does not exist"
     fi
   - nvm install 10
-  - composer install
+  - if [[ "${WP_TRAVISCI}" != "jest" ]]; then composer install; fi
 #  - bash tests/install/install-wp-tests.sh
 
 script:
-#  - tests/run_tests.sh
 #  - WP_MULTISITE=1 tests/run_tests.sh
-  - if [[ "${WP_TRAVISCI}" == "cs" ]]; then npm install && npm run lint; fi
-
-before_install:
-  - composer self-update --1

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,6 @@ module.exports = {
 		// Transform our `.~/` alias.
 		'\\.~/(.*)$': '<rootDir>/js/src/$1',
 	},
+	// Exclude e2e tests from unit testing.
+	testPathIgnorePatterns: [ '/node_modules/', '/tests/e2e/' ],
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Run unit tests on TravisCI
- Exclude JS files from `/tests/e2e/` from unit testing.

:warning:  Tastes best with https://github.com/woocommerce/google-listings-and-ads/pull/622 as all tests pass there:) 

### Screenshots:




### Detailed test instructions:

1. Run unit-tests tests locally
	  ```sh
	  npm run test-unit
	  ```
2. Check that there is no
	  ```
	   FAIL  tests/e2e/specs/login.test.js
	  ```
3. Check Travis builds at https://travis-ci.com/github/woocommerce/google-listings-and-ads/pull_requests
4. Make sure that `npm run test-unit` is run for `#623` https://travis-ci.com/github/woocommerce/google-listings-and-ads/jobs/506032836.


### Changelog Note:

> Run unit tests on Travis CI

