### PR TITLE
Silently skip Product Feed products that are no longer in WooCommerce 

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -83,7 +83,8 @@ class IssuesController extends BaseOptionsController {
 				try {
 					$issue['product_id'] = $this->product_helper->maybe_swap_for_parent_id( $issue['product_id'] );
 				} catch ( InvalidValue $e ) {
-					continue;
+					// Just don't include invalid products.
+					;
 				}
 			}
 

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -5,12 +5,11 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use WP_REST_Response as Response;
 use WP_REST_Request as Request;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
-use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -73,22 +72,22 @@ class IssuesController extends BaseOptionsController {
 			$per_page    = intval( $request['per_page'] );
 			$page        = max( 1, intval( $request['page'] ) );
 
-			try {
-				$results         = $this->merchant_statuses->get_issues( $type_filter, $per_page, $page );
-				$results['page'] = $page;
+			$results         = $this->merchant_statuses->get_issues( $type_filter, $per_page, $page );
+			$results['page'] = $page;
 
-				// Replace variation IDs with parent ID (for Edit links).
-				foreach ( $results['issues'] as &$issue ) {
-					if ( empty( $issue['product_id'] ) ) {
-						continue;
-					}
-					$issue['product_id'] = $this->product_helper->maybe_swap_for_parent_id( $issue['product_id'] );
+			// Replace variation IDs with parent ID (for Edit links).
+			foreach ( $results['issues'] as &$issue ) {
+				if ( empty( $issue['product_id'] ) ) {
+					continue;
 				}
-
-				return $this->prepare_item_for_response( $results, $request );
-			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				try {
+					$issue['product_id'] = $this->product_helper->maybe_swap_for_parent_id( $issue['product_id'] );
+				} catch ( InvalidValue $e ) {
+					continue;
+				}
 			}
+
+			return $this->prepare_item_for_response( $results, $request );
 		};
 	}
 

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -83,8 +83,12 @@ class IssuesController extends BaseOptionsController {
 				try {
 					$issue['product_id'] = $this->product_helper->maybe_swap_for_parent_id( $issue['product_id'] );
 				} catch ( InvalidValue $e ) {
-					// Just don't include invalid products.
-					;
+					// Don't include valid products
+					do_action(
+						'gla_debug_message',
+						sprintf( 'Merchant Center product ID %s not found in this WooCommerce store.', $issue['product_id'] ),
+						__METHOD__,
+					);
 				}
 			}
 

--- a/src/Exception/InvalidValue.php
+++ b/src/Exception/InvalidValue.php
@@ -70,4 +70,15 @@ class InvalidValue extends LogicException implements GoogleListingsAndAdsExcepti
 	public static function not_in_allowed_list( $key, array $allowed_values ): InvalidValue {
 		return new static( sprintf( 'The value of %s must be either of [%s].', $key, implode( ', ', $allowed_values ) ) );
 	}
+
+	/**
+	 * Create a new instance of the exception when a value isn't a valid product ID.
+	 *
+	 * @param mixed $value The provided product ID that isn't valid.
+	 *
+	 * @return static
+	 */
+	public static function not_valid_product_id( $value ): InvalidValue {
+		return new static( sprintf( 'Invalid product ID: %s', $value ) );
+	}
 }

--- a/src/Logging/DebugLogger.php
+++ b/src/Logging/DebugLogger.php
@@ -39,6 +39,7 @@ class DebugLogger implements Service, Registerable, Conditional {
 		if ( function_exists( 'wc_get_logger' ) ) {
 			$this->logger = wc_get_logger();
 
+			add_action( 'gla_debug_message', [ $this, 'log_message' ], 10, 2 );
 			add_action( 'gla_exception', [ $this, 'log_exception' ], 10, 2 );
 			add_action( 'gla_mc_client_exception', [ $this, 'log_exception' ], 10, 2 );
 			add_action( 'gla_ads_client_exception', [ $this, 'log_exception' ], 10, 2 );
@@ -49,12 +50,12 @@ class DebugLogger implements Service, Registerable, Conditional {
 	}
 
 	/**
-	 * Log a JSON response.
+	 * Log an exception.
 	 *
 	 * @param Exception $exception
 	 * @param string    $method
 	 */
-	public function log_exception( $exception, string $method ) {
+	public function log_exception( $exception, string $method ): void {
 		$this->log( $exception->getMessage(), $method );
 	}
 
@@ -64,8 +65,18 @@ class DebugLogger implements Service, Registerable, Conditional {
 	 * @param JSON   $response
 	 * @param string $method
 	 */
-	public function log_response( $response, string $method ) {
+	public function log_response( $response, string $method ): void {
 		$message = wp_json_encode( $response, JSON_PRETTY_PRINT );
+		$this->log( $message, $method );
+	}
+
+	/**
+	 * Log a generic note.
+	 *
+	 * @param string $message
+	 * @param string $method
+	 */
+	public function log_message( string $message, string $method ): void {
 		$this->log( $message, $method );
 	}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -348,11 +348,16 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			$this->product_statuses['products'][ $wc_product_id ][ $status ] = 1 + ( $this->product_statuses['products'][ $wc_product_id ][ $status ] ?? 0 );
 
 			// Aggregate parent statuses for mc_status postmeta.
-			$wc_parent_id = $product_helper->maybe_swap_for_parent_id( $wc_product_id );
-			if ( $wc_parent_id === $wc_product_id ) {
-				continue;
+			try {
+				$wc_parent_id = $product_helper->maybe_swap_for_parent_id( $wc_product_id );
+				if ( $wc_parent_id === $wc_product_id ) {
+					continue;
+				}
+				$this->product_statuses['parents'][ $wc_parent_id ][ $status ] = 1 + ( $this->product_statuses['parents'][ $wc_parent_id ][ $status ] ?? 0 );
+			} catch ( InvalidValue $e ) {
+				// Just don't include invalid products (or their parents).
+				;
 			}
-			$this->product_statuses['parents'][ $wc_parent_id ][ $status ] = 1 + ( $this->product_statuses['parents'][ $wc_parent_id ][ $status ] ?? 0 );
 		}
 	}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -275,6 +275,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			$wc_product = wc_get_product( $wc_product_id );
 			// Skip products that are no longer in WooCommerce.
 			if ( ! $wc_product ) {
+				do_action(
+					'gla_debug_message',
+					sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $product->getProductId() ),
+					__METHOD__,
+				);
 				continue;
 			}
 
@@ -344,6 +349,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			// Skip products that are no longer in WooCommerce.
 			$wc_product = wc_get_product( $wc_product_id );
 			if ( ! $wc_product ) {
+				do_action(
+					'gla_debug_message',
+					sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $product->getProductId() ),
+					__METHOD__,
+				);
 				continue;
 			}
 
@@ -362,8 +372,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 				}
 				$this->product_statuses['parents'][ $wc_parent_id ][ $status ] = 1 + ( $this->product_statuses['parents'][ $wc_parent_id ][ $status ] ?? 0 );
 			} catch ( InvalidValue $e ) {
-				// Just don't include invalid products (or their parents).
-				;
+
+				// Don't include invalid products (or their parents).
+				do_action(
+					'gla_debug_message',
+					sprintf( 'Merchant Center product ID %s not found in this WooCommerce store.', $wc_product_id ),
+					__METHOD__,
+				);
 			}
 		}
 	}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -268,9 +268,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$created_at     = $this->current_time->format( 'Y-m-d H:i:s' );
 		foreach ( $mc_statuses as $product ) {
 			$wc_product_id = $product_helper->get_wc_product_id( $product->getProductId() );
-			$wc_product    = wc_get_product( $wc_product_id );
-
 			// Skip products not synced by this extension.
+			if ( ! $wc_product_id ) {
+				continue;
+			}
+			$wc_product = wc_get_product( $wc_product_id );
+			// Skip products that are no longer in WooCommerce.
 			if ( ! $wc_product ) {
 				continue;
 			}
@@ -334,9 +337,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 		foreach ( $mc_statuses as $product ) {
 			$wc_product_id = $product_helper->get_wc_product_id( $product->getProductId() );
-
 			// Skip products not synced by this extension.
 			if ( ! $wc_product_id ) {
+				continue;
+			}
+			// Skip products that are no longer in WooCommerce.
+			$wc_product = wc_get_product( $wc_product_id );
+			if ( ! $wc_product ) {
 				continue;
 			}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -16,9 +16,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
-use Exception;
 use Google_Service_ShoppingContent_ProductStatus as Shopping_Product_Status;
 use DateTime;
+use Exception;
 
 /**
  * Class MerchantStatuses
@@ -72,6 +72,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		'products' => [],
 		'parents'  => [],
 	];
+
+	/**
+	 * @var string[] Lookup of WooCommerce Product Names.
+	 */
+	protected $product_name_lookup = [];
 
 	/**
 	 * MerchantStatuses constructor.
@@ -148,7 +153,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$page_token        = null;
 		do {
 			$response = $this->container->get( Merchant::class )->get_productstatuses( $page_token );
-			$statuses = $response->getResources();
+			$statuses = $this->filter_valid_statuses( $response->getResources() );
 			$this->refresh_product_issues( $statuses );
 			$this->sum_status_counts( $statuses );
 
@@ -233,6 +238,53 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	}
 
 	/**
+	 * Return only the valid statuses from a provided array. Invalid statuses:
+	 * - Aren't synced by this extension (invalid ID format), or
+	 * - Map to products no longer in WooCommerce (deleted or uploaded by a previous connection).
+	 * Also populates the $product_name_lookup used in refresh_product_issues()
+	 *
+	 * @param Shopping_Product_Status[] $mc_statuses
+	 * @return Shopping_Product_Status[] Statuses found to be valid.
+	 */
+	protected function filter_valid_statuses( array $mc_statuses ): array {
+		/** @var ProductHelper $product_helper */
+		$product_helper = $this->container->get( ProductHelper::class );
+
+		return array_values(
+			array_filter(
+				$mc_statuses,
+				function( $product ) use ( $product_helper ) {
+					$wc_product_id = $product_helper->get_wc_product_id( $product->getProductId() );
+					// Skip products not synced by this extension.
+					if ( ! $wc_product_id ) {
+						return false;
+					}
+
+					// Product previously found/validated.
+					if ( ! empty( $this->product_name_lookup[ $wc_product_id ] ) ) {
+						return true;
+					}
+
+					$wc_product = wc_get_product( $wc_product_id );
+					// Skip products that are no longer in WooCommerce.
+					if ( ! $wc_product ) {
+						do_action(
+							'gla_debug_message',
+							sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $product->getProductId() ),
+							__METHOD__ . ' in remove_invalid_statuses()',
+						);
+						return false;
+					}
+
+					$this->product_name_lookup[ $wc_product_id ] = $wc_product->get_name();
+					return true;
+				}
+			)
+		);
+
+	}
+
+	/**
 	 * Retrieve all account-level issues and store them in the database.
 	 *
 	 * @throws Exception If the account state can't be retrieved from Google.
@@ -258,33 +310,19 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * Retrieve all product-level issues and store them in the database.
 	 *
-	 * @param Shopping_Product_Status[] $mc_statuses
+	 * @param Shopping_Product_Status[] $validated_mc_statuses Product statuses of validated products.
 	 */
-	protected function refresh_product_issues( array $mc_statuses ): void {
+	protected function refresh_product_issues( array $validated_mc_statuses ): void {
 		/** @var ProductHelper $product_helper */
 		$product_helper = $this->container->get( ProductHelper::class );
 
 		$product_issues = [];
 		$created_at     = $this->current_time->format( 'Y-m-d H:i:s' );
-		foreach ( $mc_statuses as $product ) {
+		foreach ( $validated_mc_statuses as $product ) {
 			$wc_product_id = $product_helper->get_wc_product_id( $product->getProductId() );
-			// Skip products not synced by this extension.
-			if ( ! $wc_product_id ) {
-				continue;
-			}
-			$wc_product = wc_get_product( $wc_product_id );
-			// Skip products that are no longer in WooCommerce.
-			if ( ! $wc_product ) {
-				do_action(
-					'gla_debug_message',
-					sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $product->getProductId() ),
-					__METHOD__,
-				);
-				continue;
-			}
 
 			$product_issue_template = [
-				'product'    => $wc_product->get_name(),
+				'product'    => $this->product_name_lookup[ $wc_product_id ],
 				'product_id' => $wc_product_id,
 			];
 			foreach ( $product->getItemLevelIssues() as $item_level_issue ) {
@@ -334,30 +372,15 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * Add the provided status counts to the overall totals.
 	 *
-	 * @param Shopping_Product_Status[] $mc_statuses
+	 * @param Shopping_Product_Status[] $validated_mc_statuses Product statuses of validated products.
 	 */
-	protected function sum_status_counts( array $mc_statuses ): void {
+	protected function sum_status_counts( array $validated_mc_statuses ): void {
 		/** @var ProductHelper $product_helper */
 		$product_helper = $this->container->get( ProductHelper::class );
 
-		foreach ( $mc_statuses as $product ) {
+		foreach ( $validated_mc_statuses as $product ) {
 			$wc_product_id = $product_helper->get_wc_product_id( $product->getProductId() );
-			// Skip products not synced by this extension.
-			if ( ! $wc_product_id ) {
-				continue;
-			}
-			// Skip products that are no longer in WooCommerce.
-			$wc_product = wc_get_product( $wc_product_id );
-			if ( ! $wc_product ) {
-				do_action(
-					'gla_debug_message',
-					sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $product->getProductId() ),
-					__METHOD__,
-				);
-				continue;
-			}
-
-			$status = $this->get_product_shopping_status( $product );
+			$status        = $this->get_product_shopping_status( $product );
 			if ( is_null( $status ) ) {
 				continue;
 			}

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
@@ -10,7 +11,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
-use Exception;
 use Google_Service_ShoppingContent_Product as GoogleProduct;
 use WC_Product;
 use WC_Product_Variation;
@@ -253,12 +253,12 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param int $product_id
 	 *
 	 * @return int The parent ID or product ID of it doesn't have a parent.
-	 * @throws Exception If the ID doesn't reference a valid product.
+	 * @throws InvalidValue If the given ID doesn't reference a valid product.
 	 */
 	public function maybe_swap_for_parent_id( int $product_id ): ?int {
 		$product = wc_get_product( $product_id );
 		if ( ! $product ) {
-			throw new Exception( __( 'Invalid product ID.', 'google-listings-and-ads' ) );
+			throw InvalidValue::not_valid_product_id( $product_id );
 		}
 		if ( $product instanceof WC_Product_Variation ) {
 			return $product->get_parent_id();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #647.

Fixes a problem with products in the Merchant Center that aren't in WooCommerce (either recently deleted and pending MC removal, or uploaded by a previous connection) in the Product Feed endpoints, or just the Product Statistics endpoint after #629 ([updated error message that differs from the issue](https://user-images.githubusercontent.com/228780/119124176-ab4bcc00-ba30-11eb-99c6-b590cf0ebe70.png)).

Products that aren't found in WooCommerce are now silently skipped*, and aren't included in Product Statistics or Product Issues.

* Silently skipped products _do_ leave a DEBUG log message.
> Merchant Center product online:en:AU:gla_549 not found in this WooCommerce store.

### Detailed test instructions:
1. See testing instructions in the issue (#647).
**Note** - After products are deleted, the changes are mirrored to the Merchant Center, so the Product Feed page needs to be refreshed quickly in order to generate in the error. Alternatively, delete the synchronization task from the pending Scheduled Actions.

### Changelog Note:

> Fix - silently skip products that are no longer in WooCommerce.
