### PR TITLE
Bump `@wordpress/scripts` to 16.1.3 (from 12.5.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7261,13 +7261,31 @@
 			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.9.0.tgz",
-			"integrity": "sha512-Eo8ByPd3iZ6az4UmdLD2xYLp1/7os/H80l28Y5OlS4DozkD3vcWCBReynWoBax74u3oJ9wWN5b/8oSxGwIKXYQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-3.1.4.tgz",
+			"integrity": "sha512-SoFdhgt75symEJz57QwzDrcZzuSZ9Fxxr1adplSHHYfvRXBm/vDM0x6jeb2pHtVWH0Ltax4Z/yelRgv982nNYA==",
 			"dev": true,
 			"requires": {
 				"json2php": "^0.0.4",
-				"webpack-sources": "^1.3.0"
+				"webpack-sources": "^2.2.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"webpack-sources": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.0.tgz",
+					"integrity": "sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.1",
+						"source-map": "^0.6.1"
+					}
+				}
 			}
 		},
 		"@wordpress/deprecated": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6532,9 +6532,9 @@
 			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-5.2.2.tgz",
-			"integrity": "sha512-xn/uOJRrkXBZoVv/iR4vc6GOAmmBpNSujO+ZoJzdy0zSJqV8vgzt7y/uZZetpJuyZAD8lR3aHxL7MUWos2PtfA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.2.0.tgz",
+			"integrity": "sha512-uNdR8TjUZgTF43psvAPGW/jnKMD+Mr8XiVhJGcVjrKwDoVBvHjtoKSpfafvkrESIHmMz2HgB4+NdqFHL5hhZlg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.13.10",
@@ -6543,11 +6543,50 @@
 				"@babel/preset-env": "^7.13.10",
 				"@babel/preset-typescript": "^7.13.0",
 				"@babel/runtime": "^7.13.10",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^3.0.3",
-				"@wordpress/browserslist-config": "^3.0.3",
-				"@wordpress/element": "^2.20.3",
-				"@wordpress/warning": "^1.4.2",
-				"core-js": "^3.6.4"
+				"@wordpress/babel-plugin-import-jsx-pragma": "^3.0.5",
+				"@wordpress/browserslist-config": "^4.0.1",
+				"@wordpress/element": "^3.1.1",
+				"@wordpress/warning": "^2.1.1",
+				"browserslist": "^4.16.6",
+				"core-js": "^3.12.1"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.1.1.tgz",
+					"integrity": "sha512-OaqKQVEV3CCTdrx/G7fMbmxhrxjApobHUAGAVYCCR1MIqScfluYJRLWFLx8tlkl/Qm/UbF9IfdXS1lphufvYog==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.1.1",
+						"lodash": "^4.17.21",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.1.1.tgz",
+					"integrity": "sha512-ZIkLxGLBhXkZu3t0yF82/brPV5aCOGCXGiH0EMV8GCohhXCNIfQwwFrZ5gd5NyNX5Q8alTLsiA84azJd+n0XiQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/warning": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.1.1.tgz",
+					"integrity": "sha512-EX+/6P2bWO0zRrKJYx1yck0rY2K5z5aPb67DTU+2ggcowW8JRP7hBzGdzhXqoE32oMS7RO97nG3uD9sZtn2DJA==",
+					"dev": true
+				},
+				"core-js": {
+					"version": "3.15.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.1.tgz",
+					"integrity": "sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/base-styles": {
@@ -6745,9 +6784,9 @@
 			}
 		},
 		"@wordpress/browserslist-config": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.3.tgz",
-			"integrity": "sha512-hbGJt0+EKiVaa1VhVnm4nwWEzXH7/KMJVsEwk3IZjoYTqKLOWw3zQa6E7eh+jdJifEFrPkQNZs4QcICv6Z+1kQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-4.0.1.tgz",
+			"integrity": "sha512-mmLxc21NWxZSSPvD592tmzpBlme+nB0fbG1xO+EldS4vQkeWIQUZlNbrMijZM/hpFaBqDEJCAZFUPUpw1XwBWg==",
 			"dev": true
 		},
 		"@wordpress/components": {
@@ -8201,52 +8240,13 @@
 			"dev": true
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-2.1.2.tgz",
-			"integrity": "sha512-y5W7NcT5CK3V6mEco36fMURJtR4cEibmV42ZzQ9mZdln1zzdrpnJUsMj4CscO4eSMv9hzNaYT97SCQWB8j5NVg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.3.tgz",
+			"integrity": "sha512-X0fzam0s+mK03Joe20LO0XAvrUUqTGmWEpMB0dyxh1RzzNqDeWbabiX5Bej6M9xze/HsF6net73ENHuz7jsZ7g==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^3.4.2",
-				"@wordpress/postcss-themes": "^3.0.3",
-				"autoprefixer": "^9.8.6",
-				"postcss-custom-properties": "^10.0.0"
-			}
-		},
-		"@wordpress/postcss-themes": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-themes/-/postcss-themes-3.0.3.tgz",
-			"integrity": "sha512-Af6sCRK3twS3snx6nZIVDsycZypzyf2FgWRAEVmmQgI4ITLcxr0t7yqNLIkvdkKuPqKxgJ/NzUHPzqqovR7oXg==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.32"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"@wordpress/base-styles": "^3.5.3",
+				"autoprefixer": "^10.2.5"
 			}
 		},
 		"@wordpress/prettier-config": {
@@ -8375,56 +8375,59 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-14.1.1.tgz",
-			"integrity": "sha512-BaYVzUXWy6Bx9Bx1mtAtg4UQyl+pNmRMLpukU97Jo4SITOEsBzagdcJBCTwuLuE3FqmfZMxuYuUeBJftIngXEQ==",
+			"version": "16.1.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.3.tgz",
+			"integrity": "sha512-AqKpKl3QWlVZk/eCgpsI1EZWW+dkcIck3JA1wQ/Fs2FjribmKhkzpQ2diLaK8ZqnFLtmb9UlTGnVmZ8uJLbBBA==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.2.0",
-				"@wordpress/babel-preset-default": "^5.2.1",
-				"@wordpress/dependency-extraction-webpack-plugin": "^3.1.2",
-				"@wordpress/eslint-plugin": "^9.0.3",
-				"@wordpress/jest-preset-default": "^7.0.3",
-				"@wordpress/npm-package-json-lint-config": "^4.0.3",
-				"@wordpress/postcss-plugins-preset": "^2.1.2",
-				"@wordpress/prettier-config": "^1.0.3",
-				"@wordpress/stylelint-config": "^19.0.3",
+				"@wordpress/babel-preset-default": "^6.2.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^3.1.4",
+				"@wordpress/eslint-plugin": "^9.0.6",
+				"@wordpress/jest-preset-default": "^7.0.5",
+				"@wordpress/npm-package-json-lint-config": "^4.0.5",
+				"@wordpress/postcss-plugins-preset": "^3.1.3",
+				"@wordpress/prettier-config": "^1.0.5",
+				"@wordpress/stylelint-config": "^19.0.5",
 				"babel-jest": "^26.6.3",
 				"babel-loader": "^8.2.2",
 				"chalk": "^4.0.0",
 				"check-node-version": "^4.1.0",
 				"clean-webpack-plugin": "^3.0.0",
 				"cross-spawn": "^5.1.0",
-				"css-loader": "^3.5.2",
+				"css-loader": "^5.1.3",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
 				"eslint": "^7.17.0",
 				"eslint-plugin-markdown": "^1.0.2",
 				"expect-puppeteer": "^4.4.0",
 				"file-loader": "^6.2.0",
+				"filenamify": "^4.2.0",
 				"ignore-emit-webpack-plugin": "^2.0.6",
 				"jest": "^26.6.3",
+				"jest-circus": "^26.6.3",
 				"jest-dev-server": "^4.4.0",
 				"jest-environment-node": "^26.6.2",
 				"markdownlint": "^0.18.0",
 				"markdownlint-cli": "^0.21.0",
 				"merge-deep": "^3.0.3",
-				"mini-css-extract-plugin": "^0.9.0",
+				"mini-css-extract-plugin": "^1.3.9",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^5.0.0",
-				"postcss-loader": "^3.0.0",
+				"postcss": "^8.2.15",
+				"postcss-loader": "^4.2.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
-				"puppeteer-core": "^5.5.0",
+				"puppeteer-core": "^9.0.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
 				"sass": "^1.26.11",
-				"sass-loader": "^8.0.2",
+				"sass-loader": "^10.1.1",
 				"source-map-loader": "^0.2.4",
 				"stylelint": "^13.8.0",
 				"terser-webpack-plugin": "^3.0.3",
-				"thread-loader": "^2.1.3",
-				"url-loader": "^3.0.0",
-				"webpack": "^4.42.0",
+				"thread-loader": "^3.0.1",
+				"url-loader": "^4.1.1",
+				"webpack": "^4.46.0",
 				"webpack-bundle-analyzer": "^4.2.0",
 				"webpack-cli": "^3.3.11",
 				"webpack-livereload-plugin": "^2.3.0",
@@ -9980,6 +9983,17 @@
 						"find-up": "^4.0.0"
 					}
 				},
+				"postcss": {
+					"version": "8.3.5",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+					"integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+					"dev": true,
+					"requires": {
+						"colorette": "^1.2.2",
+						"nanoid": "^3.1.23",
+						"source-map-js": "^0.6.2"
+					}
+				},
 				"prelude-ls": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11141,51 +11155,24 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "9.8.6",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-			"integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.6.tgz",
+			"integrity": "sha512-8lChSmdU6dCNMCQopIf4Pe5kipkAGj/fvTMslCsih0uHpOrXOPUEVOmYMMqmw3cekQkSD7EhIeuYl5y0BLdKqg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.12.0",
-				"caniuse-lite": "^1.0.30001109",
-				"colorette": "^1.2.1",
+				"browserslist": "^4.16.6",
+				"caniuse-lite": "^1.0.30001230",
+				"colorette": "^1.2.2",
+				"fraction.js": "^4.1.1",
 				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.32",
 				"postcss-value-parser": "^4.1.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-value-parser": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
 					"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -11913,32 +11900,6 @@
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
-			}
-		},
-		"caller-callsite": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-			"dev": true,
-			"requires": {
-				"callsites": "^2.0.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-					"dev": true
-				}
-			}
-		},
-		"caller-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-			"dev": true,
-			"requires": {
-				"caller-callsite": "^2.0.0"
 			}
 		},
 		"callsites": {
@@ -12745,55 +12706,32 @@
 			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
 		},
 		"css-loader": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
-			"integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
+			"version": "5.2.6",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.6.tgz",
+			"integrity": "sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^5.3.1",
-				"cssesc": "^3.0.0",
-				"icss-utils": "^4.1.1",
-				"loader-utils": "^1.2.3",
-				"normalize-path": "^3.0.0",
-				"postcss": "^7.0.32",
-				"postcss-modules-extract-imports": "^2.0.0",
-				"postcss-modules-local-by-default": "^3.0.2",
-				"postcss-modules-scope": "^2.2.0",
-				"postcss-modules-values": "^3.0.0",
+				"icss-utils": "^5.1.0",
+				"loader-utils": "^2.0.0",
+				"postcss": "^8.2.15",
+				"postcss-modules-extract-imports": "^3.0.0",
+				"postcss-modules-local-by-default": "^4.0.0",
+				"postcss-modules-scope": "^3.0.0",
+				"postcss-modules-values": "^4.0.0",
 				"postcss-value-parser": "^4.1.0",
-				"schema-utils": "^2.7.0",
-				"semver": "^6.3.0"
+				"schema-utils": "^3.0.0",
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
-					}
-				},
 				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+					"version": "8.3.5",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+					"integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
+						"colorette": "^1.2.2",
+						"nanoid": "^3.1.23",
+						"source-map-js": "^0.6.2"
 					}
 				},
 				"postcss-value-parser": {
@@ -12802,25 +12740,24 @@
 					"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 					"dev": true
 				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+				"schema-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
+					}
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
 					}
 				}
 			}
@@ -13127,6 +13064,12 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
+		"dedent": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+			"dev": true
+		},
 		"deep-extend": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
@@ -13282,9 +13225,9 @@
 			"dev": true
 		},
 		"devtools-protocol": {
-			"version": "0.0.818844",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-			"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+			"version": "0.0.869402",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+			"integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA==",
 			"dev": true
 		},
 		"diff-sequences": {
@@ -14980,6 +14923,23 @@
 			"dev": true,
 			"optional": true
 		},
+		"filename-reserved-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+			"dev": true
+		},
+		"filenamify": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+			"integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+			"dev": true,
+			"requires": {
+				"filename-reserved-regex": "^2.0.0",
+				"strip-outer": "^1.0.1",
+				"trim-repeated": "^1.0.0"
+			}
+		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -15472,6 +15432,12 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
+		},
+		"fraction.js": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
+			"integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+			"dev": true
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -16206,41 +16172,10 @@
 			}
 		},
 		"icss-utils": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-			"integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.14"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+			"dev": true
 		},
 		"ieee754": {
 			"version": "1.2.1",
@@ -16265,15 +16200,6 @@
 			"integrity": "sha512-/zC18RWCC2wz4ZwnS4UoujGWzvSKy28DLjtE+jrGBOXej6YdmityhBDzE8E0NlktEqi4tgdNbydX8B6G4haHSQ==",
 			"dev": true
 		},
-		"import-cwd": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
-			"integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
-			"dev": true,
-			"requires": {
-				"import-from": "^2.1.0"
-			}
-		},
 		"import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -16281,23 +16207,6 @@
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
-			}
-		},
-		"import-from": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
-			"dev": true,
-			"requires": {
-				"resolve-from": "^3.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
-				}
 			}
 		},
 		"import-lazy": {
@@ -16655,12 +16564,6 @@
 				}
 			}
 		},
-		"is-directory": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-			"dev": true
-		},
 		"is-docker": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -16832,12 +16735,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
 			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-			"dev": true
-		},
-		"is-url-superb": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
-			"integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
 			"dev": true
 		},
 		"is-utf8": {
@@ -18364,6 +18261,1016 @@
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
+					}
+				}
+			}
+		},
+		"jest-circus": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.6.3.tgz",
+			"integrity": "sha512-ACrpWZGcQMpbv13XbzRzpytEJlilP/Su0JtNCi5r/xLpOUhnaIJr8leYYpLEMgPFURZISEHrnnpmB54Q/UziPw==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/babel__traverse": "^7.0.4",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"co": "^4.6.0",
+				"dedent": "^0.7.0",
+				"expect": "^26.6.2",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^26.6.2",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-runner": "^26.6.3",
+				"jest-runtime": "^26.6.3",
+				"jest-snapshot": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"pretty-format": "^26.6.2",
+				"stack-utils": "^2.0.2",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"@jest/console": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+					"integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"jest-message-util": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"slash": "^3.0.0"
+					}
+				},
+				"@jest/source-map": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+					"integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
+					"dev": true,
+					"requires": {
+						"callsites": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"source-map": "^0.6.0"
+					}
+				},
+				"@jest/test-result": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+					"integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"collect-v8-coverage": "^1.0.0"
+					}
+				},
+				"@jest/test-sequencer": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+					"integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
+					"dev": true,
+					"requires": {
+						"@jest/test-result": "^26.6.2",
+						"graceful-fs": "^4.2.4",
+						"jest-haste-map": "^26.6.2",
+						"jest-runner": "^26.6.3",
+						"jest-runtime": "^26.6.3"
+					}
+				},
+				"@jest/transform": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+					"integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/types": "^26.6.2",
+						"babel-plugin-istanbul": "^6.0.0",
+						"chalk": "^4.0.0",
+						"convert-source-map": "^1.4.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"graceful-fs": "^4.2.4",
+						"jest-haste-map": "^26.6.2",
+						"jest-regex-util": "^26.0.0",
+						"jest-util": "^26.6.2",
+						"micromatch": "^4.0.2",
+						"pirates": "^4.0.1",
+						"slash": "^3.0.0",
+						"source-map": "^0.6.1",
+						"write-file-atomic": "^3.0.0"
+					}
+				},
+				"@types/prettier": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
+					"integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+					"dev": true
+				},
+				"acorn": {
+					"version": "8.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+					"dev": true
+				},
+				"acorn-globals": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+					"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+					"dev": true,
+					"requires": {
+						"acorn": "^7.1.1",
+						"acorn-walk": "^7.1.1"
+					},
+					"dependencies": {
+						"acorn": {
+							"version": "7.4.1",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+							"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+							"dev": true
+						}
+					}
+				},
+				"acorn-walk": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+					"dev": true
+				},
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"dev": true,
+					"requires": {
+						"debug": "4"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"anymatch": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+					"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+					"dev": true,
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
+				"babel-jest": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+					"integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
+					"dev": true,
+					"requires": {
+						"@jest/transform": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/babel__core": "^7.1.7",
+						"babel-plugin-istanbul": "^6.0.0",
+						"babel-preset-jest": "^26.6.2",
+						"chalk": "^4.0.0",
+						"graceful-fs": "^4.2.4",
+						"slash": "^3.0.0"
+					}
+				},
+				"babel-plugin-istanbul": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+					"integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@istanbuljs/load-nyc-config": "^1.0.0",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-instrument": "^4.0.0",
+						"test-exclude": "^6.0.0"
+					}
+				},
+				"babel-plugin-jest-hoist": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+					"integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.3.3",
+						"@babel/types": "^7.3.3",
+						"@types/babel__core": "^7.0.0",
+						"@types/babel__traverse": "^7.0.6"
+					}
+				},
+				"babel-preset-current-node-syntax": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+					"integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+					"dev": true,
+					"requires": {
+						"@babel/plugin-syntax-async-generators": "^7.8.4",
+						"@babel/plugin-syntax-bigint": "^7.8.3",
+						"@babel/plugin-syntax-class-properties": "^7.8.3",
+						"@babel/plugin-syntax-import-meta": "^7.8.3",
+						"@babel/plugin-syntax-json-strings": "^7.8.3",
+						"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+						"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+						"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+						"@babel/plugin-syntax-top-level-await": "^7.8.3"
+					}
+				},
+				"babel-preset-jest": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+					"integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+					"dev": true,
+					"requires": {
+						"babel-plugin-jest-hoist": "^26.6.2",
+						"babel-preset-current-node-syntax": "^1.0.0"
+					}
+				},
+				"camelcase": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"cssom": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+					"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+					"dev": true
+				},
+				"cssstyle": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+					"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+					"dev": true,
+					"requires": {
+						"cssom": "~0.3.6"
+					},
+					"dependencies": {
+						"cssom": {
+							"version": "0.3.8",
+							"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+							"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+							"dev": true
+						}
+					}
+				},
+				"data-urls": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+					"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+					"dev": true,
+					"requires": {
+						"abab": "^2.0.3",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^8.0.0"
+					}
+				},
+				"deepmerge": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+					"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+					"dev": true
+				},
+				"detect-newline": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+					"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+					"dev": true
+				},
+				"domexception": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+					"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+					"dev": true,
+					"requires": {
+						"webidl-conversions": "^5.0.0"
+					},
+					"dependencies": {
+						"webidl-conversions": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+							"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+							"dev": true
+						}
+					}
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"escodegen": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+					"integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+					"dev": true,
+					"requires": {
+						"esprima": "^4.0.1",
+						"estraverse": "^5.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					}
+				},
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"form-data": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+					"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+					"dev": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.8",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"html-encoding-sniffer": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+					"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-encoding": "^1.0.5"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+					"dev": true,
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+					"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+					"dev": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.7.5",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.0.0",
+						"semver": "^6.3.0"
+					}
+				},
+				"jest-config": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+					"integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/test-sequencer": "^26.6.3",
+						"@jest/types": "^26.6.2",
+						"babel-jest": "^26.6.3",
+						"chalk": "^4.0.0",
+						"deepmerge": "^4.2.2",
+						"glob": "^7.1.1",
+						"graceful-fs": "^4.2.4",
+						"jest-environment-jsdom": "^26.6.2",
+						"jest-environment-node": "^26.6.2",
+						"jest-get-type": "^26.3.0",
+						"jest-jasmine2": "^26.6.3",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-validate": "^26.6.2",
+						"micromatch": "^4.0.2",
+						"pretty-format": "^26.6.2"
+					}
+				},
+				"jest-docblock": {
+					"version": "26.0.0",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+					"integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+					"dev": true,
+					"requires": {
+						"detect-newline": "^3.0.0"
+					}
+				},
+				"jest-each": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+					"integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"chalk": "^4.0.0",
+						"jest-get-type": "^26.3.0",
+						"jest-util": "^26.6.2",
+						"pretty-format": "^26.6.2"
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+					"integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^26.6.2",
+						"@jest/fake-timers": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"jest-mock": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jsdom": "^16.4.0"
+					}
+				},
+				"jest-environment-node": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+					"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^26.6.2",
+						"@jest/fake-timers": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"jest-mock": "^26.6.2",
+						"jest-util": "^26.6.2"
+					}
+				},
+				"jest-haste-map": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+					"integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"@types/graceful-fs": "^4.1.2",
+						"@types/node": "*",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-regex-util": "^26.0.0",
+						"jest-serializer": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-worker": "^26.6.2",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
+					}
+				},
+				"jest-jasmine2": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+					"integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
+					"dev": true,
+					"requires": {
+						"@babel/traverse": "^7.1.0",
+						"@jest/environment": "^26.6.2",
+						"@jest/source-map": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"co": "^4.6.0",
+						"expect": "^26.6.2",
+						"is-generator-fn": "^2.0.0",
+						"jest-each": "^26.6.2",
+						"jest-matcher-utils": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-runtime": "^26.6.3",
+						"jest-snapshot": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"pretty-format": "^26.6.2",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-leak-detector": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+					"integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
+					"dev": true,
+					"requires": {
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.6.2"
+					}
+				},
+				"jest-resolve": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+					"integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"chalk": "^4.0.0",
+						"graceful-fs": "^4.2.4",
+						"jest-pnp-resolver": "^1.2.2",
+						"jest-util": "^26.6.2",
+						"read-pkg-up": "^7.0.1",
+						"resolve": "^1.18.1",
+						"slash": "^3.0.0"
+					}
+				},
+				"jest-runner": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+					"integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^26.6.2",
+						"@jest/environment": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"emittery": "^0.7.1",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.3",
+						"jest-docblock": "^26.0.0",
+						"jest-haste-map": "^26.6.2",
+						"jest-leak-detector": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-resolve": "^26.6.2",
+						"jest-runtime": "^26.6.3",
+						"jest-util": "^26.6.2",
+						"jest-worker": "^26.6.2",
+						"source-map-support": "^0.5.6",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-runtime": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+					"integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^26.6.2",
+						"@jest/environment": "^26.6.2",
+						"@jest/fake-timers": "^26.6.2",
+						"@jest/globals": "^26.6.2",
+						"@jest/source-map": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/transform": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.6.0",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.3",
+						"jest-haste-map": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-mock": "^26.6.2",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.2",
+						"jest-snapshot": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-validate": "^26.6.2",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-serializer": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+					"integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"graceful-fs": "^4.2.4"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+					"integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.2",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.2",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.2",
+						"jest-get-type": "^26.3.0",
+						"jest-haste-map": "^26.6.2",
+						"jest-matcher-utils": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-resolve": "^26.6.2",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.2",
+						"semver": "^7.3.2"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "7.3.5",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+							"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+							"dev": true,
+							"requires": {
+								"lru-cache": "^6.0.0"
+							}
+						}
+					}
+				},
+				"jest-validate": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+					"integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"camelcase": "^6.0.0",
+						"chalk": "^4.0.0",
+						"jest-get-type": "^26.3.0",
+						"leven": "^3.1.0",
+						"pretty-format": "^26.6.2"
+					}
+				},
+				"jest-worker": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"jsdom": {
+					"version": "16.6.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
+					"integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+					"dev": true,
+					"requires": {
+						"abab": "^2.0.5",
+						"acorn": "^8.2.4",
+						"acorn-globals": "^6.0.0",
+						"cssom": "^0.4.4",
+						"cssstyle": "^2.3.0",
+						"data-urls": "^2.0.0",
+						"decimal.js": "^10.2.1",
+						"domexception": "^2.0.1",
+						"escodegen": "^2.0.0",
+						"form-data": "^3.0.0",
+						"html-encoding-sniffer": "^2.0.1",
+						"http-proxy-agent": "^4.0.1",
+						"https-proxy-agent": "^5.0.0",
+						"is-potential-custom-element-name": "^1.0.1",
+						"nwsapi": "^2.2.0",
+						"parse5": "6.0.1",
+						"saxes": "^5.0.1",
+						"symbol-tree": "^3.2.4",
+						"tough-cookie": "^4.0.0",
+						"w3c-hr-time": "^1.0.2",
+						"w3c-xmlserializer": "^2.0.0",
+						"webidl-conversions": "^6.1.0",
+						"whatwg-encoding": "^1.0.5",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^8.5.0",
+						"ws": "^7.4.5",
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"parse5": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+					"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					}
+				},
+				"saxes": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+					"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+					"dev": true,
+					"requires": {
+						"xmlchars": "^2.2.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"test-exclude": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+					"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+					"dev": true,
+					"requires": {
+						"@istanbuljs/schema": "^0.1.2",
+						"glob": "^7.1.4",
+						"minimatch": "^3.0.4"
+					}
+				},
+				"throat": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+					"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+					"integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.33",
+						"punycode": "^2.1.1",
+						"universalify": "^0.1.2"
+					}
+				},
+				"tr46": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+					"integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.1"
+					}
+				},
+				"w3c-xmlserializer": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+					"integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+					"dev": true,
+					"requires": {
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"webidl-conversions": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "8.6.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
+					"integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.7.0",
+						"tr46": "^2.1.0",
+						"webidl-conversions": "^6.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"write-file-atomic": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"is-typedarray": "^1.0.0",
+						"signal-exit": "^3.0.2",
+						"typedarray-to-buffer": "^3.1.5"
+					}
+				},
+				"ws": {
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
+					"integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -21868,6 +22775,12 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"klona": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+			"integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
+			"dev": true
+		},
 		"known-css-properties": {
 			"version": "0.21.0",
 			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
@@ -21968,9 +22881,9 @@
 			}
 		},
 		"loader-runner": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+			"integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
 			"dev": true
 		},
 		"loader-utils": {
@@ -22814,46 +23727,25 @@
 			}
 		},
 		"mini-css-extract-plugin": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
-			"integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.0.tgz",
+			"integrity": "sha512-nPFKI7NSy6uONUo9yn2hIfb9vyYvkFu95qki0e21DQ9uaqNKDP15DGpK0KnV6wDroWxPHtExrdEwx/yDQ8nVRw==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"normalize-url": "1.9.1",
-				"schema-utils": "^1.0.0",
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^3.0.0",
 				"webpack-sources": "^1.1.0"
 			},
 			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
-					}
-				},
 				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
 				}
 			}
@@ -23073,6 +23965,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"nanoid": {
+			"version": "3.1.23",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"dev": true
+		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -23279,18 +24177,6 @@
 			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
 			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
 			"dev": true
-		},
-		"normalize-url": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"dev": true,
-			"requires": {
-				"object-assign": "^4.0.1",
-				"prepend-http": "^1.0.0",
-				"query-string": "^4.1.0",
-				"sort-keys": "^1.0.0"
-			}
 		},
 		"npm-package-json-lint": {
 			"version": "5.1.0",
@@ -24078,58 +24964,14 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "6.0.23",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-			"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-			"requires": {
-				"chalk": "^2.4.1",
-				"source-map": "^0.6.1",
-				"supports-color": "^5.4.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-custom-properties": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-10.0.0.tgz",
-			"integrity": "sha512-55BPj5FudpCiPZzBaO+MOeqmwMDa+nV9/0QBJBfhZjYg6D9hE+rW9lpMBLTJoF4OTXnS5Po4yM1nMlgkPbCxFg==",
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+			"integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.17",
-				"postcss-values-parser": "^4.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"colorette": "^1.2.2",
+				"nanoid": "^3.1.23",
+				"source-map-js": "^0.6.2"
 			}
 		},
 		"postcss-html": {
@@ -24249,123 +25091,50 @@
 				}
 			}
 		},
-		"postcss-load-config": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
-			"integrity": "sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==",
+		"postcss-loader": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
+			"integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "^5.0.0",
-				"import-cwd": "^2.0.0"
+				"cosmiconfig": "^7.0.0",
+				"klona": "^2.0.4",
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^3.0.0",
+				"semver": "^7.3.4"
 			},
 			"dependencies": {
 				"cosmiconfig": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
 					"dev": true,
 					"requires": {
-						"import-fresh": "^2.0.0",
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.13.1",
-						"parse-json": "^4.0.0"
-					}
-				},
-				"import-fresh": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-					"dev": true,
-					"requires": {
-						"caller-path": "^2.0.0",
-						"resolve-from": "^3.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
-				}
-			}
-		},
-		"postcss-loader": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
-			"integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.1.0",
-				"postcss": "^7.0.0",
-				"postcss-load-config": "^2.0.0",
-				"schema-utils": "^1.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
-					}
-				},
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.2.1",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.10.0"
 					}
 				},
 				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"lru-cache": "^6.0.0"
 					}
 				}
 			}
@@ -24377,162 +25146,46 @@
 			"dev": true
 		},
 		"postcss-modules-extract-imports": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-			"integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.5"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+			"dev": true
 		},
 		"postcss-modules-local-by-default": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
-			"integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+			"integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
 			"dev": true,
 			"requires": {
-				"icss-utils": "^4.1.1",
-				"postcss": "^7.0.32",
+				"icss-utils": "^5.0.0",
 				"postcss-selector-parser": "^6.0.2",
 				"postcss-value-parser": "^4.1.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-value-parser": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
 					"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
 		"postcss-modules-scope": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
-			"integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+			"integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.6",
-				"postcss-selector-parser": "^6.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"postcss-selector-parser": "^6.0.4"
 			}
 		},
 		"postcss-modules-values": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-			"integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+			"integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
 			"dev": true,
 			"requires": {
-				"icss-utils": "^4.0.0",
-				"postcss": "^7.0.6"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"icss-utils": "^5.0.0"
 			}
 		},
 		"postcss-resolve-nested-selector": {
@@ -24674,61 +25327,10 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
-		"postcss-values-parser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz",
-			"integrity": "sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==",
-			"dev": true,
-			"requires": {
-				"color-name": "^1.1.4",
-				"is-url-superb": "^4.0.0",
-				"postcss": "^7.0.5"
-			},
-			"dependencies": {
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.36",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
 		"prettier": {
@@ -24972,25 +25574,34 @@
 			}
 		},
 		"puppeteer-core": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-			"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-9.1.1.tgz",
+			"integrity": "sha512-zbedbitVIGhmgz0nt7eIdLsnaoVZSlNJfBivqm2w67T8LR2bU1dvnruDZ8nQO0zn++Iet7zHbAOdnuS5+H2E7A==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
-				"devtools-protocol": "0.0.818844",
+				"devtools-protocol": "0.0.869402",
 				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"node-fetch": "^2.6.1",
 				"pkg-dir": "^4.2.0",
 				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
+				"proxy-from-env": "^1.1.0",
 				"rimraf": "^3.0.2",
 				"tar-fs": "^2.0.0",
 				"unbzip2-stream": "^1.3.3",
 				"ws": "^7.2.3"
 			},
 			"dependencies": {
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"dev": true,
+					"requires": {
+						"debug": "4"
+					}
+				},
 				"extract-zip": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -25020,6 +25631,16 @@
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+					"dev": true,
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
 					}
 				},
 				"locate-path": {
@@ -25088,16 +25709,6 @@
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
 			"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
-		},
-		"query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"dev": true,
-			"requires": {
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			}
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -26196,6 +26807,23 @@
 				"mkdirp": "^0.5.1",
 				"postcss": "^6.0.23",
 				"strip-json-comments": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "6.0.23",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.4.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"run-async": {
@@ -26399,62 +27027,36 @@
 			}
 		},
 		"sass-loader": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-			"integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.2.0.tgz",
+			"integrity": "sha512-kUceLzC1gIHz0zNJPpqRsJyisWatGYNFRmv2CKZK2/ngMJgLqxTbXwe/hJ85luyvZkgqU3VlJ33UVF2T/0g6mw==",
 			"dev": true,
 			"requires": {
-				"clone-deep": "^4.0.1",
-				"loader-utils": "^1.2.3",
-				"neo-async": "^2.6.1",
-				"schema-utils": "^2.6.1",
-				"semver": "^6.3.0"
+				"klona": "^2.0.4",
+				"loader-utils": "^2.0.0",
+				"neo-async": "^2.6.2",
+				"schema-utils": "^3.0.0",
+				"semver": "^7.3.2"
 			},
 			"dependencies": {
-				"clone-deep": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-					"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+				"schema-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4",
-						"kind-of": "^6.0.2",
-						"shallow-clone": "^3.0.0"
-					}
-				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"shallow-clone": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-					"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.2"
+						"lru-cache": "^6.0.0"
 					}
 				}
 			}
@@ -26793,15 +27395,6 @@
 				}
 			}
 		},
-		"sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "^1.0.0"
-			}
-		},
 		"source-list-map": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -26812,6 +27405,12 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+			"integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+			"dev": true
 		},
 		"source-map-loader": {
 			"version": "0.2.4",
@@ -27143,12 +27742,6 @@
 			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
 			"dev": true
 		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"dev": true
-		},
 		"string-convert": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
@@ -27306,6 +27899,15 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
+		"strip-outer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
+		},
 		"style-search": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
@@ -27400,20 +28002,26 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
 				"astral-regex": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
 					"dev": true
+				},
+				"autoprefixer": {
+					"version": "9.8.6",
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
+					"integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.12.0",
+						"caniuse-lite": "^1.0.30001109",
+						"colorette": "^1.2.1",
+						"normalize-range": "^0.1.2",
+						"num2fraction": "^1.2.2",
+						"postcss": "^7.0.32",
+						"postcss-value-parser": "^4.1.0"
+					}
 				},
 				"balanced-match": {
 					"version": "2.0.0",
@@ -27429,6 +28037,32 @@
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.3.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						},
+						"has-flag": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+							"dev": true
+						},
+						"supports-color": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^4.0.0"
+							}
+						}
 					}
 				},
 				"color-convert": {
@@ -27526,12 +28160,6 @@
 						"which": "^1.3.1"
 					}
 				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"hosted-git-info": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
@@ -27626,15 +28254,6 @@
 						"supports-color": "^6.1.0"
 					},
 					"dependencies": {
-						"ansi-styles": {
-							"version": "3.2.1",
-							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-							"dev": true,
-							"requires": {
-								"color-convert": "^1.9.0"
-							}
-						},
 						"chalk": {
 							"version": "2.4.2",
 							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -27655,36 +28274,6 @@
 										"has-flag": "^3.0.0"
 									}
 								}
-							}
-						},
-						"color-convert": {
-							"version": "1.9.3",
-							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-							"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-							"dev": true,
-							"requires": {
-								"color-name": "1.1.3"
-							}
-						},
-						"color-name": {
-							"version": "1.1.3",
-							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-							"dev": true
-						},
-						"has-flag": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-							"dev": true
-						},
-						"supports-color": {
-							"version": "6.1.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-							"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
 							}
 						}
 					}
@@ -27791,6 +28380,17 @@
 						"ansi-styles": "^4.0.0",
 						"astral-regex": "^2.0.0",
 						"is-fullwidth-code-point": "^3.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.3.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						}
 					}
 				},
 				"source-map": {
@@ -27820,12 +28420,12 @@
 					}
 				},
 				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^4.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"table": {
@@ -28277,34 +28877,27 @@
 			"dev": true
 		},
 		"thread-loader": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
-			"integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-3.0.4.tgz",
+			"integrity": "sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==",
 			"dev": true,
 			"requires": {
-				"loader-runner": "^2.3.1",
-				"loader-utils": "^1.1.0",
-				"neo-async": "^2.6.0"
+				"json-parse-better-errors": "^1.0.2",
+				"loader-runner": "^4.1.0",
+				"loader-utils": "^2.0.0",
+				"neo-async": "^2.6.2",
+				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+				"schema-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
 				}
 			}
@@ -28554,6 +29147,15 @@
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
 			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
 			"dev": true
+		},
+		"trim-repeated": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
 		},
 		"trim-trailing-lines": {
 			"version": "1.1.4",
@@ -28946,34 +29548,25 @@
 			}
 		},
 		"url-loader": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-3.0.0.tgz",
-			"integrity": "sha512-a84JJbIA5xTFTWyjjcPdnsu+41o/SNE8SpXMdUvXs6Q+LuhCD9E2+0VCiuDWqgo3GGXVlFHzArDmBpj9PgWn4A==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
+			"integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.2.3",
-				"mime": "^2.4.4",
-				"schema-utils": "^2.5.0"
+				"loader-utils": "^2.0.0",
+				"mime-types": "^2.1.27",
+				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+				"schema-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
 				}
 			}
@@ -29552,6 +30145,12 @@
 					"requires": {
 						"minimist": "^1.2.0"
 					}
+				},
+				"loader-runner": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+					"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+					"dev": true
 				},
 				"loader-utils": {
 					"version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1040,6 +1040,15 @@
 				"@babel/helper-plugin-utils": "^7.14.5"
 			}
 		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+			"integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
 		"@babel/plugin-transform-arrow-functions": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
@@ -1405,6 +1414,17 @@
 				"@babel/helper-plugin-utils": "^7.14.5"
 			}
 		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.14.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.6.tgz",
+			"integrity": "sha512-XlTdBq7Awr4FYIzqhmYY80WN0V0azF74DMPyFqVHBvf81ZUgc4X7ZOpx6O8eLDK6iM5cCQzeyJw0ynTaefixRA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.14.6",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-typescript": "^7.14.5"
+			}
+		},
 		"@babel/plugin-transform-unicode-escapes": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
@@ -1538,6 +1558,17 @@
 				"@babel/plugin-transform-react-jsx": "^7.14.5",
 				"@babel/plugin-transform-react-jsx-development": "^7.14.5",
 				"@babel/plugin-transform-react-pure-annotations": "^7.14.5"
+			}
+		},
+		"@babel/preset-typescript": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.14.5.tgz",
+			"integrity": "sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-validator-option": "^7.14.5",
+				"@babel/plugin-transform-typescript": "^7.14.5"
 			}
 		},
 		"@babel/runtime": {
@@ -2526,6 +2557,43 @@
 						"repeat-string": "^1.6.1"
 					}
 				}
+			}
+		},
+		"@jest/environment": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+			"integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"jest-mock": "^26.6.2"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+			"integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"@sinonjs/fake-timers": "^6.0.1",
+				"@types/node": "*",
+				"jest-message-util": "^26.6.2",
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2"
+			}
+		},
+		"@jest/globals": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+			"integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"expect": "^26.6.2"
 			}
 		},
 		"@jest/reporters": {
@@ -4295,6 +4363,12 @@
 				}
 			}
 		},
+		"@polka/url": {
+			"version": "1.0.0-next.15",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
+			"integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==",
+			"dev": true
+		},
 		"@popperjs/core": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
@@ -4307,6 +4381,15 @@
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/fake-timers": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
 			}
 		},
 		"@slack/logger": {
@@ -4677,6 +4760,12 @@
 				"react-error-boundary": "^3.1.0"
 			}
 		},
+		"@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"dev": true
+		},
 		"@types/aria-query": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
@@ -4928,6 +5017,12 @@
 			"integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
 			"dev": true
 		},
+		"@types/stack-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+			"dev": true
+		},
 		"@types/tapable": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.7.tgz",
@@ -5031,6 +5126,38 @@
 			"optional": true,
 			"requires": {
 				"@types/node": "*"
+			}
+		},
+		"@typescript-eslint/eslint-plugin": {
+			"version": "4.28.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.0.tgz",
+			"integrity": "sha512-KcF6p3zWhf1f8xO84tuBailV5cN92vhS+VT7UJsPzGBm9VnQqfI9AsiMUFUCYHTYPg1uCCo+HyiDnpDuvkAMfQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "4.28.0",
+				"@typescript-eslint/scope-manager": "4.28.0",
+				"debug": "^4.3.1",
+				"functional-red-black-tree": "^1.0.1",
+				"regexpp": "^3.1.0",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"regexpp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+					"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
@@ -6399,26 +6526,27 @@
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.7.0.tgz",
-			"integrity": "sha512-yR+rSyfHKfevW84vKBOERpjEslD/o00CaYMftywVYOjsOQ8GLS6xv/VgDcpQ8JomJ9eRRInLRpeGKTM3lOa4xQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.0.5.tgz",
+			"integrity": "sha512-1xzZGFV5Bwox4XcE59I88q0/robJ35LoQNkKPC4tmfzd1XaAoJCZpp5T8LSJJtKKloeoO1JstrvMf3ltZLQ5IA==",
 			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "4.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.20.0.tgz",
-			"integrity": "sha512-VKPoC5We2GNxon5umOeZ7NIP4CfP7X5gqslSnNrLW4kD1XgmbVaCs2ISFF8+mObVVb6KAzbaUjI6OWljcUb5UA==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-5.2.2.tgz",
+			"integrity": "sha512-xn/uOJRrkXBZoVv/iR4vc6GOAmmBpNSujO+ZoJzdy0zSJqV8vgzt7y/uZZetpJuyZAD8lR3aHxL7MUWos2PtfA==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.12.9",
+				"@babel/core": "^7.13.10",
 				"@babel/plugin-transform-react-jsx": "^7.12.7",
-				"@babel/plugin-transform-runtime": "^7.12.1",
-				"@babel/preset-env": "^7.12.7",
-				"@babel/runtime": "^7.12.5",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^2.7.0",
-				"@wordpress/browserslist-config": "^2.7.0",
-				"@wordpress/element": "^2.19.0",
-				"@wordpress/warning": "^1.3.0",
+				"@babel/plugin-transform-runtime": "^7.13.10",
+				"@babel/preset-env": "^7.13.10",
+				"@babel/preset-typescript": "^7.13.0",
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^3.0.3",
+				"@wordpress/browserslist-config": "^3.0.3",
+				"@wordpress/element": "^2.20.3",
+				"@wordpress/warning": "^1.4.2",
 				"core-js": "^3.6.4"
 			}
 		},
@@ -6617,9 +6745,9 @@
 			}
 		},
 		"@wordpress/browserslist-config": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.7.0.tgz",
-			"integrity": "sha512-pB45JlfmHuEigNFZ1X+CTgIsOT3/TTb9iZxw1DHXge/7ytY8FNhtcNwTfF9IgnS6/xaFRZBqzw4DyH4sP1Lyxg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.3.tgz",
+			"integrity": "sha512-hbGJt0+EKiVaa1VhVnm4nwWEzXH7/KMJVsEwk3IZjoYTqKLOWw3zQa6E7eh+jdJifEFrPkQNZs4QcICv6Z+1kQ==",
 			"dev": true
 		},
 		"@wordpress/components": {
@@ -8067,27 +8195,27 @@
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-3.1.0.tgz",
-			"integrity": "sha512-SYRWpzpQaSsBUiRO+ssqg6AHjgCF4j2npstGTGaKdVs/B720fLFzeyONuMmo1ZtMb9v6MyEWxVz5ON6dDgmVYg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.0.5.tgz",
+			"integrity": "sha512-kckj06QsUe7fSGYWiOhsXbAgU2sL9s/gy7GynvQCqOPPiLGpJ8PvCx8OLMaT0T75CXFqieGvfS8Dtf+d84mFvg==",
 			"dev": true
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-1.6.0.tgz",
-			"integrity": "sha512-WPToVlX99PiUSSxSbwAR2wJtIpbcnnRkB48sIIkDvw7rCpSWkh6OLuzfj0o5g+JCYuNL1OnQXFA8EtydNEZ9Sw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-2.1.2.tgz",
+			"integrity": "sha512-y5W7NcT5CK3V6mEco36fMURJtR4cEibmV42ZzQ9mZdln1zzdrpnJUsMj4CscO4eSMv9hzNaYT97SCQWB8j5NVg==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^3.3.0",
-				"@wordpress/postcss-themes": "^2.6.0",
+				"@wordpress/base-styles": "^3.4.2",
+				"@wordpress/postcss-themes": "^3.0.3",
 				"autoprefixer": "^9.8.6",
 				"postcss-custom-properties": "^10.0.0"
 			}
 		},
 		"@wordpress/postcss-themes": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-themes/-/postcss-themes-2.6.0.tgz",
-			"integrity": "sha512-Q22s1KSVdtoK0Z0ND06V2QwTx/U4KvJhWFmoI8IzYW/LGlk8BkQJhHH157Y9vFliwpMlQpqfXW6/zOg2XtvHzQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-themes/-/postcss-themes-3.0.3.tgz",
+			"integrity": "sha512-Af6sCRK3twS3snx6nZIVDsycZypzyf2FgWRAEVmmQgI4ITLcxr0t7yqNLIkvdkKuPqKxgJ/NzUHPzqqovR7oXg==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.32"
@@ -8247,54 +8375,60 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "12.6.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-12.6.1.tgz",
-			"integrity": "sha512-pDLtACFrP5gUA414qrE49dUrR7yMy40+//1e/5Nx821lnmDb7GAGWGo1gX4lJ2gbfSjePwmRoZe6Mph87vSnLQ==",
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-14.1.1.tgz",
+			"integrity": "sha512-BaYVzUXWy6Bx9Bx1mtAtg4UQyl+pNmRMLpukU97Jo4SITOEsBzagdcJBCTwuLuE3FqmfZMxuYuUeBJftIngXEQ==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.2.0",
-				"@wordpress/babel-preset-default": "^4.20.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^2.9.0",
-				"@wordpress/eslint-plugin": "^7.4.0",
-				"@wordpress/jest-preset-default": "^6.6.0",
-				"@wordpress/npm-package-json-lint-config": "^3.1.0",
-				"@wordpress/postcss-plugins-preset": "^1.6.0",
-				"@wordpress/prettier-config": "^0.4.0",
-				"babel-jest": "^25.3.0",
-				"babel-loader": "^8.1.0",
+				"@wordpress/babel-preset-default": "^5.2.1",
+				"@wordpress/dependency-extraction-webpack-plugin": "^3.1.2",
+				"@wordpress/eslint-plugin": "^9.0.3",
+				"@wordpress/jest-preset-default": "^7.0.3",
+				"@wordpress/npm-package-json-lint-config": "^4.0.3",
+				"@wordpress/postcss-plugins-preset": "^2.1.2",
+				"@wordpress/prettier-config": "^1.0.3",
+				"@wordpress/stylelint-config": "^19.0.3",
+				"babel-jest": "^26.6.3",
+				"babel-loader": "^8.2.2",
 				"chalk": "^4.0.0",
-				"check-node-version": "^3.1.1",
+				"check-node-version": "^4.1.0",
 				"clean-webpack-plugin": "^3.0.0",
 				"cross-spawn": "^5.1.0",
 				"css-loader": "^3.5.2",
+				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^7.1.0",
+				"eslint": "^7.17.0",
 				"eslint-plugin-markdown": "^1.0.2",
+				"expect-puppeteer": "^4.4.0",
+				"file-loader": "^6.2.0",
 				"ignore-emit-webpack-plugin": "^2.0.6",
-				"jest": "^25.3.0",
-				"jest-puppeteer": "^4.4.0",
+				"jest": "^26.6.3",
+				"jest-dev-server": "^4.4.0",
+				"jest-environment-node": "^26.6.2",
 				"markdownlint": "^0.18.0",
 				"markdownlint-cli": "^0.21.0",
+				"merge-deep": "^3.0.3",
 				"mini-css-extract-plugin": "^0.9.0",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^5.0.0",
 				"postcss-loader": "^3.0.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
-				"puppeteer": "npm:puppeteer-core@3.0.0",
+				"puppeteer-core": "^5.5.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
 				"sass": "^1.26.11",
 				"sass-loader": "^8.0.2",
 				"source-map-loader": "^0.2.4",
-				"stylelint": "^13.6.0",
-				"stylelint-config-wordpress": "^17.0.0",
+				"stylelint": "^13.8.0",
 				"terser-webpack-plugin": "^3.0.3",
 				"thread-loader": "^2.1.3",
 				"url-loader": "^3.0.0",
 				"webpack": "^4.42.0",
-				"webpack-bundle-analyzer": "^3.6.1",
+				"webpack-bundle-analyzer": "^4.2.0",
 				"webpack-cli": "^3.3.11",
-				"webpack-livereload-plugin": "^2.3.0"
+				"webpack-livereload-plugin": "^2.3.0",
+				"webpack-sources": "^2.2.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -8306,129 +8440,236 @@
 						"@babel/highlight": "^7.10.4"
 					}
 				},
+				"@jest/console": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+					"integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"jest-message-util": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"slash": "^3.0.0"
+					}
+				},
+				"@jest/core": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+					"integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^26.6.2",
+						"@jest/reporters": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/transform": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-changed-files": "^26.6.2",
+						"jest-config": "^26.6.3",
+						"jest-haste-map": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.2",
+						"jest-resolve-dependencies": "^26.6.3",
+						"jest-runner": "^26.6.3",
+						"jest-runtime": "^26.6.3",
+						"jest-snapshot": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-validate": "^26.6.2",
+						"jest-watcher": "^26.6.2",
+						"micromatch": "^4.0.2",
+						"p-each-series": "^2.1.0",
+						"rimraf": "^3.0.0",
+						"slash": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"@jest/reporters": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+					"integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
+					"dev": true,
+					"requires": {
+						"@bcoe/v8-coverage": "^0.2.3",
+						"@jest/console": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/transform": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"chalk": "^4.0.0",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.2.4",
+						"istanbul-lib-coverage": "^3.0.0",
+						"istanbul-lib-instrument": "^4.0.3",
+						"istanbul-lib-report": "^3.0.0",
+						"istanbul-lib-source-maps": "^4.0.0",
+						"istanbul-reports": "^3.0.2",
+						"jest-haste-map": "^26.6.2",
+						"jest-resolve": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-worker": "^26.6.2",
+						"node-notifier": "^8.0.0",
+						"slash": "^3.0.0",
+						"source-map": "^0.6.0",
+						"string-length": "^4.0.1",
+						"terminal-link": "^2.0.0",
+						"v8-to-istanbul": "^7.0.0"
+					}
+				},
+				"@jest/source-map": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+					"integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
+					"dev": true,
+					"requires": {
+						"callsites": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"source-map": "^0.6.0"
+					}
+				},
+				"@jest/test-result": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+					"integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"collect-v8-coverage": "^1.0.0"
+					}
+				},
+				"@jest/test-sequencer": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+					"integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
+					"dev": true,
+					"requires": {
+						"@jest/test-result": "^26.6.2",
+						"graceful-fs": "^4.2.4",
+						"jest-haste-map": "^26.6.2",
+						"jest-runner": "^26.6.3",
+						"jest-runtime": "^26.6.3"
+					}
+				},
 				"@jest/transform": {
-					"version": "25.5.1",
-					"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.5.1.tgz",
-					"integrity": "sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==",
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+					"integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
 					"dev": true,
 					"requires": {
 						"@babel/core": "^7.1.0",
-						"@jest/types": "^25.5.0",
+						"@jest/types": "^26.6.2",
 						"babel-plugin-istanbul": "^6.0.0",
-						"chalk": "^3.0.0",
+						"chalk": "^4.0.0",
 						"convert-source-map": "^1.4.0",
 						"fast-json-stable-stringify": "^2.0.0",
 						"graceful-fs": "^4.2.4",
-						"jest-haste-map": "^25.5.1",
-						"jest-regex-util": "^25.2.6",
-						"jest-util": "^25.5.0",
+						"jest-haste-map": "^26.6.2",
+						"jest-regex-util": "^26.0.0",
+						"jest-util": "^26.6.2",
 						"micromatch": "^4.0.2",
 						"pirates": "^4.0.1",
-						"realpath-native": "^2.0.0",
 						"slash": "^3.0.0",
 						"source-map": "^0.6.1",
 						"write-file-atomic": "^3.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
 					}
 				},
-				"@jest/types": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-					"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
+				"@types/prettier": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
+					"integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+					"dev": true
 				},
-				"@types/istanbul-reports": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-					"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+				"@wordpress/dependency-extraction-webpack-plugin": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-3.1.4.tgz",
+					"integrity": "sha512-SoFdhgt75symEJz57QwzDrcZzuSZ9Fxxr1adplSHHYfvRXBm/vDM0x6jeb2pHtVWH0Ltax4Z/yelRgv982nNYA==",
 					"dev": true,
 					"requires": {
-						"@types/istanbul-lib-coverage": "*",
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@typescript-eslint/experimental-utils": {
-					"version": "2.34.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
-					"integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.3",
-						"@typescript-eslint/typescript-estree": "2.34.0",
-						"eslint-scope": "^5.0.0",
-						"eslint-utils": "^2.0.0"
-					}
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "2.34.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
-					"integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
-					"dev": true,
-					"requires": {
-						"debug": "^4.1.1",
-						"eslint-visitor-keys": "^1.1.0",
-						"glob": "^7.1.6",
-						"is-glob": "^4.0.1",
-						"lodash": "^4.17.15",
-						"semver": "^7.3.2",
-						"tsutils": "^3.17.1"
+						"json2php": "^0.0.4",
+						"webpack-sources": "^2.2.0"
 					}
 				},
 				"@wordpress/eslint-plugin": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
-					"integrity": "sha512-HJpDYz2drtC9rY8MiYtYJ3cimioEIweGyb3P2DQTjUZ3sC4AGg+97PhXLHUdKfsFQ31JRxyLS9kKuGdDVBwWww==",
+					"version": "9.0.6",
+					"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-9.0.6.tgz",
+					"integrity": "sha512-ytkG93uzlHlItPR2MDkhUXtnnyw80rwSFZDovsHvMKrB9JjDem2pZnnUjwIOl+zb/9nittUJw6HA5AwCBDw+MQ==",
 					"dev": true,
 					"requires": {
-						"@wordpress/prettier-config": "^0.4.0",
+						"@typescript-eslint/eslint-plugin": "^4.15.0",
+						"@typescript-eslint/parser": "^4.15.0",
+						"@wordpress/prettier-config": "^1.0.5",
 						"babel-eslint": "^10.1.0",
 						"cosmiconfig": "^7.0.0",
-						"eslint-config-prettier": "^6.10.1",
-						"eslint-plugin-jest": "^23.8.2",
-						"eslint-plugin-jsdoc": "^30.2.2",
-						"eslint-plugin-jsx-a11y": "^6.2.3",
-						"eslint-plugin-prettier": "^3.1.2",
-						"eslint-plugin-react": "^7.20.0",
-						"eslint-plugin-react-hooks": "^4.0.4",
+						"eslint-config-prettier": "^7.1.0",
+						"eslint-plugin-import": "^2.22.1",
+						"eslint-plugin-jest": "^24.1.3",
+						"eslint-plugin-jsdoc": "^30.7.13",
+						"eslint-plugin-jsx-a11y": "^6.4.1",
+						"eslint-plugin-prettier": "^3.3.0",
+						"eslint-plugin-react": "^7.22.0",
+						"eslint-plugin-react-hooks": "^4.2.0",
 						"globals": "^12.0.0",
 						"prettier": "npm:wp-prettier@2.2.1-beta-1",
 						"requireindex": "^1.2.0"
 					}
 				},
-				"@wordpress/prettier-config": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-0.4.0.tgz",
-					"integrity": "sha512-7c4VeugkCwDkaHSD7ffxoP0VC5c///gCTEAT032OhI5Rik2dPxE3EkNAB2NhotGE8M4dMAg4g5Wj2OWZIn8TFw==",
+				"@wordpress/jest-console": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-4.0.5.tgz",
+					"integrity": "sha512-njpD0WUBd36FDVgFK7oTBTnxPIyy3e5bJdoJkYjqjw5WlRm2RtCeV0Kc5Lss1ZbtMX9oaSiZ9ih62pHXXFeKdQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"jest-matcher-utils": "^26.6.2",
+						"lodash": "^4.17.21"
+					}
+				},
+				"@wordpress/jest-preset-default": {
+					"version": "7.0.5",
+					"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-7.0.5.tgz",
+					"integrity": "sha512-Kf8TmGLqYb0hO44wiG57dRAROugGiplFIUG9jZnELTyppKkI/Q3ePJXVf+JmZsyzBw86OaNqSCAipTp5jWHhgw==",
+					"dev": true,
+					"requires": {
+						"@wordpress/jest-console": "^4.0.5",
+						"babel-jest": "^26.6.3",
+						"enzyme": "^3.11.0",
+						"enzyme-adapter-react-16": "^1.15.2",
+						"enzyme-to-json": "^3.4.4"
+					}
+				},
+				"acorn-globals": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+					"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+					"dev": true,
+					"requires": {
+						"acorn": "^7.1.1",
+						"acorn-walk": "^7.1.1"
+					}
+				},
+				"acorn-walk": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
 					"dev": true
+				},
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"dev": true,
+					"requires": {
+						"debug": "4"
+					}
 				},
 				"ansi-regex": {
 					"version": "5.0.0",
@@ -8462,31 +8703,19 @@
 					"dev": true
 				},
 				"babel-jest": {
-					"version": "25.5.1",
-					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
-					"integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+					"integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
 					"dev": true,
 					"requires": {
-						"@jest/transform": "^25.5.1",
-						"@jest/types": "^25.5.0",
+						"@jest/transform": "^26.6.2",
+						"@jest/types": "^26.6.2",
 						"@types/babel__core": "^7.1.7",
 						"babel-plugin-istanbul": "^6.0.0",
-						"babel-preset-jest": "^25.5.0",
-						"chalk": "^3.0.0",
+						"babel-preset-jest": "^26.6.2",
+						"chalk": "^4.0.0",
 						"graceful-fs": "^4.2.4",
 						"slash": "^3.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
 					}
 				},
 				"babel-plugin-istanbul": {
@@ -8503,25 +8732,52 @@
 					}
 				},
 				"babel-plugin-jest-hoist": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
-					"integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+					"integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
 					"dev": true,
 					"requires": {
 						"@babel/template": "^7.3.3",
 						"@babel/types": "^7.3.3",
+						"@types/babel__core": "^7.0.0",
 						"@types/babel__traverse": "^7.0.6"
 					}
 				},
-				"babel-preset-jest": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
-					"integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
+				"babel-preset-current-node-syntax": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+					"integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
 					"dev": true,
 					"requires": {
-						"babel-plugin-jest-hoist": "^25.5.0",
-						"babel-preset-current-node-syntax": "^0.1.2"
+						"@babel/plugin-syntax-async-generators": "^7.8.4",
+						"@babel/plugin-syntax-bigint": "^7.8.3",
+						"@babel/plugin-syntax-class-properties": "^7.8.3",
+						"@babel/plugin-syntax-import-meta": "^7.8.3",
+						"@babel/plugin-syntax-json-strings": "^7.8.3",
+						"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+						"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+						"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+						"@babel/plugin-syntax-top-level-await": "^7.8.3"
 					}
+				},
+				"babel-preset-jest": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+					"integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+					"dev": true,
+					"requires": {
+						"babel-plugin-jest-hoist": "^26.6.2",
+						"babel-preset-current-node-syntax": "^1.0.0"
+					}
+				},
+				"camelcase": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+					"dev": true
 				},
 				"chalk": {
 					"version": "4.1.1",
@@ -8531,6 +8787,17 @@
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
 					}
 				},
 				"color-convert": {
@@ -8570,26 +8837,68 @@
 						"lru-cache": "^4.0.1",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
+					}
+				},
+				"cssom": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+					"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+					"dev": true
+				},
+				"cssstyle": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+					"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+					"dev": true,
+					"requires": {
+						"cssom": "~0.3.6"
 					},
 					"dependencies": {
-						"lru-cache": {
-							"version": "4.1.5",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-							"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-							"dev": true,
-							"requires": {
-								"pseudomap": "^1.0.2",
-								"yallist": "^2.1.2"
-							}
-						},
-						"which": {
-							"version": "1.3.1",
-							"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-							"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-							"dev": true,
-							"requires": {
-								"isexe": "^2.0.0"
-							}
+						"cssom": {
+							"version": "0.3.8",
+							"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+							"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+							"dev": true
+						}
+					}
+				},
+				"data-urls": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+					"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+					"dev": true,
+					"requires": {
+						"abab": "^2.0.3",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^8.0.0"
+					}
+				},
+				"deepmerge": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+					"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+					"dev": true
+				},
+				"detect-newline": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+					"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+					"dev": true
+				},
+				"domexception": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+					"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+					"dev": true,
+					"requires": {
+						"webidl-conversions": "^5.0.0"
+					},
+					"dependencies": {
+						"webidl-conversions": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+							"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+							"dev": true
 						}
 					}
 				},
@@ -8604,6 +8913,60 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 					"dev": true
+				},
+				"escodegen": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+					"integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+					"dev": true,
+					"requires": {
+						"esprima": "^4.0.1",
+						"estraverse": "^5.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					},
+					"dependencies": {
+						"levn": {
+							"version": "0.3.0",
+							"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+							"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+							"dev": true,
+							"requires": {
+								"prelude-ls": "~1.1.2",
+								"type-check": "~0.3.2"
+							}
+						},
+						"optionator": {
+							"version": "0.8.3",
+							"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+							"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+							"dev": true,
+							"requires": {
+								"deep-is": "~0.1.3",
+								"fast-levenshtein": "~2.0.6",
+								"levn": "~0.3.0",
+								"prelude-ls": "~1.1.2",
+								"type-check": "~0.3.2",
+								"word-wrap": "~1.2.3"
+							}
+						},
+						"prelude-ls": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+							"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+							"dev": true
+						},
+						"type-check": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+							"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+							"dev": true,
+							"requires": {
+								"prelude-ls": "~1.1.2"
+							}
+						}
+					}
 				},
 				"eslint": {
 					"version": "7.29.0",
@@ -8663,12 +9026,6 @@
 								"which": "^2.0.1"
 							}
 						},
-						"eslint-visitor-keys": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-							"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-							"dev": true
-						},
 						"globals": {
 							"version": "13.9.0",
 							"resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
@@ -8676,6 +9033,24 @@
 							"dev": true,
 							"requires": {
 								"type-fest": "^0.20.2"
+							}
+						},
+						"lru-cache": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+							"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+							"dev": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						},
+						"semver": {
+							"version": "7.3.5",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+							"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+							"dev": true,
+							"requires": {
+								"lru-cache": "^6.0.0"
 							}
 						},
 						"shebang-command": {
@@ -8692,25 +9067,22 @@
 							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 							"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 							"dev": true
+						},
+						"which": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+							"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+							"dev": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						},
+						"yallist": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+							"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+							"dev": true
 						}
-					}
-				},
-				"eslint-config-prettier": {
-					"version": "6.15.0",
-					"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-					"integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
-					"dev": true,
-					"requires": {
-						"get-stdin": "^6.0.0"
-					}
-				},
-				"eslint-plugin-jest": {
-					"version": "23.20.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz",
-					"integrity": "sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/experimental-utils": "^2.5.0"
 					}
 				},
 				"eslint-utils": {
@@ -8720,7 +9092,21 @@
 					"dev": true,
 					"requires": {
 						"eslint-visitor-keys": "^1.1.0"
+					},
+					"dependencies": {
+						"eslint-visitor-keys": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+							"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+							"dev": true
+						}
 					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
 				},
 				"espree": {
 					"version": "7.3.1",
@@ -8731,18 +9117,68 @@
 						"acorn": "^7.4.0",
 						"acorn-jsx": "^5.3.1",
 						"eslint-visitor-keys": "^1.3.0"
+					},
+					"dependencies": {
+						"eslint-visitor-keys": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+							"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+							"dev": true
+						}
 					}
 				},
-				"extract-zip": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				},
+				"execa": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 					"dev": true,
 					"requires": {
-						"@types/yauzl": "^2.9.1",
-						"debug": "^4.1.1",
-						"get-stream": "^5.1.0",
-						"yauzl": "^2.10.0"
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "7.0.3",
+							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+							"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+							"dev": true,
+							"requires": {
+								"path-key": "^3.1.0",
+								"shebang-command": "^2.0.0",
+								"which": "^2.0.1"
+							}
+						},
+						"shebang-command": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+							"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+							"dev": true,
+							"requires": {
+								"shebang-regex": "^3.0.0"
+							}
+						},
+						"which": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+							"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+							"dev": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						}
 					}
 				},
 				"file-entry-cache": {
@@ -8755,13 +9191,13 @@
 					}
 				},
 				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
 				"flat-cache": {
@@ -8779,6 +9215,17 @@
 					"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
 					"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
 					"dev": true
+				},
+				"form-data": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+					"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+					"dev": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.8",
+						"mime-types": "^2.1.12"
+					}
 				},
 				"get-stream": {
 					"version": "5.2.0",
@@ -8804,11 +9251,56 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
+				"html-encoding-sniffer": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+					"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-encoding": "^1.0.5"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+					"dev": true,
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"import-local": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+					"dev": true,
+					"requires": {
+						"pkg-dir": "^4.2.0",
+						"resolve-cwd": "^3.0.0"
+					}
+				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+					"dev": true
+				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "3.0.0",
@@ -8826,85 +9318,464 @@
 						"@istanbuljs/schema": "^0.1.2",
 						"istanbul-lib-coverage": "^3.0.0",
 						"semver": "^6.3.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+					"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "^3.0.0",
+						"make-dir": "^3.0.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+					"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.1.1",
+						"istanbul-lib-coverage": "^3.0.0",
+						"source-map": "^0.6.1"
+					}
+				},
+				"istanbul-reports": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+					"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+					"dev": true,
+					"requires": {
+						"html-escaper": "^2.0.0",
+						"istanbul-lib-report": "^3.0.0"
+					}
+				},
+				"jest": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+					"integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^26.6.3",
+						"import-local": "^3.0.2",
+						"jest-cli": "^26.6.3"
 					},
 					"dependencies": {
-						"semver": {
-							"version": "6.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-							"dev": true
-						}
-					}
-				},
-				"jest-haste-map": {
-					"version": "25.5.1",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
-					"integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"@types/graceful-fs": "^4.1.2",
-						"anymatch": "^3.0.3",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^2.1.2",
-						"graceful-fs": "^4.2.4",
-						"jest-serializer": "^25.5.0",
-						"jest-util": "^25.5.0",
-						"jest-worker": "^25.5.0",
-						"micromatch": "^4.0.2",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7",
-						"which": "^2.0.2"
-					}
-				},
-				"jest-regex-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-					"dev": true
-				},
-				"jest-serializer": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
-					"integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.4"
-					}
-				},
-				"jest-util": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
-					"integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"chalk": "^3.0.0",
-						"graceful-fs": "^4.2.4",
-						"is-ci": "^2.0.0",
-						"make-dir": "^3.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+						"jest-cli": {
+							"version": "26.6.3",
+							"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+							"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
 							"dev": true,
 							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
+								"@jest/core": "^26.6.3",
+								"@jest/test-result": "^26.6.2",
+								"@jest/types": "^26.6.2",
+								"chalk": "^4.0.0",
+								"exit": "^0.1.2",
+								"graceful-fs": "^4.2.4",
+								"import-local": "^3.0.2",
+								"is-ci": "^2.0.0",
+								"jest-config": "^26.6.3",
+								"jest-util": "^26.6.2",
+								"jest-validate": "^26.6.2",
+								"prompts": "^2.0.1",
+								"yargs": "^15.4.1"
 							}
 						}
 					}
 				},
-				"jest-worker": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
-					"integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
+				"jest-changed-files": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+					"integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
 					"dev": true,
 					"requires": {
+						"@jest/types": "^26.6.2",
+						"execa": "^4.0.0",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-config": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+					"integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/test-sequencer": "^26.6.3",
+						"@jest/types": "^26.6.2",
+						"babel-jest": "^26.6.3",
+						"chalk": "^4.0.0",
+						"deepmerge": "^4.2.2",
+						"glob": "^7.1.1",
+						"graceful-fs": "^4.2.4",
+						"jest-environment-jsdom": "^26.6.2",
+						"jest-environment-node": "^26.6.2",
+						"jest-get-type": "^26.3.0",
+						"jest-jasmine2": "^26.6.3",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-validate": "^26.6.2",
+						"micromatch": "^4.0.2",
+						"pretty-format": "^26.6.2"
+					}
+				},
+				"jest-docblock": {
+					"version": "26.0.0",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+					"integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+					"dev": true,
+					"requires": {
+						"detect-newline": "^3.0.0"
+					}
+				},
+				"jest-each": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+					"integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"chalk": "^4.0.0",
+						"jest-get-type": "^26.3.0",
+						"jest-util": "^26.6.2",
+						"pretty-format": "^26.6.2"
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+					"integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^26.6.2",
+						"@jest/fake-timers": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"jest-mock": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jsdom": "^16.4.0"
+					}
+				},
+				"jest-environment-node": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+					"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^26.6.2",
+						"@jest/fake-timers": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"jest-mock": "^26.6.2",
+						"jest-util": "^26.6.2"
+					}
+				},
+				"jest-haste-map": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+					"integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"@types/graceful-fs": "^4.1.2",
+						"@types/node": "*",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-regex-util": "^26.0.0",
+						"jest-serializer": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-worker": "^26.6.2",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
+					}
+				},
+				"jest-jasmine2": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+					"integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
+					"dev": true,
+					"requires": {
+						"@babel/traverse": "^7.1.0",
+						"@jest/environment": "^26.6.2",
+						"@jest/source-map": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"co": "^4.6.0",
+						"expect": "^26.6.2",
+						"is-generator-fn": "^2.0.0",
+						"jest-each": "^26.6.2",
+						"jest-matcher-utils": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-runtime": "^26.6.3",
+						"jest-snapshot": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"pretty-format": "^26.6.2",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-leak-detector": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+					"integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
+					"dev": true,
+					"requires": {
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.6.2"
+					}
+				},
+				"jest-resolve": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+					"integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"chalk": "^4.0.0",
+						"graceful-fs": "^4.2.4",
+						"jest-pnp-resolver": "^1.2.2",
+						"jest-util": "^26.6.2",
+						"read-pkg-up": "^7.0.1",
+						"resolve": "^1.18.1",
+						"slash": "^3.0.0"
+					},
+					"dependencies": {
+						"read-pkg-up": {
+							"version": "7.0.1",
+							"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+							"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+							"dev": true,
+							"requires": {
+								"find-up": "^4.1.0",
+								"read-pkg": "^5.2.0",
+								"type-fest": "^0.8.1"
+							}
+						}
+					}
+				},
+				"jest-resolve-dependencies": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+					"integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"jest-regex-util": "^26.0.0",
+						"jest-snapshot": "^26.6.2"
+					}
+				},
+				"jest-runner": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+					"integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^26.6.2",
+						"@jest/environment": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"emittery": "^0.7.1",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.3",
+						"jest-docblock": "^26.0.0",
+						"jest-haste-map": "^26.6.2",
+						"jest-leak-detector": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-resolve": "^26.6.2",
+						"jest-runtime": "^26.6.3",
+						"jest-util": "^26.6.2",
+						"jest-worker": "^26.6.2",
+						"source-map-support": "^0.5.6",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-runtime": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+					"integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^26.6.2",
+						"@jest/environment": "^26.6.2",
+						"@jest/fake-timers": "^26.6.2",
+						"@jest/globals": "^26.6.2",
+						"@jest/source-map": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/transform": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.6.0",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.3",
+						"jest-haste-map": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-mock": "^26.6.2",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.2",
+						"jest-snapshot": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-validate": "^26.6.2",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-serializer": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+					"integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"graceful-fs": "^4.2.4"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+					"integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.2",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.2",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.2",
+						"jest-get-type": "^26.3.0",
+						"jest-haste-map": "^26.6.2",
+						"jest-matcher-utils": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-resolve": "^26.6.2",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.2",
+						"semver": "^7.3.2"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+							"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+							"dev": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						},
+						"semver": {
+							"version": "7.3.5",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+							"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+							"dev": true,
+							"requires": {
+								"lru-cache": "^6.0.0"
+							}
+						},
+						"yallist": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+							"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+							"dev": true
+						}
+					}
+				},
+				"jest-validate": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+					"integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"camelcase": "^6.0.0",
+						"chalk": "^4.0.0",
+						"jest-get-type": "^26.3.0",
+						"leven": "^3.1.0",
+						"pretty-format": "^26.6.2"
+					}
+				},
+				"jest-watcher": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+					"integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
+					"dev": true,
+					"requires": {
+						"@jest/test-result": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.0.0",
+						"jest-util": "^26.6.2",
+						"string-length": "^4.0.1"
+					}
+				},
+				"jest-worker": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
+					}
+				},
+				"jsdom": {
+					"version": "16.6.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
+					"integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+					"dev": true,
+					"requires": {
+						"abab": "^2.0.5",
+						"acorn": "^8.2.4",
+						"acorn-globals": "^6.0.0",
+						"cssom": "^0.4.4",
+						"cssstyle": "^2.3.0",
+						"data-urls": "^2.0.0",
+						"decimal.js": "^10.2.1",
+						"domexception": "^2.0.1",
+						"escodegen": "^2.0.0",
+						"form-data": "^3.0.0",
+						"html-encoding-sniffer": "^2.0.1",
+						"http-proxy-agent": "^4.0.1",
+						"https-proxy-agent": "^5.0.0",
+						"is-potential-custom-element-name": "^1.0.1",
+						"nwsapi": "^2.2.0",
+						"parse5": "6.0.1",
+						"saxes": "^5.0.1",
+						"symbol-tree": "^3.2.4",
+						"tough-cookie": "^4.0.0",
+						"w3c-hr-time": "^1.0.2",
+						"w3c-xmlserializer": "^2.0.0",
+						"webidl-conversions": "^6.1.0",
+						"whatwg-encoding": "^1.0.5",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^8.5.0",
+						"ws": "^7.4.5",
+						"xml-name-validator": "^3.0.0"
+					},
+					"dependencies": {
+						"acorn": {
+							"version": "8.4.1",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+							"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+							"dev": true
+						}
 					}
 				},
 				"json-schema-traverse": {
@@ -8944,7 +9815,35 @@
 							"requires": {
 								"error-ex": "^1.2.0"
 							}
+						},
+						"strip-bom": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+							"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+							"dev": true,
+							"requires": {
+								"is-utf8": "^0.2.0"
+							}
 						}
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"make-dir": {
@@ -8954,14 +9853,69 @@
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
+					}
+				},
+				"node-notifier": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.2.tgz",
+					"integrity": "sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"growly": "^1.3.0",
+						"is-wsl": "^2.2.0",
+						"semver": "^7.3.2",
+						"shellwords": "^0.1.1",
+						"uuid": "^8.3.0",
+						"which": "^2.0.2"
 					},
 					"dependencies": {
+						"lru-cache": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+							"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						},
 						"semver": {
-							"version": "6.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-							"dev": true
+							"version": "7.3.5",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+							"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"lru-cache": "^6.0.0"
+							}
+						},
+						"which": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+							"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						},
+						"yallist": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+							"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+							"dev": true,
+							"optional": true
 						}
+					}
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
 					}
 				},
 				"optionator": {
@@ -8978,14 +9932,32 @@
 						"word-wrap": "^1.2.3"
 					}
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+				"p-each-series": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+					"integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+					"dev": true
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"p-limit": "^2.2.0"
 					}
+				},
+				"parse5": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+					"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
 				},
 				"path-key": {
 					"version": "3.1.1",
@@ -8999,6 +9971,15 @@
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
 				"prelude-ls": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9011,47 +9992,23 @@
 					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 					"dev": true
 				},
-				"puppeteer": {
-					"version": "npm:puppeteer-core@3.0.0",
-					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-					"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
-					"dev": true,
-					"requires": {
-						"@types/mime-types": "^2.1.0",
-						"debug": "^4.1.0",
-						"extract-zip": "^2.0.0",
-						"https-proxy-agent": "^4.0.0",
-						"mime": "^2.0.3",
-						"mime-types": "^2.1.25",
-						"progress": "^2.0.1",
-						"proxy-from-env": "^1.0.0",
-						"rimraf": "^3.0.2",
-						"tar-fs": "^2.0.0",
-						"unbzip2-stream": "^1.3.3",
-						"ws": "^7.2.3"
-					}
-				},
 				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
 					},
 					"dependencies": {
-						"path-type": {
-							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-							"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-							"dev": true,
-							"requires": {
-								"graceful-fs": "^4.1.2",
-								"pify": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
 						}
 					}
 				},
@@ -9063,18 +10020,70 @@
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"dev": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+							"dev": true,
+							"requires": {
+								"pinkie-promise": "^2.0.0"
+							}
+						},
+						"path-type": {
+							"version": "1.1.0",
+							"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+							"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.2",
+								"pify": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						},
+						"read-pkg": {
+							"version": "1.1.0",
+							"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+							"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+							"dev": true,
+							"requires": {
+								"load-json-file": "^1.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^1.0.0"
+							}
+						}
 					}
-				},
-				"realpath-native": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
-					"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
-					"dev": true
 				},
 				"regexpp": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
 					"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+					"dev": true
+				},
+				"resolve-cwd": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+					"dev": true,
+					"requires": {
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
 				},
 				"rimraf": {
@@ -9086,14 +10095,20 @@
 						"glob": "^7.1.3"
 					}
 				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+				"saxes": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+					"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"xmlchars": "^2.2.0"
 					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				},
 				"shebang-regex": {
 					"version": "3.0.0",
@@ -9118,6 +10133,16 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
+				"string-length": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+					"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+					"dev": true,
+					"requires": {
+						"char-regex": "^1.0.2",
+						"strip-ansi": "^6.0.0"
+					}
+				},
 				"string-width": {
 					"version": "4.2.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -9139,13 +10164,10 @@
 					}
 				},
 				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+					"dev": true
 				},
 				"strip-json-comments": {
 					"version": "3.1.1",
@@ -9201,6 +10223,32 @@
 						"minimatch": "^3.0.4"
 					}
 				},
+				"throat": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+					"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+					"integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.33",
+						"punycode": "^2.1.1",
+						"universalify": "^0.1.2"
+					}
+				},
+				"tr46": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+					"integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.1"
+					}
+				},
 				"type-check": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -9210,13 +10258,77 @@
 						"prelude-ls": "^1.2.1"
 					}
 				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"dev": true,
+					"optional": true
+				},
+				"v8-to-istanbul": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
+					"integrity": "sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==",
 					"dev": true,
 					"requires": {
-						"isexe": "^2.0.0"
+						"@types/istanbul-lib-coverage": "^2.0.1",
+						"convert-source-map": "^1.6.0",
+						"source-map": "^0.7.3"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.7.3",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+							"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+							"dev": true
+						}
+					}
+				},
+				"w3c-xmlserializer": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+					"integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+					"dev": true,
+					"requires": {
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"webidl-conversions": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+					"dev": true
+				},
+				"webpack-sources": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.0.tgz",
+					"integrity": "sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.1",
+						"source-map": "^0.6.1"
+					}
+				},
+				"whatwg-url": {
+					"version": "8.6.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
+					"integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.7.0",
+						"tr46": "^2.1.0",
+						"webidl-conversions": "^6.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"write-file-atomic": {
@@ -9242,6 +10354,43 @@
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+							"dev": true
+						}
+					}
 				}
 			}
 		},
@@ -9469,16 +10618,6 @@
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
 			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
-		},
-		"accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"dev": true,
-			"requires": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			}
 		},
 		"acorn": {
 			"version": "7.4.1",
@@ -9799,12 +10938,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
 			"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
-			"dev": true
-		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
 			"dev": true
 		},
 		"array-includes": {
@@ -10415,18 +11548,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"bfj": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
-			"integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
-			"dev": true,
-			"requires": {
-				"bluebird": "^3.5.5",
-				"check-types": "^8.0.3",
-				"hoopy": "^0.1.4",
-				"tryer": "^1.0.1"
-			}
-		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -10483,80 +11604,6 @@
 				"error": "^7.0.0",
 				"raw-body": "~1.1.0",
 				"safe-json-parse": "~1.0.1"
-			},
-			"dependencies": {
-				"bytes": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-					"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
-					"dev": true
-				},
-				"raw-body": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-					"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-					"dev": true,
-					"requires": {
-						"bytes": "1",
-						"string_decoder": "0.10"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
-		"body-parser": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-			"dev": true,
-			"requires": {
-				"bytes": "3.1.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"on-finished": "~2.3.0",
-				"qs": "6.7.0",
-				"raw-body": "2.4.0",
-				"type-is": "~1.6.17"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
-				}
 			}
 		},
 		"body-scroll-lock": {
@@ -10780,9 +11827,9 @@
 			"dev": true
 		},
 		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+			"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
 			"dev": true
 		},
 		"cacache": {
@@ -10951,6 +11998,12 @@
 				"supports-color": "^5.3.0"
 			}
 		},
+		"char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true
+		},
 		"character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
@@ -10981,25 +12034,75 @@
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"check-node-version": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.3.0.tgz",
-			"integrity": "sha512-OAtp7prQf+8YYKn2UB/fK1Ppb9OT+apW56atoKYUvucYLPq69VozOY0B295okBwCKymk2cictrS3qsdcZwyfzw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.1.0.tgz",
+			"integrity": "sha512-TSXGsyfW5/xY2QseuJn8/hleO2AU7HxVCdkc900jp1vcfzF840GkjvRT7CHl8sRtWn23n3X3k0cwH9RXeRwhfw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.3.0",
+				"chalk": "^3.0.0",
 				"map-values": "^1.0.1",
 				"minimist": "^1.2.0",
 				"object-filter": "^1.0.2",
-				"object.assign": "^4.0.4",
 				"run-parallel": "^1.1.4",
-				"semver": "^5.0.3"
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
-		},
-		"check-types": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
-			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
-			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.10",
@@ -11122,6 +12225,12 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"cjs-module-lexer": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+			"integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
+			"dev": true
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -11441,29 +12550,6 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.2"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
-				}
-			}
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
-		},
 		"continuable-cache": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
@@ -11484,18 +12570,6 @@
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				}
 			}
-		},
-		"cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-			"dev": true
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
@@ -12041,6 +13115,12 @@
 				}
 			}
 		},
+		"decimal.js": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.0.tgz",
+			"integrity": "sha512-MrQRs2gyD//7NeHi9TtsfClkf+cFAewDz+PZHR8ILKglLmBMyVX3ymQ+oeznE3tjrS7beTN+6JXb2C3JDHm7ug==",
+			"dev": true
+		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -12179,12 +13259,6 @@
 			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
 			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
 		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
-		},
 		"des.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -12194,12 +13268,6 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
 			}
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
 		},
 		"detect-file": {
 			"version": "1.0.0",
@@ -12211,6 +13279,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
+		"devtools-protocol": {
+			"version": "0.0.818844",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+			"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
 			"dev": true
 		},
 		"diff-sequences": {
@@ -12439,18 +13513,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
-		},
-		"ejs": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-			"integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-			"dev": true
-		},
 		"electron-to-chromium": {
 			"version": "1.3.754",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.754.tgz",
@@ -12479,6 +13541,12 @@
 					"dev": true
 				}
 			}
+		},
+		"emittery": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+			"integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
+			"dev": true
 		},
 		"emoji-flags": {
 			"version": "1.3.0",
@@ -12518,12 +13586,6 @@
 				"@emotion/weak-memoize": "0.2.5",
 				"hoist-non-react-statics": "^3.3.0"
 			}
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.13",
@@ -12778,12 +13840,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-			"dev": true
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
 			"dev": true
 		},
 		"escape-string-regexp": {
@@ -13447,12 +14503,6 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-			"dev": true
-		},
 		"eventemitter3": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
@@ -13570,84 +14620,51 @@
 				"os-homedir": "^1.0.1"
 			}
 		},
+		"expect": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+			"integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"ansi-styles": "^4.0.0",
+				"jest-get-type": "^26.3.0",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-regex-util": "^26.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				}
+			}
+		},
 		"expect-puppeteer": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz",
 			"integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==",
 			"dev": true
-		},
-		"express": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-			"dev": true,
-			"requires": {
-				"accepts": "~1.3.7",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.19.0",
-				"content-disposition": "0.5.3",
-				"content-type": "~1.0.4",
-				"cookie": "0.4.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.1.2",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.5",
-				"qs": "6.7.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.1.2",
-				"send": "0.17.1",
-				"serve-static": "1.14.1",
-				"setprototypeof": "1.1.1",
-				"statuses": "~1.5.0",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"path-to-regexp": {
-					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
-				}
-			}
 		},
 		"extend": {
 			"version": "3.0.2",
@@ -13933,18 +14950,35 @@
 				"flat-cache": "^2.0.1"
 			}
 		},
+		"file-loader": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+			"integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^3.0.0"
+			},
+			"dependencies": {
+				"schema-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
+					}
+				}
+			}
+		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
 			"dev": true,
 			"optional": true
-		},
-		"filesize": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-			"dev": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -13960,38 +14994,6 @@
 			"resolved": "https://registry.npmjs.org/filter-console/-/filter-console-0.1.1.tgz",
 			"integrity": "sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==",
 			"dev": true
-		},
-		"finalhandler": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"statuses": "~1.5.0",
-				"unpipe": "~1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
 		},
 		"find-cache-dir": {
 			"version": "3.3.1",
@@ -14471,12 +15473,6 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"forwarded": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-			"dev": true
-		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -14506,12 +15502,6 @@
 			"requires": {
 				"hey-listen": "^1.0.5"
 			}
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-			"dev": true
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -14706,9 +15696,9 @@
 			"dev": true
 		},
 		"get-stdin": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+			"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
 			"dev": true
 		},
 		"get-stream": {
@@ -14897,13 +15887,12 @@
 			"dev": true
 		},
 		"gzip-size": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-			"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+			"integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
 			"dev": true,
 			"requires": {
-				"duplexer": "^0.1.1",
-				"pify": "^4.0.1"
+				"duplexer": "^0.1.2"
 			}
 		},
 		"h2o2": {
@@ -15093,12 +16082,6 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
-		"hoopy": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
-			"dev": true
-		},
 		"hosted-git-info": {
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -15153,32 +16136,33 @@
 				"entities": "^2.0.0"
 			}
 		},
-		"http-errors": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-			"dev": true,
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
-				}
-			}
-		},
 		"http-parser-js": {
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
 			"integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
 			"dev": true
+		},
+		"http-proxy-agent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"dev": true,
+			"requires": {
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"dev": true,
+					"requires": {
+						"debug": "4"
+					}
+				}
+			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
@@ -15524,12 +16508,6 @@
 			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
 			"dev": true
 		},
-		"ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"dev": true
-		},
 		"irregular-plurals": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
@@ -15788,6 +16766,12 @@
 			"requires": {
 				"isobject": "^3.0.1"
 			}
+		},
+		"is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true
 		},
 		"is-promise": {
 			"version": "4.0.0",
@@ -19187,6 +20171,147 @@
 				}
 			}
 		},
+		"jest-matcher-utils": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+			"integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^26.6.2",
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.6.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-message-util": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+			"integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/types": "^26.6.2",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
+				"micromatch": "^4.0.2",
+				"pretty-format": "^26.6.2",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-mock": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+			"integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"@types/node": "*"
+			}
+		},
 		"jest-pnp-resolver": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
@@ -19202,6 +20327,12 @@
 				"expect-puppeteer": "^4.4.0",
 				"jest-environment-puppeteer": "^4.4.0"
 			}
+		},
+		"jest-regex-util": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+			"dev": true
 		},
 		"jest-resolve": {
 			"version": "24.9.0",
@@ -20142,6 +21273,71 @@
 					"requires": {
 						"is-number": "^3.0.0",
 						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
+		"jest-util": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+			"integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
+				"is-ci": "^2.0.0",
+				"micromatch": "^4.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -21182,12 +22378,6 @@
 						"graceful-readlink": ">= 1.0.0"
 					}
 				},
-				"get-stdin": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-					"dev": true
-				},
 				"ignore": {
 					"version": "5.1.8",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -21323,12 +22513,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
 			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-			"dev": true
-		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
 		"memize": {
@@ -21521,12 +22705,6 @@
 				}
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -21537,12 +22715,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
 			"dev": true
 		},
 		"micromark": {
@@ -21937,12 +23109,6 @@
 				"railroad-diagrams": "^1.0.0",
 				"randexp": "0.4.6"
 			}
-		},
-		"negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-			"dev": true
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -22402,15 +23568,6 @@
 				"es-abstract": "^1.18.2"
 			}
 		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -22681,12 +23838,6 @@
 					"dev": true
 				}
 			}
-		},
-		"parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"dev": true
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -23707,16 +24858,6 @@
 				"reflect.ownkeys": "^0.2.0"
 			}
 		},
-		"proxy-addr": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-			"dev": true,
-			"requires": {
-				"forwarded": "0.2.0",
-				"ipaddr.js": "1.9.1"
-			}
-		},
 		"proxy-from-env": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -23830,6 +24971,113 @@
 				}
 			}
 		},
+		"puppeteer-core": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+			"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"devtools-protocol": "0.0.818844",
+				"extract-zip": "^2.0.0",
+				"https-proxy-agent": "^4.0.0",
+				"node-fetch": "^2.6.1",
+				"pkg-dir": "^4.2.0",
+				"progress": "^2.0.1",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^3.0.2",
+				"tar-fs": "^2.0.0",
+				"unbzip2-stream": "^1.3.3",
+				"ws": "^7.2.3"
+			},
+			"dependencies": {
+				"extract-zip": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+					"dev": true,
+					"requires": {
+						"@types/yauzl": "^2.9.1",
+						"debug": "^4.1.1",
+						"get-stream": "^5.1.0",
+						"yauzl": "^2.10.0"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"node-fetch": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+					"dev": true
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"ws": {
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
+					"integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+					"dev": true
+				}
+			}
+		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -23919,32 +25167,21 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"dev": true
-		},
 		"raw-body": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+			"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
 			"dev": true,
 			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
+				"bytes": "1",
+				"string_decoder": "0.10"
 			},
 			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
 				}
 			}
 		},
@@ -25268,58 +26505,6 @@
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
 		},
-		"send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
-				"mime": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				}
-			}
-		},
 		"serialize-javascript": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
@@ -25327,18 +26512,6 @@
 			"dev": true,
 			"requires": {
 				"randombytes": "^2.1.0"
-			}
-		},
-		"serve-static": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-			"dev": true,
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.17.1"
 			}
 		},
 		"set-blocking": {
@@ -25373,12 +26546,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-			"dev": true
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -25469,6 +26636,17 @@
 			"version": "0.5.11",
 			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
 			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og=="
+		},
+		"sirv": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.12.tgz",
+			"integrity": "sha512-+jQoCxndz7L2tqQL4ZyzfDhky0W/4ZJip3XoOuxyQWnAwMxindLl3Xv1qT4x1YX/re0leShvTm8Uk0kQspGhBg==",
+			"dev": true,
+			"requires": {
+				"@polka/url": "^1.0.0-next.15",
+				"mime": "^2.3.1",
+				"totalist": "^1.0.0"
+			}
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -25800,6 +26978,23 @@
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
 			"dev": true
 		},
+		"stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				}
+			}
+		},
 		"state-toggle": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
@@ -25826,12 +27021,6 @@
 					}
 				}
 			}
-		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"dev": true
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -26694,17 +27883,6 @@
 				"stylelint-config-recommended": "^3.0.0"
 			}
 		},
-		"stylelint-config-wordpress": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-wordpress/-/stylelint-config-wordpress-17.0.0.tgz",
-			"integrity": "sha512-qUU2kVMd2ezIV9AzRdgietIfnavRRENt4180A1OMoVXIowRjjhohZgBiyVPV5EtNKo3GTO63l8g/QGNG27/h9g==",
-			"dev": true,
-			"requires": {
-				"stylelint-config-recommended": "^3.0.0",
-				"stylelint-config-recommended-scss": "^4.2.0",
-				"stylelint-scss": "^3.17.2"
-			}
-		},
 		"stylelint-scss": {
 			"version": "3.19.0",
 			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.19.0.tgz",
@@ -27317,12 +28495,6 @@
 			"resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
 			"integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
 		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-			"dev": true
-		},
 		"topo": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
@@ -27339,6 +28511,12 @@
 					"dev": true
 				}
 			}
+		},
+		"totalist": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+			"integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.5.0",
@@ -27387,12 +28565,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
 			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-			"dev": true
-		},
-		"tryer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
 			"dev": true
 		},
 		"ts-essentials": {
@@ -27483,16 +28655,6 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
 			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 			"dev": true
-		},
-		"type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"dev": true,
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			}
 		},
 		"typedarray": {
 			"version": "0.0.6",
@@ -27685,10 +28847,10 @@
 				"unist-util-is": "^3.0.0"
 			}
 		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
 		"unquote": {
@@ -27898,12 +29060,6 @@
 				"object.getownpropertydescriptors": "^2.1.1"
 			}
 		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"dev": true
-		},
 		"uuid": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
@@ -27948,12 +29104,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
 			"integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -28506,40 +29656,94 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz",
-			"integrity": "sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.2.tgz",
+			"integrity": "sha512-PIagMYhlEzFfhMYOzs5gFT55DkUdkyrJi/SxJp8EF3YMWhS+T9vvs2EoTetpk5qb6VsCq02eXTlRDOydRhDFAQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.1",
-				"acorn-walk": "^7.1.1",
-				"bfj": "^6.1.1",
-				"chalk": "^2.4.1",
-				"commander": "^2.18.0",
-				"ejs": "^2.6.1",
-				"express": "^4.16.3",
-				"filesize": "^3.6.1",
-				"gzip-size": "^5.0.0",
-				"lodash": "^4.17.19",
-				"mkdirp": "^0.5.1",
-				"opener": "^1.5.1",
-				"ws": "^6.0.0"
+				"acorn": "^8.0.4",
+				"acorn-walk": "^8.0.0",
+				"chalk": "^4.1.0",
+				"commander": "^6.2.0",
+				"gzip-size": "^6.0.0",
+				"lodash": "^4.17.20",
+				"opener": "^1.5.2",
+				"sirv": "^1.0.7",
+				"ws": "^7.3.1"
 			},
 			"dependencies": {
-				"acorn-walk": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+				"acorn": {
+					"version": "8.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
 					"dev": true
 				},
-				"ws": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-					"integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+				"acorn-walk": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.0.tgz",
+					"integrity": "sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"async-limiter": "~1.0.0"
+						"color-convert": "^2.0.1"
 					}
+				},
+				"chalk": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"commander": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"ws": {
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
+					"integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"prearchive": "rm -rf vendor && composer install --no-dev && composer dump-autoload -o",
 		"archive": "composer archive --file=$npm_package_name --format=zip",
 		"postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
-		"i18n": "php -d memory_limit=1024M `which wp` i18n make-pot ./ languages/$npm_package_name.pot --slug=$npm_package_name --domain=$npm_package_name --exclude=bin,data,js/src,node_modules,tests,vendor",
+		"i18n": "php -d memory_limit=8024M `which wp` i18n make-pot ./ languages/$npm_package_name.pot --slug=$npm_package_name --domain=$npm_package_name --exclude=bin,data,js/src,node_modules,tests,vendor",
 		"check-engines": "wp-scripts check-engines",
 		"check-licenses": "wp-scripts check-licenses",
 		"format:js": "wp-scripts format-js",
@@ -48,10 +48,11 @@
 		"@woocommerce/e2e-utils": "^0.1.5",
 		"@woocommerce/eslint-plugin": "^1.2.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^2.7.0",
-		"@wordpress/scripts": "^14.1.1",
+		"@wordpress/scripts": "^16.1.3",
 		"@wordpress/stylelint-config": "^19.0.5",
 		"eslint-import-resolver-webpack": "^0.13.1",
 		"h2o2": "^8.2.0",
+		"postcss": "^8.3.5",
 		"prettier": "npm:wp-prettier@^2.0.5"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@woocommerce/e2e-environment": "^0.2.2",
 		"@woocommerce/e2e-utils": "^0.1.5",
 		"@woocommerce/eslint-plugin": "^1.2.0",
-		"@wordpress/dependency-extraction-webpack-plugin": "^2.7.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^3.1.4",
 		"@wordpress/scripts": "^16.1.3",
 		"@wordpress/stylelint-config": "^19.0.5",
 		"eslint-import-resolver-webpack": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@woocommerce/e2e-utils": "^0.1.5",
 		"@woocommerce/eslint-plugin": "^1.2.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^2.7.0",
-		"@wordpress/scripts": "^12.5.0",
+		"@wordpress/scripts": "^14.1.1",
 		"@wordpress/stylelint-config": "^19.0.5",
 		"eslint-import-resolver-webpack": "^0.13.1",
 		"h2o2": "^8.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,7 +83,7 @@ const updatedSassOptions = {
 	sassOptions: {
 		includePaths: [ 'js/src/css/abstracts' ],
 	},
-	prependData:
+	additionalData:
 		'@import "_colors"; ' +
 		'@import "_variables"; ' +
 		'@import "_mixins"; ' +


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Bump @wordpress/scripts to 16.1.3 (from 12.5.0) (2a822dc, 81de5f8)
	Add postcss@8.3.5 as this is required peer dependency.
	Update webpack conf to use the latest version of Sass options.

- Bump @wordpress/dependency-extraction-webpack-plugin to 3.1.4 from 2.9.0 (9ea9379)

The idea is to reduce our legacy, and hopefully reduce the bundle size by removing IE support.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. checkout this branch
2. `npm install && npm run build && npm run test-unit && npm run test:e2e`


### Changelog entry

> Tweak - Updated `@wordpress/scripts` and `@wordpress/dependency-extraction-webpack-plugin` dependencies.

### Additional info

What's really strange and somewhat blocking is that `index.js` bundle size **increased over 2.5 times**
![image](https://user-images.githubusercontent.com/17435/123262144-d9bd3b00-d4f7-11eb-80aa-df6d1ce75f51.png)

https://ja2r7.app.goo.gl/CVpKPeNaRRy3Ls5c8



(https://github.com/woocommerce/google-listings-and-ads/pull/819)