### PR TITLE
Use woocommerce_gla as filter and action prefix

### DIFF
--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -68,7 +68,7 @@ class Ads implements OptionsAwareInterface {
 		} catch ( ApiException $e ) {
 			// Do not act upon error as we might not have permission to access this account yet.
 			if ( 'PERMISSION_DENIED' !== $e->getStatus() ) {
-				do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+				do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 			}
 		} catch ( ValidationException $e ) {
 			// If no billing setups are found, just return UNKNOWN

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -83,7 +83,7 @@ class AdsCampaign implements OptionsAwareInterface {
 
 			return $return;
 		} catch ( ApiException $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			/* translators: %s Error message */
 			throw new Exception( sprintf( __( 'Error retrieving campaigns: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
@@ -132,7 +132,7 @@ class AdsCampaign implements OptionsAwareInterface {
 				'status' => CampaignStatus::ENABLED,
 			] + $params;
 		} catch ( ApiException $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			if ( $this->has_api_exception_error( $e, 'DUPLICATE_CAMPAIGN_NAME' ) ) {
 				throw new Exception( __( 'A campaign with this name already exists', 'google-listings-and-ads' ) );
@@ -164,7 +164,7 @@ class AdsCampaign implements OptionsAwareInterface {
 
 			return [];
 		} catch ( ApiException $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			/* translators: %s Error message */
 			throw new Exception( sprintf( __( 'Error retrieving campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
@@ -206,7 +206,7 @@ class AdsCampaign implements OptionsAwareInterface {
 
 			return $campaign_id;
 		} catch ( ApiException $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			/* translators: %s Error message */
 			throw new Exception( sprintf( __( 'Error editing campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
@@ -235,7 +235,7 @@ class AdsCampaign implements OptionsAwareInterface {
 
 			return $this->parse_campaign_id( $deleted_campaign->getResourceName() );
 		} catch ( ApiException $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			if ( $this->has_api_exception_error( $e, 'OPERATION_NOT_PERMITTED_FOR_REMOVED_RESOURCE' ) ) {
 				throw new Exception( __( 'This campaign has already been deleted', 'google-listings-and-ads' ) );

--- a/src/API/Google/AdsConversionAction.php
+++ b/src/API/Google/AdsConversionAction.php
@@ -92,7 +92,7 @@ class AdsConversionAction implements OptionsAwareInterface {
 			return $this->get_conversion_action( $added_conversion_action->getResourceName() );
 
 		} catch ( Exception $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 			$message = $e->getMessage();
 			if ( $e instanceof ApiException ) {
 
@@ -128,7 +128,7 @@ class AdsConversionAction implements OptionsAwareInterface {
 
 			return $this->convert_conversion_action( $conversion_action );
 		} catch ( Exception $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 			$message = $e->getMessage();
 			if ( $e instanceof ApiException ) {
 				$message = $e->getBasicMessage();

--- a/src/API/Google/AdsReport.php
+++ b/src/API/Google/AdsReport.php
@@ -86,7 +86,7 @@ class AdsReport implements OptionsAwareInterface {
 
 			return $this->report_data;
 		} catch ( ApiException $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			/* translators: %s Error message */
 			throw new Exception( sprintf( __( 'Unable to retrieve campaign report data: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -63,11 +63,11 @@ class Connection implements OptionsAwareInterface {
 				return $response['oauthUrl'];
 			}
 
-			do_action( 'gla_guzzle_invalid_response', $response, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
 
 			throw new Exception( __( 'Unable to connect Google account', 'google-listings-and-ads' ) );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			throw new Exception( __( 'Unable to connect Google account', 'google-listings-and-ads' ) );
 		}
@@ -88,11 +88,11 @@ class Connection implements OptionsAwareInterface {
 
 			return $result->getBody()->getContents();
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			return $e->getMessage();
 		} catch ( Exception $e ) {
-			do_action( 'gla_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
 
 			return $e->getMessage();
 		}
@@ -118,12 +118,12 @@ class Connection implements OptionsAwareInterface {
 				return $response;
 			}
 
-			do_action( 'gla_guzzle_invalid_response', $response, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
 
 			$message = $response['message'] ?? __( 'Invalid response when retrieving status', 'google-listings-and-ads' );
 			throw new Exception( $message, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error retrieving status', 'google-listings-and-ads' ) ) );
 		}

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -80,10 +80,10 @@ class Merchant implements OptionsAwareInterface {
 			$id     = $this->options->get_merchant_id();
 			$params = $overwrite ? [ 'overwrite' => true ] : [];
 			$this->service->accounts->claimwebsite( $id, $id, $params );
-			do_action( 'gla_site_claim_success', [ 'details' => 'google_proxy' ] );
+			do_action( 'woocommerce_gla_site_claim_success', [ 'details' => 'google_proxy' ] );
 		} catch ( GoogleException $e ) {
-			do_action( 'gla_mc_client_exception', $e, __METHOD__ );
-			do_action( 'gla_site_claim_failure', [ 'details' => 'google_proxy' ] );
+			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'google_proxy' ] );
 
 			$error_message = __( 'Unable to claim website.', 'google-listings-and-ads' );
 			if ( 403 === $e->getCode() ) {
@@ -107,7 +107,7 @@ class Merchant implements OptionsAwareInterface {
 		try {
 			$mc_account = $this->service->accounts->get( $id, $id );
 		} catch ( GoogleException $e ) {
-			do_action( 'gla_mc_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to retrieve merchant center account.', 'google-listings-and-ads' ), $e->getCode() );
 		}
 		return $mc_account;
@@ -126,7 +126,7 @@ class Merchant implements OptionsAwareInterface {
 		try {
 			$mc_account_status = $this->service->accountstatuses->get( $id, $id );
 		} catch ( GoogleException $e ) {
-			do_action( 'gla_mc_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to retrieve merchant center account status.', 'google-listings-and-ads' ), $e->getCode() );
 		}
 		return $mc_account_status;
@@ -160,7 +160,7 @@ class Merchant implements OptionsAwareInterface {
 		try {
 			$mc_account = $this->service->accounts->update( $mc_account->getId(), $mc_account->getId(), $mc_account );
 		} catch ( GoogleException $e ) {
-			do_action( 'gla_mc_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to update merchant center account.', 'google-listings-and-ads' ), $e->getCode() );
 		}
 		return $mc_account;

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -92,7 +92,7 @@ class MerchantReport implements OptionsAwareInterface {
 
 			return $this->report_data;
 		} catch ( GoogleException $e ) {
-			do_action( 'gla_mc_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to retrieve report data.', 'google-listings-and-ads' ), $e->getCode() );
 		}
 	}

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -67,7 +67,7 @@ class Proxy implements OptionsAwareInterface {
 
 			return $ids;
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error retrieving accounts', 'google-listings-and-ads' ) ) );
 		}
@@ -114,12 +114,12 @@ class Proxy implements OptionsAwareInterface {
 				return $id;
 			}
 
-			do_action( 'gla_guzzle_invalid_response', $response, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
 
 			$error = $response['message'] ?? __( 'Invalid response when creating account', 'google-listings-and-ads' );
 			throw new Exception( $error, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) ) );
 		}
@@ -165,12 +165,12 @@ class Proxy implements OptionsAwareInterface {
 				return true;
 			}
 
-			do_action( 'gla_guzzle_invalid_response', $response, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
 
 			$error = $response['message'] ?? __( 'Invalid response when linking merchant to MCA', 'google-listings-and-ads' );
 			throw new Exception( $error, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error linking merchant to MCA', 'google-listings-and-ads' ) ) );
 		}
@@ -202,18 +202,18 @@ class Proxy implements OptionsAwareInterface {
 			$response = json_decode( $result->getBody()->getContents(), true );
 
 			if ( 200 === $result->getStatusCode() && isset( $response['status'] ) && 'success' === $response['status'] ) {
-				do_action( 'gla_site_claim_success', [ 'details' => 'google_manager' ] );
+				do_action( 'woocommerce_gla_site_claim_success', [ 'details' => 'google_manager' ] );
 				return true;
 			}
 
-			do_action( 'gla_guzzle_invalid_response', $response, __METHOD__ );
-			do_action( 'gla_site_claim_failure', [ 'details' => 'google_manager' ] );
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+			do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'google_manager' ] );
 
 			$error = $response['message'] ?? __( 'Invalid response when claiming website', 'google-listings-and-ads' );
 			throw new Exception( $error, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
-			do_action( 'gla_site_claim_failure', [ 'details' => 'google_manager' ] );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'google_manager' ] );
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error claiming website', 'google-listings-and-ads' ) ) );
 		}
@@ -240,7 +240,7 @@ class Proxy implements OptionsAwareInterface {
 
 			return $ids;
 		} catch ( ApiException $e ) {
-			do_action( 'gla_ads_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			// Return an empty list if the user has not signed up to ads yet.
 			if ( $this->has_api_exception_error( $e, 'NOT_ADS_USER' ) ) {
@@ -302,12 +302,12 @@ class Proxy implements OptionsAwareInterface {
 				];
 			}
 
-			do_action( 'gla_guzzle_invalid_response', $response, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
 
 			$error = $response['message'] ?? __( 'Invalid response when creating account', 'google-listings-and-ads' );
 			throw new Exception( $error, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) ) );
 		}
@@ -344,12 +344,12 @@ class Proxy implements OptionsAwareInterface {
 				return [ 'id' => $id ];
 			}
 
-			do_action( 'gla_guzzle_invalid_response', $response, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
 
 			$error = $response['message'] ?? __( 'Invalid response when linking account', 'google-listings-and-ads' );
 			throw new Exception( $error, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error linking account', 'google-listings-and-ads' ) ) );
 		}
@@ -402,7 +402,7 @@ class Proxy implements OptionsAwareInterface {
 
 			return new TosAccepted( 200 === $result->getStatusCode(), $result->getBody()->getContents() );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			return new TosAccepted( false, $e->getMessage() );
 		}
@@ -437,7 +437,7 @@ class Proxy implements OptionsAwareInterface {
 				$result->getBody()->getContents() ?? $result->getReasonPhrase()
 			);
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'gla_guzzle_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
 			return new TosAccepted( false, $e->getMessage() );
 		}

--- a/src/API/Google/SiteVerification.php
+++ b/src/API/Google/SiteVerification.php
@@ -77,7 +77,7 @@ class SiteVerification {
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			$response = $service->webResource->getToken( $post_body );
 		} catch ( GoogleException $e ) {
-			do_action( 'gla_sv_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_sv_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to retrieve site verification token.', 'google-listings-and-ads' ) );
 		}
 
@@ -110,7 +110,7 @@ class SiteVerification {
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			$service->webResource->insert( self::VERIFICATION_METHOD, $post_body );
 		} catch ( GoogleException $e ) {
-			do_action( 'gla_sv_client_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_sv_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to insert site verification.', 'google-listings-and-ads' ) );
 		}
 

--- a/src/API/Site/Controllers/Ads/SetupCompleteController.php
+++ b/src/API/Site/Controllers/Ads/SetupCompleteController.php
@@ -43,7 +43,7 @@ class SetupCompleteController extends BaseController {
 	 */
 	protected function get_setup_complete_callback(): callable {
 		return function( Request $request ) {
-			do_action( 'gla_ads_setup_completed' );
+			do_action( 'woocommerce_gla_ads_setup_completed' );
 
 			return new Response(
 				[

--- a/src/API/Site/Controllers/BaseController.php
+++ b/src/API/Site/Controllers/BaseController.php
@@ -148,7 +148,7 @@ abstract class BaseController extends WC_REST_Controller implements Registerable
 		$prepared = $this->add_additional_fields_to_object( $prepared, $request );
 		$prepared = $this->filter_response_by_context( $prepared, $context );
 		$prepared = apply_filters(
-			'gla_prepared_response_' . $this->get_route_name( $request ),
+			'woocommerce_gla_prepared_response_' . $this->get_route_name( $request ),
 			$prepared,
 			$request
 		);

--- a/src/API/Site/Controllers/Google/SiteVerificationController.php
+++ b/src/API/Site/Controllers/Google/SiteVerificationController.php
@@ -81,7 +81,7 @@ class SiteVerificationController extends BaseOptionsController {
 			try {
 				$meta_tag = $this->site_verification->get_token( $site_url );
 			} catch ( Exception $e ) {
-				do_action( "{$this->get_slug()}_site_verify_failure", [ 'step' => 'token' ] );
+				do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'token' ] );
 
 				return $this->get_failure_status( $e->getMessage() );
 			}
@@ -101,18 +101,18 @@ class SiteVerificationController extends BaseOptionsController {
 				if ( $this->site_verification->insert( $site_url ) ) {
 					$site_verification_options['verified'] = 'yes';
 					$this->options->update( OptionsInterface::SITE_VERIFICATION, $site_verification_options );
-					do_action( "{$this->get_slug()}_site_verify_success", [] );
+					do_action( 'woocommerce_gla_site_verify_success', [] );
 
 					return $this->get_success_status( __( 'Site successfully verified.', 'google-listings-and-ads' ) );
 				}
 			} catch ( Exception $e ) {
-				do_action( "{$this->get_slug()}_site_verify_failure", [ 'step' => 'meta-tag' ] );
+				do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'meta-tag' ] );
 
 				return $this->get_failure_status( $e->getMessage() );
 			}
 
 			// Should never reach this point.
-			do_action( "{$this->get_slug()}_site_verify_failure", [ 'step' => 'unknown' ] );
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'unknown' ] );
 
 			return $this->get_failure_status();
 		};

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -440,12 +440,12 @@ class AccountController extends BaseOptionsController {
 
 					// Sub-account: request overwrite confirmation.
 					if ( $state['set_id']['data']['from_mca'] ?? true ) {
-						do_action( 'gla_site_claim_overwrite_required', [] );
+						do_action( 'woocommerce_gla_site_claim_overwrite_required', [] );
 
 						$step['data']['overwrite_required'] = true;
 						$e                                  = new ExceptionWithResponseData( $e->getMessage(), $e->getCode(), null, $data );
 					} else {
-						do_action( 'gla_site_claim_failure', [ 'details' => 'independent_account' ] );
+						do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'independent_account' ] );
 
 						// Independent account: overwrite not possible.
 						throw new ExceptionWithResponseData(
@@ -481,7 +481,7 @@ class AccountController extends BaseOptionsController {
 	private function verify_site(): void {
 		$site_url = esc_url_raw( apply_filters( 'woocommerce_gla_site_url', site_url() ) );
 		if ( ! wc_is_valid_url( $site_url ) ) {
-			do_action( 'gla_site_verify_failure', [ 'step' => 'site-url' ] );
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'site-url' ] );
 			throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
 		}
 
@@ -496,7 +496,7 @@ class AccountController extends BaseOptionsController {
 		try {
 			$meta_tag = $site_verification->get_token( $site_url );
 		} catch ( Exception $e ) {
-			do_action( 'gla_site_verify_failure', [ 'step' => 'token' ] );
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'token' ] );
 			throw $e;
 		}
 
@@ -515,18 +515,18 @@ class AccountController extends BaseOptionsController {
 			if ( $site_verification->insert( $site_url ) ) {
 				$site_verification_options['verified'] = $site_verification::VERIFICATION_STATUS_VERIFIED;
 				$this->options->update( OptionsInterface::SITE_VERIFICATION, $site_verification_options );
-				do_action( 'gla_site_verify_success', [] );
+				do_action( 'woocommerce_gla_site_verify_success', [] );
 
 				return;
 			}
 		} catch ( Exception $e ) {
-			do_action( 'gla_site_verify_failure', [ 'step' => 'meta-tag' ] );
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'meta-tag' ] );
 
 			throw $e;
 		}
 
 		// Should never reach this point.
-		do_action( 'gla_site_verify_failure', [ 'step' => 'unknown' ] );
+		do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'unknown' ] );
 
 		throw new Exception( __( 'Site verification failed.', 'google-listings-and-ads' ) );
 	}
@@ -602,7 +602,7 @@ class AccountController extends BaseOptionsController {
 				$clean_account_website_url = $this->strip_url_protocol( $account_website_url );
 				$clean_site_website_url    = $this->strip_url_protocol( $site_website_url );
 
-				do_action( 'gla_url_switch_required', [] );
+				do_action( 'woocommerce_gla_url_switch_required', [] );
 
 				throw new ExceptionWithResponseData(
 					sprintf(
@@ -623,7 +623,7 @@ class AccountController extends BaseOptionsController {
 			$mc_account->setWebsiteUrl( $site_website_url );
 			$this->merchant->update_account( $mc_account );
 
-			do_action( 'gla_url_switch_success', [] );
+			do_action( 'woocommerce_gla_url_switch_success', [] );
 		}
 	}
 

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -94,7 +94,7 @@ class IssuesController extends BaseOptionsController {
 				} catch ( InvalidValue $e ) {
 					// Don't include valid products
 					do_action(
-						'gla_debug_message',
+						'woocommerce_gla_debug_message',
 						sprintf( 'Merchant Center product ID %s not found in this WooCommerce store.', $issue['product_id'] ),
 						__METHOD__,
 					);

--- a/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
@@ -66,7 +66,7 @@ class SettingsSyncController extends BaseController {
 				$this->settings->sync_taxes();
 				$this->settings->sync_shipping();
 
-				do_action( 'gla_mc_settings_sync' );
+				do_action( 'woocommerce_gla_mc_settings_sync' );
 
 				return new Response(
 					[
@@ -76,7 +76,7 @@ class SettingsSyncController extends BaseController {
 					201
 				);
 			} catch ( Exception $e ) {
-				do_action( 'gla_exception', $e, __METHOD__ );
+				do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
 
 				try {
 					$decoded = $this->json_decode_message( $e->getMessage() );

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -226,6 +226,6 @@ class Admin implements Service, Registerable, Conditional {
 	 * @return bool Whether reports should be enabled .
 	 */
 	protected function enableReports(): bool {
-		return apply_filters( 'gla_enable_reports', true );
+		return apply_filters( 'woocommerce_gla_enable_reports', true );
 	}
 }

--- a/src/Admin/Product/Attributes/AttributesForm.php
+++ b/src/Admin/Product/Attributes/AttributesForm.php
@@ -70,12 +70,12 @@ class AttributesForm extends Form {
 			 *
 			 * @see AttributeManager::map_attribute_types
 			 */
-			$applicable_types = apply_filters( "gla_attribute_applicable_product_types_{$attribute_id}", $applicable_types, $attribute_type );
+			$applicable_types = apply_filters( "woocommerce_gla_attribute_applicable_product_types_{$attribute_id}", $applicable_types, $attribute_type );
 
 			/**
 			 * Filters the list of product types to hide the attribute for.
 			 */
-			$hidden_types = apply_filters( "gla_attribute_hidden_product_types_{$attribute_id}", [] );
+			$hidden_types = apply_filters( "woocommerce_gla_attribute_hidden_product_types_{$attribute_id}", [] );
 
 			$visible_types = array_diff( $applicable_types, $hidden_types );
 
@@ -111,7 +111,7 @@ class AttributesForm extends Form {
 		if ( $attribute instanceof WithValueOptionsInterface ) {
 			$value_options = $attribute::get_value_options();
 		}
-		$value_options = apply_filters( "gla_product_attribute_value_options_{$attribute::get_id()}", $value_options );
+		$value_options = apply_filters( "woocommerce_gla_product_attribute_value_options_{$attribute::get_id()}", $value_options );
 
 		if ( ! empty( $value_options ) ) {
 			if ( ! $input instanceof Select && ! $input instanceof SelectWithTextInput ) {

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -148,7 +148,7 @@ class AttributesTab implements Service, Registerable, Conditional {
 	 * @return array of WooCommerce product types (e.g. 'simple', 'variable', etc.)
 	 */
 	protected function get_applicable_product_types(): array {
-		return apply_filters( 'gla_attributes_tab_applicable_product_types', [ 'simple', 'variable' ] );
+		return apply_filters( 'woocommerce_gla_attributes_tab_applicable_product_types', [ 'simple', 'variable' ] );
 	}
 
 	/**

--- a/src/Assets/AdminScriptWithBuiltDependenciesAsset.php
+++ b/src/Assets/AdminScriptWithBuiltDependenciesAsset.php
@@ -61,7 +61,7 @@ class AdminScriptWithBuiltDependenciesAsset extends AdminScriptAsset {
 
 			return new DependencyArray( include $build_dependency_path );
 		} catch ( Throwable $e ) {
-			do_action( 'gla_exception', $e, __METHOD__ );
+			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
 			return $fallback;
 		}
 	}

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -83,7 +83,7 @@ class ConnectionTest implements Service, Registerable {
 	 * Add menu entries
 	 */
 	protected function register_admin_menu() {
-		if ( apply_filters( 'gla_enable_connection_test', false ) ) {
+		if ( apply_filters( 'woocommerce_gla_enable_connection_test', false ) ) {
 			add_menu_page(
 				'Connection Test',
 				'Connection Test',

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -76,7 +76,7 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 		$this->check_if_plugin_files_updated();
 
 		$db_version = $this->get_db_version();
-		if ( $db_version !== $this->get_version() || apply_filters( 'gla_force_run_install', false ) ) {
+		if ( $db_version !== $this->get_version() || apply_filters( 'woocommerce_gla_force_run_install', false ) ) {
 			$this->install();
 
 			if ( '' === $db_version ) {

--- a/src/Integration/WooCommerceBrands.php
+++ b/src/Integration/WooCommerceBrands.php
@@ -51,13 +51,13 @@ class WooCommerceBrands implements IntegrationInterface {
 	 */
 	public function init(): void {
 		add_filter(
-			'gla_product_attribute_value_options_brand',
+			'woocommerce_gla_product_attribute_value_options_brand',
 			function ( array $value_options ) {
 				return $this->add_value_option( $value_options );
 			}
 		);
 		add_filter(
-			'gla_product_attribute_value_brand',
+			'woocommerce_gla_product_attribute_value_brand',
 			function ( $value, WC_Product $product ) {
 				return $this->get_brand( $value, $product );
 			},

--- a/src/Integration/WooCommerceProductBundles.php
+++ b/src/Integration/WooCommerceProductBundles.php
@@ -68,7 +68,7 @@ class WooCommerceProductBundles implements IntegrationInterface {
 
 		// recalculate the product price for bundles
 		add_filter(
-			'gla_product_attribute_value_price',
+			'woocommerce_gla_product_attribute_value_price',
 			function ( float $price, WC_Product $product, bool $tax_excluded ) {
 				return $this->calculate_price( $price, $product, $tax_excluded );
 			},
@@ -76,7 +76,7 @@ class WooCommerceProductBundles implements IntegrationInterface {
 			3
 		);
 		add_filter(
-			'gla_product_attribute_value_sale_price',
+			'woocommerce_gla_product_attribute_value_sale_price',
 			function ( float $sale_price, WC_Product $product, bool $tax_excluded ) {
 				return $this->calculate_sale_price( $sale_price, $product, $tax_excluded );
 			},
@@ -86,7 +86,7 @@ class WooCommerceProductBundles implements IntegrationInterface {
 
 		// filter unsupported bundle products
 		add_filter(
-			'gla_get_sync_ready_products_pre_filter',
+			'woocommerce_gla_get_sync_ready_products_pre_filter',
 			function ( array $products ) {
 				return $this->get_sync_ready_bundle_products( $products );
 			}
@@ -109,7 +109,7 @@ class WooCommerceProductBundles implements IntegrationInterface {
 			}
 
 			add_filter(
-				"gla_attribute_applicable_product_types_{$attribute_id}",
+				"woocommerce_gla_attribute_applicable_product_types_{$attribute_id}",
 				function ( array $applicable_types ) {
 					return $this->add_bundle_type( $applicable_types );
 				}
@@ -118,7 +118,7 @@ class WooCommerceProductBundles implements IntegrationInterface {
 
 		// hide the isBundle attribute on 'bundle' products (we set it automatically to true)
 		add_filter(
-			'gla_attribute_hidden_product_types_isBundle',
+			'woocommerce_gla_attribute_hidden_product_types_isBundle',
 			function ( array $applicable_types ) {
 				return $this->add_bundle_type( $applicable_types );
 			}

--- a/src/Integration/YoastWooCommerceSeo.php
+++ b/src/Integration/YoastWooCommerceSeo.php
@@ -38,19 +38,19 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 	 */
 	public function init(): void {
 		add_filter(
-			'gla_product_attribute_value_options_mpn',
+			'woocommerce_gla_product_attribute_value_options_mpn',
 			function ( array $value_options ) {
 				return $this->add_value_option( $value_options );
 			}
 		);
 		add_filter(
-			'gla_product_attribute_value_options_gtin',
+			'woocommerce_gla_product_attribute_value_options_gtin',
 			function ( array $value_options ) {
 				return $this->add_value_option( $value_options );
 			}
 		);
 		add_filter(
-			'gla_product_attribute_value_mpn',
+			'woocommerce_gla_product_attribute_value_mpn',
 			function ( $value, WC_Product $product ) {
 				return $this->get_mpn( $value, $product );
 			},
@@ -58,7 +58,7 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 			2
 		);
 		add_filter(
-			'gla_product_attribute_value_gtin',
+			'woocommerce_gla_product_attribute_value_gtin',
 			function ( $value, WC_Product $product ) {
 				return $this->get_gtin( $value, $product );
 			},

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -23,6 +23,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GlobalSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\ViewFactory;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DeprecatedFilters;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\InstallTimestamp;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\FirstInstallInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
@@ -127,6 +128,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		ProductFactory::class         => true,
 		AttributesTab::class          => true,
 		VariationsAttributes::class   => true,
+		DeprecatedFilters::class      => true,
 	];
 
 	/**
@@ -254,5 +256,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 				return new DBInstaller( ...$arguments );
 			}
 		);
+
+		$this->share_with_tags( DeprecatedFilters::class );
 	}
 }

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -208,7 +208,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 				try {
 					$request = $request->withHeader( 'Authorization', $this->generate_auth_header() );
 				} catch ( WPError $error ) {
-					do_action( 'gla_guzzle_client_exception', $error, __METHOD__ . ' in add_auth_header()' );
+					do_action( 'woocommerce_gla_guzzle_client_exception', $error, __METHOD__ . ' in add_auth_header()' );
 					throw new Exception( __( 'Jetpack authorization header error.', 'google-listings-and-ads' ), $error->getCode() );
 				}
 

--- a/src/Internal/DeprecatedFilters.php
+++ b/src/Internal/DeprecatedFilters.php
@@ -1,0 +1,77 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use WC_Deprecated_Hooks;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Deprecated Filters class.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Internal
+ */
+class DeprecatedFilters extends WC_Deprecated_Hooks implements Service {
+
+	/**
+	 * Array of deprecated hooks we need to handle.
+	 * Format of 'new' => 'old'.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_hooks = [
+		'woocommerce_gla_enable_connection_test' => 'gla_enable_connection_test',
+		'woocommerce_gla_enable_debug_logging'   => 'gla_enable_debug_logging',
+		'woocommerce_gla_enable_reports'         => 'gla_enable_reports',
+	];
+
+	/**
+	 * Array of versions when each hook has been deprecated.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_version = [
+		'gla_enable_connection_test' => '1.0.1',
+		'gla_enable_debug_logging'   => '1.0.1',
+		'gla_enable_reports'         => '1.0.1',
+	];
+
+	/**
+	 * Hook into the new hook so we can handle deprecated hooks once fired.
+	 *
+	 * @param string $hook_name Hook name.
+	 */
+	public function hook_in( $hook_name ) {
+		add_filter( $hook_name, [ $this, 'maybe_handle_deprecated_hook' ], -1000, 8 );
+	}
+
+	/**
+	 * If the old hook is in-use, trigger it.
+	 *
+	 * @param  string $new_hook          New hook name.
+	 * @param  string $old_hook          Old hook name.
+	 * @param  array  $new_callback_args New callback args.
+	 * @param  mixed  $return_value      Returned value.
+	 * @return mixed
+	 */
+	public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value ) {
+		if ( has_filter( $old_hook ) ) {
+			$this->display_notice( $old_hook, $new_hook );
+			$return_value = $this->trigger_hook( $old_hook, $new_callback_args );
+		}
+		return $return_value;
+	}
+
+	/**
+	 * Fire off a legacy hook with it's args.
+	 *
+	 * @param  string $old_hook          Old hook name.
+	 * @param  array  $new_callback_args New callback args.
+	 * @return mixed
+	 */
+	protected function trigger_hook( $old_hook, $new_callback_args ) {
+		return apply_filters_ref_array( $old_hook, $new_callback_args );
+	}
+}

--- a/src/Jobs/ActionSchedulerJobMonitor.php
+++ b/src/Jobs/ActionSchedulerJobMonitor.php
@@ -65,7 +65,7 @@ class ActionSchedulerJobMonitor implements Service {
 	 * @return int
 	 */
 	protected function get_failure_rate_threshold(): int {
-		return absint( apply_filters( "{$this->get_slug()}/batched_job_monitor/failure_rate_threshold", 5 ) );
+		return absint( apply_filters( 'woocommerce_gla/batched_job_monitor/failure_rate_threshold', 5 ) );
 	}
 
 }

--- a/src/Logging/DebugLogger.php
+++ b/src/Logging/DebugLogger.php
@@ -30,7 +30,7 @@ class DebugLogger implements Service, Registerable, Conditional {
 	 * @return bool Whether the service is needed.
 	 */
 	public static function is_needed(): bool {
-		return apply_filters( 'gla_enable_debug_logging', true );
+		return apply_filters( 'woocommerce_gla_enable_debug_logging', true );
 	}
 
 	/**
@@ -40,14 +40,14 @@ class DebugLogger implements Service, Registerable, Conditional {
 		if ( function_exists( 'wc_get_logger' ) ) {
 			$this->logger = wc_get_logger();
 
-			add_action( 'gla_debug_message', [ $this, 'log_message' ], 10, 2 );
-			add_action( 'gla_exception', [ $this, 'log_exception' ], 10, 2 );
-			add_action( 'gla_error', [ $this, 'log_error' ], 10, 2 );
-			add_action( 'gla_mc_client_exception', [ $this, 'log_exception' ], 10, 2 );
-			add_action( 'gla_ads_client_exception', [ $this, 'log_exception' ], 10, 2 );
-			add_action( 'gla_sv_client_exception', [ $this, 'log_exception' ], 10, 2 );
-			add_action( 'gla_guzzle_client_exception', [ $this, 'log_exception' ], 10, 2 );
-			add_action( 'gla_guzzle_invalid_response', [ $this, 'log_response' ], 10, 2 );
+			add_action( 'woocommerce_gla_debug_message', [ $this, 'log_message' ], 10, 2 );
+			add_action( 'woocommerce_gla_exception', [ $this, 'log_exception' ], 10, 2 );
+			add_action( 'woocommerce_gla_error', [ $this, 'log_error' ], 10, 2 );
+			add_action( 'woocommerce_gla_mc_client_exception', [ $this, 'log_exception' ], 10, 2 );
+			add_action( 'woocommerce_gla_ads_client_exception', [ $this, 'log_exception' ], 10, 2 );
+			add_action( 'woocommerce_gla_sv_client_exception', [ $this, 'log_exception' ], 10, 2 );
+			add_action( 'woocommerce_gla_guzzle_client_exception', [ $this, 'log_exception' ], 10, 2 );
+			add_action( 'woocommerce_gla_guzzle_invalid_response', [ $this, 'log_response' ], 10, 2 );
 		}
 	}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -282,7 +282,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 					// Skip products that are no longer in WooCommerce.
 					if ( ! $wc_product ) {
 						do_action(
-							'gla_debug_message',
+							'woocommerce_gla_debug_message',
 							sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $product->getProductId() ),
 							__METHOD__ . ' in remove_invalid_statuses()',
 						);
@@ -477,7 +477,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 				// Don't include invalid products (or their parents).
 				do_action(
-					'gla_debug_message',
+					'woocommerce_gla_debug_message',
 					sprintf( 'Merchant Center product ID %s not found in this WooCommerce store.', $wc_product_id ),
 					__METHOD__,
 				);

--- a/src/Options/AdsSetupCompleted.php
+++ b/src/Options/AdsSetupCompleted.php
@@ -22,12 +22,12 @@ class AdsSetupCompleted implements OptionsAwareInterface, Registerable, Service 
 	/**
 	 * Register a service.
 	 *
-	 * TODO: call `do_action( 'gla_ads_settings_sync' );` when the initial Google Ads account,
+	 * TODO: call `do_action( 'woocommerce_gla_ads_settings_sync' );` when the initial Google Ads account,
 	 *       paid campaign, and billing setup is completed.
 	 */
 	public function register(): void {
 		add_action(
-			'gla_ads_setup_completed',
+			'woocommerce_gla_ads_setup_completed',
 			function() {
 				$this->set_completed_timestamp();
 			}

--- a/src/Options/MerchantSetupCompleted.php
+++ b/src/Options/MerchantSetupCompleted.php
@@ -24,7 +24,7 @@ class MerchantSetupCompleted implements OptionsAwareInterface, Registerable, Ser
 	 */
 	public function register(): void {
 		add_action(
-			'gla_mc_settings_sync',
+			'woocommerce_gla_mc_settings_sync',
 			function() {
 				$this->set_completed_timestamp();
 			}

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -90,7 +90,7 @@ final class Options implements OptionsInterface, Service {
 
 		$result = add_option( $this->prefix_name( $name ), $this->raw_value( $value ) );
 
-		do_action( "gla_options_updated_{$name}", $value );
+		do_action( "woocommerce_gla_options_updated_{$name}", $value );
 
 		return $result;
 	}
@@ -110,7 +110,7 @@ final class Options implements OptionsInterface, Service {
 
 		$result = update_option( $this->prefix_name( $name ), $this->raw_value( $value ) );
 
-		do_action( "gla_options_updated_{$name}", $value );
+		do_action( "woocommerce_gla_options_updated_{$name}", $value );
 
 		return $result;
 	}
@@ -128,7 +128,7 @@ final class Options implements OptionsInterface, Service {
 
 		$result = delete_option( $this->prefix_name( $name ) );
 
-		do_action( "gla_options_deleted_{$name}" );
+		do_action( "woocommerce_gla_options_deleted_{$name}" );
 
 		return $result;
 	}

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -211,7 +211,7 @@ class AttributeManager implements Service {
 		$attribute_types = $this->get_attribute_types_for_product( $product );
 		if ( ! isset( $attribute_types[ $attribute_id ] ) ) {
 			do_action(
-				'gla_error',
+				'woocommerce_gla_error',
 				sprintf( 'Attribute "%s" is not supported for a "%s" product (ID: %s).', $attribute_id, $product->get_type(), $product->get_id() ),
 				__METHOD__
 			);
@@ -224,7 +224,7 @@ class AttributeManager implements Service {
 	 * @throws InvalidClass If any of the given attribute classes do not implement the AttributeInterface.
 	 */
 	protected function map_attribute_types(): void {
-		$available_attributes = apply_filters( 'gla_product_attribute_types', self::ATTRIBUTES );
+		$available_attributes = apply_filters( 'woocommerce_gla_product_attribute_types', self::ATTRIBUTES );
 
 		$this->attribute_types_map = [];
 		foreach ( $available_attributes as $attribute_type ) {
@@ -239,7 +239,7 @@ class AttributeManager implements Service {
 			 * @param string[] $applicable_types Array of WooCommerce product types
 			 * @param string   $attribute_type   Attribute class name (FQN)
 			 */
-			$applicable_types = apply_filters( "gla_attribute_applicable_product_types_{$attribute_id}", $applicable_types, $attribute_type );
+			$applicable_types = apply_filters( "woocommerce_gla_attribute_applicable_product_types_{$attribute_id}", $applicable_types, $attribute_type );
 
 			foreach ( $applicable_types as $product_type ) {
 				$this->attribute_types_map[ $product_type ]                  = $this->attribute_types_map[ $product_type ] ?? [];

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -160,7 +160,7 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 
 			if ( ! $this->product_helper->is_sync_ready( $product ) ) {
 				do_action(
-					'gla_debug_message',
+					'woocommerce_gla_debug_message',
 					sprintf( 'Skipping product (ID: %s) because it is not ready to be synced.', $product->get_id() ),
 					__METHOD__
 				);
@@ -180,7 +180,7 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 				$this->mark_as_invalid( $validation_result );
 
 				do_action(
-					'gla_debug_message',
+					'woocommerce_gla_debug_message',
 					sprintf( 'Skipping product (ID: %s) because it does not pass validation: %s', $product->get_id(), json_encode( $validation_result ) ),
 					__METHOD__
 				);

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -160,7 +160,7 @@ class ProductMetaHandler implements Service, Registerable {
 	protected static function validate_meta_key( string $key ) {
 		if ( ! self::is_meta_key_valid( $key ) ) {
 			do_action(
-				'gla_error',
+				'woocommerce_gla_error',
 				sprintf( 'Product meta key is invalid: %s', $key ),
 				__METHOD__
 			);

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -175,7 +175,7 @@ class ProductRepository implements Service {
 		 *
 		 * @param WC_Product[] $products Sync-ready WooCommerce products
 		 */
-		$products = apply_filters( 'gla_get_sync_ready_products_pre_filter', $products );
+		$products = apply_filters( 'woocommerce_gla_get_sync_ready_products_pre_filter', $products );
 
 		$results = [];
 		foreach ( $products as $product ) {
@@ -192,7 +192,7 @@ class ProductRepository implements Service {
 		 *
 		 * @param WC_Product[] $results Sync-ready WooCommerce products
 		 */
-		return apply_filters( 'gla_get_sync_ready_products_filter', $results );
+		return apply_filters( 'woocommerce_gla_get_sync_ready_products_filter', $results );
 	}
 
 	/**

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -104,7 +104,7 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 				array_walk( $updated_products, [ $this->batch_helper, 'mark_as_synced' ] );
 				array_walk( $invalid_products, [ $this->batch_helper, 'mark_as_invalid' ] );
 			} catch ( Exception $exception ) {
-				do_action( 'gla_exception', $exception, __METHOD__ );
+				do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
 
 				throw new ProductSyncerException( sprintf( 'Error updating Google product: %s', $exception->getMessage() ), 0, $exception );
 			}
@@ -113,13 +113,13 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 		$this->handle_update_errors( $invalid_products );
 
 		do_action(
-			'gla_batch_updated_products',
+			'woocommerce_gla_batch_updated_products',
 			$updated_products,
 			$invalid_products
 		);
 
 		do_action(
-			'gla_debug_message',
+			'woocommerce_gla_debug_message',
 			sprintf(
 				"Submitted %s products:\n%s\n%s Failed:\n%s",
 				count( $updated_products ),
@@ -181,7 +181,7 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 
 				array_walk( $deleted_products, [ $this->batch_helper, 'mark_as_unsynced' ] );
 			} catch ( Exception $exception ) {
-				do_action( 'gla_exception', $exception, __METHOD__ );
+				do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
 
 				throw new ProductSyncerException( sprintf( 'Error deleting Google products: %s', $exception->getMessage() ), 0, $exception );
 			}
@@ -190,13 +190,13 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 		$this->handle_delete_errors( $invalid_products );
 
 		do_action(
-			'gla_batch_deleted_products',
+			'woocommerce_gla_batch_deleted_products',
 			$deleted_products,
 			$invalid_products
 		);
 
 		do_action(
-			'gla_debug_message',
+			'woocommerce_gla_debug_message',
 			sprintf(
 				"Deleted %s products:\n%s\n%s Failed:\n%s",
 				count( $deleted_products ),
@@ -224,11 +224,11 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 	 */
 	protected function handle_update_errors( array $invalid_products ) {
 		$error_products = $this->batch_helper->get_internal_error_products( $invalid_products );
-		if ( ! empty( $error_products ) && apply_filters( 'gla_products_update_retry_on_failure', true, $invalid_products ) ) {
-			do_action( 'gla_batch_retry_update_products', $error_products );
+		if ( ! empty( $error_products ) && apply_filters( 'woocommerce_gla_products_update_retry_on_failure', true, $invalid_products ) ) {
+			do_action( 'woocommerce_gla_batch_retry_update_products', $error_products );
 
 			do_action(
-				'gla_error',
+				'woocommerce_gla_error',
 				sprintf( 'Internal API errors while submitting the following products: %s', join( ', ', $error_products ) ),
 				__METHOD__
 			);
@@ -251,7 +251,7 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 			// not found
 			if ( $invalid_product->has_error( GoogleProductService::NOT_FOUND_ERROR_REASON ) ) {
 				do_action(
-					'gla_error',
+					'woocommerce_gla_error',
 					sprintf(
 						'Attempted to delete product "%s" (WooCommerce Product ID: %s) but it did not exist in Google Merchant Center, removing the synced product ID from database.',
 						$google_product_id,
@@ -270,11 +270,11 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 		}
 
 		// call an action to retry if any products with internal errors exist
-		if ( ! empty( $internal_error_ids ) && apply_filters( 'gla_products_delete_retry_on_failure', true, $invalid_products ) ) {
-			do_action( 'gla_batch_retry_delete_products', $internal_error_ids );
+		if ( ! empty( $internal_error_ids ) && apply_filters( 'woocommerce_gla_products_delete_retry_on_failure', true, $invalid_products ) ) {
+			do_action( 'woocommerce_gla_batch_retry_delete_products', $internal_error_ids );
 
 			do_action(
-				'gla_error',
+				'woocommerce_gla_error',
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions
 				sprintf( 'Internal API errors while deleting the following products: %s', print_r( $internal_error_ids, true ) ),
 				__METHOD__
@@ -289,7 +289,7 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 	 */
 	protected function validate_merchant_center_setup(): void {
 		if ( ! $this->merchant_center->is_setup_complete() ) {
-			do_action( 'gla_error', 'Can not sync any products before setting up Google Merchant Center.', __METHOD__ );
+			do_action( 'woocommerce_gla_error', 'Can not sync any products before setting up Google Merchant Center.', __METHOD__ );
 
 			throw new ProductSyncerException( __( 'Google Merchant Center has not been set up correctly. Please review your configuration.', 'google-listings-and-ads' ) );
 		}

--- a/src/Product/StartProductSync.php
+++ b/src/Product/StartProductSync.php
@@ -36,7 +36,7 @@ class StartProductSync implements Registerable, Service {
 	 */
 	public function register(): void {
 		add_action(
-			'gla_mc_settings_sync',
+			'woocommerce_gla_mc_settings_sync',
 			function() {
 				$this->on_settings_sync();
 			}

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -177,7 +177,7 @@ class SyncerHooks implements Service, Registerable, MerchantCenterAwareInterface
 			$this->set_already_scheduled( $product_id );
 
 			do_action(
-				'gla_debug_message',
+				'woocommerce_gla_debug_message',
 				sprintf( 'Deleting product (ID: %s) from Google Merchant Center because it is not ready to be synced.', $product->get_id() ),
 				__METHOD__
 			);

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -429,7 +429,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 			 * @param WC_Product $product WooCommerce product
 			 * @param bool       $tax_excluded Whether tax is excluded from product price
 			 */
-			$price = apply_filters( 'gla_product_attribute_value_price', $price, $product, $this->tax_excluded );
+			$price = apply_filters( 'woocommerce_gla_product_attribute_value_price', $price, $product, $this->tax_excluded );
 
 			$this->setPrice(
 				new Google_Service_ShoppingContent_Price(
@@ -479,7 +479,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 			 * @param WC_Product $product      WooCommerce product
 			 * @param bool       $tax_excluded Whether tax is excluded from product price
 			 */
-			$sale_price = apply_filters( 'gla_product_attribute_value_sale_price', $sale_price, $product, $this->tax_excluded );
+			$sale_price = apply_filters( 'woocommerce_gla_product_attribute_value_sale_price', $sale_price, $product, $this->tax_excluded );
 
 			// If the sale price dates no longer apply, make sure we don't include a sale price.
 			$now                 = new WC_DateTime();
@@ -653,7 +653,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 		$gla_attributes = [];
 		foreach ( $attributes as $attribute_id => $attribute_value ) {
 			if ( property_exists( $this, $attribute_id ) ) {
-				$gla_attributes[ $attribute_id ] = apply_filters( "gla_product_attribute_value_{$attribute_id}", $attribute_value, $this->get_wc_product() );
+				$gla_attributes[ $attribute_id ] = apply_filters( "woocommerce_gla_product_attribute_value_{$attribute_id}", $attribute_value, $this->get_wc_product() );
 			}
 		}
 

--- a/src/Tracking/Events/Loaded.php
+++ b/src/Tracking/Events/Loaded.php
@@ -16,7 +16,7 @@ class Loaded extends BaseEvent {
 	 * Register the tracking class.
 	 */
 	public function register(): void {
-		add_action( $this->get_slug() . '_extension_loaded', [ $this, 'track_loaded' ] );
+		add_action( 'woocommerce_gla_extension_loaded', [ $this, 'track_loaded' ] );
 	}
 
 	/**

--- a/src/Tracking/Events/SiteClaimEvents.php
+++ b/src/Tracking/Events/SiteClaimEvents.php
@@ -18,11 +18,11 @@ class SiteClaimEvents extends BaseEvent {
 	 * Register the tracking class.
 	 */
 	public function register(): void {
-		add_action( 'gla_site_claim_overwrite_required', [ $this, 'track_site_claim_overwrite_required' ] );
-		add_action( 'gla_site_claim_success', [ $this, 'track_site_claim_success' ] );
-		add_action( 'gla_site_claim_failure', [ $this, 'track_site_claim_failure' ] );
-		add_action( 'gla_url_switch_required', [ $this, 'track_url_switch_required' ] );
-		add_action( 'gla_url_switch_success', [ $this, 'track_url_switch_success' ] );
+		add_action( 'woocommerce_gla_site_claim_overwrite_required', [ $this, 'track_site_claim_overwrite_required' ] );
+		add_action( 'woocommerce_gla_site_claim_success', [ $this, 'track_site_claim_success' ] );
+		add_action( 'woocommerce_gla_site_claim_failure', [ $this, 'track_site_claim_failure' ] );
+		add_action( 'woocommerce_gla_url_switch_required', [ $this, 'track_url_switch_required' ] );
+		add_action( 'woocommerce_gla_url_switch_success', [ $this, 'track_url_switch_success' ] );
 	}
 
 	/**

--- a/src/Tracking/Events/SiteVerificationEvents.php
+++ b/src/Tracking/Events/SiteVerificationEvents.php
@@ -14,8 +14,8 @@ class SiteVerificationEvents extends BaseEvent {
 	 * Register the tracking class.
 	 */
 	public function register(): void {
-		add_action( $this->get_slug() . '_site_verify_success', [ $this, 'track_site_verify_success' ] );
-		add_action( $this->get_slug() . '_site_verify_failure', [ $this, 'track_site_verify_failure' ] );
+		add_action( 'woocommerce_gla_site_verify_success', [ $this, 'track_site_verify_success' ] );
+		add_action( 'woocommerce_gla_site_verify_failure', [ $this, 'track_site_verify_failure' ] );
 	}
 
 	/**

--- a/src/View/PHPView.php
+++ b/src/View/PHPView.php
@@ -84,7 +84,7 @@ class PHPView implements View {
 				ob_end_clean();
 			}
 
-			do_action( 'gla_exception', $exception, __METHOD__ );
+			do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
 
 			throw ViewException::invalid_view_exception(
 				$this->path,
@@ -133,7 +133,7 @@ class PHPView implements View {
 			return $this->context[ $property ];
 		}
 
-		do_action( 'gla_error', sprintf( 'View property "%s" is missing or undefined.', $property ), __METHOD__ );
+		do_action( 'woocommerce_gla_error', sprintf( 'View property "%s" is missing or undefined.', $property ), __METHOD__ );
 
 		/*
 		 * We only throw an exception here if we are in debugging mode, as we
@@ -161,7 +161,7 @@ class PHPView implements View {
 		$path = path_join( $this->get_views_base_path(), $path );
 
 		if ( ! is_readable( $path ) ) {
-			do_action( 'gla_error', sprintf( 'View not found in path "%s".', $path ), __METHOD__ );
+			do_action( 'woocommerce_gla_error', sprintf( 'View not found in path "%s".', $path ), __METHOD__ );
 
 			throw ViewException::invalid_path( $path );
 		}
@@ -205,7 +205,7 @@ class PHPView implements View {
 			return $this->sanitize_context_variable( $this->context[ $property ] );
 		}
 
-		do_action( 'gla_error', sprintf( 'View property "%s" is missing or undefined.', $property ), __METHOD__ );
+		do_action( 'woocommerce_gla_error', sprintf( 'View property "%s" is missing or undefined.', $property ), __METHOD__ );
 
 		/*
 		 * We only throw an exception here if we are in debugging mode, as we

--- a/tests/mocks/mocking.md
+++ b/tests/mocks/mocking.md
@@ -2,11 +2,11 @@ Mocking responses for development & testing
 ---
 
 This folder contains set of sample data, that could be used to mock server-side API responses for development end testing.
-You can use them by using `gla_prepared_response_{route}` filter, like the following snippet
+You can use them by using `woocommerce_gla_prepared_response_{route}` filter, like the following snippet
 
 ```php
 add_filter(
-	'gla_prepared_response_mc-reports-products',
+	'woocommerce_gla_prepared_response_mc-reports-products',
 	function( $response ) {
 		return json_decode( file_get_contents( __DIR__ . '/google-listings-and-ads/tests/mocks/mc/reports/products.json' ), true ) ?: [];
 	},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR standardizes the filter and action prefix. Since most of our hooks were already using the `woocommerce_gla` prefix, I decided to use the same here (this seems most inline with what is used in WC core).
Most of the hooks and filters are used internally so far, so it's best to change these as soon as possible.

Closes #741

### Detailed test instructions:

1. Add the right prefix to any custom code snippets like `add_filter( 'woocommerce_gla_enable_connection_test', '__return_true' );`
2. Test syncing products and editing GLA product attributes
3. Tryout some of the compatible plugins like Bundles and Brands
4. Confirm that setting of the attributes and syncing bundled products continues to work as intended
5. Check the WooCommerce > Status > Logs to confirm we are still getting new debug / error log entries

### Changelog entry
* Tweak - Standardize action and filter hook prefix.
