### PR TITLE
Improve guzzle conflicts

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -95,6 +95,10 @@ foreach ( $replacements as $namespace => $path ) {
 		},
 		$composer_files
 	);
+
+	// Update the namespace in vendor/composer/installed.json
+	// This file is used to generate the classmaps.
+	replace_in_json_file( "{$vendor_dir}/composer/installed.json", $namespace, $new_namespace );
 }
 
 function find_files( string $path ): array {

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -29,14 +29,17 @@ $dependencies = [
 // Namespaces which are used directly within the code.
 $direct_replacements = [
 	'guzzlehttp' => [
-		'GuzzleHttp\Psr7\Utils::streamFor',
-		'GuzzleHttp\Psr7\Utils::tryFopen',
-		'GuzzleHttp\Psr7\Message::bodySummary',
 		'GuzzleHttp\Client(',
 		'GuzzleHttp\ClientInterface::MAJOR_VERSION',
 		'GuzzleHttp\ClientInterface::VERSION',
+		'GuzzleHttp\describe_type',
 		'GuzzleHttp\HandlerStack::create',
 		'GuzzleHttp\Message\ResponseInterface)',
+		'GuzzleHttp\Promise\promise_for',
+		'GuzzleHttp\Psr7\Message::bodySummary',
+		'GuzzleHttp\Psr7\str',
+		'GuzzleHttp\Psr7\Utils::streamFor',
+		'GuzzleHttp\Psr7\Utils::tryFopen',
 	],
 ];
 

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -81,20 +81,19 @@ foreach ( $replacements as $namespace => $path ) {
 		file_put_contents( $file, $contents );
 	}
 
-	// Update the namespace in the composer.json file.
-	$composer_file = "{$vendor_dir}/{$path}/composer.json";
-	if ( ! file_exists( $composer_file ) ) {
-		continue;
-	}
-
-	$composer_contents = file_get_contents( $composer_file );
-	file_put_contents(
-		$composer_file,
-		str_replace(
-			addslashes( "{$namespace}\\" ),
-			addslashes( "{$new_namespace}\\{$namespace}\\" ),
-			$composer_contents
+	// Update the namespace in the composer.json files.
+	$composer_files = array_filter(
+		explode(
+			"\n",
+			`find {$vendor_dir}/{$path} -iname 'composer.json'`
 		)
+	);
+
+	array_map(
+		function( $file ) use ( $namespace, $new_namespace ) {
+			return replace_in_json_file( $file, $namespace, $new_namespace );
+		},
+		$composer_files
 	);
 }
 
@@ -121,4 +120,20 @@ function find_files( string $path ): array {
 	}
 
 	return $files;
+}
+
+function replace_in_json_file( string $file, string $namespace, string $new_namespace ) {
+	if ( ! file_exists( $file ) ) {
+		return;
+	}
+
+	$contents = file_get_contents( $file );
+	file_put_contents(
+		$file,
+		str_replace(
+			addslashes( "{$namespace}\\" ),
+			addslashes( "{$new_namespace}\\{$namespace}\\" ),
+			$contents
+		)
+	);
 }

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,7 @@
   "license": "GPL-3.0",
   "autoload": {
     "psr-4": {
-      "Automattic\\WooCommerce\\GoogleListingsAndAds\\": "src/",
-      "Automattic\\WooCommerce\\GoogleListingsAndAds\\Vendor\\League\\Container\\": "vendor/league/container/src/",
-      "Automattic\\WooCommerce\\GoogleListingsAndAds\\Vendor\\League\\ISO3166\\": "vendor/league/iso3166/src/",
-      "Automattic\\WooCommerce\\GoogleListingsAndAds\\Vendor\\Google\\Auth\\": "vendor/google/auth/src/",
-      "Automattic\\WooCommerce\\GoogleListingsAndAds\\Vendor\\GuzzleHttp\\": "vendor/guzzlehttp/guzzle/src/",
-      "Automattic\\WooCommerce\\GoogleListingsAndAds\\Vendor\\GuzzleHttp\\Promise\\": "vendor/guzzlehttp/promises/src/",
-      "Automattic\\WooCommerce\\GoogleListingsAndAds\\Vendor\\GuzzleHttp\\Psr7\\": "vendor/guzzlehttp/psr7/src/"
+      "Automattic\\WooCommerce\\GoogleListingsAndAds\\": "src/"
     }
   },
   "autoload-dev": {
@@ -55,7 +49,8 @@
       "Google\\Task\\Composer::cleanup",
       "php ./bin/prefix-vendor-namespace.php",
       "composer run-script remove-google-ads-api-version-support -- 6 7",
-      "bash ./bin/cleanup-vendor-files.sh"
+      "bash ./bin/cleanup-vendor-files.sh",
+      "composer dump-autoload"
     ],
     "post-install-cmd": [ "@install-scripts" ],
     "post-update-cmd": [ "@install-scripts" ],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR isn't really a fix for the guzzle conflict anymore, because in #830 we changed to a package version which no longer calls the deprecated functions. This avoids the conflict because the fatal error was coming from a conflicting version of the deprecated function.

Instead this PR provides a series of improvements to the `prefix-vendor-namespace.php` script which will be essential if we add additional packages to be prefixed.
In addition to this I created a [WIKI page](https://github.com/woocommerce/google-listings-and-ads/wiki/Replacing-Namespace) describing the steps for adding a new package.

Closes #845 

### Detailed test instructions:

1. Checkout this PR
2. Run `rm -rf vendor && composer install`
3. Check `vendor/composer/autoload_psr4.php` and `vendor/composer/jetpack_autoload_psr4.php`
4. Search for `GuzzleHttp` or the namespace of another package we replace
5. Confirm that each replaced namespace is included once in the file and not as both old and new:
```
GuzzleHttp\\Psr7\\
Automattic\\WooCommerce\\GoogleListingsAndAds\\Vendor\\GuzzleHttp\\Psr7\\
```
6. An additional test can be done to confirm that requests send without conflicts (but since we no longer use deprecated functions it doesn't conflict.

### Changelog entry
* Tweak - Improve namespace replacements in conflicting composer packages.