### PR TITLE
Prevent conflicts in channel visibility meta box form

### DIFF
--- a/src/Admin/MetaBox/AbstractMetaBox.php
+++ b/src/Admin/MetaBox/AbstractMetaBox.php
@@ -131,6 +131,21 @@ abstract class AbstractMetaBox implements MetaBoxInterface {
 	}
 
 	/**
+	 * Appends a prefix to the given field ID and returns it.
+	 *
+	 * @param string $field_id
+	 *
+	 * @return string
+	 *
+	 * @since x.x.x
+	 */
+	protected function prefix_field_id( string $field_id ): string {
+		$box_id = $this->prefix_id( $this->get_id() );
+
+		return "{$box_id}_{$field_id}";
+	}
+
+	/**
 	 * Returns an array of variables to be used in the view.
 	 *
 	 * @param WP_Post $post The WordPress post object the box is loaded for.

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -147,7 +147,7 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 		$field_id = $this->get_visibility_field_id();
 		// phpcs:disable WordPress.Security.NonceVerification
 		// nonce is verified by self::verify_nonce
-		if ( ! $this->verify_nonce() || ! isset( $_POST[ $field_id ] ) || ! empty( $already_updated[ $product_id ] ) ) {
+		if ( ! $this->verify_nonce() || ! isset( $_POST[ $field_id ] ) || isset( $already_updated[ $product_id ] ) ) {
 			return;
 		}
 

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -127,9 +127,7 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	 * Register a service.
 	 */
 	public function register(): void {
-		add_action( 'woocommerce_new_product', [ $this, 'handle_submission' ] );
-		add_action( 'woocommerce_update_product', [ $this, 'handle_submission' ] );
-		add_action( 'woocommerce_process_product_meta', [ $this, 'handle_submission' ], 10, 2 );
+		add_action( 'woocommerce_process_product_meta', [ $this, 'handle_submission' ] );
 	}
 
 	/**

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -141,8 +141,14 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 			return;
 		}
 
-		$product = $this->product_helper->get_wc_product( $product_id );
 		try {
+			$product = $this->product_helper->get_wc_product( $product_id );
+
+			// only update the value for supported product types
+			if ( ! in_array( $product->get_type(), ProductSyncer::get_supported_product_types(), true ) ) {
+				return;
+			}
+
 			$visibility = empty( $_POST[ $field_id ] ) ?
 				ChannelVisibility::cast( ChannelVisibility::SYNC_AND_SHOW ) :
 				ChannelVisibility::cast( sanitize_key( $_POST[ $field_id ] ) );

--- a/src/HelperTraits/ViewHelperTrait.php
+++ b/src/HelperTraits/ViewHelperTrait.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -11,6 +13,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits
  */
 trait ViewHelperTrait {
+
+	use PluginHelper;
 
 	/**
 	 * Returns the list of allowed HTML tags used for view sanitization.
@@ -46,5 +50,18 @@ trait ViewHelperTrait {
 				'option' => $allowed_attributes,
 			]
 		);
+	}
+
+	/**
+	 * Appends a prefix to the given ID and returns it.
+	 *
+	 * @param string $id
+	 *
+	 * @return string
+	 *
+	 * @since x.x.x
+	 */
+	protected function prefix_id( string $id ): string {
+		return "{$this->get_slug()}_$id";
 	}
 }

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -109,7 +109,7 @@ class SyncerHooks implements Service, Registerable, MerchantCenterAwareInterface
 		add_action( 'woocommerce_update_product_variation', $update, 90 );
 
 		// if we don't attach to these we miss product gallery updates.
-		add_action( 'woocommerce_process_product_meta', $update, 90, 2 );
+		add_action( 'woocommerce_process_product_meta', $update, 90 );
 
 		// when a product is trashed or removed, schedule a delete job.
 		add_action( 'wp_trash_post', $pre_delete, 90 );

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -23,6 +23,11 @@ $product = $this->product;
 $visibility = $this->visibility;
 
 /**
+ * @var string
+ */
+$field_id = $this->field_id;
+
+/**
  * @var string $sync_status
  */
 if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
@@ -43,7 +48,7 @@ $has_issues = ! empty( $issues );
 	<?php
 	woocommerce_wp_select(
 		[
-			'id'      => 'visibility',
+			'id'      => $field_id,
 			'value'   => $visibility,
 			'label'   => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
 			'options' => [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a prefix to the `visibility` field used in the `Channel Visibility` metabox to prevent any conflicts with other plugins or code snippets sending the same field in the `$_POST` request.

It should resolve an issue faced by a user when going through the setup process: https://wordpress.org/support/topic/not-able-to-get-through-setup/


### Detailed test instructions:

1. Edit a product and change the channel visibility value
2. Confirm that the channel visibility value changes for the product

### Changelog entry

> Fix - Prevent conflicts when storing the channel visibility value