### PR TITLE
Fix fatal in Product Feed API

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Exception;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
@@ -66,7 +66,7 @@ class ProductFeedController extends BaseController {
 					'total'    => $this->query_helper->count( $request ),
 					'page'     => $request['per_page'] > 0 && $request['page'] > 0 ? $request['page'] : 1,
 				];
-			} catch ( InvalidValue $e ) {
+			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
 		};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Related to #620.

The product feed REST API endpoint was only catching the `InvalidValue` error:
https://github.com/woocommerce/google-listings-and-ads/blob/7cf98875b508b7a4de64d3c2b700909aeb23d9bd/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php#L61-L73

However, in the `MerchantStatuses` class, the Merchant Center connection status can also throw an `Exception`:
https://github.com/woocommerce/google-listings-and-ads/blob/2f55baac797479188162300c29f4ef616781991a/src/MerchantCenter/MerchantStatuses.php#L141-L144

This PR simply updates the try-catch to also catch that error and return an error response for it.

### Detailed test instructions:

1. Connect to Merchant Center account by completing onboarding wizard.
2. Open the Product Feed page `wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed`
3. In another tab, disconnect the Merchant Center account using the `MC Disconnect` button on Connection Test.
4. In the database, clear the Merchant Statuses cache:
    ```sql
    DELETE  FROM `wp_options` WHERE `option_name` LIKE '%_gla_mc_statuses'
    ```
1. Reload the Product Feed tab and confirm that 3 toast error messages appear (the order may vary):
    ![image](https://user-images.githubusercontent.com/228780/118618513-fe6d1700-b7c3-11eb-9731-3c90d94d3f49.png)
    - There should also be 3 `400` responses in the network inspector.
1. Confirm that there's no error message in the log.

### Changelog Note:

> Fix - Catch fatal error in product feed page.
