### PR TITLE
Double check product's sync ready status returned by repository

### DIFF
--- a/src/Integration/WooCommerceProductBundles.php
+++ b/src/Integration/WooCommerceProductBundles.php
@@ -86,7 +86,7 @@ class WooCommerceProductBundles implements IntegrationInterface {
 
 		// filter unsupported bundle products
 		add_filter(
-			'gla_get_sync_ready_products',
+			'gla_get_sync_ready_products_pre_filter',
 			function ( array $products ) {
 				return $this->get_sync_ready_bundle_products( $products );
 			}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -228,9 +228,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( MerchantAccountState::class );
 		$this->share_with_tags( MerchantStatuses::class );
 		$this->share_with_tags( ProductMetaHandler::class );
-		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class );
-		$this->share_with_tags( ProductFactory::class, AttributeManager::class );
 		$this->share( ProductHelper::class, ProductMetaHandler::class, WC::class );
+		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class, ProductHelper::class );
+		$this->share_with_tags( ProductFactory::class, AttributeManager::class );
 		$this->share_with_tags(
 			BatchProductHelper::class,
 			ProductMetaHandler::class,

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -290,6 +290,27 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	}
 
 	/**
+	 * Whether the sync has failed repeatedly for the product within the given timeframe.
+	 *
+	 * @param WC_Product $product
+	 *
+	 * @return bool
+	 *
+	 * @see ProductSyncer::FAILURE_THRESHOLD        The number of failed attempts allowed per timeframe
+	 * @see ProductSyncer::FAILURE_THRESHOLD_WINDOW The specified timeframe
+	 */
+	public function is_sync_failed_recently( WC_Product $product ): bool {
+		$failed_attempts = $this->meta_handler->get_failed_sync_attempts( $product );
+		$failed_at       = $this->meta_handler->get_sync_failed_at( $product );
+
+		// if it has failed more times than the specified threshold AND if syncing it has failed within the specified window
+		return ! empty( $failed_attempts ) &&
+			   ! empty( $failed_at ) &&
+			   $failed_attempts > ProductSyncer::FAILURE_THRESHOLD &&
+			   $failed_at > strtotime( sprintf( '-%s', ProductSyncer::FAILURE_THRESHOLD_WINDOW ) );
+	}
+
+	/**
 	 * @param WC_Product $wc_product
 	 *
 	 * @return string

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -304,9 +304,7 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 		$failed_at       = $this->meta_handler->get_sync_failed_at( $product );
 
 		// if it has failed more times than the specified threshold AND if syncing it has failed within the specified window
-		return ! empty( $failed_attempts ) &&
-			   ! empty( $failed_at ) &&
-			   $failed_attempts > ProductSyncer::FAILURE_THRESHOLD &&
+		return $failed_attempts > ProductSyncer::FAILURE_THRESHOLD &&
 			   $failed_at > strtotime( sprintf( '-%s', ProductSyncer::FAILURE_THRESHOLD_WINDOW ) );
 	}
 

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -192,7 +192,7 @@ class ProductRepository implements Service {
 		 *
 		 * @param WC_Product[] $results Sync-ready WooCommerce products
 		 */
-		return apply_filters( 'gla_get_sync_ready_products_post_filter', $results );
+		return apply_filters( 'gla_get_sync_ready_products_filter', $results );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The query to get sync-ready products returns variations that are not sync-ready because the variation's channel visibility metadata is only set on the parent product. This change checks the sync-ready status of the products returned by the query and takes into account the parent product status.

There was also an issue with draft variations being sent to the product syncer because the `draft` status is only set on the parent variable product. This PR also resolves that issue by checking the parent product's status.

Note that in both cases the variations would not be synced because the ProductSyncer checks the sync-ready status before submitting them to Google. This change only affects the repository method to fetch those sync-ready products so that they don't get scheduled to sync at all.

Split from #728

### Detailed test instructions:

1. Attempt to sync a variable product with its channel visibility set to `don't sync and show` via the connection test page
2. The variations should NOT be scheduled to sync (in the action scheduler job)
3. Also try with a `draft` variable product and make sure its variations are not scheduled to sync

