### PR TITLE
Update apiclient library to version 2.10

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -29,7 +29,8 @@ $dependencies = [
 // Namespaces which are used directly within the code.
 $direct_replacements = [
 	'guzzlehttp' => [
-		'GuzzleHttp\Psr7\stream_for',
+		'GuzzleHttp\Psr7\Utils::streamFor',
+		'GuzzleHttp\Psr7\Utils::tryFopen',
 		'GuzzleHttp\Psr7\Message::bodySummary',
 		'GuzzleHttp\Client(',
 		'GuzzleHttp\ClientInterface::MAJOR_VERSION',

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "automattic/jetpack-autoloader": "^2.4",
     "automattic/jetpack-config": "^1.4",
     "automattic/jetpack-connection": "^1.20",
-    "google/apiclient": "^2.7",
+    "google/apiclient": "^2.10",
     "googleads/google-ads-php": "^8.0",
     "league/container": "^3.3",
     "league/iso3166": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -481,16 +481,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v5.2.1",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23"
+                "reference": "d2113d9b2e0e349796e72d2a63cf9319100382d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
-                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d2113d9b2e0e349796e72d2a63cf9319100382d2",
+                "reference": "d2113d9b2e0e349796e72d2a63cf9319100382d2",
                 "shasum": ""
             },
             "require": {
@@ -498,6 +498,9 @@
             },
             "require-dev": {
                 "phpunit/phpunit": ">=4.8 <=9"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
             },
             "type": "library",
             "autoload": {
@@ -529,27 +532,27 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v5.2.1"
+                "source": "https://github.com/firebase/php-jwt/tree/v5.4.0"
             },
-            "time": "2021-02-12T00:02:00+00:00"
+            "time": "2021-06-23T19:00:23+00:00"
         },
         {
             "name": "google/apiclient",
-            "version": "v2.9.1",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "2fb6e702aca5d68203fa737f89f6f774022494c6"
+                "reference": "b86b0c974bc998499e080f3d3178aaab06d07ee3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/2fb6e702aca5d68203fa737f89f6f774022494c6",
-                "reference": "2fb6e702aca5d68203fa737f89f6f774022494c6",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/b86b0c974bc998499e080f3d3178aaab06d07ee3",
+                "reference": "b86b0c974bc998499e080f3d3178aaab06d07ee3",
                 "shasum": ""
             },
             "require": {
                 "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
-                "google/apiclient-services": "~0.13",
+                "google/apiclient-services": "^0.200.0",
                 "google/auth": "^1.10",
                 "guzzlehttp/guzzle": "~5.3.3||~6.0||~7.0",
                 "guzzlehttp/psr7": "^1.2",
@@ -559,7 +562,7 @@
             },
             "require-dev": {
                 "cache/filesystem-adapter": "^0.3.2|^1.1",
-                "composer/composer": "^1.10",
+                "composer/composer": "^1.10.22",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "phpcompatibility/php-compatibility": "^9.2",
                 "phpunit/phpunit": "^5.7||^8.5.13",
@@ -598,35 +601,38 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.9.1"
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.10.0"
             },
-            "time": "2021-01-19T17:48:59+00:00"
+            "time": "2021-06-23T18:16:21+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.164.0",
+            "version": "v0.200.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "266557af3f595681eb9199853641f334a913d1bf"
+                "reference": "0375af405757b36f3bcc82e19d7daf61e0b4cfd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/266557af3f595681eb9199853641f334a913d1bf",
-                "reference": "266557af3f595681eb9199853641f334a913d1bf",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/0375af405757b36f3bcc82e19d7daf61e0b4cfd8",
+                "reference": "0375af405757b36f3bcc82e19d7daf61e0b4cfd8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8|^5"
+                "phpunit/phpunit": "^5.7||^8.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Google_Service_": "src"
-                }
+                "psr-4": {
+                    "Google\\Service\\": "src"
+                },
+                "files": [
+                    "autoload.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -639,22 +645,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.164.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.200.0"
             },
-            "time": "2021-03-13T12:20:04+00:00"
+            "time": "2021-06-18T15:00:35+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.15.0",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "b346c07de6613e26443d7b4830e5e1933b830dc4"
+                "reference": "c747738d2dd450f541f09f26510198fbedd1c8a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/b346c07de6613e26443d7b4830e5e1933b830dc4",
-                "reference": "b346c07de6613e26443d7b4830e5e1933b830dc4",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/c747738d2dd450f541f09f26510198fbedd1c8a0",
+                "reference": "c747738d2dd450f541f09f26510198fbedd1c8a0",
                 "shasum": ""
             },
             "require": {
@@ -662,13 +668,13 @@
                 "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7.0",
                 "guzzlehttp/psr7": "^1.2",
                 "php": ">=5.4",
-                "psr/cache": "^1.0",
+                "psr/cache": "^1.0|^2.0",
                 "psr/http-message": "^1.0"
             },
             "require-dev": {
                 "guzzlehttp/promises": "0.1.1|^1.3",
                 "kelvinmo/simplejwt": "^0.2.5|^0.5.1",
-                "phpseclib/phpseclib": "^2",
+                "phpseclib/phpseclib": "^2.0.31",
                 "phpunit/phpunit": "^4.8.36|^5.7",
                 "sebastian/comparator": ">=1.2.3",
                 "squizlabs/php_codesniffer": "^3.5"
@@ -696,9 +702,9 @@
             "support": {
                 "docs": "https://googleapis.github.io/google-auth-library-php/master/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.15.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.16.0"
             },
-            "time": "2021-02-05T20:50:04+00:00"
+            "time": "2021-06-22T18:06:03+00:00"
         },
         {
             "name": "google/common-protos",
@@ -982,22 +988,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.2.0",
+            "version": "7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "0aa74dfb41ae110835923ef10a9d803a22d50e79"
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/0aa74dfb41ae110835923ef10a9d803a22d50e79",
-                "reference": "0aa74dfb41ae110835923ef10a9d803a22d50e79",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.4",
-                "guzzlehttp/psr7": "^1.7",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0"
             },
@@ -1005,6 +1011,7 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-curl": "*",
                 "php-http/client-integration-tests": "^3.0",
                 "phpunit/phpunit": "^8.5.5 || ^9.3.5",
@@ -1018,7 +1025,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.1-dev"
+                    "dev-master": "7.3-dev"
                 }
             },
             "autoload": {
@@ -1060,7 +1067,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.2.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
             },
             "funding": [
                 {
@@ -1080,7 +1087,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-10T11:47:56+00:00"
+            "time": "2021-03-23T11:33:13+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1139,16 +1146,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.7.0",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3"
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/53330f47520498c0ae1f61f7e2c90f55690c06a3",
-                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
                 "shasum": ""
             },
             "require": {
@@ -1208,9 +1215,9 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.7.0"
+                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
             },
-            "time": "2020-09-30T07:37:11+00:00"
+            "time": "2021-04-26T09:17:50+00:00"
         },
         {
             "name": "league/container",
@@ -1933,16 +1940,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -1966,7 +1973,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -1977,9 +1984,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.3"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2020-03-23T09:12:05+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -5,15 +5,15 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
-use Google_Service_ShoppingContent as ShoppingService;
-use Google_Service_ShoppingContent_Account as MC_Account;
-use Google_Service_ShoppingContent_AccountAdsLink as MC_Account_Ads_Link;
-use Google_Service_ShoppingContent_AccountStatus as MC_Account_Status;
-use Google_Service_ShoppingContent_ProductstatusesCustomBatchResponse as MC_Product_Status_Batch_Response;
-use Google_Service_ShoppingContent_ProductstatusesCustomBatchRequest as MC_Product_Status_Batch_Request;
-use Google_Service_ShoppingContent_ProductstatusesListResponse as MC_Product_Status_List_Response;
-use Google_Service_ShoppingContent_Product as Product;
 use Google\Exception as GoogleException;
+use Google\Service\ShoppingContent;
+use Google\Service\ShoppingContent\Account;
+use Google\Service\ShoppingContent\AccountAdsLink;
+use Google\Service\ShoppingContent\AccountStatus;
+use Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
+use Google\Service\ShoppingContent\ProductstatusesCustomBatchRequest;
+use Google\Service\ShoppingContent\ProductstatusesListResponse;
+use Google\Service\ShoppingContent\Product;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -30,16 +30,16 @@ class Merchant implements OptionsAwareInterface {
 	/**
 	 * The shopping service.
 	 *
-	 * @var ShoppingService
+	 * @var ShoppingContent
 	 */
 	protected $service;
 
 	/**
 	 * Merchant constructor.
 	 *
-	 * @param ShoppingService $service
+	 * @param ShoppingContent $service
 	 */
-	public function __construct( ShoppingService $service ) {
+	public function __construct( ShoppingContent $service ) {
 		$this->service = $service;
 	}
 
@@ -100,10 +100,10 @@ class Merchant implements OptionsAwareInterface {
 	 * Retrieve the user's Merchant Center account information.
 	 *
 	 * @param int $id Optional - the Merchant Center account to retrieve
-	 * @return MC_Account The user's Merchant Center account.
+	 * @return Account The user's Merchant Center account.
 	 * @throws Exception If the account can't be retrieved.
 	 */
-	public function get_account( int $id = 0 ): MC_Account {
+	public function get_account( int $id = 0 ): Account {
 		$id = $id ?: $this->options->get_merchant_id();
 
 		try {
@@ -119,10 +119,10 @@ class Merchant implements OptionsAwareInterface {
 	 * Retrieve the user's Merchant Center account information.
 	 *
 	 * @param int $id Optional - the Merchant Center account to retrieve
-	 * @return MC_Account_Status The user's Merchant Center account.
+	 * @return AccountStatus The user's Merchant Center account status.
 	 * @throws Exception If the account can't be retrieved.
 	 */
-	public function get_accountstatus( int $id = 0 ): MC_Account_Status {
+	public function get_accountstatus( int $id = 0 ): AccountStatus {
 		$id = $id ?: $this->options->get_merchant_id();
 
 		try {
@@ -139,9 +139,9 @@ class Merchant implements OptionsAwareInterface {
 	 *
 	 * @param string|null $page_token
 	 *
-	 * @return MC_Product_Status_List_Response A page of the Merchant Center product statuses.
+	 * @return ProductstatusesListResponse A page of the Merchant Center product statuses.
 	 */
-	public function get_productstatuses( ?string $page_token ): MC_Product_Status_List_Response {
+	public function get_productstatuses( ?string $page_token ): ProductstatusesListResponse {
 		$merchant_id = $this->options->get_merchant_id();
 		$opt_params  = [ 'maxResults' => 250 ];
 		if ( ! empty( $page_token ) ) {
@@ -157,9 +157,9 @@ class Merchant implements OptionsAwareInterface {
 	 *
 	 * @param string[] $mc_product_ids
 	 *
-	 * @return MC_Product_Status_Batch_Response;
+	 * @return ProductstatusesCustomBatchResponse;
 	 */
-	public function get_productstatuses_batch( array $mc_product_ids ): MC_Product_Status_Batch_Response {
+	public function get_productstatuses_batch( array $mc_product_ids ): ProductstatusesCustomBatchResponse {
 		$merchant_id = $this->options->get_merchant_id();
 		$entries     = [];
 		foreach ( $mc_product_ids as $index => $id ) {
@@ -172,7 +172,7 @@ class Merchant implements OptionsAwareInterface {
 		}
 
 		// Retrieve batch.
-		$request = new MC_Product_Status_Batch_Request();
+		$request = new ProductstatusesCustomBatchRequest();
 		$request->setEntries( $entries );
 		return $this->service->productstatuses->custombatch( $request );
 	}
@@ -180,19 +180,19 @@ class Merchant implements OptionsAwareInterface {
 	/**
 	 * Update the provided Merchant Center account information.
 	 *
-	 * @param MC_Account $mc_account The Account data to update.
+	 * @param Account $account The Account data to update.
 	 *
-	 * @return MC_Account The user's Merchant Center account.
+	 * @return Account The user's Merchant Center account.
 	 * @throws Exception If the account can't be retrieved.
 	 */
-	public function update_account( MC_Account $mc_account ): MC_Account {
+	public function update_account( Account $account ): Account {
 		try {
-			$mc_account = $this->service->accounts->update( $mc_account->getId(), $mc_account->getId(), $mc_account );
+			$account = $this->service->accounts->update( $account->getId(), $account->getId(), $account );
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to update merchant center account.', 'google-listings-and-ads' ), $e->getCode() );
 		}
-		return $mc_account;
+		return $account;
 	}
 
 	/**
@@ -214,7 +214,7 @@ class Merchant implements OptionsAwareInterface {
 			}
 		}
 
-		$link = new MC_Account_Ads_Link();
+		$link = new AccountAdsLink();
 		$link->setAdsId( $ads_id );
 		$link->setStatus( 'active' );
 		$account->setAdsLinks( array_merge( $ads_links, [ $link ] ) );

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -13,9 +13,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use DateTime;
 use Exception;
 use Google\Exception as GoogleException;
-use Google_Service_ShoppingContent as ShoppingService;
-use Google_Service_ShoppingContent_ReportRow as ReportRow;
-use Google_Service_ShoppingContent_Segments as Segments;
+use Google\Service\ShoppingContent;
+use Google\Service\ShoppingContent\ReportRow;
+use Google\Service\ShoppingContent\Segments;
 
 /**
  * Trait MerchantReportTrait
@@ -30,7 +30,7 @@ class MerchantReport implements OptionsAwareInterface {
 	/**
 	 * The shopping service.
 	 *
-	 * @var ShoppingService
+	 * @var ShoppingContent
 	 */
 	protected $service;
 
@@ -44,10 +44,10 @@ class MerchantReport implements OptionsAwareInterface {
 	/**
 	 * Merchant Report constructor.
 	 *
-	 * @param ShoppingService $service
+	 * @param ShoppingContent $service
 	 * @param ProductHelper   $product_helper
 	 */
-	public function __construct( ShoppingService $service, ProductHelper $product_helper ) {
+	public function __construct( ShoppingContent $service, ProductHelper $product_helper ) {
 		$this->service        = $service;
 		$this->product_helper = $product_helper;
 	}

--- a/src/API/Google/Query/MerchantQuery.php
+++ b/src/API/Google/Query/MerchantQuery.php
@@ -4,10 +4,10 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidProperty;
-use Google_Service_ShoppingContent as ShoppingService;
-use Google_Service_ShoppingContent_SearchRequest as SearchRequest;
-use Google_Service_ShoppingContent_SearchResponse as SearchResponse;
 use Google\Exception as GoogleException;
+use Google\Service\ShoppingContent;
+use Google\Service\ShoppingContent\SearchRequest;
+use Google\Service\ShoppingContent\SearchResponse;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -21,7 +21,7 @@ abstract class MerchantQuery extends Query {
 	/**
 	 * Client which handles the query.
 	 *
-	 * @var ShoppingService
+	 * @var ShoppingContent
 	 */
 	protected $client = null;
 
@@ -42,12 +42,12 @@ abstract class MerchantQuery extends Query {
 	/**
 	 * Set the client which will handle the query.
 	 *
-	 * @param ShoppingService $client Client instance.
+	 * @param ShoppingContent $client Client instance.
 	 * @param int             $id     Account ID.
 	 *
 	 * @return QueryInterface
 	 */
-	public function set_client( ShoppingService $client, int $id ): QueryInterface {
+	public function set_client( ShoppingContent $client, int $id ): QueryInterface {
 		$this->client = $client;
 		$this->id     = $id;
 

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -7,15 +7,15 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery as Ra
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery as TimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
-use Google_Service_ShoppingContent as ShoppingService;
-use Google_Service_ShoppingContent_AccountTax as AccountTax;
-use Google_Service_ShoppingContent_AccountTaxTaxRule as TaxRule;
-use Google_Service_ShoppingContent_DeliveryTime as DeliveryTime;
-use Google_Service_ShoppingContent_Price as Price;
-use Google_Service_ShoppingContent_RateGroup as RateGroup;
-use Google_Service_ShoppingContent_Service as Service;
-use Google_Service_ShoppingContent_ShippingSettings as ShippingSettings;
-use Google_Service_ShoppingContent_Value as Value;
+use Google\Service\ShoppingContent;
+use Google\Service\ShoppingContent\AccountTax;
+use Google\Service\ShoppingContent\AccountTaxTaxRule as TaxRule;
+use Google\Service\ShoppingContent\DeliveryTime;
+use Google\Service\ShoppingContent\Price;
+use Google\Service\ShoppingContent\RateGroup;
+use Google\Service\ShoppingContent\Service;
+use Google\Service\ShoppingContent\ShippingSettings;
+use Google\Service\ShoppingContent\Value;
 use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -319,10 +319,10 @@ class Settings {
 	/**
 	 * Get the Shopping Service object.
 	 *
-	 * @return ShoppingService
+	 * @return ShoppingContent
 	 */
-	protected function get_shopping_service(): ShoppingService {
-		return $this->container->get( ShoppingService::class );
+	protected function get_shopping_service(): ShoppingContent {
+		return $this->container->get( ShoppingContent::class );
 	}
 
 	/**

--- a/src/API/Google/SiteVerification.php
+++ b/src/API/Google/SiteVerification.php
@@ -6,11 +6,11 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Google\Service\Exception as GoogleException;
 use Exception;
-use Google_Service_SiteVerification as SiteVerificationService;
-use Google_Service_SiteVerification_SiteVerificationWebResourceResource as WebResource;
-use Google_Service_SiteVerification_SiteVerificationWebResourceResourceSite as WebResourceSite;
-use Google_Service_SiteVerification_SiteVerificationWebResourceGettokenRequest as GetTokenRequest;
-use Google_Service_SiteVerification_SiteVerificationWebResourceGettokenRequestSite as GetTokenRequestSite;
+use Google\Service\SiteVerification as SiteVerificationService;
+use Google\Service\SiteVerification\SiteVerificationWebResourceResource as WebResource;
+use Google\Service\SiteVerification\SiteVerificationWebResourceResourceSite as WebResourceSite;
+use Google\Service\SiteVerification\SiteVerificationWebResourceGettokenRequest as GetTokenRequest;
+use Google\Service\SiteVerification\SiteVerificationWebResourceGettokenRequestSite as GetTokenRequestSite;
 use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
-use Google_Service_ShoppingContent_Account as MC_Account;
+use Google\Service\ShoppingContent\Account as MC_Account;
 use Exception;
 use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
@@ -587,10 +587,10 @@ class AccountController extends BaseOptionsController {
 			throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
 		}
 
-		/** @var MC_Account $mc_account */
-		$mc_account = $this->merchant->get_account( $merchant_id );
+		/** @var Account $account */
+		$account = $this->merchant->get_account( $merchant_id );
 
-		$account_website_url = $mc_account->getWebsiteUrl();
+		$account_website_url = $account->getWebsiteUrl();
 
 		if ( untrailingslashit( $site_website_url ) !== untrailingslashit( $account_website_url ) ) {
 
@@ -623,8 +623,8 @@ class AccountController extends BaseOptionsController {
 				);
 			}
 
-			$mc_account->setWebsiteUrl( $site_website_url );
-			$this->merchant->update_account( $mc_account );
+			$account->setWebsiteUrl( $site_website_url );
+			$this->merchant->update_account( $account );
 
 			do_action( 'woocommerce_gla_url_switch_success', [] );
 		}

--- a/src/Google/BatchProductEntry.php
+++ b/src/Google/BatchProductEntry.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Google;
 
-use Google_Service_ShoppingContent_Product as GoogleProduct;
+use Google\Service\ShoppingContent\Product as GoogleProduct;
 use JsonSerializable;
 
 defined( 'ABSPATH' ) || exit;

--- a/src/Google/GoogleProductService.php
+++ b/src/Google/GoogleProductService.php
@@ -9,12 +9,12 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Google\Exception as GoogleException;
-use Google_Service_ShoppingContent as GoogleShoppingService;
-use Google_Service_ShoppingContent_Product as GoogleProduct;
-use Google_Service_ShoppingContent_ProductsCustomBatchRequest as GoogleBatchRequest;
-use Google_Service_ShoppingContent_ProductsCustomBatchRequestEntry as GoogleBatchRequestEntry;
-use Google_Service_ShoppingContent_ProductsCustomBatchResponse as GoogleBatchResponse;
-use Google_Service_ShoppingContent_ProductsCustomBatchResponseEntry as GoogleBatchResponseEntry;
+use Google\Service\ShoppingContent;
+use Google\Service\ShoppingContent\Product as GoogleProduct;
+use Google\Service\ShoppingContent\ProductsCustomBatchRequest as GoogleBatchRequest;
+use Google\Service\ShoppingContent\ProductsCustomBatchRequestEntry as GoogleBatchRequestEntry;
+use Google\Service\ShoppingContent\ProductsCustomBatchResponse as GoogleBatchResponse;
+use Google\Service\ShoppingContent\ProductsCustomBatchResponseEntry as GoogleBatchResponseEntry;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -43,16 +43,16 @@ class GoogleProductService implements OptionsAwareInterface, Service {
 	protected const METHOD_INSERT = 'insert';
 
 	/**
-	 * @var GoogleShoppingService
+	 * @var ShoppingContent
 	 */
 	protected $shopping_service;
 
 	/**
 	 * GoogleProductService constructor.
 	 *
-	 * @param GoogleShoppingService $shopping_service
+	 * @param ShoppingContent $shopping_service
 	 */
-	public function __construct( GoogleShoppingService $shopping_service ) {
+	public function __construct( ShoppingContent $shopping_service ) {
 		$this->shopping_service = $shopping_service;
 	}
 

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -33,7 +33,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definiti
 use Exception;
 use Google\Client;
 use Google\Service\ShoppingContent;
-use Google\Service\SiteVerification as GoogleSiteVerification;
+use Google\Service\SiteVerification as SiteVerificationService;
 use Jetpack_Options;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
@@ -163,7 +163,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			$this->get_connect_server_url_root( 'google/google-mc' )
 		);
 		$this->add(
-			GoogleSiteVerification::class,
+			SiteVerificationService::class,
 			Client::class,
 			$this->get_connect_server_url_root( 'google/google-sv' )
 		);

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -32,8 +32,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Argument
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\Definition;
 use Exception;
 use Google\Client;
-use Google_Service_ShoppingContent;
-use Google_Service_SiteVerification;
+use Google\Service\ShoppingContent;
+use Google\Service\SiteVerification as GoogleSiteVerification;
 use Jetpack_Options;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
@@ -59,23 +59,23 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
-		Client::class                         => true,
-		Google_Service_ShoppingContent::class => true,
-		GoogleAdsClient::class                => true,
-		GuzzleClient::class                   => true,
-		Proxy::class                          => true,
-		Merchant::class                       => true,
-		Ads::class                            => true,
-		AdsCampaign::class                    => true,
-		AdsCampaignBudget::class              => true,
-		AdsConversionAction::class            => true,
-		AdsGroup::class                       => true,
-		AdsReport::class                      => true,
-		'connect_server_root'                 => true,
-		Connection::class                     => true,
-		GoogleProductService::class           => true,
-		SiteVerification::class               => true,
-		Settings::class                       => true,
+		Client::class               => true,
+		ShoppingContent::class      => true,
+		GoogleAdsClient::class      => true,
+		GuzzleClient::class         => true,
+		Proxy::class                => true,
+		Merchant::class             => true,
+		Ads::class                  => true,
+		AdsCampaign::class          => true,
+		AdsCampaignBudget::class    => true,
+		AdsConversionAction::class  => true,
+		AdsGroup::class             => true,
+		AdsReport::class            => true,
+		'connect_server_root'       => true,
+		Connection::class           => true,
+		GoogleProductService::class => true,
+		SiteVerification::class     => true,
+		Settings::class             => true,
 	];
 
 	/**
@@ -105,8 +105,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			AdsGroup::class
 		);
 
-		$this->share( Merchant::class, Google_Service_ShoppingContent::class );
-		$this->share( MerchantReport::class, Google_Service_ShoppingContent::class, ProductHelper::class );
+		$this->share( Merchant::class, ShoppingContent::class );
+		$this->share( MerchantReport::class, ShoppingContent::class, ProductHelper::class );
 
 		$this->add(
 			SiteVerification::class,
@@ -158,19 +158,16 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	protected function register_google_classes() {
 		$this->add( Client::class )->addMethodCall( 'setHttpClient', [ ClientInterface::class ] );
 		$this->add(
-			Google_Service_ShoppingContent::class,
+			ShoppingContent::class,
 			Client::class,
 			$this->get_connect_server_url_root( 'google/google-mc' )
 		);
 		$this->add(
-			Google_Service_SiteVerification::class,
+			GoogleSiteVerification::class,
 			Client::class,
 			$this->get_connect_server_url_root( 'google/google-sv' )
 		);
-		$this->share(
-			GoogleProductService::class,
-			Google_Service_ShoppingContent::class
-		);
+		$this->share( GoogleProductService::class, ShoppingContent::class );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -20,7 +20,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
-use Google_Service_ShoppingContent_ProductStatus as Shopping_Product_Status;
+use Google\Service\ShoppingContent\ProductStatus as GoogleProductStatus;
 use DateTime;
 use Exception;
 
@@ -292,7 +292,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 *
 	 * @param string[] $google_ids
 	 *
-	 * @return Shopping_Product_Status[] Statuses found to be valid.
+	 * @return GoogleProductStatus[] Statuses found to be valid.
 	 */
 	protected function filter_valid_statuses( array $google_ids ): array {
 		/** @var Merchant $merchant */
@@ -380,7 +380,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * Retrieve all product-level issues and store them in the database.
 	 *
-	 * @param Shopping_Product_Status[] $validated_mc_statuses Product statuses of validated products.
+	 * @param GoogleProductStatus[] $validated_mc_statuses Product statuses of validated products.
 	 */
 	protected function refresh_product_issues( array $validated_mc_statuses ): void {
 		/** @var ProductHelper $product_helper */
@@ -501,7 +501,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * Add the provided status counts to the overall totals.
 	 *
-	 * @param Shopping_Product_Status[] $validated_mc_statuses Product statuses of validated products.
+	 * @param GoogleProductStatus[] $validated_mc_statuses Product statuses of validated products.
 	 */
 	protected function sum_status_counts( array $validated_mc_statuses ): void {
 		/** @var ProductHelper $product_helper */
@@ -636,11 +636,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 * Return the product's shopping status in the Google Merchant Center.
 	 * Active, Pending, Disapproved, Expiring.
 	 *
-	 * @param Shopping_Product_Status $product_status
+	 * @param GoogleProductStatus $product_status
 	 *
 	 * @return string|null
 	 */
-	protected function get_product_shopping_status( Shopping_Product_Status $product_status ): ?string {
+	protected function get_product_shopping_status( GoogleProductStatus $product_status ): ?string {
 		$status = null;
 		foreach ( $product_status->getDestinationStatuses() as $d ) {
 			if ( 'SurfacesAcrossGoogle' === $d->getDestination() ) {

--- a/src/Product/Attributes/Adult.php
+++ b/src/Product/Attributes/Adult.php
@@ -19,7 +19,7 @@ class Adult extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'adult';

--- a/src/Product/Attributes/AgeGroup.php
+++ b/src/Product/Attributes/AgeGroup.php
@@ -19,7 +19,7 @@ class AgeGroup extends AbstractAttribute implements WithValueOptionsInterface {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'ageGroup';

--- a/src/Product/Attributes/AttributeInterface.php
+++ b/src/Product/Attributes/AttributeInterface.php
@@ -19,7 +19,7 @@ interface AttributeInterface {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string;
 

--- a/src/Product/Attributes/Brand.php
+++ b/src/Product/Attributes/Brand.php
@@ -19,7 +19,7 @@ class Brand extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'brand';

--- a/src/Product/Attributes/Color.php
+++ b/src/Product/Attributes/Color.php
@@ -19,7 +19,7 @@ class Color extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'color';

--- a/src/Product/Attributes/Condition.php
+++ b/src/Product/Attributes/Condition.php
@@ -19,7 +19,7 @@ class Condition extends AbstractAttribute implements WithValueOptionsInterface {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'condition';

--- a/src/Product/Attributes/GTIN.php
+++ b/src/Product/Attributes/GTIN.php
@@ -19,7 +19,7 @@ class GTIN extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'gtin';

--- a/src/Product/Attributes/Gender.php
+++ b/src/Product/Attributes/Gender.php
@@ -19,7 +19,7 @@ class Gender extends AbstractAttribute implements WithValueOptionsInterface {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'gender';

--- a/src/Product/Attributes/IsBundle.php
+++ b/src/Product/Attributes/IsBundle.php
@@ -19,7 +19,7 @@ class IsBundle extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'isBundle';

--- a/src/Product/Attributes/MPN.php
+++ b/src/Product/Attributes/MPN.php
@@ -19,7 +19,7 @@ class MPN extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'mpn';

--- a/src/Product/Attributes/Material.php
+++ b/src/Product/Attributes/Material.php
@@ -19,7 +19,7 @@ class Material extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'material';

--- a/src/Product/Attributes/Multipack.php
+++ b/src/Product/Attributes/Multipack.php
@@ -19,7 +19,7 @@ class Multipack extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'multipack';

--- a/src/Product/Attributes/Pattern.php
+++ b/src/Product/Attributes/Pattern.php
@@ -19,7 +19,7 @@ class Pattern extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'pattern';

--- a/src/Product/Attributes/Size.php
+++ b/src/Product/Attributes/Size.php
@@ -19,7 +19,7 @@ class Size extends AbstractAttribute {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'size';

--- a/src/Product/Attributes/SizeSystem.php
+++ b/src/Product/Attributes/SizeSystem.php
@@ -19,7 +19,7 @@ class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface 
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'sizeSystem';

--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -19,7 +19,7 @@ class SizeType extends AbstractAttribute implements WithValueOptionsInterface {
 	 *
 	 * @return string
 	 *
-	 * @see \Google_Service_ShoppingContent_Product for the list of properties.
+	 * @see Google\Service\ShoppingContent\Product for the list of properties.
 	 */
 	public static function get_id(): string {
 		return 'sizeType';

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
-use Google_Service_ShoppingContent_Product as GoogleProduct;
+use Google\Service\ShoppingContent\Product as GoogleProduct;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WC_Product;
 use WC_Product_Variable;

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
-use Google_Service_ShoppingContent_Product as GoogleProduct;
+use Google\Service\ShoppingContent\Product as GoogleProduct;
 use WC_Product;
 use WC_Product_Variation;
 

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -12,11 +12,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AgeGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\Validator\GooglePriceConstraint;
 use Automattic\WooCommerce\GoogleListingsAndAds\Validator\Validatable;
 use DateInterval;
-use Google_Service_ShoppingContent_Price;
-use Google_Service_ShoppingContent_Product;
-use Google_Service_ShoppingContent_ProductShipping;
-use Google_Service_ShoppingContent_ProductShippingDimension;
-use Google_Service_ShoppingContent_ProductShippingWeight;
+use Google\Service\ShoppingContent\Price as GooglePrice;
+use Google\Service\ShoppingContent\Product as GoogleProduct;
+use Google\Service\ShoppingContent\ProductShipping as GoogleProductShipping;
+use Google\Service\ShoppingContent\ProductShippingDimension as GoogleProductShippingDimension;
+use Google\Service\ShoppingContent\ProductShippingWeight as GoogleProductShippingWeight;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -34,7 +34,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
  */
-class WCProductAdapter extends Google_Service_ShoppingContent_Product implements Validatable {
+class WCProductAdapter extends GoogleProduct implements Validatable {
 	use PluginHelper;
 
 	public const AVAILABILITY_IN_STOCK     = 'in stock';
@@ -259,7 +259,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 		}
 
 		$new_shipping = [
-			new Google_Service_ShoppingContent_ProductShipping( $product_shipping ),
+			new GoogleProductShipping( $product_shipping ),
 		];
 
 		if ( ! $this->shipping_country_exists( $country ) ) {
@@ -307,7 +307,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 
 		if ( $length > 0 && $width > 0 && $height > 0 ) {
 			$this->setShippingLength(
-				new Google_Service_ShoppingContent_ProductShippingDimension(
+				new GoogleProductShippingDimension(
 					[
 						'unit'  => $unit,
 						'value' => $length,
@@ -315,7 +315,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 				)
 			);
 			$this->setShippingWidth(
-				new Google_Service_ShoppingContent_ProductShippingDimension(
+				new GoogleProductShippingDimension(
 					[
 						'unit'  => $unit,
 						'value' => $width,
@@ -323,7 +323,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 				)
 			);
 			$this->setShippingHeight(
-				new Google_Service_ShoppingContent_ProductShippingDimension(
+				new GoogleProductShippingDimension(
 					[
 						'unit'  => $unit,
 						'value' => $height,
@@ -350,7 +350,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 
 		$weight = wc_get_weight( $this->wc_product->get_weight(), $unit );
 		$this->setShippingWeight(
-			new Google_Service_ShoppingContent_ProductShippingWeight(
+			new GoogleProductShippingWeight(
 				[
 					'unit'  => $unit,
 					'value' => $weight,
@@ -469,7 +469,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 			$price = apply_filters( 'woocommerce_gla_product_attribute_value_price', $price, $product, $this->tax_excluded );
 
 			$this->setPrice(
-				new Google_Service_ShoppingContent_Price(
+				new GooglePrice(
 					[
 						'currency' => get_woocommerce_currency(),
 						'value'    => $price,
@@ -523,7 +523,7 @@ class WCProductAdapter extends Google_Service_ShoppingContent_Product implements
 			$sale_price_end_date = $product->get_date_on_sale_to();
 			if ( empty( $sale_price_end_date ) || $sale_price_end_date >= $now ) {
 				$this->setSalePrice(
-					new Google_Service_ShoppingContent_Price(
+					new GooglePrice(
 						[
 							'currency' => get_woocommerce_currency(),
 							'value'    => $sale_price,

--- a/src/Validator/GooglePriceConstraintValidator.php
+++ b/src/Validator/GooglePriceConstraintValidator.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Validator;
 
-use Google_Service_ShoppingContent_Price as GooglePrice;
+use Google\Service\ShoppingContent\Price as GooglePrice;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the Google apiclient library to version 2.10

```
composer update google/apiclient --with-dependencies

- Upgrading firebase/php-jwt (v5.2.1 => v5.4.0)
- Upgrading google/apiclient (v2.9.1 => v2.10.0)
- Upgrading google/apiclient-services (v0.164.0 => v0.200.0)
- Upgrading google/auth (v1.15.0 => v1.16.0)
- Upgrading guzzlehttp/guzzle (7.2.0 => 7.3.0)
- Upgrading guzzlehttp/psr7 (1.7.0 => 1.8.2)
- Upgrading psr/log (1.1.3 => 1.1.4)
```

There are a few minor changes from Guzzle 7.2 > 7.3, since we replace the namespace in this library it needed a few minor adjustments in the script we use to replace the namespace.

The biggest change is that the apiclient services change to using namespaces, which is what we take advantage of in this PR.

Closes #814

### Detailed test instructions:

1. Checkout this PR and run `composer install`
2. Test all requests to the merchant center services
3. Onboarding of an existing MC account (goes through all the site verification steps)
4. Syncing products
5. Clear the product status transient on the connection test page and reload the Product Feed page (goes through all the product status requests)
6. Confirm that we don't receive any warning/errors



### Changelog entry
* Update - Version 2.10 of the apiclient library.
* Update - Switch apiclient services to namespaces.