### PR TITLE
Add event trackings when the "Launch paid campaign" buttons are clicked

### DIFF
--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -19,6 +19,7 @@ import { useAppDispatch } from '.~/data';
 import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
 import createCampaign from '.~/apis/createCampaign';
 import validateForm from '.~/utils/paid-ads/validateForm';
+import { recordLaunchPaidCampaignClickEvent } from '.~/utils/recordEvent';
 
 const CreatePaidAdsCampaignForm = () => {
 	const [ loading, setLoading ] = useState( false );
@@ -35,6 +36,9 @@ const CreatePaidAdsCampaignForm = () => {
 		try {
 			const { amount, country: countryArr } = values;
 			const country = countryArr && countryArr[ 0 ];
+
+			recordLaunchPaidCampaignClickEvent( amount, country );
+
 			await createCampaign( amount, country );
 
 			createNotice(

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -15,6 +15,7 @@ import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
 import SetupAdsFormContent from './setup-ads-form-content';
 import useSetupCompleteCallback from './useSetupCompleteCallback';
 import validateForm from '.~/utils/paid-ads/validateForm';
+import { recordLaunchPaidCampaignClickEvent } from '.~/utils/recordEvent';
 
 // when amount is null or undefined in an onChange callback,
 // it will cause runtime error with the Form component.
@@ -65,6 +66,9 @@ const SetupAdsForm = () => {
 			onSubmitCallback={ ( values ) => {
 				const { amount, country: countryArr } = values;
 				const country = countryArr && countryArr[ 0 ];
+
+				recordLaunchPaidCampaignClickEvent( amount, country );
+
 				handleSetupComplete( amount, country, () => {
 					setSubmitted( true );
 				} );

--- a/js/src/utils/recordEvent.js
+++ b/js/src/utils/recordEvent.js
@@ -3,6 +3,10 @@
  */
 import { recordEvent } from '@woocommerce/tracks';
 
+/**
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ */
+
 export const recordTableHeaderToggleEvent = ( report, column, status ) => {
 	recordEvent( 'gla_table_header_toggle', {
 		report,
@@ -68,6 +72,16 @@ export const recordSetupAdsEvent = ( target, trigger = 'click' ) => {
 		target,
 		trigger,
 	} );
+};
+
+/**
+ * Records `gla_launch_paid_campaign_clicked` tracking event.
+ *
+ * @param {number} budget Daily average cost of the paid campaign.
+ * @param {CountryCode} audience Country code of the paid campaign audience country.
+ */
+export const recordLaunchPaidCampaignClickEvent = ( budget, audience ) => {
+	recordEvent( 'gla_launch_paid_campaign_clicked', { audience, budget } );
 };
 
 export default recordEvent;

--- a/js/src/utils/recordEvent.js
+++ b/js/src/utils/recordEvent.js
@@ -75,13 +75,16 @@ export const recordSetupAdsEvent = ( target, trigger = 'click' ) => {
 };
 
 /**
- * Records `gla_launch_paid_campaign_clicked` tracking event.
+ * Records `gla_launch_paid_campaign_button_click` tracking event.
  *
  * @param {number} budget Daily average cost of the paid campaign.
  * @param {CountryCode} audience Country code of the paid campaign audience country.
  */
 export const recordLaunchPaidCampaignClickEvent = ( budget, audience ) => {
-	recordEvent( 'gla_launch_paid_campaign_clicked', { audience, budget } );
+	recordEvent( 'gla_launch_paid_campaign_button_click', {
+		audience,
+		budget,
+	} );
 };
 
 export default recordEvent;

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -81,8 +81,8 @@ All event names are prefixed by `wcadmin_gla_`.
   * `context`: indicate the place where the button is located, e.g. `setup-ads`.
 
 * `launch_paid_campaign_button_click` - Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign
-  * `audience`: daily average cost of the paid campaign
-  * `budget`: country code of the paid campaign audience country
+  * `audience`: country code of the paid campaign audience country
+  * `budget`: daily average cost of the paid campaign
 
 * `mc_account_connect_button_click` - Clicking on the button to connect an existing Google Merchant Center account.
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -80,7 +80,7 @@ All event names are prefixed by `wcadmin_gla_`.
 * `help_click` - "Help" button is clicked.
   * `context`: indicate the place where the button is located, e.g. `setup-ads`.
 
-* `launch_paid_campaign_clicked` - Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign
+* `launch_paid_campaign_button_click` - Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign
   * `audience`: daily average cost of the paid campaign
   * `budget`: country code of the paid campaign audience country
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -80,6 +80,10 @@ All event names are prefixed by `wcadmin_gla_`.
 * `help_click` - "Help" button is clicked.
   * `context`: indicate the place where the button is located, e.g. `setup-ads`.
 
+* `launch_paid_campaign_clicked` - Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign
+  * `audience`: daily average cost of the paid campaign
+  * `budget`: country code of the paid campaign audience country
+
 * `mc_account_connect_button_click` - Clicking on the button to connect an existing Google Merchant Center account.
 
 * `mc_account_create_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #699 

- Add `launch_paid_campaign_button_click ` event trackings when "Launch paid campaign" buttons are clicked

### Screenshots:

![2021-06-01 14 26 39](https://user-images.githubusercontent.com/17420811/120278220-97814f00-c2e7-11eb-985d-bed4699f03fa.png)

### Detailed test instructions:

1. Open the DevTool console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to enable tracking debugging mode
2. Go to the Ads setup flow or paid campaign creation page
3. Finish the form and click the "Launch paid campaign" button to add a new paid campaign
4. The `gla_launch_paid_campaign_button_click` event should be logged on the DevTool console with respective `audience` and `budget`


### Changelog Note:

> Add event trackings when the "Launch paid campaign" buttons are clicked
