### PR TITLE
Order billing status results by newest entries first

### DIFF
--- a/src/API/Google/Query/AdsBillingStatusQuery.php
+++ b/src/API/Google/Query/AdsBillingStatusQuery.php
@@ -17,6 +17,12 @@ class AdsBillingStatusQuery extends AdsQuery {
 	 */
 	public function __construct() {
 		parent::__construct( 'billing_setup' );
-		$this->columns( [ 'billing_setup.status' ] );
+		$this->columns(
+			[
+				'status'          => 'billing_setup.status',
+				'start_date_time' => 'billing_setup.start_date_time',
+			]
+		);
+		$this->set_order( 'start_date_time', 'DESC' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since we only check the first result returned in the billing status, this PR changes the sorting order in the query to return the newest results first.

The query is changed to:
```
SELECT billing_setup.status,billing_setup.start_date_time FROM billing_setup ORDER BY billing_setup.start_date_time DESC
```

Which results in the following response:
```json
{
	"results": [
		{
			"billingSetup": {
				"resourceName": "customers/***/billingSetups/***",
				"status": "APPROVED",
				"startDateTime": "2021-02-22 14:34:11"
			}
		},
		{
			"billingSetup": {
				"resourceName": "customers/***/billingSetups/***",
				"status": "CANCELLED",
				"startDateTime": "2020-08-21 09:46:14"
			}
		}
	],
	"fieldMask": "billingSetup.status,billingSetup.startDateTime"
}
```

Closes #835

### Detailed test instructions:

1. Use an ads account which has both a cancelled and an approved billing status
2. Send a request to `GET /wc/gla/ads/billing-status`
3. Confirm that we receive the `approved` status and not the older `cancelled` status

### Changelog entry
* Fix - Order billing status results by newest entries first.