### PR TITLE
Fall back to 'SurfacesAcrossGoogle' status if 'Shopping' isn't available for Product Feed

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -494,12 +494,16 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 * @return string|null
 	 */
 	protected function get_product_shopping_status( Shopping_Product_Status $product_status ): ?string {
+		$status = null;
 		foreach ( $product_status->getDestinationStatuses() as $d ) {
-			if ( $d->getDestination() === 'Shopping' ) {
-				return $d->getStatus();
+			if ( $d->getDestination() === 'SurfacesAcrossGoogle' ) {
+				$status = $d->getStatus();
+			} elseif ( $d->getDestination() === 'Shopping' ) {
+				$status = $d->getStatus();
+				break;
 			}
 		}
-		return null;
+		return $status;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

For some (new?) accounts, the process of getting the account and products reviewed may take a while ("up to 3 business days") and the products are shown as `Pending`. In the API, this is indicated in the `SurfaceAcrossGoogle` destination, but the process to parse the statuses from `productstatuses.list` only looks for the `Shopping` destination. 

While these accounts/products are pending, the `Shopping` destination isn't included, and in the Product Feed, these products show as "Not Synced", even though they have actually been submitted:
![image](https://user-images.githubusercontent.com/228780/119808741-b5fcda00-bee4-11eb-8578-aac3dbc80607.png)
![image](https://user-images.githubusercontent.com/228780/119809025-fb210c00-bee4-11eb-86c6-843e417b12a5.png)


This PR defaults to using the `SurfacesAcrossGoogle` destination status when the `Shopping` status isn't available, to provide more accurate information:
![image](https://user-images.githubusercontent.com/228780/119808909-dcbb1080-bee4-11eb-9767-162696c68e2b.png)
![image](https://user-images.githubusercontent.com/228780/119808949-e775a580-bee4-11eb-9752-9639f6e4a660.png)

Once the products are reviewed (approved or disapproved), the `Shopping` destination status will be used.

#### Notes
- The original Product Feed page load will probably still cache the pre-sync "Not synced" status for all products (since the background AS job won't have run yet). This will be the status for 1 hour (cache lifetime), even though the status in the MC might already be `Pending`. (It test, there's a clear cache button in Connection Test page to reset the cache, see Step 3 below).


### Screenshots:

_Free listings with a `Pending` status_
![image](https://user-images.githubusercontent.com/228780/119808354-54d50680-bee4-11eb-8530-90dca81a4339.png)


### Detailed test instructions:

1. Connect to a new MC account, and sync some products.
2. Once the AS background job has submitted the products to the API, check the status in the MC panel (`https://merchants.google.com/mc/items`).
3. Pending products in the MC panel should also show as pending on the extension Product Feed page (`/wp-admin/admin.php?page=wc-admin&path=/google/product-feed`). 
    - It might be necessary to clear the MC statuses cache to see the pending statuses: (Connection Test -> Merchant Center -> More Merchant Center -> Clear Status Cache).


### Changelog Note:

> Tweak - Fall back to SurfacesAcrossGoogle status for products pending review.
