### PR TITLE
Cleanup countries per product

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
 		"use-debounce": "^5.2.0"
 	},
 	"config": {
-		"wp_org_slug": "google-listings-and-ads"
+		"wp_org_slug": "google-listings-and-ads",
+    "version_replace_paths": [
+      "src"
+    ]
 	}
 }

--- a/src/DB/Installer.php
+++ b/src/DB/Installer.php
@@ -44,8 +44,11 @@ class Installer implements Service, FirstInstallInterface, InstallableInterface 
 
 	/**
 	 * Run installation logic for this class.
+	 *
+	 * @param string $old_version Previous version before updating.
+	 * @param string $new_version Current version after updating.
 	 */
-	public function install(): void {
+	public function install( string $old_version, string $new_version ): void {
 		foreach ( $this->tables as $table ) {
 			$table->install();
 		}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -93,8 +93,11 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	 * Run on every plugin update.
 	 */
 	protected function install(): void {
+		$old_version = $this->get_db_version();
+		$new_version = $this->get_version();
+
 		foreach ( $this->installables as $installable ) {
-			$installable->install();
+			$installable->install( $old_version, $new_version );
 		}
 	}
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -221,8 +221,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			ProductMetaHandler::class,
 			ProductHelper::class,
 			ValidatorInterface::class,
-			ProductFactory::class,
-			WC::class
+			ProductFactory::class
 		);
 		$this->share_with_tags(
 			ProductSyncer::class,

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -25,6 +25,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ResubmitExpiringProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update\CleanupProductTargetCountriesJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update\PluginUpdate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -53,6 +55,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		ActionSchedulerInterface::class  => true,
 		AsyncActionRunner::class         => true,
 		ActionSchedulerJobMonitor::class => true,
+		PluginUpdateJobs::class          => true,
 		ProductSyncStats::class          => true,
 		SyncerHooks::class               => true,
 		Service::class                   => true,
@@ -102,6 +105,10 @@ class JobServiceProvider extends AbstractServiceProvider {
 		);
 
 		$this->share_with_tags( StartProductSync::class, JobRepository::class );
+		$this->share_with_tags( PluginUpdate::class, JobRepository::class );
+
+		// Share plugin update jobs
+		$this->share_product_syncer_job( CleanupProductTargetCountriesJob::class );
 	}
 
 	/**

--- a/src/Internal/Interfaces/InstallableInterface.php
+++ b/src/Internal/Interfaces/InstallableInterface.php
@@ -14,6 +14,9 @@ interface InstallableInterface {
 
 	/**
 	 * Run installation logic for this class.
+	 *
+	 * @param string $old_version Previous version before updating.
+	 * @param string $new_version Current version after updating.
 	 */
-	public function install(): void;
+	public function install( string $old_version, string $new_version ): void;
 }

--- a/src/Jobs/Update/CleanupProductTargetCountriesJob.php
+++ b/src/Jobs/Update/CleanupProductTargetCountriesJob.php
@@ -1,0 +1,55 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractProductSyncerBatchedJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncerException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CleanupProductTargetCountriesJob
+ *
+ * Deletes the previous list of target countries which was in use before the
+ * Global Offers option became available.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update
+ */
+class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
+
+	/**
+	 * Get the name of the job.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'cleanup_product_target_countries';
+	}
+
+	/**
+	 * Get a single batch of items.
+	 *
+	 * If no items are returned the job will stop.
+	 *
+	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 *
+	 * @return array
+	 */
+	public function get_batch( int $batch_number ): array {
+		return $this->product_repository->find_synced_product_ids( $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Process batch items.
+	 *
+	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 *
+	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
+	 */
+	protected function process_items( array $items ) {
+		$products      = $this->product_repository->find_by_ids( $items );
+		$stale_entries = $this->batch_product_helper->generate_stale_countries_request_entries( $products );
+		$this->product_syncer->delete_by_batch_requests( $stale_entries );
+	}
+}

--- a/src/Jobs/Update/CleanupProductTargetCountriesJob.php
+++ b/src/Jobs/Update/CleanupProductTargetCountriesJob.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * Deletes the previous list of target countries which was in use before the
  * Global Offers option became available.
  *
+ * @since x.x.x
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update
  */
 class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {

--- a/src/Jobs/Update/PluginUpdate.php
+++ b/src/Jobs/Update/PluginUpdate.php
@@ -1,0 +1,74 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Runs update jobs when the plugin is updated.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update
+ */
+class PluginUpdate implements Service, InstallableInterface {
+
+	/**
+	 * @var JobRepository
+	 */
+	protected $job_repository;
+
+	/**
+	 * PluginUpdate constructor.
+	 *
+	 * @param JobRepository $job_repository
+	 */
+	public function __construct( JobRepository $job_repository ) {
+		$this->job_repository = $job_repository;
+	}
+
+	/**
+	 * Update Jobs that need to be run per version.
+	 *
+	 * @var array
+	 */
+	private $updates = [
+		'1.0.1' => [
+			CleanupProductTargetCountriesJob::class,
+		],
+	];
+
+	/**
+	 * Run installation logic for this class.
+	 *
+	 * @param string $old_version Previous version before updating.
+	 * @param string $new_version Current version after updating.
+	 */
+	public function install( string $old_version, string $new_version ): void {
+		foreach ( $this->updates as $version => $jobs ) {
+			if ( version_compare( $old_version, $version, '<' ) ) {
+				$this->start_jobs( $jobs );
+			}
+		}
+	}
+
+	/**
+	 * Start a list of jobs.
+	 *
+	 * @param array $jobs List of jobs
+	 */
+	protected function start_jobs( array $jobs ): void {
+		foreach ( $jobs as $job ) {
+			try {
+				$this->job_repository->get( $job )->start();
+			} catch ( JobException $e ) {
+				do_action( 'gla_exception', $e, __METHOD__ );
+			}
+		}
+	}
+
+}

--- a/src/Jobs/Update/PluginUpdate.php
+++ b/src/Jobs/Update/PluginUpdate.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Runs update jobs when the plugin is updated.
  *
+ * @since x.x.x
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update
  */
 class PluginUpdate implements Service, InstallableInterface {

--- a/src/Jobs/Update/PluginUpdate.php
+++ b/src/Jobs/Update/PluginUpdate.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -39,6 +40,7 @@ class PluginUpdate implements Service, InstallableInterface {
 	private $updates = [
 		'1.0.1' => [
 			CleanupProductTargetCountriesJob::class,
+			UpdateAllProducts::class,
 		],
 	];
 

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -115,6 +115,19 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	}
 
 	/**
+	 * Return the main target country (default Store country).
+	 * If the store country is not included then use the first target country.
+	 *
+	 * @return string
+	 */
+	public function get_main_target_country(): string {
+		$target_countries = $this->get_target_countries();
+		$shop_country     = $this->container->get( WC::class )->get_base_country();
+
+		return in_array( $shop_country, $target_countries, true ) ? $shop_country : $target_countries[0];
+	}
+
+	/**
 	 * Get the connected merchant account.
 	 *
 	 * @return array

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -118,6 +118,8 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * Return the main target country (default Store country).
 	 * If the store country is not included then use the first target country.
 	 *
+	 * @since x.x.x
+	 *
 	 * @return string
 	 */
 	public function get_main_target_country(): string {

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -12,7 +12,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Google_Service_ShoppingContent_Product as GoogleProduct;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WC_Product;
@@ -54,31 +53,23 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 	protected $product_factory;
 
 	/**
-	 * @var WC
-	 */
-	protected $wc;
-
-	/**
 	 * BatchProductHelper constructor.
 	 *
 	 * @param ProductMetaHandler $meta_handler
 	 * @param ProductHelper      $product_helper
 	 * @param ValidatorInterface $validator
 	 * @param ProductFactory     $product_factory
-	 * @param WC                 $wc
 	 */
 	public function __construct(
 		ProductMetaHandler $meta_handler,
 		ProductHelper $product_helper,
 		ValidatorInterface $validator,
-		ProductFactory $product_factory,
-		WC $wc
+		ProductFactory $product_factory
 	) {
 		$this->meta_handler    = $meta_handler;
 		$this->product_helper  = $product_helper;
 		$this->validator       = $validator;
 		$this->product_factory = $product_factory;
-		$this->wc              = $wc;
 	}
 
 	/**
@@ -186,10 +177,8 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 				continue;
 			}
 
-			$target_countries = $this->merchant_center->get_target_countries();
-			$shop_country     = $this->wc->get_base_country();
-
-			$main_target_country = in_array( $shop_country, $target_countries, true ) ? $shop_country : $target_countries[0];
+			$target_countries    = $this->merchant_center->get_target_countries();
+			$main_target_country = $this->merchant_center->get_main_target_country();
 
 			// validate the product
 			$adapted_product   = $this->product_factory->create( $product, $main_target_country );

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -268,4 +268,30 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 
 		return $request_entries;
 	}
+
+	/**
+	 * Returns an array of request entries for Google products that should no
+	 * longer be submitted for every target country.
+	 *
+	 * @param WC_Product[] $products
+	 *
+	 * @return BatchProductIDRequestEntry[]
+	 */
+	public function generate_stale_countries_request_entries( array $products ): array {
+		$main_target_country = $this->merchant_center->get_main_target_country();
+
+		$request_entries = [];
+		foreach ( $products as $product ) {
+			$google_ids = $this->meta_handler->get_google_ids( $product );
+			$stale_ids  = array_diff_key( $google_ids, array_flip( [ $main_target_country ] ) );
+			foreach ( $stale_ids as $stale_id ) {
+				$request_entries[ $stale_id ] = new BatchProductIDRequestEntry(
+					$product->get_id(),
+					$stale_id
+				);
+			}
+		}
+
+		return $request_entries;
+	}
 }

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -273,6 +273,8 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 	 * Returns an array of request entries for Google products that should no
 	 * longer be submitted for every target country.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param WC_Product[] $products
 	 *
 	 * @return BatchProductIDRequestEntry[]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a follow-on to #791

The PR adds the functionality to schedule a particular set of jobs to run for a specific version. These jobs will only be triggered when updating the plugin. We use this code to trigger the job `CleanupProductTargetCountriesJob` which removes any previously synced products for countries other then the main target country.

Since we needed to reuse the code to get the main target country, this was moved to a helper function in the MerchantCenterService (this also removed an added dependency in the BatchProductHelper).

Closes #790 

### Detailed test instructions:

1. Start with trunk and a site which has multiple target countries selected
2. Sync all the products and confirm they appear for all the countries in https://merchants.google.com/
3. Checkout this PR and bump the plugin version to 1.0.1
4. Wait till all scheduled actions have been completed (we should see scheduled actions like `gla/jobs/cleanup_product_target_countries/create_batch`)
5. After waiting a bit confirm that the countries (except main target country) have been removed in https://merchants.google.com/
6. The remaining products should have the shipping set to multiple countries

Test with WR to update `@since` versions (WR 2.0.4 or newer needs to be used):
`wr vb:replace --folder=<folder where you have the plugin installed> --product_version=1.2.3 https://github.com/woocommerce/google-listings-and-ads/tree/trunk`

### Changelog entry
* Fix - Cleanup target countries per product.