### PR TITLE
Retrieve product IDs and use update_post_meta

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -547,8 +547,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		/** @var ProductRepository $product_repository */
 		$product_repository = $this->container->get( ProductRepository::class );
 
-		foreach ( $product_repository->find() as $product ) {
-			$product_meta->update_mc_status( $product, $all_product_statuses[ $product->get_id() ] ?? MCStatus::NOT_SYNCED );
+		foreach ( $product_repository->find_ids() as $product_id ) {
+			update_post_meta(
+				$product_id,
+				$this->prefix_meta_key( ProductMetaHandler::KEY_MC_STATUS ),
+				$all_product_statuses[ $product_id ] ?? MCStatus::NOT_SYNCED
+			);
 		}
 	}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -546,11 +546,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$product_meta = $this->container->get( ProductMetaHandler::class );
 		/** @var ProductRepository $product_repository */
 		$product_repository = $this->container->get( ProductRepository::class );
+		$mc_status_key      = $this->prefix_meta_key( ProductMetaHandler::KEY_MC_STATUS );
 
 		foreach ( $product_repository->find_ids() as $product_id ) {
 			update_post_meta(
 				$product_id,
-				$this->prefix_meta_key( ProductMetaHandler::KEY_MC_STATUS ),
+				$mc_status_key,
 				$all_product_statuses[ $product_id ] ?? MCStatus::NOT_SYNCED
 			);
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a regression introduced in #729 which changed a query to retrieve all `WC_Products` instead of product IDs. For stores with thousands of products/variations, this can cause memory or timeout errors.

#### Notes
- The fix uses vanilla `update_post_meta`, but will need to be revisited again with regards to #753 
- It still requires each product's Merchant Center status meta value to be updated individually, which is time consuming. This is a candidate for a batched background job.

### Detailed test instructions:

1. Sync some products. 
2. Visit Product Feed page and confirm that the "Status" in the Product Feed table shows updated statuses
    - It may be necessary to wait a couple of minutes for the Google API to reflect changes, and to clear the MC status cache (in Connection Test).

### Changelog Note:

> Fix - Memory limit or execution timeout when updating products' Merchant Center statuses.
