### PR TITLE
Fix TypeError in WooCommerce Brands integration

### DIFF
--- a/src/Integration/WooCommerceBrands.php
+++ b/src/Integration/WooCommerceBrands.php
@@ -88,7 +88,7 @@ class WooCommerceBrands implements IntegrationInterface {
 			$product_id = $product instanceof WC_Product_Variation ? $product->get_parent_id() : $product->get_id();
 
 			$terms = $this->wp->get_the_terms( $product_id, 'product_brand' );
-			if ( ! $this->wp->is_wp_error( $terms ) ) {
+			if ( false !== $terms && ! $this->wp->is_wp_error( $terms ) ) {
 				return $this->get_brand_from_terms( $terms );
 			}
 		}

--- a/src/Integration/WooCommerceBrands.php
+++ b/src/Integration/WooCommerceBrands.php
@@ -88,7 +88,7 @@ class WooCommerceBrands implements IntegrationInterface {
 			$product_id = $product instanceof WC_Product_Variation ? $product->get_parent_id() : $product->get_id();
 
 			$terms = $this->wp->get_the_terms( $product_id, 'product_brand' );
-			if ( false !== $terms && ! $this->wp->is_wp_error( $terms ) ) {
+			if ( is_array( $terms ) ) {
 				return $this->get_brand_from_terms( $terms );
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes the error reported here: <https://wordpress.org/support/topic/google-listings-ads-plugin-problem/#post-14605566>
> `Fatal error: Uncaught TypeError: Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceBrands::get_brand_from_terms(): Argument #1 ($terms) must be of type array, bool given, called in /…/google-listings-and-ads/src/Integration/WooCommerceBrands.php on line 93 and defined in /…google-listings-and-ads/src/Integration/WooCommerceBrands.php on line 109`



When the WooCommerce Brands plugin is active and a product has the Brands attribute set to "From WooCommerce Brands", but no brands selected, `WP::get_the_terms()` returns `false`.
![image](https://user-images.githubusercontent.com/228780/123808932-76fde200-d8f1-11eb-8ae1-5da19fda67e8.png)

This boolean value isn't handled in `WooCommerceBrands::get_brand()` and when passed to `WooCommerceBrands::get_brand_from_terms()`, which expects an array, it causes the error.


### Detailed test instructions:

1. Connect Merchant Center account and sync a product.
2. Activate WooCommerce Brands and change the product's `Brand` attribute to 'From WooCommerce Brands'. DON'T choose a brand for the product.
3. Wait for the product to sync (or force the sync from the Scheduled Actions table).
4. Confirm no error in the debug log.
5. DO choose a brand and make sure it syncs to Merchant Center correctly.


### Changelog entry

> Fix - TypeError in WooCommerce Brands integration.