### PR TITLE
Add unit tests for functions within `.~/data/utils.js`

### DIFF
--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -151,9 +151,10 @@ export const fieldsToPerformance = (
  *
  * @param {number} [value] The primary report field fetched from report API.
  * @param {number} [base] The secondary report field fetched from report API.
- * @return {number | null} The calculated performance data of each metric. `null` if any number is missing, or the result is not finite.
+ * @return {number | null} The delta percentage calculated by the `value` compared to the `base` and then rounded to second decimal.
+ *                         `null` if any number is not number type, or the result is not finite.
  */
-function calculateDelta( value, base ) {
+export function calculateDelta( value, base ) {
 	let delta = null;
 	if ( typeof value === 'number' && typeof base === 'number' ) {
 		delta = 0;

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -1,7 +1,13 @@
 /**
  * Internal dependencies
  */
-import { getReportQuery, getReportKey, freeFields, paidFields } from './utils';
+import {
+	getReportQuery,
+	getReportKey,
+	calculateDelta,
+	freeFields,
+	paidFields,
+} from './utils';
 
 /**
  * Calls given function with all combinations of possible categories and dataReferences.
@@ -150,5 +156,41 @@ describe( 'getReportKey', () => {
 		};
 
 		expect( getReportKey( '', '', reportQuery ) ).toBe( sameKey );
+	} );
+} );
+
+describe( 'calculateDelta', () => {
+	it( 'should return null if any parameter to be calculated is not a number', () => {
+		expect( calculateDelta() ).toBeNull();
+		expect( calculateDelta( 1 ) ).toBeNull();
+
+		expect( calculateDelta( 1, null ) ).toBeNull();
+		expect( calculateDelta( undefined, 1 ) ).toBeNull();
+
+		expect( calculateDelta( 1, '' ) ).toBeNull();
+		expect( calculateDelta( '1', 1 ) ).toBeNull();
+
+		expect( calculateDelta( true, 1 ) ).toBeNull();
+		expect( calculateDelta( 1, {} ) ).toBeNull();
+	} );
+
+	it( 'should return null if the result is not finite', () => {
+		expect( calculateDelta( 1, 0 ) ).toBeNull();
+		expect( calculateDelta( NaN, 1 ) ).toBeNull();
+	} );
+
+	it( 'should return 0 if both base and value are 0', () => {
+		expect( calculateDelta( 0, 0 ) ).toBe( 0 );
+	} );
+
+	it( 'should return delta percentage rounded to second decimal', () => {
+		expect( calculateDelta( 20, 10 ) ).toBe( 100 );
+		expect( calculateDelta( 25, 10 ) ).toBe( 150 );
+
+		expect( calculateDelta( 0, 10 ) ).toBe( -100 );
+		expect( calculateDelta( 5, 10 ) ).toBe( -50 );
+
+		expect( calculateDelta( 4, 3 ) ).toBe( 33.33 );
+		expect( calculateDelta( 5, 3 ) ).toBe( 66.67 );
 	} );
 } );

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -65,4 +65,44 @@ describe( 'getReportQuery', () => {
 			).toHaveProperty( 'orderby', freeFields[ 0 ] );
 		} );
 	} );
+
+	it( 'should have no `ids` field if the query does not contain `programs` or `products`', () => {
+		forAnyCategoryAndDateReference( ( category, dateReference ) => {
+			const query = {};
+
+			expect(
+				getReportQuery( category, 'free', query, dateReference ).ids
+			).toBeUndefined();
+		} );
+	} );
+
+	it( 'should have `ids` field if the programs report query contains `programs`', () => {
+		const query = {
+			programs: '123,456',
+		};
+
+		expect(
+			getReportQuery( 'programs', 'free', query, 'primary' ).ids
+		).toBe( query.programs );
+	} );
+
+	it( 'should have transformed `ids` field if the products report query contains `products`', () => {
+		// Search single product.
+		const oneProductQuery = {
+			products: '2468',
+		};
+
+		expect(
+			getReportQuery( 'products', 'free', oneProductQuery, 'primary' ).ids
+		).toBe( 'gla_2468' );
+
+		// Search multiple products.
+		const productsQuery = {
+			products: '123,456,7890',
+		};
+
+		expect(
+			getReportQuery( 'products', 'free', productsQuery, 'primary' ).ids
+		).toBe( 'gla_123,gla_456,gla_7890' );
+	} );
 } );

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -79,8 +79,8 @@ describe( 'getReportQuery', () => {
 			const query = {};
 
 			expect(
-				getReportQuery( category, 'free', query, dateReference ).ids
-			).toBeUndefined();
+				getReportQuery( category, 'free', query, dateReference )
+			).not.toHaveProperty( 'ids' );
 		} );
 	} );
 
@@ -90,8 +90,8 @@ describe( 'getReportQuery', () => {
 		};
 
 		expect(
-			getReportQuery( 'programs', 'free', query, 'primary' ).ids
-		).toBe( query.programs );
+			getReportQuery( 'programs', 'free', query, 'primary' )
+		).toHaveProperty( 'ids', query.programs );
 	} );
 
 	it( 'When the products report query contains `products`, should have `ids` field, with values prepended with `gla_`', () => {
@@ -101,8 +101,8 @@ describe( 'getReportQuery', () => {
 		};
 
 		expect(
-			getReportQuery( 'products', 'free', oneProductQuery, 'primary' ).ids
-		).toBe( 'gla_2468' );
+			getReportQuery( 'products', 'free', oneProductQuery, 'primary' )
+		).toHaveProperty( 'ids', 'gla_2468' );
 
 		// Search multiple products.
 		const productsQuery = {
@@ -110,8 +110,8 @@ describe( 'getReportQuery', () => {
 		};
 
 		expect(
-			getReportQuery( 'products', 'free', productsQuery, 'primary' ).ids
-		).toBe( 'gla_123,gla_456,gla_7890' );
+			getReportQuery( 'products', 'free', productsQuery, 'primary' )
+		).toHaveProperty( 'ids', 'gla_123,gla_456,gla_7890' );
 	} );
 } );
 

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -198,6 +198,19 @@ describe( 'calculateDelta', () => {
 } );
 
 describe( 'mapReportFieldsToPerformance', () => {
+	it( 'should apply default values for `primary` and `secondary`', () => {
+		const primary = { hello: 0 };
+		const secondary = { howdy: 1 };
+
+		expect( mapReportFieldsToPerformance() ).toEqual( {} );
+		expect( mapReportFieldsToPerformance( undefined, secondary ) ).toEqual(
+			{}
+		);
+		expect( mapReportFieldsToPerformance( primary ) ).toHaveProperty(
+			'hello'
+		);
+	} );
+
 	it( 'should take keys of `primary` as metric field keys', () => {
 		const primary = { hello: 0, howdy: 1 };
 		const primaryKeys = Object.keys( primary );

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -231,7 +231,7 @@ describe( 'mapReportFieldsToPerformance', () => {
 		} );
 	} );
 
-	it( "When the metric field doesn't exists in one of `primary` and `secondary`, should flag anticipated data is not returned from API", () => {
+	it( "When the metric field doesn't exist in one of `primary` and `secondary`, should flag anticipated data is not returned from API", () => {
 		// "a" does not exist in `secondary`
 		let performance = mapReportFieldsToPerformance( { a: 1 }, { b: 2 } );
 		expect( performance ).toMatchObject( {

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getReportQuery, freeFields, paidFields } from './utils';
+import { getReportQuery, getReportKey, freeFields, paidFields } from './utils';
 
 /**
  * Calls given function with all combinations of possible categories and dataReferences.
@@ -104,5 +104,51 @@ describe( 'getReportQuery', () => {
 		expect(
 			getReportQuery( 'products', 'free', productsQuery, 'primary' ).ids
 		).toBe( 'gla_123,gla_456,gla_7890' );
+	} );
+} );
+
+describe( 'getReportKey', () => {
+	it( 'should get a key with given `category`, `type` and `reportQuery`', () => {
+		const reportQuery = {
+			foo: 'bar',
+		};
+
+		expect( getReportKey( 'programs', 'free', reportQuery ) ).toBe(
+			'programs:free:{"foo":"bar"}'
+		);
+		expect( getReportKey( 'products', 'paid', reportQuery ) ).toBe(
+			'products:paid:{"foo":"bar"}'
+		);
+	} );
+
+	it( 'should get the same key regardless of the property order within the `reportQuery` object', () => {
+		const sameKey = '::{"apple":"","banana":"","cat":"","dog":""}';
+
+		let reportQuery = {
+			apple: '',
+			banana: '',
+			cat: '',
+			dog: '',
+		};
+
+		expect( getReportKey( '', '', reportQuery ) ).toBe( sameKey );
+
+		reportQuery = {
+			dog: '',
+			cat: '',
+			banana: '',
+			apple: '',
+		};
+
+		expect( getReportKey( '', '', reportQuery ) ).toBe( sameKey );
+
+		reportQuery = {
+			banana: '',
+			dog: '',
+			apple: '',
+			cat: '',
+		};
+
+		expect( getReportKey( '', '', reportQuery ) ).toBe( sameKey );
 	} );
 } );

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -94,7 +94,7 @@ describe( 'getReportQuery', () => {
 		).toBe( query.programs );
 	} );
 
-	it( 'When the products report query contains `products`, should have transformed `ids` field', () => {
+	it( 'When the products report query contains `products`, should have `ids` field, with values prepended with `gla_`', () => {
 		// Search single product.
 		const oneProductQuery = {
 			products: '2468',

--- a/js/src/data/utils.test.js
+++ b/js/src/data/utils.test.js
@@ -74,7 +74,7 @@ describe( 'getReportQuery', () => {
 		} );
 	} );
 
-	it( 'should have no `ids` field if the query does not contain `programs` or `products`', () => {
+	it( 'When the query does not contain `programs` or `products`, should have no `ids` field', () => {
 		forAnyCategoryAndDateReference( ( category, dateReference ) => {
 			const query = {};
 
@@ -84,7 +84,7 @@ describe( 'getReportQuery', () => {
 		} );
 	} );
 
-	it( 'should have `ids` field if the programs report query contains `programs`', () => {
+	it( 'When the programs report query contains `programs`, should have `ids` field', () => {
 		const query = {
 			programs: '123,456',
 		};
@@ -94,7 +94,7 @@ describe( 'getReportQuery', () => {
 		).toBe( query.programs );
 	} );
 
-	it( 'should have transformed `ids` field if the products report query contains `products`', () => {
+	it( 'When the products report query contains `products`, should have transformed `ids` field', () => {
 		// Search single product.
 		const oneProductQuery = {
 			products: '2468',
@@ -129,7 +129,7 @@ describe( 'getReportKey', () => {
 		);
 	} );
 
-	it( 'should get the same key regardless of the property order within the `reportQuery` object', () => {
+	it( 'Regardless of the property order within the `reportQuery` object, should get the same key', () => {
 		const sameKey = '::{"apple":"","banana":"","cat":"","dog":""}';
 
 		let reportQuery = {
@@ -162,7 +162,7 @@ describe( 'getReportKey', () => {
 } );
 
 describe( 'calculateDelta', () => {
-	it( 'should return null if any parameter to be calculated is not a number', () => {
+	it( 'When any given parameter is not a number, should return null', () => {
 		expect( calculateDelta() ).toBeNull();
 		expect( calculateDelta( 1 ) ).toBeNull();
 
@@ -176,12 +176,12 @@ describe( 'calculateDelta', () => {
 		expect( calculateDelta( 1, {} ) ).toBeNull();
 	} );
 
-	it( 'should return null if the result is not finite', () => {
+	it( 'When the result is not finite, should return null', () => {
 		expect( calculateDelta( 1, 0 ) ).toBeNull();
 		expect( calculateDelta( NaN, 1 ) ).toBeNull();
 	} );
 
-	it( 'should return 0 if both base and value are 0', () => {
+	it( 'When both `base` and `value` are 0, should return 0', () => {
 		expect( calculateDelta( 0, 0 ) ).toBe( 0 );
 	} );
 
@@ -208,7 +208,7 @@ describe( 'mapReportFieldsToPerformance', () => {
 		expect( keys ).toEqual( expect.arrayContaining( primaryKeys ) );
 	} );
 
-	it( "should take specified `fields` as metric field keys if it's given", () => {
+	it( 'When the specified `fields` is given, should take it as metric field keys', () => {
 		const primary = { hello: 0, howdy: 1 };
 		const performance = mapReportFieldsToPerformance(
 			primary,
@@ -221,7 +221,7 @@ describe( 'mapReportFieldsToPerformance', () => {
 		expect( keys ).toEqual( expect.arrayContaining( freeFields ) );
 	} );
 
-	it( 'should flag no anticipated data is missing if the same field exists in both `primary` and `secondary`', () => {
+	it( 'When the metric field exists in both `primary` and `secondary`, should flag no anticipated data is missing', () => {
 		const performance = mapReportFieldsToPerformance( { a: 1 }, { a: 2 } );
 
 		expect( performance ).toMatchObject( {
@@ -231,7 +231,7 @@ describe( 'mapReportFieldsToPerformance', () => {
 		} );
 	} );
 
-	it( "should flag anticipated data is not returned from API if the field doesn't exists in one of `primary` and `secondary`", () => {
+	it( "When the metric field doesn't exists in one of `primary` and `secondary`, should flag anticipated data is not returned from API", () => {
 		// "a" does not exist in `secondary`
 		let performance = mapReportFieldsToPerformance( { a: 1 }, { b: 2 } );
 		expect( performance ).toMatchObject( {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add unit tests for functions within `.~/data/utils.js`

- Add test cases for the returning `ids` field of `getReportQuery` function
- Add test cases for `getReportKey`, `calculateDelta`, and `mapReportFieldsToPerformance` functions

### Detailed test instructions:

1. Run `npm run test-unit` and make sure all these tests pass

### Changelog entry
