### PR TITLE
Prefetch product feed data to prevent multiple duplicated Google API requests

### DIFF
--- a/js/src/hooks/useMCProductStatistics.js
+++ b/js/src/hooks/useMCProductStatistics.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+
+/**
+ * Call `useAppSelectDispatch` with `"getMCProductStatistics"`.
+ *
+ * @return {useAppSelectDispatch} Result of useAppSelectDispatch.
+ */
+const useMCProductStatistics = () => {
+	return useAppSelectDispatch( 'getMCProductStatistics' );
+};
+
+export default useMCProductStatistics;

--- a/js/src/product-feed/index.js
+++ b/js/src/product-feed/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import TabNav from '../tab-nav';
@@ -8,17 +13,32 @@ import SubmissionSuccessGuide from './submission-success-guide';
 import ProductStatistics from './product-statistics';
 import ComingSoonNotice from './coming-soon-notice';
 import './index.scss';
+import useProductFeedPrefetch from './useProductFeedPrefetch';
+import AppSpinner from '.~/components/app-spinner';
 
 const ProductFeed = () => {
+	const { hasFinishedResolution, data } = useProductFeedPrefetch();
+
 	return (
 		<>
 			<TabNav initialName="product-feed" />
 			<SubmissionSuccessGuide />
 			<ComingSoonNotice />
 			<div className="gla-product-feed">
-				<ProductStatistics />
-				<IssuesTableCard />
-				<ProductFeedTableCard trackEventReportId="product-feed" />
+				{ ! hasFinishedResolution && <AppSpinner /> }
+				{ hasFinishedResolution &&
+					! data &&
+					__(
+						'An error occurred while retrieving your product feed. Please try again later.',
+						'google-listings-and-ads'
+					) }
+				{ hasFinishedResolution && data && (
+					<>
+						<ProductStatistics />
+						<IssuesTableCard />
+						<ProductFeedTableCard trackEventReportId="product-feed" />
+					</>
+				) }
 			</div>
 		</>
 	);

--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -12,14 +12,12 @@ import {
 /**
  * Internal dependencies
  */
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
 import ProductStatusHelpPopover from './product-status-help-popover';
 import './index.scss';
 
 const ProductStatistics = () => {
-	const { hasFinishedResolution, data } = useAppSelectDispatch(
-		'getMCProductStatistics'
-	);
+	const { hasFinishedResolution, data } = useMCProductStatistics();
 
 	return (
 		<div className="gla-product-statistics">

--- a/js/src/product-feed/useProductFeedPrefetch.js
+++ b/js/src/product-feed/useProductFeedPrefetch.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
+
+/**
+ * This hook calls the API side to prefetch the product feed data
+ * (product status statistics, issues and product feed) from Google API
+ * and store the data into cache on the server side.
+ *
+ * Under the hood, it is essentially calling product status statistics API
+ * in useMCProductStatistics.
+ *
+ * This hook is a "quick win" solution to address
+ * the Product Feed triplicated requests issue:
+ * https://github.com/woocommerce/google-listings-and-ads/issues/615
+ *
+ * In the future, when we have a better stable long term solution,
+ * this hook would become unnecessary and can be removed.
+ *
+ * @return {useMCProductStatistics} Result of useMCProductStatistics.
+ */
+const useProductFeedPrefetch = () => {
+	return useMCProductStatistics();
+};
+
+export default useProductFeedPrefetch;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #615 .

This PR is the "quick win" solution mentioned in https://github.com/woocommerce/google-listings-and-ads/issues/615#issuecomment-842994405. In the Product Feed page, we will call the `GET /mc/product-statistics` API first, so that the server side will call Google API and get data into cache. When `GET /mc/product-statistics` is done, we will then call `GET /mc/issues` and `GET /mc/product-feed` simultaneously, which should get their data from the stored cached data in our server side without hitting Google API again.

### Screenshots:

Demo video with my voice (https://d.pr/v/BC83RF):

https://user-images.githubusercontent.com/417342/118671820-5fc7d100-b82a-11eb-90d5-2432d796a32d.mp4

### Detailed test instructions:

1. Open your browser dev tools network panel.
2. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed
3. The `GET /mc/product-statistics` should be called first. The UI should display a loading indicator.
4. When `GET /mc/product-statistics` is done, `GET /mc/issues` and `GET /mc/product-feed` should be called simultaneously, and the UI should display corresponding loading indicators.
5. When the above API calls are all done, all their data should be displayed in the UI. 

### Changelog Note:

Prefetch product feed data to prevent duplicated Google API calls.
