### PR TITLE
Check if product description is not empty before using it

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -147,7 +147,9 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 		// prepend the parent product description to the variation product
 		if ( $this->is_variation() && ! empty( $this->wc_product->get_parent_id() ) ) {
 			$parent_product     = wc_get_product( $this->wc_product->get_parent_id() );
-			$parent_description = $parent_product->get_description() ?? $parent_product->get_short_description();
+			$parent_description = ! empty( $parent_product->get_description() ) ?
+				$parent_product->get_description() :
+				$parent_product->get_short_description();
 			$new_line           = ! empty( $description ) && ! empty( $parent_description ) ? PHP_EOL : '';
 			$description        = $parent_description . $new_line . $description;
 		}

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -140,7 +140,9 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 	 * @return string
 	 */
 	protected function get_wc_product_description(): string {
-		$description = $this->wc_product->get_description() ?? $this->wc_product->get_short_description();
+		$description = ! empty( $this->wc_product->get_description() ) ?
+			$this->wc_product->get_description() :
+			$this->wc_product->get_short_description();
 
 		// prepend the parent product description to the variation product
 		if ( $this->is_variation() && ! empty( $this->wc_product->get_parent_id() ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The product description is returned as an empty string (and not null) if it's not set. This `empty` check fixes the issue where the short description was never used because the value was never returned as `null`.

This can be used as a temporary fix for #782 until we implement a method for users to choose which description they want.

### Detailed test instructions:

1. Create a valid product without description and add a short description to it under `Product short description` panel
2. Sync the product and make sure there are no errors and the product is synced to Google

### Changelog entry

> Fix - Use product's short description if no description is set