### PR TITLE
Make the free shipping threshold be able to set up with $0

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -34,7 +34,7 @@ const checkErrors = (
 	if (
 		values.shipping_rate === 'flat' &&
 		values.offers_free_shipping &&
-		! values.free_shipping_threshold
+		values.free_shipping_threshold < 0
 	) {
 		errors.free_shipping_threshold = __(
 			'Please specify minimum order price for free shipping',

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -37,7 +37,7 @@ const checkErrors = (
 		values.free_shipping_threshold < 0
 	) {
 		errors.free_shipping_threshold = __(
-			'Please specify minimum order price for free shipping',
+			'Please specify a valid minimum order price for free shipping',
 			'google-listings-and-ads'
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR based on #670 to have relevant changes of `AppInputPriceControl`

Closes #673 

- Change the validation condition of the free shipping threshold to include $0 order amount

### Screenshots:

#### MC setup flow

![image](https://user-images.githubusercontent.com/17420811/119943387-8ffb3680-bfc5-11eb-8dda-0a2ca4b99cc3.png)

#### Edit free listings

![image](https://user-images.githubusercontent.com/17420811/119943414-9c7f8f00-bfc5-11eb-92e2-28dc25a8c293.png)

### Detailed test instructions:

#### MC setup flow

1. Go to the final step of MC setup flow
2. Tick "I also offer free shipping for all countries for products over a certain price." option
3. Set "I offer free shipping for products priced over" to `0` or other positive numbers
4. Complete other settings
5. The "Complete setup" button at the bottom should be able to proceed to finish the setup

#### Edit free listings

1. Go to edit free listings from the dashboard page
2. Tick "I also offer free shipping for all countries for products over a certain price." option
3. Set "I offer free shipping for products priced over" to `0` or other positive numbers
4. The "Save changes" button at the bottom should be able to proceed to save

### Changelog Note:

> Make the free shipping threshold be able to set up with $0
