### PR TITLE
Redirect to onboarding / get started page on plugin activation

### DIFF
--- a/src/Admin/ActivationRedirect.php
+++ b/src/Admin/ActivationRedirect.php
@@ -1,0 +1,130 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Activateable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+
+/**
+ * Class ActivationRedirect
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
+ */
+class ActivationRedirect implements Activateable, Service, Registerable, OptionsAwareInterface, MerchantCenterAwareInterface {
+
+	use MerchantCenterAwareTrait;
+	use OptionsAwareTrait;
+	use PluginHelper;
+
+	protected const OPTION = OptionsInterface::REDIRECT_TO_ONBOARDING;
+
+	protected const PARAMS = [
+		'page' => 'wc-admin',
+		'path' => '/google/start',
+	];
+
+	/**
+	 * Register a service.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action(
+			'admin_init',
+			function () {
+				$this->maybe_redirect_to_onboarding();
+			}
+		);
+	}
+
+	/**
+	 * Activate a service.
+	 *
+	 * @return void
+	 */
+	public function activate(): void {
+		// Do not take any action if activated in a REST request (via wc-admin).
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return;
+		}
+
+		if (
+			// Only redirect to onboarding when activated on its own. Either with a link...
+			isset( $_GET['action'] ) && 'activate' === $_GET['action'] // phpcs:ignore WordPress.Security.NonceVerification
+			// ...or with a bulk action.
+			|| isset( $_POST['checked'] ) && is_array( $_POST['checked'] ) && 1 === count( $_POST['checked'] ) // phpcs:ignore WordPress.Security.NonceVerification
+		) {
+			$this->options->update( self::OPTION, 'yes' );
+		}
+	}
+
+	/**
+	 * Checks if merchant should be redirected to the onboarding page if it is not.
+	 *
+	 * @return bool True if the redirection should have happened
+	 */
+	protected function maybe_redirect_to_onboarding(): bool {
+		if ( wp_doing_ajax() ) {
+			return false;
+		}
+
+		// If we have redirected before do not attempt to redirect again.
+		if ( 'yes' !== $this->options->get( self::OPTION ) ) {
+			return false;
+		}
+
+		// Do not redirect if setup is already complete
+		if ( $this->merchant_center->is_setup_complete() ) {
+			$this->options->update( self::OPTION, 'no' );
+			return false;
+		}
+
+		// if we are on the get started page don't redirect again
+		if ( $this->is_onboarding_page() && 'yes' === $this->options->get( self::OPTION, 'yes' ) ) {
+			$this->options->update( self::OPTION, 'no' );
+			return false;
+		}
+
+		// Redirect if setup is not complete
+		$this->redirect_to_onboarding_page();
+		return true;
+	}
+
+	/**
+	 * Utility function to check if are on the main "Get Started" onboarding page.
+	 *
+	 * @return bool
+	 */
+	protected function is_onboarding_page(): bool {
+		// If we are already in the onboarding page, return true
+		if ( count( self::PARAMS ) === count( array_intersect_assoc( $_GET, self::PARAMS ) ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Utility function to immediately redirect to the main "Get Started" onboarding page.
+	 * Note that this function immediately ends the execution.
+	 *
+	 * @return void
+	 */
+	protected function redirect_to_onboarding_page(): void {
+		// If we are already on the onboarding page, do nothing.
+		if ( $this->is_onboarding_page() ) {
+			return;
+		}
+
+		wp_safe_redirect( admin_url( add_query_arg( self::PARAMS, 'admin.php' ) ) );
+		exit();
+	}
+}

--- a/src/Admin/ActivationRedirect.php
+++ b/src/Admin/ActivationRedirect.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 /**
  * Class ActivationRedirect
@@ -22,7 +21,6 @@ class ActivationRedirect implements Activateable, Service, Registerable, Options
 
 	use MerchantCenterAwareTrait;
 	use OptionsAwareTrait;
-	use PluginHelper;
 
 	protected const OPTION = OptionsInterface::REDIRECT_TO_ONBOARDING;
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer as DBInstaller;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\ActivationRedirect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityMetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer;
@@ -85,6 +86,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = [
 		Installer::class              => true,
+		ActivationRedirect::class     => true,
 		Admin::class                  => true,
 		Reports::class                => true,
 		Programs::class               => true,
@@ -187,6 +189,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			MerchantCenterService::class,
 			AdsService::class
 		);
+		$this->conditionally_share_with_tags( ActivationRedirect::class );
 		$this->conditionally_share_with_tags( GetStarted::class );
 		$this->conditionally_share_with_tags( SetupMerchantCenter::class );
 		$this->conditionally_share_with_tags( SetupAds::class );

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -38,6 +38,7 @@ final class Options implements OptionsInterface, Service {
 		self::MERCHANT_ID            => true,
 		self::SHIPPING_RATES         => true,
 		self::SHIPPING_TIMES         => true,
+		self::REDIRECT_TO_ONBOARDING => true,
 		self::SITE_VERIFICATION      => true,
 		self::TARGET_AUDIENCE        => true,
 		self::WP_TOS_ACCEPTED        => true,

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -23,6 +23,7 @@ interface OptionsInterface {
 	public const MERCHANT_ACCOUNT_STATE = 'merchant_account_state';
 	public const MERCHANT_CENTER        = 'merchant_center';
 	public const MERCHANT_ID            = 'merchant_id';
+	public const REDIRECT_TO_ONBOARDING = 'redirect_to_onboarding';
 	public const SHIPPING_RATES         = 'shipping_rates';
 	public const SHIPPING_TIMES         = 'shipping_times';
 	public const SITE_VERIFICATION      = 'site_verification';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As per the title, this changeset should redirect merchants to our onboarding / get started page when the plugin is activated. There are some caveats.

Merchants should be redirected to the onboarding flow when activating from the main WordPress plugin page and they have NOT completed setup previously.

Once redirected they should be able to browse around the dashboard still - i.e. they should not be forced to complete setup.

When activating the extension via the Marketing Hub it should not redirect - merchants can click "Finish Setup" button to be redirected to the onboarding flow.

When activating the extension in bulk with other extensions it should not redirect (to avoid redirection wars with other extensions)

If merchants are redirected to the onboarding flow, choose not to complete the setup and uninstall the extension but later reactivate the extension from the plugin page, they should be redirected as normal.

In general, I've tried to follow a similar line of thinking to WC Pay - some reference links
* https://github.com/Automattic/woocommerce-payments/blob/trunk/woocommerce-payments.php#L30
* https://github.com/Automattic/woocommerce-payments/blob/trunk/includes/class-wc-payments-account.php#L235-L296

Closes #666

### Detailed test instructions:

1. Clone, install, build
2. Rename `gla_mc_setup_completed_at` to something else like `gla_mc_setup_completed_at_derp` to trick the site into thinking you haven't completed the setup
3. Deactivate GLA if you have it active
4. From Dashboard -> Plugins activate GLA
5. See that you are redirected to the getting started page
6. Make sure you can still go elsewhere in the admin without being forced back to onboarding
7. Check for `gla_redirect_to_onboarding` option set to 'no'
8. Repeat from 3 to check you be redirected on subsequent activations if setup is not complete
9. Deactivate GLA
10. Try a bulk activate by selecting multiple plugins
11. Ensure you are NOT redirected
12. Re-set `gla_mc_setup_completed_at`  back to the proper name
13. Deactive GLA
14. Try activating GLA again
15. Ensure you are NOT redirected (because you have already completed setup).

Bonus Points
* Install wc-admin 5.4 (with out Marketing Hub changes and onboarding)
* Install and activate GLA from the Marketing Hub - make sure you are NOT redirected and "Finish Setup" button is displayed correctly
* Try installing GLA from the onboarding flow and make sure installing/activating GLA does not interfere with the overall Woo onboarding flow

### Changelog Note:

> Tweak - Redirect merchants to the onboarding flow on plugin activation.
