### PR TITLE
Return empty if no matching attributes found

### DIFF
--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -180,6 +180,10 @@ class AttributeManager implements Service {
 		// re-index the attributes map array to avoid string ($product_type) array keys
 		$match_attributes = array_values( $match_attributes );
 
+		if ( empty( $match_attributes ) ) {
+			return [];
+		}
+
 		// merge all of the attribute arrays from the map (there might be duplicates) and return the results
 		return array_merge( ...$match_attributes );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #763.

This PR fixes an issue with the attributes tab form where it threw an error if loaded for an unsupported product.


### Detailed test instructions:

Follow the reproducing steps in #763 and make sure no error is thrown.


### Changelog Note:

> Fix - Fatal error when loading product edit page for unsupported products
