### PR TITLE
Throw an error if no ID is provided

### DIFF
--- a/src/API/Google/Query/AdsQuery.php
+++ b/src/API/Google/Query/AdsQuery.php
@@ -46,8 +46,13 @@ abstract class AdsQuery extends Query {
 	 * @param int             $id     Account ID.
 	 *
 	 * @return QueryInterface
+	 * @throws InvalidProperty If the ID is empty.
 	 */
 	public function set_client( GoogleAdsClient $client, int $id ): QueryInterface {
+		if ( empty( $id ) ) {
+			throw InvalidProperty::not_null( get_class( $this ), 'id' );
+		}
+
 		$this->client = $client;
 		$this->id     = $id;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of fix for #734.

This PR simply fixes the error message that's returned by the API in the situation described by the issue - instead of indicating that the `client` is missing, it indicates that the `id` is missing (i.e., there's no Ads account connected).

The _true_ fix will be on the front end - the two REST API calls for Ads report data (to `/wp-json/wc/gla/ads/reports/programs`) should be omitted if the `glaData.adsSetupComplete` property is `false`.

### Screenshots
The requests to the `/mc/reports/programs` endpoint go through, but the `/ads/reports/programs` requests fail:
![image](https://user-images.githubusercontent.com/228780/120818800-3e1d5800-c553-11eb-9fb8-9e79ae1da310.png)


### Detailed test instructions:

1. Navigate to the Reports -> Programs page on a setup _without_ an Ads account connected.
2. Confirm that the error report for requests to the `/ads/reports/programs` endpoint indicate that the `id` is missing.


### Changelog Note:

- Fix - don't request Ads reporting data if no Ads account is connected.
