### PR TITLE
Update travis config to use latest version of WP and WC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ env:
     - WP_DIR=/tmp/wordpress
     - WP_CORE_DIR="${WP_DIR}/src"
     - WP_TESTS_DIR="${WP_DIR}/tests/phpunit"
-    - WP_LATEST=5.5
+    - WP_LATEST=5.7
   matrix:
-    - WP_VERSION="${WP_LATEST}" WC_VERSION=master
-    - WP_VERSION="${WP_LATEST}" WC_VERSION=4.7.0-rc.1
-    - WP_VERSION=5.4 WC_VERSION=4.7.0-rc.1
-    - WP_VERSION=5.3 WC_VERSION=4.7.0-rc.1
+    - WP_VERSION="${WP_LATEST}" WC_VERSION=trunk
+    - WP_VERSION="${WP_LATEST}" WC_VERSION=5.2
+    - WP_VERSION=5.6 WC_VERSION=5.2
+    - WP_VERSION=5.5 WC_VERSION=5.2
 
 # Additional tests
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,9 @@ env:
     - WP_CORE_DIR="${WP_DIR}/src"
     - WP_TESTS_DIR="${WP_DIR}/tests/phpunit"
     - WP_LATEST=5.7
+    - WC_LATEST=trunk
   matrix:
-    - WP_VERSION="${WP_LATEST}" WC_VERSION=trunk
+    - WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}"
     - WP_VERSION="${WP_LATEST}" WC_VERSION=5.2
     - WP_VERSION=5.6 WC_VERSION=5.2
     - WP_VERSION=5.5 WC_VERSION=5.2
@@ -39,11 +40,11 @@ matrix:
   include:
     - name: "JS unit tests"
       language: node_js # Takes version from `.nvmrc`, runs `npm ci` automatically.
-      env: WP_VERSION="${WP_LATEST}" WC_VERSION=trunk WP_TRAVISCI=jest WP_MULTISITE=0
+      env: WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}" WP_TRAVISCI=jest WP_MULTISITE=0
       script: npm run test-unit
     - name: "Coding standard check"
       php: 7.4
-      env: WP_VERSION="${WP_LATEST}" WC_VERSION=trunk WP_TRAVISCI=cs WP_MULTISITE=0
+      env: WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}" WP_TRAVISCI=cs WP_MULTISITE=0
       script: npm ci && npm run lint
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ matrix:
   include:
     - name: "JS unit tests"
       language: node_js # Takes version from `.nvmrc`, runs `npm ci` automatically.
-      env: WP_VERSION="${WP_LATEST}" WC_VERSION=master WP_TRAVISCI=jest WP_MULTISITE=0
+      env: WP_VERSION="${WP_LATEST}" WC_VERSION=trunk WP_TRAVISCI=jest WP_MULTISITE=0
       script: npm run test-unit
     - name: "Coding standard check"
       php: 7.4
-      env: WP_VERSION="${WP_LATEST}" WC_VERSION=master WP_TRAVISCI=cs WP_MULTISITE=0
+      env: WP_VERSION="${WP_LATEST}" WC_VERSION=trunk WP_TRAVISCI=cs WP_MULTISITE=0
       script: npm ci && npm run lint
 
 before_install:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the WooCommerce and WordPress versions in our Travis configurations to the latest versions we support.

### Detailed test instructions:

1. Check that Travis build runs successfully