### PR TITLE
Add the reconnect status endpoint

### DIFF
--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -3,12 +3,14 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAccountQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsBillingStatusQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Exception;
 use Google\Ads\GoogleAds\Util\FieldMasks;
+use Google\Ads\GoogleAds\V6\Enums\AccessRoleEnum\AccessRole;
 use Google\Ads\GoogleAds\V6\Enums\MerchantCenterLinkStatusEnum\MerchantCenterLinkStatus;
 use Google\Ads\GoogleAds\V6\Resources\MerchantCenterLink;
 use Google\Ads\GoogleAds\V6\Services\MerchantCenterLinkOperation;
@@ -101,6 +103,35 @@ class Ads implements OptionsAwareInterface {
 			$this->options->get_ads_id(),
 			$operation
 		);
+	}
+
+	/**
+	 * Check if we have access to the merchant account.
+	 *
+	 * @param string $email Email address of the connected account.
+	 *
+	 * @return bool
+	 */
+	public function has_access( string $email ): bool {
+		$ads_id = $this->options->get_ads_id();
+
+		try {
+			$results = ( new AdsAccountQuery() )
+			->set_client( $this->client, $ads_id )
+			->where( 'customer_user_access.email_address', $email )
+			->get_results();
+
+			foreach ( $results->iterateAllElements() as $row ) {
+				$access = $row->getCustomerUserAccess();
+				if ( AccessRole::ADMIN === $access->getAccessRole() ) {
+					return true;
+				}
+			}
+		} catch ( ApiException $e ) {
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -145,7 +145,11 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 
 		$ads_id = $this->options->get_ads_id();
 		if ( $ads_id ) {
+			/** @var Ads $ads */
+			$ads = $this->container->get( Ads::class );
+
 			$status['ads_account'] = $ads_id;
+			$status['ads_access']  = $ads->has_access( $email ) ? 'yes' : 'no';
 		}
 
 		return $status;

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -3,12 +3,13 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Exception;
-use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientExceptionInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -16,26 +17,17 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class Connection
  *
+ * ContainerAware used to access:
+ * - Client
+ * - Merchant
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
-class Connection implements OptionsAwareInterface {
+class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 
 	use ApiExceptionTrait;
+	use ContainerAwareTrait;
 	use OptionsAwareTrait;
-
-	/**
-	 * @var ContainerInterface
-	 */
-	protected $container;
-
-	/**
-	 * Connection constructor.
-	 *
-	 * @param ContainerInterface $container
-	 */
-	public function __construct( ContainerInterface $container ) {
-		$this->container = $container;
-	}
 
 	/**
 	 * Get the connection URL for performing a connection redirect.

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -134,6 +134,10 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 		$status = $this->get_status();
 		$email  = $status['email'] ?: '';
 
+		if ( ! isset( $response['status'] ) || 'connected' !== $response['status'] ) {
+			return $status;
+		}
+
 		$merchant_id = $this->options->get_merchant_id();
 		if ( $merchant_id ) {
 			/** @var Merchant $merchant */

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -135,7 +135,7 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 		$status = $this->get_status();
 		$email  = $status['email'] ?: '';
 
-		if ( ! isset( $response['status'] ) || 'connected' !== $response['status'] ) {
+		if ( ! isset( $status['status'] ) || 'connected' !== $status['status'] ) {
 			return $status;
 		}
 

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -130,6 +130,36 @@ class Connection implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Get the reconnect status which checks:
+	 * - The Google account is connected
+	 * - We have access to the connected MC account
+	 * - We have access to the connected Ads account
+	 *
+	 * @return array
+	 * @throws Exception When a ClientException is caught or the response contains an error.
+	 */
+	public function get_reconnect_status(): array {
+		$status = $this->get_status();
+		$email  = $status['email'] ?: '';
+
+		$merchant_id = $this->options->get_merchant_id();
+		if ( $merchant_id ) {
+			/** @var Merchant $merchant */
+			$merchant = $this->container->get( Merchant::class );
+
+			$status['merchant_account'] = $merchant_id;
+			$status['merchant_access']  = $merchant->has_access( $email ) ? 'yes' : 'no';
+		}
+
+		$ads_id = $this->options->get_ads_id();
+		if ( $ads_id ) {
+			$status['ads_account'] = $ads_id;
+		}
+
+		return $status;
+	}
+
+	/**
 	 * Get the Google connection URL.
 	 *
 	 * @return string

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * Class Connection
  *
  * ContainerAware used to access:
+ * - Ads
  * - Client
  * - Merchant
  *

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -222,4 +222,29 @@ class Merchant implements OptionsAwareInterface {
 
 		return true;
 	}
+
+	/**
+	 * Check if we have access to the merchant account.
+	 *
+	 * @param string $email Email address of the connected account.
+	 *
+	 * @return bool
+	 */
+	public function has_access( string $email ): bool {
+		$id = $this->options->get_merchant_id();
+
+		try {
+			$account = $this->service->accounts->get( $id, $id );
+
+			foreach ( $account->getUsers() as $user ) {
+				if ( $email === $user->getEmailAddress() && $user->getAdmin() ) {
+					return true;
+				}
+			}
+		} catch ( GoogleException $e ) {
+			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
+		}
+
+		return false;
+	}
 }

--- a/src/API/Google/Query/AdsAccountQuery.php
+++ b/src/API/Google/Query/AdsAccountQuery.php
@@ -1,0 +1,22 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsAccountQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
+class AdsAccountQuery extends AdsQuery {
+
+	/**
+	 * Query constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'customer_user_access' );
+		$this->columns( [ 'customer_user_access.resource_name', 'customer_user_access.access_role' ] );
+	}
+}

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -65,6 +65,16 @@ class AccountController extends BaseController {
 				],
 			]
 		);
+		$this->register_route(
+			'google/reconnected',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_reconnected_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
 	}
 
 	/**
@@ -115,6 +125,25 @@ class AccountController extends BaseController {
 					'active' => array_key_exists( 'status', $status ) && ( 'connected' === $status['status'] ) ? 'yes' : 'no',
 					'email'  => array_key_exists( 'email', $status ) ? $status['email'] : '',
 				];
+			} catch ( Exception $e ) {
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function to determine if we have access to the dependent services.
+	 *
+	 * @return callable
+	 */
+	protected function get_reconnected_callback(): callable {
+		return function() {
+			try {
+				$status           = $this->connection->get_reconnect_status();
+				$status['active'] = array_key_exists( 'status', $status ) && ( 'connected' === $status['status'] ) ? 'yes' : 'no';
+				unset( $status['status'] );
+
+				return $status;
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -90,7 +90,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->register_ads_client();
 		$this->register_google_classes();
 		$this->add( Proxy::class, ContainerInterface::class );
-		$this->add( Connection::class, ContainerInterface::class );
+		$this->add( Connection::class );
 		$this->add( Settings::class, ContainerInterface::class );
 
 		$this->share( Ads::class, GoogleAdsClient::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the endpoint `/wc/gla/google/reconnected`, the intention of this endpoint is to use only when we are reconnecting the API. We use a separate endpoint for this because it will trigger three calls to the Google API:
1. Get account email
2. Check MC account permissions
3. Check Ads account permissions

When either `merchant_access` or `ads_access` returns false we should prompt them to switch Google accounts or reconnect everything.

Resolves part of #486

### Detailed test instructions:

1. Connect all accounts
2. Send a request to `GET /wc/gla/google/reconnected` and receive a response like:
```json
{
	"email": "test@gmail.com",
	"merchant_account": 1234567890,
	"merchant_access": "yes",
	"ads_account": 5678901234,
	"ads_access": "yes",
	"active": "yes"
}
```
3. Use the connection test to disconnect the Google account
4. Resend a request to `GET /wc/gla/google/reconnected` and receive a similar response like /wc/gla/google/connected
```json
{
	"active": "no",
}
```
5. Use the connection test to reconnect with a different Google account
6. Resend a request to `GET /wc/gla/google/reconnected` and receive a response like:
```json
{
	"email": "test@gmail.com",
	"merchant_account": 1234567890,
	"merchant_access": "no",
	"ads_account": 5678901234,
	"ads_access": "no",
	"active": "yes"
}
```

### Changelog entry
* Add - Endpoint for checking access to previously connected accounts.
