### PR TITLE
Do not request ads reports when the setup is incomplete.

### DIFF
--- a/js/src/reports/programs/useProgramsReport.js
+++ b/js/src/reports/programs/useProgramsReport.js
@@ -15,7 +15,11 @@ import {
 	addBaseToPerformance,
 } from '../utils';
 import useUrlQuery from '.~/hooks/useUrlQuery';
-import { FREE_LISTINGS_PROGRAM_ID, REPORT_PROGRAM_PARAM } from '.~/constants';
+import {
+	FREE_LISTINGS_PROGRAM_ID,
+	REPORT_PROGRAM_PARAM,
+	glaData,
+} from '.~/constants';
 
 const category = 'programs';
 const emptyData = {
@@ -167,16 +171,22 @@ function getReports( getReport, query, dateReference ) {
 		queriedPrograms.length === 0 ||
 		queriedPrograms.some( ( id ) => id !== FREE_LISTINGS_PROGRAM_ID );
 
+	// TODO: ideally adsSetupComplete should be retrieved from API endpoint
+	// and then put into wp-data.
+	// With that in place, then we don't need to depend on glaData
+	// which requires force reload using window.location.href.
+	const shouldFetchPaid = containsPaid && glaData.adsSetupComplete;
+
 	const result = {
 		free:
 			( containsFree &&
 				getReport( category, 'free', query, dateReference ) ) ||
 			emptyReport,
 		paid:
-			( containsPaid &&
+			( shouldFetchPaid &&
 				getReport( category, 'paid', query, dateReference ) ) ||
 			emptyReport,
-		expectBoth: containsFree && containsFree,
+		expectBoth: shouldFetchPaid && containsFree,
 	};
 	return result;
 }


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Do not request Ads reports when the setup is incomplete.
Fixes https://github.com/woocommerce/google-listings-and-ads/issues/734


### Screenshots:


![Screencast showing no ads request being made](https://user-images.githubusercontent.com/17435/120828853-4da19e80-c55d-11eb-9882-538f933f25cc.gif)

### Detailed test instructions:

0. Make sure your Ads account is disconnected.
1. Open browser devtools, network tab
1. Navigate to the **Reports -> Programs  (with "All Google programs" selected)**[`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Freports%2Fprograms) page 
2. Confirm that no request is being sent to `/wp-json/wc/gla/ads/reports/programs`


### Changelog Note:

- Fix - don't request Ads reporting data if no Ads account is connected.

### Additional notes:
1. One edge case is not covered, could be handled by another PR/issue
	  - user with the connected accounts visits **Reports > Programs > "Single program [Campaign 1]"**
	  - bookmarks the page/saves the URL/history
	  - disconnects the account
	  - re-visit the page from history or bookmark