### PR TITLE
Add track events for account connections

### DIFF
--- a/js/src/components/google-account/connect-account.js
+++ b/js/src/components/google-account/connect-account.js
@@ -45,6 +45,7 @@ const ConnectAccount = ( props ) => {
 					isSecondary
 					disabled={ disabled }
 					loading={ loading || data }
+					eventName="gla_connect_google_account_button_click"
 					onClick={ handleConnectClick }
 				>
 					{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/components/google-account/connect-account.js
+++ b/js/src/components/google-account/connect-account.js
@@ -45,7 +45,7 @@ const ConnectAccount = ( props ) => {
 					isSecondary
 					disabled={ disabled }
 					loading={ loading || data }
-					eventName="gla_connect_google_account_button_click"
+					eventName="gla_google_account_connect_button_click"
 					onClick={ handleConnectClick }
 				>
 					{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/connect-ads.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/connect-ads.js
@@ -65,6 +65,7 @@ const ConnectAds = ( props ) => {
 						isSecondary
 						loading={ loading || isResolving }
 						disabled={ ! value }
+						eventName="gla_connect_ads_account_button_click"
 						onClick={ handleConnectClick }
 					>
 						{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/connect-ads.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/connect-ads.js
@@ -65,7 +65,7 @@ const ConnectAds = ( props ) => {
 						isSecondary
 						loading={ loading || isResolving }
 						disabled={ ! value }
-						eventName="gla_connect_ads_account_button_click"
+						eventName="gla_ads_account_connect_button_click"
 						onClick={ handleConnectClick }
 					>
 						{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/terms-modal/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/terms-modal/index.js
@@ -34,7 +34,7 @@ const TermsModal = ( props ) => {
 					key="1"
 					isPrimary
 					disabled={ ! agree }
-					eventName="gla_create_new_ads_account_button_click"
+					eventName="gla_ads_account_create_button_click"
 					onClick={ handleCreateAccountClick }
 				>
 					{ __( 'Create account', 'google-listings-and-ads' ) }

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/terms-modal/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/terms-modal/index.js
@@ -34,6 +34,7 @@ const TermsModal = ( props ) => {
 					key="1"
 					isPrimary
 					disabled={ ! agree }
+					eventName="gla_create_new_ads_account_button_click"
 					onClick={ handleCreateAccountClick }
 				>
 					{ __( 'Create account', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -95,6 +95,7 @@ const ConnectMCCard = ( props ) => {
 						isSecondary
 						loading={ loading }
 						disabled={ ! value }
+						eventName="gla_connect_mc_account_button_click"
 						onClick={ handleConnectClick }
 					>
 						{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc-card/index.js
@@ -95,7 +95,7 @@ const ConnectMCCard = ( props ) => {
 						isSecondary
 						loading={ loading }
 						disabled={ ! value }
-						eventName="gla_connect_mc_account_button_click"
+						eventName="gla_mc_account_connect_button_click"
 						onClick={ handleConnectClick }
 					>
 						{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/terms-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/terms-modal/index.js
@@ -34,7 +34,7 @@ const TermsModal = ( props ) => {
 					key="1"
 					isPrimary
 					disabled={ ! agree }
-					eventName="gla_create_new_mc_account_button_click"
+					eventName="gla_mc_account_create_button_click"
 					onClick={ handleCreateAccountClick }
 				>
 					{ __( 'Create account', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/terms-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/terms-modal/index.js
@@ -34,6 +34,7 @@ const TermsModal = ( props ) => {
 					key="1"
 					isPrimary
 					disabled={ ! agree }
+					eventName="gla_create_new_mc_account_button_click"
 					onClick={ handleCreateAccountClick }
 				>
 					{ __( 'Create account', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/connect-account.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/connect-account.js
@@ -42,6 +42,7 @@ const ConnectAccount = () => {
 				<AppButton
 					isSecondary
 					loading={ loading || data }
+					eventName="gla_connect_wordpress_account_button_click"
 					onClick={ handleConnectClick }
 				>
 					{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/connect-account.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/connect-account.js
@@ -42,7 +42,7 @@ const ConnectAccount = () => {
 				<AppButton
 					isSecondary
 					loading={ loading || data }
-					eventName="gla_connect_wordpress_account_button_click"
+					eventName="gla_wordpress_account_connect_button_click"
 					onClick={ handleConnectClick }
 				>
 					{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -121,6 +121,18 @@ All event names are prefixed by `wcadmin_gla_`.
 * `tooltip_viewed` - Viewing tooltip
   * `id`: (tooltip identifier)
 
+* `connect_wordpress_account_button_click` - Clicking on the button to connect WordPress.com account.
+
+* `connect_google_account_button_click` - Clicking on the button to connect Google account.
+
+* `connect_mc_account_button_click` - Clicking on the button to connect an existing Google Merchant Center account.
+
+* `create_new_mc_account_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
+
+* `connect_ads_account_button_click` - Clicking on the button to connect an existing Google Ads account.
+
+* `create_new_ads_account_button_click` - Clicking on the button to create a new Google Ads account, after agreeing to the terms and conditions.
+
 <!-- -- >
 ## Developer Info
 All new tracking info should be updated in this readme.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -121,17 +121,17 @@ All event names are prefixed by `wcadmin_gla_`.
 * `tooltip_viewed` - Viewing tooltip
   * `id`: (tooltip identifier)
 
-* `connect_wordpress_account_button_click` - Clicking on the button to connect WordPress.com account.
+* `wordpress_account_connect_button_click` - Clicking on the button to connect WordPress.com account.
 
-* `connect_google_account_button_click` - Clicking on the button to connect Google account.
+* `google_account_connect_button_click` - Clicking on the button to connect Google account.
 
-* `connect_mc_account_button_click` - Clicking on the button to connect an existing Google Merchant Center account.
+* `mc_account_connect_button_click` - Clicking on the button to connect an existing Google Merchant Center account.
 
-* `create_new_mc_account_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
+* `mc_account_create_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
 
-* `connect_ads_account_button_click` - Clicking on the button to connect an existing Google Ads account.
+* `ads_account_connect_button_click` - Clicking on the button to connect an existing Google Ads account.
 
-* `create_new_ads_account_button_click` - Clicking on the button to create a new Google Ads account, after agreeing to the terms and conditions.
+* `ads_account_create_button_click` - Clicking on the button to create a new Google Ads account, after agreeing to the terms and conditions.
 
 <!-- -- >
 ## Developer Info

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -23,6 +23,10 @@ All event names are prefixed by `wcadmin_gla_`.
   * `context`: indicate the place where the button is located.
   * `href`: indicate the destination where the users is directed to, e.g. `'/google/setup-ads'` or `'/google/campaigns/create'`.
 
+* `ads_account_connect_button_click` - Clicking on the button to connect an existing Google Ads account.
+
+* `ads_account_create_button_click` - Clicking on the button to create a new Google Ads account, after agreeing to the terms and conditions.
+
 * `ads_set_up_billing_click` - "Set up billing" button for Google Ads account is clicked.
   * `context`: indicate the place where the button is located, e.g. `setup-ads`.
   * `link_id`: a unique ID for the button within the context, e.g. `set-up-billing`.
@@ -63,12 +67,18 @@ All event names are prefixed by `wcadmin_gla_`.
   * `context`: indicate which link is clicked
   * `href`: link's URL
 
+* `google_account_connect_button_click` - Clicking on the button to connect Google account.
+
 * `google_ads_account_link_click` - Clicking on a Google Ads account text link.
   * `context`: indicate which page / module the link is in
   * `link_id`: a unique ID for the link within the page / module
 
 * `help_click` - "Help" button is clicked.
   * `context`: indicate the place where the button is located, e.g. `setup-ads`.
+
+* `mc_account_connect_button_click` - Clicking on the button to connect an existing Google Merchant Center account.
+
+* `mc_account_create_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
 
 * `modal_closed` - A modal is closed
   * `context`: indicate which modal is closed
@@ -122,16 +132,6 @@ All event names are prefixed by `wcadmin_gla_`.
   * `id`: (tooltip identifier)
 
 * `wordpress_account_connect_button_click` - Clicking on the button to connect WordPress.com account.
-
-* `google_account_connect_button_click` - Clicking on the button to connect Google account.
-
-* `mc_account_connect_button_click` - Clicking on the button to connect an existing Google Merchant Center account.
-
-* `mc_account_create_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
-
-* `ads_account_connect_button_click` - Clicking on the button to connect an existing Google Ads account.
-
-* `ads_account_create_button_click` - Clicking on the button to create a new Google Ads account, after agreeing to the terms and conditions.
 
 <!-- -- >
 ## Developer Info


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #685 .

This PR adds track events for account connections (WordPress.com, Google, Google MC, Google Ads) in the Setup MC and Setup Ads flow.

The list of events added are in the form of `gla_{account_type}_{button_type}_click`, i.e.:

* `gla_wordpress_account_connect_button_click` - Clicking on the button to connect WordPress.com account.
* `gla_google_account_connect_button_click` - Clicking on the button to connect Google account.
* `gla_mc_account_connect_button_click` - Clicking on the button to connect an existing Google Merchant Center account.
* `gla_mc_account_create_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
* `gla_ads_account_connect_button_click` - Clicking on the button to connect an existing Google Ads account.
* `gla_ads_account_create_button_click` - Clicking on the button to create a new Google Ads account, after agreeing to the terms and conditions.

#### Technical note: 

This PR makes use of the `AppButton`'s `eventName` props which was introduced in PR https://github.com/woocommerce/google-listings-and-ads/pull/505. It really makes things easier and simpler. 😄 🎉 

### Screenshots:

Demo video with my voice: (https://d.pr/v/iNktJb)

https://user-images.githubusercontent.com/417342/120367096-0b9d1080-c343-11eb-813c-95eb8c50d393.mov

### Detailed test instructions:

1. Open the DevTool console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to enable tracking debugging mode
2. Go through the Setup MC flow. Make sure that there are corresponding track events when you click on the connect account button or create account button for WordPress.com account, Google account and Google MC account.
3. Go through the Setup Ads flow. Make sure that there are corresponding track events when you click on the connect account button or create account button for Google Ads account. 

### Changelog Note:

Add track events for account connections.
