### PR TITLE
Tracking settings

### DIFF
--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -75,16 +75,22 @@ class TrackerSnapshot implements Conditional, ContainerAwareInterface, OptionsAw
 	 */
 	protected function get_settings(): array {
 		/** @var MerchantCenterService $mc_service */
-		$mc_service = $this->container->get( MerchantCenterService::class );
+		$mc_service  = $this->container->get( MerchantCenterService::class );
+		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER );
 
 		return [
-			'version'          => $this->get_version(),
-			'db_version'       => $this->options->get( OptionsInterface::DB_VERSION ),
-			'tos_accepted'     => $this->get_boolean_value( OptionsInterface::WP_TOS_ACCEPTED ),
-			'google_connected' => $this->get_boolean_value( OptionsInterface::GOOGLE_CONNECTED ),
-			'mc_setup'         => $this->get_boolean_value( OptionsInterface::MC_SETUP_COMPLETED_AT ),
-			'ads_setup'        => $this->get_boolean_value( OptionsInterface::ADS_SETUP_COMPLETED_AT ),
-			'target_audience'  => $mc_service->get_target_countries(),
+			'version'                 => $this->get_version(),
+			'db_version'              => $this->options->get( OptionsInterface::DB_VERSION ),
+			'tos_accepted'            => $this->get_boolean_value( OptionsInterface::WP_TOS_ACCEPTED ),
+			'google_connected'        => $this->get_boolean_value( OptionsInterface::GOOGLE_CONNECTED ),
+			'mc_setup'                => $this->get_boolean_value( OptionsInterface::MC_SETUP_COMPLETED_AT ),
+			'ads_setup'               => $this->get_boolean_value( OptionsInterface::ADS_SETUP_COMPLETED_AT ),
+			'target_audience'         => $mc_service->get_target_countries(),
+			'shipping_rate'           => $mc_settings['shipping_rate'] ?? '',
+			'shipping_time'           => $mc_settings['shipping_time'] ?? '',
+			'offers_free_shipping'    => ! empty( $mc_settings['offers_free_shipping'] ) ? 'yes' : 'no',
+			'free_shipping_threshold' => $mc_settings['free_shipping_threshold'] ?? '',
+			'tax_rate'                => $mc_settings['tax_rate'] ?? '',
 		];
 	}
 

--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -79,14 +79,14 @@ class TrackerSnapshot implements Conditional, OptionsAwareInterface, Registerabl
 	}
 
 	/**
-	 * Get boolean value from options.
+	 * Get boolean value from options, return as yes or no.
 	 *
 	 * @param string $key Option key name.
 	 *
-	 * @return bool
+	 * @return string
 	 */
-	protected function get_boolean_value( string $key ): bool {
-		return (bool) $this->options->get( $key );
+	protected function get_boolean_value( string $key ): string {
+		return (bool) $this->options->get( $key ) ? 'yes' : 'no';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds additional data about the extension plugin to the tracking event `woocommerce_tracker_data`.
WooCommerce uses yes/no for boolean values, whereas AutomateWoo sends them as actual boolean values. This PR uses yes/no like is done in WooCommerce.

Closes #687

### Detailed test instructions:

1. Add a code snippet to temporarily log the tracker data:
```php
add_action(
	'admin_init',
	function() {
		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
		error_log( json_encode( $tracks, JSON_PRETTY_PRINT ) );
	}
);
```
2. Refresh a page to confirm that the data is logged 
3. Check the log file to confirm that the data is shown as expected
```json
{
    "extensions": {
        "gla": {
            "settings": {
                "version": "0.6.0",
                "db_version": "0.6.0",
                "tos_accepted": "yes",
                "google_connected": "yes",
                "mc_setup": "yes",
                "ads_setup": "yes",
                "target_audience": [
                    "IE"
                ],
                "shipping_rate": "flat",
                "shipping_time": "flat",
                "offers_free_shipping": "no",
                "free_shipping_threshold": "",
                "tax_rate": ""
            }
        }
    }
}
```


### Changelog Note:
* Add - Tracking settings.
