### PR TITLE
Check product exists with helper function

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -62,6 +62,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks as TracksProxy;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\TaskList\CompleteSetup;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\Loaded;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteVerificationEvents;
@@ -228,7 +229,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( ProductMetaHandler::class );
 		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class );
 		$this->share_with_tags( ProductFactory::class, AttributeManager::class );
-		$this->share( ProductHelper::class, ProductMetaHandler::class );
+		$this->share( ProductHelper::class, ProductMetaHandler::class, WC::class );
 		$this->share_with_tags(
 			BatchProductHelper::class,
 			ProductMetaHandler::class,

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -83,10 +83,9 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param BatchProductEntry $product_entry
 	 */
 	public function mark_as_synced( BatchProductEntry $product_entry ) {
-		$wc_product     = wc_get_product( $product_entry->get_wc_product_id() );
+		$wc_product     = $this->product_helper->get_wc_product( $product_entry->get_wc_product_id() );
 		$google_product = $product_entry->get_google_product();
 
-		$this->validate_instanceof( $wc_product, WC_Product::class );
 		$this->validate_instanceof( $google_product, GoogleProduct::class );
 
 		$this->product_helper->mark_as_synced( $wc_product, $google_product );
@@ -96,9 +95,7 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param BatchProductEntry $product_entry
 	 */
 	public function mark_as_unsynced( BatchProductEntry $product_entry ) {
-		$wc_product = wc_get_product( $product_entry->get_wc_product_id() );
-
-		$this->validate_instanceof( $wc_product, WC_Product::class );
+		$wc_product = $this->product_helper->get_wc_product( $product_entry->get_wc_product_id() );
 
 		$this->product_helper->mark_as_unsynced( $wc_product );
 	}
@@ -111,10 +108,8 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param BatchInvalidProductEntry $product_entry
 	 */
 	public function mark_as_invalid( BatchInvalidProductEntry $product_entry ) {
-		$wc_product = wc_get_product( $product_entry->get_wc_product_id() );
+		$wc_product = $this->product_helper->get_wc_product( $product_entry->get_wc_product_id() );
 		$errors     = $product_entry->get_errors();
-
-		$this->validate_instanceof( $wc_product, WC_Product::class );
 
 		$this->product_helper->mark_as_invalid( $wc_product, $errors );
 	}

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use Google_Service_ShoppingContent_Product as GoogleProduct;
@@ -33,12 +34,19 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	protected $meta_handler;
 
 	/**
+	 * @var WC
+	 */
+	protected $wc;
+
+	/**
 	 * ProductHelper constructor.
 	 *
 	 * @param ProductMetaHandler $meta_handler
+	 * @param WC                 $wc
 	 */
-	public function __construct( ProductMetaHandler $meta_handler ) {
+	public function __construct( ProductMetaHandler $meta_handler, WC $wc ) {
 		$this->meta_handler = $meta_handler;
+		$this->wc           = $wc;
 	}
 
 	/**
@@ -69,7 +77,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 
 		// mark the parent product as synced if it's a variation
 		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
-			$parent_product = wc_get_product( $product->get_parent_id() );
+			$parent_product = $this->get_wc_product( $product->get_parent_id() );
 			$this->mark_as_synced( $parent_product, $google_product );
 		}
 	}
@@ -89,7 +97,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 
 		// mark the parent product as un-synced if it's a variation
 		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
-			$parent_product = wc_get_product( $product->get_parent_id() );
+			$parent_product = $this->get_wc_product( $product->get_parent_id() );
 			$this->mark_as_unsynced( $parent_product );
 		}
 	}
@@ -126,7 +134,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 		// mark the parent product as invalid if it's a variation
 		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
 			$wc_parent_id   = $product->get_parent_id();
-			$parent_product = wc_get_product( $wc_parent_id );
+			$parent_product = $this->get_wc_product( $wc_parent_id );
 
 			$parent_errors = ! empty( $this->meta_handler->get_errors( $wc_parent_id ) ) ?
 				$this->meta_handler->get_errors( $wc_parent_id ) :
@@ -151,7 +159,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 		// mark the parent product as pending if it's a variation
 		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
 			$wc_parent_id   = $product->get_parent_id();
-			$parent_product = wc_get_product( $wc_parent_id );
+			$parent_product = $this->get_wc_product( $wc_parent_id );
 			$this->mark_as_pending( $parent_product );
 		}
 	}
@@ -192,6 +200,18 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 			return 0;
 		}
 		return intval( $matches[1] );
+	}
+
+	/**
+	 * Get WooCommerce product
+	 *
+	 * @param int|false $product_id
+	 *
+	 * @return WC_Product
+	 * @throws InvalidValue If the given ID doesn't reference a valid product.
+	 */
+	public function get_wc_product( $product_id ): WC_Product {
+		return $this->wc->get_product( $product_id );
 	}
 
 	/**
@@ -256,10 +276,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @throws InvalidValue If the given ID doesn't reference a valid product.
 	 */
 	public function maybe_swap_for_parent_id( int $product_id ): int {
-		$product = wc_get_product( $product_id );
-		if ( ! $product ) {
-			throw InvalidValue::not_valid_product_id( $product_id );
-		}
+		$product = $this->get_wc_product( $product_id );
 		if ( $product instanceof WC_Product_Variation ) {
 			return $product->get_parent_id();
 		}

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Proxies;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use WC_Product;
 use WC_Countries;
 
 defined( 'ABSPATH' ) || exit;
@@ -66,5 +68,22 @@ class WC {
 	 */
 	public function get_wc_countries(): WC_Countries {
 		return $this->wc_countries;
+	}
+
+	/**
+	 * Get a WooCommerce product and confirm it exists.
+	 *
+	 * @param int|false $product_id
+	 *
+	 * @return WC_Product
+	 * @throws InvalidValue When the product does not exist.
+	 */
+	public function get_product( $product_id ): WC_Product {
+		$product = wc_get_product( $product_id );
+		if ( ! $product instanceof WC_Product ) {
+			throw InvalidValue::not_valid_product_id( $product_id );
+		}
+
+		return $product;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We use a regular pattern of loading a product and then confirming it's valid. So this was moved into a helper function in the WC proxy class so it can be reused by other classes. The helper function throws an exception if the product is no longer available.

Note: This PR only addresses the calls in `ProductHelper` and `BatchProductHelper`, we need another issue to refactor other code which calls `wc_get_product` directly.

Closes #658

### Detailed test instructions:

1. Test some syncing of products both directly and async to confirm we haven't broken any functionality
2. Create a product (with name, description, image, price to pass validation)
3. Wait for the product to be synced and show in the merchant center
4. Trash the product and then empty the trash before the scheduled delete sync happens
5. Wait for the scheduled delete to occur
6. Go to WooCommerce > Status > Scheduled Actions > Failed and confirm we see a nice error instead of fatal

![image](https://user-images.githubusercontent.com/11388669/119827305-e3e81b80-bef0-11eb-9130-c53abf5e59ae.png)


### Changelog Note:
* Fix - Check product exists with helper function