### PR TITLE
Watch 401 response error globally and redirect to the reconnection page

### DIFF
--- a/js/src/data/api-fetch-middlewares.js
+++ b/js/src/data/api-fetch-middlewares.js
@@ -1,0 +1,56 @@
+/**
+ * Internal dependencies
+ */
+import { API_NAMESPACE } from './constants';
+
+/**
+ * @callback onErrorResponseCallback
+ * @param {Object} response The error response instance.
+ * @return {Promise<any>|any} Reject or throw the response error if want to continue original error handling process.
+ *                            Otherwise, resolve recovery result if the error could be processed here.
+ */
+
+/**
+ * Create a middleware with a callback to watch and handle the error response instance globally.
+ *
+ * @param  {onErrorResponseCallback} onErrorResponse A callback to be invoked when receiving error response.
+ * @return {import('@wordpress/api-fetch').APIFetchMiddleware} A middleware to watch and handle the error response instance globally.
+ */
+export function createErrorResponseCatcher( onErrorResponse ) {
+	const regexApiNamespace = new RegExp( `^${ API_NAMESPACE }\/` );
+
+	return function errorResponseCatcher( options, next ) {
+		// Requests issued from other places go to the original middlewares
+		if ( ! regexApiNamespace.test( options.path ) ) {
+			return next( options );
+		}
+
+		const { parse: shouldParseResponse = true } = options;
+
+		return next( { ...options, parse: false } )
+			.catch( onErrorResponse )
+			.catch( ( response ) => {
+				if ( shouldParseResponse && response.json ) {
+					return response
+						.json()
+						.then( ( errMessage ) => Promise.reject( errMessage ) );
+				}
+
+				throw response;
+			} )
+			.then( ( response ) => {
+				// Ref: https://github.com/WordPress/gutenberg/blob/%40wordpress/api-fetch%405.1.1/packages/api-fetch/src/utils/response.js#L14-L24
+				if ( shouldParseResponse ) {
+					if ( response.status === 204 ) {
+						return null;
+					}
+
+					return response.json
+						? response.json()
+						: Promise.reject( response );
+				}
+
+				return response;
+			} );
+	};
+}

--- a/js/src/data/api-fetch-middlewares.js
+++ b/js/src/data/api-fetch-middlewares.js
@@ -20,7 +20,7 @@ export function createErrorResponseCatcher( onErrorResponse ) {
 	const regexApiNamespace = new RegExp( `^${ API_NAMESPACE }\/` );
 
 	return function errorResponseCatcher( options, next ) {
-		// Requests issued from other places go to the original middlewares
+		// Requests issued from other places return and call the next middlewares with original options directly.
 		if ( ! regexApiNamespace.test( options.path ) ) {
 			return next( options );
 		}

--- a/js/src/data/api-fetch-middlewares.js
+++ b/js/src/data/api-fetch-middlewares.js
@@ -42,7 +42,8 @@ export function createErrorResponseCatcher( onErrorResponse ) {
 
 		const { parse: shouldParseResponse = true } = options;
 
-		// Call onErrorResponse callback, then parse its fullfilment value to JSON if needed (and possible).
+		// Call onErrorResponse callback when receiving error response,
+		// then parse its fulfillment value to JSON if needed (and possible).
 		return next( { ...options, parse: false } )
 			.catch( onErrorResponse )
 			.catch( async ( response ) => {
@@ -53,12 +54,13 @@ export function createErrorResponseCatcher( onErrorResponse ) {
 				);
 			} )
 			.then( ( response ) => {
-				// Parse the "recovered" value.
+				// Handle the successful response or the "recovered" value resolved from onErrorResponse callback.
 				// Ref: https://github.com/WordPress/gutenberg/blob/%40wordpress/api-fetch%405.1.1/packages/api-fetch/src/utils/response.js#L14-L24
 				if ( shouldParseResponse && response.status === 204 ) {
 					return null;
 				}
 
+				// Resolve with the response, parsed to JSON if required and possible.
 				return responseOrJSON( response, shouldParseResponse );
 			} );
 	};

--- a/js/src/data/api-fetch-middlewares.js
+++ b/js/src/data/api-fetch-middlewares.js
@@ -40,6 +40,9 @@ export function createErrorResponseCatcher( onErrorResponse ) {
 			return next( options );
 		}
 
+		// To align with the original interface, set the default value of `parse` to `true`. Ref:
+		// - https://github.com/WordPress/gutenberg/tree/%40wordpress/api-fetch%405.1.1/packages/api-fetch#parse-boolean-default-true
+		// - https://github.com/WordPress/gutenberg/blob/%40wordpress/api-fetch%405.1.1/packages/api-fetch/src/index.js#L89
 		const { parse: shouldParseResponse = true } = options;
 
 		// Call onErrorResponse callback when receiving error response,

--- a/js/src/data/api-fetch-middlewares.js
+++ b/js/src/data/api-fetch-middlewares.js
@@ -11,7 +11,7 @@ import { API_NAMESPACE } from './constants';
  * @param {boolean} shouldParseResponse `true` - if we should try to parse response to JSON.
  * @return {Response|Promise} Non-parsed `response`, or promise for parsed JSON. Rejects with `response`, if parsing fails.
  */
-async function responseOrJSON( response, shouldParseResponse ) {
+function responseOrJSON( response, shouldParseResponse ) {
 	if ( shouldParseResponse ) {
 		return response.json ? response.json() : Promise.reject( response );
 	}

--- a/js/src/data/api-fetch-middlewares.test.js
+++ b/js/src/data/api-fetch-middlewares.test.js
@@ -26,8 +26,13 @@ describe( 'createErrorResponseCatcher', () => {
 
 	const passReject = ( response ) => Promise.reject( response );
 
-	const optionsDefaultParse = { path: `${ API_NAMESPACE }/hi` };
-	const optionsDontParse = { path: `${ API_NAMESPACE }/hi`, parse: false };
+	let optionsDefaultParse;
+	let optionsDontParse;
+
+	beforeEach( () => {
+		optionsDefaultParse = { path: `${ API_NAMESPACE }/hi` };
+		optionsDontParse = { path: `${ API_NAMESPACE }/hi`, parse: false };
+	} );
 
 	describe( 'force overwrite `parse` option to `false` and return the same result', () => {
 		let middleware;

--- a/js/src/data/api-fetch-middlewares.test.js
+++ b/js/src/data/api-fetch-middlewares.test.js
@@ -80,21 +80,21 @@ describe( 'createErrorResponseCatcher', () => {
 		} );
 
 		it( 'should resolve response instance when indicating `parse: false` in a successful response', async () => {
-			const handler = createFetchHandler( 200, { data: 'hi' } );
-			const result = await middleware( optionsDontParse, handler );
+			// The response instance should be passed through directly without any parse process of this middleware.
+			const responseInstance = {};
+			const next = () => Promise.resolve( responseInstance );
+			const promise = middleware( optionsDontParse, next );
 
-			expect( result.status ).toEqual( 200 );
-			expect( result.json ).toBeInstanceOf( Function );
+			await expect( promise ).resolves.toBe( responseInstance );
 		} );
 
 		it( 'should reject response instance when indicating `parse: false` in a failed response', async () => {
-			const handler = createFetchHandler( 418, { message: 'oops' } );
-			const promise = middleware( optionsDontParse, handler );
+			// The response instance should be passed through directly without any parse process of this middleware.
+			const responseInstance = {};
+			const next = () => Promise.reject( responseInstance );
+			const promise = middleware( optionsDontParse, next );
 
-			await expect( promise ).rejects.toMatchObject( {
-				status: 418,
-				json: expect.any( Function ),
-			} );
+			await expect( promise ).rejects.toBe( responseInstance );
 		} );
 	} );
 

--- a/js/src/data/api-fetch-middlewares.test.js
+++ b/js/src/data/api-fetch-middlewares.test.js
@@ -1,0 +1,105 @@
+/**
+ * Internal dependencies
+ */
+import { createErrorResponseCatcher } from './api-fetch-middlewares';
+import { API_NAMESPACE } from './constants';
+
+describe( 'createErrorResponseCatcher', () => {
+	// Ref: https://github.com/WordPress/gutenberg/blob/%40wordpress/api-fetch%405.1.1/packages/api-fetch/src/index.js#L68-L81
+	const checkStatus = ( response ) => {
+		if ( response.status >= 200 && response.status < 300 ) {
+			return response;
+		}
+
+		throw response;
+	};
+
+	const createFetchHandler = ( status, jsonParsedData ) => () => {
+		const response = {
+			status,
+			json() {
+				return Promise.resolve( jsonParsedData );
+			},
+		};
+		return Promise.resolve( response ).then( checkStatus );
+	};
+
+	const passReject = ( response ) => Promise.reject( response );
+
+	const optionsDefaultParse = { path: `${ API_NAMESPACE }/hi` };
+	const optionsDontParse = { path: `${ API_NAMESPACE }/hi`, parse: false };
+
+	describe( 'force overwrite `parse` option to `false` and return the same result', () => {
+		let middleware;
+
+		beforeEach( () => {
+			middleware = createErrorResponseCatcher( passReject );
+		} );
+
+		it( 'should only handle requests where the path belongs to this plugin', async () => {
+			const data = {};
+			const optionsOtherNamespace = { path: '' };
+			const callback = jest.fn().mockImplementation( ( options ) => {
+				expect( options ).toBe( optionsOtherNamespace );
+				return data;
+			} );
+
+			const result = await middleware( optionsOtherNamespace, callback );
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+			expect( result ).toBe( data );
+		} );
+
+		it( 'should resolve parsed response body by default in a successful response', async () => {
+			const handler = createFetchHandler( 200, { data: 'hi' } );
+			const result = await middleware( optionsDefaultParse, handler );
+			expect( result ).toEqual( { data: 'hi' } );
+		} );
+
+		it( 'should reject parsed response body by default in a failed response', async () => {
+			const handler = createFetchHandler( 418, { message: 'oops' } );
+			const promise = middleware( optionsDefaultParse, handler );
+			await expect( promise ).rejects.toEqual( { message: 'oops' } );
+		} );
+
+		it( 'should resolve response instance when indicating `parse: false` in a successful response', async () => {
+			const handler = createFetchHandler( 200, { data: 'hi' } );
+			const result = await middleware( optionsDontParse, handler );
+			expect( result.status ).toEqual( 200 );
+			expect( result.json ).toBeInstanceOf( Function );
+		} );
+
+		it( 'should reject response instance when indicating `parse: false` in a failed response', async () => {
+			const handler = createFetchHandler( 418, { message: 'oops' } );
+			const promise = middleware( optionsDontParse, handler );
+			await expect( promise ).rejects.toMatchObject( {
+				status: 418,
+				json: expect.any( Function ),
+			} );
+		} );
+	} );
+
+	describe( 'Catch error response', () => {
+		it( 'should invoke callback function with response instance regardless of the original `parse` option', async () => {
+			const callback = jest.fn().mockImplementation( passReject );
+			const middleware = createErrorResponseCatcher( callback );
+
+			let handler = createFetchHandler( 418, { message: 'oops' } );
+			let promise = middleware( optionsDefaultParse, handler );
+			await expect( promise ).rejects.toMatchObject( expect.anything() );
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+			expect( callback ).toHaveBeenCalledWith( {
+				status: 418,
+				json: expect.any( Function ),
+			} );
+
+			handler = createFetchHandler( 500, { message: 'ouch' } );
+			promise = middleware( optionsDontParse, handler );
+			await expect( promise ).rejects.toMatchObject( expect.anything() );
+			expect( callback ).toHaveBeenCalledTimes( 2 );
+			expect( callback ).toHaveBeenCalledWith( {
+				status: 500,
+				json: expect.any( Function ),
+			} );
+		} );
+	} );
+} );

--- a/js/src/data/api-fetch-middlewares.test.js
+++ b/js/src/data/api-fetch-middlewares.test.js
@@ -44,13 +44,16 @@ describe( 'createErrorResponseCatcher', () => {
 		it( 'should only handle requests where the path belongs to this plugin', async () => {
 			const data = {};
 			const optionsOtherNamespace = { path: '' };
-			const callback = jest.fn().mockImplementation( ( options ) => {
+			const mockCallback = jest.fn().mockImplementation( ( options ) => {
 				expect( options ).toBe( optionsOtherNamespace );
 				return data;
 			} );
 
-			const result = await middleware( optionsOtherNamespace, callback );
-			expect( callback ).toHaveBeenCalledTimes( 1 );
+			const result = await middleware(
+				optionsOtherNamespace,
+				mockCallback
+			);
+			expect( mockCallback ).toHaveBeenCalledTimes( 1 );
 			expect( result ).toBe( data );
 		} );
 
@@ -85,14 +88,14 @@ describe( 'createErrorResponseCatcher', () => {
 
 	describe( 'Catch error response', () => {
 		it( 'should invoke callback function with response instance regardless of the original `parse` option', async () => {
-			const callback = jest.fn().mockImplementation( passReject );
-			const middleware = createErrorResponseCatcher( callback );
+			const mockCallback = jest.fn().mockImplementation( passReject );
+			const middleware = createErrorResponseCatcher( mockCallback );
 
 			let handler = createFetchHandler( 418, { message: 'oops' } );
 			let promise = middleware( optionsDefaultParse, handler );
 			await expect( promise ).rejects.toMatchObject( expect.anything() );
-			expect( callback ).toHaveBeenCalledTimes( 1 );
-			expect( callback ).toHaveBeenCalledWith( {
+			expect( mockCallback ).toHaveBeenCalledTimes( 1 );
+			expect( mockCallback ).toHaveBeenCalledWith( {
 				status: 418,
 				json: expect.any( Function ),
 			} );
@@ -100,8 +103,8 @@ describe( 'createErrorResponseCatcher', () => {
 			handler = createFetchHandler( 500, { message: 'ouch' } );
 			promise = middleware( optionsDontParse, handler );
 			await expect( promise ).rejects.toMatchObject( expect.anything() );
-			expect( callback ).toHaveBeenCalledTimes( 2 );
-			expect( callback ).toHaveBeenCalledWith( {
+			expect( mockCallback ).toHaveBeenCalledTimes( 2 );
+			expect( mockCallback ).toHaveBeenCalledWith( {
 				status: 500,
 				json: expect.any( Function ),
 			} );

--- a/js/src/data/api-fetch-middlewares.test.js
+++ b/js/src/data/api-fetch-middlewares.test.js
@@ -53,6 +53,7 @@ describe( 'createErrorResponseCatcher', () => {
 				optionsOtherNamespace,
 				mockCallback
 			);
+
 			expect( mockCallback ).toHaveBeenCalledTimes( 1 );
 			expect( result ).toBe( data );
 		} );
@@ -60,18 +61,21 @@ describe( 'createErrorResponseCatcher', () => {
 		it( 'should resolve parsed response body by default in a successful response', async () => {
 			const handler = createFetchHandler( 200, { data: 'hi' } );
 			const result = await middleware( optionsDefaultParse, handler );
+
 			expect( result ).toEqual( { data: 'hi' } );
 		} );
 
 		it( 'should reject parsed response body by default in a failed response', async () => {
 			const handler = createFetchHandler( 418, { message: 'oops' } );
 			const promise = middleware( optionsDefaultParse, handler );
+
 			await expect( promise ).rejects.toEqual( { message: 'oops' } );
 		} );
 
 		it( 'should resolve response instance when indicating `parse: false` in a successful response', async () => {
 			const handler = createFetchHandler( 200, { data: 'hi' } );
 			const result = await middleware( optionsDontParse, handler );
+
 			expect( result.status ).toEqual( 200 );
 			expect( result.json ).toBeInstanceOf( Function );
 		} );
@@ -79,6 +83,7 @@ describe( 'createErrorResponseCatcher', () => {
 		it( 'should reject response instance when indicating `parse: false` in a failed response', async () => {
 			const handler = createFetchHandler( 418, { message: 'oops' } );
 			const promise = middleware( optionsDontParse, handler );
+
 			await expect( promise ).rejects.toMatchObject( {
 				status: 418,
 				json: expect.any( Function ),
@@ -93,6 +98,7 @@ describe( 'createErrorResponseCatcher', () => {
 
 			let handler = createFetchHandler( 418, { message: 'oops' } );
 			let promise = middleware( optionsDefaultParse, handler );
+
 			await expect( promise ).rejects.toMatchObject( expect.anything() );
 			expect( mockCallback ).toHaveBeenCalledTimes( 1 );
 			expect( mockCallback ).toHaveBeenCalledWith( {
@@ -102,6 +108,7 @@ describe( 'createErrorResponseCatcher', () => {
 
 			handler = createFetchHandler( 500, { message: 'ouch' } );
 			promise = middleware( optionsDontParse, handler );
+
 			await expect( promise ).rejects.toMatchObject( expect.anything() );
 			expect( mockCallback ).toHaveBeenCalledTimes( 2 );
 			expect( mockCallback ).toHaveBeenCalledWith( {

--- a/js/src/data/api-fetch-middlewares.test.js
+++ b/js/src/data/api-fetch-middlewares.test.js
@@ -66,21 +66,32 @@ describe( 'createErrorResponseCatcher', () => {
 			optionsDontParse = { path: `${ API_NAMESPACE }/hi`, parse: false };
 		} );
 
-		describe( 'should overwrite default value of `parse` option to `false` and return the same result', () => {
+		it( 'should force the value of `parse` option to `false` for the next middleware', async () => {
+			const middleware = createErrorResponseCatcher( passReject );
+			const next = jest
+				.fn()
+				.mockImplementation( createFetchHandler( 200, {} ) )
+				.mockName( 'next middleware' );
+			await middleware( optionsDefaultParse, next );
+
+			expect( next ).toHaveBeenCalledWith( optionsDontParse );
+		} );
+
+		describe( 'should parse final result according to the given `parse` option', () => {
 			let middleware;
 
 			beforeEach( () => {
 				middleware = createErrorResponseCatcher( passReject );
 			} );
 
-			it( 'For a successful response, should resolve parsed response body by default', async () => {
+			it( 'For a successful response, by default, should resolve with parsed response body', async () => {
 				const handler = createFetchHandler( 200, { data: 'hi' } );
 				const result = await middleware( optionsDefaultParse, handler );
 
 				expect( result ).toEqual( { data: 'hi' } );
 			} );
 
-			it( 'For a failed response, should reject parsed response body by default', async () => {
+			it( 'For a failed response, by default, should reject with parsed response body', async () => {
 				const handler = createFetchHandler( 418, { message: 'oops' } );
 				const promise = middleware( optionsDefaultParse, handler );
 

--- a/js/src/data/index.js
+++ b/js/src/data/index.js
@@ -3,6 +3,8 @@
  */
 import { controls } from '@wordpress/data-controls';
 import { registerStore, useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -12,6 +14,8 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 import * as resolvers from './resolvers';
 import reducer from './reducer';
+import { createErrorResponseCatcher } from './api-fetch-middlewares';
+import { getReconnectAccountsUrl } from '.~/utils/urls';
 
 registerStore( STORE_KEY, {
 	actions,
@@ -20,6 +24,17 @@ registerStore( STORE_KEY, {
 	controls,
 	reducer,
 } );
+
+apiFetch.use(
+	createErrorResponseCatcher( ( response ) => {
+		if ( response.status === 401 ) {
+			getHistory().replace( getReconnectAccountsUrl() );
+		}
+
+		// Throws error response to subsequent middlewares
+		throw response;
+	} )
+);
 
 export { STORE_KEY };
 

--- a/js/src/settings/index.js
+++ b/js/src/settings/index.js
@@ -1,11 +1,26 @@
 /**
+ * External dependencies
+ */
+import { getQuery } from '@woocommerce/navigation';
+
+/**
  * Internal dependencies
  */
 import NavigationClassic from '.~/components/navigation-classic';
 import DisconnectAccounts from './disconnect-accounts';
+import ReconnectAccounts from './reconnect-accounts';
+
+import { subpaths } from '.~/utils/urls';
+
 import './index.scss';
 
 const Settings = () => {
+	const { subpath } = getQuery();
+
+	if ( subpath === subpaths.reconnectAccounts ) {
+		return <ReconnectAccounts />;
+	}
+
 	return (
 		<div className="gla-settings">
 			<NavigationClassic />

--- a/js/src/settings/reconnect-accounts/index.js
+++ b/js/src/settings/reconnect-accounts/index.js
@@ -1,0 +1,4 @@
+export default function ReconnectAccounts() {
+	// TODO: implement the Google account reconnection page.
+	return <div>Google account reconnection page</div>;
+}

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -4,11 +4,13 @@
 import { getNewPath } from '@woocommerce/navigation';
 
 const dashboardPath = '/google/dashboard';
+const settingsPath = '/google/settings';
 
 export const subpaths = {
 	editFreeListings: '/free-listings/edit',
 	editCampaign: '/campaigns/edit',
 	createCampaign: '/campaigns/create',
+	reconnectAccounts: '/reconnect-accounts',
 };
 
 export const getEditFreeListingsUrl = () => {
@@ -24,4 +26,12 @@ export const getEditCampaignUrl = ( programId ) => {
 
 export const getCreateCampaignUrl = () => {
 	return getNewPath( { subpath: subpaths.createCampaign }, dashboardPath );
+};
+
+export const getReconnectAccountsUrl = () => {
+	return getNewPath(
+		{ subpath: subpaths.reconnectAccounts },
+		settingsPath,
+		null
+	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implemented partial #486 and based on #833.

Please refer to the reconnection step 1 with the **Google account reconnection flow** section in the #486 description.

- Implement a middleware to handle error response instance globally
- Redirect to the reconnection page if receives any 401 response

### Screenshots:

![Kapture 2021-06-28 at 19 25 47](https://user-images.githubusercontent.com/17420811/123629749-3c3f6f80-d847-11eb-8b13-7b0bbf52dede.gif)


### Detailed test instructions:

1. Disconnect Google account from the Connection Test page
2. Go to the dashboard page or any other page which will request data through Google credentials
3. When receiving any 401 response error, the browser should be redirected to the reconnection page `/wp-admin/admin.php?page=wc-admin&subpath=%2Freconnect-accounts&path=%2Fgoogle%2Fsettings`

### Changelog entry
