### PR TITLE
Show "Unavailable" and more descriptive tooltip when Google API fails

### DIFF
--- a/js/src/components/trackable-link/index.js
+++ b/js/src/components/trackable-link/index.js
@@ -18,12 +18,12 @@ import recordEvent from '.~/utils/recordEvent';
 const TrackableLink = ( props ) => {
 	const { eventName, eventProps, onClick = () => {}, ...rest } = props;
 
-	const handleClick = () => {
+	const handleClick = ( e ) => {
 		if ( eventName ) {
 			recordEvent( eventName, eventProps );
 		}
 
-		onClick();
+		onClick( e );
 	};
 
 	return <Link { ...rest } onClick={ handleClick }></Link>;

--- a/js/src/dashboard/summary-section/performance-card.js
+++ b/js/src/dashboard/summary-section/performance-card.js
@@ -13,7 +13,8 @@ import SummaryCard from './summary-card';
  * @typedef {import('@woocommerce/components').SummaryNumber} SummaryNumber
  */
 
-const googleMCURL = 'https://merchants.google.com/mc/reporting/dashboard';
+const googleMCReportingDashboardURL =
+	'https://merchants.google.com/mc/reporting/dashboard';
 
 /**
  * Returns a Card with performance matrics according to the given data.
@@ -47,8 +48,11 @@ const PerformanceCard = ( {
 				</p>
 				<AppButton
 					eventName="gla_google_mc_link_click"
-					eventProps={ { context: 'dashboard', href: googleMCURL } }
-					href={ googleMCURL }
+					eventProps={ {
+						context: 'dashboard',
+						href: googleMCReportingDashboardURL,
+					} }
+					href={ googleMCReportingDashboardURL }
 					target="_blank"
 					isSmall
 					isSecondary

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -128,14 +128,32 @@ export function mapReportFieldsToPerformance(
 }
 
 /**
- * Calculate performance data by each metric.
+ * Calculate deltas and map indidual ReportField metrics to PerformanceData field.
  *
- * @param {number} [value] The primary report fields fetched from report API.
- * @param {number} [base] The secondary report fields fetched from report API.
+ * @param {number} [value] The primary report field fetched from report API.
+ * @param {number} [base] The secondary report field fetched from report API.
  * @param {MISSING_FREE_LISTINGS_DATA} [missingFreeListingsData] Flag indicating whether the data miss entries from Free Listings.
  * @return {PerformanceData} The calculated performance data of each metric.
  */
-export function fieldsToPerformance( value, base, missingFreeListingsData ) {
+export const fieldsToPerformance = (
+	value,
+	base,
+	missingFreeListingsData
+) => ( {
+	value,
+	delta: calculateDelta( value, base ),
+	prevValue: base,
+	missingFreeListingsData,
+} );
+
+/**
+ * Calculate delta.
+ *
+ * @param {number} [value] The primary report field fetched from report API.
+ * @param {number} [base] The secondary report field fetched from report API.
+ * @return {number | null} The calculated performance data of each metric. `null` if any number is missing, or the result is not finite.
+ */
+function calculateDelta( value, base ) {
 	let delta = null;
 	if ( typeof value === 'number' && typeof base === 'number' ) {
 		delta = 0;
@@ -145,7 +163,7 @@ export function fieldsToPerformance( value, base, missingFreeListingsData ) {
 		}
 	}
 
-	return { value, delta, prevValue: base, missingFreeListingsData };
+	return delta;
 }
 
 /**

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -11,6 +11,19 @@ import round from '.~/utils/round';
 
 export const freeFields = [ 'clicks', 'impressions' ];
 export const paidFields = [ 'sales', 'conversions', 'spend', ...freeFields ];
+/**
+ * Reasons why the free listings data may be missing.
+ *
+ * @enum {number}
+ */
+export const MISSING_FREE_LISTINGS_DATA = Object.freeze( {
+	/** 0 - No anticipated data is missing. */
+	NONE: 0,
+	/** 1 - The data for this metric is not (yet) available in the API and was not even requested. */
+	FOR_METRIC: 1,
+	/** 2 - The data was requested but Google API failed to return it. */
+	FOR_REQUEST: 2,
+} );
 
 /**
  * Get report query for fetching performance data from API.
@@ -91,13 +104,24 @@ export function getReportKey( category, type, reportQuery ) {
  *
  * @param {ReportFieldsSchema} primary The primary report fields fetched from report API.
  * @param {ReportFieldsSchema} secondary The secondary report fields fetched from report API.
+ * @param {Array<string>} [fields] Array of expected metrics.
  * @return {PerformanceData} The calculated performance data of each metric.
  */
-export function mapReportFieldsToPerformance( primary, secondary ) {
-	return Object.keys( primary ).reduce(
+export function mapReportFieldsToPerformance(
+	primary = {},
+	secondary = {},
+	fields
+) {
+	return ( fields || Object.keys( primary ) ).reduce(
 		( acc, key ) => ( {
 			...acc,
-			[ key ]: fieldsToPerformance( primary[ key ], secondary[ key ] ),
+			[ key ]: fieldsToPerformance(
+				primary[ key ],
+				secondary[ key ],
+				! primary[ key ] || ! secondary[ key ]
+					? MISSING_FREE_LISTINGS_DATA.FOR_REQUEST
+					: MISSING_FREE_LISTINGS_DATA.NONE
+			),
 		} ),
 		{}
 	);
@@ -106,17 +130,19 @@ export function mapReportFieldsToPerformance( primary, secondary ) {
 /**
  * Calculate performance data by each metric.
  *
- * @param {ReportFieldsSchema} value The primary report fields fetched from report API.
- * @param {ReportFieldsSchema} base The secondary report fields fetched from report API.
- * @param {boolean} [missingFreeListingsData] Flag indicating whether the data miss entries from Free Listings.
+ * @param {number} [value] The primary report fields fetched from report API.
+ * @param {number} [base] The secondary report fields fetched from report API.
+ * @param {MISSING_FREE_LISTINGS_DATA} [missingFreeListingsData] Flag indicating whether the data miss entries from Free Listings.
  * @return {PerformanceData} The calculated performance data of each metric.
  */
 export function fieldsToPerformance( value, base, missingFreeListingsData ) {
-	let delta = 0;
-
-	if ( value !== base ) {
-		const percent = ( ( value - base ) / base ) * 100;
-		delta = Number.isFinite( percent ) ? round( percent ) : null;
+	let delta = null;
+	if ( typeof value === 'number' && typeof base === 'number' ) {
+		delta = 0;
+		if ( value !== base ) {
+			const percent = ( ( value - base ) / base ) * 100;
+			delta = Number.isFinite( percent ) ? round( percent ) : null;
+		}
 	}
 
 	return { value, delta, prevValue: base, missingFreeListingsData };
@@ -151,5 +177,5 @@ export function fieldsToPerformance( value, base, missingFreeListingsData ) {
  * @property {number} value Value of the current period.
  * @property {number} prevValue Value of the previous period.
  * @property {number} delta The delta of the current value compared to the previous value.
- * @property {boolean} [missingFreeListingsData] Flag indicating whether the data miss entries from Free Listings.
+ * @property {MISSING_FREE_LISTINGS_DATA} [missingFreeListingsData] Flag indicating whether the data miss entries from Free Listings.
  */

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -81,13 +81,13 @@ const MetricNumber = ( {
 	}
 	if ( missingFreeListingsData === MISSING_FREE_LISTINGS_DATA.FOR_REQUEST ) {
 		const text = __(
-			'Please try again later, or go to <linkOfGoogleMerchantCenter /> to track your performance for Google Free Listings.',
+			'Please try again later, or go to <googleMerchantCenterLink /> to track your performance for Google Free Listings.',
 			'google-listings-and-ads'
 		);
 
 		infos.push(
 			createInterpolateElement( text, {
-				linkOfGoogleMerchantCenter: (
+				googleMerchantCenterLink: (
 					<TrackableLink
 						eventName="gla_google_mc_link_click"
 						eventProps={ {
@@ -112,7 +112,7 @@ const MetricNumber = ( {
 
 		// `aria-label` prop only accepts a pure text.
 		const textElement = createInterpolateElement( text, {
-			linkOfGoogleMerchantCenter: (
+			googleMerchantCenterLink: (
 				<>
 					{ sprintf(
 						// translators: %s: link to Google Merchant Center.

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -11,15 +11,11 @@ import GridiconInfoOutline from 'gridicons/dist/info-outline';
  */
 import './metric-number.scss';
 import AppTooltip from '.~/components/app-tooltip';
-import TrackableLink from '.~/components/trackable-link';
 import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
 import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
 import { MISSING_FREE_LISTINGS_DATA } from '.~/data/utils';
 
 const numberFormatSetting = { precision: 0 };
-
-const googleMCReportingDashboardURL =
-	'https://merchants.google.com/mc/reporting/dashboard';
 
 /**
  * SummeryNumber annotated about missing data.
@@ -78,23 +74,11 @@ const MetricNumber = ( {
 			<>
 				{ createInterpolateElement(
 					__(
-						'This data is currently available for paid campaigns only.<br/><br/>Please try again later, or go to <link>merchants.google.com</link> to track your performance for Google Free Listings. ',
+						'This data is currently available for paid campaigns only.<br/><br/>Please try again later, or go to merchants.google.com to track your performance for Google Free Listings.',
 						'google-listings-and-ads'
 					),
 					{
 						br: <br />,
-						link: (
-							<TrackableLink
-								eventName="gla_google_mc_link_click"
-								eventProps={ {
-									context: 'reports',
-									href: googleMCReportingDashboardURL,
-								} }
-								type="external"
-								target="_blank"
-								href={ googleMCReportingDashboardURL }
-							/>
-						),
 					}
 				) }
 			</>

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -18,7 +18,6 @@ import { MISSING_FREE_LISTINGS_DATA } from '.~/data/utils';
 
 const numberFormatSetting = { precision: 0 };
 
-const unavalable = __( 'Unavailable', 'google-listings-and-ads' );
 const googleMCURL = 'https://merchants.google.com/mc/reporting/dashboard';
 
 /**
@@ -53,7 +52,10 @@ const MetricNumber = ( {
 		const formatFn = isCurrency ? formatAmount : formatNumber;
 
 		return {
-			value: value === undefined ? unavalable : formatFn( value ),
+			value:
+				value === undefined
+					? __( 'Unavailable', 'google-listings-and-ads' )
+					: formatFn( value ),
 			prevValue: formatFn( prevValue ),
 		};
 	}, [ isCurrency, value, prevValue, formatNumber, formatAmount ] );

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	useMemo,
 	createInterpolateElement,
@@ -112,7 +112,18 @@ const MetricNumber = ( {
 
 		// `aria-label` prop only accepts a pure text.
 		const textElement = createInterpolateElement( text, {
-			linkOfGoogleMerchantCenter: <>{ googleMCReportingDashboardURL }</>,
+			linkOfGoogleMerchantCenter: (
+				<>
+					{ sprintf(
+						// translators: %s: link to Google Merchant Center.
+						__(
+							'Google Merchant Center (%s)',
+							'google-listings-and-ads'
+						),
+						googleMCReportingDashboardURL
+					) }
+				</>
+			),
 		} );
 		ariaInfos.push( renderToString( textElement ) );
 	}

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
+import { useMemo, createInterpolateElement } from '@wordpress/element';
 import { SummaryNumber } from '@woocommerce/components';
 import GridiconInfoOutline from 'gridicons/dist/info-outline';
 
@@ -11,10 +11,14 @@ import GridiconInfoOutline from 'gridicons/dist/info-outline';
  */
 import './metric-number.scss';
 import AppTooltip from '.~/components/app-tooltip';
+import TrackableLink from '.~/components/trackable-link';
 import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
 import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
 
 const numberFormatSetting = { precision: 0 };
+
+const unavalable = __( 'Unavailable', 'google-listings-and-ads' );
+const googleMCURL = 'https://merchants.google.com/mc/reporting/dashboard';
 
 /**
  * SummeryNumber annotated about missing data.
@@ -48,19 +52,50 @@ const MetricNumber = ( {
 		const formatFn = isCurrency ? formatAmount : formatNumber;
 
 		return {
-			value: formatFn( value ),
+			value: value === null ? unavalable : formatFn( value ),
 			prevValue: formatFn( prevValue ),
 		};
 	}, [ isCurrency, value, prevValue, formatNumber, formatAmount ] );
 
 	let markedLabel = label;
+	let infoText;
 
 	// Until ~Q4 2021, metrics for all programs, may lack data for free listings.
-	if ( missingFreeListingsData ) {
-		const infoText = __(
-			'This data is available for paid campaigns only.',
+	// And Free Listings API may not respond with data.
+	if ( value === null ) {
+		infoText = (
+			<>
+				{ createInterpolateElement(
+					__(
+						'This data is currently available for paid campaigns only.<br/><br/>Please try again later, or go to <link>merchants.google.com</link> to track your performance for Google Free Listings. ',
+						'google-listings-and-ads'
+					),
+					{
+						br: <br />,
+						link: (
+							<TrackableLink
+								eventName="gla_google_mc_link_click"
+								eventProps={ {
+									context: 'reports',
+									href: googleMCURL,
+								} }
+								type="external"
+								target="_blank"
+								href={ googleMCURL }
+							/>
+						),
+					}
+				) }
+			</>
+		);
+	} else if ( missingFreeListingsData ) {
+		infoText = __(
+			'This data is currently available for paid campaigns only.',
 			'google-listings-and-ads'
 		);
+	}
+
+	if ( infoText ) {
 		markedLabel = (
 			<div className="gla-reports__metric-label">
 				{ label }

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -18,7 +18,8 @@ import { MISSING_FREE_LISTINGS_DATA } from '.~/data/utils';
 
 const numberFormatSetting = { precision: 0 };
 
-const googleMCURL = 'https://merchants.google.com/mc/reporting/dashboard';
+const googleMCReportingDashboardURL =
+	'https://merchants.google.com/mc/reporting/dashboard';
 
 /**
  * SummeryNumber annotated about missing data.
@@ -87,11 +88,11 @@ const MetricNumber = ( {
 								eventName="gla_google_mc_link_click"
 								eventProps={ {
 									context: 'reports',
-									href: googleMCURL,
+									href: googleMCReportingDashboardURL,
 								} }
 								type="external"
 								target="_blank"
-								href={ googleMCURL }
+								href={ googleMCReportingDashboardURL }
 							/>
 						),
 					}

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo, createInterpolateElement } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { SummaryNumber } from '@woocommerce/components';
 import GridiconInfoOutline from 'gridicons/dist/info-outline';
 
@@ -58,42 +58,41 @@ const MetricNumber = ( {
 	}, [ isCurrency, value, prevValue, formatNumber, formatAmount ] );
 
 	let markedLabel = label;
-	let infoText;
+	const infos = [];
 
 	// Until ~Q4 2021, metrics for all programs, may lack data for free listings.
 	// And Free Listings API may not respond with data.
-	if ( missingFreeListingsData === MISSING_FREE_LISTINGS_DATA.FOR_METRIC ) {
-		infoText = __(
-			'This data is currently available for paid campaigns only.',
-			'google-listings-and-ads'
+	if ( missingFreeListingsData !== MISSING_FREE_LISTINGS_DATA.NONE ) {
+		infos.push(
+			__(
+				'This data is currently available for paid campaigns only.',
+				'google-listings-and-ads'
+			)
 		);
-	} else if (
-		missingFreeListingsData === MISSING_FREE_LISTINGS_DATA.FOR_REQUEST
-	) {
-		infoText = (
-			<>
-				{ createInterpolateElement(
-					__(
-						'This data is currently available for paid campaigns only.<br/><br/>Please try again later, or go to merchants.google.com to track your performance for Google Free Listings.',
-						'google-listings-and-ads'
-					),
-					{
-						br: <br />,
-					}
-				) }
-			</>
+	}
+	if ( missingFreeListingsData === MISSING_FREE_LISTINGS_DATA.FOR_REQUEST ) {
+		infos.push(
+			__(
+				'Please try again later, or go to merchants.google.com to track your performance for Google Free Listings.',
+				'google-listings-and-ads'
+			)
 		);
 	}
 
-	if ( infoText ) {
+	if ( infos.length > 0 ) {
+		const infoElements = infos.map( ( info, index ) => (
+			<div className="gla-reports__metric-info" key={ index }>
+				{ info }
+			</div>
+		) );
 		markedLabel = (
 			<div className="gla-reports__metric-label">
 				{ label }
-				<AppTooltip text={ infoText }>
+				<AppTooltip text={ infoElements }>
 					<GridiconInfoOutline
 						className="gla-reports__metric-infoicon"
 						role="img"
-						aria-label={ infoText }
+						aria-label={ infos.join( ' ' ) }
 						size={ 16 }
 					/>
 				</AppTooltip>

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -14,6 +14,7 @@ import AppTooltip from '.~/components/app-tooltip';
 import TrackableLink from '.~/components/trackable-link';
 import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
 import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
+import { MISSING_FREE_LISTINGS_DATA } from '.~/data/utils';
 
 const numberFormatSetting = { precision: 0 };
 
@@ -52,7 +53,7 @@ const MetricNumber = ( {
 		const formatFn = isCurrency ? formatAmount : formatNumber;
 
 		return {
-			value: value === null ? unavalable : formatFn( value ),
+			value: value === undefined ? unavalable : formatFn( value ),
 			prevValue: formatFn( prevValue ),
 		};
 	}, [ isCurrency, value, prevValue, formatNumber, formatAmount ] );
@@ -62,7 +63,14 @@ const MetricNumber = ( {
 
 	// Until ~Q4 2021, metrics for all programs, may lack data for free listings.
 	// And Free Listings API may not respond with data.
-	if ( value === null ) {
+	if ( missingFreeListingsData === MISSING_FREE_LISTINGS_DATA.FOR_METRIC ) {
+		infoText = __(
+			'This data is currently available for paid campaigns only.',
+			'google-listings-and-ads'
+		);
+	} else if (
+		missingFreeListingsData === MISSING_FREE_LISTINGS_DATA.FOR_REQUEST
+	) {
 		infoText = (
 			<>
 				{ createInterpolateElement(
@@ -87,11 +95,6 @@ const MetricNumber = ( {
 					}
 				) }
 			</>
-		);
-	} else if ( missingFreeListingsData ) {
-		infoText = __(
-			'This data is currently available for paid campaigns only.',
-			'google-listings-and-ads'
 		);
 	}
 

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -97,6 +97,9 @@ const MetricNumber = ( {
 						type="external"
 						target="_blank"
 						href={ googleMCReportingDashboardURL }
+						// Stop propagation to avoid triggering the <SummaryNumber> `href` prop
+						// that redirects the browser to incorrect pages.
+						onClick={ ( e ) => e.stopPropagation() }
 					>
 						{ __(
 							'Google Merchant Center',

--- a/js/src/reports/metric-number.scss
+++ b/js/src/reports/metric-number.scss
@@ -22,3 +22,13 @@ $icon-color: #949494;
 		fill: darken($color: $icon-color, $amount: 20%);
 	}
 }
+// Provide gutters for tooltip infos.
+// We could have use `gap` on a tooltip, but `<Tooltip>` does not expose it,
+// so let's avoid reliying on its undocumented implementation details.
+.gla-reports__metric-info {
+	margin-bottom: 1em;
+}
+
+.gla-reports__metric-info:last-child {
+	margin-bottom: 0;
+}

--- a/js/src/reports/metric-number.scss
+++ b/js/src/reports/metric-number.scss
@@ -4,7 +4,9 @@
 	gap: 8px;
 
 	.components-tooltip .components-popover__content {
-		text-align: left;
+		min-width: 27em;
+		max-width: 40em;
+		white-space: normal;
 	}
 }
 

--- a/js/src/reports/metric-number.scss
+++ b/js/src/reports/metric-number.scss
@@ -7,18 +7,6 @@
 		min-width: 27em;
 		max-width: 40em;
 		white-space: normal;
-
-		$link-color:  #9ec2e6;
-
-		a {
-			color: $link-color;
-		}
-		a:hover {
-			color: darken($color: $link-color, $amount: 20%);
-		}
-		a:active {
-			color: darken($color: $link-color, $amount: 25%);
-		}
 	}
 }
 

--- a/js/src/reports/metric-number.scss
+++ b/js/src/reports/metric-number.scss
@@ -4,9 +4,21 @@
 	gap: 8px;
 
 	.components-tooltip .components-popover__content {
-		min-width: 27em;
+		min-width: 32em;
 		max-width: 40em;
 		white-space: normal;
+
+		$link-color:  #9ec2e6;
+
+		a {
+			color: $link-color;
+		}
+		a:hover {
+			color: darken($color: $link-color, $amount: 20%);
+		}
+		a:active {
+			color: darken($color: $link-color, $amount: 25%);
+		}
 	}
 }
 

--- a/js/src/reports/metric-number.scss
+++ b/js/src/reports/metric-number.scss
@@ -7,6 +7,18 @@
 		min-width: 27em;
 		max-width: 40em;
 		white-space: normal;
+
+		$link-color:  #9ec2e6;
+
+		a {
+			color: $link-color;
+		}
+		a:hover {
+			color: darken($color: $link-color, $amount: 20%);
+		}
+		a:active {
+			color: darken($color: $link-color, $amount: 25%);
+		}
 	}
 }
 

--- a/js/src/reports/metric-number.scss
+++ b/js/src/reports/metric-number.scss
@@ -2,6 +2,10 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
+
+	.components-tooltip .components-popover__content {
+		text-align: left;
+	}
 }
 
 $icon-color: #949494;

--- a/js/src/reports/products/useProductsReport.js
+++ b/js/src/reports/products/useProductsReport.js
@@ -43,7 +43,8 @@ export default function useProductsReport( type ) {
 					intervals: primary.data.intervals || emptyData.intervals,
 					totals: mapReportFieldsToPerformance(
 						primary.data.totals,
-						secondary.data.totals
+						secondary.data.totals,
+						primary.reportQuery.fields
 					),
 				};
 			}


### PR DESCRIPTION
_Requires #745_

### Changes proposed in this Pull Request:

- Show "Unavailable" and a more descriptive tooltip, on the report pages, when Google API fails to respond with data. (41d2a0d)
	Fixes #748


### Screenshots:
![programs](https://user-images.githubusercontent.com/17435/121088257-bdc25580-c7e5-11eb-8c7e-8ab9dfa61ae4.gif)



### Detailed test instructions:

0. Reproduce scenario when Google does not respond with Free Listings report, or mock the data with 
	  ```php
	  add_filter(
	      'gla_prepared_response_mc-reports-programs',
	      function( $response ) {
		      return [];
	      },
	  );
	  add_filter(
	      'gla_prepared_response_ads-reports-programs',
	      function( $response ) {
		      return json_decode( file_get_contents( __DIR__ . '/tests/mocks/ads/reports/programs.json' ), true ) ?: [];
	      },
	  );
	  add_filter(
	      'gla_prepared_response_ads-reports-products',
	      function( $response ) {
		      return json_decode( file_get_contents( __DIR__ . '/tests/mocks/ads/reports/products.json' ), true ) ?: [];
	      },
	  );
	  add_filter(
	      'gla_prepared_response_mc-reports-products',
	      function( $response ) {
		      return [];
	      },
	  );
	  ```
1. Go to **GLA > Reports** 
2. Hover over tooltips in the performance summary section
3. Switch between `All Google programs, Single "Free", Single "Campaign"`
4. Switch between Programs and Products reports.


### Changelog entry

> Tweak - Show "Unavailable" and more descriptive tooltip when Google reports API fails

### Additional comments:
- For some reason, the link from the tooltip, does not work as `external` even though it's marked as one.
- [x] ~Currently, we show the same message for metrics that miss data due to API failure (`500`, no data), and when the API responds successfully, but without this particular metrics (the "Before Q1 2022" -scenario)~

### Doubts:
@j111q Do you have any comments for the below?

1. I made the `merchants.google.com` a clickable link, to make it easier for users to go there.
2. By default `Tooltip`'s text is aligned to the center, I [set it to `left`](https://github.com/woocommerce/google-listings-and-ads/commit/17e0610c0575be48e4ac9e39b66ff0e2caec7818) in this case, but maybe we should keep it consistent?
	![image](https://user-images.githubusercontent.com/17435/120866152-a5f19400-c58f-11eb-807a-9afb7271198c.png)
	