### PR TITLE
Tiny: Reduce the default productstatus batch size to 1000

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -174,7 +174,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		 $this->refresh_account_issues();
 
 		// Update MC product issues and tabulate statistics in batches.
-		$chunk_size = apply_filters( 'woocommerce_gla_merchant_status_google_ids_chunk', 5000 );
+		$chunk_size = apply_filters( 'woocommerce_gla_merchant_status_google_ids_chunk', 1000 );
 		foreach ( array_chunk( $this->get_synced_google_ids(), $chunk_size ) as $google_ids ) {
 			$mc_product_statuses = $this->filter_valid_statuses( $google_ids );
 			$this->refresh_product_issues( $mc_product_statuses );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR simply reduces the chunk/batch size for the process of retrieving product statuses during merchant status cache generation/update. In testing, on site with low memory, the 5000-item chunk size occasionally ran out of memory.

### Detailed test instructions:

1. Generate the merchant status cache `GET /wp-json/wc/gla/mc/product-statistics/refresh`
2. Confirm there are no errors or timeouts. 

### Changelog entry
Tweak - Reduce the default productstatus batch size.