### PR TITLE
Hide unpublished products from the product feed

### DIFF
--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -83,6 +83,11 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );
 
 		foreach ( $this->product_repository->find( $args, $limit, $offset ) as $product ) {
+			// Skip unpublished products.
+			if ( 'publish' !== $product->get_status() ) {
+				continue;
+			}
+
 			$id     = $product->get_id();
 			$errors = $product_helper->get_validation_errors( $product );
 

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -83,11 +83,6 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );
 
 		foreach ( $this->product_repository->find( $args, $limit, $offset ) as $product ) {
-			// Skip unpublished products.
-			if ( 'publish' !== $product->get_status() ) {
-				continue;
-			}
-
 			$id     = $product->get_id();
 			$errors = $product_helper->get_validation_errors( $product );
 
@@ -138,6 +133,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 
 		$args = [
 			'type'    => $product_types,
+			'status'  => 'publish',
 			'orderby' => [ 'title' => 'ASC' ],
 		];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR hides unpublished products from the Product Feed

#### Notes
This fixes the particular query generated for the Product Feed, but there should probably be a `ProductRepository`-level control on whether draft products are included or not, similar to what's done for `get_sync_ready_products_query_args()`:
https://github.com/woocommerce/google-listings-and-ads/blob/e3f792ce172273cf1e4b6e33240c4ab1428bdc6f/src/Product/ProductRepository.php#L251-L254

### Screenshots:

_Draft products showing("Draft" added manually to name)_
![image](https://user-images.githubusercontent.com/228780/121048381-0b739980-c7b7-11eb-939a-c67121480e4a.png)

_Draft products no longer showing_
![image](https://user-images.githubusercontent.com/228780/121048411-10d0e400-c7b7-11eb-93dd-0911b35ecb6b.png)


### Detailed test instructions:
1. Sync product with Merchant Center
2. Create a new DRAFT product.
3. Confirm the new draft product isn't visible in the Product Feed (`/wp-admin/admin.php?page=wc-admin&path=/google/product-feed`)
  - There should also be 10 results on every page in the Product Feed


### Changelog Note:
- Fix - Hide unpublished products from the Product Feed
