### PR TITLE
Small ProductQueryFeedHelper Fix

### DIFF
--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -26,7 +26,6 @@ defined( 'ABSPATH' ) || exit;
  * ContainerAware used to access:
  * - MerchantStatuses
  * - ProductHelper
- * - ProductMetaHandler
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\DB
  */
@@ -80,8 +79,6 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 
 		/** @var ProductHelper $product_helper */
 		$product_helper = $this->container->get( ProductHelper::class );
-		/** @var ProductMetaHandler $meta_handler */
-		$meta_handler = $this->container->get( ProductMetaHandler::class );
 
 		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );
 

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -87,7 +87,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 
 		foreach ( $this->product_repository->find( $args, $limit, $offset ) as $product ) {
 			$id     = $product->get_id();
-			$errors = $this->product_helper->get_validation_errors( $product );
+			$errors = $product_helper->get_validation_errors( $product );
 
 			$products[ $id ] = [
 				'id'      => $id,

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -38,7 +38,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fixes a small type from #712, to use the local variable `$product_helper` instead of the non-existent method property `$this->product_helper`. 
- Removes a couple `ProductMetaHandler` references that weren't used anymore.

### Detailed test instructions:

1.  Load the Product Feed page on a site with Merchant Center connected and products synced.
2. Confirm that there's no warning or associated fatal in the log:
    ```
    PHP Warning:  Undefined property: Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper::$product_helper in /…/plugins/google-listings-and-ads/src/DB/ProductFeedQueryHelper.php on line 90
    PHP Fatal error:  Uncaught Error: Call to a member function get_validation_errors() on null in /…/plugins/google-listings-and-ads/src/DB/ProductFeedQueryHelper.php:90
    ```


### Changelog Note:

> Fix - Undefined property warning and related fatal error.
