### PR TITLE
Clarify GLA header tags

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -113,16 +113,16 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	protected function display_global_site_tag( string $ads_conversion_id ) {
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
-		<!-- Global site tag (gtag.js) - Google Ads: <?php echo esc_js( $ads_conversion_id ); ?> -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_js( $ads_conversion_id ); ?>"></script>
-		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
-			gtag('set', 'developer_id.<?php echo esc_js( self::DEVELOPER_ID ); ?>', true);
+<!-- Global site tag (gtag.js) - Google Ads: <?php echo esc_js( $ads_conversion_id ); ?> - Google Listings & Ads -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_js( $ads_conversion_id ); ?>"></script>
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+	gtag('set', 'developer_id.<?php echo esc_js( self::DEVELOPER_ID ); ?>', true);
 
-			gtag('config','<?php echo esc_js( $ads_conversion_id ); ?>');
-		</script>
+	gtag('config','<?php echo esc_js( $ads_conversion_id ); ?>');
+</script>
 		<?php
 		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	}

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -113,6 +113,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	protected function display_global_site_tag( string $ads_conversion_id ) {
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
+
 <!-- Global site tag (gtag.js) - Google Ads: <?php echo esc_js( $ads_conversion_id ); ?> - Google Listings & Ads -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_js( $ads_conversion_id ); ?>"></script>
 <script>

--- a/src/Google/SiteVerificationMeta.php
+++ b/src/Google/SiteVerificationMeta.php
@@ -49,6 +49,7 @@ class SiteVerificationMeta implements Service, Registerable {
 		if ( empty( $this->settings['meta_tag'] ) ) {
 			return;
 		}
+		echo '<!-- Google site verification - Google Listings & Ads -->' . PHP_EOL;
 		echo wp_kses(
 			$this->settings['meta_tag'],
 			[


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #813.

- Adds an HTML comment before the Site Verification `<meta>` tag to indicate that it was inserted by Google Listings & Ads.
- Updates the HTML comment before the global site tag `<script>` snippet, also to indicate that it was inserted by Google Listings & Ads.
- Removes unnecessary indentation from the global site tag snippet.

### Detailed test instructions:

1. Connect Merchant Center and Ads accounts.
2. Visit the public-facing store.
3. View the page source code and confirm:
    - The `google-site-verification` meta tag is preceded by the new HTML comment:
    `<!-- Google site verification - Google Listings & Ads -->`
    - The global site tag snippet's HTML comment also indicates that it belongs to GLA:
    `<!-- Global site tag (gtag.js) - Google Ads: AW-8675309 - Google Listings & Ads -->`
    _(Note: won't display if WooCommerce Google Analytics Integration plugin is activated)_

### Changelog entry

> Tweak - Clarify which HTML header tags are inserted by GLA.