### PR TITLE
Expose pre-sync errors

### DIFF
--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -96,11 +96,11 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 		$product_id = $post->ID;
 		$product    = wc_get_product( $product_id );
 		return [
-			'product_id' => $product_id,
-			'product'    => $product,
-			'visibility' => $this->product_helper->get_visibility( $product ),
-			'synced_at'  => $this->meta_handler->get_synced_at( $product_id ),
-			'issues'     => [], // todo: replace this with the list of issues retrieved from Google's Product Statuses API
+			'product_id'  => $product_id,
+			'product'     => $product,
+			'visibility'  => $this->product_helper->get_visibility( $product ),
+			'sync_status' => $this->meta_handler->get_sync_status( $product_id ),
+			'issues'      => $this->meta_handler->get_errors( $product_id ),
 		];
 	}
 

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -95,12 +95,20 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	protected function get_view_context( WP_Post $post, array $args ): array {
 		$product_id = $post->ID;
 		$product    = wc_get_product( $product_id );
+		$errors     = $this->meta_handler->get_errors( $product_id ) ?: [];
+
+		// Combine errors for variable products, which have a variation-indexed array of errors.
+		$first_key = array_key_first( $errors );
+		if ( ! empty( $errors ) && is_numeric( $first_key ) && 0 !== $first_key ) {
+			$errors = array_unique( array_merge( ...$errors ) );
+		}
+
 		return [
 			'product_id'  => $product_id,
 			'product'     => $product,
 			'visibility'  => $this->product_helper->get_visibility( $product ),
 			'sync_status' => $this->meta_handler->get_sync_status( $product_id ),
-			'issues'      => $this->meta_handler->get_errors( $product_id ),
+			'issues'      => $errors,
 		];
 	}
 

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -95,20 +95,13 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	protected function get_view_context( WP_Post $post, array $args ): array {
 		$product_id = $post->ID;
 		$product    = wc_get_product( $product_id );
-		$errors     = $this->meta_handler->get_errors( $product_id ) ?: [];
-
-		// Combine errors for variable products, which have a variation-indexed array of errors.
-		$first_key = array_key_first( $errors );
-		if ( ! empty( $errors ) && is_numeric( $first_key ) && 0 !== $first_key ) {
-			$errors = array_unique( array_merge( ...$errors ) );
-		}
 
 		return [
 			'product_id'  => $product_id,
 			'product'     => $product,
 			'visibility'  => $this->product_helper->get_visibility( $product ),
 			'sync_status' => $this->meta_handler->get_sync_status( $product_id ),
-			'issues'      => $errors,
+			'issues'      => $this->product_helper->get_validation_errors( $product ),
 		];
 	}
 

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -86,13 +86,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 
 		foreach ( $this->product_repository->find( $args, $limit, $offset ) as $product ) {
 			$id     = $product->get_id();
-			$errors = $meta_handler->get_errors( $id ) ?: [];
-
-			// Combine errors for variable products, which have a variation-indexed array of errors.
-			$first_key = array_key_first( $errors );
-			if ( ! empty( $errors ) && is_numeric( $first_key ) && 0 !== $first_key ) {
-				$errors = array_unique( array_merge( ...$errors ) );
-			}
+			$errors = $this->product_helper->get_validation_errors( $product );
 
 			$products[ $id ] = [
 				'id'      => $id,

--- a/src/Logging/DebugLogger.php
+++ b/src/Logging/DebugLogger.php
@@ -39,6 +39,7 @@ class DebugLogger implements Service, Registerable, Conditional {
 		if ( function_exists( 'wc_get_logger' ) ) {
 			$this->logger = wc_get_logger();
 
+			add_action( 'gla_log_errors', [ $this, 'log_errors' ], 10, 3 );
 			add_action( 'gla_debug_message', [ $this, 'log_message' ], 10, 2 );
 			add_action( 'gla_exception', [ $this, 'log_exception' ], 10, 2 );
 			add_action( 'gla_mc_client_exception', [ $this, 'log_exception' ], 10, 2 );
@@ -47,6 +48,24 @@ class DebugLogger implements Service, Registerable, Conditional {
 			add_action( 'gla_guzzle_client_exception', [ $this, 'log_exception' ], 10, 2 );
 			add_action( 'gla_guzzle_invalid_response', [ $this, 'log_response' ], 10, 2 );
 		}
+	}
+
+	/**
+	 * Log a list of error messages.
+	 *
+	 * @param string $message
+	 * @param array  $errors
+	 * @param string $method
+	 */
+	public function log_errors( string $message, array $errors, string $method ): void {
+		$this->log(
+			sprintf(
+				'%s %s',
+				$message,
+				wp_json_encode( $errors, JSON_PRETTY_PRINT )
+			),
+			$method
+		);
 	}
 
 	/**

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -118,6 +118,13 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 
 		$wc_product_id = $product->get_id();
 
+		do_action(
+			'gla_log_errors',
+			sprintf( 'Error syncing product ID %d', $wc_product_id ),
+			$errors,
+			__METHOD__
+		);
+
 		$this->meta_handler->update_errors( $wc_product_id, $errors );
 		$this->meta_handler->update_sync_status( $wc_product_id, SyncStatus::HAS_ERRORS );
 		$this->update_empty_visibility( $product );

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -307,4 +307,22 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 		}
 		return $product_id;
 	}
+
+	/**
+	 * Get validation errors for a specific product.
+	 * Combines errors for variable products, which have a variation-indexed array of errors.
+	 *
+	 * @param WC_Product $product
+	 * @return array
+	 */
+	public function get_validation_errors( WC_Product $product ): array {
+		$errors = $this->meta_handler->get_errors( $product->get_id() ) ?: [];
+
+		$first_key = array_key_first( $errors );
+		if ( ! empty( $errors ) && is_numeric( $first_key ) && 0 !== $first_key ) {
+			$errors = array_unique( array_merge( ...$errors ) );
+		}
+
+		return $errors;
+	}
 }

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -25,8 +25,8 @@ $visibility = $this->visibility;
 /**
  * @var string $sync_status
  */
-$sync_status = $this->sync_status;
-$show_status = $visibility === ChannelVisibility::SYNC_AND_SHOW && $sync_status !== SyncStatus::SYNCED;
+$sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
+$show_status = $visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
 
 /**
  * @var array $issues

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -25,7 +25,11 @@ $visibility = $this->visibility;
 /**
  * @var string $sync_status
  */
-$sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
+if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
+	$sync_status = __( 'Issues detected', 'google-listings-and-ads' );
+} else {
+	$sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
+}
 $show_status = $visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
 
 /**

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -2,6 +2,7 @@
 declare( strict_types=1 );
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
 
 defined( 'ABSPATH' ) || exit;
@@ -22,10 +23,10 @@ $product = $this->product;
 $visibility = $this->visibility;
 
 /**
- * @var int $synced_at Timestamp
+ * @var string $sync_status
  */
-$synced_at = $this->synced_at;
-$is_synced = ! empty( $synced_at );
+$sync_status = $this->sync_status;
+$show_status = $visibility === ChannelVisibility::SYNC_AND_SHOW && $sync_status !== SyncStatus::SYNCED;
 
 /**
  * @var array $issues
@@ -48,21 +49,17 @@ $has_issues = ! empty( $issues );
 		]
 	);
 	?>
-	<?php if ( 0 === 1 ) : // Temporarily hide the sync status. See https://github.com/woocommerce/google-listings-and-ads/issues/152#issuecomment-776408166 ?>
-	<div class="sync-status notice-alt notice-large notice-warning">
+	<?php if ( $show_status ) : ?>
+	<div class="sync-status notice-alt notice-large notice-warning" style="border-left-style: solid">
 		<p><strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong></p>
-		<p><?php echo $is_synced ? 'Synced' : 'Not synced'; ?></p>
-		<?php if ( $is_synced && $has_issues ) : ?>
+		<p><?php echo esc_html( $sync_status ); ?></p>
+		<?php if ( $has_issues ) : ?>
 			<div class="gla-product-issues">
 				<p><strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong></p>
 				<ul>
-					<li>Missing description</li>
-				</ul>
-			</div>
-			<div class="gla-product-suggested-actions">
-				<p><strong><?php esc_html_e( 'Suggested actions', 'google-listings-and-ads' ); ?></strong></p>
-				<ul>
-					<li>Add a description for this product</li>
+					<?php foreach ( $issues as $issue ) : ?>
+					<li><?php echo esc_html( $issue ); ?></li>
+					<?php endforeach; ?>
 				</ul>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When we sync a product it goes through some pre checks to validate that it's ready for syncing. We save the list of these errors in product meta but it's not exposed in the UI. This PR addresses this to add some initial indication where it's gone wrong to assist with troubleshooting.

We initially decided [not to include the sync status](https://github.com/woocommerce/google-listings-and-ads/issues/152#issuecomment-776408166), however in this case the product is blocked from syncing so the issues never appear in the Product Issues list.

This is missing some design and could be refined, but it only shows the status if it is set to sync and the sync wasn't successful. The intention is to add an initial aid for troubleshooting, the design can be refined after v1.

Closes #664

### Detailed test instructions:

1. Create a new product without price/image/description and set it to sync to Google
2. Save the product (status after reload show be pending)
![image](https://user-images.githubusercontent.com/11388669/120327843-1c696a00-c2e2-11eb-9d72-83c5ff55da76.png)
3. Wait till the async action completed and then refresh the product edit page
4. Confirm that the errors are shown
![image](https://user-images.githubusercontent.com/11388669/120327964-41f67380-c2e2-11eb-8d1c-547af7fe8e86.png)
5. Check the WooCommerce > Status > Logs > latest gla log file, and confirm we see the errors there
```
2021-06-01T13:03:33+00:00 DEBUG Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper::mark_as_invalid Error syncing product ID 113 [
    "[description] This value should not be blank.",
    "[imageLink] This value should not be blank.",
    "[price] This value should not be null."
]
```


### Changelog Note:

* Fix - Show pre-sync errors when editing product.