### PR TITLE
Use product name or title in products report

### DIFF
--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -29,9 +29,6 @@ const CompareProductsTableCard = ( {
 	products,
 	...restProps
 } ) => {
-	// TODO: the product name is not yet available from API and needs to be implemented later.
-	const nameCell = ( row ) => `Product #${ row.id }`;
-
 	return (
 		<CompareTableCard
 			title={ __( 'Products', 'google-listings-and-ads' ) }
@@ -40,7 +37,7 @@ const CompareProductsTableCard = ( {
 				'google-listings-and-ads'
 			) }
 			nameHeader={ __( 'Product title', 'google-listings-and-ads' ) }
-			nameCell={ nameCell }
+			nameCell={ ( row ) => row.name || row.title }
 			compareBy={ compareBy }
 			compareParam={ compareParam }
 			metrics={ metrics }

--- a/js/src/reports/products/compare-products-table-card.js
+++ b/js/src/reports/products/compare-products-table-card.js
@@ -37,7 +37,7 @@ const CompareProductsTableCard = ( {
 				'google-listings-and-ads'
 			) }
 			nameHeader={ __( 'Product title', 'google-listings-and-ads' ) }
-			nameCell={ ( row ) => row.name || row.title }
+			nameCell={ ( row ) => row.name }
 			compareBy={ compareBy }
 			compareParam={ compareParam }
 			metrics={ metrics }


### PR DESCRIPTION
_Requires https://github.com/woocommerce/google-listings-and-ads/pull/669_

### Changes proposed in this Pull Request:

Use product name or title in products report, 
as provided by the API.

Use `name` if given by the Google API  for Ads, or `title` that contains title fetched from local DB by our API for Free listings.

Fixes #585


### Screenshots:

![Screencast showing product titles shown in compare table for the free and paid campaign, that matches the name and title given in the API response](https://user-images.githubusercontent.com/17435/119876604-5aecd680-bf28-11eb-960a-718be650590a.gif)



### Detailed test instructions:

0. Make sure you have some test data, like in https://github.com/woocommerce/google-listings-and-ads/pull/659
1. Go to Products Report [`/wp-admin/admin.php?page=wc-admin&path=/google/reports/products`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=/google/reports/products)
2. Check the product titles matches the names served by our API
3. Switch to "Show data from [Free listings]"
4. Check the product titles matches the ones served by our API


### Changelog Note:

> Fix - Render product titles on the products report page as given by the API.

### Additional notes:

We render `name | title` as given by the API, so if we fail to find a matching product in local DB, we will show its id (`"gla_123"`), as not "Product #123" as before. See https://github.com/woocommerce/google-listings-and-ads/pull/669#pullrequestreview-670442520
