### PR TITLE
Add unit tests for ProductRepository

### DIFF
--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -217,26 +217,6 @@ class ProductRepository implements Service {
 	}
 
 	/**
-	 * Find and return an array of WooCommerce product IDs already awaiting sync to Google Merchant Center.
-	 *
-	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
-	 * @param int $offset Amount to offset product results.
-	 *
-	 * @return int[] Array of WooCommerce product IDs
-	 */
-	public function find_sync_pending_product_ids( int $limit = -1, int $offset = 0 ): array {
-		$args['meta_query'] = [
-			[
-				'key'     => ProductMetaHandler::KEY_GOOGLE_IDS,
-				'compare' => 'NOT EXISTS',
-			],
-			$this->get_sync_ready_products_meta_query(),
-		];
-
-		return $this->find_ids( $args, $limit, $offset );
-	}
-
-	/**
 	 * @param array $args Array of WooCommerce args (except 'return'), and product metadata.
 	 *
 	 * @return array
@@ -299,54 +279,6 @@ class ProductRepository implements Service {
 	}
 
 	/**
-	 * Find and return an array of WooCommerce product IDs that are pending synchronization,
-	 * but have failed pre-sync validation. Excludes variable parent products.
-	 *
-	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
-	 * @param int $offset Amount to offset product results.
-	 *
-	 * @return int[] Array of WooCommerce product IDs
-	 */
-	public function find_presync_error_product_ids( int $limit = -1, int $offset = 0 ): array {
-		$product_types = ProductSyncer::get_supported_product_types();
-		$args          = [
-			'type'       => array_diff( $product_types, [ 'variable' ] ),
-			'meta_query' => [
-				'relation' => 'AND',
-				$this->get_sync_ready_products_meta_query(),
-				[
-					[
-						'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
-						'compare' => '=',
-						'value'   => SyncStatus::HAS_ERRORS,
-					],
-				],
-			],
-		];
-
-		return $this->find_ids( $args, $limit, $offset );
-	}
-
-	/**
-	 * @return array
-	 */
-	protected function get_presync_error_products_meta_query() {
-		return [
-			'relation' => 'AND',
-			$this->get_sync_ready_products_meta_query(),
-			[
-				[
-					[
-						'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
-						'compare' => '=',
-						'value'   => SyncStatus::HAS_ERRORS,
-					],
-				],
-			],
-		];
-	}
-
-	/**
 	 * Find and return an array of WooCommerce product IDs that are marked as MC not_synced.
 	 * Excludes variations and variable products without variations.
 	 *
@@ -365,35 +297,6 @@ class ProductRepository implements Service {
 				[
 					'key'     => ProductMetaHandler::KEY_MC_STATUS,
 					'compare' => '=',
-					'value'   => MCStatus::NOT_SYNCED,
-				],
-			],
-		];
-
-		return $this->find_ids( $args, $limit, $offset );
-	}
-
-	/**
-	 * Find and return an array of WooCommerce product IDs that are NOT marked as MC not_synced.
-	 * Excludes variations and variable products without variations.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
-	 * @param int $offset Amount to offset product results.
-	 *
-	 * @return int[] Array of WooCommerce product IDs
-	 */
-	public function find_mc_synced_product_ids( int $limit = -1, int $offset = 0 ): array {
-		$types = ProductSyncer::get_supported_product_types();
-		$types = array_diff( $types, [ 'variation' ] );
-		$args  = [
-			'status'     => 'publish',
-			'type'       => $types,
-			'meta_query' => [
-				[
-					'key'     => ProductMetaHandler::KEY_MC_STATUS,
-					'compare' => '!=',
 					'value'   => MCStatus::NOT_SYNCED,
 				],
 			],

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -245,11 +245,7 @@ class ProductRepository implements Service {
 		$args['meta_query'] = $this->get_sync_ready_products_meta_query();
 
 		// don't include variable products in query
-		$args['type']        = ProductSyncer::get_supported_product_types();
-		$variable_type_index = array_search( 'variable', $args['type'], true );
-		if ( false !== $variable_type_index ) {
-			unset( $args['type'][ $variable_type_index ] );
-		}
+		$args['type'] = array_diff( ProductSyncer::get_supported_product_types(), [ 'variable' ] );
 
 		// only include published products
 		if ( empty( $args['status'] ) ) {

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -156,6 +156,10 @@ trait ProductTrait {
 		return $adapted;
 	}
 
+	protected static function get_product_id( WC_Product $product ) {
+		return $product->get_id();
+	}
+
 	/**
 	 * @return array
 	 */

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -113,6 +113,8 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 	public function test_find_by_ids() {
 		$product_1 = WC_Helper_Product::create_simple_product();
 		$product_2 = WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_variation_product();
 
 		$ids = [
 			$product_1->get_id(),

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -1,0 +1,272 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
+use WC_Helper_Product;
+use WC_Product;
+
+/**
+ * Class ProductRepositoryTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ *
+ * @property ProductRepository  $product_repository
+ * @property ProductMetaHandler $product_meta
+ * @property ProductHelper      $product_helper
+ */
+class ProductRepositoryTest extends ContainerAwareUnitTest {
+
+	use ProductTrait;
+
+	public function test_find_returns_all_supported_products() {
+		// supported
+		$simple_product   = WC_Helper_Product::create_simple_product();
+		$variable_product = WC_Helper_Product::create_variation_product();
+
+		// unsupported
+		WC_Helper_Product::create_external_product();
+
+		$results = $this->product_repository->find();
+
+		$variations = array_map( 'wc_get_product', $variable_product->get_children() );
+		$this->assertCount( count( $variations ) + 2, $results );
+		$this->assertEqualSets(
+			array_merge(
+				[
+					wc_get_product( $simple_product->get_id() ),
+					wc_get_product( $variable_product->get_id() ),
+				],
+				$variations
+			),
+			$results
+		);
+	}
+
+	public function test_find_always_returns_objects() {
+		WC_Helper_Product::create_simple_product();
+		$results = $this->product_repository->find( [ 'return' => 'ids' ] );
+		$this->assertContainsOnlyInstancesOf( WC_Product::class, $results );
+	}
+
+	public function test_find_returns_limited_and_based_on_offset() {
+		WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_variation_product();
+
+		$results_unlimited = $this->product_repository->find();
+
+		$results = $this->product_repository->find( [], 1, 1 );
+		$this->assertCount( 1, $results );
+		$this->assertEquals( [ wc_get_product( $results_unlimited[1]->get_id() ) ], $results );
+	}
+
+	public function test_find_ids_always_returns_integer_ids() {
+		WC_Helper_Product::create_simple_product();
+		$results = $this->product_repository->find_ids( [ 'return' => 'objects' ] );
+		$this->assertContainsOnly( 'integer', $results );
+	}
+
+	public function test_find_passes_query_args() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$product_1->set_status( 'draft' );
+		$product_1->save();
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$product_2->set_status( 'draft' );
+		$product_2->save();
+		$this->product_meta->update_errors( $product_2, [ 'Error' ] );
+
+		$product_3 = WC_Helper_Product::create_simple_product();
+		$product_3->set_status( 'publish' );
+		$product_3->save();
+
+		WC_Helper_Product::create_variation_product();
+
+		$query_args = [
+			'status'     => 'draft',
+			'type'       => [ 'simple' ],
+			'meta_query' => [
+				'relation' => 'OR',
+				[
+					'key'     => ProductMetaHandler::KEY_ERRORS,
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => ProductMetaHandler::KEY_ERRORS,
+					'compare' => '=',
+					'value'   => '',
+				],
+			],
+		];
+		$this->assertEquals( [ $product_1->get_id() ], $this->product_repository->find_ids( $query_args ) );
+		$this->assertEquals( [ wc_get_product( $product_1 ) ], $this->product_repository->find( $query_args ) );
+	}
+
+	public function test_find_by_ids() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$product_2 = WC_Helper_Product::create_simple_product();
+
+		$ids = [
+			$product_1->get_id(),
+			$product_2->get_id(),
+		];
+
+		$this->assertEqualSets(
+			array_map( 'wc_get_product', $ids ),
+			$this->product_repository->find_by_ids( $ids )
+		);
+	}
+
+	public function test_find_synced_products() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+
+		WC_Helper_Product::create_simple_product();
+
+		$this->assertEquals(
+			[ wc_get_product( $product_1->get_id() ) ],
+			$this->product_repository->find_synced_products()
+		);
+
+		$this->assertEquals(
+			[ $product_1->get_id() ],
+			$this->product_repository->find_synced_product_ids()
+		);
+	}
+
+	public function test_find_sync_ready_products() {
+		// create some products that are not sync ready
+
+		// manually set to dont-sync-and-show
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_meta->update_visibility( $product_1, ChannelVisibility::DONT_SYNC_AND_SHOW );
+
+		// product status is set to private and therefore not supported
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_meta->update_visibility( $product_2, ChannelVisibility::SYNC_AND_SHOW );
+		$product_2->set_status( 'private' );
+		$product_2->save();
+
+		// product type is not supported
+		$product_3 = WC_Helper_Product::create_external_product();
+		$this->product_meta->update_visibility( $product_3, ChannelVisibility::SYNC_AND_SHOW );
+
+		// syncing this product has failed several times recently
+		$product_4 = WC_Helper_Product::create_simple_product();
+		$this->product_meta->update_visibility( $product_4, ChannelVisibility::SYNC_AND_SHOW );
+		$this->product_meta->update_failed_sync_attempts( $product_4, ProductSyncer::FAILURE_THRESHOLD + 1 );
+		$this->product_meta->update_sync_failed_at( $product_4, strtotime( '+1 year' ) );
+
+		// a simple product that is sync ready
+		$simple_product = WC_Helper_Product::create_simple_product();
+		$this->product_meta->update_visibility( $simple_product, ChannelVisibility::SYNC_AND_SHOW );
+
+		// a variable product that is sync ready along with all its variations
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$this->product_meta->update_visibility( wc_get_product( $variable_product ), ChannelVisibility::SYNC_AND_SHOW );
+		foreach ( $variable_product->get_children() as $variation_id ) {
+			$this->product_meta->update_visibility( wc_get_product( $variation_id ), ChannelVisibility::SYNC_AND_SHOW );
+		}
+
+		$results = $this->product_repository->find_sync_ready_products();
+
+		// compare the IDs because the objects might not be identical
+		$result_ids = array_map(
+			function ( WC_Product $product ) {
+				return $product->get_id();
+			},
+			$results
+		);
+		$this->assertEquals(
+			array_merge( [ $simple_product->get_id() ], $variable_product->get_children() ),
+			$result_ids
+		);
+		$this->assertEquals(
+			array_merge( [ $simple_product->get_id() ], $variable_product->get_children() ),
+			$this->product_repository->find_sync_ready_product_ids()
+		);
+	}
+
+	public function test_find_expiring_product_ids() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
+		$this->product_meta->update_synced_at( $product_2, strtotime( '-30 days' ) );
+
+		$product_3 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_invalid( $product_3, [ 'Error 1' ] );
+
+		$this->assertEquals(
+			[ $product_2->get_id() ],
+			$this->product_repository->find_expiring_product_ids()
+		);
+	}
+
+	public function test_find_mc_not_synced_product_ids() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_meta->update_mc_status( $product_2, MCStatus::NOT_SYNCED );
+
+		WC_Helper_Product::create_simple_product();
+
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$this->product_meta->update_mc_status( $variable_product, MCStatus::NOT_SYNCED );
+		foreach ( $variable_product->get_children() as $variation_id ) {
+			$this->product_meta->update_mc_status( wc_get_product( $variation_id ), MCStatus::NOT_SYNCED );
+		}
+
+		$this->assertEqualSets(
+			[ $product_2->get_id(), $variable_product->get_id() ],
+			$this->product_repository->find_mc_not_synced_product_ids()
+		);
+	}
+
+	public function test_find_all_synced_google_ids() {
+		$synced_google_ids = [];
+
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock( 'online:en:US:gla_' . $product_1->get_id() ) );
+		$synced_google_ids[] = 'online:en:US:gla_' . $product_1->get_id();
+
+		// a synced product with an invalid google id set
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock( 'online:en:US:gla_' . $product_2->get_id() ) );
+		$product_2->update_meta_data( '_wc_gla_google_ids', 1 );
+		$product_2->save();
+
+		WC_Helper_Product::create_simple_product();
+
+		$variable_product = WC_Helper_Product::create_variation_product();
+		foreach ( $variable_product->get_children() as $variation_id ) {
+			$this->product_helper->mark_as_synced( wc_get_product( $variation_id ), $this->generate_google_product_mock( 'online:en:US:gla_' . $variation_id ) );
+			$synced_google_ids[] = 'online:en:US:gla_' . $variation_id;
+		}
+
+		$this->assertEqualSets(
+			$synced_google_ids,
+			$this->product_repository->find_all_synced_google_ids()
+		);
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->product_meta       = $this->container->get( ProductMetaHandler::class );
+		$this->product_helper     = $this->container->get( ProductHelper::class );
+		$this->product_repository = $this->container->get( ProductRepository::class );
+	}
+}

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -37,16 +37,16 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 
 		$results = $this->product_repository->find();
 
-		$variations = array_map( 'wc_get_product', $variable_product->get_children() );
-		$this->assertCount( count( $variations ) + 2, $results );
+		$expected = array_merge(
+			[
+				wc_get_product( $simple_product->get_id() ),
+				wc_get_product( $variable_product->get_id() ),
+			],
+			array_map( 'wc_get_product', $variable_product->get_children() )
+		);
+		$this->assertCount( count( $expected ), $results );
 		$this->assertEqualSets(
-			array_merge(
-				[
-					wc_get_product( $simple_product->get_id() ),
-					wc_get_product( $variable_product->get_id() ),
-				],
-				$variations
-			),
+			$expected,
 			$results
 		);
 	}

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -37,17 +37,23 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 
 		$results = $this->product_repository->find();
 
+		$this->assertContainsOnlyInstancesOf( WC_Product::class, $results );
+
 		$expected = array_merge(
 			[
-				wc_get_product( $simple_product->get_id() ),
-				wc_get_product( $variable_product->get_id() ),
+				$simple_product->get_id(),
+				$variable_product->get_id(),
 			],
-			array_map( 'wc_get_product', $variable_product->get_children() )
+			$variable_product->get_children()
 		);
+
 		$this->assertCount( count( $expected ), $results );
-		$this->assertEqualSets(
+
+		// compare the IDs because the objects might not be identical
+		$result_ids = array_map( [ __CLASS__, 'get_product_id' ], $results );
+		$this->assertEquals(
 			$expected,
-			$results
+			$result_ids
 		);
 	}
 
@@ -64,8 +70,12 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		$results_unlimited = $this->product_repository->find();
 
 		$results = $this->product_repository->find( [], 1, 1 );
+
 		$this->assertCount( 1, $results );
-		$this->assertEquals( [ wc_get_product( $results_unlimited[1]->get_id() ) ], $results );
+
+		// compare the IDs because the objects might not be identical
+		$result_ids = array_map( [ __CLASS__, 'get_product_id' ], $results );
+		$this->assertEquals( [ $results_unlimited[1]->get_id() ], $result_ids );
 	}
 
 	public function test_find_ids_always_returns_integer_ids() {
@@ -107,7 +117,10 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 			],
 		];
 		$this->assertEquals( [ $product_1->get_id() ], $this->product_repository->find_ids( $query_args ) );
-		$this->assertEquals( [ wc_get_product( $product_1 ) ], $this->product_repository->find( $query_args ) );
+
+		// compare the IDs because the objects might not be identical
+		$result_ids = array_map( [ __CLASS__, 'get_product_id' ], $this->product_repository->find( $query_args ) );
+		$this->assertEquals( [ $product_1->get_id() ], $result_ids );
 	}
 
 	public function test_find_by_ids() {
@@ -133,9 +146,11 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 
 		WC_Helper_Product::create_simple_product();
 
+		// compare the IDs because the objects might not be identical
+		$result_ids = array_map( [ __CLASS__, 'get_product_id' ], $this->product_repository->find_synced_products() );
 		$this->assertEquals(
-			[ wc_get_product( $product_1->get_id() ) ],
-			$this->product_repository->find_synced_products()
+			[ $product_1->get_id() ],
+			$result_ids
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
Changes proposed in this Pull Request:

This PR adds unit tests for the `ProductRepository` class. It also removes unused functions from the ProductRepository class. These methods were previously added here but I noticed that they are no longer used anywhere.

I was thinking of deprecating them first but not sure if it's worth the effort since they are very specific methods and unlikely used by any third parties.

Continuing from #846

### Detailed test instructions:

- Run `phpunit` and make sure all the tests pass
