### PR TITLE
Add table's pagination tracking events to the product feed page

### DIFF
--- a/js/src/components/edit-product-link/index.js
+++ b/js/src/components/edit-product-link/index.js
@@ -3,13 +3,28 @@
  */
 import { Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
+import { queueRecordEvent } from '@woocommerce/tracks';
 
-const EditProductLink = ( props ) => {
-	const { productId } = props;
+const noop = () => {};
+
+/**
+ * Renders a link that points to the product edit page.
+ * Click event tracking would be attached if giving the `eventName` prop.
+ *
+ * @param {Object} props React props.
+ * @param {number} props.productId Product ID.
+ * @param {string} [props.eventName] The event name to record.
+ * @param {Object} [props.eventProps] Event properties to include in the event.
+ */
+const EditProductLink = ( { productId, eventName, eventProps } ) => {
 	const editProductLink = `post.php?action=edit&post=${ productId }`;
 
+	const handleClick = eventName
+		? () => queueRecordEvent( eventName, eventProps )
+		: noop;
+
 	return (
-		<Link href={ editProductLink } type="wp-admin">
+		<Link href={ editProductLink } onClick={ handleClick } type="wp-admin">
 			{ __( 'Edit', 'google-listings-and-ads' ) }
 		</Link>
 	);

--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -155,6 +155,11 @@ const IssuesTableCard = () => {
 										display: el.type === 'product' && (
 											<EditProductLink
 												productId={ el.product_id }
+												eventName="gla_edit_product_issue_click"
+												eventProps={ {
+													code: el.code,
+													issue: el.issue,
+												} }
 											/>
 										),
 									},

--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -21,6 +21,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { recordTablePageEvent } from '.~/utils/recordEvent';
 import AppTableCardDiv from '.~/components/app-table-card-div';
 import EditProductLink from '.~/components/edit-product-link';
 import HelpPopover from '.~/components/help-popover';
@@ -90,8 +91,9 @@ const IssuesTableCard = () => {
 		}
 	);
 
-	const handlePageChange = ( newPage ) => {
+	const handlePageChange = ( newPage, direction ) => {
 		setPage( newPage );
+		recordTablePageEvent( 'issues-to-resolve', newPage, direction );
 	};
 
 	return (

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -34,6 +34,8 @@ import statusLabelMap from './statusLabelMap';
 
 const PER_PAGE = 10;
 const EVENT_CONTEXT = 'product-feed';
+const toVisibilityEventProp = ( visible ) =>
+	visible ? 'sync_and_show' : 'dont_sync_and_show';
 
 /**
  * Product Feed table.
@@ -146,7 +148,7 @@ const ProductFeedTableCard = () => {
 			recordEvent( 'gla_bulk_edit_clicked', {
 				context: EVENT_CONTEXT,
 				number_of_items: length,
-				visibility_to: visible ? 'sync_and_show' : 'dont_sync_and_show',
+				visibility_to: toVisibilityEventProp( visible ),
 			} );
 		} );
 
@@ -228,6 +230,13 @@ const ProductFeedTableCard = () => {
 										display: (
 											<EditProductLink
 												productId={ el.id }
+												eventName="gla_edit_product_click"
+												eventProps={ {
+													status: el.status,
+													visibility: toVisibilityEventProp(
+														el.visible
+													),
+												} }
 											/>
 										),
 									},

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -146,7 +146,7 @@ const ProductFeedTableCard = () => {
 			createNotice( 'success', message );
 		} );
 
-		recordEvent( 'gla_bulk_edit_clicked', {
+		recordEvent( 'gla_bulk_edit_click', {
 			context: EVENT_CONTEXT,
 			number_of_items: length,
 			visibility_to: toVisibilityEventProp( visible ),

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -144,12 +144,12 @@ const ProductFeedTableCard = () => {
 				length
 			);
 			createNotice( 'success', message );
+		} );
 
-			recordEvent( 'gla_bulk_edit_clicked', {
-				context: EVENT_CONTEXT,
-				number_of_items: length,
-				visibility_to: toVisibilityEventProp( visible ),
-			} );
+		recordEvent( 'gla_bulk_edit_clicked', {
+			context: EVENT_CONTEXT,
+			number_of_items: length,
+			visibility_to: toVisibilityEventProp( visible ),
 		} );
 
 		handleSelectAllCheckboxChange( false );

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -22,7 +22,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { recordTablePageEvent } from '.~/utils/recordEvent';
+import recordEvent, { recordTablePageEvent } from '.~/utils/recordEvent';
 import AppTableCardDiv from '.~/components/app-table-card-div';
 import EditProductLink from '.~/components/edit-product-link';
 import './index.scss';
@@ -33,6 +33,7 @@ import EditVisibilityAction from './edit-visibility-action';
 import statusLabelMap from './statusLabelMap';
 
 const PER_PAGE = 10;
+const EVENT_CONTEXT = 'product-feed';
 
 /**
  * Product Feed table.
@@ -74,7 +75,7 @@ const ProductFeedTableCard = () => {
 			...query,
 			page: newPage,
 		} );
-		recordTablePageEvent( 'product-feed', newPage, direction );
+		recordTablePageEvent( EVENT_CONTEXT, newPage, direction );
 	};
 
 	const handleSort = ( orderby, order ) => {
@@ -141,6 +142,12 @@ const ProductFeedTableCard = () => {
 				length
 			);
 			createNotice( 'success', message );
+
+			recordEvent( 'gla_bulk_edit_clicked', {
+				context: EVENT_CONTEXT,
+				number_of_items: length,
+				visibility_to: visible ? 'sync_and_show' : 'dont_sync_and_show',
+			} );
 		} );
 
 		handleSelectAllCheckboxChange( false );

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -22,6 +22,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { recordTablePageEvent } from '.~/utils/recordEvent';
 import AppTableCardDiv from '.~/components/app-table-card-div';
 import EditProductLink from '.~/components/edit-product-link';
 import './index.scss';
@@ -68,11 +69,12 @@ const ProductFeedTableCard = () => {
 		}
 	};
 
-	const handlePageChange = ( newPage ) => {
+	const handlePageChange = ( newPage, direction ) => {
 		setQuery( {
 			...query,
 			page: newPage,
 		} );
+		recordTablePageEvent( 'product-feed', newPage, direction );
 	};
 
 	const handleSort = ( orderby, order ) => {

--- a/js/src/utils/recordEvent.js
+++ b/js/src/utils/recordEvent.js
@@ -18,6 +18,30 @@ export const recordTableHeaderToggleEvent = ( report, column, status ) => {
 export const recordTableSortEvent = ( report, column, direction ) => {
 	recordEvent( 'gla_table_sort', { report, column, direction } );
 };
+
+/**
+ * Records table's page tracking event.
+ * When the `direction` is 'goto', then the event name would be 'gla_table_go_to_page'.
+ * Otherwise, the event name would be 'gla_table_page_click'.
+ *
+ * @param {string} context Name of the table.
+ * @param {number} page Page number of the table. Start from 1.
+ * @param {string} direction Direction of page to be changed. 'next', 'previous', or 'goto'.
+ */
+export const recordTablePageEvent = ( context, page, direction ) => {
+	const properties = { context };
+	let eventName;
+
+	if ( direction === 'goto' ) {
+		eventName = 'gla_table_go_to_page';
+		properties.page = page;
+	} else {
+		eventName = 'gla_table_page_click';
+		properties.direction = direction;
+	}
+	recordEvent( eventName, properties );
+};
+
 /**
  * Records `gla_datepicker_update` tracking event, with data that comes from
  * `DateRangeFilterPicker`'s `onRangeSelect` callback.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -32,6 +32,11 @@ All event names are prefixed by `wcadmin_gla_`.
   * `link_id`: a unique ID for the button within the context, e.g. `set-up-billing`.
   * `href`: indicate the destination where the users is directed to.
 
+* `bulk_edit_clicked` - Triggered when the product feed "bulk edit" functionality is being used
+  * `context`: name of the table
+  * `number_of_items`: edit how many items
+  * `visibility_to`: `("sync_and_show" | "dont_sync_and_show")`
+
 * `chart_tab_click` - Triggered when a chart tab is clicked
   * `report`: name of the report (e.g. `"reports-programs" | "reports-products"`)
   * `context`: metric key of the clicked tab (e.g. `"sales" | "conversions" | "clicks" | "impressions" | "spend"`).

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -141,7 +141,7 @@ All event names are prefixed by `wcadmin_gla_`.
 
 * `table_go_to_page` - When table pagination is changed by entering page via "Go to page" input
   * `context`: name of the table
-  * `page`: Page number of the table. Start from 1.
+  * `page`: page number (starting at 1)
 
 * `table_header_toggle` - Toggling display of table columns
   * `report`: name of the report table (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -32,7 +32,7 @@ All event names are prefixed by `wcadmin_gla_`.
   * `link_id`: a unique ID for the button within the context, e.g. `set-up-billing`.
   * `href`: indicate the destination where the users is directed to.
 
-* `bulk_edit_clicked` - Triggered when the product feed "bulk edit" functionality is being used
+* `bulk_edit_click` - Triggered when the product feed "bulk edit" functionality is being used
   * `context`: name of the table
   * `number_of_items`: edit how many items
   * `visibility_to`: `("sync_and_show" | "dont_sync_and_show")`

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -126,10 +126,18 @@ All event names are prefixed by `wcadmin_gla_`.
 
 * `site_verify_success` - When a site is successfully verified with Google
 
+* `table_go_to_page` - When table pagination is changed by entering page via "Go to page" input
+  * `context`: name of the table
+  * `page`: Page number of the table. Start from 1.
+
 * `table_header_toggle` - Toggling display of table columns
   * `report`: name of the report table (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)
   * `column`: name of the column
   * `status`: (`on`|`off`)
+
+* `table_page_click` - When table pagination is clicked
+  * `context`: name of the table
+  * `direction`: direction of page to be changed. `("next" | "previous")`
 
 * `table_sort` - Sorting table
   * `report`: name of the report table (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -57,6 +57,14 @@ All event names are prefixed by `wcadmin_gla_`.
   * `context`: indicate which link is clicked
   * `href`: link's URL
 
+* `edit_product_click` - Trigger when edit links are clicked from product feed table
+  * `status`: `("approved" | "partially_approved" | "expiring" | "pending" | "disapproved" | "not_synced")`
+  * `visibility`: `("sync_and_show" | "dont_sync_and_show")`
+
+* `edit_product_issue_click` - Trigger when edit links are clicked from Issues to resolve table
+  * `code`: issue code returned from Google
+  * `issue`: issue description returned from Google
+
 * `filter` - Triggered when changing products & variations filter
   * `report`: name of the report (e.g. `"reports-products"`)
   * `filter`: value of the filter (e.g. `"all" | "single-product" | "compare-products"`)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #698 

- Add `table_go_to_page` and `table_page_click` tracking events to the **Product Feed** and **Issue to resolve** tables in the product feed page

### Screenshots:

![Kapture 2021-05-31 at 19 29 15](https://user-images.githubusercontent.com/17420811/120186970-c98ea480-c246-11eb-89bd-ce9a5516e28b.gif)

### Detailed test instructions:

1. Open the DevTool console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to enable tracking debugging mode
2. Go to the product feed page
3. Click on the pagination "<" and ">" buttons under the **Issues to resolve** or **Product Feed** tables
    - The `gla_table_page_click` event should be logged on the DevTool console with respective `context` and `direction`
4. Change page number by "Go to page" input under the **Product Feed** table
    - The `table_go_to_page` event should be logged on the DevTool console with respective `context` and `page`

### Changelog Note:

> Add table's pagination tracking events to the **Product Feed** and **Issue to resolve** tables in the product feed page
