### PR TITLE
Handle null postmeta values

### DIFF
--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -256,7 +256,7 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 		$target_audience = $this->merchant_center->get_target_countries();
 		$request_entries = [];
 		foreach ( $products as $product ) {
-			$google_ids = $this->meta_handler->get_google_ids( $product );
+			$google_ids = $this->meta_handler->get_google_ids( $product ) ?: [];
 			$stale_ids  = array_diff_key( $google_ids, array_flip( $target_audience ) );
 			foreach ( $stale_ids as $stale_id ) {
 				$request_entries[ $stale_id ] = new BatchProductIDRequestEntry(
@@ -284,7 +284,7 @@ class BatchProductHelper implements Service, MerchantCenterAwareInterface {
 
 		$request_entries = [];
 		foreach ( $products as $product ) {
-			$google_ids = $this->meta_handler->get_google_ids( $product );
+			$google_ids = $this->meta_handler->get_google_ids( $product ) ?: [];
 			$stale_ids  = array_diff_key( $google_ids, array_flip( [ $main_target_country ] ) );
 			foreach ( $stale_ids as $stale_id ) {
 				$request_entries[ $stale_id ] = new BatchProductIDRequestEntry(

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -322,9 +322,9 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 *
 	 * @param WC_Product $wc_product
 	 *
-	 * @return string
+	 * @return string|null
 	 */
-	public function get_sync_status( WC_Product $wc_product ): string {
+	public function get_sync_status( WC_Product $wc_product ): ?string {
 		return $this->meta_handler->get_sync_status( $wc_product );
 	}
 
@@ -333,9 +333,9 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	 *
 	 * @param WC_Product $wc_product
 	 *
-	 * @return string
+	 * @return string|null
 	 */
-	public function get_mc_status( WC_Product $wc_product ): string {
+	public function get_mc_status( WC_Product $wc_product ): ?string {
 		if ( $wc_product instanceof WC_Product_Variation ) {
 			return $this->meta_handler->get_mc_status( $this->get_wc_product( $wc_product->get_parent_id() ) );
 		}

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -305,9 +305,9 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	/**
 	 * @param WC_Product $wc_product
 	 *
-	 * @return string
+	 * @return string|null
 	 */
-	public function get_visibility( WC_Product $wc_product ): string {
+	public function get_visibility( WC_Product $wc_product ): ?string {
 		$visibility = $this->meta_handler->get_visibility( $wc_product );
 		if ( $wc_product instanceof WC_Product_Variation ) {
 			// todo: we might need to define visibility per variation later.

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -201,9 +201,9 @@ class ProductHelper implements Service, MerchantCenterAwareInterface {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @return string[] An array of Google product IDs stored for each WooCommerce product
+	 * @return string[]|null An array of Google product IDs stored for each WooCommerce product
 	 */
-	public function get_synced_google_product_ids( WC_Product $product ): array {
+	public function get_synced_google_product_ids( WC_Product $product ): ?array {
 		return $this->meta_handler->get_google_ids( $product );
 	}
 

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -19,28 +19,28 @@ defined( 'ABSPATH' ) || exit;
  *
  * @method update_synced_at( WC_Product $product, $value )
  * @method delete_synced_at( WC_Product $product )
- * @method get_synced_at( WC_Product $product ): int
+ * @method get_synced_at( WC_Product $product ): int|null
  * @method update_google_ids( WC_Product $product, array $value )
  * @method delete_google_ids( WC_Product $product )
- * @method get_google_ids( WC_Product $product ): array
+ * @method get_google_ids( WC_Product $product ): array|null
  * @method update_visibility( WC_Product $product, $value )
  * @method delete_visibility( WC_Product $product )
- * @method get_visibility( WC_Product $product ): string
+ * @method get_visibility( WC_Product $product ): string|null
  * @method update_errors( WC_Product $product, array $value )
  * @method delete_errors( WC_Product $product )
- * @method get_errors( WC_Product $product ): array
+ * @method get_errors( WC_Product $product ): array|null
  * @method update_failed_sync_attempts( WC_Product $product, int $value )
  * @method delete_failed_sync_attempts( WC_Product $product )
- * @method get_failed_sync_attempts( WC_Product $product ): int
+ * @method get_failed_sync_attempts( WC_Product $product ): int|null
  * @method update_sync_failed_at( WC_Product $product, int $value )
  * @method delete_sync_failed_at( WC_Product $product )
- * @method get_sync_failed_at( WC_Product $product ): int
+ * @method get_sync_failed_at( WC_Product $product ): int|null
  * @method update_sync_status( WC_Product $product, string $value )
  * @method delete_sync_status( WC_Product $product )
- * @method get_sync_status( WC_Product $product ): string
+ * @method get_sync_status( WC_Product $product ): string|null
  * @method update_mc_status( WC_Product $product, string $value )
  * @method delete_mc_status( WC_Product $product )
- * @method get_mc_status( WC_Product $product ): string
+ * @method get_mc_status( WC_Product $product ): string|null
  */
 class ProductMetaHandler implements Service, Registerable {
 
@@ -138,7 +138,7 @@ class ProductMetaHandler implements Service, Registerable {
 	 * @param WC_Product $product
 	 * @param string     $key
 	 *
-	 * @return mixed|null The value, or null if the meta key doesn't exist.
+	 * @return mixed The value, or null if the meta key doesn't exist.
 	 *
 	 * @throws InvalidMeta If the meta key is invalid.
 	 */

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -138,7 +138,7 @@ class ProductMetaHandler implements Service, Registerable {
 	 * @param WC_Product $product
 	 * @param string     $key
 	 *
-	 * @return mixed The value
+	 * @return mixed|null The value, or null if the meta key doesn't exist.
 	 *
 	 * @throws InvalidMeta If the meta key is invalid.
 	 */

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -32,7 +32,7 @@ $field_id = $this->field_id;
  */
 if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
 	$sync_status = __( 'Issues detected', 'google-listings-and-ads' );
-} else {
+} elseif ( ! is_null( $this->sync_status ) ) {
 	$sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
 }
 $show_status = $visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Changes in #753 mean the meta handler `get_` methods can now return a `null` value if the postmeta record doesn't exits, which isn't contemplated in a lot of places where they're used. This PR tries to find them all and handle null values.

### Screenshots:
_Example_
![image](https://user-images.githubusercontent.com/228780/122941611-d69a4180-d375-11eb-8770-ae8fc565bf3f.png)


### Detailed test instructions:

1. Add a new product - confirm there are no fatals on the edit form.
2. General extension usage with no fatals
3. 


### Changelog entry

- Fix - Handle null postmeta values gracefully.