### PR TITLE
Product pre-sync issue handling tweaks

### DIFF
--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
@@ -188,6 +189,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 		$this->container->get( MerchantStatuses::class )->delete();
 
+		$this->container->get( MerchantIssueTable::class )->truncate();
 		$this->container->get( ShippingRateTable::class )->truncate();
 		$this->container->get( ShippingTimeTable::class )->truncate();
 	}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -470,16 +470,16 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 				continue;
 			}
 
+			$product = get_post( $product_id );
 			// Don't store pre-sync errors for unpublished (draft, trashed) products.
-			if ( 'publish' !== get_post_status( $product_id ) ) {
+			if ( 'publish' !== get_post_status( $product ) ) {
 				continue;
 			}
 
-			$product_name = get_the_title( $product_id );
 			foreach ( $presync_errors as $text ) {
 				$issue_parts      = $this->parse_presync_issue_text( $text );
 				$product_issues[] = [
-					'product'              => $product_name,
+					'product'              => $product->post_title,
 					'product_id'           => $product_id,
 					'code'                 => $issue_parts['code'],
 					'severity'             => self::SEVERITY_ERROR,

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -470,6 +470,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 				continue;
 			}
 
+			// Don't store pre-sync errors for unpublished (draft, trashed) products.
+			if ( 'publish' !== get_post_status( $product_id ) ) {
+				continue;
+			}
+
 			$product_name = get_the_title( $product_id );
 			foreach ( $presync_errors as $text ) {
 				$issue_parts      = $this->parse_presync_issue_text( $text );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes two changes to the Merchant Issues table:
1. When the Merchant Center account is disconnected, the `wp_gla_merchant_issues` table is truncated. 
2. When the Merchant Center status cache is generated, pre-sync errors for products are only copied to the `wp_gla_merchant_issues` table if the product is `published`. This prevents products with pre-sync errors from being displayed in the table.

#### Notes
- The changes swap out `get_the_title` for `get_post` and add `get_post_status`.
    - There should be no noticeable performance change since `get_the_title` invoked `get_post` already, and `get_post_status` will use the cache.
    - `get_the_title` was HTML-encoding variant names `V-Neck T-Shirt - blue` became ` V-Neck T-Shirt &#8211; blue`


### Detailed test instructions:

1. Connect a Merchant Center account using the onboarding wizard and sync some products (ensure some have pre-sync errors and some a disapproved).
2. Visit the Product Feed page
    - Confirm there are records in the `wp_gla_merchant_issues` table.
2. Disconnect the Merchant Center account (using Connection Test, for example).
    - Confirm that the `wp_gla_merchant_issues` table has been truncated.
3. Move a pre-sync error and disapproved product to the trash (or unpublish them).
4. Re-connect to the Merchant Center account using the onboarding wizard and let the products sync again.
2. Visit the Product Feed page
   - Confirm that the trashed products aren't displayed in the "Issues to resolve" table.
**Bonus**
- Untrash products, clear Merchant Center status cache (using Connection Test) and visit Product Feed page again.
    - Confirm that there the restored products' issues are included in the "Issues to resolve" table.

### Changelog entry

> Tweak - Clear Merchant Center issues table on account disconnect.
> Tweak - Omit unpublished products from issues to resolve.