### PR TITLE
Hide the ChannelVisibilityMetaBox for unsupported products

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -189,6 +189,13 @@ class Admin implements Service, Registerable, Conditional {
 	 * @param MetaBoxInterface $meta_box
 	 */
 	public function add_meta_box( MetaBoxInterface $meta_box ) {
+		add_filter(
+			"postbox_classes_{$meta_box->get_screen()}_{$meta_box->get_id()}",
+			function ( array $classes ) use ( $meta_box ) {
+				return array_merge( $classes, $meta_box->get_classes() );
+			}
+		);
+
 		add_meta_box(
 			$meta_box->get_id(),
 			$meta_box->get_title(),

--- a/src/Admin/MetaBox/AbstractMetaBox.php
+++ b/src/Admin/MetaBox/AbstractMetaBox.php
@@ -71,6 +71,15 @@ abstract class AbstractMetaBox implements MetaBoxInterface {
 	}
 
 	/**
+	 * Returns an array of CSS classes to apply to the box.
+	 *
+	 * @return array
+	 */
+	public function get_classes(): array {
+		return [];
+	}
+
+	/**
 	 * Function that fills the box with the desired content.
 	 *
 	 * The function should echo its output.

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -141,13 +141,11 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 			return;
 		}
 
-		$product = $this->product_helper->get_wc_product( $product_id );
-		if ( $product instanceof WC_Product ) {
-			$visibility = empty( $_POST['visibility'] ) ?
-				ChannelVisibility::cast( ChannelVisibility::SYNC_AND_SHOW ) :
-				ChannelVisibility::cast( sanitize_key( $_POST['visibility'] ) );
-			$this->meta_handler->update_visibility( $product, $visibility );
-		}
+		$product    = $this->product_helper->get_wc_product( $product_id );
+		$visibility = empty( $_POST['visibility'] ) ?
+			ChannelVisibility::cast( ChannelVisibility::SYNC_AND_SHOW ) :
+			ChannelVisibility::cast( sanitize_key( $_POST['visibility'] ) );
+		$this->meta_handler->update_visibility( $product, $visibility );
 		// phpcs:enable WordPress.Security.NonceVerification
 	}
 }

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use WC_Product;
 use WP_Post;
@@ -85,6 +86,22 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	}
 
 	/**
+	 * Returns an array of CSS classes to apply to the box.
+	 *
+	 * @return array
+	 */
+	public function get_classes(): array {
+		$supported_types = ProductSyncer::get_supported_product_types();
+
+		return array_map(
+			function ( string $product_type ) {
+				return "show_if_{$product_type}";
+			},
+			$supported_types
+		);
+	}
+
+	/**
 	 * Returns an array of variables to be used in the view.
 	 *
 	 * @param WP_Post $post The WordPress post object the box is loaded for.
@@ -94,7 +111,7 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	 */
 	protected function get_view_context( WP_Post $post, array $args ): array {
 		$product_id = $post->ID;
-		$product    = wc_get_product( $product_id );
+		$product    = $this->product_helper->get_wc_product( $product_id );
 
 		return [
 			'product_id'  => $product_id,
@@ -124,7 +141,7 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 			return;
 		}
 
-		$product = wc_get_product( $product_id );
+		$product = $this->product_helper->get_wc_product( $product_id );
 		if ( $product instanceof WC_Product ) {
 			$visibility = empty( $_POST['visibility'] ) ?
 				ChannelVisibility::cast( ChannelVisibility::SYNC_AND_SHOW ) :

--- a/src/Admin/MetaBox/MetaBoxInterface.php
+++ b/src/Admin/MetaBox/MetaBoxInterface.php
@@ -79,4 +79,11 @@ interface MetaBoxInterface extends Service, Conditional, Renderable {
 	 * @return array
 	 */
 	public function get_callback_args(): array;
+
+	/**
+	 * Returns an array of CSS classes to apply to the box.
+	 *
+	 * @return array
+	 */
+	public function get_classes(): array;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #737.

This PR adds `show_if` classes to the Channel Visibility meta box to dynamically hide and display it based on the product type. It hides the box when the product type is unsupported.

Note that this only hides the box on the UI and we still update the `_wc_gla_visibility` meta for these products but I don't think that could be an issue.

### Detailed test instructions:

1. Edit a product or add a new one
2. Change the product type to something that we don't support (like Grouped product)
3. The channel visibility box should be hidden
