### PR TITLE
Change JetPack connection name

### DIFF
--- a/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
@@ -46,7 +46,7 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$jetpack_id = new RawArgument( $this->get_slug() );
+		$jetpack_id = new RawArgument( 'google-listings-and-ads' );
 		$this->share( Manager::class )->addArgument( $jetpack_id );
 
 		$this->share( Config::class )->addMethodCall(

--- a/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
@@ -46,7 +46,7 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$jetpack_id = new RawArgument( 'connection-test' );
+		$jetpack_id = new RawArgument( $this->get_slug() );
 		$this->share( Manager::class )->addArgument( $jetpack_id );
 
 		$this->share( Config::class )->addMethodCall(

--- a/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
@@ -55,7 +55,7 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 				new RawArgument( 'connection' ),
 				[
 					'slug' => $jetpack_id->getValue(),
-					'name' => __( 'Connection Test', 'google-listings-and-ads' ),
+					'name' => __( 'Google Listings and Ads', 'google-listings-and-ads' ),
 				],
 			]
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #626

This PR changes the Jetpack connection name from "Connection Test" to "Google Listings and Ads"

### Screenshots:

![image](https://user-images.githubusercontent.com/73110514/118949818-a7557680-b96a-11eb-975a-9a95b303ae1f.png)


### Detailed test instructions:

1. Go to Jetpack > Dashboard, scroll down to the "Manage site connection" link, click it
2. See "Google Listings and Ads" used as the name

### Changelog Note:

> Fix - Change JetPack connection name
