### PR TITLE
Add the missing second parameter deps for all usages of `useSelect`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,12 @@
     "import/resolver": "webpack"
   },
   "rules": {
-    "@wordpress/no-unsafe-wp-apis" : 1
+    "@wordpress/no-unsafe-wp-apis" : 1,
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "useSelect"
+      }
+    ]
   }
 }

--- a/js/src/components/free-listings/configure-product-listings/useSettings.js
+++ b/js/src/components/free-listings/configure-product-listings/useSettings.js
@@ -20,7 +20,7 @@ const useSettings = () => {
 		return {
 			settings,
 		};
-	} );
+	}, [] );
 };
 
 export default useSettings;

--- a/js/src/dashboard/summary-section/usePerformance.js
+++ b/js/src/dashboard/summary-section/usePerformance.js
@@ -2,14 +2,13 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { getQuery } from '@woocommerce/navigation';
-import { getCurrentDates } from '@woocommerce/date';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '.~/data/constants';
 import { mapReportFieldsToPerformance } from '.~/data/utils';
+import useUrlQuery from '.~/hooks/useUrlQuery';
 
 /**
  * Get performance results by program type.
@@ -19,31 +18,35 @@ import { mapReportFieldsToPerformance } from '.~/data/utils';
  * @return {PerformanceSchema} The fetched performance results.
  */
 export default function usePerformance( type ) {
-	const query = getQuery();
-	const currentDate = getCurrentDates( query );
-	const deps = [
-		type,
-		currentDate.primary.range,
-		currentDate.secondary.range,
-	];
+	const query = useUrlQuery();
 
-	return useSelect( ( select ) => {
-		const { getDashboardPerformance } = select( STORE_KEY );
-		const primary = getDashboardPerformance( type, query, 'primary' );
-		const secondary = getDashboardPerformance( type, query, 'secondary' );
+	return useSelect(
+		( select ) => {
+			const { getDashboardPerformance } = select( STORE_KEY );
+			const primary = getDashboardPerformance( type, query, 'primary' );
+			const secondary = getDashboardPerformance(
+				type,
+				query,
+				'secondary'
+			);
 
-		let data = null;
-		const loaded = primary.loaded && secondary.loaded;
+			let data = null;
+			const loaded = primary.loaded && secondary.loaded;
 
-		if ( loaded && primary.data && secondary.data ) {
-			data = mapReportFieldsToPerformance( primary.data, secondary.data );
-		}
+			if ( loaded && primary.data && secondary.data ) {
+				data = mapReportFieldsToPerformance(
+					primary.data,
+					secondary.data
+				);
+			}
 
-		return {
-			loaded,
-			data,
-		};
-	}, deps );
+			return {
+				loaded,
+				data,
+			};
+		},
+		[ type, query ]
+	);
 }
 
 /**

--- a/js/src/hooks/useAdminUrl.js
+++ b/js/src/hooks/useAdminUrl.js
@@ -15,7 +15,7 @@ const useAdminUrl = () => {
 			'wc_admin',
 			'adminUrl'
 		);
-	} );
+	}, [] );
 };
 
 export default useAdminUrl;

--- a/js/src/hooks/useCountryKeyNameMap.js
+++ b/js/src/hooks/useCountryKeyNameMap.js
@@ -22,7 +22,7 @@ const useCountryKeyNameMap = () => {
 			'wc_admin',
 			'countries'
 		);
-	} );
+	}, [] );
 };
 
 export default useCountryKeyNameMap;

--- a/js/src/hooks/useExistingGoogleAdsAccounts.js
+++ b/js/src/hooks/useExistingGoogleAdsAccounts.js
@@ -18,7 +18,7 @@ const useExistingGoogleAdsAccounts = () => {
 		);
 
 		return { existingAccounts, isResolving };
-	} );
+	}, [] );
 };
 
 export default useExistingGoogleAdsAccounts;

--- a/js/src/hooks/useExistingGoogleMCAccounts.js
+++ b/js/src/hooks/useExistingGoogleMCAccounts.js
@@ -18,7 +18,7 @@ const useExistingGoogleMCAccounts = () => {
 		);
 
 		return { existingAccounts, isResolving };
-	} );
+	}, [] );
 };
 
 export default useExistingGoogleMCAccounts;

--- a/js/src/hooks/useGetCountries.js
+++ b/js/src/hooks/useGetCountries.js
@@ -35,7 +35,7 @@ const useGetCountries = () => {
 			loading,
 			data,
 		};
-	} );
+	}, [] );
 };
 
 export default useGetCountries;

--- a/js/src/hooks/useGoogleAdsAccount.js
+++ b/js/src/hooks/useGoogleAdsAccount.js
@@ -21,25 +21,28 @@ const useGoogleAdsAccount = () => {
 		dispatcher.invalidateResolution( googleAdsAccountSelector, [] );
 	}, [ dispatcher ] );
 
-	return useSelect( ( select ) => {
-		if ( ! google || google.active === 'no' ) {
+	return useSelect(
+		( select ) => {
+			if ( ! google || google.active === 'no' ) {
+				return {
+					googleAdsAccount: undefined,
+					isResolving,
+				};
+			}
+
+			const acc = select( STORE_KEY )[ googleAdsAccountSelector ]();
+			const isResolvingGoogleAdsAccount = select( STORE_KEY ).isResolving(
+				googleAdsAccountSelector
+			);
+
 			return {
-				googleAdsAccount: undefined,
-				isResolving,
+				googleAdsAccount: acc,
+				isResolving: isResolvingGoogleAdsAccount,
+				refetchGoogleAdsAccount,
 			};
-		}
-
-		const acc = select( STORE_KEY )[ googleAdsAccountSelector ]();
-		const isResolvingGoogleAdsAccount = select( STORE_KEY ).isResolving(
-			googleAdsAccountSelector
-		);
-
-		return {
-			googleAdsAccount: acc,
-			isResolving: isResolvingGoogleAdsAccount,
-			refetchGoogleAdsAccount,
-		};
-	} );
+		},
+		[ google, isResolving, refetchGoogleAdsAccount ]
+	);
 };
 
 export default useGoogleAdsAccount;

--- a/js/src/hooks/useGoogleAdsAccountBillingStatus.js
+++ b/js/src/hooks/useGoogleAdsAccountBillingStatus.js
@@ -17,7 +17,7 @@ const useGoogleAdsAccountBillingStatus = () => {
 		return {
 			billingStatus,
 		};
-	} );
+	}, [] );
 };
 
 export default useGoogleAdsAccountBillingStatus;

--- a/js/src/hooks/useShippingRates.js
+++ b/js/src/hooks/useShippingRates.js
@@ -19,7 +19,7 @@ const useShippingRates = () => {
 			loading,
 			data,
 		};
-	} );
+	}, [] );
 };
 
 export default useShippingRates;

--- a/js/src/hooks/useShippingTimes.js
+++ b/js/src/hooks/useShippingTimes.js
@@ -19,7 +19,7 @@ const useShippingTimes = () => {
 			loading,
 			data,
 		};
-	} );
+	}, [] );
 };
 
 export default useShippingTimes;

--- a/js/src/hooks/useStoreCountry.js
+++ b/js/src/hooks/useStoreCountry.js
@@ -17,5 +17,5 @@ export default function useStoreCountry() {
 		const [ code ] = general.woocommerce_default_country.split( ':' );
 
 		return { code, name: countryNames[ code ] };
-	} );
+	}, [] );
 }

--- a/js/src/hooks/useTargetAudience.js
+++ b/js/src/hooks/useTargetAudience.js
@@ -19,7 +19,7 @@ const useTargetAudience = () => {
 			loading,
 			data,
 		};
-	} );
+	}, [] );
 };
 
 export default useTargetAudience;

--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.js
@@ -77,7 +77,7 @@ const useTargetAudienceFinalCountryCodes = () => {
 			targetAudience: storedTargetAudience,
 			getFinalCountries,
 		};
-	} );
+	}, [] );
 };
 
 export default useTargetAudienceFinalCountryCodes;

--- a/js/src/reports/products/products-report-filters.js
+++ b/js/src/reports/products/products-report-filters.js
@@ -85,26 +85,30 @@ const ProductsReportFilters = ( props ) => {
 	 * TODO: Check why it's so disjoint with fetching product data (label) in filter config.
 	 * https://github.com/woocommerce/woocommerce-admin/commit/c7de3559d9180cf6ecf9a20b72fc20f0a6658518#diff-28cbd3395bb82ac11cadfbf5c5432ef382c9759b297ddd64ef1b93313bef9e52R129-R156
 	 */
-	const isVariable = useSelect( ( select ) => {
-		const isSingleProductView =
-			! query.search &&
-			query.products &&
-			query.products.split( ',' ).length === 1;
-		if ( ! isSingleProductView ) {
-			return false;
-		}
-		const productId = parseInt( query.products, 10 );
-		const includeArgs = { include: productId };
+	const isVariable = useSelect(
+		( select ) => {
+			const isSingleProductView =
+				! query.search &&
+				query.products &&
+				query.products.split( ',' ).length === 1;
+			if ( ! isSingleProductView ) {
+				return false;
+			}
+			const productId = parseInt( query.products, 10 );
+			const includeArgs = { include: productId };
 
-		const { getItems } = select( ITEMS_STORE_NAME );
-		// TODO Look at similar usage to populate tags in the Search component.
-		const products = getItems( 'products', includeArgs );
-		return (
-			products &&
-			products.get( productId ) &&
-			products.get( productId ).type === 'variable'
-		);
-	} );
+			const { getItems } = select( ITEMS_STORE_NAME );
+			// TODO Look at similar usage to populate tags in the Search component.
+			const products = getItems( 'products', includeArgs );
+			return (
+				products &&
+				products.get( productId ) &&
+				products.get( productId ).type === 'variable'
+			);
+		},
+		[ query.search, query.products ]
+	);
+
 	const updatedQuery = {
 		...query,
 		'is-variable': isVariable,

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/useGetRemainingCountryCodes.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/useGetRemainingCountryCodes.js
@@ -23,7 +23,7 @@ const useGetRemainingCountryCodes = () => {
 		return select( STORE_KEY )
 			.getShippingRates()
 			.map( ( el ) => el.countryCode );
-	} );
+	}, [] );
 
 	if ( ! selectedCountryCodes ) {
 		return [];

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,9 +10,9 @@ import { useSelect } from '@wordpress/data';
 import AppInputPriceControl from '.~/components/app-input-price-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AddRateButton from './add-rate-button';
-import { STORE_KEY } from '.~/data';
 import CountriesPriceInputForm from './countries-price-input-form';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
+import useShippingRates from '.~/hooks/useShippingRates';
 import getCountriesPriceArray from './getCountriesPriceArray';
 import AppSpinner from '.~/components/app-spinner';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
@@ -23,9 +22,7 @@ const ShippingRateSetup = ( props ) => {
 	const {
 		formProps: { getInputProps, values },
 	} = props;
-	const shippingRates = useSelect( ( select ) =>
-		select( STORE_KEY ).getShippingRates()
-	);
+	const { data: shippingRates } = useShippingRates();
 	const { code: currencyCode } = useStoreCurrency();
 	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/useGetRemainingCountryCodes.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/useGetRemainingCountryCodes.js
@@ -23,7 +23,7 @@ const useGetRemainingCountryCodes = () => {
 		return select( STORE_KEY )
 			.getShippingTimes()
 			.map( ( el ) => el.countryCode );
-	} );
+	}, [] );
 
 	if ( ! selectedCountryCodes ) {
 		return [];

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/index.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { useSelect } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import AppSpinner from '.~/components/app-spinner';
-import { STORE_KEY } from '.~/data';
+import useShippingTimes from '.~/hooks/useShippingTimes';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AddTimeButton from './add-time-button';
@@ -16,9 +11,7 @@ import CountriesTimeInputForm from './countries-time-input-form';
 import './index.scss';
 
 const ShippingTimeSetup = () => {
-	const shippingTimes = useSelect( ( select ) =>
-		select( STORE_KEY ).getShippingTimes()
-	);
+	const { data: shippingTimes } = useShippingTimes();
 	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
 	if ( ! selectedCountryCodes ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- Add the missing second parameter deps for all usages of `useSelect`
- Add the eslint checking for `useSelect` deps rule
- Use `useShippingRates` and `useShippingTimes` hooks instead of `useSelect` in the MC setup flow

### Screenshots:

Eslint would show a warning if any dependency is missing in the deps array

![image](https://user-images.githubusercontent.com/17420811/121655579-4b958d80-cad1-11eb-8412-9d1f33f0639d.png)


### Detailed test instructions:

1. Look around plugin pages to see if there are any errors or incorrect states

### Changelog entry
