### PR TITLE
Automatically set default values for Setup MC and Edit Free Listings' Target Audience

### DIFF
--- a/js/src/components/free-listings/choose-audience/form-content.js
+++ b/js/src/components/free-listings/choose-audience/form-content.js
@@ -91,21 +91,6 @@ const FormContent = ( props ) => {
 							<VerticalGapLayout>
 								<AppRadioContentControl
 									{ ...getInputProps( 'location' ) }
-									label={ __(
-										'All countries',
-										'google-listings-and-ads'
-									) }
-									value="all"
-								>
-									<RadioHelperText>
-										{ __(
-											'Your listings will be shown in all supported countries.',
-											'google-listings-and-ads'
-										) }
-									</RadioHelperText>
-								</AppRadioContentControl>
-								<AppRadioContentControl
-									{ ...getInputProps( 'location' ) }
 									collapsible={ true }
 									label={ __(
 										'Selected countries only',
@@ -122,6 +107,21 @@ const FormContent = ( props ) => {
 									<RadioHelperText>
 										{ __(
 											'Can’t find a country? Only supported countries can be selected.',
+											'google-listings-and-ads'
+										) }
+									</RadioHelperText>
+								</AppRadioContentControl>
+								<AppRadioContentControl
+									{ ...getInputProps( 'location' ) }
+									label={ __(
+										'All countries',
+										'google-listings-and-ads'
+									) }
+									value="all"
+								>
+									<RadioHelperText>
+										{ __(
+											'Your listings will be shown in all supported countries.',
 											'google-listings-and-ads'
 										) }
 									</RadioHelperText>

--- a/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
@@ -18,6 +18,7 @@ import SupportedCountrySelect from '.~/components/supported-country-select';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import useAutoSaveTargetAudienceEffect from './useAutoSaveTargetAudienceEffect';
 import useAutoClearShippingEffect from './useAutoClearShippingEffect';
+import useAutoSetLocationCountriesEffect from './useAutoSetLocationCountriesEffect';
 import '.~/components/free-listings/choose-audience/index.scss';
 
 /**
@@ -32,6 +33,7 @@ const FormContent = ( props ) => {
 	const { values, isValidForm, getInputProps, handleSubmit } = formProps;
 	const { locale, language } = values;
 
+	useAutoSetLocationCountriesEffect( formProps );
 	useAutoSaveTargetAudienceEffect( values );
 	useAutoClearShippingEffect( values.location, values.countries );
 

--- a/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
@@ -94,21 +94,6 @@ const FormContent = ( props ) => {
 							<VerticalGapLayout>
 								<AppRadioContentControl
 									{ ...getInputProps( 'location' ) }
-									label={ __(
-										'All countries',
-										'google-listings-and-ads'
-									) }
-									value="all"
-								>
-									<RadioHelperText>
-										{ __(
-											'Your listings will be shown in all supported countries.',
-											'google-listings-and-ads'
-										) }
-									</RadioHelperText>
-								</AppRadioContentControl>
-								<AppRadioContentControl
-									{ ...getInputProps( 'location' ) }
 									collapsible={ true }
 									label={ __(
 										'Selected countries only',
@@ -125,6 +110,21 @@ const FormContent = ( props ) => {
 									<RadioHelperText>
 										{ __(
 											'Can’t find a country? Only supported countries can be selected.',
+											'google-listings-and-ads'
+										) }
+									</RadioHelperText>
+								</AppRadioContentControl>
+								<AppRadioContentControl
+									{ ...getInputProps( 'location' ) }
+									label={ __(
+										'All countries',
+										'google-listings-and-ads'
+									) }
+									value="all"
+								>
+									<RadioHelperText>
+										{ __(
+											'Your listings will be shown in all supported countries.',
 											'google-listings-and-ads'
 										) }
 									</RadioHelperText>

--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoSetLocationCountriesEffect.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoSetLocationCountriesEffect.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useStoreCountry from '.~/hooks/useStoreCountry';
+
+/**
+ * Automatically set `location` to be `selected` and `countries` to be `[ storeCountryCode ]`
+ * when `values.location === null && values.countries.length === 0` (i.e. when users first visit the page).
+ *
+ * This is done by calling `onChange` from `getInputProps`, simulating user's manual input action.
+ *
+ * @param {Object} formProps formProps.
+ */
+const useAutoSetLocationCountriesEffect = ( formProps ) => {
+	const { values, getInputProps } = formProps;
+	const { code: storeCountryCode } = useStoreCountry();
+
+	const hasNoLocationCountries =
+		values.location === null && values.countries.length === 0;
+
+	const setLocationCountries = useCallback( () => {
+		getInputProps( 'location' ).onChange( 'selected' );
+		getInputProps( 'countries' ).onChange( [ storeCountryCode ] );
+	}, [ getInputProps, storeCountryCode ] );
+
+	useEffect( () => {
+		if ( hasNoLocationCountries ) {
+			setLocationCountries();
+		}
+	}, [ hasNoLocationCountries, setLocationCountries ] );
+};
+
+export default useAutoSetLocationCountriesEffect;

--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoSetLocationCountriesEffect.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoSetLocationCountriesEffect.js
@@ -32,8 +32,9 @@ const useAutoSetLocationCountriesEffect = ( formProps ) => {
 			return;
 		}
 
-		const countriesValue =
-			data && data[ storeCountryCode ] ? [ storeCountryCode ] : [];
+		const countriesValue = data[ storeCountryCode ]
+			? [ storeCountryCode ]
+			: [];
 
 		getInputProps( 'location' ).onChange( 'selected' );
 		getInputProps( 'countries' ).onChange( countriesValue );

--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoSetLocationCountriesEffect.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoSetLocationCountriesEffect.js
@@ -7,10 +7,13 @@ import { useCallback, useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import useStoreCountry from '.~/hooks/useStoreCountry';
+import useGetCountries from '.~/hooks/useGetCountries';
 
 /**
  * Automatically set `location` to be `selected` and `countries` to be `[ storeCountryCode ]`
  * when `values.location === null && values.countries.length === 0` (i.e. when users first visit the page).
+ *
+ * If the `storeCountryCode` is not in the list of the MC supported countries, then `countries` would be set to empty array `[]`.
  *
  * This is done by calling `onChange` from `getInputProps`, simulating user's manual input action.
  *
@@ -19,14 +22,22 @@ import useStoreCountry from '.~/hooks/useStoreCountry';
 const useAutoSetLocationCountriesEffect = ( formProps ) => {
 	const { values, getInputProps } = formProps;
 	const { code: storeCountryCode } = useStoreCountry();
+	const { data } = useGetCountries();
 
 	const hasNoLocationCountries =
 		values.location === null && values.countries.length === 0;
 
 	const setLocationCountries = useCallback( () => {
+		if ( ! data ) {
+			return;
+		}
+
+		const countriesValue =
+			data && data[ storeCountryCode ] ? [ storeCountryCode ] : [];
+
 		getInputProps( 'location' ).onChange( 'selected' );
-		getInputProps( 'countries' ).onChange( [ storeCountryCode ] );
-	}, [ getInputProps, storeCountryCode ] );
+		getInputProps( 'countries' ).onChange( countriesValue );
+	}, [ data, getInputProps, storeCountryCode ] );
 
 	useEffect( () => {
 		if ( hasNoLocationCountries ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #776 .

- Display the "Selected countries only" option above "All countries" option in both Setup MC Target Audience page and Edit Free Listings.
- For Setup MC Target Audience page, when location and countries are not set, it will automatically set the location value to `"selected"` and countries value to the store's country.
	- If the store'c country is not in the list of MC supported countries, then the countries value would not be set, and users have to set it on their own.

### Screenshots:

Demo video with my voice: (https://d.pr/v/uAUIDu)

https://user-images.githubusercontent.com/417342/121648968-a2e42f80-caca-11eb-9a04-44f8988dcace.mov

### Detailed test instructions:

1. Open https://gla1.loca.lt/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc
2. Proceed to connect your accounts in Step 1. Click on Continue to go to Step 2 Target Audience. 
3. In Step 2, when loading is done, you should see "Selected countries only" is selected by default, and the dropdown would be populated with your store's country.
4. Complete the Setup MC flow.
5. Go to edit free listings page. The UI should be similar to the Edit Free Listings - "Selected countries only" option should be above "All countries" option.

### Changelog entry

Automatically set default values for Setup MC and Edit Free Listings' Target Audience.
