### PR TITLE
Fix the incorrect enabled state after removing a disabled program from the programs table

### DIFF
--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -113,7 +113,7 @@ const AllProgramsTableCard = ( props ) => {
 							el.id === FREE_LISTINGS_PROGRAM_ID ? (
 								<FreeListingsDisabledToggle />
 							) : (
-								<ProgramToggle program={ el } />
+								<ProgramToggle key={ el.id } program={ el } />
 							),
 					},
 					{

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -121,7 +121,10 @@ const AllProgramsTableCard = ( props ) => {
 							<div className="program-actions">
 								<EditProgramButton programId={ el.id } />
 								{ el.id !== FREE_LISTINGS_PROGRAM_ID && (
-									<RemoveProgramButton programId={ el.id } />
+									<RemoveProgramButton
+										key={ el.id }
+										programId={ el.id }
+									/>
 								) }
 							</div>
 						),

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -104,6 +104,10 @@ const AllProgramsTableCard = ( props ) => {
 			}
 			headers={ headers }
 			rows={ data.map( ( el ) => {
+				// Since the <Table> component uses array index as key to render rows,
+				// it might cause incorrect state control if a column has an internal state.
+				// So we have to specific `key` prop on some components of the `display` to work around it.
+				// Ref: https://github.com/woocommerce/woocommerce-admin/blob/v2.1.2/packages/components/src/table/table.js#L288-L289
 				return [
 					{ display: el.title },
 					{ display: el.country },
@@ -118,13 +122,10 @@ const AllProgramsTableCard = ( props ) => {
 					},
 					{
 						display: (
-							<div className="program-actions">
+							<div className="program-actions" key={ el.id }>
 								<EditProgramButton programId={ el.id } />
 								{ el.id !== FREE_LISTINGS_PROGRAM_ID && (
-									<RemoveProgramButton
-										key={ el.id }
-										programId={ el.id }
-									/>
+									<RemoveProgramButton programId={ el.id } />
 								) }
 							</div>
 						),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #762 

Changes to the programs table on the Dashboard page

- Fix the incorrect enabled state after removing a disabled program
- Bonus: cancel the focus from the "Remove" links after removing a program

### Screenshots:

#### The enabled states are correct after the remove

![Kapture 2021-06-09 at 16 03 32](https://user-images.githubusercontent.com/17420811/121318927-4a802700-c93e-11eb-8bc4-04380e0fc6b1.gif)

#### Cancel the focus

![image](https://user-images.githubusercontent.com/17420811/121319900-3be63f80-c93f-11eb-9d06-405d15e242a4.png)

In the first demo GIF, the focus is locating to the next "Remove" link after the remove. This demo GIF shows that the https://github.com/woocommerce/google-listings-and-ads/commit/82975fe46348c6fce0b8ab1f890b3ee4ccc2301f was to fix this minor issue.

![Kapture 2021-06-09 at 16 03 40](https://user-images.githubusercontent.com/17420811/121319756-19542680-c93f-11eb-94b2-e540a59314ae.gif)

### Detailed test instructions:

1. Create at least two paid programs
2. Disabled the program at the top of the programs table and then remove it
3. The enabled state of the program, which is under that removed program, should be the correct state

### Changelog entry

- The incorrect enabled state after removing a disabled program from the programs table
- Cancel the focus from the "Remove" links after removing a program from the programs table
