### PR TITLE
Align not synced product stats

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -506,7 +506,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 		/** @var ProductRepository $product_repository */
 		$product_repository                         = $this->container->get( ProductRepository::class );
-		$product_statistics[ MCStatus::NOT_SYNCED ] = count( $product_repository->find_sync_pending_product_ids() );
+		$product_statistics[ MCStatus::NOT_SYNCED ] = count( $product_repository->find_not_synced_product_ids() );
 
 		$this->mc_statuses = [
 			'timestamp'  => $this->current_time->getTimestamp(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This adds a `find_not_synced_product_ids()` method to the `ProductRepository` which returns IDs of products that are `published`, simple/variable, and:
- Set to `sync-and-show` but have pre-sync errors, or
- Set to `dont-sync-and-show`.


This ensures that the numbers in the Product Stats section better line up with the numbers of `Not Synced` products in the Product Feed.

#### Notes
- Previously, the Product Stats showed `sync_ready` products, which were products with `sync-and-show` and errors. However, this included variations and _excluded_ `dont-sync-and-show` products, which meant that the numbers didn't line up with the number of `Not synced` products in the Product Feed
- Since the Product Feed only shows Simple and Variable (parent) products, this count does the same. Variations/geo combinations are still counted once synced to Merchant Center, however.
- Variable products without any variations aren't counted (but do appear as `Not synced` in the Product Feed).
- Like #755, this also excludes draft products, which were previously counted in Product Stats.

### Screenshots:

_Previously, the Product Stats show 37 Not Synced, but the Product Feed only has 2.5 pages of Not Synced products (~25)_
![image](https://user-images.githubusercontent.com/228780/121064699-31ee0080-c7c8-11eb-96d9-90946fd65578.png)

_Now, Product Stats show 23 Not Synced. The Product Feed has 27 products - 3 are drafts, and 1 is a variable product without variations_
![image](https://user-images.githubusercontent.com/228780/121065175-c0628200-c7c8-11eb-89d5-d2547e2af4c7.png)


### Detailed test instructions:
1.  Sync a store with Merchant Center. Make sure some products are set to "Don't Sync and Show", and some have pre-sync errors (no image or price, for example).
2. Clear the MC Status cache (on the Connection Test page).
3. Load the Product Feed page, sort the Product Feed table by "Status" and confirm that the number of Not Synced in the top Product Stats section lines up with the number of Not Synced products in the Product Feed table.


### Changelog Note:

> Fix - More accurately calculate not synced product stats.
