### PR TITLE
Use a constant batch size (100) for update all product job

### DIFF
--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -88,7 +88,12 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 * @return int
 	 */
 	protected function get_batch_size(): int {
-		return 100;
+		/**
+		 * Filters the batch size for the job.
+		 *
+		 * @param string Job's name
+		 */
+		return apply_filters( 'woocommerce_gla_batched_job_size', 100, $this->get_name() );
 	}
 
 	/**

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -26,17 +26,6 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	}
 
 	/**
-	 * Calculate and return batch size considering target audiences per product.
-	 *
-	 * @return int
-	 */
-	protected function get_batch_size(): int {
-		$batch_size = (int) floor( 200 / count( $this->merchant_center->get_target_countries() ) );
-		// between 2 and 50 products per batch
-		return min( max( $batch_size, 2 ), 50 );
-	}
-
-	/**
 	 * Get a single batch of items.
 	 *
 	 * If no items are returned the job will stop.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We no longer submit a separate product for each target country so we don't need to decrease the batch size if the user has multiple target countries selected.

Related to #791.

### Detailed test instructions:

1. Run the update all products job via Connection Test page (async)
2. Make sure the products are updated in batches of 100


### Changelog entry

> Tweak - Set batch size to 100 for the "update all products" job