### PR TITLE
Sort report API results by date index

### DIFF
--- a/src/API/Google/AdsReport.php
+++ b/src/API/Google/AdsReport.php
@@ -77,6 +77,11 @@ class AdsReport implements OptionsAwareInterface {
 				$this->report_data['next_page'] = $page->getNextPageToken();
 			}
 
+			// Sort intervals to generate an ordered graph.
+			if ( isset( $this->report_data['intervals'] ) ) {
+				ksort( $this->report_data['intervals'] );
+			}
+
 			$this->remove_report_indexes( [ 'products', 'campaigns', 'intervals' ] );
 
 			return $this->report_data;

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -73,6 +73,11 @@ class MerchantReport implements OptionsAwareInterface {
 				$this->report_data['next_page'] = $results->getNextPageToken();
 			}
 
+			// Sort intervals to generate an ordered graph.
+			if ( isset( $this->report_data['intervals'] ) ) {
+				ksort( $this->report_data['intervals'] );
+			}
+
 			$this->remove_report_indexes( [ 'products', 'free_listings', 'intervals' ] );
 
 			return $this->report_data;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolves the API part of #589

When we order the report results by a different field (ex. sales), the report intervals might not be populated in order in the array. Since we already use the date as the array index it's relatively quick to sort the results. This PR does so sorting them by key.

### Detailed test instructions:

1. Before applying the PR retrieve a products report for campaigns, view the spend report and sort the table by spend
2. Notice that even though we get all the results they aren't in the right order, which causes the graph to be populated incorrectly
![image](https://user-images.githubusercontent.com/11388669/119156384-1951bc80-ba4c-11eb-93ea-1d3618da08b5.png)
3. Apply the PR and refresh the page and notice that the graph now show correctly
![image](https://user-images.githubusercontent.com/11388669/119156490-2ec6e680-ba4c-11eb-8bbc-00c9a0eaaf10.png)

What this PR does not resolve is the aggregation of multiple requests, whether they come from dividing the requests using pagination. Or when free listings and campaigns are combined, which we can see on the programs page:

![image](https://user-images.githubusercontent.com/11388669/119156650-58800d80-ba4c-11eb-9c8b-4213a39cac91.png)

Sorting it does improve the result but it needs to be fully aggregated in the UI to solve that completely.

### Changelog Note:
* Tweak - Sort report API results by date index.