### PR TITLE
Change to use batch upsert actions for saving shipping data on the Edit Free Listings page

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -648,29 +648,6 @@ export function receiveReport( reportKey, data ) {
 	};
 }
 
-// TODO: deprecated actions to be removed after relevant actions migrating to corresponding batch actions.
-export function* upsertShippingRate( shippingRate ) {
-	const { countryCode, currency, rate } = shippingRate;
-	yield upsertShippingRates( {
-		countryCodes: [ countryCode ],
-		currency,
-		rate,
-	} );
-}
-
-export function* deleteShippingRate( countryCode ) {
-	yield deleteShippingRates( [ countryCode ] );
-}
-
-export function* upsertShippingTime( shippingTime ) {
-	const { countryCode, time } = shippingTime;
-	yield upsertShippingTimes( { countryCodes: [ countryCode ], time } );
-}
-
-export function* deleteShippingTime( countryCode ) {
-	yield deleteShippingTimes( [ countryCode ] );
-}
-
 export function* fetchMCSetup() {
 	try {
 		const response = yield apiFetch( {

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -52,28 +52,26 @@ function isNotOurStep( location ) {
  * we need to send deletes and adds separately.
  * Also, we need to send upserts separately for each price.
  *
- * @param {(individualCountrySetting: ShippingRate) => Promise} upsertAction
- * @param {(countries: Array<CountryCode>) => Promise} deleteAction
- * @param {Array<ShippingRate>} oldData
+ * @param {(groupedCountrySetting: ShippingRate) => Promise} batchUpsertAction
  * @param {Array<ShippingRate>} newData
+ * @param {Function} getGroupKey A callback function to ask for a unique key for each shipping group.
  */
-function saveShippingData( upsertAction, deleteAction, oldData, newData ) {
-	const mapCountryCode = ( rate ) => rate.countryCode;
-	const currentCountries = new Set( newData.map( mapCountryCode ) );
+function saveShippingData( batchUpsertAction, newData, getGroupKey ) {
+	const groupMap = new Map();
+	newData.forEach( ( item ) => {
+		const key = getGroupKey( item );
+		const { countryCode, ...rest } = item;
+		let group = groupMap.get( key );
 
-	// Send upserts.
-	const actions = newData.map( upsertAction );
+		if ( ! group ) {
+			group = { ...rest, countryCodes: [] };
+			groupMap.set( key, group );
+		}
 
-	const deletedCountries = oldData
-		.map( mapCountryCode )
-		.filter( ( country ) => ! currentCountries.has( country ) );
+		group.countryCodes.push( countryCode );
+	} );
 
-	if ( deletedCountries.length ) {
-		// Send delete.
-		actions.concat( deleteAction( deletedCountries ) );
-	}
-	// TODO: implement better batched upsert that accpets an array of ShippingRates (with different prices)
-	return actions;
+	return Array.from( groupMap.values() ).map( batchUpsertAction );
 }
 
 /**
@@ -94,10 +92,8 @@ export default function EditFreeCampaign() {
 	const {
 		saveTargetAudience,
 		saveSettings,
-		upsertShippingRate, // We need to use this one, as we serve non-aggregated ShippingRates
-		deleteShippingRates,
-		upsertShippingTime, // We need to use this one, as we serve non-aggregated ShippingTimes
-		deleteShippingTimes,
+		upsertShippingRates,
+		upsertShippingTimes,
 	} = useAppDispatch();
 
 	const [ targetAudience, updateTargetAudience ] = useState(
@@ -186,16 +182,14 @@ export default function EditFreeCampaign() {
 				saveTargetAudience( targetAudience ),
 				saveSettings( settings ),
 				...saveShippingData(
-					upsertShippingRate,
-					deleteShippingRates,
-					savedShippingRates,
-					shippingRates
+					upsertShippingRates,
+					shippingRates,
+					( item ) => `${ item.currency }:${ item.rate }`
 				),
 				...saveShippingData(
-					upsertShippingTime,
-					deleteShippingTimes,
-					savedShippingTimes,
-					shippingTimes
+					upsertShippingTimes,
+					shippingTimes,
+					( item ) => item.time
 				),
 			] );
 			// Sync data once our changes are saved, even partially succesfully.

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -48,9 +48,9 @@ function isNotOurStep( location ) {
  */
 
 /**
- * Due to lack of single API for updating shipping data alltogether,
- * we need to send deletes and adds separately.
- * Also, we need to send upserts separately for each price.
+ * Due to the lack of a single API for updating shipping data altogether,
+ * we need to send upserts separately for each price/time.
+ * Deletes are not needed, as we validate the form not to miss any available country.
  *
  * @param {(groupedCountrySetting: ShippingRate) => Promise} batchUpsertAction
  * @param {Array<ShippingRate>} newData


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #690 

Change to use batch upsert actions for saving shipping data on the Edit Free Listings page

- Group shipping data and update them with batch upsert when saving data in the edit free listings page
- Remove shipping data deletion due to the deletions would not happen after added the validation by #645 
- Remove unneeded shipping related upsert/delete actions

### Screenshots:

![Kapture 2021-05-28 at 19 12 49](https://user-images.githubusercontent.com/17420811/119975692-bf6f6a80-bfe8-11eb-8e7b-1a7986e61fb1.gif)

### Detailed test instructions:

1. Go to the edit free listings page from dashboard
2. Select all countries as the audience at the first step
3. Fill shipping data at the second step and click the "Save changes" button
4. The total number of API calls for upserting shipping rates and times should align to the group numbers on edit UI
5. Should not have any API error

### Changelog Note:

> Change to use batch upsert actions for saving shipping data on the Edit Free Listings page
