### PR TITLE
Add validations to fix that the free listings setup/edit forms could be submitted with a negative shipping rate/time

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -23,10 +23,11 @@ const checkErrors = (
 
 	if (
 		values.shipping_rate === 'flat' &&
-		shippingRates.length < finalCountryCodes.length
+		( shippingRates.length < finalCountryCodes.length ||
+			shippingRates.some( ( el ) => el.rate < 0 ) )
 	) {
 		errors.shipping_rate = __(
-			'Please specify shipping rates for all the countries.',
+			'Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0.',
 			'google-listings-and-ads'
 		);
 	}
@@ -54,10 +55,11 @@ const checkErrors = (
 
 	if (
 		values.shipping_time === 'flat' &&
-		shippingTimes.length < finalCountryCodes.length
+		( shippingTimes.length < finalCountryCodes.length ||
+			shippingTimes.some( ( el ) => el.time < 0 ) )
 	) {
 		errors.shipping_time = __(
-			'Please specify shipping times for all the countries.',
+			'Please specify shipping times for all the countries. And the estimated shipping time cannot be less than 0.',
 			'google-listings-and-ads'
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This issue was noticed when reviewing #670, but the issue is not in its scope.

- Add range validations for shipping rates/times in the checkErrors.js

### Bug
The negative shipping rate or time should not be a valid value.

![image](https://user-images.githubusercontent.com/17420811/120144930-59b3f600-c215-11eb-93f1-907740c5a8b0.png)



### Screenshots:

![Kapture 2021-05-31 at 15 03 03](https://user-images.githubusercontent.com/17420811/120155038-0cd71c00-c223-11eb-9fc9-9ef6fcd0fe0b.gif)

### Detailed test instructions:

1. Go to the MC setup or the Free Listings Edit page
2. When entering a negative number on any shipping time or rate on the form inputs, after moving out the cursor focus from input (onBlur event), the "Complete setup" or "Save changes" button should be disabled

### Changelog Note:

> Fix that the free listings setup/edit forms could be submitted with a negative shipping rate/time
