### PR TITLE
Override values for enhanced free listings issue

### DIFF
--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -132,10 +132,10 @@ const IssuesTableCard = () => {
 								return [
 									{
 										display:
-											el.type === 'account' ? (
-												<ErrorIcon />
-											) : (
+											el.severity === 'warning' ? (
 												<WarningIcon />
+											) : (
+												<ErrorIcon />
 											),
 									},
 									{ display: el.product },

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -146,6 +146,11 @@ class IssuesController extends BaseOptionsController {
 							'description' => __( 'Documentation URL for issue and/or action.', 'google-listings-and-ads' ),
 							'context'     => [ 'view' ],
 						],
+						'severity'             => [
+							'type'        => 'string',
+							'description' => __( 'Severity level of the issue: warning or error.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
 						'applicable_countries' => [
 							'type'        => 'array',
 							'description' => __( 'Country codes of the product audience.', 'google-listings-and-ads' ),

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -41,6 +41,13 @@ class IssuesController extends BaseOptionsController {
 		parent::__construct( $server );
 		$this->merchant_statuses = $merchant_statuses;
 		$this->product_helper    = $product_helper;
+
+		add_filter(
+			'gla_merchant_issue_override',
+			function( $issue ) {
+				return $this->maybe_override_issue_values( $issue );
+			}
+		);
 	}
 
 	/**
@@ -77,6 +84,8 @@ class IssuesController extends BaseOptionsController {
 
 			// Replace variation IDs with parent ID (for Edit links).
 			foreach ( $results['issues'] as &$issue ) {
+				$issue = apply_filters( 'gla_merchant_issue_override', $issue );
+
 				if ( empty( $issue['product_id'] ) ) {
 					continue;
 				}
@@ -210,5 +219,25 @@ class IssuesController extends BaseOptionsController {
 	 */
 	protected function get_schema_title(): string {
 		return 'merchant_issues';
+	}
+
+
+	/**
+	 * In very rare instances, issue values need to be overridden manually.
+	 *
+	 * @param array $issue
+	 *
+	 * @return array The original issue with any possibly overridden values.
+	 */
+	protected function maybe_override_issue_values( array $issue ): array {
+		$is_account_issue = MerchantStatuses::TYPE_ACCOUNT === $issue['type'];
+		if ( $is_account_issue && "Account isn't eligible for enhanced free listings" === $issue['issue'] ) {
+			$issue['issue']      = 'Show products on additional surfaces across Google through enhanced free listings';
+			$issue['severity']   = MerchantStatuses::SEVERITY_WARNING;
+			$issue['action']     = 'Read about enhanced free listings';
+			$issue['action_url'] = 'https://support.google.com/merchants/answer/9199328?hl=en';
+		}
+
+		return $issue;
 	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -43,7 +43,7 @@ class IssuesController extends BaseOptionsController {
 		$this->product_helper    = $product_helper;
 
 		add_filter(
-			'gla_merchant_issue_override',
+			'woocommerce_gla_merchant_issue_override',
 			function( $issue ) {
 				return $this->maybe_override_issue_values( $issue );
 			}
@@ -84,7 +84,7 @@ class IssuesController extends BaseOptionsController {
 
 			// Replace variation IDs with parent ID (for Edit links).
 			foreach ( $results['issues'] as &$issue ) {
-				$issue = apply_filters( 'gla_merchant_issue_override', $issue );
+				$issue = apply_filters( 'woocommerce_gla_merchant_issue_override', $issue );
 
 				if ( empty( $issue['product_id'] ) ) {
 					continue;

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -29,12 +29,13 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `product_id` bigint(20) NOT NULL,
     `issue` varchar(200) NOT NULL,
     `code` varchar(100) NOT NULL,
-    `severity` varchar(20) NOT NULL,
+    `severity` varchar(20) NOT NULL DEFAULT 'warning',
     `product` varchar(100) NOT NULL,
     `action` varchar(100) NOT NULL,
     `action_url` varchar(100) NOT NULL,
     `applicable_countries` text NOT NULL,
     `source` varchar(10) NOT NULL DEFAULT 'mc',
+    `type` varchar(10) NOT NULL DEFAULT 'product',
     `created_at` datetime NOT NULL,
     PRIMARY KEY `id` (`id`),
     UNIQUE KEY `product_issue` (`product_id`, `issue`)
@@ -78,6 +79,7 @@ SQL;
 			'action_url'           => true,
 			'applicable_countries' => true,
 			'source'               => true,
+			'type'                 => true,
 			'created_at'           => true,
 		];
 	}

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -29,10 +29,12 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `product_id` bigint(20) NOT NULL,
     `issue` varchar(200) NOT NULL,
     `code` varchar(100) NOT NULL,
+    `severity` varchar(20) NOT NULL,
     `product` varchar(100) NOT NULL,
     `action` varchar(100) NOT NULL,
     `action_url` varchar(100) NOT NULL,
     `applicable_countries` text NOT NULL,
+    `source` varchar(10) NOT NULL DEFAULT 'mc',
     `created_at` datetime NOT NULL,
     PRIMARY KEY `id` (`id`),
     UNIQUE KEY `product_issue` (`product_id`, `issue`)
@@ -69,11 +71,13 @@ SQL;
 			'id'                   => true,
 			'product_id'           => true,
 			'code'                 => true,
+			'severity'             => true,
 			'issue'                => true,
 			'product'              => true,
 			'action'               => true,
 			'action_url'           => true,
 			'applicable_countries' => true,
+			'source'               => true,
 			'created_at'           => true,
 		];
 	}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -54,6 +54,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	public const TYPE_PRODUCT = 'product';
 
 	/**
+	 * Issue severity levels.
+	 */
+	public const SEVERITY_WARNING = 'warning';
+	public const SEVERITY_ERROR   = 'error';
+
+	/**
 	 * @var DateTime $current_time For cache age operations.
 	 */
 	protected $current_time;
@@ -227,7 +233,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 				'code'       => $row['code'],
 				'action'     => $row['action'],
 				'action_url' => $row['action_url'],
-				'severity'   => $this->is_warning_severity( $row ) ? 'warning' : 'error',
+				'severity'   => $this->get_issue_severity( $row ),
 			];
 			if ( $issue['product_id'] ) {
 				$issue['applicable_countries'] = json_decode( $row['applicable_countries'], true );
@@ -613,14 +619,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	}
 
 	/**
-	 * Return true if a Merchant Issue's severity is warning-level.
+	 * Return a standardized Merchant Issue severity value.
 	 *
 	 * @param array $row
 	 *
-	 * @return bool
+	 * @return string
 	 */
-	protected function is_warning_severity( array $row ): bool {
-		return in_array(
+	protected function get_issue_severity( array $row ): string {
+		$is_warning = in_array(
 			$row['severity'],
 			[
 				'warning',
@@ -630,5 +636,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			],
 			true
 		);
+
+		return $is_warning ? self::SEVERITY_WARNING : self::SEVERITY_ERROR;
 	}
 }

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -227,7 +227,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 				'code'       => $row['code'],
 				'action'     => $row['action'],
 				'action_url' => $row['action_url'],
-				'severity'   => $row['severity'],
+				'severity'   => $this->is_warning_severity( $row ) ? 'warning' : 'error',
 			];
 			if ( $issue['product_id'] ) {
 				$issue['applicable_countries'] = json_decode( $row['applicable_countries'], true );
@@ -610,5 +610,25 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			'code'  => 'presync_error_' . $matches[1],
 			'issue' => "{$matches[2]} [{$matches[1]}]",
 		];
+	}
+
+	/**
+	 * Return true if a Merchant Issue's severity is warning-level.
+	 *
+	 * @param array $row
+	 *
+	 * @return bool
+	 */
+	protected function is_warning_severity( array $row ): bool {
+		return in_array(
+			$row['severity'],
+			[
+				'warning',
+				'suggested',
+				'demoted',
+				'unaffected',
+			],
+			true
+		);
 	}
 }

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -206,8 +206,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 		// Filter by type if valid.
 		if ( in_array( $type, $this->get_valid_issue_types(), true ) ) {
-			$compare = self::TYPE_ACCOUNT === $type ? '=' : '>';
-			$issue_query->where( 'product_id', 0, $compare );
+			$issue_query->where( 'type', $type );
 		} elseif ( null !== $type ) {
 			throw InvalidValue::not_in_allowed_list( 'type filter', $this->get_valid_issue_types() );
 		}
@@ -221,13 +220,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$issues = [];
 		foreach ( $issue_query->get_results() as $row ) {
 			$issue = [
-				'type'       => $row['product_id'] ? self::TYPE_PRODUCT : self::TYPE_ACCOUNT,
+				'type'       => $row['type'],
 				'product_id' => intval( $row['product_id'] ),
 				'product'    => $row['product'],
 				'issue'      => $row['issue'],
 				'code'       => $row['code'],
 				'action'     => $row['action'],
 				'action_url' => $row['action_url'],
+				'severity'   => $row['severity'],
 			];
 			if ( $issue['product_id'] ) {
 				$issue['applicable_countries'] = json_decode( $row['applicable_countries'], true );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -631,7 +631,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			$row['severity'],
 			[
 				'warning',
-				'suggested',
+				'suggestion',
 				'demoted',
 				'unaffected',
 			],

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -312,7 +312,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 				'action'     => __( 'Read more about this account issue', 'google-listings-and-ads' ),
 				'action_url' => $issue->getDocumentation(),
 				'created_at' => $created_at,
-				'type'       => 'account',
+				'type'       => self::TYPE_ACCOUNT,
 				'severity'   => $issue->getSeverity(),
 			];
 		}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -428,7 +428,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 					'product'              => $p->get_name(),
 					'product_id'           => $p->get_id(),
 					'code'                 => $issue_parts['code'],
-					'severity'             => 'error',
+					'severity'             => self::SEVERITY_ERROR,
 					'issue'                => $issue_parts['issue'],
 					'action'               => __( 'Update this attribute in your product data', 'google-listings-and-ads' ),
 					'action_url'           => 'https://support.google.com/merchants/answer/10538362?hl=en&ref_topic=6098333',

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -207,7 +207,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 
 		// Ensure account issues are shown first.
-		$issue_query->set_order( 'product_id' );
+		$issue_query->set_order( 'type' );
+		$issue_query->set_order( 'product' );
 		$issue_query->set_order( 'issue' );
 
 		// Filter by type if valid.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #717.

This PR adds the `woocommerce_gla_merchant_issue_override` filter for overriding issue values in the REST API endpoint response, and adds a method to override one specific account-level error.

#### Notes
- The updated account-level issue flagged in the issue #717 now points to https://support.google.com/merchants/answer/9199328?hl=en
- Issue severity was not initially included in the API response, so it has been added:
    - New `severity` column in the `wp_gla_merchant_issues` table that stores the exact text returned by the API.
    - New `severity` attribute in the REST response that is forced into one of two values: `warning` or `error`:
        - `error` is used by default, and generally applies to pre-sync errors, errors that cause disapproval, or account-level issues with an error severity.
        - `warning` is used for several specific values: `warning`, `suggestion`, `demoted` and `unaffected`.
    - This value is also used to inform which icon to display in the table (red or yellow)
- Also adds a couple other new columns to the `wp_gla_merchant_issues` table:
    - `type` column, which is either 'product' or 'account'. This is useful to sort the product issues by product name instead of product ID.
    - `source` column, which is either `mc` or `pre-sync` for now. Not currently used, but was left out of #713 to avoid modifying the table.
- The REST API response will now include the `severity` attribute for account- and product-level issues (which can be used to determine the icon to display):
    <details>
    <summary>See response example</summary>
    
    ```json
    {
        "type": "account",
        "product": "All products",
        "issue": "No Google Ads account linked",
        "code": "missing_ad_words_link",
        "action": "Read more about this account issue",
        "action_url": "https://support.google.com/merchants/answer/6159060",
        "severity": "error"
    },
    {
        "type": "product",
        "product_id": 624,
        "product": "Album",
        "issue": "This value should not be blank [image]",
        "code": "presync_error_image",
        "action": "Update this attribute in your product data",
        "action_url": "https://support.google.com/merchants/answer/10538362?hl=en&ref_topic=6098333",
        "severity": "error",
        "applicable_countries": [ "all" ]
    },
    {
        "type": "product",
        "product_id": 17,
        "product": "Apple Socks",
        "issue": "Text too short [description]",
        "code": "description_short",
        "action": "Add a more detailed description for your product",
        "action_url": "https://support.google.com/merchants/answer/6098336",
        "severity": "warning",
        "applicable_countries": [ "US"   ]
    },
    ```
    </details>
- For some small subset of users that are upgrading to the version that introduces these changes, and already have their Merchant Center issues cached, they'll see all issues mixed together by type and shown as warnings until the cache is refreshed. Once the cache expires, however, the Issues list will appear as intended.

### Screenshots:
_Updated listing_
![image](https://user-images.githubusercontent.com/228780/120679045-0651da00-c499-11eb-9b28-9d17f7d439ad.png)


### Detailed test instructions:
1. Update the plugin version in `google-listings-and-ads.php` to apply the [`wp_gla_merchant_issues` table updates](https://github.com/woocommerce/google-listings-and-ads/compare/fix/717-enhanced-free-listings-warning?expand=1#diff-0f1b77c0e155b372b2801badb8847a612274caf27bfa5506e399e1133c7a3f2f)
1. Open the Product Feed page for a store that is fully connected and has synced products (`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed`). If this is an pre-existing connection, clear the Merchant Center cache (Connection Test → More Merchant Center → Clear Status Cache) before loading the Product Feed page.
    - Confirm that the first account-level issue has the correct updated text and URL and icon.
    - Confirm that the product-level issues are now sorted by Name instead of ID.
2. Make a REST request to get all issues `GET /wp-json/wc/gla/mc/issues`
    - Confirm that the first account-level issue has the correct updated text and URL.
    - Confirm that the account-level issue also has a severity of `warning`.
    - Confirm that the product-level issues are now sorted by Name instead of ID.
    - Confirm that all issues include the `severity` attribute, with values of `warning` or `error`.
    - Confirm that the icons in the Product Feed page match the `severity` values in the REST API response.

### Changelog Note:

> Fix - Override the enhanced listings account-level error values.
