### PR TITLE
Include pre-sync product errors in the issues API

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -387,27 +387,26 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 * Include local presync product validation issues in the merchant issues table.
 	 */
 	protected function refresh_presync_product_issues(): void {
-
 		/** @var ProductRepository $product_repository */
 		$product_repository = $this->container->get( ProductRepository::class );
-		$products = $product_repository->find_presync_error_products();
-		$product_issues = [];
-		$created_at     = $this->current_time->format( 'Y-m-d H:i:s' );
+		$products           = $product_repository->find_presync_error_products();
+		$product_issues     = [];
+		$created_at         = $this->current_time->format( 'Y-m-d H:i:s' );
 
-		foreach($products as $p) {
+		foreach ( $products as $p ) {
 			// Skip parent products (so product titles clearly indicate which variation neds fixing).
 			if ( $p->get_type() === 'variable' ) {
 				continue;
 			}
 
-			$presync_errors = $p->get_meta($this->prefix_meta_key( ProductMetaHandler::KEY_ERRORS ) );
+			$presync_errors = $p->get_meta( $this->prefix_meta_key( ProductMetaHandler::KEY_ERRORS ) );
 			// Skip products without error descriptions.
 			if ( empty( $presync_errors ) ) {
 				continue;
 			}
 
-			foreach( $presync_errors as $text ) {
-				$issue_parts = $this->parse_presync_issue_text( $text );
+			foreach ( $presync_errors as $text ) {
+				$issue_parts      = $this->parse_presync_issue_text( $text );
 				$product_issues[] = [
 					'product'              => $p->get_name(),
 					'product_id'           => $p->get_id(),
@@ -582,7 +581,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 */
 	protected function parse_presync_issue_text( string $text ): array {
 		$matches = [];
-		preg_match( '/^\[([^\]]+)\]\s*(.+)$/', $text, $matches);
+		preg_match( '/^\[([^\]]+)\]\s*(.+)$/', $text, $matches );
 		if ( count( $matches ) !== 3 ) {
 			return [
 				'code'  => 'presync_error_attrib',
@@ -591,7 +590,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		}
 
 		// Convert imageLink to image
-		if( 'imageLink' === $matches[1] ) {
+		if ( 'imageLink' === $matches[1] ) {
 			$matches[1] = 'image';
 		}
 		$matches[2] = trim( $matches[2], ' .' );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -331,7 +331,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			$wc_product_id = $product_helper->get_wc_product_id( $product->getProductId() );
 
 			// Unsynced issues shouldn't be shown.
-			if ( $this->product_data_lookup[ $wc_product_id ]['visibility'] === ChannelVisibility::DONT_SYNC_AND_SHOW ) {
+			if ( ChannelVisibility::DONT_SYNC_AND_SHOW === $this->product_data_lookup[ $wc_product_id ]['visibility'] ) {
 				continue;
 			}
 
@@ -395,7 +395,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 		foreach ( $products as $p ) {
 			// Skip parent products (so product titles clearly indicate which variation neds fixing).
-			if ( $p->get_type() === 'variable' ) {
+			if ( 'variable' === $p->get_type() ) {
 				continue;
 			}
 
@@ -541,9 +541,9 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	protected function get_product_shopping_status( Shopping_Product_Status $product_status ): ?string {
 		$status = null;
 		foreach ( $product_status->getDestinationStatuses() as $d ) {
-			if ( $d->getDestination() === 'SurfacesAcrossGoogle' ) {
+			if ( 'SurfacesAcrossGoogle' === $d->getDestination() ) {
 				$status = $d->getStatus();
-			} elseif ( $d->getDestination() === 'Shopping' ) {
+			} elseif ( 'Shopping' === $d->getDestination() ) {
 				$status = $d->getStatus();
 				break;
 			}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -584,7 +584,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		preg_match( '/^\[([^\]]+)\]\s*(.+)$/', $text, $matches );
 		if ( count( $matches ) !== 3 ) {
 			return [
-				'code'  => 'presync_error_attrib',
+				'code'  => 'presync_error_attrib_' . md5( $text ),
 				'issue' => $text,
 			];
 		}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -394,7 +394,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$created_at         = $this->current_time->format( 'Y-m-d H:i:s' );
 
 		foreach ( $products as $p ) {
-			// Skip parent products (so product titles clearly indicate which variation neds fixing).
+			// Skip parent products (so product titles clearly indicate which variation needs fixing).
 			if ( 'variable' === $p->get_type() ) {
 				continue;
 			}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -151,7 +151,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			throw new Exception( __( 'No Merchant Center account connected.', 'google-listings-and-ads' ) );
 		}
 
-		// Update product stats and issues page by page.
+		// Update MC product stats and issues page by page.
 		$this->mc_statuses = [];
 		$page_token        = null;
 		do {
@@ -168,6 +168,9 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 		// Update account issues.
 		$this->refresh_account_issues();
+
+		// Update presync product validation issues.
+		$this->refresh_presync_product_issues();
 
 		// Delete stale issues.
 		$delete_before = clone $this->current_time;
@@ -366,7 +369,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			}
 		);
 
-		// Product issue cleanup: sorting (by product ID) and sort applicable countries.
+		// Product issue cleanup: sorting (by product ID) and encode applicable countries.
 		ksort( $product_issues );
 		$product_issues = array_map(
 			function ( $unique_key, $issue ) {
@@ -378,6 +381,49 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		);
 
 		$this->container->get( MerchantIssueQuery::class )->update_or_insert( array_values( $product_issues ) );
+	}
+
+	/**
+	 * Include local presync product validation issues in the merchant issues table.
+	 */
+	protected function refresh_presync_product_issues(): void {
+
+		/** @var ProductRepository $product_repository */
+		$product_repository = $this->container->get( ProductRepository::class );
+		$products = $product_repository->find_presync_error_products();
+		$product_issues = [];
+		$created_at     = $this->current_time->format( 'Y-m-d H:i:s' );
+
+		foreach($products as $p) {
+			// Skip parent products (so product titles clearly indicate which variation neds fixing).
+			if ( $p->get_type() === 'variable' ) {
+				continue;
+			}
+
+			$presync_errors = $p->get_meta($this->prefix_meta_key( ProductMetaHandler::KEY_ERRORS ) );
+			// Skip products without error descriptions.
+			if ( empty( $presync_errors ) ) {
+				continue;
+			}
+
+			foreach( $presync_errors as $text ) {
+				$issue_parts = $this->parse_presync_issue_text( $text );
+				$product_issues[] = [
+					'product'              => $p->get_name(),
+					'product_id'           => $p->get_id(),
+					'code'                 => $issue_parts['code'],
+					'issue'                => $issue_parts['issue'],
+					'action'               => __( 'Update this attribute in your product data', 'google-listings-and-ads' ),
+					'action_url'           => 'https://support.google.com/merchants/answer/10538362?hl=en&ref_topic=6098333',
+					'applicable_countries' => '["all"]',
+					'created_at'           => $created_at,
+				];
+			}
+		}
+
+		/** @var MerchantIssueQuery $issue_query */
+		$issue_query = $this->container->get( MerchantIssueQuery::class );
+		$issue_query->update_or_insert( $product_issues );
 	}
 
 	/**
@@ -524,6 +570,33 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		return [
 			self::TYPE_ACCOUNT,
 			self::TYPE_PRODUCT,
+		];
+	}
+
+	/**
+	 * Parse the code and formatted issue text out of the presync validation error text.
+	 *
+	 * @param string $text
+	 *
+	 * @return string[] With indexes `code` and `issue`
+	 */
+	protected function parse_presync_issue_text( string $text ): array {
+		$matches = [];
+		preg_match( '/^\[([^\]]+)\]\s*(.+)$/', $text, $matches);
+		if ( count( $matches ) !== 3 ) {
+			return [
+				'code'  => 'presync_error_attrib',
+				'issue' => $text,
+			];
+		}
+
+		// Convert imageLink to image
+		if( 'imageLink' === $matches[1] ) {
+			$matches[1] = 'image';
+		}
+		return [
+			'code'  => 'presync_error_' . $matches[1],
+			'issue' => "{$matches[2]} [{$matches[1]}]",
 		];
 	}
 }

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -594,6 +594,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		if( 'imageLink' === $matches[1] ) {
 			$matches[1] = 'image';
 		}
+		$matches[2] = trim( $matches[2], ' .' );
 		return [
 			'code'  => 'presync_error_' . $matches[1],
 			'issue' => "{$matches[2]} [{$matches[1]}]",

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use WC_Product;
 
 /**
@@ -287,6 +288,33 @@ class ProductRepository implements Service {
 		];
 
 		return $this->find_ids( $args, $limit, $offset );
+	}
+
+
+
+	/**
+	 * Find and return an array of WooCommerce product objects that are pending synchronization,
+	 * but have failed pre-sync validation.
+	 *
+	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
+	 * @param int $offset Amount to offset product results.
+	 *
+	 * @return WC_Product[] Array of WooCommerce product objects
+	 */
+	public function find_presync_error_products( int $limit = -1, int $offset = 0 ): array {
+		$args['meta_query'] = [
+			'relation' => 'AND',
+			$this->get_sync_ready_products_meta_query(),
+			[
+				[
+					'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
+					'compare' => '=',
+					'value'   => SyncStatus::HAS_ERRORS,
+				],
+			],
+		];
+
+		return $this->find( $args, $limit, $offset );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #712.

This includes pre-sync errors when refreshing the data in the `wp_gla_merchant_issues` table, formatted in a similar fashion as the issues returned by Merchant Center.

#### Notes
- Only issues for `simple` and `variation` products are included (this last one ensure that product titles are descriptive, e.g., `Gloves - Large`)
- The action text and link are hard-coded to [`Update this attribute in your product data`](https://support.google.com/merchants/answer/10538362?hl=en&ref_topic=6098333)
- The pre-sync issues are only included for products that are marked as `has-errors` and `sync-and-show`; so synced products won't be included, and neither will products that have had errors but are set to `dont-sync-and-show`.
- The issue descriptions are updated to match the Merchant Center format of `text [attribute]`: `This value should not be blank [description]`
- The pre-sync issues will only be refreshed when the Merchant Center issues are, currently every hour. So even if the user visits the product and fixes the issues, it may still show on the Product Feed page for a short period (it may be interesting to reduce the cache time).
- The affected countries are set to `["all"]` and the error code is `presync_error_[ATTRIB]`

### Detailed test instructions:

1. Connect a Merchant Center account and sync some products (they shouldn't be approved so should show as issues).
2. Create a new product without a description.
3. Clear the Merchant Center status cache (Connection Test → More Merchant Center → Clear Status Cache button)
4. Visit the Product Feed page (`/wp-admin/admin.php?page=wc-admin&path=/google/product-feed`) and confirm that product is included with the correct text (`This value should not be blank [description]`). 
    - The new product will be on the last page of issues as the issues are ordered by product ID.
5. Fix the product, clear the status cache again, and refresh the product feed page.
6. Confirm that the new product no longer appears in the issues table.
Bonus: test with a variable product, and confirm that the individual variations appear in the issues table (but the `Edit` link points to the parent variable product).

### Changelog Note:

* Fix - Include pre-sync errors in the issues table.
