### PR TITLE
Reports mocked responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
 				"use-debounce": "^5.2.0"
 			},
 			"devDependencies": {
+				"@hapi/hapi": "^20.1.3",
 				"@testing-library/react": "^11.1.0",
 				"@testing-library/react-hooks": "^5.1.1",
 				"@woocommerce/eslint-plugin": "^1.0.0-beta.0",
@@ -36,6 +37,7 @@
 				"@wordpress/e2e-test-utils": "^4.15.0",
 				"@wordpress/env": "^2.1.0",
 				"@wordpress/scripts": "^12.5.0",
+				"h2o2": "^8.2.0",
 				"prettier": "npm:wp-prettier@^2.0.5",
 				"stylelint-config-wordpress": "^17.0.0"
 			}
@@ -1467,10 +1469,87 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
+		"node_modules/@hapi/accept": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+			"integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/accept/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
 		"node_modules/@hapi/address": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
 			"integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+			"dev": true
+		},
+		"node_modules/@hapi/ammo": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+			"integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/ammo/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/b64": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+			"integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/b64/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/boom": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
+			"integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/boom/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/bounce": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+			"integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/bounce/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
 			"dev": true
 		},
 		"node_modules/@hapi/bourne": {
@@ -1479,10 +1558,173 @@
 			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
 			"dev": true
 		},
+		"node_modules/@hapi/call": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+			"integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/call/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/catbox": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+			"integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/podium": "4.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/catbox-memory": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+			"integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/catbox-memory/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/catbox/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/content": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+			"integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/cryptiles": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+			"integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hapi/file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+			"integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+			"dev": true
+		},
+		"node_modules/@hapi/hapi": {
+			"version": "20.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.3.tgz",
+			"integrity": "sha512-ImOkrixD1kPUuvmSklwytPQ0sG8AtqydwU0JzvITLE6Z7wPMVf9i9LIMWywKPxHTNhCZ6W3oKP9yRjqM/IkHMQ==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/accept": "^5.0.1",
+				"@hapi/ammo": "^5.0.1",
+				"@hapi/boom": "^9.1.0",
+				"@hapi/bounce": "^2.0.0",
+				"@hapi/call": "^8.0.0",
+				"@hapi/catbox": "^11.1.1",
+				"@hapi/catbox-memory": "^5.0.0",
+				"@hapi/heavy": "^7.0.1",
+				"@hapi/hoek": "^9.0.4",
+				"@hapi/mimos": "^6.0.0",
+				"@hapi/podium": "^4.1.1",
+				"@hapi/shot": "^5.0.5",
+				"@hapi/somever": "^3.0.0",
+				"@hapi/statehood": "^7.0.3",
+				"@hapi/subtext": "^7.0.3",
+				"@hapi/teamwork": "^5.1.0",
+				"@hapi/topo": "^5.0.0",
+				"@hapi/validate": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hapi/hapi/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/hapi/node_modules/@hapi/topo": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+			"integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"node_modules/@hapi/heavy": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+			"integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/heavy/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
 		"node_modules/@hapi/hoek": {
 			"version": "8.5.1",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
 			"integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+			"dev": true
+		},
+		"node_modules/@hapi/iron": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+			"integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/b64": "5.x.x",
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/cryptiles": "5.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/iron/node_modules/@hapi/bourne": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+			"dev": true
+		},
+		"node_modules/@hapi/iron/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
 			"dev": true
 		},
 		"node_modules/@hapi/joi": {
@@ -1497,6 +1739,172 @@
 				"@hapi/topo": "3.x.x"
 			}
 		},
+		"node_modules/@hapi/mimos": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+			"integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x",
+				"mime-db": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/mimos/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/nigel": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+			"integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "^9.0.4",
+				"@hapi/vise": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hapi/nigel/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/pez": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+			"integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/b64": "5.x.x",
+				"@hapi/boom": "9.x.x",
+				"@hapi/content": "^5.0.2",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/nigel": "4.x.x"
+			}
+		},
+		"node_modules/@hapi/pez/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/podium": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+			"integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x",
+				"@hapi/teamwork": "5.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/podium/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/shot": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+			"integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/shot/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/somever": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
+			"integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/bounce": "2.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/somever/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/statehood": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+			"integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bounce": "2.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/cryptiles": "5.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/iron": "6.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/statehood/node_modules/@hapi/bourne": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+			"dev": true
+		},
+		"node_modules/@hapi/statehood/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/subtext": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+			"integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/content": "^5.0.2",
+				"@hapi/file": "2.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/pez": "^5.0.1",
+				"@hapi/wreck": "17.x.x"
+			}
+		},
+		"node_modules/@hapi/subtext/node_modules/@hapi/bourne": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+			"dev": true
+		},
+		"node_modules/@hapi/subtext/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/teamwork": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+			"integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/@hapi/topo": {
 			"version": "3.1.6",
 			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
@@ -1505,6 +1913,69 @@
 			"dependencies": {
 				"@hapi/hoek": "^8.3.0"
 			}
+		},
+		"node_modules/@hapi/validate": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+			"integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0",
+				"@hapi/topo": "^5.0.0"
+			}
+		},
+		"node_modules/@hapi/validate/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/validate/node_modules/@hapi/topo": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+			"integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"node_modules/@hapi/vise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+			"integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/vise/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
+		},
+		"node_modules/@hapi/wreck": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+			"integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/wreck/node_modules/@hapi/bourne": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+			"dev": true
+		},
+		"node_modules/@hapi/wreck/node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -6876,6 +7347,30 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
 			"dev": true
 		},
+		"node_modules/boom": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
+			"integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
+			"deprecated": "This module has moved and is now available at @hapi/boom. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+			"dev": true,
+			"dependencies": {
+				"hoek": "6.x.x"
+			}
+		},
+		"node_modules/boom/node_modules/hoek": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+			"integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+			"deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+			"dev": true
+		},
+		"node_modules/bourne": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/bourne/-/bourne-1.1.2.tgz",
+			"integrity": "sha512-b2dgVkTZhkQirNMohgC00rWfpVqEi9y5tKM1k3JvoNx05ODtfQoPPd4js9CYFQoY0IM8LAmnJulEuWv74zjUOg==",
+			"deprecated": "This module has moved and is now available at @hapi/bourne. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+			"dev": true
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -11603,6 +12098,22 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/h2o2": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/h2o2/-/h2o2-8.2.0.tgz",
+			"integrity": "sha512-TwWWSk1tMg03VkSKQTrTSXWKogmpYts5Uj5W6GN9CedFJY5EtL5vz2nndd9s5qxxSMP6Wj8jyGrj/6qV9d4KDg==",
+			"deprecated": "This module has moved and is now available at @hapi/h2o2. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+			"dev": true,
+			"dependencies": {
+				"boom": "7.x.x",
+				"hoek": "5.x.x",
+				"joi": "13.x.x",
+				"wreck": "14.x.x"
+			},
+			"engines": {
+				"node": ">=8.x.x"
+			}
+		},
 		"node_modules/har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -11803,6 +12314,16 @@
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"node_modules/hoek": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+			"integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+			"deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+			"dev": true,
+			"engines": {
+				"node": ">=8.9.0"
 			}
 		},
 		"node_modules/hoist-non-react-statics": {
@@ -12898,6 +13419,18 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
+		},
+		"node_modules/isemail": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+			"integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "2.x.x"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -15011,6 +15544,21 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/joi": {
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+			"integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+			"deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+			"dev": true,
+			"dependencies": {
+				"hoek": "5.x.x",
+				"isemail": "3.x.x",
+				"topo": "3.x.x"
+			},
+			"engines": {
+				"node": ">=8.9.0"
 			}
 		},
 		"node_modules/js-base64": {
@@ -22829,6 +23377,23 @@
 				"node": ">=0.6"
 			}
 		},
+		"node_modules/topo": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+			"integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+			"deprecated": "This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+			"dev": true,
+			"dependencies": {
+				"hoek": "6.x.x"
+			}
+		},
+		"node_modules/topo/node_modules/hoek": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+			"integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+			"deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+			"dev": true
+		},
 		"node_modules/tough-cookie": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -24414,6 +24979,25 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"node_modules/wreck": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/wreck/-/wreck-14.2.0.tgz",
+			"integrity": "sha512-NFFft3SMgqrJbXEVfYifh+QDWFxni+98/I7ut7rLbz3F0XOypluHsdo3mdEYssGSirMobM3fGlqhyikbWKDn2Q==",
+			"deprecated": "This module has moved and is now available at @hapi/wreck. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+			"dev": true,
+			"dependencies": {
+				"boom": "7.x.x",
+				"bourne": "1.x.x",
+				"hoek": "6.x.x"
+			}
+		},
+		"node_modules/wreck/node_modules/hoek": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+			"integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+			"deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
 			"dev": true
 		},
 		"node_modules/write": {
@@ -26020,11 +26604,98 @@
 				"strip-json-comments": "^3.1.1"
 			}
 		},
+		"@hapi/accept": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+			"integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
 		"@hapi/address": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
 			"integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
 			"dev": true
+		},
+		"@hapi/ammo": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+			"integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/b64": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+			"integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/boom": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
+			"integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/bounce": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+			"integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
 		},
 		"@hapi/bourne": {
 			"version": "1.3.2",
@@ -26032,11 +26703,180 @@
 			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
 			"dev": true
 		},
+		"@hapi/call": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+			"integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/catbox": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+			"integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/podium": "4.x.x",
+				"@hapi/validate": "1.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/catbox-memory": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+			"integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/content": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+			"integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x"
+			}
+		},
+		"@hapi/cryptiles": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+			"integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x"
+			}
+		},
+		"@hapi/file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+			"integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+			"dev": true
+		},
+		"@hapi/hapi": {
+			"version": "20.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.3.tgz",
+			"integrity": "sha512-ImOkrixD1kPUuvmSklwytPQ0sG8AtqydwU0JzvITLE6Z7wPMVf9i9LIMWywKPxHTNhCZ6W3oKP9yRjqM/IkHMQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/accept": "^5.0.1",
+				"@hapi/ammo": "^5.0.1",
+				"@hapi/boom": "^9.1.0",
+				"@hapi/bounce": "^2.0.0",
+				"@hapi/call": "^8.0.0",
+				"@hapi/catbox": "^11.1.1",
+				"@hapi/catbox-memory": "^5.0.0",
+				"@hapi/heavy": "^7.0.1",
+				"@hapi/hoek": "^9.0.4",
+				"@hapi/mimos": "^6.0.0",
+				"@hapi/podium": "^4.1.1",
+				"@hapi/shot": "^5.0.5",
+				"@hapi/somever": "^3.0.0",
+				"@hapi/statehood": "^7.0.3",
+				"@hapi/subtext": "^7.0.3",
+				"@hapi/teamwork": "^5.1.0",
+				"@hapi/topo": "^5.0.0",
+				"@hapi/validate": "^1.1.1"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				},
+				"@hapi/topo": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+					"integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+					"dev": true,
+					"requires": {
+						"@hapi/hoek": "^9.0.0"
+					}
+				}
+			}
+		},
+		"@hapi/heavy": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+			"integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/validate": "1.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
 		"@hapi/hoek": {
 			"version": "8.5.1",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
 			"integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
 			"dev": true
+		},
+		"@hapi/iron": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+			"integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+			"dev": true,
+			"requires": {
+				"@hapi/b64": "5.x.x",
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/cryptiles": "5.x.x",
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/bourne": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+					"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+					"dev": true
+				},
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
 		},
 		"@hapi/joi": {
 			"version": "15.1.1",
@@ -26050,6 +26890,182 @@
 				"@hapi/topo": "3.x.x"
 			}
 		},
+		"@hapi/mimos": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+			"integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x",
+				"mime-db": "1.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/nigel": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+			"integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "^9.0.4",
+				"@hapi/vise": "^4.0.0"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/pez": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+			"integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+			"dev": true,
+			"requires": {
+				"@hapi/b64": "5.x.x",
+				"@hapi/boom": "9.x.x",
+				"@hapi/content": "^5.0.2",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/nigel": "4.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/podium": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+			"integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x",
+				"@hapi/teamwork": "5.x.x",
+				"@hapi/validate": "1.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/shot": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+			"integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x",
+				"@hapi/validate": "1.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/somever": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
+			"integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+			"dev": true,
+			"requires": {
+				"@hapi/bounce": "2.x.x",
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/statehood": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+			"integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bounce": "2.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/cryptiles": "5.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/iron": "6.x.x",
+				"@hapi/validate": "1.x.x"
+			},
+			"dependencies": {
+				"@hapi/bourne": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+					"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+					"dev": true
+				},
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/subtext": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+			"integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/content": "^5.0.2",
+				"@hapi/file": "2.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/pez": "^5.0.1",
+				"@hapi/wreck": "17.x.x"
+			},
+			"dependencies": {
+				"@hapi/bourne": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+					"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+					"dev": true
+				},
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/teamwork": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+			"integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
+			"dev": true
+		},
 		"@hapi/topo": {
 			"version": "3.1.6",
 			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
@@ -26057,6 +27073,75 @@
 			"dev": true,
 			"requires": {
 				"@hapi/hoek": "^8.3.0"
+			}
+		},
+		"@hapi/validate": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+			"integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "^9.0.0",
+				"@hapi/topo": "^5.0.0"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				},
+				"@hapi/topo": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+					"integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+					"dev": true,
+					"requires": {
+						"@hapi/hoek": "^9.0.0"
+					}
+				}
+			}
+		},
+		"@hapi/vise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+			"integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
+			}
+		},
+		"@hapi/wreck": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+			"integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/hoek": "9.x.x"
+			},
+			"dependencies": {
+				"@hapi/bourne": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+					"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+					"dev": true
+				},
+				"@hapi/hoek": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+					"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+					"dev": true
+				}
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
@@ -30812,6 +31897,29 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
 			"dev": true
 		},
+		"boom": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
+			"integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
+			"dev": true,
+			"requires": {
+				"hoek": "6.x.x"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "6.1.3",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+					"integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+					"dev": true
+				}
+			}
+		},
+		"bourne": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/bourne/-/bourne-1.1.2.tgz",
+			"integrity": "sha512-b2dgVkTZhkQirNMohgC00rWfpVqEi9y5tKM1k3JvoNx05ODtfQoPPd4js9CYFQoY0IM8LAmnJulEuWv74zjUOg==",
+			"dev": true
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -34824,6 +35932,18 @@
 				"pify": "^4.0.1"
 			}
 		},
+		"h2o2": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/h2o2/-/h2o2-8.2.0.tgz",
+			"integrity": "sha512-TwWWSk1tMg03VkSKQTrTSXWKogmpYts5Uj5W6GN9CedFJY5EtL5vz2nndd9s5qxxSMP6Wj8jyGrj/6qV9d4KDg==",
+			"dev": true,
+			"requires": {
+				"boom": "7.x.x",
+				"hoek": "5.x.x",
+				"joi": "13.x.x",
+				"wreck": "14.x.x"
+			}
+		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -34992,6 +36112,12 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
+		},
+		"hoek": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+			"integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+			"dev": true
 		},
 		"hoist-non-react-statics": {
 			"version": "3.3.2",
@@ -35863,6 +36989,15 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
+		},
+		"isemail": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+			"integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+			"dev": true,
+			"requires": {
+				"punycode": "2.x.x"
+			}
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -37554,6 +38689,17 @@
 						"has-flag": "^4.0.0"
 					}
 				}
+			}
+		},
+		"joi": {
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+			"integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+			"dev": true,
+			"requires": {
+				"hoek": "5.x.x",
+				"isemail": "3.x.x",
+				"topo": "3.x.x"
 			}
 		},
 		"js-base64": {
@@ -44166,6 +45312,23 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
 		},
+		"topo": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+			"integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+			"dev": true,
+			"requires": {
+				"hoek": "6.x.x"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "6.1.3",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+					"integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+					"dev": true
+				}
+			}
+		},
 		"tough-cookie": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -45526,6 +46689,25 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"wreck": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/wreck/-/wreck-14.2.0.tgz",
+			"integrity": "sha512-NFFft3SMgqrJbXEVfYifh+QDWFxni+98/I7ut7rLbz3F0XOypluHsdo3mdEYssGSirMobM3fGlqhyikbWKDn2Q==",
+			"dev": true,
+			"requires": {
+				"boom": "7.x.x",
+				"bourne": "1.x.x",
+				"hoek": "6.x.x"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "6.1.3",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+					"integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+					"dev": true
+				}
+			}
 		},
 		"write": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
 		"test-e2e:initialize": ". ./tests/e2e/initialize.sh",
 		"test-unit": "wp-scripts test-unit-js",
 		"test-unit:watch": "npm run test-unit -- --watch",
+		"test-proxy": "node ./tests/proxy",
 		"wp-env": "wp-env"
 	},
 	"devDependencies": {
+		"@hapi/hapi": "^20.1.3",
 		"@testing-library/react": "^11.1.0",
 		"@testing-library/react-hooks": "^5.1.1",
 		"@woocommerce/eslint-plugin": "^1.0.0-beta.0",
@@ -44,6 +46,7 @@
 		"@wordpress/e2e-test-utils": "^4.15.0",
 		"@wordpress/env": "^2.1.0",
 		"@wordpress/scripts": "^12.5.0",
+		"h2o2": "^8.2.0",
 		"prettier": "npm:wp-prettier@^2.0.5",
 		"stylelint-config-wordpress": "^17.0.0"
 	},

--- a/tests/mocks/mc/reports/programs-pagetwo.json
+++ b/tests/mocks/mc/reports/programs-pagetwo.json
@@ -1,0 +1,44 @@
+{
+	"free_listings": [
+		{
+			"type": "footwo",
+			"subtotals": {
+				"clicks": 139,
+				"impressions": 16037
+			}
+		}
+	],
+	"intervals": [
+		{
+			"interval": "2020-07",
+			"subtotals": {
+				"sales": 0,
+				"spend": 38,
+				"clicks": 90,
+				"impressions": 9941
+			}
+		},
+		{
+			"interval": "2020-08",
+			"subtotals": {
+				"sales": 11,
+				"spend": 35.01,
+				"clicks": 64,
+				"impressions": 6997
+			}
+		},
+		{
+			"interval": "2020-09",
+			"subtotals": {
+				"sales": 5,
+				"spend": 23,
+				"clicks": 3,
+				"impressions": 500
+			}
+		}
+	],
+	"totals": {
+		"clicks": 5626,
+		"impressions": 23340
+	}
+}

--- a/tests/proxy/config.js
+++ b/tests/proxy/config.js
@@ -4,5 +4,5 @@ module.exports = {
 	host: 'localhost',
 	connectServer:
 		process.env.WOOCOMMERCE_CONNECT_SERVER ||
-		'https://api-vigo.woocommerce.com',
+		'https://api-vipgo.woocommerce.com',
 };

--- a/tests/proxy/config.js
+++ b/tests/proxy/config.js
@@ -1,0 +1,8 @@
+'use strict';
+module.exports = {
+	port: 5500,
+	host: 'localhost',
+	connectServer:
+		process.env.WOOCOMMERCE_CONNECT_SERVER ||
+		'https://api-vigo.woocommerce.com',
+};

--- a/tests/proxy/handler.js
+++ b/tests/proxy/handler.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports.checkRequest = ( request ) => {
+	if ( request.params.path.includes( 'googleAds:search' ) ) {
+		const body = JSON.parse( request.payload );
+		if ( body.query.includes( 'shopping_performance_view' ) ) {
+			const file = body.query.includes( 'segments.product_item_id' )
+				? 'products'
+				: 'programs';
+			const page = body.pageToken ? '-' + body.pageToken : '';
+
+			return require( `./mocks/ads/reports/${ file }${ page }.json` );
+		}
+	}
+	if ( request.params.path.includes( 'reports/search' ) ) {
+		const body = JSON.parse( request.payload );
+		const file = body.query.includes( 'segments.offer_id' )
+			? 'products'
+			: 'programs';
+		const page = body.pageToken ? '-' + body.pageToken : '';
+
+		return require( `./mocks/mc/reports/${ file }${ page }.json` );
+	}
+
+	return false;
+};

--- a/tests/proxy/index.js
+++ b/tests/proxy/index.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const Hapi = require( '@hapi/hapi' );
+const H2o2 = require( 'h2o2' );
+const config = require( './config' );
+const handler = require( './handler' );
+
+const init = async () => {
+	const server = Hapi.server( {
+		port: config.port,
+		host: config.host,
+	} );
+	await server.register( H2o2 );
+
+	server.route( {
+		method: '*',
+		path: '/{path*}',
+		config: {
+			handler: ( request, h ) => {
+				const response = handler.checkRequest( request );
+				if ( response ) {
+					return response;
+				}
+
+				return h.proxy( {
+					uri: `${ config.connectServer }/${ request.params.path }${
+						request.url.search || ''
+					}`,
+					passThrough: true,
+				} );
+			},
+			payload: {
+				parse: false,
+			},
+		},
+	} );
+
+	await server.start();
+
+	// eslint-disable-next-line no-console
+	console.log(
+		'Proxy server running on %s > %s',
+		server.info.uri,
+		config.connectServer
+	);
+};
+
+init();

--- a/tests/proxy/mocks/ads/reports/products.json
+++ b/tests/proxy/mocks/ads/reports/products.json
@@ -1,0 +1,102 @@
+{
+  "results": [
+    {
+      "metrics": {
+        "clicks": "12",
+        "conversions": 1,
+        "conversionsValue": 20,
+        "costMicros": "6650000",
+        "impressions": "1987"
+      },
+      "segments": {
+        "date": "2021-05-01",
+        "productItemId": "gla_123",
+        "productTitle": "Product One"
+      }
+    },
+    {
+      "metrics": {
+        "clicks": "98",
+        "conversions": 3,
+        "conversionsValue": 15,
+        "costMicros": "2260000",
+        "impressions": "123"
+      },
+      "segments": {
+        "date": "2021-05-02",
+        "productItemId": "gla_123",
+        "productTitle": "Product One"
+      }
+    },
+    {
+      "metrics": {
+        "clicks": "7",
+        "conversions": 5,
+        "conversionsValue": 82,
+        "costMicros": "120000",
+        "impressions": "842"
+      },
+      "segments": {
+        "date": "2021-05-03",
+        "productItemId": "345",
+        "productTitle": "Product Two"
+      }
+    },
+    {
+      "metrics": {
+        "clicks": "83",
+        "conversions": 2,
+        "conversionsValue": 34,
+        "costMicros": "7890000",
+        "impressions": "2831"
+      },
+      "segments": {
+        "date": "2021-05-04",
+        "productItemId": "345",
+        "productTitle": "Product Two"
+      }
+    },
+    {
+      "metrics": {
+        "clicks": "118",
+        "conversions": 7,
+        "conversionsValue": 123,
+        "costMicros": "82360000",
+        "impressions": "9627"
+      },
+      "segments": {
+        "date": "2021-05-05",
+        "productItemId": "345",
+        "productTitle": "Product Two"
+      }
+    },
+    {
+      "metrics": {
+        "clicks": "12",
+        "conversions": 0,
+        "conversionsValue": 0,
+        "costMicros": "1020000",
+        "impressions": "375"
+      },
+      "segments": {
+        "date": "2021-05-06",
+        "productItemId": "567",
+        "productTitle": "Product Three"
+      }
+    },
+    {
+      "metrics": {
+        "clicks": "83",
+        "conversions": 8,
+        "conversionsValue": 964,
+        "costMicros": "3680000",
+        "impressions": "1450"
+      },
+      "segments": {
+        "date": "2021-05-07",
+        "productItemId": "567",
+        "productTitle": "Product Three"
+      }
+    }
+  ]
+}

--- a/tests/proxy/mocks/ads/reports/programs.json
+++ b/tests/proxy/mocks/ads/reports/programs.json
@@ -1,0 +1,123 @@
+{
+  "results": [
+    {
+      "campaign": {
+        "status": "ENABLED",
+        "name": "Spring",
+        "id": "1234567890"
+      },
+      "metrics": {
+        "clicks": "12",
+        "conversions": 1,
+        "conversionsValue": 20,
+        "costMicros": "6650000",
+        "impressions": "1987"
+      },
+      "segments": {
+        "date": "2021-05-01"
+      }
+    },
+    {
+      "campaign": {
+        "status": "ENABLED",
+        "name": "Summer",
+        "id": "3456789012"
+      },
+      "metrics": {
+        "clicks": "98",
+        "conversions": 3,
+        "conversionsValue": 15,
+        "costMicros": "2260000",
+        "impressions": "123"
+      },
+      "segments": {
+        "date": "2021-05-02"
+      }
+    },
+    {
+      "campaign": {
+        "status": "ENABLED",
+        "name": "Autumn",
+        "id": "5678901234"
+      },
+      "metrics": {
+        "clicks": "7",
+        "conversions": 5,
+        "conversionsValue": 82,
+        "costMicros": "120000",
+        "impressions": "842"
+      },
+      "segments": {
+        "date": "2021-05-03"
+      }
+    },
+    {
+      "campaign": {
+        "status": "ENABLED",
+        "name": "Winter",
+        "id": "7890123456"
+      },
+      "metrics": {
+        "clicks": "83",
+        "conversions": 2,
+        "conversionsValue": 34,
+        "costMicros": "7890000",
+        "impressions": "2831"
+      },
+      "segments": {
+        "date": "2021-05-04"
+      }
+    },
+    {
+      "campaign": {
+        "status": "ENABLED",
+        "name": "Summer",
+        "id": "3456789012"
+      },
+      "metrics": {
+        "clicks": "118",
+        "conversions": 7,
+        "conversionsValue": 123,
+        "costMicros": "82360000",
+        "impressions": "9627"
+      },
+      "segments": {
+        "date": "2021-05-05"
+      }
+    },
+    {
+      "campaign": {
+        "status": "ENABLED",
+        "name": "Winter",
+        "id": "7890123456"
+      },
+      "metrics": {
+        "clicks": "12",
+        "conversions": 0,
+        "conversionsValue": 0,
+        "costMicros": "1020000",
+        "impressions": "375"
+      },
+      "segments": {
+        "date": "2021-05-06"
+      }
+    },
+    {
+      "campaign": {
+        "status": "ENABLED",
+        "name": "Winter",
+        "id": "7890123456"
+      },
+      "metrics": {
+        "clicks": "83",
+        "conversions": 8,
+        "conversionsValue": 964,
+        "costMicros": "3680000",
+        "impressions": "1450"
+      },
+      "segments": {
+        "date": "2021-05-07"
+      }
+    }
+  ]
+}

--- a/tests/proxy/mocks/mc/reports/products.json
+++ b/tests/proxy/mocks/mc/reports/products.json
@@ -1,0 +1,74 @@
+{
+  "results": [
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 1 },
+        "offerId": "gla_123"
+      },
+      "metrics": {
+        "clicks": 18,
+        "impressions": 234
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 2 },
+        "offerId": "gla_123"
+      },
+      "metrics": {
+        "clicks": 89,
+        "impressions": 400
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 3 },
+        "offerId": "gla_345"
+      },
+      "metrics": {
+        "clicks": 2,
+        "impressions": 130
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 4 },
+        "offerId": "gla_345"
+      },
+      "metrics": {
+        "clicks": 123,
+        "impressions": 589
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 5 },
+        "offerId": "gla_345"
+      },
+      "metrics": {
+        "clicks": 98,
+        "impressions": 100
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 6 },
+        "offerId": "gla_678"
+      },
+      "metrics": {
+        "clicks": 9,
+        "impressions": 12
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 7 },
+        "offerId": "gla_678"
+      },
+      "metrics": {
+        "clicks": 18,
+        "impressions": 251
+      }
+    }
+  ]
+}

--- a/tests/proxy/mocks/mc/reports/programs-pagetwo.json
+++ b/tests/proxy/mocks/mc/reports/programs-pagetwo.json
@@ -1,0 +1,67 @@
+{
+  "results": [
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 8 }
+      },
+      "metrics": {
+        "clicks": 81,
+        "impressions": 99
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 9 }
+      },
+      "metrics": {
+        "clicks": 12,
+        "impressions": 240
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 10 }
+      },
+      "metrics": {
+        "clicks": 27,
+        "impressions": 380
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 11 }
+      },
+      "metrics": {
+        "clicks": 34,
+        "impressions": 167
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 12 }
+      },
+      "metrics": {
+        "clicks": 2,
+        "impressions": 87
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 13 }
+      },
+      "metrics": {
+        "clicks": 32,
+        "impressions": 478
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 14 }
+      },
+      "metrics": {
+        "clicks": 7,
+        "impressions": 125
+      }
+    }
+  ]
+}

--- a/tests/proxy/mocks/mc/reports/programs.json
+++ b/tests/proxy/mocks/mc/reports/programs.json
@@ -1,0 +1,68 @@
+{
+  "results": [
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 1 }
+      },
+      "metrics": {
+        "clicks": 12,
+        "impressions": 123
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 2 }
+      },
+      "metrics": {
+        "clicks": 89,
+        "impressions": 400
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 3 }
+      },
+      "metrics": {
+        "clicks": 2,
+        "impressions": 130
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 4 }
+      },
+      "metrics": {
+        "clicks": 123,
+        "impressions": 589
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 5 }
+      },
+      "metrics": {
+        "clicks": 98,
+        "impressions": 100
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 6 }
+      },
+      "metrics": {
+        "clicks": 9,
+        "impressions": 12
+      }
+    },
+    {
+      "segments": {
+        "date": { "year": 2021, "month": 5, "day": 7 }
+      },
+      "metrics": {
+        "clicks": 18,
+        "impressions": 251
+      }
+    }
+  ],
+  "nextPageToken": "pagetwo"
+}

--- a/tests/proxy/proxy.md
+++ b/tests/proxy/proxy.md
@@ -1,0 +1,22 @@
+Using a proxy for mocked data
+---
+
+Since data returned from the Google API can rely on actual live campaigns, the purpose of this proxy is to mock some of that data.
+
+Prerequisites:
+`npm install`
+
+To run:
+`npm run test-proxy`
+
+Run using a local connect server:
+`WOOCOMMERCE_CONNECT_SERVER=http://localhost:5000 npm run test-proxy`
+
+On your test site you will need to run a PHP snippet to use the proxy to handle any requests:
+
+```php
+define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://localhost:5500' );
+```
+
+
+At the moment only the report data is mocked, the rest of the requests are sent on to the connect server. The mocks folder contains example responses for the reports.

--- a/tests/proxy/proxy.md
+++ b/tests/proxy/proxy.md
@@ -6,11 +6,18 @@ Since data returned from the Google API can rely on actual live campaigns, the p
 Prerequisites:
 `npm install`
 
-To run:
-`npm run test-proxy`
+### Run proxy
 
-Run using a local connect server:
-`WOOCOMMERCE_CONNECT_SERVER=http://localhost:5000 npm run test-proxy`
+```
+npm run test-proxy
+```
+
+Or, if you want to use a local connect server:
+```
+WOOCOMMERCE_CONNECT_SERVER=http://localhost:5000 npm run test-proxy
+```
+
+### Connect test site to proxy
 
 On your test site you will need to run a PHP snippet to use the proxy to handle any requests:
 
@@ -23,5 +30,15 @@ Or, if your test site is running within a docker container, the PHP snippet woul
 ```php
 define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://host.docker.internal:5500' );
 ```
+
+#### Non Mac users
+To make `host.docker.internal` work on non-Mac environments, you will need to add a flag `--add-host=host.docker.internal:host-gateway` or config to your `docker-composer.yml`:
+```yml
+  phpfpm:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
+### Available mocks
 
 At the moment only the report data is mocked, the rest of the requests are sent on to the connect server. The mocks folder contains example responses for the reports.

--- a/tests/proxy/proxy.md
+++ b/tests/proxy/proxy.md
@@ -18,5 +18,10 @@ On your test site you will need to run a PHP snippet to use the proxy to handle 
 define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://localhost:5500' );
 ```
 
+Or, if your test site is running within a docker container, the PHP snippet would be the following instead:
+
+```php
+define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://host.docker.internal:5500' );
+```
 
 At the moment only the report data is mocked, the rest of the requests are sent on to the connect server. The mocks folder contains example responses for the reports.

--- a/tests/proxy/proxy.md
+++ b/tests/proxy/proxy.md
@@ -32,12 +32,7 @@ define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://host.docker.internal:5500'
 ```
 
 #### Non Mac users
-To make `host.docker.internal` work on non-Mac environments, you will need to add a flag `--add-host=host.docker.internal:host-gateway` or config to your `docker-composer.yml`:
-```yml
-  phpfpm:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-```
+`host.docker.internal` works only on Mac environments. On others, you would have to use `172.17.0.1` instead of `localhost` in the PHP snippet and in `tests/proxy/config.js`.
 
 ### Available mocks
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a helper proxy which can be used to mock some of the report responses. This is to aid in testing the reports without any live campaign data.

Note: The mocked responses are in the format that would be returned by the Google API, which is different then the format for the files in `tests/mocks`

### Detailed test instructions:

1. See `tests/proxy/proxy.md`