### PR TITLE
Don't use order in product query by default

### DIFF
--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -476,6 +476,11 @@ class ProductRepository implements Service {
 			$args['type'] = ProductSyncer::get_supported_product_types();
 		}
 
+		// use no ordering unless specified in arguments. overrides the default WooCommerce query args
+		if ( empty( $args['orderby'] ) ) {
+			$args['orderby'] = 'none';
+		}
+
 		return $args;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since we don't care about the order of products in any of our queries done in `ProductRepository`, I think it's best to leave the default `orderby` argument to `none`. This simple change improves the query performance for large datasets significantly.

When I tested the query on my large website (with ~50,000 products and variations) it reduced the un-limited  `find_sync_ready_products` query execution time from ~17s to ~4s  (4x reduction).

When you limit the `find_sync_ready_products` query to `100` (our default batch size) it reduces the query execution time from  ~12s to ~0.3s.

Query 1 - With `ORDER BY`:

```
 SELECT wp_posts.*
FROM   wp_posts
       LEFT JOIN wp_term_relationships
              ON ( wp_posts.id = wp_term_relationships.object_id )
       LEFT JOIN wp_postmeta
              ON ( wp_posts.id = wp_postmeta.post_id
                   AND wp_postmeta.meta_key = '_wc_gla_visibility' )
       LEFT JOIN wp_postmeta AS mt1
              ON ( wp_posts.id = mt1.post_id )
WHERE  1 = 1
       AND (( wp_term_relationships.term_taxonomy_id IN ( 2 )
               OR NOT EXISTS (SELECT 1
                              FROM   wp_term_relationships
                                     INNER JOIN wp_term_taxonomy
                                             ON
                                     wp_term_taxonomy.term_taxonomy_id =
                                     wp_term_relationships.term_taxonomy_id
                              WHERE  wp_term_taxonomy.taxonomy = 'product_type'
                                     AND wp_term_relationships.object_id =
                                         wp_posts.id)
            ))
       AND ( wp_postmeta.post_id IS NULL
              OR ( mt1.meta_key = '_wc_gla_visibility'
                   AND mt1.meta_value != 'dont-sync-and-show' ) )
       AND wp_posts.post_type IN ( 'product_variation', 'product' )
       AND (( wp_posts.post_status = 'publish' ))
GROUP  BY wp_posts.id
ORDER  BY wp_posts.post_date DESC
LIMIT  100;  
```

Query 2 - Without `ORDER BY`:

```
SELECT wp_posts.*
FROM   wp_posts
       LEFT JOIN wp_term_relationships
              ON ( wp_posts.id = wp_term_relationships.object_id )
       LEFT JOIN wp_postmeta
              ON ( wp_posts.id = wp_postmeta.post_id
                   AND wp_postmeta.meta_key = '_wc_gla_visibility' )
       LEFT JOIN wp_postmeta AS mt1
              ON ( wp_posts.id = mt1.post_id )
WHERE  1 = 1
       AND (( wp_term_relationships.term_taxonomy_id IN ( 2 )
               OR NOT EXISTS (SELECT 1
                              FROM   wp_term_relationships
                                     INNER JOIN wp_term_taxonomy
                                             ON
                                     wp_term_taxonomy.term_taxonomy_id =
                                     wp_term_relationships.term_taxonomy_id
                              WHERE  wp_term_taxonomy.taxonomy = 'product_type'
                                     AND wp_term_relationships.object_id =
                                         wp_posts.id)
            ))
       AND ( wp_postmeta.post_id IS NULL
              OR ( mt1.meta_key = '_wc_gla_visibility'
                   AND mt1.meta_value != 'dont-sync-and-show' ) )
       AND wp_posts.post_type IN ( 'product_variation', 'product' )
       AND (( wp_posts.post_status = 'publish' ))
GROUP  BY wp_posts.id
LIMIT  100;  
```

```
+----------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Query_ID | Duration    | Query                                                                                                                                                                                                                                                                                                        |
+----------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|        1 | 11.98151525 | SELECT   wp_posts.* FROM wp_posts  LEFT JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id) LEFT JOIN wp_postmeta ON (wp_posts.ID = wp_postmeta.post_id AND wp_postmeta.meta_key = '_wc_gla_visibility' )  LEFT JOIN wp_postmeta AS mt1 ON ( wp_posts.ID = mt1.post_id ) WHERE 1=1 |
|        2 |  0.03011700 | SELECT   wp_posts.* FROM wp_posts  LEFT JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id) LEFT JOIN wp_postmeta ON (wp_posts.ID = wp_postmeta.post_id AND wp_postmeta.meta_key = '_wc_gla_visibility' )  LEFT JOIN wp_postmeta AS mt1 ON ( wp_posts.ID = mt1.post_id ) WHERE 1=1 |
+----------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

### Detailed test instructions:

The execution speed on `create_batch` jobs for the `update all products` job must be improved on large sets of products

### Changelog entry

> Tweak - Optimize product queries