### PR TITLE
Add FAQs to step 1 of the MC setup flow

### DIFF
--- a/js/src/components/faqs-panel/index.js
+++ b/js/src/components/faqs-panel/index.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Panel, PanelBody, PanelRow } from '@wordpress/components';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
+
+const getPanelToggleHandler = ( trackName, id ) => ( isOpened ) => {
+	recordEvent( trackName, {
+		id,
+		action: isOpened ? 'expand' : 'collapse',
+	} );
+};
+
+/**
+ * @typedef {Object} FaqItem
+ * @property {string} trackId Track ID of this FAQ.
+ * @property {JSX.Element} question The question of this FAQ.
+ * @property {JSX.Element} answer The answer of this FAQ.
+ */
+
+/**
+ * Renders a toggleable FAQs by the Panel layout
+ *
+ * @param {Object} props React props.
+ * @param {string} props.trackName The track event name to be recorded when toggling on FAQ items.
+ * @param {Array<FaqItem>} props.faqItems FAQ items for rendering.
+ */
+export default function FaqsPanel( { trackName, faqItems } ) {
+	return (
+		<Panel
+			className="gla-fags-panel"
+			header={ __(
+				'Frequently asked questions',
+				'google-listings-and-ads'
+			) }
+		>
+			{ faqItems.map( ( { trackId, question, answer } ) => {
+				return (
+					<PanelBody
+						key={ trackId }
+						title={ question }
+						initialOpen={ false }
+						onToggle={ getPanelToggleHandler( trackName, trackId ) }
+					>
+						<PanelRow>{ answer }</PanelRow>
+					</PanelBody>
+				);
+			} ) }
+		</Panel>
+	);
+}

--- a/js/src/components/faqs-panel/index.scss
+++ b/js/src/components/faqs-panel/index.scss
@@ -1,0 +1,7 @@
+.gla-fags-panel {
+	margin-bottom: calc(var(--main-gap) * 1.5);
+
+	.components-panel__row {
+		display: block;
+	}
+}

--- a/js/src/get-started-page/faqs.js
+++ b/js/src/get-started-page/faqs.js
@@ -1,22 +1,14 @@
 /**
  * External dependencies
  */
-import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
+import FaqsPanel from '.~/components/faqs-panel';
 import AppDocumentationLink from '.~/components/app-documentation-link';
-
-const recordToggleEvent = ( id, isOpened ) => {
-	recordEvent( 'gla_get_started_faq', {
-		id,
-		action: isOpened ? 'expand' : 'collapse',
-	} );
-};
 
 const faqItems = [
 	{
@@ -272,32 +264,7 @@ const faqItems = [
 ];
 
 const Faqs = () => {
-	const getPanelToggleHandler = ( id ) => ( isOpened ) => {
-		recordToggleEvent( id, isOpened );
-	};
-
-	return (
-		<Panel
-			className="gla-get-started-fags"
-			header={ __(
-				'Frequently asked questions',
-				'google-listings-and-ads'
-			) }
-		>
-			{ faqItems.map( ( { trackId, question, answer } ) => {
-				return (
-					<PanelBody
-						key={ trackId }
-						title={ question }
-						initialOpen={ false }
-						onToggle={ getPanelToggleHandler( trackId ) }
-					>
-						<PanelRow>{ answer }</PanelRow>
-					</PanelBody>
-				);
-			} ) }
-		</Panel>
-	);
+	return <FaqsPanel trackName="gla_get_started_faq" faqItems={ faqItems } />;
 };
 
 export default Faqs;

--- a/js/src/get-started-page/faqs.js
+++ b/js/src/get-started-page/faqs.js
@@ -243,7 +243,7 @@ const faqItems = [
 					<li>
 						{ createInterpolateElement(
 							__(
-								'Full terms and conditions can be found here <link>http://www.google.com/ads/coupons/terms.html</link>.',
+								'Full terms and conditions can be found here <link>https://www.google.com/ads/coupons/terms.html</link>.',
 								'google-listings-and-ads'
 							),
 							{
@@ -251,7 +251,7 @@ const faqItems = [
 									<AppDocumentationLink
 										context="faqs"
 										linkId="terms-and-conditions-of-google-ads-coupons"
-										href="http://www.google.com/ads/coupons/terms.html"
+										href="https://www.google.com/ads/coupons/terms.html"
 									/>
 								),
 							}

--- a/js/src/get-started-page/index.scss
+++ b/js/src/get-started-page/index.scss
@@ -2,14 +2,7 @@
 	max-width: 824px;
 	margin: 0 auto;
 
-	.components-card,
-	.components-panel {
+	.components-card {
 		margin-bottom: calc(var(--main-gap) * 1.5);
-	}
-}
-
-.gla-get-started-fags {
-	.components-panel__row {
-		display: block;
 	}
 }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Section from '.~/wcdl/section';
+import FaqsPanel from '.~/components/faqs-panel';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+
+const faqItems = [
+	{
+		trackId: 'why-do-i-need-a-wp-account',
+		question: __(
+			'Why do I need a WordPress.com account?',
+			'google-listings-and-ads'
+		),
+		answer: __(
+			'We use a WordPress.com account to connect your site to the WooCommerce and Google servers. It ensures that requests (e.g. product feed, clicks, sales, etc) from your site are securely and correctly attributed to your store. It enables a connection to your self-hosted site, and provides a common authentication interface across disparate server configurations and architectures.',
+			'google-listings-and-ads'
+		),
+	},
+	{
+		trackId: 'why-do-i-need-a-google-mc-account',
+		question: __(
+			'Why do I need a Google Merchant Center account?',
+			'google-listings-and-ads'
+		),
+		answer: (
+			<>
+				<p>
+					{ __(
+						'Google Merchant Center helps you sync your store and product data with Google and makes the information available for both free listings on the Shopping tab and Google Shopping Ads. That means everything about your stores and products is available to shoppers when they search on a Google property.',
+						'google-listings-and-ads'
+					) }
+				</p>
+				<p>
+					{ createInterpolateElement(
+						__(
+							'If you create a new Merchant Center account through this application, it will be associated with Google’s Comparison Shopping Service (Google Shopping) by default. You can change the CSS associated with your account at any time. <link>Please find more information here</link>.',
+							'google-listings-and-ads'
+						),
+						{
+							link: (
+								<AppDocumentationLink
+									context="faqs"
+									linkId="find-a-partner"
+									href="https://comparisonshoppingpartners.withgoogle.com/find_a_partner/"
+								/>
+							),
+						}
+					) }
+				</p>
+			</>
+		),
+	},
+];
+
+export default function Faqs() {
+	return (
+		<Section>
+			<FaqsPanel trackName="gla_setup_mc_faq" faqItems={ faqItems } />
+		</Section>
+	);
+}

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -17,6 +17,7 @@ import StepContentFooter from '.~/components/stepper/step-content-footer';
 import WordPressDotComAccount from './wordpressdotcom-account';
 import GoogleAccount from '.~/components/google-account';
 import GoogleMCAccount from './google-mc-account';
+import Faqs from './faqs';
 
 const SetupAccounts = ( props ) => {
 	const { onContinue = () => {} } = props;
@@ -52,6 +53,7 @@ const SetupAccounts = ( props ) => {
 			<WordPressDotComAccount />
 			<GoogleAccount disabled={ isGoogleAccountDisabled } />
 			<GoogleMCAccount disabled={ isGoogleMCAccountDisabled } />
+			<Faqs />
 			<StepContentFooter>
 				<Button
 					isPrimary

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -60,6 +60,10 @@ All event names are prefixed by `wcadmin_gla_`.
   * `target`: button ID
   * `trigger`: action (e.g. `click`)
 
+* `setup_mc_faq` - Clicking on faq items to collapse or expand it in the Setup Merchant Center page
+  * `id`: (faq identifier)
+  * `action`: (`expand`|`collapse`)
+
 * `modal_open` - A modal is opend
   * `context`: indicate which modal is opened
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #639

- Extract the faps panel from the Get Started page as a shared component
- Add FAQs to step 1 of the MC setup flow

Bonus 😆 

- Replace `http` by `https` for links in the FAQs of the Get Started page

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/119083451-89ebdf80-ba32-11eb-8d0b-5a533a0f3a68.png)

![Kapture 2021-05-21 at 12 40 14](https://user-images.githubusercontent.com/17420811/119083573-ca4b5d80-ba32-11eb-913a-7020bfc170b0.gif)

### Detailed test instructions:

1. Open the DevTool console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to enable tracking debugging mode
2. Head to the MC setup page: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`
3. The FQAs should display at the same position and contents of the visual design
4. Toggle FAQs and click on the link within content, and relevant events should be logged in the DevTool

### Changelog Note:

> Add FAQs to step 1 of the Merchant Center setup flow
