### PR TITLE
Changes to Success Modal after first setup

### DIFF
--- a/js/src/components/guide-page-content/index.scss
+++ b/js/src/components/guide-page-content/index.scss
@@ -6,16 +6,25 @@
 		line-height: 32px;
 		font-weight: 400;
 		font-size: 24px;
-		color: $gray-900;
+		color: $gray-700;
 	}
 
 	&__body {
 		line-height: 24px;
 		font-size: 16px;
 		color: $gray-700;
+
 		> p {
+			margin: 1.5em 0;
 			line-height: inherit;
 			font-size: inherit;
+		}
+
+		> cite {
+			display: block;
+			line-height: 18px;
+			font-size: 11px;
+			font-style: normal;
 		}
 	}
 

--- a/js/src/components/paid-ads/add-paid-campaign-button.js
+++ b/js/src/components/paid-ads/add-paid-campaign-button.js
@@ -30,12 +30,14 @@ import recordEvent from '.~/utils/recordEvent';
  * @param {string} [props.eventProps.href] Destination path. This would default to a path with
  * `'/google/setup-ads'` when users have not completed ads setup, or
  * `'/google/campaigns/create'` when users have completed ads setup.
+ * @param {string} [props.buttonText] Customize the text of this button.
  * @return {AppButton} AppButton
  */
 const AddPaidCampaignButton = ( props ) => {
 	const {
 		eventName = 'gla_add_paid_campaign_clicked',
 		eventProps,
+		buttonText,
 		onClick = () => {},
 		...rest
 	} = props;
@@ -57,7 +59,8 @@ const AddPaidCampaignButton = ( props ) => {
 
 	return (
 		<AppButton isSmall isSecondary onClick={ handleClick } { ...rest }>
-			{ __( 'Add paid campaign', 'google-listings-and-ads' ) }
+			{ buttonText ||
+				__( 'Add paid campaign', 'google-listings-and-ads' ) }
 		</AppButton>
 	);
 };

--- a/js/src/components/paid-ads/add-paid-campaign-button.js
+++ b/js/src/components/paid-ads/add-paid-campaign-button.js
@@ -30,14 +30,13 @@ import recordEvent from '.~/utils/recordEvent';
  * @param {string} [props.eventProps.href] Destination path. This would default to a path with
  * `'/google/setup-ads'` when users have not completed ads setup, or
  * `'/google/campaigns/create'` when users have completed ads setup.
- * @param {string} [props.buttonText] Customize the text of this button.
  * @return {AppButton} AppButton
  */
 const AddPaidCampaignButton = ( props ) => {
 	const {
 		eventName = 'gla_add_paid_campaign_clicked',
 		eventProps,
-		buttonText,
+		children,
 		onClick = () => {},
 		...rest
 	} = props;
@@ -59,8 +58,7 @@ const AddPaidCampaignButton = ( props ) => {
 
 	return (
 		<AppButton isSmall isSecondary onClick={ handleClick } { ...rest }>
-			{ buttonText ||
-				__( 'Add paid campaign', 'google-listings-and-ads' ) }
+			{ children || __( 'Add paid campaign', 'google-listings-and-ads' ) }
 		</AppButton>
 	);
 };

--- a/js/src/external-components/wordpress/guide/finish-button.js
+++ b/js/src/external-components/wordpress/guide/finish-button.js
@@ -1,0 +1,29 @@
+/**
+ * This file was cloned from @wordpress/components 12.0.8
+ * https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/guide/finish-button.js
+ *
+ * To meet the requirement of
+ * https://github.com/woocommerce/google-listings-and-ads/issues/555
+ */
+/**
+ * External dependencies
+ */
+import { useRef, useLayoutEffect } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+
+export default function FinishButton( props ) {
+	const ref = useRef();
+
+	// Focus the button on mount if nothing else is focused. This prevents a
+	// focus loss when the 'Next' button is swapped out.
+	useLayoutEffect( () => {
+		const { ownerDocument } = ref.current;
+		const { activeElement, body } = ownerDocument;
+
+		if ( ! activeElement || activeElement === body ) {
+			ref.current.focus();
+		}
+	}, [] );
+
+	return <Button { ...props } ref={ ref } />;
+}

--- a/js/src/external-components/wordpress/guide/icons.js
+++ b/js/src/external-components/wordpress/guide/icons.js
@@ -1,0 +1,22 @@
+/**
+ * This file was cloned from @wordpress/components 12.0.8
+ * https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/guide/icons.js
+ *
+ * To meet the requirement of
+ * https://github.com/woocommerce/google-listings-and-ads/issues/555
+ */
+/**
+ * External dependencies
+ */
+import { SVG, Circle } from '@wordpress/primitives';
+
+export const PageControlIcon = ( { isSelected } ) => (
+	<SVG width="8" height="8" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Circle
+			cx="4"
+			cy="4"
+			r="4"
+			fill={ isSelected ? '#419ECD' : '#E1E3E6' }
+		/>
+	</SVG>
+);

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -20,6 +20,12 @@ import PageControl from './page-control';
 import FinishButton from './finish-button';
 
 /**
+ * @callback renderFinishCallback
+ * @param {JSX.Element} finishButton The built-in finish button of this Guide component.
+ * @return {JSX.Element} React element for rendering.
+ */
+
+/**
  * `Guide` is a React component that renders a user guide in a modal.
  * The guide consists of several pages which the user can step through one by one.
  * The guide is finished when the modal is closed or when the user clicks *Finish* on the last page of the guide.
@@ -29,6 +35,7 @@ import FinishButton from './finish-button';
  * @param {string} props.contentLabel This property is used as the modal's accessibility label.
  *                                    It is required for accessibility reasons.
  * @param {string} [props.finishButtonText] Use this to customize the label of the *Finish* button shown at the end of the guide.
+ * @param {renderFinishCallback} [props.renderFinish] A function for rendering custom finish block shown at the end of the guide.
  * @param {Function} props.onFinish A function which is called when the guide is finished.
  *                                  The guide is finished when the modal is closed
  *                                  or when the user clicks *Finish* on the last page of the guide.
@@ -39,6 +46,7 @@ export default function Guide( {
 	className,
 	contentLabel,
 	finishButtonText,
+	renderFinish = ( finishButton ) => finishButton,
 	onFinish,
 	pages,
 } ) {
@@ -61,6 +69,21 @@ export default function Guide( {
 
 	if ( pages.length === 0 ) {
 		return null;
+	}
+
+	let finishBlock = null;
+
+	if ( ! canGoForward ) {
+		const finishButton = (
+			<FinishButton
+				className="components-guide__finish-button"
+				onClick={ onFinish }
+			>
+				{ finishButtonText || __( 'Finish' ) }
+			</FinishButton>
+		);
+
+		finishBlock = renderFinish( finishButton );
 	}
 
 	return (
@@ -88,15 +111,6 @@ export default function Guide( {
 					/>
 
 					{ pages[ currentPage ].content }
-
-					{ ! canGoForward && (
-						<FinishButton
-							className="components-guide__inline-finish-button"
-							onClick={ onFinish }
-						>
-							{ finishButtonText || __( 'Finish' ) }
-						</FinishButton>
-					) }
 				</div>
 
 				<div className="components-guide__footer">
@@ -116,14 +130,7 @@ export default function Guide( {
 							{ __( 'Next' ) }
 						</Button>
 					) }
-					{ ! canGoForward && (
-						<FinishButton
-							className="components-guide__finish-button"
-							onClick={ onFinish }
-						>
-							{ finishButtonText || __( 'Finish' ) }
-						</FinishButton>
-					) }
+					{ finishBlock }
 				</div>
 			</div>
 		</Modal>

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -19,12 +19,28 @@ import { Modal, KeyboardShortcuts, Button } from '@wordpress/components';
 import PageControl from './page-control';
 import FinishButton from './finish-button';
 
+/**
+ * `Guide` is a React component that renders a user guide in a modal.
+ * The guide consists of several pages which the user can step through one by one.
+ * The guide is finished when the modal is closed or when the user clicks *Finish* on the last page of the guide.
+ *
+ * @param {Object} props React props.
+ * @param {string} [props.className] A custom class to add to the modal.
+ * @param {string} props.contentLabel This property is used as the modal's accessibility label.
+ *                                    It is required for accessibility reasons.
+ * @param {string} [props.finishButtonText] Use this to customize the label of the *Finish* button shown at the end of the guide.
+ * @param {Function} props.onFinish A function which is called when the guide is finished.
+ *                                  The guide is finished when the modal is closed
+ *                                  or when the user clicks *Finish* on the last page of the guide.
+ * @param {Array<Object>} props.pages A list of objects describing each page in the guide.
+ *                                    Each object must contain a 'content' property and may optionally contain a 'image' property.
+ */
 export default function Guide( {
 	className,
 	contentLabel,
 	finishButtonText,
 	onFinish,
-	pages = [],
+	pages,
 } ) {
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -1,0 +1,129 @@
+/**
+ * This file was cloned from @wordpress/components 12.0.8
+ * https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/guide/index.js
+ *
+ * To meet the requirement of
+ * https://github.com/woocommerce/google-listings-and-ads/issues/555
+ */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { useState, useEffect, Children } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
+import { __ } from '@wordpress/i18n';
+import { Modal, KeyboardShortcuts, Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PageControl from './page-control';
+import FinishButton from './finish-button';
+
+export default function Guide( {
+	children,
+	className,
+	contentLabel,
+	finishButtonText,
+	onFinish,
+	pages = [],
+} ) {
+	const [ currentPage, setCurrentPage ] = useState( 0 );
+
+	useEffect( () => {
+		if ( Children.count( children ) ) {
+			deprecated( 'Passing children to <Guide>', {
+				alternative: 'the `pages` prop',
+			} );
+		}
+	}, [ children ] );
+
+	if ( Children.count( children ) ) {
+		pages = Children.map( children, ( child ) => ( { content: child } ) );
+	}
+
+	const canGoBack = currentPage > 0;
+	const canGoForward = currentPage < pages.length - 1;
+
+	const goBack = () => {
+		if ( canGoBack ) {
+			setCurrentPage( currentPage - 1 );
+		}
+	};
+
+	const goForward = () => {
+		if ( canGoForward ) {
+			setCurrentPage( currentPage + 1 );
+		}
+	};
+
+	if ( pages.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className={ classnames( 'components-guide', className ) }
+			contentLabel={ contentLabel }
+			onRequestClose={ onFinish }
+		>
+			<KeyboardShortcuts
+				key={ currentPage }
+				shortcuts={ {
+					left: goBack,
+					right: goForward,
+				} }
+			/>
+
+			<div className="components-guide__container">
+				<div className="components-guide__page">
+					{ pages[ currentPage ].image }
+
+					<PageControl
+						currentPage={ currentPage }
+						numberOfPages={ pages.length }
+						setCurrentPage={ setCurrentPage }
+					/>
+
+					{ pages[ currentPage ].content }
+
+					{ ! canGoForward && (
+						<FinishButton
+							className="components-guide__inline-finish-button"
+							onClick={ onFinish }
+						>
+							{ finishButtonText || __( 'Finish' ) }
+						</FinishButton>
+					) }
+				</div>
+
+				<div className="components-guide__footer">
+					{ canGoBack && (
+						<Button
+							className="components-guide__back-button"
+							onClick={ goBack }
+						>
+							{ __( 'Previous' ) }
+						</Button>
+					) }
+					{ canGoForward && (
+						<Button
+							className="components-guide__forward-button"
+							onClick={ goForward }
+						>
+							{ __( 'Next' ) }
+						</Button>
+					) }
+					{ ! canGoForward && (
+						<FinishButton
+							className="components-guide__finish-button"
+							onClick={ onFinish }
+						>
+							{ finishButtonText || __( 'Finish' ) }
+						</FinishButton>
+					) }
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -9,8 +9,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useState, useEffect, Children } from '@wordpress/element';
-import deprecated from '@wordpress/deprecated';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Modal, KeyboardShortcuts, Button } from '@wordpress/components';
 
@@ -21,7 +20,6 @@ import PageControl from './page-control';
 import FinishButton from './finish-button';
 
 export default function Guide( {
-	children,
 	className,
 	contentLabel,
 	finishButtonText,
@@ -29,18 +27,6 @@ export default function Guide( {
 	pages = [],
 } ) {
 	const [ currentPage, setCurrentPage ] = useState( 0 );
-
-	useEffect( () => {
-		if ( Children.count( children ) ) {
-			deprecated( 'Passing children to <Guide>', {
-				alternative: 'the `pages` prop',
-			} );
-		}
-	}, [ children ] );
-
-	if ( Children.count( children ) ) {
-		pages = Children.map( children, ( child ) => ( { content: child } ) );
-	}
 
 	const canGoBack = currentPage > 0;
 	const canGoForward = currentPage < pages.length - 1;

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -34,6 +34,7 @@ import FinishButton from './finish-button';
  * @param {string} [props.className] A custom class to add to the modal.
  * @param {string} props.contentLabel This property is used as the modal's accessibility label.
  *                                    It is required for accessibility reasons.
+ * @param {string} [props.backButtonText] Use this to customize the label of the *Previous* button shown at the end of the guide.
  * @param {string} [props.finishButtonText] Use this to customize the label of the *Finish* button shown at the end of the guide.
  * @param {renderFinishCallback} [props.renderFinish] A function for rendering custom finish block shown at the end of the guide.
  * @param {Function} props.onFinish A function which is called when the guide is finished.
@@ -45,6 +46,7 @@ import FinishButton from './finish-button';
 export default function Guide( {
 	className,
 	contentLabel,
+	backButtonText,
 	finishButtonText,
 	renderFinish = ( finishButton ) => finishButton,
 	onFinish,
@@ -119,7 +121,7 @@ export default function Guide( {
 							className="components-guide__back-button"
 							onClick={ goBack }
 						>
-							{ __( 'Previous' ) }
+							{ backButtonText || __( 'Previous' ) }
 						</Button>
 					) }
 					{ canGoForward && (

--- a/js/src/external-components/wordpress/guide/page-control.js
+++ b/js/src/external-components/wordpress/guide/page-control.js
@@ -1,0 +1,55 @@
+/**
+ * This file was cloned from @wordpress/components 12.0.8
+ * https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/guide/page-control.js
+ *
+ * To meet the requirement of
+ * https://github.com/woocommerce/google-listings-and-ads/issues/555
+ */
+/**
+ * External dependencies
+ */
+import { times } from 'lodash';
+import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { PageControlIcon } from './icons';
+
+export default function PageControl( {
+	currentPage,
+	numberOfPages,
+	setCurrentPage,
+} ) {
+	return (
+		<ul
+			className="components-guide__page-control"
+			aria-label={ __( 'Guide controls' ) }
+		>
+			{ times( numberOfPages, ( page ) => (
+				<li
+					key={ page }
+					// Set aria-current="step" on the active page, see https://www.w3.org/TR/wai-aria-1.1/#aria-current
+					aria-current={ page === currentPage ? 'step' : undefined }
+				>
+					<Button
+						key={ page }
+						icon={
+							<PageControlIcon
+								isSelected={ page === currentPage }
+							/>
+						}
+						aria-label={ sprintf(
+							/* translators: 1: current page number 2: total number of pages */
+							__( 'Page %1$d of %2$d' ),
+							page + 1,
+							numberOfPages
+						) }
+						onClick={ () => setCurrentPage( page ) }
+					/>
+				</li>
+			) ) }
+		</ul>
+	);
+}

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -171,11 +171,9 @@ const GuideImplementation = () => {
 						context: GUIDE_NAME,
 						action: 'create-paid-campaign',
 					} }
-					buttonText={ __(
-						'Create paid campaign',
-						'google-listings-and-ads'
-					) }
-				/>
+				>
+					{ __( 'Create paid campaign', 'google-listings-and-ads' ) }
+				</AddPaidCampaignButton>
 			</>
 		);
 	}, [] );

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -25,7 +25,7 @@ import './index.scss';
 
 const GUIDE_NAME = 'submission-success';
 const EVENT_NAME = 'gla_modal_closed';
-const CONFIRM_BUTTON_CLASS = 'components-guide__finish-button';
+const LATER_BUTTON_CLASS = 'components-guide__finish-button';
 
 const productFeedPath = getNewPath(
 	{ guide: undefined },
@@ -137,8 +137,8 @@ const handleGuideFinish = ( e ) => {
 	// Since there is no built-in way to distinguish the modal/guide is closed by what action,
 	// here is a workaround by identifying the close button's class name.
 	const target = e.currentTarget || e.target;
-	const action = target.classList.contains( CONFIRM_BUTTON_CLASS )
-		? 'confirm'
+	const action = target.classList.contains( LATER_BUTTON_CLASS )
+		? 'maybe-later'
 		: 'dismiss';
 	recordEvent( EVENT_NAME, {
 		context: GUIDE_NAME,
@@ -157,7 +157,7 @@ const GuideImplementation = () => {
 				<div className="gla-submission-success-guide__space_holder" />
 				<Button
 					isSecondary
-					className={ CONFIRM_BUTTON_CLASS }
+					className={ LATER_BUTTON_CLASS }
 					onClick={ handleGuideFinish }
 				>
 					{ __( 'Maybe later', 'google-listings-and-ads' ) }

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -27,6 +27,11 @@ const GUIDE_NAME = 'submission-success';
 const EVENT_NAME = 'gla_modal_closed';
 const CONFIRM_BUTTON_CLASS = 'components-guide__finish-button';
 
+const productFeedPath = getNewPath(
+	{ guide: undefined },
+	'/google/product-feed'
+);
+
 const image = (
 	<div className="gla-submission-success-guide__logo-block">
 		<div className="gla-submission-success-guide__logo-item">
@@ -45,20 +50,30 @@ const pages = [
 		content: (
 			<GuidePageContent
 				title={ __(
-					'You have successfully set up Google Listings & Ads!',
+					'You have successfully set up Google Listings & Ads! 🎉',
 					'google-listings-and-ads'
 				) }
 			>
 				<p>
 					{ __(
-						'You can review and edit your product feed at any time on this page. We will also notify you of any product feed issues to ensure your products get approved and perform well on Google.',
+						'Google reviews product listings in 3-5 days. If approved, your products will automatically be live and searchable on Google.',
 						'google-listings-and-ads'
 					) }
 				</p>
 				<p>
-					{ __(
-						'Google reviews product listings in 3-5 days. If approved, your products will automatically be live and searchable on Google.',
-						'google-listings-and-ads'
+					{ createInterpolateElement(
+						__(
+							'<productFeedLink>Manage and edit your product feed in WooCommerce.</productFeedLink> We will also notify you of any product feed issues to ensure your products get approved and perform well on Google.',
+							'google-listings-and-ads'
+						),
+						{
+							productFeedLink: (
+								<ContentLink
+									href={ productFeedPath }
+									context="product-feed"
+								/>
+							),
+						}
 					) }
 				</p>
 			</GuidePageContent>
@@ -69,43 +84,55 @@ const pages = [
 		content: (
 			<GuidePageContent
 				title={ __(
-					`You've been automatically enrolled in Google's Free Listings program.`,
+					'Boost listings with up to $150 free ad credits',
 					'google-listings-and-ads'
 				) }
 			>
-				{ createInterpolateElement(
-					__(
-						'Once approved, your products will be listed as part of a free program, <freeListingsLink>Google Free Listings</freeListingsLink>. You can opt out of this program in <merchantCenterLink>Google Merchant Center</merchantCenterLink>.',
+				<p>
+					{ createInterpolateElement(
+						__(
+							'Give your products a boost and create a paid <link>Smart Shopping campaign</link>! Your ads will run once your products are approved by Google.',
+							'google-listings-and-ads'
+						),
+						{
+							link: (
+								<ContentLink
+									href="https://support.google.com/google-ads/answer/7674739"
+									context="about-smart-shopping-campaigns"
+								/>
+							),
+						}
+					) }
+				</p>
+				<p>
+					{ __(
+						'Get up to $150* in free ad credit for if you’re new to Google Ads. You can edit or cancel your campaign at any time.',
 						'google-listings-and-ads'
-					),
-					{
-						// TODO: The free listings link will be added when its URL is ready
-						freeListingsLink: (
-							<ContentLink
-								href="/"
-								context="setup-mc-free-listings"
-							/>
+					) }
+				</p>
+				<cite>
+					{ createInterpolateElement(
+						__(
+							'*Ad credit amounts vary by country and region. Eligibility criteria: The account has no other promotions applied. The account is billed to a country where Google Partners promotions are offered. The account served its first ad impression within the last 14 days. Review the static terms <link>here</link>.',
+							'google-listings-and-ads'
 						),
-						merchantCenterLink: (
-							<ContentLink
-								href="https://www.google.com/retail/solutions/merchant-center/"
-								context="setup-mc-merchant-center"
-							/>
-						),
-					}
-				) }
+						{
+							link: (
+								<ContentLink
+									href="https://www.google.com/ads/coupons/terms.html"
+									context="terms-of-ads-coupons"
+								/>
+							),
+						}
+					) }
+				</cite>
 			</GuidePageContent>
 		),
 	},
 ];
 
 const handleGuideFinish = ( e ) => {
-	const nextQuery = {
-		...getQuery(),
-		guide: undefined,
-	};
-	const path = getNewPath( nextQuery );
-	getHistory().replace( path );
+	getHistory().replace( productFeedPath );
 
 	// Since there is no built-in way to distinguish the modal/guide is closed by what action,
 	// here is a workaround by identifying the close button's class name.
@@ -156,6 +183,7 @@ const GuideImplementation = () => {
 	return (
 		<Guide
 			className="gla-submission-success-guide"
+			backButtonText={ __( 'Back', 'google-listings-and-ads' ) }
 			pages={ pages }
 			renderFinish={ renderFinish }
 			onFinish={ handleGuideFinish }

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -2,9 +2,13 @@
  * External dependencies
  */
 import { getHistory, getNewPath, getQuery } from '@woocommerce/navigation';
-import { createInterpolateElement, useEffect } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useEffect,
+	useCallback,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Guide } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -12,12 +16,15 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { ReactComponent as GoogleLogoSvg } from './google-logo.svg';
 import { ReactComponent as WooCommerceLogoSvg } from './woocommerce-logo.svg';
+import Guide from '.~/external-components/wordpress/guide';
 import GuidePageContent, {
 	ContentLink,
 } from '.~/components/guide-page-content';
+import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
 import './index.scss';
 
 const GUIDE_NAME = 'submission-success';
+const EVENT_NAME = 'gla_modal_closed';
 const CONFIRM_BUTTON_CLASS = 'components-guide__finish-button';
 
 const image = (
@@ -92,8 +99,6 @@ const pages = [
 	},
 ];
 
-// TODO: The current close method is temporarily for demo.
-//       Need to reconsider how this guide modal would be triggered later.
 const handleGuideFinish = ( e ) => {
 	const nextQuery = {
 		...getQuery(),
@@ -108,7 +113,7 @@ const handleGuideFinish = ( e ) => {
 	const action = target.classList.contains( CONFIRM_BUTTON_CLASS )
 		? 'confirm'
 		: 'dismiss';
-	recordEvent( 'gla_modal_closed', {
+	recordEvent( EVENT_NAME, {
 		context: GUIDE_NAME,
 		action,
 	} );
@@ -119,11 +124,40 @@ const GuideImplementation = () => {
 		recordEvent( 'gla_modal_open', { context: GUIDE_NAME } );
 	}, [] );
 
+	const renderFinish = useCallback( () => {
+		return (
+			<>
+				<div className="gla-submission-success-guide__space_holder" />
+				<Button
+					isSecondary
+					className={ CONFIRM_BUTTON_CLASS }
+					onClick={ handleGuideFinish }
+				>
+					{ __( 'Maybe later', 'google-listings-and-ads' ) }
+				</Button>
+				<AddPaidCampaignButton
+					isPrimary
+					isSecondary={ false }
+					isSmall={ false }
+					eventName={ EVENT_NAME }
+					eventProps={ {
+						context: GUIDE_NAME,
+						action: 'create-paid-campaign',
+					} }
+					buttonText={ __(
+						'Create paid campaign',
+						'google-listings-and-ads'
+					) }
+				/>
+			</>
+		);
+	}, [] );
+
 	return (
 		<Guide
 			className="gla-submission-success-guide"
-			finishButtonText={ __( 'Got it', 'google-listings-and-ads' ) }
 			pages={ pages }
+			renderFinish={ renderFinish }
 			onFinish={ handleGuideFinish }
 		/>
 	);
@@ -134,9 +168,6 @@ const GuideImplementation = () => {
  *
  * Show this guide modal by visiting the path with a specific query `guide=submission-success`.
  * For example: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed&guide=submission-success`.
- *
- * TODO: The current open method is temporarily for demo.
- *       Need to reconsider how this guide modal would be triggered later.
  */
 export default function SubmissionSuccessGuide() {
 	const isOpen = getQuery().guide === GUIDE_NAME;

--- a/js/src/product-feed/submission-success-guide/index.scss
+++ b/js/src/product-feed/submission-success-guide/index.scss
@@ -48,6 +48,13 @@
 			@media (max-width: $break-small) {
 				// Prevent layout break on small mobile devices
 				position: static;
+				flex-wrap: wrap;
+
+				.components-button {
+					justify-content: center;
+					width: 100%;
+					margin-top: 12px;
+				}
 			}
 			justify-content: flex-end;
 			width: 100%;
@@ -104,5 +111,9 @@
 		height: 63px;
 		margin: 0 28px;
 		background-color: $gray-600;
+	}
+
+	&__space_holder {
+		flex: 1 1 0;
 	}
 }

--- a/js/src/product-feed/submission-success-guide/index.scss
+++ b/js/src/product-feed/submission-success-guide/index.scss
@@ -3,7 +3,7 @@
 		height: auto;
 		@include break-small() {
 			max-width: 517px;
-			height: 556px;
+			max-height: none;
 		}
 	}
 
@@ -59,7 +59,7 @@
 			justify-content: flex-end;
 			width: 100%;
 			height: auto;
-			margin: 0;
+			margin: calc(var(--large-gap) / 2) 0 0;
 			padding: 0 $grid-unit-30 $grid-unit-30;
 			box-sizing: border-box;
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -65,8 +65,8 @@ All event names are prefixed by `wcadmin_gla_`.
 
 * `modal_closed` - A modal is closed
   * `context`: indicate which modal is closed
-  * `action`: indicate the modal is closed by what action (e.g. `confirm`|`dismiss` | `create-another-campaign`)
-    * `confirm` is used when the confirm button on the modal is clicked
+  * `action`: indicate the modal is closed by what action (e.g. `maybe-later`|`dismiss` | `create-another-campaign`)
+    * `maybe-later` is used when the "Maybe later" button on the modal is clicked
     * `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, or pressing ESC
     * `create-another-campaign` is used when the button "Create another campaign" is clicked
     * `create-paid-campaign` is used when the button "Create paid campaign" is clicked

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -69,6 +69,7 @@ All event names are prefixed by `wcadmin_gla_`.
     * `confirm` is used when the confirm button on the modal is clicked
     * `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, or pressing ESC
     * `create-another-campaign` is used when the button "Create another campaign" is clicked
+    * `create-paid-campaign` is used when the button "Create paid campaign" is clicked
 
 * `modal_content_link_click` - Clicking on a text link within the modal content
   * `context`: indicate which link is clicked


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #555

- Clone the Guide of `@wordpress/components` to extend features (ref: https://github.com/woocommerce/google-listings-and-ads/issues/555#issuecomment-843125024)
    - Add a render function for the cloned Guide to customize the finish block
    - Add a prop for the cloned Guide to customize the button text
- Add a "Create paid campaign" button to the success modal in the product feed page
- Update contents and style to meet the new changes of the success modal

### Screenshots:

#### First page

![image](https://user-images.githubusercontent.com/17420811/118781681-e7135400-b8bf-11eb-8c0d-5ffaf220eb03.png)

#### Second page

![image](https://user-images.githubusercontent.com/17420811/118781699-ec709e80-b8bf-11eb-8d44-8a4c33dca768.png)

#### Demo GIF

![Kapture 2021-05-19 at 16 13 56](https://user-images.githubusercontent.com/17420811/118779786-f98c8e00-b8bd-11eb-9763-d6e819abe640.gif)

### Detailed test instructions:

1. Open the DevTool console and execute `localStorage.setItem( 'debug', 'wc-admin:*' );` to enable tracking debugging mode
2. Go to product feed page with opened success modal: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed&guide=submission-success`
3. The contents of success modal should fit with the visual design
4. Click on the "Manage and edit your product feed in WooCommerce" link should open the product feed page in a new tab
5. Click on the "Create paid campaign" button should go to the ads campaign setup page in the current tab
6. Click on the "Maybe later" button should close the success modal
7. The related events should be logged on the DevTool console

### Changelog Note:

> Update contents and style, and add a "Create paid campaign" button to the success modal in the product feed page
