### PR TITLE
Always convert to boolean when we set or delete a transient

### DIFF
--- a/src/Options/Transients.php
+++ b/src/Options/Transients.php
@@ -72,7 +72,7 @@ final class Transients implements TransientsInterface, Service {
 
 		$this->validate_transient_key( $name );
 		$this->transients[ $name ] = $value;
-		return set_transient( $this->prefix_name( $name ), $value, $expiration );
+		return boolval( set_transient( $this->prefix_name( $name ), $value, $expiration ) );
 	}
 
 	/**
@@ -86,7 +86,7 @@ final class Transients implements TransientsInterface, Service {
 		$this->validate_transient_key( $name );
 		unset( $this->transients[ $name ] );
 
-		return delete_transient( $this->prefix_name( $name ) );
+		return boolval( delete_transient( $this->prefix_name( $name ) ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a conflict with the litespeed cache plugin which returns an int when deleting a transient. I'm not able to reproduce the error with the plugin because enabling cache requires:
> To use the caching functions you must have a LiteSpeed web server or be using QUIC.cloud CDN

Instead I replicated the same fatal error with a code snippet that does something similar to the plugin code:
```php
require_once ABSPATH . WPINC . '/class-wp-object-cache.php';
class Cache_Break extends WP_Object_Cache {
	public function delete( $key, $group = 'default', $deprecated = false ) {
		parent::delete( $key, $group, $deprecated );
		return 1;
	}
}

add_action(
	'init',
	function () {
		$GLOBALS['_wp_using_ext_object_cache'] = true;
		$GLOBALS['wp_object_cache'] = new Cache_Break();
	}
);
```

Both the `wp_cache_set` function and the litespeed cache set function always returns true. However since it's possible to override it in the same way, I added the boolval just in case there is another solution that does this differently.

Closes #841

### Detailed test instructions:

1. Add the code snippet on your test site
2. "Clear Status Cache" on the Connection Test page
3. Confirm that the fatal error occurs
4. Check out this PR and repeat the test
5. Confirm that the fatal error no longer occurs

### Changelog entry
* Fix - Conflict with LiteSpeed cache plugin.