### PR TITLE
Fix the problem of the "Create another campaign" button not working

### DIFF
--- a/js/src/dashboard/campaign-creation-success-guide/index.js
+++ b/js/src/dashboard/campaign-creation-success-guide/index.js
@@ -10,6 +10,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
+import { getCreateCampaignUrl } from '.~/utils/urls';
 import AppModal from '.~/components/app-modal';
 import GuidePageContent, {
 	ContentLink,
@@ -20,8 +21,6 @@ import './index.scss';
 const GUIDE_NAME = 'campaign-creation-success';
 const CTA_CREATE_ANOTHER_CAMPAIGN = 'create-another-campaign';
 
-// TODO: The current close method is temporarily for demo.
-//       Need to reconsider how this guide modal would be triggered later.
 const handleCloseWithAction = ( e, specifiedAction ) => {
 	const action = specifiedAction || e.currentTarget.dataset.action;
 	const nextQuery = {
@@ -31,8 +30,7 @@ const handleCloseWithAction = ( e, specifiedAction ) => {
 	getHistory().replace( getNewPath( nextQuery ) );
 
 	if ( action === CTA_CREATE_ANOTHER_CAMPAIGN ) {
-		// TODO: Mutate nextQuery to direct user to campaign creation path after that page ready.
-		getHistory().push( getNewPath( nextQuery ) );
+		getHistory().push( getCreateCampaignUrl() );
 	}
 
 	recordEvent( 'gla_modal_closed', {
@@ -107,9 +105,6 @@ const GuideImplementation = () => {
  *
  * Show this guide modal by visiting the path with a specific query `guide=campaign-creation-success`.
  * For example: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&guide=campaign-creation-success`.
- *
- * TODO: The current open method is temporarily for demo.
- *       Need to reconsider how this guide modal would be triggered later.
  */
 export default function CampaignCreationSuccessGuide() {
 	const isOpen = getQuery().guide === GUIDE_NAME;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #759 

- Implement the redirection of the "Create another campaign" button on the campaign creation success modal

### Screenshots:

![Kapture 2021-06-08 at 10 58 32](https://user-images.githubusercontent.com/17420811/121116593-5e962c80-c849-11eb-9fd8-8d602c8827cd.gif)

### Detailed test instructions:

1. Go to the dashboard page with the opening campaign creation success modal: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&guide=campaign-creation-success`
2. Click on the "Create another campaign" button
3. It should redirect the browser to the campaign creation page

### Changelog Note:

> Fix the problem of the "Create another campaign" button not working
