### PR TITLE
Show selected program label in the filter on program report page load

### DIFF
--- a/js/src/reports/programs/filter-config.js
+++ b/js/src/reports/programs/filter-config.js
@@ -21,7 +21,7 @@ export const createProgramsFilterConfig = () => {
 	let resolveAdsCampaigns;
 	let promiseProgramsList;
 
-	function waitNextData() {
+	function waitForNextData() {
 		adsCampaigns = null;
 		promiseProgramsList = new Promise( ( resolve ) => {
 			resolveAdsCampaigns = resolve;
@@ -31,7 +31,7 @@ export const createProgramsFilterConfig = () => {
 	}
 
 	// Call for initializing
-	waitNextData();
+	waitForNextData();
 
 	const autocompleter = {
 		name: 'programs',
@@ -139,13 +139,13 @@ export const createProgramsFilterConfig = () => {
 		if ( loaded ) {
 			// Handle the case of no change in `loaded` status between continuous updates.
 			if ( adsCampaigns && adsCampaigns !== data ) {
-				waitNextData();
+				waitForNextData();
 			}
 
 			adsCampaigns = data;
 			resolveAdsCampaigns();
 		} else if ( adsCampaigns ) {
-			waitNextData();
+			waitForNextData();
 		}
 		return filterConfig;
 	};

--- a/js/src/reports/programs/filter-config.test.js
+++ b/js/src/reports/programs/filter-config.test.js
@@ -9,11 +9,14 @@ function getAutocompleterOptions( config ) {
 }
 
 describe( 'createProgramsFilterConfig', () => {
-	const programA = { id: 'A' };
-	const programB = { id: 'B' };
-	const dataA = { loaded: true, data: [ programA ] };
-	const dataB = { loaded: true, data: [ programB ] };
-	const dataLoading = { loaded: false, data: [] };
+	let programA, programB, dataA, dataB, dataLoading;
+	beforeEach( () => {
+		programA = { id: 'A' };
+		programB = { id: 'B' };
+		dataA = { loaded: true, data: [ programA ] };
+		dataB = { loaded: true, data: [ programB ] };
+		dataLoading = { loaded: false, data: [] };
+	} );
 
 	test( 'should wait for data loaded to resolve programs asynchronously', () => {
 		const getConfig = createProgramsFilterConfig();

--- a/js/src/reports/programs/filter-config.test.js
+++ b/js/src/reports/programs/filter-config.test.js
@@ -18,82 +18,172 @@ describe( 'createProgramsFilterConfig', () => {
 		dataLoading = { loaded: false, data: [] };
 	} );
 
-	test( 'should wait for data loaded to resolve programs asynchronously', async () => {
-		const getConfig = createProgramsFilterConfig();
+	describe( 'options', () => {
+		test( 'should wait for data loaded to resolve programs asynchronously', async () => {
+			const getConfig = createProgramsFilterConfig();
 
-		const config = getConfig( dataLoading );
-		const initialOptions = getAutocompleterOptions( config );
+			const config = getConfig( dataLoading );
+			const initialOptions = getAutocompleterOptions( config );
 
-		// Not easily testable with Jest:
-		// expect( initialOptions ).to.be.not.fulfilled;
+			// Not easily testable with Jest:
+			// expect( initialOptions ).to.be.not.fulfilled;
 
-		// Use the initial options promise, and assert it will eventually be resolved with programs that wil come.
-		const initialOptionsAssertion = initialOptions().then( ( programs ) => {
-			// The promise from the initial config should resolve with first loaded data.
-			expect( programs ).toContain( programA );
+			// Use the initial options promise, and assert it will eventually be resolved with programs that wil come.
+			const initialOptionsAssertion = initialOptions().then(
+				( programs ) => {
+					// The promise from the initial config should resolve with first loaded data.
+					expect( programs ).toContain( programA );
+				}
+			);
+
+			// Feed the config with data.
+			const configWithA = getConfig( dataA );
+
+			// Assert options will resolve with programs.
+			const optionsWithA = getAutocompleterOptions( configWithA );
+			expect( await optionsWithA() ).toContain( programA );
+
+			// Make sure the initial promise is also resolved and asserted.
+			// Eslint complains about await for some reason.
+			return initialOptionsAssertion;
 		} );
 
-		// Feed the config with data.
-		const configWithA = getConfig( dataA );
+		test( 'should keep updating and resolving programs if no change in `loaded` status between continuous updates', async () => {
+			const getConfig = createProgramsFilterConfig();
 
-		// Assert options will resolve with programs.
-		const optionsWithA = getAutocompleterOptions( configWithA );
-		expect( await optionsWithA() ).toContain( programA );
+			getConfig( dataA );
+			// Update with the same data.
+			const configA = getConfig( dataA );
+			const options = getAutocompleterOptions( configA );
+			expect( await options() ).toContain( programA );
 
-		// Make sure the initial promise is also resolved and asserted.
-		// Eslint complains about await for some reason.
-		return initialOptionsAssertion;
+			// Update with a new data.
+			const configB = getConfig( dataB );
+			const optionsAfterB = getAutocompleterOptions( configB );
+
+			// Assert the options will eventually resolve with new programs.
+			const programsAfterB = await optionsAfterB();
+			expect( programsAfterB ).not.toContain( programA );
+			expect( programsAfterB ).toContain( programB );
+		} );
+
+		test( 'should resolve next programs if the `loaded` status is changed', async () => {
+			const getConfig = createProgramsFilterConfig();
+
+			const config = getConfig( dataA );
+			const options = getAutocompleterOptions( config );
+			expect( await options() ).toContain( programA );
+
+			// Start loading new data.
+			const configReloading = getConfig( dataLoading );
+			const optionsReloading = getAutocompleterOptions( configReloading );
+			// Not easily testable with Jest:
+			// expect( initialOptions ).to.be.not.fulfilled;
+
+			// We want assert it will eventually resolve with new data, without waiting for it here.
+			const loadingOptionsAssertion = optionsReloading().then(
+				( programs ) => {
+					// The promise from the reloading config, should resolve with the loaded data.
+					expect( programs ).toContain( programB );
+				}
+			);
+
+			// Update with a new data.
+			const configWithB = getConfig( dataB );
+			const optionsAfterB = getAutocompleterOptions( configWithB );
+			const programsAfterB = await optionsAfterB();
+			expect( programsAfterB ).not.toContain( programA );
+			expect( programsAfterB ).toContain( programB );
+
+			// Make sure the initial promise is also resolved and asserted.
+			// Eslint complains about await for some reason.
+			return loadingOptionsAssertion;
+		} );
 	} );
 
-	test( 'should keep updating and resolving programs if no change in `loaded` status between continuous updates', async () => {
-		const getConfig = createProgramsFilterConfig();
+	describe( 'getLabels', () => {
+		function getGetLabels( config ) {
+			const filter = config.filters.find(
+				( el ) => el?.settings?.getLabels
+			);
+			return filter.settings.getLabels;
+		}
+		let labelA, labelB;
+		beforeEach( () => {
+			labelA = { key: programA.id, label: programA.name };
+			labelB = { key: programB.id, label: programB.name };
+		} );
+		test( 'after initial run should provide getLabels that would eventually resolve with data', () => {
+			const getConfig = createProgramsFilterConfig();
 
-		getConfig( dataA );
-		// Update with the same data.
-		const configA = getConfig( dataA );
-		const options = getAutocompleterOptions( configA );
-		expect( await options() ).toContain( programA );
+			const config = getConfig( dataLoading );
+			const initialGetLabels = getGetLabels( config );
 
-		// Update with a new data.
-		const configB = getConfig( dataB );
-		const optionsAfterB = getAutocompleterOptions( configB );
+			// Not easily testable with Jest:
+			// expect( initialOptions ).to.be.not.fulfilled;
 
-		// Assert the options will eventually resolve with new programs.
-		const programsAfterB = await optionsAfterB();
-		expect( programsAfterB ).not.toContain( programA );
-		expect( programsAfterB ).toContain( programB );
-	} );
+			// Use the initial options promise, and assert it will eventually be resolved with programs that wil come.
+			const initialOptionsAssertion = initialGetLabels(
+				'' + programA.id
+			).then( ( labels ) => {
+				expect( labels ).toContainEqual( labelA );
+			} );
 
-	test( 'should resolve next programs if the `loaded` status is changed', async () => {
-		const getConfig = createProgramsFilterConfig();
+			// Feed the config with data.
+			getConfig( dataA );
 
-		const config = getConfig( dataA );
-		const options = getAutocompleterOptions( config );
-		expect( await options() ).toContain( programA );
+			// Make sure the initial promise is resolved and asserted.
+			// Eslint complains about await for some reason.
+			return initialOptionsAssertion;
+		} );
 
-		// Start loading new data.
-		const configReloading = getConfig( dataLoading );
-		const optionsReloading = getAutocompleterOptions( configReloading );
-		// Not easily testable with Jest:
-		// expect( initialOptions ).to.be.not.fulfilled;
+		test( 'after data is loaded getLabels should resolve with it', async () => {
+			const getConfig = createProgramsFilterConfig();
+			// Initial loading.
+			getConfig( dataLoading );
+			// Feed the config with data.
+			const getLabels = getGetLabels( getConfig( dataA ) );
 
-		// We want assert it will eventually resolve with new data, without waiting for it here.
-		const loadingOptionsAssertion = optionsReloading().then(
-			( programs ) => {
-				// The promise from the reloading config, should resolve with the loaded data.
-				expect( programs ).toContain( programB );
-			}
-		);
+			expect( await getLabels( '' + programA.id ) ).toContainEqual(
+				labelA
+			);
+		} );
 
-		// Update with a new data.
-		const configWithB = getConfig( dataB );
-		const optionsAfterB = getAutocompleterOptions( configWithB );
-		const programsAfterB = await optionsAfterB();
-		expect( programsAfterB ).not.toContain( programA );
-		expect( programsAfterB ).toContain( programB );
+		test( 'after data is updated getLabels should resolve with the new data', async () => {
+			const getConfig = createProgramsFilterConfig();
+			// Initial loading.
+			getConfig( dataLoading );
+			// First data.
+			getConfig( dataA );
+			// Update the config with the new data.
+			const getLabels = getGetLabels( getConfig( dataB ) );
 
-		// Make sure the initial promise is also resolved and asserted.
-		// Eslint complains about await for some reason.
-		return loadingOptionsAssertion;
+			const updatedLabels = await getLabels( '' + programB.id );
+
+			expect( updatedLabels ).not.toContainEqual( labelA );
+			expect( updatedLabels ).toContainEqual( labelB );
+		} );
+
+		test( 'when the new data is being loaded getLabels should return a promise that eventually resolves with the new data.', async () => {
+			const getConfig = createProgramsFilterConfig();
+			// Initial loading.
+			getConfig( dataLoading );
+			// First data.
+			getConfig( dataA );
+			// Re-loading.
+			const getLabels = getGetLabels( getConfig( dataLoading ) );
+			// Assert this promise.
+			const reloadingLabels = getLabels( '' + programB.id ).then(
+				( updatedLabels ) => {
+					expect( updatedLabels ).not.toContainEqual( labelA );
+					expect( updatedLabels ).toContainEqual( labelB );
+				}
+			);
+			// Update.
+			getConfig( dataB );
+
+			// Wait for resolution.
+			return reloadingLabels;
+		} );
 	} );
 } );

--- a/js/src/reports/programs/filter-config.test.js
+++ b/js/src/reports/programs/filter-config.test.js
@@ -1,0 +1,88 @@
+/**
+ * Internal dependencies
+ */
+import { createProgramsFilterConfig } from './filter-config';
+
+function getAutocompleterOptions( config ) {
+	const filter = config.filters.find( ( el ) => el?.settings?.autocompleter );
+	return filter.settings.autocompleter.options;
+}
+
+describe( 'createProgramsFilterConfig', () => {
+	const programA = { id: 'A' };
+	const programB = { id: 'B' };
+	const dataA = { loaded: true, data: [ programA ] };
+	const dataB = { loaded: true, data: [ programB ] };
+	const dataLoading = { loaded: false, data: [] };
+
+	test( 'should wait for data loaded to resolve programs asynchronously', () => {
+		const getConfig = createProgramsFilterConfig();
+
+		return Promise.resolve()
+			.then( () => {
+				const config = getConfig( dataLoading );
+				const options = getAutocompleterOptions( config );
+
+				// Simulate data status from being loading to loaded,
+				// so it should not return the pending `options()` to block this test case.
+				options().then( ( programs ) => {
+					// The promise from the initial config should be resolved as well.
+					expect( programs.includes( programA ) ).toBe( true );
+				} );
+			} )
+			.then( () => {
+				const config = getConfig( dataA );
+				const options = getAutocompleterOptions( config );
+				return options().then( ( programs ) => {
+					expect( programs.includes( programA ) ).toBe( true );
+				} );
+			} );
+	} );
+
+	test( 'should keep updating and resolving programs if no change in `loaded` status between continuous updates', () => {
+		const getConfig = createProgramsFilterConfig();
+
+		getConfig( dataA );
+
+		return Promise.resolve()
+			.then( () => {
+				const config = getConfig( dataA );
+				const options = getAutocompleterOptions( config );
+				return options().then( ( programs ) => {
+					expect( programs.includes( programA ) ).toBe( true );
+				} );
+			} )
+			.then( () => {
+				const config = getConfig( dataB );
+				const options = getAutocompleterOptions( config );
+				return options().then( ( programs ) => {
+					expect( programs.includes( programA ) ).toBe( false );
+					expect( programs.includes( programB ) ).toBe( true );
+				} );
+			} );
+	} );
+
+	test( 'should resolve next programs if the `loaded` status is changed', () => {
+		const getConfig = createProgramsFilterConfig();
+
+		return Promise.resolve()
+			.then( () => {
+				const config = getConfig( dataA );
+				const options = getAutocompleterOptions( config );
+				return options().then( ( programs ) => {
+					expect( programs.includes( programA ) ).toBe( true );
+				} );
+			} )
+			.then( () => {
+				getConfig( dataLoading );
+			} )
+			.then( () => {
+				const config = getConfig( dataB );
+				const options = getAutocompleterOptions( config );
+				return options().then( ( programs ) => {
+					expect( programs.includes( programA ) ).toBe( false );
+					expect( programs.includes( programB ) ).toBe( true );
+				} );
+			} );
+	} );
+} );

--- a/js/src/reports/programs/filter-config.test.js
+++ b/js/src/reports/programs/filter-config.test.js
@@ -11,8 +11,8 @@ function getAutocompleterOptions( config ) {
 describe( 'createProgramsFilterConfig', () => {
 	let programA, programB, dataA, dataB, dataLoading;
 	beforeEach( () => {
-		programA = { id: 'A' };
-		programB = { id: 'B' };
+		programA = { id: 65 };
+		programB = { id: 66 };
 		dataA = { loaded: true, data: [ programA ] };
 		dataB = { loaded: true, data: [ programB ] };
 		dataLoading = { loaded: false, data: [] };

--- a/js/src/reports/programs/programs-report-filters.js
+++ b/js/src/reports/programs/programs-report-filters.js
@@ -19,13 +19,14 @@ import {
 	recordDatepickerUpdateEvent,
 	recordFilterEvent,
 } from '.~/utils/recordEvent';
-import { programsFilter } from './filter-config';
+import { createProgramsFilterConfig } from './filter-config';
 import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import ReportFilters from '.~/external-components/woocommerce/filters';
 
 // TODO: Consider importing it from something like '@woocommerce/wc-admin-settings'.
 const siteLocale = wcSettings.locale.siteLocale;
+const getProgramsFilter = createProgramsFilterConfig();
 
 /**
  * Set of filters to be used in Programs Report page.
@@ -39,7 +40,7 @@ const siteLocale = wcSettings.locale.siteLocale;
  */
 const ProgramsReportFilters = ( props ) => {
 	const { query, trackEventId } = props;
-	const { data: adsCampaigns } = useAdsCampaigns();
+	const filtersConfig = [ getProgramsFilter( useAdsCampaigns() ) ];
 
 	const { period, compare, before, after } = getDateParamsFromQuery( query );
 	const { primary: primaryDate, secondary: secondaryDate } = getCurrentDates(
@@ -81,8 +82,6 @@ const ProgramsReportFilters = ( props ) => {
 		} );
 
 	const updatedQuery = { ...query };
-
-	const filtersConfig = [ programsFilter( adsCampaigns ) ];
 
 	return (
 		<ReportFilters


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #651 

- Show selected program label in the filter on Programs Report page load

### Screenshots:

![Kapture 2021-05-28 at 12 58 32](https://user-images.githubusercontent.com/17420811/119931807-a9e04d80-bfb4-11eb-871f-c2c717e64f97.gif)

### Detailed test instructions:

1. Go to Programs Report page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms`
2. Select a paid program by the dropdown filter
3. Reload the page
4. The selected program label should show up in the filter on page load

### Changelog Note:

> Show selected program label in the filter on Programs Report page load
