### PR TITLE
Fix the formatting string of "day" for status box on the Product Feed page

### DIFF
--- a/js/src/product-feed/product-statistics/status-box.js
+++ b/js/src/product-feed/product-statistics/status-box.js
@@ -71,7 +71,7 @@ function getSyncResult( {
 				totalSynced,
 				'google-listings-and-ads'
 			),
-			formatDate( 'n F Y, h:ia', new Date( timestamp * 1000 ) ),
+			formatDate( 'j F Y, h:ia', new Date( timestamp * 1000 ) ),
 			totalSynced
 		),
 	};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A quick fix for #802

Fix the formatting string of "day" for status box on the Product Feed page

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/122899703-a1462180-d37e-11eb-8a83-c73663ac7571.png)

### Detailed test instructions:

Head to the Product Feed page and check if the date displayed in the sync status box is correct

### Changelog entry

> Fix - Correct formatting string of "day" for status box on the Product Feed page
