### PR TITLE
Fix fatal error when duplicating and trashing synced variable products

### DIFF
--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -277,9 +277,16 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @return bool
 	 */
 	public function is_sync_ready( WC_Product $product ): bool {
+		$product_status = $product->get_status();
+		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
+			// Check the post status of the parent product if it's a variation
+			$parent         = $this->get_wc_product( $product->get_parent_id() );
+			$product_status = $parent->get_status();
+		}
+
 		return ( ChannelVisibility::DONT_SYNC_AND_SHOW !== $this->get_visibility( $product ) ) &&
 			   ( in_array( $product->get_type(), ProductSyncer::get_supported_product_types(), true ) ) &&
-			   ( 'publish' === $product->get_status() );
+			   ( 'publish' === $product_status );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #740.

This PR resolves a problem where duplicating or trashing variable products lead to a fatal error.

 It adds several hooks to the `SyncerHooks` class to handle each variation separately instead of updating/deleting the parent product. This is mainly because, during the `duplication` and `trashing` processes, WooCommerce creates/deletes each variation separately. 

In the case of `trash`, WooCommerce removes all variations and then fires the action `trashed_post` for the parent product, leaving us with an empty variable product object that has no children. We now hook into the `woocommerce_delete_product_variation` and `woocommerce_trash_product_variation` actions to handle the deletion of variations and avoid handing the parent variable products.

When duplicating a product, WooCommerce creates a `draft` new product that had no children and then creates and adds the variations to it. However, for some reason, the variations are `published` and not `draft` like the parent. Therefore, the status of a variation product must always be checked via its parent. The `ProductHelper::is_sync_ready` method has been modified to reflect this.

Another issue we had was that when duplicating the product, WooCommerce copied over all of the product's metadata, which included several metadata we use to specify a product's sync status (more specifically: `_wc_gla_google_ids`, `_wc_gla_sync_status`, `_wc_gla_sync_failed_at`, `_wc_gla_errors`, `_wc_gla_failed_sync_attempts`, `_wc_gla_mc_status`, and `_wc_gla_synced_at`). This in combination with the above issue (not detecting draft variations) caused the syncer to think that this new draft product is wrongly synced and try to delete it, causing the fatal error mentioned in #740.

### Detailed test instructions:

1. Create a variable product and add variations.
2. Publish it and wait for it to sync to MC
3. Duplicate the product and make sure it does not sync to MC while it's `draft`
4. Publish the duplicated product and make sure it is synced to MC
5. Trash this product and check that it is deleted from MC
6. Untrash this product and make sure that it gets re-submitted to MC
7. Try the above steps with a simple product as well

### Changelog Note:

Fix - Fatal error when duplicating and trashing synced variable products
