### PR TITLE
Return 401 when retrieving status data

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -98,7 +98,7 @@ class IssuesController extends BaseOptionsController {
 				try {
 					$issue['product_id'] = $this->product_helper->maybe_swap_for_parent_id( $issue['product_id'] );
 				} catch ( InvalidValue $e ) {
-					// Don't include valid products
+					// Don't include invalid products
 					do_action(
 						'woocommerce_gla_debug_message',
 						sprintf( 'Merchant Center product ID %s not found in this WooCommerce store.', $issue['product_id'] ),

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -8,8 +8,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use WP_REST_Request as Request;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Exception;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -79,8 +81,12 @@ class IssuesController extends BaseOptionsController {
 			$per_page    = intval( $request['per_page'] );
 			$page        = max( 1, intval( $request['page'] ) );
 
-			$results         = $this->merchant_statuses->get_issues( $type_filter, $per_page, $page );
-			$results['page'] = $page;
+			try {
+				$results         = $this->merchant_statuses->get_issues( $type_filter, $per_page, $page );
+				$results['page'] = $page;
+			} catch ( Exception $e ) {
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+			}
 
 			// Replace variation IDs with parent ID (for Edit links).
 			foreach ( $results['issues'] as &$issue ) {

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -68,6 +68,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 	 * @return array
 	 *
 	 * @throws InvalidValue If the orderby value isn't valid.
+	 * @throws Exception If the status data can't be retrieved from Google.
 	 */
 	public function get( WP_REST_Request $request ): array {
 		$this->request          = $request;

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -54,8 +54,16 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * @return bool
 	 */
 	public function is_connected(): bool {
-		$google_connected = boolval( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) );
-		return $google_connected && $this->is_setup_complete();
+		return $this->is_google_connected() && $this->is_setup_complete();
+	}
+
+	/**
+	 * Get whether the dependent Google account is connected.
+	 *
+	 * @return bool
+	 */
+	public function is_google_connected(): bool {
+		return boolval( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -163,8 +163,15 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			return;
 		}
 
-		// Save a request if no MC account connected.
-		if ( ! $this->container->get( MerchantCenterService::class )->is_connected() ) {
+		// Save a request if accounts are not connected.
+		$mc_service = $this->container->get( MerchantCenterService::class );
+		if ( ! $mc_service->is_connected() ) {
+
+			// Return a 401 to redirect to reconnect flow if the Google account is not connected.
+			if ( ! $mc_service->is_google_connected() ) {
+				throw new Exception( __( 'Google Account is not connected.', 'google-listings-and-ads' ), 401 );
+			}
+
 			throw new Exception( __( 'No Merchant Center account connected.', 'google-listings-and-ads' ) );
 		}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -169,10 +169,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 			// Return a 401 to redirect to reconnect flow if the Google account is not connected.
 			if ( ! $mc_service->is_google_connected() ) {
-				throw new Exception( __( 'Google Account is not connected.', 'google-listings-and-ads' ), 401 );
+				throw new Exception( __( 'Google account is not connected.', 'google-listings-and-ads' ), 401 );
 			}
 
-			throw new Exception( __( 'No Merchant Center account connected.', 'google-listings-and-ads' ) );
+			throw new Exception( __( 'Merchant Center account is not set up.', 'google-listings-and-ads' ) );
 		}
 
 		$this->mc_statuses = [];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR specifically checks if the Google Account is not connected when we retrieve the status data. This error returns a 401 error which triggers the UI to enter the reconnect flow.

Closes #847 

### Detailed test instructions:

1. Set the Google Account as disconnected by setting the option `gla_google_connected` to 0 in the `wp_options` table
2. Clear the status transient from the Connection test page
3. Send a request to `GET /wc/gla/mc/product-statistics`
4. Confirm we get a 401 response with the message "Google Account is not connected."


### Changelog entry
* Tweak - 401 error when retrieving status data and Google account is not connected.