### PR TITLE
Prevent showing all 401 response errors in the general error message UI

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -13,7 +13,11 @@ import { API_NAMESPACE } from './constants';
 
 export function handleFetchError( error, message ) {
 	const { createNotice } = dispatch( 'core/notices' );
-	createNotice( 'error', message );
+
+	// Only show errors that are not authorization issues.
+	if ( error.statusCode !== 401 ) {
+		createNotice( 'error', message );
+	}
 
 	// eslint-disable-next-line no-console
 	console.log( error );

--- a/js/src/data/index.js
+++ b/js/src/data/index.js
@@ -29,6 +29,22 @@ apiFetch.use(
 	createErrorResponseCatcher( ( response ) => {
 		if ( response.status === 401 ) {
 			getHistory().replace( getReconnectAccountsUrl() );
+
+			// Inject the status code to let the subsequent handlers can identify the 401 response error.
+			return ( response.json || response.text )
+				.call( response )
+				.then( ( errorInfo ) => {
+					if ( typeof errorInfo === 'string' ) {
+						return { message: errorInfo };
+					}
+					return errorInfo;
+				} )
+				.then( ( errorInfo ) => {
+					return Promise.reject( {
+						...errorInfo,
+						statusCode: response.status,
+					} );
+				} );
 		}
 
 		// Throws error response to subsequent middlewares


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up PR discussed at https://github.com/woocommerce/google-listings-and-ads/pull/838#issuecomment-870296465 and based on #838.

- Prevent showing all 401 response errors in the general error message UI

### Screenshots:

![Kapture 2021-07-01 at 11 05 11](https://user-images.githubusercontent.com/17420811/124059289-6ec2b580-da5d-11eb-837b-b0205adcd4c8.gif)


### Detailed test instructions:

1. Disconnect Google account from the Connection Test page
2. Go to the dashboard page
3. There should no error message show up on the left-bottom side when receiving 401 response errors, and the browser should be redirected to the reconnection page

### Changelog entry

> Tweak - Prevent showing all 401 response errors in the general error message UI
