### PR TITLE
Use Grid Layout to align AppRadioContentControl.

### DIFF
--- a/js/src/components/app-radio-content-control/index.scss
+++ b/js/src/components/app-radio-content-control/index.scss
@@ -1,6 +1,23 @@
 .app-radio-content-control {
-	.app-radio-content-control__content:not(:empty) {
-		margin-top: $grid-unit-10;
-		margin-left: 30px;
+	display: grid;
+	grid-template-columns: [input-start] auto [text-start] 1fr;
+	// Make browser without `column-gap` (mobile Opera and Samsung) use same gap, for both.
+	gap: $grid-unit-10;
+	column-gap: 10px;
+
+	// Hack to align multiple lines of label after the radio/checkbox to the same indentation,
+	// by placing them on the same brid.
+	.components-radio-control,
+	.components-base-control__field,
+	.components-radio-control__option {
+		display: contents;
+
+	}
+	.components-radio-control__input[type="radio"] {
+		margin: 0;
+	}
+	.app-radio-content-control__content {
+		grid-column: text-start;
 	}
 }
+

--- a/js/src/components/app-radio-content-control/index.scss
+++ b/js/src/components/app-radio-content-control/index.scss
@@ -18,6 +18,9 @@
 	}
 	.app-radio-content-control__content {
 		grid-column: text-start;
+		&:empty {
+			display: none;
+		}
 	}
 }
 

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.scss
@@ -16,4 +16,17 @@
 	.price-over-input {
 		max-width: 300px;
 	}
+
+	// Align CheckboxControl and its multiline desription, into two columns.
+	.components-base-control__field {
+		display: grid;
+		grid-template-columns: [input-start] auto [text-start] 1fr;
+		// Make browser without `column-gap` (mobile Opera and Samsung) use same gap, for both.
+		gap: $grid-unit-10;
+		column-gap: 10px;
+
+		.components-checkbox-control__input-container {
+			margin: 0;
+		}
+	}
 }

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -39,6 +39,11 @@
 	border: none;
 }
 
+// hack to fix InputControl suffix's empty right margin.
+.components-input-control__suffix {
+	margin-right: 8px;
+}
+
 // Hack to fix the Tooltip position of the top-right side close button in a Modal component.
 // The follow up can be found here: https://github.com/woocommerce/google-listings-and-ads/issues/203
 .components-modal {

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -39,24 +39,6 @@
 	border: none;
 }
 
-// hack to align multiple lines of label after the radio/checkbox to the same indentation
-.components-base-control__field,
-.components-radio-control__option {
-	display: flex;
-
-	> label {
-		flex: 1 1 0;
-	}
-}
-.components-radio-control__input[type="radio"] {
-	margin-right: 10px;
-}
-
-// hack to fix InputControl suffix's empty right margin.
-.components-input-control__suffix {
-	margin-right: 8px;
-}
-
 // Hack to fix the Tooltip position of the top-right side close button in a Modal component.
 // The follow up can be found here: https://github.com/woocommerce/google-listings-and-ads/issues/203
 .components-modal {


### PR DESCRIPTION
_This is a PRoposed improvement for https://github.com/woocommerce/google-listings-and-ads/pull/720_
### Changes proposed in this Pull Request:

Use Grid Layout to align AppRadioContentControl.

### Screenshots:
![image](https://user-images.githubusercontent.com/17435/120677630-93942f00-c497-11eb-8f8f-c8491e10cecb.png)

![image](https://user-images.githubusercontent.com/17435/120677519-72cbd980-c497-11eb-8e5d-a6c34041812d.png)



### Detailed test instructions:

Same as at https://github.com/woocommerce/google-listings-and-ads/pull/720#issue-659971464

1. Go to the MC setup and the Edit free listings pages
2. Resize the browser width to make the text break to multi-line in the label
3. The visual results should look closer to the design on Figma

### Additional comments

1. Currently, I set column-gap to `10px` and row-gap to one grid unit (`8px`), to match the previous implementation. However, maybe we would like to unify it to the shared grid unit in both directions.
