### PR TITLE
Warning for Reclaim URL

### DIFF
--- a/js/src/components/content-button-layout/index.js
+++ b/js/src/components/content-button-layout/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import './index.scss';
@@ -8,7 +13,7 @@ const ContentButtonLayout = ( props ) => {
 
 	return (
 		<div
-			className={ `gla-content-button-layout ${ className }` }
+			className={ classnames( 'gla-content-button-layout', className ) }
 			{ ...rest }
 		/>
 	);

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -9,6 +9,7 @@ import { CheckboxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import toAccountText from '.~/utils/toAccountText';
+import recordEvent from '.~/utils/recordEvent';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import AppButton from '.~/components/app-button';
 import Section from '.~/wcdl/section';
@@ -60,6 +61,9 @@ const ReclaimUrlCard = ( props ) => {
 	}
 
 	const handleCheckboxChange = ( v ) => {
+		recordEvent( 'gla_mc_account_reclaim_url_agreement_check', {
+			checked: v,
+		} );
 		setChecked( v );
 	};
 
@@ -106,6 +110,7 @@ const ReclaimUrlCard = ( props ) => {
 						isDestructive
 						disabled={ ! checked }
 						loading={ loading }
+						eventName="gla_mc_account_reclaim_url_button_click"
 						onClick={ handleReclaimClick }
 					>
 						{ __( 'Reclaim my URL', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useState } from '@wordpress/element';
+import { CheckboxControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,9 +18,11 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import { useAppDispatch } from '.~/data';
 import ContentButtonLayout from '.~/components/content-button-layout';
 import ReclaimUrlFailCard from './reclaim-url-fail-card';
+import './index.scss';
 
 const ReclaimUrlCard = ( props ) => {
 	const { id, websiteUrl } = props;
+	const [ checked, setChecked ] = useState( false );
 	const { createNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
 	const [
@@ -56,12 +59,14 @@ const ReclaimUrlCard = ( props ) => {
 		return <ReclaimUrlFailCard onRetry={ handleRetry } />;
 	}
 
+	const handleCheckboxChange = ( v ) => {
+		setChecked( v );
+	};
+
 	return (
-		<Section.Card>
+		<Section.Card className="gla-reclaim-url-card">
 			<Section.Card.Body>
-				<ContentButtonLayout>
-					<Subsection.Title>{ toAccountText( id ) }</Subsection.Title>
-				</ContentButtonLayout>
+				<Subsection.Title>{ toAccountText( id ) }</Subsection.Title>
 				<ContentButtonLayout>
 					<div>
 						<Subsection.Title>
@@ -75,15 +80,31 @@ const ReclaimUrlCard = ( props ) => {
 								}
 							) }
 						</Subsection.Title>
-						<Subsection.HelperText>
-							{ __(
-								'If you reclaim this URL, it will cause any existing product listings or ads to stop running, and the other verified account will be notified that they have lost their claim.',
-								'google-listings-and-ads'
+						<Subsection.HelperText className="gla-reclaim-url-card__warning">
+							{ createInterpolateElement(
+								__(
+									'<strong>Warning:</strong> If you reclaim this URL, it will cause any existing product listings or ads to stop running, and any existing shipping or tax configurations will be lost. The other verified account will be notified that they have lost their claim.',
+									'google-listings-and-ads'
+								),
+								{
+									strong: <strong />,
+								}
 							) }
 						</Subsection.HelperText>
+						<CheckboxControl
+							label={ __(
+								'Yes, I understand the implications of reclaiming my URL.',
+								'google-listings-and-ads'
+							) }
+							checked={ checked }
+							disabled={ loading }
+							onChange={ handleCheckboxChange }
+						></CheckboxControl>
 					</div>
 					<AppButton
 						isSecondary
+						isDestructive
+						disabled={ ! checked }
 						loading={ loading }
 						onClick={ handleReclaimClick }
 					>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.scss
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.scss
@@ -1,0 +1,10 @@
+.gla-reclaim-url-card {
+	.gla-content-button-layout {
+		align-items: flex-start;
+	}
+
+	&__warning {
+		color: #cc1818;
+		margin-bottom: 8px;
+	}
+}

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.scss
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/reclaim-url-card/index.scss
@@ -4,7 +4,7 @@
 	}
 
 	&__warning {
-		color: #cc1818;
+		color: $alert-red;
 		margin-bottom: 8px;
 	}
 }

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -105,6 +105,11 @@ All event names are prefixed by `wcadmin_gla_`.
 
 * `mc_account_create_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
 
+* `mc_account_reclaim_url_agreement_check` - Clicking on the checkbox to agree with and understand the implications of reclaiming URL.
+  * `checked`: indicate whether the checkbox is checked or unchecked.
+
+* `mc_account_reclaim_url_button_click` - Clicking on the button to reclaim URL for a Google Merchant Center account.
+
 * `mc_url_switch`
   * `action` property is `required`: the Merchant Center account has a different, claimed URL and needs to be changed
   * `action` property is `success`: the Merchant Center account has been changed from blank, updated from a different, unclaimed URL, or after user confirmation of a required change.
@@ -145,7 +150,7 @@ All event names are prefixed by `wcadmin_gla_`.
 * `gla_site_claim` event
   * `action` property is `overwrite_required`: the site URL is claimed by another Merchant Center account and overwrite confirmation is required
   * `action` property is `success`: URL has been successfully set or overwritten.
-  * `action` property is `failure`: 
+  * `action` property is `failure`:
     *  `details` property is `independent_account`: unable to execute site claim because the provided Merchant Center account is not a sub-account of our MCA
     * `details` property is `google_proxy`: claim failed using the user creds (in the `Merchant` class)
     * `details` property is `google_manager`: claimed failed using MCA creds (paradoxically in the `Proxy` class)

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -105,7 +105,7 @@ All event names are prefixed by `wcadmin_gla_`.
 
 * `mc_account_create_button_click` - Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
 
-* `mc_account_reclaim_url_agreement_check` - Clicking on the checkbox to agree with and understand the implications of reclaiming URL.
+* `mc_account_reclaim_url_agreement_check` - Clicking on the checkbox to agree with the implications of reclaiming URL.
   * `checked`: indicate whether the checkbox is checked or unchecked.
 
 * `mc_account_reclaim_url_button_click` - Clicking on the button to reclaim URL for a Google Merchant Center account.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #781 .

This PR adds a warning in the `ReclaimUrlCard`. The "Reclaim my URL" button would be disabled by default. Users would have to click on a checkbox to agree with "Yes, I understand the implications of reclaiming my URL." When the checkbox is checked, only then the "Reclaim my URL" button would be enabled.

There are also track events added for the following actions:

- `gla_mc_account_reclaim_url_agreement_check` with `{ checked: true | false }` when users check or uncheck the checkbox.
- `gla_mc_account_reclaim_url_button_click` when users click on the "Reclaim my URL" button.

### Screenshots:

![reclaim-url-warning](https://user-images.githubusercontent.com/417342/122240403-5480c780-cef4-11eb-92b5-77ba4ae9894a.gif)

### Detailed test instructions:

Pre-requisite:

- You do not have any Google MC account connected. 
- You have multiple Google MC accounts. "Account A" has a claimed URL. "Account B" will be used to claim the URL from Account A.
- Open the DevTool console and run localStorage.setItem( 'debug', 'wc-admin:*' ); to enable tracking debugging mode

Steps:

1. Open https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc
2. In Step 1 Google Merchant Center account section, create a new account or connect an existing account to be the "Account B".
3. Reclaim URL should show up. There should be a red warning text. The "Reclaim my URL" button should be disabled by default. 
4. Check the checkbox. The "Reclaim my URL" button should be enabled. There should be a `gla_mc_account_reclaim_url_agreement_check` track event in your browser console.
5. Click on the "Reclaim my URL" button. There should be a `gla_mc_account_reclaim_url_button_click` track event in your browser console.

### Changelog entry

Adds warning message and checkbox for reclaiming URL in Google Merchant Center account connection setup.
