### PR TITLE
Fix undefined variable

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -561,19 +561,15 @@ class Proxy implements OptionsAwareInterface {
 	 * @return boolean
 	 */
 	protected function request_ads_currency(): bool {
-		if ( $use_store_currency ) {
-			$currency = get_woocommerce_currency();
-		} else {
-			try {
-				/** @var GoogleAdsClient $client */
-				$client   = $this->container->get( GoogleAdsClient::class );
-				$resource = ResourceNames::forCustomer( $this->options->get( OptionsInterface::ADS_ID ) );
-				$customer = $client->getCustomerServiceClient()->getCustomer( $resource );
-				$currency = $customer->getCurrencyCode();
-			} catch ( ApiException $e ) {
-				do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
-				$currency = null;
-			}
+		try {
+			/** @var GoogleAdsClient $client */
+			$client   = $this->container->get( GoogleAdsClient::class );
+			$resource = ResourceNames::forCustomer( $this->options->get( OptionsInterface::ADS_ID ) );
+			$customer = $client->getCustomerServiceClient()->getCustomer( $resource );
+			$currency = $customer->getCurrencyCode();
+		} catch ( ApiException $e ) {
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
+			$currency = null;
 		}
 
 		return $this->options->update( OptionsInterface::ADS_ACCOUNT_CURRENCY, $currency );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #826.

This removes a leftover reference to an undefined variable left behind by refactoring in #795 that was throwing an undefined error.

It also includes the Ads account currency option in the list of options to be removed during the Ads account disconnection process.

### Detailed test instructions:

1. Connect a Merchant Center account.
2. Try to connect an _existing_ Ads account.
3. Confirm that there's no errors or warnings in the log.
4. Confirm that the Ads account currency was set correctly ``SELECT *  FROM `wp_options` WHERE `option_name` = 'gla_ads_account_currency'``


### Changelog entry

> Fix - Remove undefined variable warning during Ads account connection.