### PR TITLE
REST endpoint for batch product channel visibility updates

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
@@ -52,11 +52,11 @@ class ProductVisibilityController extends BaseController {
 	 */
 	public function register_routes(): void {
 		$this->register_route(
-			'mc/product-visibility/batch',
+			'mc/product-visibility',
 			[
 				[
 					'methods'             => TransportMethods::EDITABLE,
-					'callback'            => $this->get_batch_update_callback(),
+					'callback'            => $this->get_update_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 				],
 				'schema' => $this->get_api_response_schema_callback(),
@@ -69,7 +69,7 @@ class ProductVisibilityController extends BaseController {
 	 *
 	 * @return callable
 	 */
-	protected function get_batch_update_callback(): callable {
+	protected function get_update_callback(): callable {
 		return function( Request $request ) {
 			$ids     = $request->get_param( 'ids' );
 			$visible = $request->get_param( 'visible' ) ? ChannelVisibility::SYNC_AND_SHOW : ChannelVisibility::DONT_SYNC_AND_SHOW;
@@ -122,7 +122,6 @@ class ProductVisibilityController extends BaseController {
 				'description'       => __( 'Products whose visibility was not changed.', 'google-listings-and-ads' ),
 				'context'           => [ 'view' ],
 				'validate_callback' => 'rest_validate_request_arg',
-				'required'          => true,
 				'items'             => [
 					'type' => 'numeric',
 				],
@@ -138,6 +137,6 @@ class ProductVisibilityController extends BaseController {
 	 * @return string
 	 */
 	protected function get_schema_title(): string {
-		return 'batch_product_visibility';
+		return 'product_visibility';
 	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
@@ -1,0 +1,143 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Exception;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ProductVisibilityController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
+ */
+class ProductVisibilityController extends BaseController {
+
+	use PluginHelper;
+
+	/**
+	 * @var ProductHelper $product_helper
+	 */
+	protected $product_helper;
+	/**
+	 * @var ProductMetaHandler $meta_handler
+	 */
+	protected $meta_handler;
+
+	/**
+	 * ProductVisibilityController constructor.
+	 *
+	 * @param RESTServer         $server
+	 * @param ProductHelper      $product_helper
+	 * @param ProductMetaHandler $meta_handler
+	 */
+	public function __construct( RESTServer $server, ProductHelper $product_helper, ProductMetaHandler $meta_handler ) {
+		parent::__construct( $server );
+		$this->product_helper = $product_helper;
+		$this->meta_handler   = $meta_handler;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'mc/product-visibility/batch',
+			[
+				[
+					'methods'             => TransportMethods::EDITABLE,
+					'callback'            => $this->get_batch_update_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
+	}
+
+	/**
+	 * Get a callback for updating products' channel visibility.
+	 *
+	 * @return callable
+	 */
+	protected function get_batch_update_callback(): callable {
+		return function( Request $request ) {
+			$ids     = $request->get_param( 'ids' );
+			$visible = $request->get_param( 'visible' ) ? ChannelVisibility::SYNC_AND_SHOW : ChannelVisibility::DONT_SYNC_AND_SHOW;
+
+			$success = [];
+			$errors  = [];
+			foreach ( $ids as $product_id ) {
+				try {
+					$product_id = $this->product_helper->maybe_swap_for_parent_id( intval( $product_id ) );
+					$product    = wc_get_product( $product_id );
+					$product->update_meta_data( $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY ), $visible );
+					$product->save();
+					$success[] = $product_id;
+				} catch ( Exception $e ) {
+					$errors[] = $product_id;
+				}
+			}
+
+			sort( $success );
+			sort( $errors );
+
+			return new Response(
+				[
+					'success' => $success,
+					'errors'  => $errors,
+				],
+				count( $errors ) ? 400 : 200
+			);
+		};
+	}
+
+	/**
+	 * Get the item schema for the controller.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'success' => [
+				'type'              => 'array',
+				'description'       => __( 'Products whose visibility was changed successfully.', 'google-listings-and-ads' ),
+				'context'           => [ 'view' ],
+				'validate_callback' => 'rest_validate_request_arg',
+				'items'             => [
+					'type' => 'numeric',
+				],
+			],
+			'errors'  => [
+				'type'              => 'array',
+				'description'       => __( 'Products whose visibility was not changed.', 'google-listings-and-ads' ),
+				'context'           => [ 'view' ],
+				'validate_callback' => 'rest_validate_request_arg',
+				'required'          => true,
+				'items'             => [
+					'type' => 'numeric',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'batch_product_visibility';
+	}
+}

--- a/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
@@ -60,7 +60,7 @@ class ProductVisibilityController extends BaseController {
 					'methods'             => TransportMethods::EDITABLE,
 					'callback'            => $this->get_update_callback(),
 					'permission_callback' => $this->get_permission_callback(),
-					'args'                => $this->get_collection_params(),
+					'args'                => $this->get_update_args(),
 				],
 				'schema' => $this->get_api_response_schema_callback(),
 			]
@@ -134,11 +134,11 @@ class ProductVisibilityController extends BaseController {
 	}
 
 	/**
-	 * Get the query params for collections.
+	 * Get the arguments for the update endpoint.
 	 *
 	 * @return array
 	 */
-	public function get_collection_params(): array {
+	public function get_update_args(): array {
 		return [
 			'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 			'ids'     => [

--- a/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
@@ -72,7 +72,14 @@ class ProductVisibilityController extends BaseController {
 	protected function get_update_callback(): callable {
 		return function( Request $request ) {
 			$ids     = $request->get_param( 'ids' );
-			$visible = $request->get_param( 'visible' ) ? ChannelVisibility::SYNC_AND_SHOW : ChannelVisibility::DONT_SYNC_AND_SHOW;
+			$visible = $request->get_param( 'visible' );
+			if ( ! is_bool( $visible ) ) {
+				return new Response(
+					[ 'message' => __( 'Visible must be true or false.', 'google-listings-and-ads' ) ],
+					400
+				);
+			}
+			$visible = $visible ? ChannelVisibility::SYNC_AND_SHOW : ChannelVisibility::DONT_SYNC_AND_SHOW;
 
 			$success = [];
 			$errors  = [];
@@ -90,7 +97,6 @@ class ProductVisibilityController extends BaseController {
 
 			sort( $success );
 			sort( $errors );
-
 			return new Response(
 				[
 					'success' => $success,

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncerException;
@@ -423,6 +424,14 @@ class ConnectionTest implements Service, Registerable {
 							</p>
 						</td>
 					</tr>
+					<tr>
+						<th>Clear Status Cache:</th>
+						<td>
+							<p>
+								<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'clear-mc-status-cache' ], $url ), 'clear-mc-status-cache' ) ); ?>">Clear</a>
+							</p>
+						</td>
+					</tr>
 				</table>
 
 				</details>
@@ -803,12 +812,17 @@ class ConnectionTest implements Service, Registerable {
 			$this->send_rest_request( $request );
 		}
 
-		if( 'wcs-google-mc-switch-url' === $_GET['action'] && check_admin_referer( 'wcs-google-mc-switch-url' ) ) {
+		if ( 'wcs-google-mc-switch-url' === $_GET['action'] && check_admin_referer( 'wcs-google-mc-switch-url' ) ) {
 			$request = new Request( 'POST', '/wc/gla/mc/accounts/switch-url' );
 			if ( is_numeric( $_GET['account_id'] ?? false ) ) {
 				$request->set_body_params( [ 'id' => $_GET['account_id'] ] );
 			}
 			$this->send_rest_request( $request );
+		}
+
+		if ( 'clear-mc-status-cache' === $_GET['action'] && check_admin_referer( 'clear-mc-status-cache' ) ) {
+			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_STATUSES );
+			$this->response .= 'Merchant Center statuses transient successfully deleted.';
 		}
 
 		if ( 'wcs-google-accounts-check' === $_GET['action'] && check_admin_referer( 'wcs-google-accounts-check' ) ) {

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductStatisticsController as MerchantCenterProductStatsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductFeedController as MerchantCenterProductFeedController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ConnectionController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductVisibilityController as MerchantCenterProductVisibilityController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ReportsController as MerchantCenterReportsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsSyncController;
@@ -35,6 +36,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
@@ -78,6 +80,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( MerchantCenterProductStatsController::class, MerchantStatuses::class );
 		$this->share( MerchantCenterIssuesController::class, MerchantStatuses::class, ProductHelper::class );
 		$this->share( MerchantCenterProductFeedController::class, ProductFeedQueryHelper::class );
+		$this->share( MerchantCenterProductVisibilityController::class, ProductHelper::class, ProductMetaHandler::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class );
 		$this->share_with_container( MerchantCenterAccountController::class );
 		$this->share_with_container( MerchantCenterReportsController::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -34,6 +34,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SupportedCountriesController;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
@@ -80,7 +81,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( MerchantCenterProductStatsController::class, MerchantStatuses::class );
 		$this->share( MerchantCenterIssuesController::class, MerchantStatuses::class, ProductHelper::class );
 		$this->share( MerchantCenterProductFeedController::class, ProductFeedQueryHelper::class );
-		$this->share( MerchantCenterProductVisibilityController::class, ProductHelper::class, ProductMetaHandler::class );
+		$this->share( MerchantCenterProductVisibilityController::class, ProductHelper::class, MerchantIssueQuery::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class );
 		$this->share_with_container( MerchantCenterAccountController::class );
 		$this->share_with_container( MerchantCenterReportsController::class );

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -255,7 +255,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @return int The parent ID or product ID of it doesn't have a parent.
 	 * @throws InvalidValue If the given ID doesn't reference a valid product.
 	 */
-	public function maybe_swap_for_parent_id( int $product_id ): ?int {
+	public function maybe_swap_for_parent_id( int $product_id ): int {
 		$product = wc_get_product( $product_id );
 		if ( ! $product ) {
 			throw InvalidValue::not_valid_product_id( $product_id );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Back-end for #627.

Adds the `POST /wc/gla/mc/product-visibility` endpoint, which accepts two attributes:
```json
{
   "ids": [ 123, 456, 789 ],
   "visible": true
}
```
The `ids` are for the products to update. The `visible` is a boolean where `true` is `sync-and-show` and `false` is `dont-sync-and-show`

The response has two attributes:
```json
# 200 if there are no errors
# 400 if any of the provided product IDs fails to be updated
{
    "success": [ 123, 789 ],
    "errors": [ 456 ]
}
```

The endpoint uses `WC_Product::save` instead of the `ProductMetaHandler` in order to trigger the product sync on the `woocommerce_product_updated` hook:
https://github.com/woocommerce/google-listings-and-ads/blob/59acb10c5762adc53c7b6a05b9bc6fff17dc89eb/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L82-L84

### Detailed test instructions:

1. Connect to Merchant Center with the onboarding wizard and sync some products.
2. Send a request to `POST /wp-json/wc/gla/mc/product-visibility` with some of the IDs
    - Confirm a `200` response with all IDs in the `success` array
    - Confirm that the products update correctly (check individual products or refresh the page to see the changes in the product feed `Channel Visibility` column)
    - Confirm that any issues related to the product are no longer displayed (currently requires a page refresh).
    - Check the Action Scheduler (`/wp-admin/tools.php?page=action-scheduler`) to see that any products that were updated have a scheduled sync action `gla/jobs/update_products/process_item` (could be pending or completed)
3. Enter an invalid product ID in the `ids` array
    - Confirm that the response is an error
3. Use a non-boolean value in `visible`
    - Confirm that the response is an error


### Changelog Note:

> Tweak - Add batch product channel visibility REST endpoint.
