### PR TITLE
Resolve getLabels immediately, if free listings are requested. …

### DIFF
--- a/js/src/reports/programs/filter-config.js
+++ b/js/src/reports/programs/filter-config.js
@@ -22,14 +22,14 @@ const freeListingsProgramsIds = new Set(
 /**
  * Compares two sets.
  *
- * @param {Set} setA
- * @param {Set} setB
+ * @param {Set} subset
+ * @param {Set} superset
  * @return {boolean} true if these are sets of same elements.
  */
-function equalSet( setA, setB ) {
-	if ( setA.size !== setB.size ) return false;
-	for ( const a of setA ) {
-		if ( ! setB.has( a ) ) {
+function isSubset( subset, superset ) {
+	if ( subset.size > superset.size ) return false;
+	for ( const a of subset ) {
+		if ( ! superset.has( a ) ) {
 			return false;
 		}
 	}
@@ -71,8 +71,8 @@ export const createProgramsFilterConfig = () => {
 		// Get program id(s) from query parameter.
 		const ids = new Set( getIdsFromQuery( param ) );
 		let programs;
-		// If it's one of static values, resolve it immediately.
-		if ( equalSet( ids, freeListingsProgramsIds ) ) {
+		// If it's a subset of static values, resolve it immediately.
+		if ( isSubset( ids, freeListingsProgramsIds ) ) {
 			programs = freeListingsPrograms;
 		} else {
 			// If there are any paid programs, resolve it once we get it.

--- a/js/src/reports/programs/filter-config.test.js
+++ b/js/src/reports/programs/filter-config.test.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { createProgramsFilterConfig } from './filter-config';
+import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
 
 function getAutocompleterOptions( config ) {
 	const filter = config.filters.find( ( el ) => el?.settings?.autocompleter );
@@ -113,6 +114,28 @@ describe( 'createProgramsFilterConfig', () => {
 			labelA = { key: programA.id, label: programA.name };
 			labelB = { key: programB.id, label: programB.name };
 		} );
+
+		test( 'if getLabel is requested for free campaign Id, its resolved immediately without waiting for capmaigns data', async () => {
+			const getConfig = createProgramsFilterConfig();
+			// Initial run.
+			const getLabels = getGetLabels( getConfig( dataLoading ) );
+			// Request free campaign
+			const freeLabelsPromise = getLabels(
+				'' + FREE_LISTINGS_PROGRAM_ID
+			);
+
+			// Not easily testable with Jest:
+			// expect( freeLabelsPromise ).to.be.resolved;
+
+			// Assert resolved value
+			expect( await freeLabelsPromise ).toContainEqual(
+				expect.objectContaining( {
+					key: FREE_LISTINGS_PROGRAM_ID,
+					label: expect.any( String ),
+				} )
+			);
+		} );
+
 		test( 'after initial run should provide getLabels that would eventually resolve with data', () => {
 			const getConfig = createProgramsFilterConfig();
 


### PR DESCRIPTION


### Changes proposed in this Pull Request:
Resolve `getLabels` immediately, if free listings are requested.
Improve the UX, so a user would not have to wait for the paid campaigns to be loaded if they request a free program from a static, hard-coded list.

Improves #651


### Screenshots:

![Screencast that shows free listings label immediately](https://user-images.githubusercontent.com/17435/120664308-1fec2500-c48b-11eb-8b3b-5fcab8f6b872.gif)



### Detailed test instructions:

1. Go to Programs Report page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms`
2. Select "Free Listings" by the dropdown filter
3. Reload the page
4. The selected program label should show up in the filter on page load immediately.


