### PR TITLE
Unset Ads currency DB option when disconnecting account.

### DIFF
--- a/src/Ads/AdsService.php
+++ b/src/Ads/AdsService.php
@@ -47,5 +47,6 @@ class AdsService implements OptionsAwareInterface, Service {
 		$this->options->delete( OptionsInterface::ADS_CONVERSION_ACTION );
 		$this->options->delete( OptionsInterface::ADS_ID );
 		$this->options->delete( OptionsInterface::ADS_SETUP_COMPLETED_AT );
+		$this->options->delete( OptionsInterface::ADS_ACCOUNT_CURRENCY );
 	}
 }

--- a/src/Ads/AdsService.php
+++ b/src/Ads/AdsService.php
@@ -42,11 +42,11 @@ class AdsService implements OptionsAwareInterface, Service {
 	 * Disconnect Ads account
 	 */
 	public function disconnect() {
+		$this->options->delete( OptionsInterface::ADS_ACCOUNT_CURRENCY );
 		$this->options->delete( OptionsInterface::ADS_ACCOUNT_STATE );
 		$this->options->delete( OptionsInterface::ADS_BILLING_URL );
 		$this->options->delete( OptionsInterface::ADS_CONVERSION_ACTION );
 		$this->options->delete( OptionsInterface::ADS_ID );
 		$this->options->delete( OptionsInterface::ADS_SETUP_COMPLETED_AT );
-		$this->options->delete( OptionsInterface::ADS_ACCOUNT_CURRENCY );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Forgot to push this change into #827.

This just unsets the `gla_ads_account_currency` option when the Ads account is disconnected.


### Detailed test instructions:

1. Connect an Ads account
2. Confirm that the Ads account currency was set correctly: 
    ``SELECT * FROM `wp_options` WHERE `option_name` = 'gla_ads_account_currency'``
2. Disconnect the Ads account.
2. Confirm that the Ads account currency was removed correctly:
    ``SELECT * FROM `wp_options` WHERE `option_name` = 'gla_ads_account_currency'``


### Changelog entry

> Tweak - Unset Ads currency DB option when disconnecting account.