### PR TITLE
Add event tracking when clicking on the chart tabs in the report pages

### DIFF
--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -27,6 +27,7 @@ const numberFormatSetting = { precision: 0 };
  * @param {string} props.label Metric label.
  * @param {string} [props.href] An internal link to the report focused on this metric.
  * @param {boolean} [props.selected] Whether show a highlight style on this metric.
+ * @param {Function} [props.onLinkClickCallback] A function to be called after a SummaryNumber, rendered as a link, is clicked.
  * @param {boolean} [props.isCurrency=false] Display `data.value` and `data.prevValue` as price format if true.
  *                                           Otherwise, display as number format.
  * @param {import('.~/data/utils').PerformanceMetrics} props.data Data as get from API.
@@ -37,6 +38,7 @@ const MetricNumber = ( {
 	label,
 	href,
 	selected,
+	onLinkClickCallback,
 	isCurrency = false,
 	data: { value, prevValue, delta, missingFreeListingsData },
 } ) => {
@@ -79,6 +81,7 @@ const MetricNumber = ( {
 			href={ href }
 			selected={ selected }
 			delta={ delta }
+			onLinkClickCallback={ onLinkClickCallback }
 			{ ...valueProps }
 		/>
 	);

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -89,6 +89,7 @@ const ProductsReport = ( { hasPaidSource } ) => {
 				metrics={ metrics }
 				loaded={ loaded }
 				totals={ totals }
+				trackEventId={ trackEventId }
 			/>
 			<ChartSection
 				metrics={ metrics }

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -99,6 +99,7 @@ const ProgramsReport = () => {
 				metrics={ availableMetrics }
 				expectedLength={ performanceMetrics.length }
 				totals={ availablePerformance }
+				trackEventId={ trackEventId }
 			/>
 			<ChartSection
 				metrics={ availableMetrics }

--- a/js/src/reports/summary-section.js
+++ b/js/src/reports/summary-section.js
@@ -7,6 +7,7 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import { recordChartTabClickEvent } from '.~/utils/recordEvent';
 import useUrlQuery from '.~/hooks/useUrlQuery';
 import MetricNumber from './metric-number';
 
@@ -24,12 +25,14 @@ const noValidData = {
  * @param {Array<Metric>} props.metrics Metrics to display.
  * @param {number} [props.expectedLength=metrics.length] Expected metrics to display, for example when the metrics array is not yet resolved.
  * @param {PerformanceData} props.totals Report's performance data.
+ * @param {string} props.trackEventId Report ID used in tracking events.
  */
 export default function SummarySection( {
 	loaded,
 	metrics,
 	expectedLength = metrics.length,
 	totals,
+	trackEventId,
 } ) {
 	const query = useUrlQuery();
 	if ( ! loaded ) {
@@ -37,6 +40,13 @@ export default function SummarySection( {
 	}
 
 	const { selectedMetric = metrics[ 0 ].key } = query;
+
+	const trackClickEvent = ( context ) => {
+		recordChartTabClickEvent( {
+			report: trackEventId,
+			context,
+		} );
+	};
 
 	return (
 		<SummaryList>
@@ -52,6 +62,7 @@ export default function SummarySection( {
 							selected={ selected }
 							isCurrency={ isCurrency }
 							data={ totals[ key ] || noValidData }
+							onLinkClickCallback={ () => trackClickEvent( key ) }
 						/>
 					);
 				} )

--- a/js/src/utils/recordEvent.js
+++ b/js/src/utils/recordEvent.js
@@ -41,6 +41,17 @@ export const recordFilterEvent = ( data ) => {
 	recordEvent( 'gla_filter', data );
 };
 
+/**
+ * Records `gla_chart_tab_click` tracking event.
+ *
+ * @param {Object} data
+ * @param {string} data.report Name of the report.
+ * @param {string} data.context Metric key of the clicked tab.
+ */
+export const recordChartTabClickEvent = ( data ) => {
+	recordEvent( 'gla_chart_tab_click', data );
+};
+
 export const recordSetupMCEvent = ( target, trigger = 'click' ) => {
 	recordEvent( 'gla_setup_mc', {
 		target,

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -28,6 +28,10 @@ All event names are prefixed by `wcadmin_gla_`.
   * `link_id`: a unique ID for the button within the context, e.g. `set-up-billing`.
   * `href`: indicate the destination where the users is directed to.
 
+* `chart_tab_click` - Triggered when a chart tab is clicked
+  * `report`: name of the report (e.g. `"reports-programs" | "reports-products"`)
+  * `context`: metric key of the clicked tab (e.g. `"sales" | "conversions" | "clicks" | "impressions" | "spend"`).
+
 * `datepicker_update` - Triggered when datepicker (date ranger picker) is updated
   * `report`: name of the report (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)
   * `compare, period, before, after`: Values selected in [datepicker](https://woocommerce.github.io/woocommerce-admin/#/components/packages/date-range-filter-picker/README?id=props)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #697 

- Add `gla_chart_tab_click` event tracking when clicking on the chart tabs in the report pages

### Screenshots:

![Kapture 2021-05-31 at 17 01 58](https://user-images.githubusercontent.com/17420811/120169040-1c119600-c232-11eb-88d9-3a57e5095d6e.gif)

### Detailed test instructions:

1. Open the DevTool console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to enable tracking debugging mode
2. Go to the report pages and click on any chart tabs
3. `gla_chart_tab_click` event should be logged on the DevTool console with respective `report` and `context`

### Changelog Note:

> Add event tracking when clicking on the chart tabs in the report pages
