### PR TITLE
Consistently return error codes from the middleware server

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -85,8 +85,11 @@ class AdsCampaign implements OptionsAwareInterface {
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Error retrieving campaigns: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error retrieving campaigns: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -135,11 +138,17 @@ class AdsCampaign implements OptionsAwareInterface {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			if ( $this->has_api_exception_error( $e, 'DUPLICATE_CAMPAIGN_NAME' ) ) {
-				throw new Exception( __( 'A campaign with this name already exists', 'google-listings-and-ads' ) );
+				throw new Exception(
+					__( 'A campaign with this name already exists', 'google-listings-and-ads' ),
+					$e->getCode()
+				);
 			}
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Error creating campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error creating campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -166,8 +175,11 @@ class AdsCampaign implements OptionsAwareInterface {
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Error retrieving campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error retrieving campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -208,8 +220,11 @@ class AdsCampaign implements OptionsAwareInterface {
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Error editing campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error editing campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -238,11 +253,17 @@ class AdsCampaign implements OptionsAwareInterface {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
 			if ( $this->has_api_exception_error( $e, 'OPERATION_NOT_PERMITTED_FOR_REMOVED_RESOURCE' ) ) {
-				throw new Exception( __( 'This campaign has already been deleted', 'google-listings-and-ads' ) );
+				throw new Exception(
+					__( 'This campaign has already been deleted', 'google-listings-and-ads' ),
+					$e->getCode()
+				);
 			}
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Error deleting campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error deleting campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
+				$e->getCode()
+			);
 		}
 	}
 

--- a/src/API/Google/AdsConversionAction.php
+++ b/src/API/Google/AdsConversionAction.php
@@ -103,8 +103,11 @@ class AdsConversionAction implements OptionsAwareInterface {
 				}
 			}
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Error creating conversion action: %s', 'google-listings-and-ads' ), $message ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error creating conversion action: %s', 'google-listings-and-ads' ), $message ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -134,8 +137,11 @@ class AdsConversionAction implements OptionsAwareInterface {
 				$message = $e->getBasicMessage();
 			}
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Error retrieving conversion action: %s', 'google-listings-and-ads' ), $message ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error retrieving conversion action: %s', 'google-listings-and-ads' ), $message ),
+				$e->getCode()
+			);
 		}
 	}
 

--- a/src/API/Google/AdsReport.php
+++ b/src/API/Google/AdsReport.php
@@ -88,8 +88,11 @@ class AdsReport implements OptionsAwareInterface {
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Unable to retrieve campaign report data: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Unable to retrieve campaign report data: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
+				$e->getCode()
+			);
 		}
 	}
 

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -72,7 +72,10 @@ class Proxy implements OptionsAwareInterface {
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
-			throw new Exception( $this->client_exception_message( $e, __( 'Error retrieving accounts', 'google-listings-and-ads' ) ) );
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error retrieving accounts', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -124,7 +127,10 @@ class Proxy implements OptionsAwareInterface {
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
-			throw new Exception( $this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) ) );
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -175,7 +181,10 @@ class Proxy implements OptionsAwareInterface {
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
-			throw new Exception( $this->client_exception_message( $e, __( 'Error linking merchant to MCA', 'google-listings-and-ads' ) ) );
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error linking merchant to MCA', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -218,7 +227,10 @@ class Proxy implements OptionsAwareInterface {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 			do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'google_manager' ] );
 
-			throw new Exception( $this->client_exception_message( $e, __( 'Error claiming website', 'google-listings-and-ads' ) ) );
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error claiming website', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -250,8 +262,11 @@ class Proxy implements OptionsAwareInterface {
 				return [];
 			}
 
-			/* translators: %s Error message */
-			throw new Exception( sprintf( __( 'Error retrieving accounts: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ) );
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error retrieving accounts: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -313,7 +328,10 @@ class Proxy implements OptionsAwareInterface {
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
-			throw new Exception( $this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) ) );
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
 		}
 	}
 
@@ -356,7 +374,10 @@ class Proxy implements OptionsAwareInterface {
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
-			throw new Exception( $this->client_exception_message( $e, __( 'Error linking account', 'google-listings-and-ads' ) ) );
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error linking account', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
 		}
 	}
 

--- a/src/API/Google/SiteVerification.php
+++ b/src/API/Google/SiteVerification.php
@@ -78,7 +78,10 @@ class SiteVerification {
 			$response = $service->webResource->getToken( $post_body );
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_sv_client_exception', $e, __METHOD__ );
-			throw new Exception( __( 'Unable to retrieve site verification token.', 'google-listings-and-ads' ) );
+			throw new Exception(
+				__( 'Unable to retrieve site verification token.', 'google-listings-and-ads' ),
+				$e->getCode()
+			);
 		}
 
 		return $response->getToken();
@@ -111,7 +114,10 @@ class SiteVerification {
 			$service->webResource->insert( self::VERIFICATION_METHOD, $post_body );
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_sv_client_exception', $e, __METHOD__ );
-			throw new Exception( __( 'Unable to insert site verification.', 'google-listings-and-ads' ) );
+			throw new Exception(
+				__( 'Unable to insert site verification.', 'google-listings-and-ads' ),
+				$e->getCode()
+			);
 		}
 
 		return true;

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -104,7 +104,7 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					$this->ads_campaign->get_campaigns()
 				);
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], 400 );
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
 		};
 	}
@@ -133,7 +133,7 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 
 				return $this->prepare_item_for_response( $campaign, $request );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], 400 );
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
 		};
 	}
@@ -161,7 +161,7 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 
 				return $this->prepare_item_for_response( $campaign, $request );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], 400 );
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
 		};
 	}
@@ -193,7 +193,7 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					'id'      => $campaign_id,
 				];
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], 400 );
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
 		};
 	}
@@ -214,7 +214,7 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					'id'      => $deleted_id,
 				];
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], 400 );
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
 		};
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR resolves the issue that the middleware status error code is not consistently passed on. The reason this needs to be consistent is because the UI should be able to detect when the tokens for the Google connection are no longer valid/available. It does this by returning a 401 status code, which needs to be passed on to the UI so we can correctly direct them to a reconnect flow, see: #486 

### Detailed test instructions:

1. Using a local WCS, set a users token to be expired in the DB table `wcc_token`, and temporarily remove the refresh token
2. View the dashboard page and confirm using the browser developer tools, that each request which retrieves data from the Google API's will return a 401 error
![image](https://user-images.githubusercontent.com/11388669/123266666-269f1280-d4f4-11eb-8d67-ed6b1e83e743.png)
3. Restore the refresh token in the DB table `wcc_token`
4. Refresh the dashboard page and confirm that the requests now return a 200 response


### Changelog entry
* Fix - Consistently return error codes from the middleware server.
