### PR TITLE
Add Tracks events for site claim and URL switching

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -80,14 +80,16 @@ class Merchant implements OptionsAwareInterface {
 			$id     = $this->options->get_merchant_id();
 			$params = $overwrite ? [ 'overwrite' => true ] : [];
 			$this->service->accounts->claimwebsite( $id, $id, $params );
+			do_action( 'gla_site_claim_success', [ 'details' => 'google_proxy' ] );
 		} catch ( GoogleException $e ) {
 			do_action( 'gla_mc_client_exception', $e, __METHOD__ );
+			do_action( 'gla_site_claim_failure', [ 'details' => 'google_proxy' ] );
+
 			$error_message = __( 'Unable to claim website.', 'google-listings-and-ads' );
 			if ( 403 === $e->getCode() ) {
 				$error_message = __( 'Website already claimed, use overwrite to complete the process.', 'google-listings-and-ads' );
 			}
 			throw new Exception( $error_message, $e->getCode() );
-
 		}
 		return true;
 	}

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -202,15 +202,18 @@ class Proxy implements OptionsAwareInterface {
 			$response = json_decode( $result->getBody()->getContents(), true );
 
 			if ( 200 === $result->getStatusCode() && isset( $response['status'] ) && 'success' === $response['status'] ) {
+				do_action( 'gla_site_claim_success', [ 'details' => 'google_manager' ] );
 				return true;
 			}
 
 			do_action( 'gla_guzzle_invalid_response', $response, __METHOD__ );
+			do_action( 'gla_site_claim_failure', [ 'details' => 'google_manager' ] );
 
 			$error = $response['message'] ?? __( 'Invalid response when claiming website', 'google-listings-and-ads' );
 			throw new Exception( $error, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'gla_site_claim_failure', [ 'details' => 'google_manager' ] );
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error claiming website', 'google-listings-and-ads' ) ) );
 		}

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -602,6 +602,8 @@ class AccountController extends BaseOptionsController {
 				$clean_account_website_url = $this->strip_url_protocol( $account_website_url );
 				$clean_site_website_url    = $this->strip_url_protocol( $site_website_url );
 
+				do_action( 'gla_url_switch_required', [] );
+
 				throw new ExceptionWithResponseData(
 					sprintf(
 					/* translators: 1: is a website URL (without the protocol) */
@@ -620,6 +622,8 @@ class AccountController extends BaseOptionsController {
 
 			$mc_account->setWebsiteUrl( $site_website_url );
 			$this->merchant->update_account( $mc_account );
+
+			do_action( 'gla_url_switch_success', [] );
 		}
 	}
 

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -440,9 +440,13 @@ class AccountController extends BaseOptionsController {
 
 					// Sub-account: request overwrite confirmation.
 					if ( $state['set_id']['data']['from_mca'] ?? true ) {
+						do_action( 'gla_site_claim_overwrite_required', [] );
+
 						$step['data']['overwrite_required'] = true;
 						$e                                  = new ExceptionWithResponseData( $e->getMessage(), $e->getCode(), null, $data );
 					} else {
+						do_action( 'gla_site_claim_failure', [ 'details' => 'independent_account' ] );
+
 						// Independent account: overwrite not possible.
 						throw new ExceptionWithResponseData(
 							__( 'Unable to claim website URL with this Merchant Center Account.', 'google-listings-and-ads' ),

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -65,6 +65,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks as TracksProxy;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\TaskList\CompleteSetup;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\Loaded;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteClaimEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteVerificationEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\EventTracking;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\TrackerSnapshot;
@@ -257,6 +258,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Share other classes.
 		$this->conditionally_share_with_tags( Loaded::class );
 		$this->conditionally_share_with_tags( SiteVerificationEvents::class );
+		$this->conditionally_share_with_tags( SiteClaimEvents::class );
 		$this->conditionally_share_with_tags( InstallTimestamp::class );
 
 		// The DB Controller has some extra setup required.

--- a/src/Proxies/Tracks.php
+++ b/src/Proxies/Tracks.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Proxies;
 
-use WC_Site_Tracking;
 use WC_Tracks;
 
 /**
@@ -19,11 +18,11 @@ class Tracks {
 	 * @param string $name       The event name to record.
 	 * @param array  $properties Array of properties to include with the event.
 	 */
-	public function record_event( string $name, array $properties = [] ) {
-		if ( ! class_exists( WC_Tracks::class ) || ! WC_Site_Tracking::is_tracking_enabled() ) {
-			return;
+	public function record_event( string $name, array $properties = [] ): void {
+		if ( class_exists( WC_Tracks::class ) ) {
+			WC_Tracks::record_event( $name, $properties );
+		} elseif ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+			wc_admin_record_tracks_event( $name, $properties );
 		}
-
-		WC_Tracks::record_event( $name, $properties );
 	}
 }

--- a/src/Tracking/EventTracking.php
+++ b/src/Tracking/EventTracking.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\BaseEvent;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\Loaded;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteClaimEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteVerificationEvents;
 use Psr\Container\ContainerInterface;
@@ -53,10 +52,11 @@ class EventTracking implements Service, Registerable {
 	 */
 	public function register(): void {
 		add_action(
-			'admin_init',
+			'init',
 			function() {
 				$this->register_events();
-			}
+			},
+			20 // After WC_Admin loads WC_Tracks class (init 10).
 		);
 	}
 

--- a/src/Tracking/EventTracking.php
+++ b/src/Tracking/EventTracking.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\BaseEvent;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\Loaded;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteClaimEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteVerificationEvents;
 use Psr\Container\ContainerInterface;
 
@@ -35,6 +36,7 @@ class EventTracking implements Service, Registerable {
 	 */
 	protected $events = [
 		SiteVerificationEvents::class,
+		SiteClaimEvents::class,
 	];
 
 	/**

--- a/src/Tracking/Events/SiteClaimEvents.php
+++ b/src/Tracking/Events/SiteClaimEvents.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events;
+
+/**
+ * This class adds actions to track for Site Claim actions:
+ * - Site claim required
+ * - Site claim success
+ * - Site claim failure
+ * - Merchant Center URL switch
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tracking
+ */
+class SiteClaimEvents extends BaseEvent {
+
+	/**
+	 * Register the tracking class.
+	 */
+	public function register(): void {
+		add_action( 'gla_site_claim_required', [ $this, 'track_site_claim_required' ] );
+		add_action( 'gla_site_claim_success', [ $this, 'track_site_claim_success' ] );
+		add_action( 'gla_site_claim_failure', [ $this, 'track_site_claim_failure' ] );
+		add_action( 'gla_url_switch_required', [ $this, 'track_url_switch_required' ] );
+		add_action( 'gla_url_switch_success', [ $this, 'track_url_switch_success' ] );
+	}
+
+	/**
+	 * Track when a site claim needs to be overwritten
+	 *
+	 * @param array $properties Optional additional properties to pass with the event.
+	 */
+	public function track_site_claim_required( array $properties = [] ): void {
+		$properties['action'] = 'required';
+		$this->track_site_claim_event( $properties );
+	}
+
+	/**
+	 * Track when a site is claimed successfully.
+	 *
+	 * @param array $properties Optional additional properties to pass with the event.
+	 */
+	public function track_site_claim_success( array $properties = [] ): void {
+		$properties['action'] = 'success';
+		$this->track_site_claim_event( $properties );
+	}
+
+	/**
+	 * Track when a site fails to be claimed.
+	 *
+	 * @param array $properties Optional additional properties to pass with the event.
+	 */
+	public function track_site_claim_failure( array $properties = [] ): void {
+		$properties['action'] = 'failure';
+		$this->track_site_claim_event( $properties );
+	}
+
+	/**
+	 * Track the generic site claim event with the action property.
+	 *
+	 * @param array $properties
+	 */
+	protected function track_site_claim_event( array $properties = [] ): void {
+		$this->record_event( 'site_claim', $properties );
+	}
+
+	/**
+	 * Track when a site requires a URL switch
+	 *
+	 * @param array $properties Optional additional properties to pass with the event.
+	 */
+	public function track_mc_url_switch_required( array $properties = [] ): void {
+		$properties['action'] = 'required';
+		$this->track_url_switch_event( $properties );
+	}
+
+	/**
+	 * Track when a site executes a successful URL switch
+	 *
+	 * @param array $properties Optional additional properties to pass with the event.
+	 */
+	public function track_url_switch_success( array $properties = [] ): void {
+		$properties['action'] = 'success';
+		$this->track_url_switch_event( $properties );
+	}
+
+	/**
+	 * Track the generic url switch event with the action property.
+	 *
+	 * @param array $properties
+	 */
+	protected function track_url_switch_event( array $properties = [] ): void {
+		$this->record_event( 'mc_url_switch', $properties );
+	}
+}

--- a/src/Tracking/Events/SiteClaimEvents.php
+++ b/src/Tracking/Events/SiteClaimEvents.php
@@ -18,7 +18,7 @@ class SiteClaimEvents extends BaseEvent {
 	 * Register the tracking class.
 	 */
 	public function register(): void {
-		add_action( 'gla_site_claim_required', [ $this, 'track_site_claim_required' ] );
+		add_action( 'gla_site_claim_overwrite_required', [ $this, 'track_site_claim_overwrite_required' ] );
 		add_action( 'gla_site_claim_success', [ $this, 'track_site_claim_success' ] );
 		add_action( 'gla_site_claim_failure', [ $this, 'track_site_claim_failure' ] );
 		add_action( 'gla_url_switch_required', [ $this, 'track_url_switch_required' ] );
@@ -26,12 +26,12 @@ class SiteClaimEvents extends BaseEvent {
 	}
 
 	/**
-	 * Track when a site claim needs to be overwritten
+	 * Track when a site claim needs to be overwritten.
 	 *
 	 * @param array $properties Optional additional properties to pass with the event.
 	 */
-	public function track_site_claim_required( array $properties = [] ): void {
-		$properties['action'] = 'required';
+	public function track_site_claim_overwrite_required( array $properties = [] ): void {
+		$properties['action'] = 'overwrite_required';
 		$this->track_site_claim_event( $properties );
 	}
 

--- a/src/Tracking/Events/SiteClaimEvents.php
+++ b/src/Tracking/Events/SiteClaimEvents.php
@@ -69,7 +69,7 @@ class SiteClaimEvents extends BaseEvent {
 	 *
 	 * @param array $properties Optional additional properties to pass with the event.
 	 */
-	public function track_mc_url_switch_required( array $properties = [] ): void {
+	public function track_url_switch_required( array $properties = [] ): void {
 		$properties['action'] = 'required';
 		$this->track_url_switch_event( $properties );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #702.

This adds Tracks events for site claim and URL switching events. There are two event types, and they have `action` and in some cases `details` properties:

- `gla_mc_url_switch` event
    - `action` property is `required`: the Merchant Center account has a different, claimed URL and needs to be changed
    - `action` property is `success`: the Merchant Center account has been changed from blank, updated from a different, unclaimed URL, or after user confirmation of a required change.
- `gla_site_claim` event
    - `action` property is `overwrite_required`: the site URL is claimed by another Merchant Center account and overwrite confirmation is required
    - `action` property is `success`: URL has been successfully set or overwritten.
    - `action` property is `failure`: 
       - `details` property is `independent_account`: unable to execute site claim because the provided Merchant Center account is not a sub-account of our MCA
       - `details` property is `google_proxy`: claim failed using the user creds (in the `Merchant` class)
       - `details` property is `google_manager`: claimed failed using MCA creds (paradoxically in the `Proxy` class)

#### Notes
- This also modifies the Tracks Proxy to fallback to `wc_admin_record_tracks_event()` if `WC_Tracks` isn't loaded (since most of the current server-side Tracks events are in the REST API and [`WooCommerce core only includes Tracks in admin, not the REST API, so we need to include it.`](https://github.com/woocommerce/woocommerce-admin/blob/3afe2e0207b8bc9efff1370672a471b698e3dc5b/includes/core-functions.php#L49)
- Site verification Tracks events still have two separate events for success and failure, not sure if they should be merged in a similar fashion as url switch and site claim (using the `action` property).


### Detailed test instructions:
1. Due to Tracks reporting delays, it's easiest to use logging:
    a. Enable WC tracking: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
    b. Add the following logging lines to the [`Proxies\Tracks` class](https://github.com/woocommerce/google-listings-and-ads/blob/b122a8acc26836fbe73ca5db6f655fd0de0cbd45/src/Proxies/Tracks.php):
    ```php
    public function record_event( string $name, array $properties = [] ): void {
      if ( class_exists( WC_Tracks::class ) ) {
        WC_Tracks::record_event( $name, $properties );
        # ⭐ ⭐ ADD THIS LINE ⬇️
        do_action( 'gla_debug_message', json_encode( $properties), $name . ' with WC_Tracks');
      } elseif ( function_exists( 'wc_admin_record_tracks_event' ) ) {
        wc_admin_record_tracks_event( $name, $properties );
        # ⭐ ⭐ ADD THIS LINE ⬇️
        do_action( 'gla_debug_message', json_encode( $properties), $name . ' with WC Admin');
      }
    }
    ````
1. Run the "Google Merchant Center account" step of Merchant Center onboarding setup with a new sub-account.
    - Confirm success log messages for site verification and site claim:
    ```
    DEBUG gla_site_verify_success with WC_Tracks {"gla_version":"0.6.0"}
    DEBUG gla_site_claim with WC Admin {"gla_version":"0.6.0","details":"google_manager","action":"success"}
    ```
    - Confirm correct Merchant Center account connection.
2. Disconnect the Merchant Center account (using Connection Test) and repeat Step 1. 
    - You'll have to confirm site claim.
    - Confirm log messages for site verification success and site claim failure, overwrite_required, and success:
    ```
    DEBUG gla_site_verify_success with WC Admin {"gla_version":"0.6.0"}
    DEBUG gla_site_claim with WC_Tracks {"gla_version":"0.6.0","details":"google_proxy","action":"failure"}
    DEBUG gla_site_claim with WC_Tracks {"gla_version":"0.6.0","action":"overwrite_required"}
    DEBUG gla_site_claim with WC Admin {"gla_version":"0.6.0","details":"google_manager","action":"success"}
    ```
    - Confirm correct Merchant Center account connection.
Bonus: Claim a different URL with an account, then run the Merchant Center account connection with that account, to confirm the URL switch log messages as well:
    ```
    DEBUG gla_mc_url_switch with WC Admin {"gla_version":"0.6.0","action":"required"}
    DEBUG gla_mc_url_switch with WC Admin {"gla_version":"0.6.0","action":"success"}
    DEBUG gla_site_verify_success with WC_Tracks {"gla_version":"0.6.0"}
    DEBUG gla_site_claim with WC_Tracks {"gla_version":"0.6.0","details":"google_proxy","action":"success"}
    ````

### Changelog Note:

- Tweak - Add Site Claim Tracks events and fallback to WooCommerce Admin WC_Tracks implementation.
