### PR TITLE
Use empty check for campaign name

### DIFF
--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -120,7 +120,7 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 				$fields = array_intersect_key( $request->get_json_params(), $this->get_schema_properties() );
 
 				// Set the default value of campaign name.
-				if ( $fields['name'] === null ) {
+				if ( empty( $fields['name'] ) ) {
 					$current_date_time = ( new DateTime( 'now', wp_timezone() ) )->format( 'Y-m-d H:i:s' );
 					$fields['name']    = sprintf(
 					/* translators: %s: current date time. */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the name isn't passed in the request we can't check if it's null since the field won't be included in the array of fields. This PR resolves the notice by using an empty check.

Closes #760

### Detailed test instructions:

1. Create a new campaign
2. Confirm there are no notices / warnings shown in the log file or on the site

### Changelog Note:
* Fix - Notice when creating campaign.