### PR TITLE
Add unit tests for ProductHelper and ProductMetaHandler

### DIFF
--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -225,7 +225,7 @@ class ProductMetaHandler implements Service, Registerable {
 	 *
 	 * @return array Sanitized array of meta query clauses.
 	 */
-	protected function sanitize_meta_query( array $queries ): array {
+	protected function sanitize_meta_query( $queries ): array {
 		$prefixed_valid_keys = array_map( [ $this, 'prefix_meta_key' ], array_keys( self::TYPES ) );
 		$clean_queries       = [];
 
@@ -265,7 +265,7 @@ class ProductMetaHandler implements Service, Registerable {
 	 *
 	 * @return array
 	 */
-	public function prefix_meta_query_keys( array $meta_queries ): array {
+	public function prefix_meta_query_keys( $meta_queries ): array {
 		$updated_queries = [];
 		if ( ! is_array( $meta_queries ) ) {
 			return $updated_queries;
@@ -277,8 +277,10 @@ class ProductMetaHandler implements Service, Registerable {
 				$updated_queries[ $key ] = $meta_query;
 
 				// First-order clause.
-			} elseif ( ( isset( $meta_query['key'] ) || isset( $meta_query['value'] ) ) && self::is_meta_key_valid( $meta_query['key'] ) ) {
-				$meta_query['key'] = $this->prefix_meta_key( $meta_query['key'] );
+			} elseif ( isset( $meta_query['key'] ) || isset( $meta_query['value'] ) ) {
+				if ( self::is_meta_key_valid( $meta_query['key'] ) ) {
+					$meta_query['key'] = $this->prefix_meta_key( $meta_query['key'] );
+				}
 			} else {
 				// Otherwise, it's a nested meta_query, so we recurse.
 				$meta_query = $this->prefix_meta_query_keys( $meta_query );

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -8,7 +8,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterSer
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC as WCProxy;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductMetaTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\SettingsTrait;
@@ -18,7 +19,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Helper_Product;
 use WC_Product;
-use WP_UnitTestCase;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -28,11 +28,11 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
  *
  * @property ProductMetaHandler               $product_meta
- * @property WCProxy                          $wc
+ * @property WC                               $wc
  * @property MockObject|MerchantCenterService $merchant_center
- * @property MockObject|ProductHelper         $product_helper
+ * @property ProductHelper                    $product_helper
  */
-class ProductHelperTest extends WP_UnitTestCase {
+class ProductHelperTest extends ContainerAwareUnitTest {
 
 	use ProductMetaTrait;
 	use ProductTrait;
@@ -676,8 +676,8 @@ class ProductHelperTest extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		$this->product_meta    = new ProductMetaHandler();
-		$this->wc              = new WCProxy( WC()->countries );
+		$this->product_meta    = $this->container->get( ProductMetaHandler::class );
+		$this->wc              = $this->container->get( WC::class );
 		$this->merchant_center = $this->createMock( MerchantCenterService::class );
 		$this->product_helper  = new ProductHelper( $this->product_meta, $this->wc, $this->merchant_center );
 	}

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -1,0 +1,684 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC as WCProxy;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductMetaTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\SettingsTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Helper_Product;
+use WC_Product;
+use WP_UnitTestCase;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ProductHelperTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ *
+ * @property ProductMetaHandler               $product_meta
+ * @property WCProxy                          $wc
+ * @property MockObject|MerchantCenterService $merchant_center
+ * @property MockObject|ProductHelper         $product_helper
+ */
+class ProductHelperTest extends WP_UnitTestCase {
+
+	use ProductMetaTrait;
+	use ProductTrait;
+	use SettingsTrait;
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_mark_as_synced( WC_Product $product ) {
+		$google_product = $this->generate_google_product_mock();
+
+		$this->merchant_center->expects( $this->any() )
+							  ->method( 'get_target_countries' )
+							  ->willReturn( [ $this->get_sample_target_country() ] );
+
+		// add some random errors residue from previous sync attempts
+		$this->product_meta->update_errors( $product, [ 'Error 1', 'Error 2' ] );
+		$this->product_meta->update_failed_sync_attempts( $product, 1 );
+		$this->product_meta->update_sync_failed_at( $product, 12345 );
+
+		$this->product_helper->mark_as_synced( $product, $google_product );
+
+		$this->assertGreaterThan( 0, $this->product_meta->get_synced_at( $product ) );
+		$this->assertEquals( SyncStatus::SYNCED, $this->product_meta->get_sync_status( $product ) );
+		$this->assertEquals( [ $google_product->getTargetCountry() => $google_product->getId() ], $this->product_meta->get_google_ids( $product ) );
+		$this->assertEquals( ChannelVisibility::SYNC_AND_SHOW, $this->product_meta->get_visibility( $product ) );
+		$this->assertEmpty( $this->product_meta->get_errors( $product ) );
+		$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
+		$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_mark_as_synced_keeps_existing_google_ids( WC_Product $product ) {
+		$google_product = $this->generate_google_product_mock();
+
+		$this->product_meta->update_google_ids( $product, [ 'AU' => 'online:en:AU:gla_1' ] );
+
+		$this->product_helper->mark_as_synced( $product, $google_product );
+
+		$this->assertEqualSets(
+			[
+				'AU' => 'online:en:AU:gla_1',
+				$google_product->getTargetCountry() => $google_product->getId(),
+			],
+			$this->product_meta->get_google_ids( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_mark_as_synced_doesnt_delete_errors_unless_all_target_countries_synced( WC_Product $product ) {
+		$google_product = $this->generate_google_product_mock();
+
+		$this->merchant_center->expects( $this->any() )
+							  ->method( 'get_target_countries' )
+							  ->willReturn( [ 'AU', $google_product->getTargetCountry() ] );
+
+		// add some random errors residue from previous sync attempts
+		$this->product_meta->update_errors( $product, [ 'Error 1', 'Error 2' ] );
+		$this->product_meta->update_failed_sync_attempts( $product, 1 );
+		$this->product_meta->update_sync_failed_at( $product, 12345 );
+
+		$this->product_helper->mark_as_synced( $product, $google_product );
+
+		$this->assertEquals( [ 'Error 1', 'Error 2' ], $this->product_meta->get_errors( $product ) );
+		$this->assertEquals( 1, $this->product_meta->get_failed_sync_attempts( $product ) );
+		$this->assertEquals( 12345, $this->product_meta->get_sync_failed_at( $product ) );
+
+		$google_product_2 = $this->generate_google_product_mock( null, 'AU' );
+
+		$this->product_helper->mark_as_synced( $product, $google_product_2 );
+
+		$this->assertEmpty( $this->product_meta->get_errors( $product ) );
+		$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
+		$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+	}
+
+	public function test_mark_as_synced_updates_both_variation_and_parent() {
+		$google_product = $this->generate_google_product_mock();
+		$parent = WC_Helper_Product::create_variation_product();
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+
+		$this->merchant_center->expects( $this->any() )
+							  ->method( 'get_target_countries' )
+							  ->willReturn( [ $this->get_sample_target_country() ] );
+
+		// add some random errors residue from previous sync attempts
+		$this->product_meta->update_errors( $variation, [ 'Error 1', 'Error 2' ] );
+		$this->product_meta->update_failed_sync_attempts( $variation, 1 );
+		$this->product_meta->update_sync_failed_at( $variation, 12345 );
+		$this->product_meta->update_errors( $parent, [ $parent->get_id() => [ 'Error 1', 'Error 2' ] ] );
+		$this->product_meta->update_failed_sync_attempts( $parent, 1 );
+		$this->product_meta->update_sync_failed_at( $parent, 12345 );
+
+		$this->product_helper->mark_as_synced( $variation, $google_product );
+
+		// get the updated parent object from DB
+		$parent = $this->wc->get_product( $variation->get_parent_id() );
+
+		// visibility is only updated for the parent
+		$this->assertEquals( ChannelVisibility::SYNC_AND_SHOW, $this->product_meta->get_visibility( $parent ) );
+
+		foreach ( [ $parent, $variation ] as $product ) {
+			$this->assertGreaterThan( 0, $this->product_meta->get_synced_at( $product ) );
+			$this->assertEquals( SyncStatus::SYNCED, $this->product_meta->get_sync_status( $product ) );
+			$this->assertEquals( [ $google_product->getTargetCountry() => $google_product->getId() ], $this->product_meta->get_google_ids( $product ) );
+			$this->assertEmpty( $this->product_meta->get_errors( $product ) );
+			$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
+			$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+		}
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_mark_as_unsynced( WC_Product $product ) {
+		// First mark the product as synced to update its meta data
+		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+
+		$this->product_helper->mark_as_unsynced( $product );
+
+		$this->assertEmpty( $this->product_meta->get_synced_at( $product ) );
+		$this->assertEquals( SyncStatus::NOT_SYNCED, $this->product_meta->get_sync_status( $product ) );
+		$this->assertEmpty( $this->product_meta->get_google_ids( $product ) );
+		$this->assertEmpty( $this->product_meta->get_errors( $product ) );
+		$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
+		$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+	}
+
+	/**
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_mark_as_unsynced_updates_both_variation_and_parent() {
+		$parent = WC_Helper_Product::create_variation_product();
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+
+		// First mark the product as synced to update its meta data
+		$this->product_helper->mark_as_synced( $variation, $this->generate_google_product_mock() );
+
+		$this->product_helper->mark_as_unsynced( $variation );
+
+		// get the updated parent object from DB
+		$parent = $this->wc->get_product( $variation->get_parent_id() );
+
+		foreach ( [ $parent, $variation ] as $product ) {
+			$this->assertEmpty( $this->product_meta->get_synced_at( $product ) );
+			$this->assertEquals( SyncStatus::NOT_SYNCED, $this->product_meta->get_sync_status( $product ) );
+			$this->assertEmpty( $this->product_meta->get_google_ids( $product ) );
+			$this->assertEmpty( $this->product_meta->get_errors( $product ) );
+			$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
+			$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+		}
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_remove_google_id( WC_Product $product ) {
+		$this->product_meta->update_google_ids(
+			$product,
+			[
+				'AU' => 'online:en:AU:gla_1',
+				'US' => 'online:en:US:gla_1',
+			]
+		);
+
+		$this->product_helper->remove_google_id( $product, 'online:en:US:gla_1' );
+
+		$this->assertEquals( [ 'AU' => 'online:en:AU:gla_1' ], $this->product_meta->get_google_ids( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_remove_google_id_marks_as_unsynced_if_empty_ids( WC_Product $product ) {
+		$this->product_meta->update_google_ids( $product, [ 'US' => 'online:en:US:gla_1', ] );
+
+		$this->product_helper->remove_google_id( $product, 'online:en:US:gla_1' );
+
+		$this->assertEmpty( $this->product_meta->get_google_ids( $product ) );
+		$this->assertFalse( $this->product_helper->is_product_synced( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_mark_as_invalid( WC_Product $product ) {
+		$errors = [
+			'Error 1',
+			'Error 2',
+		];
+
+		$this->product_helper->mark_as_invalid( $product, $errors );
+
+		$this->assertEqualSets( $errors, $this->product_meta->get_errors( $product ) );
+		$this->assertEquals( SyncStatus::HAS_ERRORS, $this->product_meta->get_sync_status( $product ) );
+
+		// Visibility is updated for a product that has none set
+		$this->assertEquals( ChannelVisibility::SYNC_AND_SHOW, $this->product_meta->get_visibility( $product ) );
+
+		// Sync attempts should not be updated when no internal error is present
+		$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
+		$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_mark_as_invalid_updates_failed_sync_attempts_if_internal_error_exists( WC_Product $product ) {
+		$errors = [
+			'Error 1',
+			'Error 2',
+			GoogleProductService::INTERNAL_ERROR_REASON => 'Internal error',
+		];
+
+		$this->product_helper->mark_as_invalid( $product, $errors );
+
+		$this->assertGreaterThan( 0, $this->product_meta->get_failed_sync_attempts( $product ) );
+		$this->assertGreaterThan( 0, $this->product_meta->get_sync_failed_at( $product ) );
+	}
+
+	public function test_mark_as_invalid_updates_both_variation_and_parent() {
+		$errors        = [
+			'Error 1',
+			'Error 2',
+		];
+		$parent_errors = [
+			'some_variation_id' => [
+				'Another Variation Error 1',
+				'Another Variation Error 2',
+			],
+		];
+
+		$parent    = WC_Helper_Product::create_variation_product();
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+
+		// Set some random errors for the parent product
+		$this->product_meta->update_errors( $parent, $parent_errors );
+
+		$this->product_helper->mark_as_invalid( $variation, $errors );
+
+		// get the updated parent object from DB
+		$parent = $this->wc->get_product( $variation->get_parent_id() );
+
+		// Visibility is updated for a parent product that has none set
+		$this->assertEquals( ChannelVisibility::SYNC_AND_SHOW, $this->product_meta->get_visibility( $parent ) );
+
+		$this->assertEqualSets( $errors, $this->product_meta->get_errors( $variation ) );
+		$this->assertEqualSets( array_merge( [ $variation->get_id() => $errors ], $parent_errors ), $this->product_meta->get_errors( $parent ) );
+
+		foreach ( [ $parent, $variation ] as $product ) {
+			$this->assertEquals( SyncStatus::HAS_ERRORS, $this->product_meta->get_sync_status( $product ) );
+
+			// Sync attempts should not be updated when no internal error is present
+			$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
+			$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+		}
+
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_mark_as_pending( WC_Product $product ) {
+		$this->product_helper->mark_as_pending( $product );
+
+		$this->assertEquals( SyncStatus::PENDING, $this->product_meta->get_sync_status( $product ) );
+	}
+
+	public function test_mark_as_pending_updates_both_variation_and_parent() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+
+		$this->product_helper->mark_as_pending( $variation );
+
+		// get the updated parent object from DB
+		$parent = $this->wc->get_product( $variation->get_parent_id() );
+
+		$this->assertEquals( SyncStatus::PENDING, $this->product_meta->get_sync_status( $variation ) );
+		$this->assertEquals( SyncStatus::PENDING, $this->product_meta->get_sync_status( $parent ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_get_synced_google_product_ids( WC_Product $product ) {
+		$this->product_meta->update_google_ids( $product, [ 'US' => 'online:en:US:gla_1' ] );
+
+		$this->assertEquals( [ 'US' => 'online:en:US:gla_1' ], $this->product_helper->get_synced_google_product_ids( $product ) );
+	}
+
+	public function test_get_wc_product_id() {
+		$google_id  = 'online:en:US:gla_1234567';
+		$product_id = $this->product_helper->get_wc_product_id( $google_id );
+
+		$this->assertEquals( 1234567, $product_id );
+	}
+
+	public function test_get_wc_product_id_returns_zero_if_no_id_matches() {
+		$google_id  = 'online:en:US:gla_invalid_id_1';
+		$product_id = $this->product_helper->get_wc_product_id( $google_id );
+
+		$this->assertEquals( 0, $product_id );
+	}
+
+	public function test_get_wc_product_title() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$google_id     = 'online:en:US:gla_' . $product->get_id();
+		$product_title = $this->product_helper->get_wc_product_title( $google_id );
+
+		$this->assertEquals( $product->get_title(), $product_title );
+	}
+
+	public function test_get_wc_product_title_returns_google_id_if_product_cant_be_found() {
+		$google_id     = 'online:en:US:gla_123456789';
+		$product_title = $this->product_helper->get_wc_product_title( $google_id );
+
+		$this->assertEquals( $google_id, $product_title );
+	}
+
+	public function test_get_wc_product() {
+		$product = WC_Helper_Product::create_simple_product();
+		$result  = $this->product_helper->get_wc_product( $product->get_id() );
+
+		$this->assertEquals( $product, $result );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_product_synced( WC_Product $product ) {
+		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+		$is_product_synced = $this->product_helper->is_product_synced( $product );
+		$this->assertTrue( $is_product_synced );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_product_synced_return_false_if_no_google_id( WC_Product $product ) {
+		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+		$this->product_meta->delete_google_ids($product);
+		$is_product_synced = $this->product_helper->is_product_synced( $product );
+		$this->assertFalse( $is_product_synced );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_product_synced_return_false_if_no_synced_at( WC_Product $product ) {
+		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+		$this->product_meta->delete_synced_at($product);
+		$is_product_synced = $this->product_helper->is_product_synced( $product );
+		$this->assertFalse( $is_product_synced );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_sync_ready_visible_published( WC_Product $product ) {
+		$product->set_status( 'publish' );
+		$product->save();
+		$this->product_meta->update_visibility( $product, ChannelVisibility::SYNC_AND_SHOW );
+		$result = $this->product_helper->is_sync_ready( $product );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_sync_ready_not_visible_published( WC_Product $product ) {
+		$product->set_status( 'publish' );
+		$product->save();
+		$this->product_meta->update_visibility( $product, ChannelVisibility::DONT_SYNC_AND_SHOW );
+		$result = $this->product_helper->is_sync_ready( $product );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_sync_ready_visible_not_published( WC_Product $product ) {
+		$product->set_status( 'draft' );
+		$product->save();
+		$this->product_meta->update_visibility( $product, ChannelVisibility::SYNC_AND_SHOW );
+		$result = $this->product_helper->is_sync_ready( $product );
+		$this->assertFalse( $result );
+	}
+
+	public function test_is_sync_ready_variation_parent_visible_and_published() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$parent->set_status( 'publish' );
+		$parent->save();
+		$this->product_meta->update_visibility( $parent, ChannelVisibility::SYNC_AND_SHOW );
+
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+		$variation->set_status( 'draft' );
+		$variation->save();
+		$this->product_meta->update_visibility( $variation, ChannelVisibility::DONT_SYNC_AND_SHOW );
+
+		$this->assertTrue( $this->product_helper->is_sync_ready( $variation ) );
+	}
+
+	public function test_is_sync_ready_variation_parent_not_visible_but_published() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$parent->set_status( 'publish' );
+		$parent->save();
+		$this->product_meta->update_visibility( $parent, ChannelVisibility::DONT_SYNC_AND_SHOW );
+
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+		$variation->set_status( 'publish' );
+		$variation->save();
+		$this->product_meta->update_visibility( $variation, ChannelVisibility::SYNC_AND_SHOW );
+		$this->assertFalse( $this->product_helper->is_sync_ready( $variation ) );
+	}
+
+	public function test_is_sync_ready_variation_parent_visible_but_not_published() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$parent->set_status( 'draft' );
+		$parent->save();
+		$this->product_meta->update_visibility( $parent, ChannelVisibility::SYNC_AND_SHOW );
+
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+		$variation->set_status( 'publish' );
+		$variation->save();
+		$this->product_meta->update_visibility( $variation, ChannelVisibility::SYNC_AND_SHOW );
+
+		$this->assertFalse( $this->product_helper->is_sync_ready( $variation ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_sync_failed_recently( WC_Product $product ) {
+		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD + 5 );
+		$this->product_meta->update_sync_failed_at( $product, strtotime( '+1 year' ) );
+		$this->assertTrue( $this->product_helper->is_sync_failed_recently( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_sync_failed_recently_less_than_threshold( WC_Product $product ) {
+		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD - 1 );
+		$this->product_meta->update_sync_failed_at( $product, strtotime( '+1 year' ) );
+		$this->assertFalse( $this->product_helper->is_sync_failed_recently( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_is_sync_failed_recently_old_failure_but_more_than_threshold( WC_Product $product ) {
+		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD + 5 );
+		$this->product_meta->update_sync_failed_at( $product, strtotime( '-1 year' ) );
+		$this->assertFalse( $this->product_helper->is_sync_failed_recently( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_get_visibility( WC_Product $product ) {
+		$this->product_meta->update_visibility( $product, ChannelVisibility::DONT_SYNC_AND_SHOW );
+		$result = $this->product_helper->get_visibility( $product );
+		$this->assertEquals( ChannelVisibility::DONT_SYNC_AND_SHOW, $result );
+	}
+
+	public function test_get_visibility_variation_product_inherits_from_parent() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+		$this->product_meta->update_visibility( $parent, ChannelVisibility::DONT_SYNC_AND_SHOW );
+		$this->product_meta->update_visibility( $variation, ChannelVisibility::SYNC_AND_SHOW );
+		$this->assertEquals( ChannelVisibility::DONT_SYNC_AND_SHOW, $this->product_helper->get_visibility( $variation ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_get_sync_status( WC_Product $product ) {
+		$this->product_meta->update_sync_status( $product, SyncStatus::SYNCED );
+		$this->assertEquals( SyncStatus::SYNCED, $this->product_helper->get_sync_status( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_get_mc_status( WC_Product $product ) {
+		$this->product_meta->update_mc_status( $product, MCStatus::APPROVED );
+		$this->assertEquals( MCStatus::APPROVED, $this->product_helper->get_mc_status( $product ) );
+	}
+
+	public function test_get_mc_status_variation_product() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+		$this->product_meta->update_mc_status( $parent, MCStatus::APPROVED );
+		$this->product_meta->update_mc_status( $variation, MCStatus::PENDING );
+		$this->assertEquals( MCStatus::APPROVED, $this->product_helper->get_mc_status( $variation ) );
+	}
+
+	public function test_maybe_swap_for_parent_id() {
+		$simple = WC_Helper_Product::create_simple_product();
+
+		$variable  = WC_Helper_Product::create_variation_product();
+		$variation = $this->wc->get_product( $variable->get_children()[0] );
+
+		$simple_product_id = $this->product_helper->maybe_swap_for_parent_id( $simple->get_id() );
+		$this->assertEquals( $simple->get_id(), $simple_product_id );
+
+		$simple_product_id = $this->product_helper->maybe_swap_for_parent_id( $simple );
+		$this->assertEquals( $simple->get_id(), $simple_product_id );
+
+		$variable_product_id = $this->product_helper->maybe_swap_for_parent_id( $variable );
+		$this->assertEquals( $variable->get_id(), $variable_product_id );
+
+		$variation_parent_id = $this->product_helper->maybe_swap_for_parent_id( $variation );
+		$this->assertEquals( $variable->get_id(), $variation_parent_id );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_get_validation_errors( WC_Product $product ) {
+		$errors = [
+			1111 => [
+				'Variation Error 1',
+				'Variation Error 2',
+			],
+			1112 => [
+				'Variation Error 1',
+				'Variation Error 3',
+			],
+			1113 => [
+				'Variation Error 1',
+				'Variation Error 4',
+			],
+		];
+
+		$this->product_meta->update_errors( $product, $errors );
+
+		$this->assertEqualSets(
+			[
+				'Variation Error 1',
+				'Variation Error 2',
+				'Variation Error 3',
+				'Variation Error 4',
+			],
+			$this->product_helper->get_validation_errors( $product )
+		);
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_blank_test_products
+	 */
+	public function test_get_validation_errors_returns_as_is_if_keys_arent_product_ids( WC_Product $product ) {
+		$errors = [
+			[
+				'Variation Error 1',
+				'Variation Error 2',
+			],
+			[
+				'Variation Error 1',
+				'Variation Error 3',
+			],
+			[
+				'Variation Error 1',
+				'Variation Error 4',
+			],
+		];
+
+		$this->product_meta->update_errors( $product, $errors );
+
+		$this->assertEquals(
+			$errors,
+			$this->product_helper->get_validation_errors( $product )
+		);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function return_blank_test_products(): array {
+		// variation products are provided separately to related tests
+		return [
+			[ WC_Helper_Product::create_simple_product() ],
+			[ WC_Helper_Product::create_variation_product() ], // WC_Product_Variable
+		];
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->product_meta    = new ProductMetaHandler();
+		$this->wc              = new WCProxy( WC()->countries );
+		$this->merchant_center = $this->createMock( MerchantCenterService::class );
+		$this->product_helper  = new ProductHelper( $this->product_meta, $this->wc, $this->merchant_center );
+	}
+}

--- a/tests/Unit/Product/ProductMetaHandlerTest.php
+++ b/tests/Unit/Product/ProductMetaHandlerTest.php
@@ -1,0 +1,212 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidMeta;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use BadMethodCallException;
+use WC_Helper_Product;
+use WP_UnitTestCase;
+
+/**
+ * Class ProductMetaHandlerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ *
+ * @property ProductMetaHandler $product_meta_handler
+ */
+class ProductMetaHandlerTest extends WP_UnitTestCase {
+
+	use ProductTrait;
+
+	public function test_magic_call_throws_exception_invalid_method_name() {
+		$this->expectException( BadMethodCallException::class);
+		$this->product_meta_handler->in1va2lid_method();
+	}
+
+	public function test_magic_call_throws_exception_method_not_allowed() {
+		$this->expectException( BadMethodCallException::class);
+		$this->product_meta_handler->need_synced_at();
+	}
+
+	public function test_magic_update_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->product_meta_handler->update_invalid_meta_key_test( $this->generate_simple_product_mock(), 1 );
+	}
+
+	public function test_magic_delete_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->product_meta_handler->delete_invalid_meta_key_test( $this->generate_simple_product_mock() );
+	}
+
+	public function test_magic_get_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->product_meta_handler->get_invalid_meta_key_test( $this->generate_simple_product_mock() );
+	}
+
+	public function test_magic_call() {
+		$product = $this->generate_simple_product_mock();
+		$key     = 'synced_at';
+		$value   = 12345;
+
+		$product_meta_handler = $this->getMockBuilder( ProductMetaHandler::class )
+									 ->setMethodsExcept( [ '__call' ] )
+									 ->getMock();
+
+		$product_meta_handler->expects( $this->once() )
+							 ->method( 'update' )
+							 ->with( $this->equalTo( $product ), $this->equalTo( $key ), $this->equalTo( $value ) );
+		$product_meta_handler->update_synced_at( $product, $value );
+
+		$product_meta_handler->expects( $this->once() )
+							 ->method( 'get' )
+							 ->with( $this->equalTo( $product ), $this->equalTo( $key ) );
+		$product_meta_handler->get_synced_at( $product );
+
+		$product_meta_handler->expects( $this->once() )
+							 ->method( 'delete' )
+							 ->with( $this->equalTo( $product ), $this->equalTo( $key ) );
+		$product_meta_handler->delete_synced_at( $product );
+	}
+
+	public function test_update_type_cast() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->product_meta_handler->update( $product, ProductMetaHandler::KEY_SYNCED_AT, '12345' );
+		$value = $product->get_meta( '_wc_gla_synced_at', true );
+		$this->assertEquals( 12345, $value );
+	}
+
+	public function test_update() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->product_meta_handler->update( $product, ProductMetaHandler::KEY_SYNCED_AT, 12345 );
+		$value = $product->get_meta( '_wc_gla_synced_at', true );
+		$this->assertEquals( 12345, $value );
+	}
+
+	public function test_update_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->product_meta_handler->update( $this->generate_simple_product_mock(), 'invalid_meta_key_test', 1 );
+	}
+
+	public function test_delete() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->update_meta_data( '_wc_gla_synced_at', 12345 );
+		$product->save_meta_data();
+
+		$this->product_meta_handler->delete( $product, ProductMetaHandler::KEY_SYNCED_AT );
+
+		$value = $product->get_meta( '_wc_gla_synced_at', true );
+		$this->assertEmpty( $value );
+	}
+
+	public function test_delete_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->product_meta_handler->delete( $this->generate_simple_product_mock(), 'invalid_meta_key_test' );
+	}
+
+	public function test_get_returns_null_if_no_value_exist() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$value = $this->product_meta_handler->get( $product, ProductMetaHandler::KEY_SYNCED_AT );
+		$this->assertNull( $value );
+	}
+
+	public function test_get() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->update_meta_data('_wc_gla_synced_at', 12345);
+		$product->save_meta_data();
+
+		$value = $this->product_meta_handler->get( $product, ProductMetaHandler::KEY_SYNCED_AT );
+		$this->assertEquals( 12345, $value );
+	}
+
+	public function test_get_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->product_meta_handler->get( $this->generate_simple_product_mock(), 'invalid_meta_key_test' );
+	}
+
+	public function test_is_meta_key_valid() {
+		$this->assertFalse( ProductMetaHandler::is_meta_key_valid( 'invalid_meta_key_test' ) );
+		$this->assertTrue( ProductMetaHandler::is_meta_key_valid( ProductMetaHandler::KEY_SYNCED_AT ) );
+	}
+
+	public function test_prefix_meta_query_keys_return_if_not_array() {
+		$meta_query = [
+			'relation' => 'OR',
+			[
+				'key'     => ProductMetaHandler::KEY_VISIBILITY,
+				'compare' => 'NOT EXISTS',
+			],
+			[
+				'relation' => 'AND',
+				[
+					'key'     => 'some_other_meta_key_we_dont_support',
+					'compare' => '=',
+					'value'   => 1,
+				],
+				[
+					'key'     => ProductMetaHandler::KEY_VISIBILITY,
+					'compare' => '!=',
+					'value'   => 'dont-sync-and-show',
+				],
+				[
+					'relation' => 'OR',
+					[
+						'key'     => ProductMetaHandler::KEY_SYNCED_AT,
+						'compare' => 'NOT EXISTS',
+					],
+					[
+						'key'     => ProductMetaHandler::KEY_SYNCED_AT,
+						'compare' => '>',
+						'value'   => 0,
+					],
+				]
+			]
+		];
+		$result = $this->product_meta_handler->prefix_meta_query_keys( $meta_query );
+
+		$expected = [
+			'relation' => 'OR',
+			[
+				'key'     => '_wc_gla_visibility',
+				'compare' => 'NOT EXISTS',
+			],
+			[
+				'relation' => 'AND',
+				[
+					'key'     => 'some_other_meta_key_we_dont_support',
+					'compare' => '=',
+					'value'   => 1,
+				],
+				[
+					'key'     => '_wc_gla_visibility',
+					'compare' => '!=',
+					'value'   => 'dont-sync-and-show',
+				],
+				[
+					'relation' => 'OR',
+					[
+						'key'     => '_wc_gla_synced_at',
+						'compare' => 'NOT EXISTS',
+					],
+					[
+						'key'     => '_wc_gla_synced_at',
+						'compare' => '>',
+						'value'   => 0,
+					],
+				]
+			]
+		];
+		$this->assertEqualSets($expected, $result);
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->product_meta_handler = new ProductMetaHandler();
+	}
+}

--- a/tests/Unit/Product/ProductMetaHandlerTest.php
+++ b/tests/Unit/Product/ProductMetaHandlerTest.php
@@ -132,7 +132,7 @@ class ProductMetaHandlerTest extends WP_UnitTestCase {
 		$this->assertTrue( ProductMetaHandler::is_meta_key_valid( ProductMetaHandler::KEY_SYNCED_AT ) );
 	}
 
-	public function test_prefix_meta_query_keys_return_if_not_array() {
+	public function test_prefix_meta_query_keys() {
 		$meta_query = [
 			'relation' => 'OR',
 			[

--- a/tests/Unit/Product/ProductMetaHandlerTest.php
+++ b/tests/Unit/Product/ProductMetaHandlerTest.php
@@ -142,11 +142,6 @@ class ProductMetaHandlerTest extends WP_UnitTestCase {
 			[
 				'relation' => 'AND',
 				[
-					'key'     => 'some_other_meta_key_we_dont_support',
-					'compare' => '=',
-					'value'   => 1,
-				],
-				[
 					'key'     => ProductMetaHandler::KEY_VISIBILITY,
 					'compare' => '!=',
 					'value'   => 'dont-sync-and-show',

--- a/tests/Unit/Product/ProductMetaHandlerTest.php
+++ b/tests/Unit/Product/ProductMetaHandlerTest.php
@@ -176,11 +176,6 @@ class ProductMetaHandlerTest extends WP_UnitTestCase {
 			[
 				'relation' => 'AND',
 				[
-					'key'     => 'some_other_meta_key_we_dont_support',
-					'compare' => '=',
-					'value'   => 1,
-				],
-				[
 					'key'     => '_wc_gla_visibility',
 					'compare' => '!=',
 					'value'   => 'dont-sync-and-show',
@@ -198,6 +193,46 @@ class ProductMetaHandlerTest extends WP_UnitTestCase {
 					],
 				]
 			]
+		];
+		$this->assertEqualSets($expected, $result);
+	}
+
+	public function test_prefix_meta_query_keys_returns_unsupported_meta_keys_intact() {
+		$meta_query = [
+			'relation' => 'OR',
+			[
+				'key'     => ProductMetaHandler::KEY_VISIBILITY,
+				'compare' => 'NOT EXISTS',
+			],
+			[
+				'key'     => 'a_meta_key_we_dont_support',
+				'compare' => '!=',
+				'value'   => null,
+			],
+			[
+				'key'     => 'some_other_meta_key_we_dont_support',
+				'compare' => '=',
+				'value'   => 1,
+			],
+		];
+		$result = $this->product_meta_handler->prefix_meta_query_keys( $meta_query );
+
+		$expected = [
+			'relation' => 'OR',
+			[
+				'key'     => '_wc_gla_visibility',
+				'compare' => 'NOT EXISTS',
+			],
+			[
+				'key'     => 'a_meta_key_we_dont_support',
+				'compare' => '!=',
+				'value'   => null,
+			],
+			[
+				'key'     => 'some_other_meta_key_we_dont_support',
+				'compare' => '=',
+				'value'   => 1,
+			],
 		];
 		$this->assertEqualSets($expected, $result);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds unit tests for two classes related to the product sync functionality: `ProductHelper` and `ProductMetaHandler`

Continuing from https://github.com/woocommerce/google-listings-and-ads/pull/846

### Detailed test instructions:

1. Run phpunit and make sure all the tests pass
