### PR TITLE
Fix the PR template format of the changelog section and update its explanations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,6 @@ _Replace this with a good description of your changes & reasoning._
 
 ### Changelog entry
 
-> (Optional) Enter a summary of all changes in this Pull Request to appear in the changelog if it's accepted. 
+> (Optional) Enter a summary of all changes, which could start with `(Fix|Add|Tweak|Update) - `, in this Pull Request to appear in the changelog if it's accepted.
+> Or remain the "Changelog entry" header with empty content if it's no need to show up in the changelog.
+> Otherwise, the title of Pull Request would be used as the changelog content.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,6 @@ _Replace this with a good description of your changes & reasoning._
 3. 
 
 
-### Changelog Note:
+### Changelog entry
 
 > (Optional) Enter a summary of all changes in this Pull Request to appear in the changelog if it's accepted. 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fix the PR template format to fit with the changelog parser of `woorelease`
- Add more explanations about the changelog format

### Detailed test instructions:

According to the [the changelog parser of `woorelease`](https://github.com/woocommerce/woorelease/blob/56223945225487530e49918d786f7203bc2db667/includes/tools/class-changelog.php#L383-L419), I tested it locally by a PHP snippet:

```php
<?php
function trim_prefix( $line ) {
	return ltrim( $line, "*>- \t" );
}

function parse_entry( $data ) {
	if ( preg_match( '/### Changelog entry[\r\n]+(.*)/s', $data['body'], $matches ) ) {
		$lines = preg_split( '/\r?\n/', $matches[1] );
		if ( ! $lines ) {
			return false;
		}

		$changes = array();
		foreach ( $lines as $line ) {
			$line = trim_prefix( $line );

			// Stop when we encounter an empty line.
			if ( empty( $line ) ) {
				break;
			}

			$changes[] = $line;
		}
	} else {
		$changes = (array) $data['title'];
	}

	foreach ( $changes as $key => $change ) {
		// Add prefix if needed.
		if ( ! preg_match( '/^(fix|add|tweak|update)\s+[-:]\s?/i', $change ) ) {
			$changes[ $key ] = 'Fix - ' . $change;
		}

		// Add suffix if needed.
		if ( ! preg_match( '/[\.\?\!]$/', $change ) ) {
			$changes[ $key ] .= '.';
		}
	}

	return $changes;
}

$pr = [
	'title' => "It's my PR title",
	'body' => "### Changes proposed in this Pull Request:
Hi there!

### Changelog entry

> This line will be prepended \"Fix - \" as a fix log
> Fix - something
> Add - new stuff
> Tweak - style
> Update - documents
",
];

var_dump( parse_entry( $pr ) );

```

### Changelog entry
