### PR TITLE
Include the Ads account currency with the status

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -293,7 +293,7 @@ class Proxy implements OptionsAwareInterface {
 			if ( 200 === $result->getStatusCode() && isset( $response['resourceName'] ) ) {
 				$id = $this->parse_ads_id( $response['resourceName'] );
 				$this->update_ads_id( $id );
-				$this->update_ads_currency( true );
+				$this->use_store_currency();
 
 				$billing_url = $response['invitationLink'] ?? '';
 				$this->update_billing_url( $billing_url );
@@ -343,7 +343,7 @@ class Proxy implements OptionsAwareInterface {
 
 			if ( 200 === $result->getStatusCode() && isset( $response['resourceName'] ) && 0 === strpos( $response['resourceName'], $name ) ) {
 				$this->update_ads_id( $id );
-				$this->update_ads_currency( false );
+				$this->request_ads_currency();
 				return [ 'id' => $id ];
 			}
 
@@ -368,7 +368,7 @@ class Proxy implements OptionsAwareInterface {
 
 		// Retrieve account currency if we haven't done so previously.
 		if ( $id && ! $this->options->get( OptionsInterface::ADS_ACCOUNT_CURRENCY ) ) {
-			$this->update_ads_currency( false );
+			$this->request_ads_currency();
 		}
 
 		$status = [
@@ -520,15 +520,24 @@ class Proxy implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Update the ads account currency.
+	 * Save the Ads account currency to the same value as the Store currency.
 	 *
 	 * @since x.x.x
 	 *
-	 * @param boolean $use_store_currency Use the store currency or request the account currency.
+	 * @return boolean
+	 */
+	protected function use_store_currency(): bool {
+		return $this->options->update( OptionsInterface::ADS_ACCOUNT_CURRENCY, get_woocommerce_currency() );
+	}
+
+	/**
+	 * Request the Ads Account currency, and cache it as an option.
+	 *
+	 * @since x.x.x
 	 *
 	 * @return boolean
 	 */
-	protected function update_ads_currency( bool $use_store_currency ): bool {
+	protected function request_ads_currency(): bool {
 		if ( $use_store_currency ) {
 			$currency = get_woocommerce_currency();
 		} else {

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -23,6 +23,7 @@ final class Options implements OptionsInterface, Service {
 	use PluginHelper;
 
 	private const VALID_OPTIONS = [
+		self::ADS_ACCOUNT_CURRENCY   => true,
 		self::ADS_ACCOUNT_STATE      => true,
 		self::ADS_BILLING_URL        => true,
 		self::ADS_ID                 => true,

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
  */
 interface OptionsInterface {
 
+	public const ADS_ACCOUNT_CURRENCY   = 'ads_account_currency';
 	public const ADS_ACCOUNT_STATE      = 'ads_account_state';
 	public const ADS_BILLING_URL        = 'ads_billing_url';
 	public const ADS_ID                 = 'ads_id';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR exposes the ads account currency in the API, when we request the account status `/wc/gla/ads/connection`. The intention is for the UI to use this value and compare it with the currency it's using to display it's information. If they are different then a warning should be shown (because we do not support currency conversions at the moment).

When the user creates an Ad account through our extension we will always use the store currency. However when they link an existing account the currency has already been set (so in this scenario we should warn the user if they don't match).

Note:
We cache the account currency permanently, so we only request it once. In the [API](https://developers.google.com/google-ads/api/reference/rpc/v8/Customer) it's marked as "immutable" so it's not possible to change it in the Google dashboard.

![image](https://user-images.githubusercontent.com/11388669/122412166-3f9c4680-cf7d-11eb-9a34-64b9a8051d7c.png)


Resolves part of #363

### Detailed test instructions:

1. Use the Connection Test page and click the "Ads Connection Status" button
2. Confirm that the response contains the currency
3. If we have a local WCS you should see only one request to `/google/google-ads/v6/customers/<customerid>`
4. Check the DB and confirm the option `gla_ads_account_currency` has the saved currency
5. Change the store currency
6. Repeat the test with the "Ads Connection Status" button
7. Confirm that the Ads account currency remains the same even if the store currency changed

### Changelog entry
* Fix - Include the Ads account currency when checking the status.