### PR TITLE
Refactor product meta to use product object instead of ID

### DIFF
--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -99,7 +99,7 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 			'product_id' => $product_id,
 			'product'    => $product,
 			'visibility' => $this->product_helper->get_visibility( $product ),
-			'synced_at'  => $this->meta_handler->get_synced_at( $product_id ),
+			'synced_at'  => $this->meta_handler->get_synced_at( $product ),
 			'issues'     => [], // todo: replace this with the list of issues retrieved from Google's Product Statuses API
 		];
 	}
@@ -128,7 +128,7 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 			$visibility = empty( $_POST['visibility'] ) ?
 				ChannelVisibility::cast( ChannelVisibility::SYNC_AND_SHOW ) :
 				ChannelVisibility::cast( sanitize_key( $_POST['visibility'] ) );
-			$this->meta_handler->update_visibility( $product_id, $visibility );
+			$this->meta_handler->update_visibility( $product, $visibility );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification
 	}

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -87,7 +87,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 
 		foreach ( $this->product_repository->find( $args, $limit, $offset ) as $product ) {
 			$id     = $product->get_id();
-			$errors = $meta_handler->get_errors( $id ) ?: [];
+			$errors = $meta_handler->get_errors( $product ) ?: [];
 
 			// Combine errors for variable products, which have a variation-indexed array of errors.
 			$first_key = array_key_first( $errors );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -526,7 +526,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		/** @var ProductMetaHandler $product_meta */
 		$product_meta = $this->container->get( ProductMetaHandler::class );
 		/** @var ProductRepository $product_repository */
-		$product_repository = $this->container->get( ProductMetaHandler::class );
+		$product_repository = $this->container->get( ProductRepository::class );
 
 		foreach ( $product_repository->find() as $product ) {
 			$product_meta->update_mc_status( $product, $all_product_statuses[ $product->get_id() ] ?? MCStatus::NOT_SYNCED );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -525,8 +525,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 		/** @var ProductMetaHandler $product_meta */
 		$product_meta = $this->container->get( ProductMetaHandler::class );
-		foreach ( $this->container->get( ProductRepository::class )->find_ids() as $product_id ) {
-			$product_meta->update_mc_status( $product_id, $all_product_statuses[ $product_id ] ?? MCStatus::NOT_SYNCED );
+		/** @var ProductRepository $product_repository */
+		$product_repository = $this->container->get( ProductMetaHandler::class );
+
+		foreach ( $product_repository->find() as $product ) {
+			$product_meta->update_mc_status( $product, $all_product_statuses[ $product->get_id() ] ?? MCStatus::NOT_SYNCED );
 		}
 	}
 

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -243,7 +243,7 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 		$target_audience = $this->merchant_center->get_target_countries();
 		$request_entries = [];
 		foreach ( $products as $product ) {
-			$google_ids = $this->meta_handler->get_google_ids( $product->get_id() );
+			$google_ids = $this->meta_handler->get_google_ids( $product );
 			$stale_ids  = array_diff_key( $google_ids, array_flip( $target_audience ) );
 			foreach ( $stale_ids as $stale_id ) {
 				$request_entries[ $stale_id ] = new BatchProductIDRequestEntry(

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -54,25 +54,23 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param GoogleProduct $google_product
 	 */
 	public function mark_as_synced( WC_Product $product, GoogleProduct $google_product ) {
-		$wc_product_id = $product->get_id();
-
-		$this->meta_handler->update_synced_at( $wc_product_id, time() );
-		$this->meta_handler->update_sync_status( $wc_product_id, SyncStatus::SYNCED );
+		$this->meta_handler->update_synced_at( $product, time() );
+		$this->meta_handler->update_sync_status( $product, SyncStatus::SYNCED );
 		$this->update_empty_visibility( $product );
 
 		// merge and update all google product ids
-		$current_google_ids = $this->meta_handler->get_google_ids( $wc_product_id );
+		$current_google_ids = $this->meta_handler->get_google_ids( $product );
 		$current_google_ids = ! empty( $current_google_ids ) ? $current_google_ids : [];
 		$google_ids         = array_unique( array_merge( $current_google_ids, [ $google_product->getTargetCountry() => $google_product->getId() ] ) );
-		$this->meta_handler->update_google_ids( $wc_product_id, $google_ids );
+		$this->meta_handler->update_google_ids( $product, $google_ids );
 
 		// check if product is synced completely and remove any previous errors if it is
 		$synced_countries = array_keys( $google_ids );
 		$target_countries = $this->merchant_center->get_target_countries();
 		if ( count( $synced_countries ) === count( $target_countries ) && empty( array_diff( $synced_countries, $target_countries ) ) ) {
-			$this->meta_handler->delete_errors( $wc_product_id );
-			$this->meta_handler->delete_failed_sync_attempts( $wc_product_id );
-			$this->meta_handler->delete_sync_failed_at( $wc_product_id );
+			$this->meta_handler->delete_errors( $product );
+			$this->meta_handler->delete_failed_sync_attempts( $product );
+			$this->meta_handler->delete_sync_failed_at( $product );
 		}
 
 		// mark the parent product as synced if it's a variation
@@ -86,14 +84,12 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param WC_Product $product
 	 */
 	public function mark_as_unsynced( WC_Product $product ) {
-		$wc_product_id = $product->get_id();
-
-		$this->meta_handler->delete_synced_at( $wc_product_id );
-		$this->meta_handler->update_sync_status( $wc_product_id, SyncStatus::NOT_SYNCED );
-		$this->meta_handler->delete_google_ids( $wc_product_id );
-		$this->meta_handler->delete_errors( $wc_product_id );
-		$this->meta_handler->delete_failed_sync_attempts( $wc_product_id );
-		$this->meta_handler->delete_sync_failed_at( $wc_product_id );
+		$this->meta_handler->delete_synced_at( $product );
+		$this->meta_handler->update_sync_status( $product, SyncStatus::NOT_SYNCED );
+		$this->meta_handler->delete_google_ids( $product );
+		$this->meta_handler->delete_errors( $product );
+		$this->meta_handler->delete_failed_sync_attempts( $product );
+		$this->meta_handler->delete_sync_failed_at( $product );
 
 		// mark the parent product as un-synced if it's a variation
 		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
@@ -107,9 +103,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param string     $google_id
 	 */
 	public function remove_google_id( WC_Product $product, string $google_id ) {
-		$wc_product_id = $product->get_id();
-
-		$google_ids = $this->meta_handler->get_google_ids( $wc_product_id );
+		$google_ids = $this->meta_handler->get_google_ids( $product );
 		if ( empty( $google_ids ) ) {
 			return;
 		}
@@ -122,7 +116,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 		unset( $google_ids[ $idx ] );
 
 		if ( ! empty( $google_ids ) ) {
-			$this->meta_handler->update_google_ids( $wc_product_id, $google_ids );
+			$this->meta_handler->update_google_ids( $product, $google_ids );
 		} else {
 			// if there are no Google IDs left then this product is no longer considered "synced"
 			$this->mark_as_unsynced( $product );
@@ -144,19 +138,17 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 			return;
 		}
 
-		$wc_product_id = $product->get_id();
-
-		$this->meta_handler->update_errors( $wc_product_id, $errors );
-		$this->meta_handler->update_sync_status( $wc_product_id, SyncStatus::HAS_ERRORS );
+		$this->meta_handler->update_errors( $product, $errors );
+		$this->meta_handler->update_sync_status( $product, SyncStatus::HAS_ERRORS );
 		$this->update_empty_visibility( $product );
 
 		if ( ! empty( $errors[ GoogleProductService::INTERNAL_ERROR_REASON ] ) ) {
 			// update failed sync attempts count in case of internal errors
-			$failed_attempts = ! empty( $this->meta_handler->get_failed_sync_attempts( $wc_product_id ) ) ?
-				$this->meta_handler->get_failed_sync_attempts( $wc_product_id ) :
+			$failed_attempts = ! empty( $this->meta_handler->get_failed_sync_attempts( $product ) ) ?
+				$this->meta_handler->get_failed_sync_attempts( $product ) :
 				0;
-			$this->meta_handler->update_failed_sync_attempts( $wc_product_id, $failed_attempts + 1 );
-			$this->meta_handler->update_sync_failed_at( $wc_product_id, time() );
+			$this->meta_handler->update_failed_sync_attempts( $product, $failed_attempts + 1 );
+			$this->meta_handler->update_sync_failed_at( $product, time() );
 		}
 
 		// mark the parent product as invalid if it's a variation
@@ -164,11 +156,11 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 			$wc_parent_id   = $product->get_parent_id();
 			$parent_product = $this->get_wc_product( $wc_parent_id );
 
-			$parent_errors = ! empty( $this->meta_handler->get_errors( $wc_parent_id ) ) ?
-				$this->meta_handler->get_errors( $wc_parent_id ) :
+			$parent_errors = ! empty( $this->meta_handler->get_errors( $parent_product ) ) ?
+				$this->meta_handler->get_errors( $parent_product ) :
 				[];
 
-			$parent_errors[ $wc_product_id ] = $errors;
+			$parent_errors[ $product->get_id() ] = $errors;
 
 			$this->mark_as_invalid( $parent_product, $parent_errors );
 		}
@@ -182,7 +174,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param WC_Product $product
 	 */
 	public function mark_as_pending( WC_Product $product ) {
-		$this->meta_handler->update_sync_status( $product->get_id(), SyncStatus::PENDING );
+		$this->meta_handler->update_sync_status( $product, SyncStatus::PENDING );
 
 		// mark the parent product as pending if it's a variation
 		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
@@ -198,11 +190,11 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @param WC_Product $product
 	 */
 	protected function update_empty_visibility( WC_Product $product ): void {
-		$product_id = $product instanceof WC_Product_Variation ? $product->get_parent_id() : $product->get_id();
-		$visibility = $this->meta_handler->get_visibility( $product_id );
+		$product    = $product instanceof WC_Product_Variation ? $this->get_wc_product( $product->get_parent_id() ) : $product;
+		$visibility = $this->meta_handler->get_visibility( $product );
 
 		if ( empty( $visibility ) ) {
-			$this->meta_handler->update_visibility( $product_id, ChannelVisibility::SYNC_AND_SHOW );
+			$this->meta_handler->update_visibility( $product, ChannelVisibility::SYNC_AND_SHOW );
 		}
 	}
 
@@ -212,7 +204,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @return string[] An array of Google product IDs stored for each WooCommerce product
 	 */
 	public function get_synced_google_product_ids( WC_Product $product ): array {
-		return $this->meta_handler->get_google_ids( $product->get_id() );
+		return $this->meta_handler->get_google_ids( $product );
 	}
 
 	/**
@@ -240,7 +232,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @return string
 	 */
 	public function get_wc_product_title( string $mc_product_id ): string {
-		$product = wc_get_product( $this->get_wc_product_id( $mc_product_id ) );
+		$product = $this->get_wc_product( $this->get_wc_product_id( $mc_product_id ) );
 		if ( ! $product ) {
 			return $mc_product_id;
 		}
@@ -266,8 +258,8 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @return bool
 	 */
 	public function is_product_synced( WC_Product $product ): bool {
-		$synced_at  = $this->meta_handler->get_synced_at( $product->get_id() );
-		$google_ids = $this->meta_handler->get_google_ids( $product->get_id() );
+		$synced_at  = $this->meta_handler->get_synced_at( $product );
+		$google_ids = $this->meta_handler->get_google_ids( $product );
 
 		return ! empty( $synced_at ) && ! empty( $google_ids );
 	}
@@ -289,10 +281,10 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @return string
 	 */
 	public function get_visibility( WC_Product $wc_product ): string {
-		$visibility = $this->meta_handler->get_visibility( $wc_product->get_id() );
+		$visibility = $this->meta_handler->get_visibility( $wc_product );
 		if ( $wc_product instanceof WC_Product_Variation ) {
 			// todo: we might need to define visibility per variation later.
-			$visibility = $this->meta_handler->get_visibility( $wc_product->get_parent_id() );
+			$visibility = $this->meta_handler->get_visibility( $this->get_wc_product( $wc_product->get_parent_id() ) );
 		}
 
 		return $visibility;
@@ -306,7 +298,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @return string
 	 */
 	public function get_sync_status( WC_Product $wc_product ): string {
-		return $this->meta_handler->get_sync_status( $wc_product->get_id() );
+		return $this->meta_handler->get_sync_status( $wc_product );
 	}
 
 	/**
@@ -318,9 +310,9 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 */
 	public function get_mc_status( WC_Product $wc_product ): string {
 		if ( $wc_product instanceof WC_Product_Variation ) {
-			return $this->meta_handler->get_mc_status( $wc_product->get_parent_id() );
+			return $this->meta_handler->get_mc_status( $this->get_wc_product( $wc_product->get_parent_id() ) );
 		}
-		return $this->meta_handler->get_mc_status( $wc_product->get_id() );
+		return $this->meta_handler->get_mc_status( $wc_product );
 	}
 
 	/**

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidArgument;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidMeta;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -18,30 +17,30 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
  *
- * @method update_synced_at( int $product_id, $value )
- * @method delete_synced_at( int $product_id )
- * @method get_synced_at( int $product_id ): int
- * @method update_google_ids( int $product_id, array $value )
- * @method delete_google_ids( int $product_id )
- * @method get_google_ids( int $product_id ): array
- * @method update_visibility( int $product_id, $value )
- * @method delete_visibility( int $product_id )
- * @method get_visibility( int $product_id ): string
- * @method update_errors( int $product_id, array $value )
- * @method delete_errors( int $product_id )
- * @method get_errors( int $product_id ): array
- * @method update_failed_sync_attempts( int $product_id, int $value )
- * @method delete_failed_sync_attempts( int $product_id )
- * @method get_failed_sync_attempts( int $product_id ): int
- * @method update_sync_failed_at( int $product_id, int $value )
- * @method delete_sync_failed_at( int $product_id )
- * @method get_sync_failed_at( int $product_id ): int
- * @method update_sync_status( int $product_id, string $value )
- * @method delete_sync_status( int $product_id )
- * @method get_sync_status( int $product_id ): string
- * @method update_mc_status( int $product_id, string $value )
- * @method delete_mc_status( int $product_id )
- * @method get_mc_status( int $product_id ): string
+ * @method update_synced_at( WC_Product $product, $value )
+ * @method delete_synced_at( WC_Product $product )
+ * @method get_synced_at( WC_Product $product ): int
+ * @method update_google_ids( WC_Product $product, array $value )
+ * @method delete_google_ids( WC_Product $product )
+ * @method get_google_ids( WC_Product $product ): array
+ * @method update_visibility( WC_Product $product, $value )
+ * @method delete_visibility( WC_Product $product )
+ * @method get_visibility( WC_Product $product ): string
+ * @method update_errors( WC_Product $product, array $value )
+ * @method delete_errors( WC_Product $product )
+ * @method get_errors( WC_Product $product ): array
+ * @method update_failed_sync_attempts( WC_Product $product, int $value )
+ * @method delete_failed_sync_attempts( WC_Product $product )
+ * @method get_failed_sync_attempts( WC_Product $product ): int
+ * @method update_sync_failed_at( WC_Product $product, int $value )
+ * @method delete_sync_failed_at( WC_Product $product )
+ * @method get_sync_failed_at( WC_Product $product ): int
+ * @method update_sync_status( WC_Product $product, string $value )
+ * @method delete_sync_status( WC_Product $product )
+ * @method get_sync_status( WC_Product $product ): string
+ * @method update_mc_status( WC_Product $product, string $value )
+ * @method delete_mc_status( WC_Product $product )
+ * @method get_mc_status( WC_Product $product ): string
  */
 class ProductMetaHandler implements Service, Registerable {
 
@@ -76,14 +75,14 @@ class ProductMetaHandler implements Service, Registerable {
 	 * @throws BadMethodCallException If the method that's called doesn't exist.
 	 * @throws InvalidMeta            If the meta key is invalid.
 	 */
-	public function __call( $name, $arguments ) {
+	public function __call( string $name, $arguments ) {
 		$found_matches = preg_match( '/^([a-z]+)_([\w\d]+)$/i', $name, $matches );
 
 		if ( ! $found_matches ) {
 			throw new BadMethodCallException( sprintf( 'The method %s does not exist in class ProductMetaHandler', $name ) );
 		}
 
-		list( $function_name, $method, $key ) = $matches;
+		[ $function_name, $method, $key ] = $matches;
 
 		// validate the method
 		if ( ! in_array( $method, [ 'update', 'delete', 'get' ], true ) ) {
@@ -101,15 +100,14 @@ class ProductMetaHandler implements Service, Registerable {
 	}
 
 	/**
-	 * @param int    $product_id
-	 * @param string $key
-	 * @param mixed  $value
+	 * @param WC_Product $product
+	 * @param string     $key
+	 * @param mixed      $value
 	 *
 	 * @throws InvalidMeta If the meta key is invalid.
 	 */
-	public function update( int $product_id, string $key, $value ) {
+	public function update( WC_Product $product, string $key, $value ) {
 		self::validate_meta_key( $key );
-		self::validate_product_id( $product_id );
 
 		if ( isset( self::TYPES[ $key ] ) ) {
 			if ( in_array( self::TYPES[ $key ], [ 'bool', 'boolean' ], true ) ) {
@@ -119,35 +117,33 @@ class ProductMetaHandler implements Service, Registerable {
 			}
 		}
 
-		update_post_meta( $product_id, $this->prefix_meta_key( $key ), $value );
+		update_post_meta( $product->get_id(), $this->prefix_meta_key( $key ), $value );
 	}
 
 	/**
-	 * @param int    $product_id
-	 * @param string $key
+	 * @param WC_Product $product
+	 * @param string     $key
 	 *
 	 * @throws InvalidMeta If the meta key is invalid.
 	 */
-	public function delete( int $product_id, string $key ) {
+	public function delete( WC_Product $product, string $key ) {
 		self::validate_meta_key( $key );
-		self::validate_product_id( $product_id );
 
-		delete_post_meta( $product_id, $this->prefix_meta_key( $key ) );
+		delete_post_meta( $product->get_id(), $this->prefix_meta_key( $key ) );
 	}
 
 	/**
-	 * @param int    $product_id
-	 * @param string $key
+	 * @param WC_Product $product
+	 * @param string     $key
 	 *
 	 * @return mixed The value
 	 *
 	 * @throws InvalidMeta If the meta key is invalid.
 	 */
-	public function get( int $product_id, string $key ) {
+	public function get( WC_Product $product, string $key ) {
 		self::validate_meta_key( $key );
-		self::validate_product_id( $product_id );
 
-		$value = get_post_meta( $product_id, $this->prefix_meta_key( $key ), true );
+		$value = get_post_meta( $product->get_id(), $this->prefix_meta_key( $key ), true );
 
 		if ( isset( self::TYPES[ $key ] ) && in_array( self::TYPES[ $key ], [ 'bool', 'boolean' ], true ) ) {
 			$value = wc_string_to_bool( $value );
@@ -174,17 +170,6 @@ class ProductMetaHandler implements Service, Registerable {
 	 */
 	public static function is_meta_key_valid( string $key ): bool {
 		return isset( self::TYPES[ $key ] );
-	}
-
-	/**
-	 * @param int $product_id
-	 *
-	 * @throws InvalidArgument If the provided wc_product_id is not a valid WooCommerce product ID.
-	 */
-	protected static function validate_product_id( int $product_id ) {
-		if ( ! wc_get_product( $product_id ) instanceof WC_Product ) {
-			throw new InvalidArgument( 'Invalid WooCommerce product ID provided.' );
-		}
 	}
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -173,8 +173,8 @@ class ProductRepository implements Service {
 		// skip products that have recently failed to sync.
 		$results = [];
 		foreach ( $products as $product ) {
-			$failed_attempts = $this->meta_handler->get_failed_sync_attempts( $product->get_id() );
-			$failed_at       = $this->meta_handler->get_sync_failed_at( $product->get_id() );
+			$failed_attempts = $this->meta_handler->get_failed_sync_attempts( $product );
+			$failed_at       = $this->meta_handler->get_sync_failed_at( $product );
 
 			// if it has failed less times than the specified threshold OR if syncing it hasn't failed within the specified window
 			if (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR refactors the methods defined in the ProductMetaHandler class and all their usages to use the WooCommerce product object instead of using the product ID. We already had the object in almost all places these methods were called and it seemed redundant to pass their IDs and then do a validation check in this class.

This will make our transition to using another method (https://github.com/woocommerce/google-listings-and-ads/issues/694) easier if we decide to go with the WooCommerce CRUD methods for handling the metadata.


### Detailed test instructions:

I don't think a test is required but since this refactor has an impact mostly on the product syncer and its related functionality, it would be a good idea to go through the process of adding a new product, syncing, editing, and removing it from the Merchant Center to see everything works as expected.
