### PR TITLE
Remove Checkbox

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
@@ -1,15 +1,7 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import AppSpinner from '.~/components/app-spinner';
-import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import ShippingCountriesForm from './countries-form';
 import './index.scss';
@@ -38,24 +30,6 @@ const ShippingTimeSetup = ( { formProps, selectedCountryCodes } ) => {
 				<ShippingCountriesForm
 					{ ...getInputProps( 'shipping_country_times' ) }
 					selectedCountryCodes={ selectedCountryCodes }
-				/>
-				<CheckboxControl
-					label={ createInterpolateElement(
-						__(
-							'I allow Google to collect and calculate my shipping times for more accurate estimates. <link>Learn more</link>',
-							'google-listings-and-ads'
-						),
-						{
-							link: (
-								<AppDocumentationLink
-									context="setup-mc-shipping-time"
-									linkId="shipping-time-allow-google-data-collection"
-									href="https://www.google.com/retail/solutions/merchant-center/"
-								/>
-							),
-						}
-					) }
-					{ ...getInputProps( 'share_shipping_time' ) }
 				/>
 			</VerticalGapLayout>
 		</div>

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -83,7 +83,6 @@ const SetupFreeListings = ( {
 					offers_free_shipping: settings.offers_free_shipping,
 					free_shipping_threshold: settings.free_shipping_threshold,
 					shipping_time: settings.shipping_time,
-					share_shipping_time: settings.share_shipping_time,
 					tax_rate: settings.tax_rate,
 					website_live: settings.website_live,
 					checkout_process_secure: settings.checkout_process_secure,

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -103,7 +103,6 @@ const SetupFreeListings = () => {
 					offers_free_shipping: settings.offers_free_shipping,
 					free_shipping_threshold: settings.free_shipping_threshold,
 					shipping_time: settings.shipping_time,
-					share_shipping_time: settings.share_shipping_time,
 					tax_rate: settings.tax_rate,
 					website_live: settings.website_live,
 					checkout_process_secure: settings.checkout_process_secure,

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
@@ -1,16 +1,12 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import AppSpinner from '.~/components/app-spinner';
-import AppDocumentationLink from '.~/components/app-documentation-link';
 import { STORE_KEY } from '.~/data';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
@@ -19,10 +15,7 @@ import getCountriesTimeArray from './getCountriesTimeArray';
 import CountriesTimeInputForm from './countries-time-input-form';
 import './index.scss';
 
-const ShippingTimeSetup = ( props ) => {
-	const {
-		formProps: { getInputProps },
-	} = props;
+const ShippingTimeSetup = () => {
 	const shippingTimes = useSelect( ( select ) =>
 		select( STORE_KEY ).getShippingTimes()
 	);
@@ -68,24 +61,6 @@ const ShippingTimeSetup = ( props ) => {
 						) }
 					</VerticalGapLayout>
 				</div>
-				<CheckboxControl
-					label={ createInterpolateElement(
-						__(
-							'I allow Google to collect and calculate my shipping times for more accurate estimates. <link>Learn more</link>',
-							'google-listings-and-ads'
-						),
-						{
-							link: (
-								<AppDocumentationLink
-									context="setup-mc-shipping-time"
-									linkId="shipping-time-allow-google-data-collection"
-									href="https://www.google.com/retail/solutions/merchant-center/"
-								/>
-							),
-						}
-					) }
-					{ ...getInputProps( 'share_shipping_time' ) }
-				/>
 			</VerticalGapLayout>
 		</div>
 	);

--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -129,13 +129,6 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'share_shipping_time'     => [
-				'type'              => 'boolean',
-				'description'       => __( 'Whether the share shipping rates with Google.', 'google-listings-and-ads' ),
-				'context'           => [ 'view', 'edit' ],
-				'validate_callback' => 'rest_validate_request_arg',
-				'default'           => false,
-			],
 			'tax_rate'                => [
 				'type'              => 'string',
 				'description'       => __(

--- a/src/Value/MerchantCenterSettings.php
+++ b/src/Value/MerchantCenterSettings.php
@@ -38,7 +38,6 @@ class MerchantCenterSettings extends ArrayWithRequiredKeys implements ValueInter
 				'offers_free_shipping'    => false,
 				'free_shipping_threshold' => 0,
 				'shipping_time'           => 'flat',
-				'share_shipping_time'     => false,
 				'tax_rate'                => 'destination',
 				'website_live'            => false,
 				'checkout_process_secure' => false,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes the "I allow Google to collect and calculate my shipping times for more accurate estimates."  checkbox from the MC add and edit flows.

Closes #674

### Screenshots:

<img width="1083" alt="Screen Shot 2021-05-27 at 8 00 17 pm" src="https://user-images.githubusercontent.com/355014/119811630-7951d280-bf26-11eb-9849-284600473fa9.png">

<img width="709" alt="Screen Shot 2021-05-27 at 8 02 17 pm" src="https://user-images.githubusercontent.com/355014/119811675-8242a400-bf26-11eb-8730-166e2a8f11c9.png">

### Detailed test instructions:

1. Clone, Install, Build
2. If you have completed MC onboarding already, edit the free campaign and ensure the checkbox is no longer there and the form still saves
3.  If you have completed MC onboarding already, edit `gla_mc_setup_completed_at` to show MC onboarding flow again and go through the process. Ensure the checkbox is no longer there and the process completes as expected. Values are saved etc.

If you already have the `gla_merchant_center` option and `share_shipping_time` set within it looks like it'll happily handle things and it will stay set.

### Changelog Note:

> Tweak - Remove share shipping times checkbox.
