### PR TITLE
Add bulk edit event and product edit link click events to the Product Feed page

### DIFF
--- a/js/src/components/edit-product-link/index.js
+++ b/js/src/components/edit-product-link/index.js
@@ -3,13 +3,28 @@
  */
 import { Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
+import { queueRecordEvent } from '@woocommerce/tracks';
 
-const EditProductLink = ( props ) => {
-	const { productId } = props;
+const noop = () => {};
+
+/**
+ * Renders a link that points to the product edit page.
+ * Click event tracking would be attached if giving the `eventName` prop.
+ *
+ * @param {Object} props React props.
+ * @param {number} props.productId Product ID.
+ * @param {string} [props.eventName] The event name to record.
+ * @param {Object} [props.eventProps] Event properties to include in the event.
+ */
+const EditProductLink = ( { productId, eventName, eventProps } ) => {
 	const editProductLink = `post.php?action=edit&post=${ productId }`;
 
+	const handleClick = eventName
+		? () => queueRecordEvent( eventName, eventProps )
+		: noop;
+
 	return (
-		<Link href={ editProductLink } type="wp-admin">
+		<Link href={ editProductLink } onClick={ handleClick } type="wp-admin">
 			{ __( 'Edit', 'google-listings-and-ads' ) }
 		</Link>
 	);

--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -155,6 +155,11 @@ const IssuesTableCard = () => {
 										display: el.type === 'product' && (
 											<EditProductLink
 												productId={ el.product_id }
+												eventName="gla_edit_product_issue_click"
+												eventProps={ {
+													code: el.code,
+													issue: el.issue,
+												} }
 											/>
 										),
 									},

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -34,6 +34,8 @@ import statusLabelMap from './statusLabelMap';
 
 const PER_PAGE = 10;
 const EVENT_CONTEXT = 'product-feed';
+const toVisibilityEventProp = ( visible ) =>
+	visible ? 'sync_and_show' : 'dont_sync_and_show';
 
 /**
  * Product Feed table.
@@ -146,7 +148,7 @@ const ProductFeedTableCard = () => {
 			recordEvent( 'gla_bulk_edit_clicked', {
 				context: EVENT_CONTEXT,
 				number_of_items: length,
-				visibility_to: visible ? 'sync_and_show' : 'dont_sync_and_show',
+				visibility_to: toVisibilityEventProp( visible ),
 			} );
 		} );
 
@@ -228,6 +230,13 @@ const ProductFeedTableCard = () => {
 										display: (
 											<EditProductLink
 												productId={ el.id }
+												eventName="gla_edit_product_click"
+												eventProps={ {
+													status: el.status,
+													visibility: toVisibilityEventProp(
+														el.visible
+													),
+												} }
 											/>
 										),
 									},

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -146,7 +146,7 @@ const ProductFeedTableCard = () => {
 			createNotice( 'success', message );
 		} );
 
-		recordEvent( 'gla_bulk_edit_clicked', {
+		recordEvent( 'gla_bulk_edit_click', {
 			context: EVENT_CONTEXT,
 			number_of_items: length,
 			visibility_to: toVisibilityEventProp( visible ),

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -144,12 +144,12 @@ const ProductFeedTableCard = () => {
 				length
 			);
 			createNotice( 'success', message );
+		} );
 
-			recordEvent( 'gla_bulk_edit_clicked', {
-				context: EVENT_CONTEXT,
-				number_of_items: length,
-				visibility_to: toVisibilityEventProp( visible ),
-			} );
+		recordEvent( 'gla_bulk_edit_clicked', {
+			context: EVENT_CONTEXT,
+			number_of_items: length,
+			visibility_to: toVisibilityEventProp( visible ),
 		} );
 
 		handleSelectAllCheckboxChange( false );

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -22,7 +22,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { recordTablePageEvent } from '.~/utils/recordEvent';
+import recordEvent, { recordTablePageEvent } from '.~/utils/recordEvent';
 import AppTableCardDiv from '.~/components/app-table-card-div';
 import EditProductLink from '.~/components/edit-product-link';
 import './index.scss';
@@ -33,6 +33,7 @@ import EditVisibilityAction from './edit-visibility-action';
 import statusLabelMap from './statusLabelMap';
 
 const PER_PAGE = 10;
+const EVENT_CONTEXT = 'product-feed';
 
 /**
  * Product Feed table.
@@ -74,7 +75,7 @@ const ProductFeedTableCard = () => {
 			...query,
 			page: newPage,
 		} );
-		recordTablePageEvent( 'product-feed', newPage, direction );
+		recordTablePageEvent( EVENT_CONTEXT, newPage, direction );
 	};
 
 	const handleSort = ( orderby, order ) => {
@@ -141,6 +142,12 @@ const ProductFeedTableCard = () => {
 				length
 			);
 			createNotice( 'success', message );
+
+			recordEvent( 'gla_bulk_edit_clicked', {
+				context: EVENT_CONTEXT,
+				number_of_items: length,
+				visibility_to: visible ? 'sync_and_show' : 'dont_sync_and_show',
+			} );
 		} );
 
 		handleSelectAllCheckboxChange( false );

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -28,7 +28,7 @@ All event names are prefixed by `wcadmin_gla_`.
   * `link_id`: a unique ID for the button within the context, e.g. `set-up-billing`.
   * `href`: indicate the destination where the users is directed to.
 
-* `bulk_edit_clicked` - Triggered when the product feed "bulk edit" functionality is being used
+* `bulk_edit_click` - Triggered when the product feed "bulk edit" functionality is being used
   * `context`: name of the table
   * `number_of_items`: edit how many items
   * `visibility_to`: `("sync_and_show" | "dont_sync_and_show")`

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -49,6 +49,14 @@ All event names are prefixed by `wcadmin_gla_`.
   * `context`: indicate which link is clicked
   * `href`: link's URL
 
+* `edit_product_click` - Trigger when edit links are clicked from product feed table
+  * `status`: `("approved" | "partially_approved" | "expiring" | "pending" | "disapproved" | "not_synced")`
+  * `visibility`: `("sync_and_show" | "dont_sync_and_show")`
+
+* `edit_product_issue_click` - Trigger when edit links are clicked from Issues to resolve table
+  * `code`: issue code returned from Google
+  * `issue`: issue description returned from Google
+
 * `filter` - Triggered when changing products & variations filter
   * `report`: name of the report (e.g. `"reports-products"`)
   * `filter`: value of the filter (e.g. `"all" | "single-product" | "compare-products"`)

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -28,6 +28,11 @@ All event names are prefixed by `wcadmin_gla_`.
   * `link_id`: a unique ID for the button within the context, e.g. `set-up-billing`.
   * `href`: indicate the destination where the users is directed to.
 
+* `bulk_edit_clicked` - Triggered when the product feed "bulk edit" functionality is being used
+  * `context`: name of the table
+  * `number_of_items`: edit how many items
+  * `visibility_to`: `("sync_and_show" | "dont_sync_and_show")`
+
 * `datepicker_update` - Triggered when datepicker (date ranger picker) is updated
   * `report`: name of the report (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)
   * `compare, period, before, after`: Values selected in [datepicker](https://woocommerce.github.io/woocommerce-admin/#/components/packages/date-range-filter-picker/README?id=props)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR based on #706 to avoid code conflicts.

Closes #700, #701

- Add bulk edit event tracking `gla_bulk_edit_click` to the product feed table
- Add click event tracking to the **EditProductLink** component
- Add click event trackings `gla_edit_product_click`  and `gla_edit_product_issue_click` to product edit links in the Product Feed page

### Screenshots:

#### 📷 . `gla_bulk_edit_click` evevnt
![2021-06-01 10 12 17](https://user-images.githubusercontent.com/17420811/120261961-90e4de80-c2cb-11eb-9e33-3df54c27f8f2.png)

#### 📷 . `gla_edit_product_click`  and `gla_edit_product_issue_click` events
![image](https://user-images.githubusercontent.com/17420811/120261977-980bec80-c2cb-11eb-9b8b-0e2e0942d3f3.png)

### Detailed test instructions:

1. Open the DevTool console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to enable tracking debugging mode
2. Go to the product feed page
3. Bulk edit product visibility by the **Product Feed** table
    - The `gla_bulk_edit_click` event should be logged on the DevTool console with respective `context`, `number_of_items` and `visibility_to`
4. Enable the "Preserve log" option of the DevTool console
5. Click any "Edit" links on the **Product Feed** table
    - The `gla_edit_product_click` event should be logged as a queued event on the DevTool console with respective `status` and `visibility`
6. Click any "Edit" links on the **Issue to resolve** table
    - The `edit_product_issue_click` event should be logged as a queued event on the DevTool console with respective `code` and `issue`

### Changelog Note:

> Add bulk edit event and product edit link click events to the Product Feed page
