### PR TITLE
Prevent render breaking when getting errors from report API in the programs report page

### DIFF
--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -66,15 +66,16 @@ const ProgramsReport = () => {
 		reportQuery: { fields, orderby, order },
 	} = useProgramsReport();
 
+	const hasFieldInResults = loaded && Object.keys( totals ).length > 0;
 	// Until ~Q4 2021, free listings, may not have all metrics.
 	// Anticipate all requested fields to come, show available once loaded.
-	const availableMetrics = loaded
+	const availableMetrics = hasFieldInResults
 		? performanceMetrics.filter( ( { key } ) =>
 				totals.hasOwnProperty( key )
 		  )
 		: performanceMetrics.filter( ( { key } ) => fields.includes( key ) );
 
-	const expectedTableMetrics = loaded
+	const expectedTableMetrics = hasFieldInResults
 		? tableMetrics.filter( ( { key } ) => totals.hasOwnProperty( key ) )
 		: tableMetrics.filter( ( { key } ) => fields.includes( key ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #661 

- Prevent render breaking when getting errors from report API in the programs report page

### Screenshots:

![Kapture 2021-05-28 at 15 51 37](https://user-images.githubusercontent.com/17420811/119949755-c5575280-bfcc-11eb-9d8f-aa4a0b5ac044.gif)

### Detailed test instructions:

To simulate the report API error response, I change the API path in **resolvers** to make it respond `404` error

https://github.com/woocommerce/google-listings-and-ads/blob/7031349f5dc93db3a646603d05f439918ca49be4/js/src/data/resolvers.js#L176

1.  Head to the programs report page: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms`
2. After the loading finished and returning with error responses, the page should be able to render instead of an empty page

### Changelog Note:

> Prevent render breaking when getting errors from report API in the programs report page
