### PR TITLE
Validate required and incompatible plugins

### DIFF
--- a/src/Exception/ExtensionRequirementException.php
+++ b/src/Exception/ExtensionRequirementException.php
@@ -33,4 +33,21 @@ class ExtensionRequirementException extends RuntimeException implements GoogleLi
 			)
 		);
 	}
+
+	/**
+	 * Create a new instance of the exception when an incompatible plugin/extension is activated.
+	 *
+	 * @param string $plugin_name The name of the incompatible plugin.
+	 *
+	 * @return static
+	 */
+	public static function incompatible_plugin( string $plugin_name ): ExtensionRequirementException {
+		return new static(
+			sprintf(
+				/* translators: 1 the incompatible plugin name */
+				__( 'Google Listings and Ads is incompatible with %1$s.', 'google-listings-and-ads' ),
+				$plugin_name
+			)
+		);
+	}
 }

--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInitializer;
-use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\WCAdminValidator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\PluginValidator;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -108,8 +108,8 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 	 * Register our services if dependency validation passes.
 	 */
 	protected function maybe_register_services(): void {
-		// Don't register anything if WooCommerce Admin isn't enabled, and show the dependency notice.
-		if ( ! WCAdminValidator::instance()->validate() ) {
+		// Don't register anything if a required plugin is missing or an incompatible plugin is active.
+		if ( ! PluginValidator::validate() ) {
 			$this->registered_services = [];
 			return;
 		}

--- a/src/Internal/Requirements/PluginValidator.php
+++ b/src/Internal/Requirements/PluginValidator.php
@@ -1,0 +1,41 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\WCAdminValidator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\WCBookingsValidator;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class PluginValidator
+ *
+ * Display admin notices for required and incompatible plugins.
+ *
+ * @package AutomatticWooCommerceGoogleListingsAndAdsInternalRequirements
+ */
+class PluginValidator {
+
+	private const PLUGINS = [
+		WCAdminValidator::class,
+		WCBookingsValidator::class,
+	];
+
+	/**
+	 * Validate all required and incompatible plugins.
+	 *
+	 * @return bool
+	 */
+	public static function validate(): bool {
+		$validated = true;
+
+		foreach ( self::PLUGINS as $plugin ) {
+			if ( ! $plugin::instance()->validate() ) {
+				$validated = false;
+			}
+		}
+
+		return $validated;
+	}
+}

--- a/src/Internal/Requirements/WCBookingsValidator.php
+++ b/src/Internal/Requirements/WCBookingsValidator.php
@@ -1,0 +1,43 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExtensionRequirementException;
+use WC_Bookings;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WCBookingsValidator
+ *
+ * @package AutomatticWooCommerceGoogleListingsAndAdsInternalRequirements
+ */
+class WCBookingsValidator extends RequirementValidator {
+
+	/**
+	 * Validate all requirements for the plugin to function properly.
+	 *
+	 * @return bool
+	 */
+	public function validate(): bool {
+		try {
+			$this->validate_wc_admin_active();
+			return true;
+		} catch ( ExtensionRequirementException $e ) {
+			$this->add_admin_notice( $e );
+			return false;
+		}
+	}
+
+	/**
+	 * Validate that the incompatible plugin is loaded.
+	 *
+	 * @throws ExtensionRequirementException When WooCommerce Bookings is active.
+	 */
+	protected function validate_wc_admin_active() {
+		if ( class_exists( WC_Bookings::class ) ) {
+			throw ExtensionRequirementException::incompatible_plugin( 'WooCommerce Bookings' );
+		}
+	}
+}

--- a/src/Internal/Requirements/WCBookingsValidator.php
+++ b/src/Internal/Requirements/WCBookingsValidator.php
@@ -22,7 +22,7 @@ class WCBookingsValidator extends RequirementValidator {
 	 */
 	public function validate(): bool {
 		try {
-			$this->validate_wc_admin_active();
+			$this->validate_wc_bookings_active();
 			return true;
 		} catch ( ExtensionRequirementException $e ) {
 			$this->add_admin_notice( $e );
@@ -35,7 +35,7 @@ class WCBookingsValidator extends RequirementValidator {
 	 *
 	 * @throws ExtensionRequirementException When WooCommerce Bookings is active.
 	 */
-	protected function validate_wc_admin_active() {
+	protected function validate_wc_bookings_active() {
 		if ( class_exists( WC_Bookings::class ) ) {
 			throw ExtensionRequirementException::incompatible_plugin( 'WooCommerce Bookings' );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR adds a plugin validator which will check for required and incompatible plugins. An admin notice will be displayed when an incompatible plugin is active and they will be required to deactivate the plugin if they wish to continue using Google Listings and Ads.

Addresses the issues in: https://github.com/woocommerce/woocommerce-bookings/issues/3004#issuecomment-854122066

### Detailed test instructions:

1. Install and activate the WooCommerce Bookings extension
2. Confirm we get the notice `Google Listings and Ads is incompatible with WooCommerce Bookings.` without any fatal errors
3. Confirm that Google Listings and Ads isn't present in the Marketing Menu
4. Disable WC Admin with the snippet `add_filter( 'woocommerce_admin_disabled', '__return_true' );`
5. Confirm that we get both notices
6. Deactivate Bookings and remove the snippet
7. Confirm that the plugin functions as normally

### Changelog Note:
* Fix - Validate required and incompatible plugins.