### PR TITLE
Add status box in the Product Feed page

### DIFF
--- a/js/src/product-feed/constants.js
+++ b/js/src/product-feed/constants.js
@@ -1,0 +1,1 @@
+export const ISSUE_TABLE_PER_PAGE = 5;

--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -29,6 +29,7 @@ import ErrorIcon from '.~/components/error-icon';
 import WarningIcon from '.~/components/warning-icon';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import { ISSUE_TABLE_PER_PAGE } from '../constants';
 import './index.scss';
 
 const headers = [
@@ -59,8 +60,6 @@ const headers = [
 	{ key: 'action', label: '', required: true },
 ];
 
-const PER_PAGE = 5;
-
 const actions = (
 	<HelpPopover id="issues-to-resolve">
 		{ createInterpolateElement(
@@ -87,7 +86,7 @@ const IssuesTableCard = () => {
 		'getMCIssues',
 		{
 			page,
-			per_page: PER_PAGE,
+			per_page: ISSUE_TABLE_PER_PAGE,
 		}
 	);
 
@@ -171,7 +170,7 @@ const IssuesTableCard = () => {
 				<CardFooter justify="center">
 					<Pagination
 						page={ page }
-						perPage={ PER_PAGE }
+						perPage={ ISSUE_TABLE_PER_PAGE }
 						total={ data?.total }
 						showPagePicker={ false }
 						showPerPagePicker={ false }

--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -1,8 +1,20 @@
 /**
+ * We use the __experimentalText component to make the card header
+ * looks the same as other card headers on the Product Feed page.
+ */
+
+/**
  * External dependencies
  */
-import { format as formatDate } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	__experimentalText as Text,
+	FlexItem,
+} from '@wordpress/components';
+
 import {
 	SummaryList,
 	SummaryListPlaceholder,
@@ -20,28 +32,19 @@ const ProductStatistics = () => {
 	const { hasFinishedResolution, data } = useMCProductStatistics();
 
 	return (
-		<div className="gla-product-statistics">
-			<div className="gla-product-statistics__last-updated">
-				{ ! hasFinishedResolution &&
-					__( 'Updating…', 'google-listings-and-ads' ) }
-				{ hasFinishedResolution &&
-					! data &&
-					__(
-						'An error occurred while loading product statistics. Please try again later.',
-						'google-listings-and-ads'
-					) }
-				{ hasFinishedResolution && data && (
-					<>
-						{ __( 'Last updated: ', 'google-listings-and-ads' ) }
-						{ formatDate(
-							'Y-m-d H:i:s',
-							new Date( data.timestamp * 1000 )
-						) }
-						<ProductStatusHelpPopover />
-					</>
-				) }
-			</div>
-			<div className="gla-product-statistics__summaries">
+		<Card className="gla-product-statistics">
+			<CardHeader justify="normal">
+				<FlexItem>
+					<Text variant="title.small" as="h2">
+						{ __( 'Overview', 'google-listings-and-ads' ) }
+					</Text>
+				</FlexItem>
+				<ProductStatusHelpPopover />
+			</CardHeader>
+			<CardBody
+				className="gla-product-statistics__summaries"
+				size={ null }
+			>
 				{ ! hasFinishedResolution && (
 					<SummaryListPlaceholder numberOfItems={ 5 } />
 				) }
@@ -91,8 +94,8 @@ const ProductStatistics = () => {
 						] }
 					</SummaryList>
 				) }
-			</div>
-		</div>
+			</CardBody>
+		</Card>
 	);
 };
 

--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -11,6 +11,7 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
+	CardFooter,
 	__experimentalText as Text,
 	FlexItem,
 } from '@wordpress/components';
@@ -26,6 +27,7 @@ import {
  */
 import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
 import ProductStatusHelpPopover from './product-status-help-popover';
+import StatusBox from './status-box';
 import './index.scss';
 
 const ProductStatistics = () => {
@@ -95,6 +97,9 @@ const ProductStatistics = () => {
 					</SummaryList>
 				) }
 			</CardBody>
+			<CardFooter gap={ 0 }>
+				<StatusBox />
+			</CardFooter>
 		</Card>
 	);
 };

--- a/js/src/product-feed/product-statistics/index.scss
+++ b/js/src/product-feed/product-statistics/index.scss
@@ -17,4 +17,46 @@
 			}
 		}
 	}
+
+	// The status box in the footer of the Overview card
+	.components-card__footer {
+		flex-direction: column;
+
+		.components-flex + .components-flex {
+			margin-top: $grid-unit-10;
+		}
+
+		.components-flex__item {
+			color: $gray-900;
+
+			&:first-child {
+				min-width: 130px;
+			}
+
+			&:nth-child(2) {
+				display: inline-flex;
+				align-items: center;
+				fill: currentColor;
+				color: #008a20;
+			}
+
+			&:last-child {
+				color: $gray-700;
+
+				&:not(:empty)::before {
+					content: "•";
+					display: inline-block;
+					margin: 0 $grid-unit-10;
+				}
+			}
+		}
+
+		.gridicon {
+			margin-right: $grid-unit-05;
+		}
+
+		.gridicons-sync {
+			transform: rotateZ(90deg);
+		}
+	}
 }

--- a/js/src/product-feed/product-statistics/index.scss
+++ b/js/src/product-feed/product-statistics/index.scss
@@ -22,6 +22,19 @@
 	.components-card__footer {
 		flex-direction: column;
 
+		@media (max-width: $break-large) {
+			.components-flex {
+				flex-direction: column;
+				align-items: normal;
+				margin: $grid-unit-15 0;
+			}
+
+			.components-flex__item:not(:first-child) {
+				margin-top: $grid-unit-10;
+				margin-left: $grid-unit-20;
+			}
+		}
+
 		.components-flex + .components-flex {
 			margin-top: $grid-unit-10;
 		}

--- a/js/src/product-feed/product-statistics/status-box.js
+++ b/js/src/product-feed/product-statistics/status-box.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
 import { Flex, FlexItem } from '@wordpress/components';
 import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
@@ -106,9 +105,7 @@ function FeedStatus() {
 
 function SyncStatus() {
 	const { data } = useAppSelectDispatch( 'getMCProductStatistics' );
-	const { Icon, highlight, status } = useMemo( () => {
-		return getSyncResult( data );
-	}, [ data ] );
+	const { Icon, highlight, status } = getSyncResult( data );
 
 	return (
 		<Flex justify="normal" gap={ 1 }>

--- a/js/src/product-feed/product-statistics/status-box.js
+++ b/js/src/product-feed/product-statistics/status-box.js
@@ -14,8 +14,8 @@ import GridiconSync from 'gridicons/dist/sync';
 import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
 import { ISSUE_TABLE_PER_PAGE } from '../constants';
 
-function getUnsolvedStatusText( totalUnsolvedIssues = NaN ) {
-	if ( Number.isNaN( totalUnsolvedIssues ) ) {
+function getUnsolvedStatusText( totalUnsolvedIssues ) {
+	if ( ! Number.isInteger( totalUnsolvedIssues ) ) {
 		return '';
 	}
 

--- a/js/src/product-feed/product-statistics/status-box.js
+++ b/js/src/product-feed/product-statistics/status-box.js
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { format as formatDate } from '@wordpress/date';
+import { Flex, FlexItem } from '@wordpress/components';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
+import GridiconSync from 'gridicons/dist/sync';
+
+/**
+ * Internal dependencies
+ */
+import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import { ISSUE_TABLE_PER_PAGE } from '../constants';
+
+function getUnsolvedStatusText( totalUnsolvedIssues = NaN ) {
+	if ( Number.isNaN( totalUnsolvedIssues ) ) {
+		return '';
+	}
+
+	if ( totalUnsolvedIssues === 0 ) {
+		return __( 'No issues to resolve 🎉', 'google-listings-and-ads' );
+	}
+
+	return sprintf(
+		// translators: %d: number of unsolved Merchant Center issues, with minimum value of 1.
+		_n(
+			'%d issue to resolve',
+			'%d issues to resolve',
+			totalUnsolvedIssues,
+			'google-listings-and-ads'
+		),
+		totalUnsolvedIssues
+	);
+}
+
+function getSyncResult( {
+	scheduled_sync: scheduledSync,
+	statistics,
+	timestamp,
+} ) {
+	if ( scheduledSync !== 0 ) {
+		return {
+			Icon: GridiconSync,
+			highlight: __( 'Sync in progress', 'google-listings-and-ads' ),
+			status: null,
+		};
+	}
+
+	const totalSynced = Object.entries( statistics ).reduce(
+		( sum, [ key, num ] ) => {
+			if ( key === 'not_synced' ) {
+				return sum;
+			}
+			return sum + num;
+		},
+		0
+	);
+
+	return {
+		Icon: GridiconCheckmarkCircle,
+		highlight: __(
+			'Automatically synced to Google',
+			'google-listings-and-ads'
+		),
+		status: sprintf(
+			// translators: %s: datetime of last update products sync status, and %d: number of synced products, with minimum value of 1.
+			_n(
+				'Last updated: %1$s, containing %2$d product',
+				'Last updated: %1$s, containing %2$d products',
+				totalSynced,
+				'google-listings-and-ads'
+			),
+			formatDate( 'n F Y, h:ia', new Date( timestamp * 1000 ) ),
+			totalSynced
+		),
+	};
+}
+
+const issuesQuery = {
+	page: 1,
+	per_page: ISSUE_TABLE_PER_PAGE,
+};
+
+function FeedStatus() {
+	const { data } = useAppSelectDispatch( 'getMCIssues', issuesQuery );
+	const status = getUnsolvedStatusText( data?.total );
+
+	return (
+		<Flex justify="normal" gap={ 1 }>
+			<FlexItem>
+				{ __( 'Feed setup:', 'google-listings-and-ads' ) }
+			</FlexItem>
+			<FlexItem>
+				<GridiconCheckmarkCircle />
+				{ __(
+					'Standard free listings setup completed',
+					'google-listings-and-ads'
+				) }
+			</FlexItem>
+			<FlexItem>{ status }</FlexItem>
+		</Flex>
+	);
+}
+
+function SyncStatus() {
+	const { data } = useAppSelectDispatch( 'getMCProductStatistics' );
+	const { Icon, highlight, status } = useMemo( () => {
+		return getSyncResult( data );
+	}, [ data ] );
+
+	return (
+		<Flex justify="normal" gap={ 1 }>
+			<FlexItem>
+				{ __( 'Sync with Google:', 'google-listings-and-ads' ) }
+			</FlexItem>
+			<FlexItem>
+				<Icon />
+				{ highlight }
+			</FlexItem>
+			<FlexItem>{ status }</FlexItem>
+		</Flex>
+	);
+}
+
+export default function StatusBox() {
+	return (
+		<>
+			<FeedStatus />
+			<SyncStatus />
+		</>
+	);
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #716 

- Add card layout to the statistics block and move the help popover into card header
- Implement the \<StatusBox\> and add it into card footer

### ❗ Additional note

With the enhancement of prefetch product feed data made by #629, if I try to re-fetch the product statistics data for updating the "Sync with Google" status, the whole product feed page would be replaced by displaying a loading spinner during the data loading. So I didn't implement the part of status auto-update in this PR.

### Screenshots:

#### 📷 . Has unsolved issues and sync in progress

![2021-06-03 19 23 04](https://user-images.githubusercontent.com/17420811/120639257-bdebe980-c4a3-11eb-8880-6f972f89314d.png)

#### 📷 . Resolved all issues and synced all products

![2021-06-03 19 21 39](https://user-images.githubusercontent.com/17420811/120639276-c0e6da00-c4a3-11eb-8090-44e19957b9b9.png)

### Detailed test instructions:

Mock the `mc/product-statistics` API with the following snippet in `google-listings-and-ads.php`
```php
add_filter(
	'gla_prepared_response_mc-product-statistics',
	function( $response ) {
		return [
			'timestamp' => 1622718951,
			'scheduled_sync' => 1,
			'statistics' => [
				'active' => 100,
				'expiring' => 200,
				'pending' => 300,
				'disapproved' => 400,
				'not_synced' => 500
			]
		];
	},
);
```

Mock the `mc/ssues` API with the following snippet in `google-listings-and-ads.php`
```php
add_filter(
	'gla_prepared_response_mc-issues',
	function( $response ) {
		return [
			'total' => 777,
			'page' => 1,
			'issues' => []
		];
	},
);
```

1. Go to the Product Feed page
2. Change mock data to see if the render logics and visual are correct

### Changelog Note:

> Add status box in the Product Feed page
