### PR TITLE
Add a param to indicate the redirect URI when back from Google authorization

### DIFF
--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -91,10 +91,10 @@ class AccountController extends BaseController {
 				$path = $next === 'setup-mc' ? '/google/setup-mc' : '/google/settings&subpath=/reconnect-accounts';
 
 				return [
-					'url' => $this->connection->connect( admin_url( "admin.php?page=wc-admin&path=$path" ) ),
+					'url' => $this->connection->connect( admin_url( "admin.php?page=wc-admin&path={$path}" ) ),
 				];
 			} catch ( Exception $e ) {
-				return new WP_REST_Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseControl
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
+use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
@@ -46,6 +47,7 @@ class AccountController extends BaseController {
 					'methods'             => TransportMethods::READABLE,
 					'callback'            => $this->get_connect_callback(),
 					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_connect_params(),
 				],
 				[
 					'methods'             => TransportMethods::DELETABLE,
@@ -83,15 +85,36 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_connect_callback(): callable {
-		return function() {
+		return function( Request $request ) {
 			try {
+				$next = $request->get_param( 'next' );
+				$path = $next === 'setup-mc' ? '/google/setup-mc' : '/google/settings&subpath=/reconnect-accounts';
+
 				return [
-					'url' => $this->connection->connect( admin_url( 'admin.php?page=wc-admin&path=/google/setup-mc' ) ),
+					'url' => $this->connection->connect( admin_url( "admin.php?page=wc-admin&path=$path" ) ),
 				];
 			} catch ( Exception $e ) {
 				return new WP_REST_Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
 		};
+	}
+
+	/**
+	 * Get the query params for the connection request.
+	 *
+	 * @return array
+	 */
+	protected function get_connect_params(): array {
+		return [
+			'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+			'next'    => [
+				'description'       => __( 'Indicate the next page name to map the redirect URI when back from Google authorization.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'default'           => 'setup-mc',
+				'enum'              => [ 'setup-mc', 'reconnect' ],
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implemented partial #486 and based on #832.

Please refer to the **Google account reconnection flow** section in the #486 description. For the reconnection step 3, this PR added a param `next` to the **GET** `/wc/gla/google/connect`, thus we can indicate the redirect URI when back from Google authorization.

### Detailed test instructions:

#### The MC onboarding flow should work as before:

1. Request to **GET** `/wc/gla/google/connect` and proceed with the Google authorization through responded `url`
2. After finish the auth, it should redirect the browser back to the MC onboarding `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc&google-mc=connected`

#### The Google reconnection flow:

1. With the new `next` param, request to **GET** `/wc/gla/google/connect?next=reconnect`, and proceed with the Google authorization through responded `url`
2. After finish the auth, it should redirect the browser back to the reconnection page `/wp-admin/admin.php?page=wc-admin&path=/google/settings&subpath=/reconnect-accounts&google-mc=connected`.
3. Please note that it will show the accounts disconnection UI in this PR, and the reconnection page will be added by the following PRs.

### Changelog entry

> Add  - Added a param to indicate the redirect URI when back from Google authorization
