### PR TITLE
Sort the merged programs table.

### DIFF
--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -134,10 +134,12 @@ export const getReportByApiQuery = ( state, category, type, reportQuery ) => {
 };
 
 /**
- * @typedef {Object} ReportData
+ * @typedef {Object} ReportSchema
  * @property {boolean} loaded Whether the data have been loaded.
- * @property {Object|null} data The report data of specified parameters. It would return `null` before the data is fetched.
+ * @property {ReportData} data Fetched report data.
+ * @template ReportData
  */
+
 /**
  * Select report data according to parameters and URL query.
  *
@@ -147,7 +149,7 @@ export const getReportByApiQuery = ( state, category, type, reportQuery ) => {
  * @param  {Object} query Query parameters in the URL.
  * @param  {string} dateReference Which date range to use, 'primary' or 'secondary'.
  *
- * @return {ReportData} Report data.
+ * @return {ReportSchema} Report data.
  */
 export const getReport = createRegistrySelector(
 	( select ) => ( state, category, type, query, dateReference ) => {

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -106,21 +106,25 @@ export const getMCProductFeed = ( state, query ) => {
 };
 
 /**
+ * @typedef {Object} ReportQuery
+ * @property {string} after Start date in 'YYYY-MM-DD' format.
+ * @property {string} before End date in 'YYYY-MM-DD' format.
+ * @property {Array<string>} fields An array of performance metrics field to retrieve.
+ * @property {string} [ids] Filter product or campaign by a comma separated list of IDs.
+ * @property {string} [orderby] Column to order the results by, this must be one of the fields in requesting.
+ * @property {string} [order] Results order, 'desc' or 'asc'.
+ * @property {string} [interval] How to segment the data. Note that the 'free' type data only supports segmenting by day,
+ *                                         but the 'paid' type report allows any of the following values:
+ *                                         'day', 'week', 'month', 'quarter', 'year'
+ */
+
+/**
  * Select report data according to parameters and report API query.
  *
  * @param  {Object} state The current store state will be injected by `wp.data`.
  * @param  {string} category Category of report, 'programs' or 'products'.
  * @param  {string} type Type of report, 'free' or 'paid'.
- * @param  {Object} reportQuery Query options of report API.
- * @param  {string} reportQuery.after Start date in 'YYYY-MM-DD' format.
- * @param  {string} reportQuery.before End date in 'YYYY-MM-DD' format.
- * @param  {Array<string>} reportQuery.fields An array of performance metrics field to retrieve.
- * @param  {string} [reportQuery.ids] Filter product or campaign by a comma separated list of IDs.
- * @param  {string} [reportQuery.orderby] Column to order the results by, this must be one of the fields in requesting.
- * @param  {string} [reportQuery.order] Results order, 'desc' or 'asc'.
- * @param  {string} [reportQuery.interval] How to segment the data. Note that the 'free' type data only supports segmenting by day,
- *                                         but the 'paid' type report allows any of the following values:
- *                                         'day', 'week', 'month', 'quarter', 'year'
+ * @param  {ReportQuery} reportQuery Query options of report API.
  *
  * @return {Object|null} The report data of specified parameters. It would return `null` before the data is fetched.
  */

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -137,6 +137,7 @@ export const getReportByApiQuery = ( state, category, type, reportQuery ) => {
  * @typedef {Object} ReportSchema
  * @property {boolean} loaded Whether the data have been loaded.
  * @property {ReportData} data Fetched report data.
+ * @property {ReportQuery} reportQuery The actual, resolved query used to request the report. Available synchronously.
  * @template ReportData
  */
 
@@ -154,18 +155,21 @@ export const getReportByApiQuery = ( state, category, type, reportQuery ) => {
 export const getReport = createRegistrySelector(
 	( select ) => ( state, category, type, query, dateReference ) => {
 		const selector = select( STORE_KEY );
-		const args = [
+		const reportQuery = getReportQuery(
 			category,
 			type,
-			getReportQuery( category, type, query, dateReference ),
-		];
+			query,
+			dateReference
+		);
+		const args = [ category, type, reportQuery ];
 
 		return {
-			data: selector.getReportByApiQuery( ...args ),
+			reportQuery,
 			loaded: selector.hasFinishedResolution(
 				'getReportByApiQuery',
 				args
 			),
+			data: selector.getReportByApiQuery( ...args ),
 		};
 	}
 );

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -35,6 +35,9 @@ export function getPerformanceQuery( type, query, dateReference ) {
 }
 
 /**
+ * @typedef {import('./selectors').ReportQuery} ReportQuery
+ */
+/**
  * Get report query for fetching report data from API.
  *
  * @param  {string} category Category of report, 'programs' or 'products'.
@@ -42,7 +45,7 @@ export function getPerformanceQuery( type, query, dateReference ) {
  * @param  {Object} query Query parameters in the URL.
  * @param  {string} dateReference Which date range to use, 'primary' or 'secondary'.
  *
- * @return {Object} The report query for fetching report data from API.
+ * @return {ReportQuery} The report query for fetching report data from API.
  */
 export function getReportQuery( category, type, query, dateReference ) {
 	const baseQuery = getPerformanceQuery( type, query, dateReference );
@@ -74,7 +77,7 @@ export function getReportQuery( category, type, query, dateReference ) {
  *
  * @param  {string} category Category of report, 'programs' or 'products'.
  * @param  {string} type Type of report, 'free' or 'paid'.
- * @param  {Object} reportQuery The query parameters of report API.
+ * @param  {ReportQuery} reportQuery The query parameters of report API.
  *
  * @return {string} The report key.
  */

--- a/js/src/reports/index.js
+++ b/js/src/reports/index.js
@@ -12,14 +12,8 @@ export { default as ProductsReport } from './products';
  */
 
 /**
- * @typedef {Object} ReportSchema
- * @property {boolean} loaded Whether the data have been loaded.
- * @property {ReportData} data Fetched report data.
- * @template {ProductsReportData | ProgramsReportData} ReportData
- */
-
-/**
- * @typedef {ReportSchema<ProductsReportData>} ProductsReportSchema
+ * @typedef {import('.~/data/selectors').ReportSchema<ProductsReportData>} ProductsReportSchema
+ * @typedef {import('.~/data/selectors').ReportSchema<ProductsReportData>} ProgramsReportSchema
  */
 
 /**

--- a/js/src/reports/programs/compare-programs-table-card.js
+++ b/js/src/reports/programs/compare-programs-table-card.js
@@ -9,7 +9,6 @@ import { useMemo } from '@wordpress/element';
  */
 import CompareTableCard from '../compare-table-card';
 import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
-import useUrlQuery from '.~/hooks/useUrlQuery';
 
 const compareBy = 'programs';
 const compareParam = 'filter';
@@ -21,20 +20,23 @@ const compareParam = 'filter';
  * @see AppTableCard
  *
  * @param {Object} props React props.
- * @param {Array<Metric>} props.metrics Metrics to display.
  * @param {boolean} props.isLoading Whether the data is still being loaded.
+ * @param {string} [props.orderby] Key by which the programs should be ordered.
+ * @param {string} [props.order] Sorting order, 'desc' or 'asc'.
+ * @param {Array<Metric>} props.metrics Metrics to display.
  * @param {Array<FreeListingsData>} props.freeListings Report's programs data.
  * @param {Array<ProgramsData>} props.campaigns Report's programs data.
  * @param {Object} [props.restProps] Properties to be forwarded to CompareTableCard.
  */
 const CompareProgramsTableCard = ( {
-	metrics,
 	isLoading,
+	orderby,
+	order,
+	metrics,
 	freeListings,
 	campaigns,
 	...restProps
 } ) => {
-	const { orderby, order } = useUrlQuery();
 	/**
 	 * Glue freeListings and campaigns together, hardcode Free Listings name and id.
 	 *
@@ -57,8 +59,8 @@ const CompareProgramsTableCard = ( {
 			...campaigns,
 		];
 
-		// Sort merged lists. Preferably, both lists should be already sorted by the server-side.
-		if ( orderby ) {
+		// Sort only merged lists. Individual lists should be already sorted by the server-side.
+		if ( campaigns.length ) {
 			mergedPrograms.sort( ( program1, program2 ) => {
 				return (
 					// Consider `undefined` the lowest.

--- a/js/src/reports/programs/filter-config.js
+++ b/js/src/reports/programs/filter-config.js
@@ -58,6 +58,8 @@ export const programsFilterConfig = ( adsCampaigns ) => {
 			'paged',
 			'per_page',
 			'selectedMetric',
+			'orderby',
+			'order',
 		],
 		param: 'filter',
 		showFilters: () => true,

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -64,6 +64,7 @@ const ProgramsReport = () => {
 	const {
 		loaded,
 		data: { totals, intervals, freeListings, campaigns },
+		reportQuery: { orderby, order },
 	} = useProgramsReport();
 
 	// Show only available data.
@@ -103,6 +104,8 @@ const ProgramsReport = () => {
 				<CompareProgramsTableCard
 					trackEventReportId={ trackEventId }
 					isLoading={ ! loaded }
+					orderby={ orderby }
+					order={ order }
 					metrics={ expectedTableMetrics }
 					freeListings={ freeListings }
 					campaigns={ campaigns }

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -14,7 +14,6 @@ import ProgramsReportFilters from './programs-report-filters';
 import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProgramsTableCard from './compare-programs-table-card';
-import '../../dashboard/index.scss';
 
 /**
  * Available metrics and their human-readable labels.
@@ -80,7 +79,7 @@ const ProgramsReport = () => {
 		: tableMetrics.filter( ( { key } ) => fields.includes( key ) );
 
 	return (
-		<div className="gla-dashboard">
+		<>
 			<TabNav initialName="reports" />
 			<SubNav initialName="programs" />
 
@@ -88,31 +87,27 @@ const ProgramsReport = () => {
 				query={ getQuery() }
 				trackEventId={ trackEventId }
 			/>
-			<div className="gla-reports__performance">
-				<SummarySection
-					loaded={ loaded }
-					metrics={ availableMetrics }
-					expectedLength={ performanceMetrics.length }
-					totals={ totals }
-				/>
-				<ChartSection
-					metrics={ availableMetrics }
-					loaded={ loaded }
-					intervals={ intervals }
-				/>
-			</div>
-			<div className="gla-dashboard__programs">
-				<CompareProgramsTableCard
-					trackEventReportId={ trackEventId }
-					isLoading={ ! loaded }
-					orderby={ orderby }
-					order={ order }
-					metrics={ expectedTableMetrics }
-					freeListings={ freeListings }
-					campaigns={ campaigns }
-				/>
-			</div>
-		</div>
+			<SummarySection
+				loaded={ loaded }
+				metrics={ availableMetrics }
+				expectedLength={ performanceMetrics.length }
+				totals={ totals }
+			/>
+			<ChartSection
+				metrics={ availableMetrics }
+				loaded={ loaded }
+				intervals={ intervals }
+			/>
+			<CompareProgramsTableCard
+				trackEventReportId={ trackEventId }
+				isLoading={ ! loaded }
+				orderby={ orderby }
+				order={ order }
+				metrics={ expectedTableMetrics }
+				freeListings={ freeListings }
+				campaigns={ campaigns }
+			/>
+		</>
 	);
 };
 

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -64,19 +64,20 @@ const ProgramsReport = () => {
 	const {
 		loaded,
 		data: { totals, intervals, freeListings, campaigns },
-		reportQuery: { orderby, order },
+		reportQuery: { fields, orderby, order },
 	} = useProgramsReport();
 
-	// Show only available data.
 	// Until ~Q4 2021, free listings, may not have all metrics.
-	const availableMetrics = performanceMetrics.filter( ( { key } ) =>
-		totals.hasOwnProperty( key )
-	);
+	// Anticipate all requested fields to come, show available once loaded.
+	const availableMetrics = loaded
+		? performanceMetrics.filter( ( { key } ) =>
+				totals.hasOwnProperty( key )
+		  )
+		: performanceMetrics.filter( ( { key } ) => fields.includes( key ) );
 
-	// Anticipate all to come, show all column headers if the data is still being loaded.
 	const expectedTableMetrics = loaded
 		? tableMetrics.filter( ( { key } ) => totals.hasOwnProperty( key ) )
-		: tableMetrics;
+		: tableMetrics.filter( ( { key } ) => fields.includes( key ) );
 
 	return (
 		<div className="gla-dashboard">

--- a/js/src/reports/programs/useProgramsReport.js
+++ b/js/src/reports/programs/useProgramsReport.js
@@ -27,7 +27,7 @@ const emptyData = {
  * @typedef { import(".~/data/utils").ReportFieldsSchema } ReportFieldsSchema
  * @typedef { import(".~/data/utils").PerformanceData } PerformanceData
  * @typedef { import("../index.js").ProgramsReportData } ProgramsReportData
- * @typedef { import("../index.js").ReportSchema<ProgramsReportData> } ProgramsReportSchema
+ * @typedef { import("../index.js").ProgramsReportSchema } ProgramsReportSchema
  */
 
 /**

--- a/js/src/reports/programs/useProgramsReport.js
+++ b/js/src/reports/programs/useProgramsReport.js
@@ -98,7 +98,8 @@ function transfromReportForType( getReport, type, query ) {
 		};
 	}
 
-	return { data, loaded };
+	const reportQuery = primary.reportQuery;
+	return { data, loaded, reportQuery };
 }
 
 /**
@@ -157,7 +158,8 @@ function transformReportAggregated( getReport, query ) {
 		};
 	}
 
-	return { data, loaded };
+	const reportQuery = paid.primary.reportQuery;
+	return { data, loaded, reportQuery };
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Forward requested query withing ReportSchema, (dbb35e9)
	so consumers could reason based on the resolved query, that was actually applied.
- Sort the merged programs table. (89791c2)
	Also with the default order resolved by the selector(22e7042)
	Fixes #636.
- In Programs Report anticipate requested fields. (f7ad9ee)
	Previously we were expecting all, now we can use only queried ones.

Other minor changes:

- Define `ReportQuery` JSDoc type. (8e2e9d9@tomalec
- Unify the use of `ReportSchema` type in JSDoc, (cda9de8)
	as `.~/data/selectors.js` was using duplicated type with conflicting name `ReportData`.
- Remove unused styles and containers from ProgramsReport.(012cc7d)

### Screenshots:
![OrderBy](https://user-images.githubusercontent.com/17435/119017412-498d5280-b99b-11eb-90b1-8eb4de15ceaf.gif)



### Detailed test instructions:

0. Make sure you have some data to test or use mocked one:
	  ```php
	  add_filter(
		  'gla_prepared_response_ads-reports-products',
		  function( $response ) {
			  return json_decode( file_get_contents( __DIR__ . '/tests/mocks/ads/reports/products.json' ), true ) ?: [];
		  },
	  );
	  add_filter(
		  'gla_prepared_response_mc-reports-products',
		  function( $response ) {
			  return json_decode( file_get_contents( __DIR__ . '/tests/mocks/mc/reports/products.json' ), true ) ?: [];
		  },
	  );
	  add_filter(
		  'gla_prepared_response_ads-reports-programs',
		  function( $response ) {
			  return json_decode( file_get_contents( __DIR__ . '/tests/mocks/ads/reports/programs.json' ), true ) ?: [];
		  },
	  );
	  add_filter(
		  'gla_prepared_response_mc-reports-programs',
		  function( $response ) {
			  return json_decode( file_get_contents( __DIR__ . '/tests/mocks/mc/reports/programs.json' ), true ) ?: [];
		  },
	  );
	  ```
1. Got to Programs Report page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms)
2. Click on Programs table column headers
3. Check if the rows are sorted accordingly.


### Changelog Note:

> Fix sorting the merged programs table.
