### PR TITLE
Fix compatibility issue that lacks required class of new WC Navigation in supported WC versions

### DIFF
--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
 
-use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
@@ -18,6 +17,7 @@ class Dashboard implements Service, Registerable, MerchantCenterAwareInterface {
 
 	use MenuFixesTrait;
 	use MerchantCenterAwareTrait;
+	use WooAdminNavigationTrait;
 
 	/**
 	 * Register a service.
@@ -30,7 +30,7 @@ class Dashboard implements Service, Registerable, MerchantCenterAwareInterface {
 		add_filter(
 			'woocommerce_marketing_menu_items',
 			function( $menu_items ) {
-				if ( Features::is_enabled( 'navigation' ) ) {
+				if ( $this->is_woo_nav_enabled() ) {
 					return $menu_items;
 				}
 
@@ -41,7 +41,7 @@ class Dashboard implements Service, Registerable, MerchantCenterAwareInterface {
 		add_action(
 			'admin_menu',
 			function() {
-				if ( Features::is_enabled( 'navigation' ) ) {
+				if ( $this->is_woo_nav_enabled() ) {
 					$this->register_navigation_pages();
 				} else {
 					$this->fix_menu_paths();

--- a/src/Menu/GetStarted.php
+++ b/src/Menu/GetStarted.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
 
-use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
@@ -18,6 +17,7 @@ class GetStarted implements Service, Registerable, MerchantCenterAwareInterface 
 
 	use MenuFixesTrait;
 	use MerchantCenterAwareTrait;
+	use WooAdminNavigationTrait;
 
 	/**
 	 * Register a service.
@@ -30,7 +30,7 @@ class GetStarted implements Service, Registerable, MerchantCenterAwareInterface 
 		add_filter(
 			'woocommerce_marketing_menu_items',
 			function( $menu_items ) {
-				if ( Features::is_enabled( 'navigation' ) ) {
+				if ( $this->is_woo_nav_enabled() ) {
 					return $menu_items;
 				}
 
@@ -41,7 +41,7 @@ class GetStarted implements Service, Registerable, MerchantCenterAwareInterface 
 		add_action(
 			'admin_menu',
 			function() {
-				if ( Features::is_enabled( 'navigation' ) ) {
+				if ( $this->is_woo_nav_enabled() ) {
 					$this->register_navigation_pages();
 				} else {
 					$this->fix_menu_paths();

--- a/src/Menu/Reports/Reports.php
+++ b/src/Menu/Reports/Reports.php
@@ -3,9 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu\Reports;
 
-use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\WooAdminNavigationTrait;
 
 /**
  * Class Reports
@@ -13,6 +13,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu\Reports
  */
 class Reports implements Service, Registerable {
+
+	use WooAdminNavigationTrait;
 
 	/**
 	 * Register a service.
@@ -23,7 +25,7 @@ class Reports implements Service, Registerable {
 			function() {
 				if (
 					apply_filters( 'gla_enable_reports', true ) &&
-					Features::is_enabled( 'navigation' )
+					$this->is_woo_nav_enabled()
 				) {
 					$this->register_navigation_pages();
 				}

--- a/src/Menu/WooAdminNavigationTrait.php
+++ b/src/Menu/WooAdminNavigationTrait.php
@@ -1,0 +1,32 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
+
+use Automattic\WooCommerce\Admin\Features\Features;
+
+/**
+ * Trait WooAdminNavigationTrait
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu
+ */
+trait WooAdminNavigationTrait {
+	/**
+	 * Whether the new WooCommerce Navigation should be used.
+	 *
+	 * @var bool
+	 */
+	private $woo_nav_enabled;
+
+	/**
+	 * Check the class availability of new WooCommerce Navigation and is it enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_woo_nav_enabled() {
+		if ( ! isset( $this->woo_nav_enabled ) ) {
+			$this->woo_nav_enabled = class_exists( Features::class ) && Features::is_enabled( 'navigation' );
+		}
+		return $this->woo_nav_enabled;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Add a new trait to check the availability of new WooCommerce Navigation and if it's enabled
- Replace `Features::is_enabled( 'navigation' )` by the new trait to fix compatibility issue

### Bug

Replicate steps:

1. Install WC with a version that doesn't have the [Automattic\WooCommerce\Admin\Features](https://woocommerce.github.io/code-reference/namespaces/automattic-woocommerce-admin-features.html) class. I tested with WC 4.9.2.
2. Deactivate the **WooCommerce Admin** plugin
3. The whole WP admin would be broken
    ![2021-06-02 16 51 05](https://user-images.githubusercontent.com/17420811/120450504-1303fe80-c3c3-11eb-9bde-7e800b99cde8.png)

### Detailed test instructions:

Follow the same steps of bug replication steps, and the WP admin should be able to use.

### Changelog Note:

> Fix compatibility issue that lacks required class of new WC Navigation in supported WC versions
