### PR TITLE
Catch invalid product ID

### DIFF
--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -232,8 +232,9 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 * @return string
 	 */
 	public function get_wc_product_title( string $mc_product_id ): string {
-		$product = $this->get_wc_product( $this->get_wc_product_id( $mc_product_id ) );
-		if ( ! $product ) {
+		try {
+			$product = $this->get_wc_product( $this->get_wc_product_id( $mc_product_id ) );
+		} catch ( InvalidValue $e ) {
 			return $mc_product_id;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Free Listings product reports were receiving errors if the product no longer exists in the WooCommerce site.

```
Invalid product ID: 2345
```

### Detailed test instructions:

1. Use some mock reports which return free listings products with non existing IDs
2. Observe the 400 error when trying to load Reports > Products > Free Listings
3. Apply PR and notice that the product falls back to using the ID

### Changelog Note:
* Fix - Fallback to product ID when name can't be found.