### PR TITLE
 Optimize presync error to issue collation process

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -412,7 +412,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$issue_action       = __( 'Update this attribute in your product data', 'google-listings-and-ads' );
 		$errors_meta_key    = $this->prefix_meta_key( ProductMetaHandler::KEY_ERRORS );
 
-		$update_chunk_limit  = 1000;
+		$update_chunk_limit  = 5000;
 		$update_chunk_offset = 0;
 		do {
 			$product_issues = [];

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -306,7 +306,7 @@ class ProductRepository implements Service {
 	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
 	 * @param int $offset Amount to offset product results.
 	 *
-	 * @return WC_Product[] Array of WooCommerce product objects
+	 * @return int[] Array of WooCommerce product IDs
 	 */
 	public function find_presync_error_product_ids( int $limit = -1, int $offset = 0 ): array {
 		$product_types = ProductSyncer::get_supported_product_types();

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -309,19 +309,21 @@ class ProductRepository implements Service {
 	 * @return WC_Product[] Array of WooCommerce product objects
 	 */
 	public function find_presync_error_product_ids( int $limit = -1, int $offset = 0 ): array {
-		$args['meta_query'] = [
-			'relation' => 'AND',
-			$this->get_sync_ready_products_meta_query(),
-			[
+		$product_types = ProductSyncer::get_supported_product_types();
+		$args          = [
+			'type'       => array_diff( $product_types, [ 'variable' ] ),
+			'meta_query' => [
+				'relation' => 'AND',
+				$this->get_sync_ready_products_meta_query(),
 				[
-					'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
-					'compare' => '=',
-					'value'   => SyncStatus::HAS_ERRORS,
+					[
+						'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
+						'compare' => '=',
+						'value'   => SyncStatus::HAS_ERRORS,
+					],
 				],
 			],
 		];
-		$product_types = ProductSyncer::get_supported_product_types();
-		$args['type']  = array_diff( $product_types, [ 'variable' ] );
 
 		return $this->find_ids( $args, $limit, $offset );
 	}

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -299,18 +299,16 @@ class ProductRepository implements Service {
 		return $this->find_ids( $args, $limit, $offset );
 	}
 
-
-
 	/**
-	 * Find and return an array of WooCommerce product objects that are pending synchronization,
-	 * but have failed pre-sync validation.
+	 * Find and return an array of WooCommerce product IDs that are pending synchronization,
+	 * but have failed pre-sync validation. Excludes variable parent products.
 	 *
 	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
 	 * @param int $offset Amount to offset product results.
 	 *
 	 * @return WC_Product[] Array of WooCommerce product objects
 	 */
-	public function find_presync_error_products( int $limit = -1, int $offset = 0 ): array {
+	public function find_presync_error_product_ids( int $limit = -1, int $offset = 0 ): array {
 		$args['meta_query'] = [
 			'relation' => 'AND',
 			$this->get_sync_ready_products_meta_query(),
@@ -322,8 +320,10 @@ class ProductRepository implements Service {
 				],
 			],
 		];
+		$product_types = ProductSyncer::get_supported_product_types();
+		$args['type']  = array_diff( $product_types, [ 'variable' ] );
 
-		return $this->find( $args, $limit, $offset );
+		return $this->find_ids( $args, $limit, $offset );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #757 .

This PR changes `ProductRepository::find_presync_error_products()` to `ProductRepository::find_presync_error_product_ids()` and excludes `variable` products from the results. Then it uses vanilla WP methods `get_post_meta` and `get_the_title` to retrieve the necessary extra data items instead of loading each WC product. It also breaks the `update_or_insert` queries into chunks of 5,000 to avoid possibly generating a 10,000+ record update.

These changes reduce the `refresh_presync_product_issues()` runtime by ~80% (from over 60 seconds to under 10 in testing).

### Detailed test instructions:
1. Sync a store's products. Make sure some fail presync validation (missing price, missing photo, etc).
3. Truncate the `wp_gla_merchant_issues` table.
4. Clear the MC status cache (using the button on Connection Test).
2. Visit the Product Feed page and confirm that the products with presync errors are listed in the Issues table.
3. Confirm that there are pre-sync issues in `wp_gla_merchant_issues` - the `source` column will be `pre-sync`



### Changelog Note:

> Fix - Optimize presync error to issue collation process.
