### PR TITLE
Use get_home_url for retrieving the site URL

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -4,11 +4,12 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\TosAccepted;
 use DateTime;
 use DateTimeZone;
@@ -28,9 +29,10 @@ defined( 'ABSPATH' ) || exit;
  */
 class Proxy implements OptionsAwareInterface {
 
-	use OptionsAwareTrait;
 	use ApiExceptionTrait;
 	use GoogleHelper;
+	use OptionsAwareTrait;
+	use PluginHelper;
 
 	/**
 	 * @var ContainerInterface
@@ -88,7 +90,7 @@ class Proxy implements OptionsAwareInterface {
 				throw new Exception( __( 'Unable to log accepted TOS', 'google-listings-and-ads' ) );
 			}
 
-			$site_url = esc_url_raw( apply_filters( 'woocommerce_gla_site_url', site_url() ) );
+			$site_url = esc_url_raw( $this->get_site_url() );
 			if ( ! wc_is_valid_url( $site_url ) ) {
 				throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
 			}

--- a/src/API/Site/Controllers/Google/SiteVerificationController.php
+++ b/src/API/Site/Controllers/Google/SiteVerificationController.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptions
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 
@@ -21,6 +22,7 @@ defined( 'ABSPATH' ) || exit;
 class SiteVerificationController extends BaseOptionsController {
 
 	use EmptySchemaPropertiesTrait;
+	use PluginHelper;
 
 	/**
 	 * @var SiteVerification
@@ -66,7 +68,7 @@ class SiteVerificationController extends BaseOptionsController {
 	 */
 	protected function get_verify_endpoint_create_callback(): callable {
 		return function() {
-			$site_url = esc_url_raw( apply_filters( 'woocommerce_gla_site_url', site_url() ) );
+			$site_url = esc_url_raw( $this->get_site_url() );
 
 			if ( ! wc_is_valid_url( $site_url ) ) {
 				return $this->get_failure_status( __( 'Invalid site URL.', 'google-listings-and-ads' ) );

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Google_Service_ShoppingContent_Account as MC_Account;
@@ -27,6 +28,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
 class AccountController extends BaseOptionsController {
+
+	use PluginHelper;
 
 	/**
 	 * @var ContainerInterface
@@ -434,7 +437,7 @@ class AccountController extends BaseOptionsController {
 					$data = [
 						'id'          => $merchant_id,
 						'website_url' => $this->strip_url_protocol(
-							esc_url_raw( apply_filters( 'woocommerce_gla_site_url', site_url() ) )
+							esc_url_raw( $this->get_site_url() )
 						),
 					];
 
@@ -479,7 +482,7 @@ class AccountController extends BaseOptionsController {
 	 * @throws Exception If any step of the site verification process fails.
 	 */
 	private function verify_site(): void {
-		$site_url = esc_url_raw( apply_filters( 'woocommerce_gla_site_url', site_url() ) );
+		$site_url = esc_url_raw( $this->get_site_url() );
 		if ( ! wc_is_valid_url( $site_url ) ) {
 			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'site-url' ] );
 			throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
@@ -551,7 +554,7 @@ class AccountController extends BaseOptionsController {
 		}
 
 		// Make sure the existing account has the correct website URL (or fail).
-		$site_url = esc_url_raw( apply_filters( 'woocommerce_gla_site_url', site_url() ) );
+		$site_url = esc_url_raw( $this->get_site_url() );
 		$this->maybe_add_merchant_center_website_url( $account_id, $site_url );
 
 		// Maybe the existing account is sub-account!

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -297,7 +297,7 @@ class ConnectionTest implements Service, Registerable {
 							<td>
 								<p>
 									<label title="Use a live site!">
-										Site URL <input name="site_url" type="text" style="width:14em; font-size:.9em" value="<?php echo esc_url( ! empty( $_GET['site_url'] ) ? $_GET['site_url'] : apply_filters( 'woocommerce_gla_site_url', site_url() ) ); ?>" />
+										Site URL <input name="site_url" type="text" style="width:14em; font-size:.9em" value="<?php echo esc_url( ! empty( $_GET['site_url'] ) ? $_GET['site_url'] : $this->get_site_url() ); ?>" />
 									</label>
 									<label title="To simulate linking with an external site">
 										MC ID <input name="account_id" type="text" style="width:8em; font-size:.9em" value="<?php echo ! empty( $_GET['account_id'] ) ? intval( $_GET['account_id'] ) : ''; ?>" />
@@ -375,7 +375,7 @@ class ConnectionTest implements Service, Registerable {
 											add_query_arg(
 												[
 													'action' => 'wcs-google-mc-switch-url',
-													'site_url' => $_GET['site_url'] ?? apply_filters( 'woocommerce_gla_site_url', site_url(), $url ),
+													'site_url' => $_GET['site_url'] ?? $this->get_site_url(),
 													'account_id' => ($_GET['account_id'] ?? false) ?: $merchant_id,
 												]
 											),

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -157,4 +157,15 @@ trait PluginHelper {
 		// TODO: Change to api.woocommerce.com when we are no longer in test phase.
 		return apply_filters( 'woocommerce_gla_wcs_url', 'https://api-vipgo.woocommerce.com' );
 	}
+
+	/**
+	 * Gets the main site URL which is used for the home page.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string
+	 */
+	protected function get_site_url(): string {
+		return apply_filters( 'woocommerce_gla_site_url', get_home_url() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In some configurations the WordPress install can be in a subfolder, one such configuration is [Bedrock](https://roots.io/bedrock/).
To still get the right URL for the home page we use the function `get_home_url` instead of `site_url`.

Closes #796 

### Detailed test instructions:

1. Move the WordPress install to a subfolder or setup a site using [Bedrock](https://roots.io/bedrock/)
2. Confirm on the Connection test page we see the Site URL like `https://domain.test/wp`
3. Apply this PR
4. Confirm on the Connection test page we see the Site URL like `https://domain.test`
5. Connect a merchant account which will go through the steps of verification, linking and claiming which will all use the new URL

### Changelog entry
* Fix - Use get_home_url for retrieving the site URL.
