### PR TITLE
Merchant Center must be setup and connected to sync products

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -1027,7 +1027,7 @@ class ConnectionTest implements Service, Registerable {
 					// schedule a job
 					/** @var UpdateProducts $update_job */
 					$update_job = $this->container->get( UpdateProducts::class );
-					$update_job->start( [ [ $product->get_id() ] ] );
+					$update_job->schedule( [ [ $product->get_id() ] ] );
 					$this->response = 'Successfully scheduled a job to sync the product ' . $product->get_id();
 				}
 			} else {
@@ -1061,7 +1061,7 @@ class ConnectionTest implements Service, Registerable {
 				// schedule a job
 				/** @var UpdateAllProducts $update_job */
 				$update_job = $this->container->get( UpdateAllProducts::class );
-				$update_job->start();
+				$update_job->schedule();
 				$this->response = 'Successfully scheduled a job to sync all products!';
 			}
 		}
@@ -1092,7 +1092,7 @@ class ConnectionTest implements Service, Registerable {
 				// schedule a job
 				/** @var DeleteAllProducts $delete_job */
 				$delete_job = $this->container->get( DeleteAllProducts::class );
-				$delete_job->start();
+				$delete_job->schedule();
 				$this->response = 'Successfully scheduled a job to delete all synced products!';
 			}
 		}
@@ -1126,7 +1126,7 @@ class ConnectionTest implements Service, Registerable {
 				// schedule a job
 				/** @var CleanupProductsJob $delete_job */
 				$delete_job = $this->container->get( CleanupProductsJob::class );
-				$delete_job->start();
+				$delete_job->schedule();
 				$this->response = 'Successfully scheduled a job to cleanup all products!';
 			}
 		}

--- a/src/Event/StartProductSync.php
+++ b/src/Event/StartProductSync.php
@@ -48,9 +48,9 @@ class StartProductSync implements Registerable, Service {
 	 */
 	protected function on_settings_sync() {
 		$cleanup = $this->job_repository->get( CleanupProductsJob::class );
-		$cleanup->start();
+		$cleanup->schedule();
 
 		$update = $this->job_repository->get( UpdateAllProducts::class );
-		$update->start();
+		$update->schedule();
 	}
 }

--- a/src/Jobs/AbstractActionSchedulerJob.php
+++ b/src/Jobs/AbstractActionSchedulerJob.php
@@ -51,13 +51,13 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	}
 
 	/**
-	 * Can the job start.
+	 * Can the job be scheduled.
 	 *
 	 * @param array|null $args
 	 *
-	 * @return bool Returns true if the job can start.
+	 * @return bool Returns true if the job can be scheduled.
 	 */
-	public function can_start( $args = [] ): bool {
+	public function can_schedule( $args = [] ): bool {
 		return ! $this->is_running( $args );
 	}
 

--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -47,7 +47,7 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 *
 	 * @param array $args
 	 */
-	public function start( array $args = [] ) {
+	public function schedule( array $args = [] ) {
 		$this->schedule_create_batch_action( 1 );
 	}
 

--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -113,7 +113,7 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 * @param int $batch_number The batch number for the new batch.
 	 */
 	protected function schedule_create_batch_action( int $batch_number ) {
-		if ( $this->can_start( [ $batch_number ] ) ) {
+		if ( $this->can_schedule( [ $batch_number ] ) ) {
 			$this->action_scheduler->schedule_immediate( $this->get_create_batch_hook(), [ $batch_number ] );
 		}
 	}

--- a/src/Jobs/AbstractProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractProductSyncerBatchedJob.php
@@ -67,13 +67,13 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	}
 
 	/**
-	 * Can the job start.
+	 * Can the job be scheduled.
 	 *
 	 * @param array|null $args
 	 *
-	 * @return bool Returns true if the job can start.
+	 * @return bool Returns true if the job can be scheduled.
 	 */
-	public function can_start( $args = [] ): bool {
+	public function can_schedule( $args = [] ): bool {
 		return ! $this->is_running( $args ) && $this->is_mc_connected();
 	}
 }

--- a/src/Jobs/AbstractProductSyncerJob.php
+++ b/src/Jobs/AbstractProductSyncerJob.php
@@ -58,13 +58,13 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob imple
 	}
 
 	/**
-	 * Can the job start.
+	 * Can the job be scheduled.
 	 *
 	 * @param array|null $args
 	 *
-	 * @return bool Returns true if the job can start.
+	 * @return bool Returns true if the job can be scheduled.
 	 */
-	public function can_start( $args = [] ): bool {
+	public function can_schedule( $args = [] ): bool {
 		return ! $this->is_running( $args ) && $this->is_mc_connected();
 	}
 }

--- a/src/Jobs/ActionSchedulerJobInterface.php
+++ b/src/Jobs/ActionSchedulerJobInterface.php
@@ -22,13 +22,13 @@ interface ActionSchedulerJobInterface extends JobInterface {
 	public function get_process_item_hook(): string;
 
 	/**
-	 * Can the job start.
+	 * Can the job be scheduled.
 	 *
 	 * @param array|null $args
 	 *
-	 * @return bool Returns true if the job can start.
+	 * @return bool Returns true if the job can be scheduled.
 	 */
-	public function can_start( $args = [] ): bool;
+	public function can_schedule( $args = [] ): bool;
 
 	/**
 	 * Start the job.

--- a/src/Jobs/ActionSchedulerJobInterface.php
+++ b/src/Jobs/ActionSchedulerJobInterface.php
@@ -31,10 +31,10 @@ interface ActionSchedulerJobInterface extends JobInterface {
 	public function can_schedule( $args = [] ): bool;
 
 	/**
-	 * Start the job.
+	 * Schedule the job.
 	 *
 	 * @param array $args
 	 */
-	public function start( array $args = [] );
+	public function schedule( array $args = [] );
 
 }

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -42,13 +42,13 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	}
 
 	/**
-	 * Start the job.
+	 * Schedule the job.
 	 *
 	 * @param array $args
 	 *
 	 * @throws JobException If no product is provided as argument. The exception will be logged by ActionScheduler.
 	 */
-	public function start( array $args = [] ) {
+	public function schedule( array $args = [] ) {
 		$args   = $args[0] ?? [];
 		$id_map = ( new ProductIDMap( $args ) )->get();
 

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -56,7 +56,7 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 			throw JobException::item_not_provided( 'Array of WooCommerce product IDs' );
 		}
 
-		if ( $this->can_start( [ $id_map ] ) ) {
+		if ( $this->can_schedule( [ $id_map ] ) ) {
 			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), [ $id_map ] );
 		}
 	}

--- a/src/Jobs/JobException.php
+++ b/src/Jobs/JobException.php
@@ -52,7 +52,7 @@ class JobException extends RuntimeException implements GoogleListingsAndAdsExcep
 		return new static(
 			sprintf(
 				/* translators: %s: the job name */
-				__( 'The "%s" job was stopped because it\'s failure rate is above the allowed threshold.', 'google-listings-and-ads' ),
+				__( 'The "%s" job was stopped because its failure rate is above the allowed threshold.', 'google-listings-and-ads' ),
 				$job_name
 			)
 		);

--- a/src/Jobs/JobInitializer.php
+++ b/src/Jobs/JobInitializer.php
@@ -51,7 +51,7 @@ class JobInitializer implements Registerable, Conditional {
 				add_action(
 					$job->get_start_hook()->get_hook(),
 					function ( ...$args ) use ( $job ) {
-						$job->start( $args );
+						$job->schedule( $args );
 					},
 					10,
 					$job->get_start_hook()->get_argument_count()

--- a/src/Jobs/JobInitializer.php
+++ b/src/Jobs/JobInitializer.php
@@ -60,7 +60,7 @@ class JobInitializer implements Registerable, Conditional {
 
 			if ( $job instanceof RecurringJobInterface &&
 				 ! $this->action_scheduler->has_scheduled_action( $job->get_start_hook()->get_hook() ) &&
-				 $job->can_start() ) {
+				 $job->can_schedule() ) {
 
 				$recurring_date_time = new DateTime( 'tomorrow 3am', wp_timezone() );
 				$schedule            = '0 3 * * *'; // 3 am every day

--- a/src/Jobs/Update/PluginUpdate.php
+++ b/src/Jobs/Update/PluginUpdate.php
@@ -54,20 +54,20 @@ class PluginUpdate implements Service, InstallableInterface {
 	public function install( string $old_version, string $new_version ): void {
 		foreach ( $this->updates as $version => $jobs ) {
 			if ( version_compare( $old_version, $version, '<' ) ) {
-				$this->start_jobs( $jobs );
+				$this->schedule_jobs( $jobs );
 			}
 		}
 	}
 
 	/**
-	 * Start a list of jobs.
+	 * Schedules a list of jobs.
 	 *
 	 * @param array $jobs List of jobs
 	 */
-	protected function start_jobs( array $jobs ): void {
+	protected function schedule_jobs( array $jobs ): void {
 		foreach ( $jobs as $job ) {
 			try {
-				$this->job_repository->get( $job )->start();
+				$this->job_repository->get( $job )->schedule();
 			} catch ( JobException $e ) {
 				do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
 			}

--- a/src/Jobs/UpdateProducts.php
+++ b/src/Jobs/UpdateProducts.php
@@ -47,13 +47,13 @@ class UpdateProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	}
 
 	/**
-	 * Start the job.
+	 * Schedule the job.
 	 *
 	 * @param array[] $args
 	 *
 	 * @throws JobException If no product is provided as argument. The exception will be logged by ActionScheduler.
 	 */
-	public function start( array $args = [] ) {
+	public function schedule( array $args = [] ) {
 		$args = $args[0] ?? [];
 		$ids  = array_filter( $args, 'is_integer' );
 

--- a/src/Jobs/UpdateProducts.php
+++ b/src/Jobs/UpdateProducts.php
@@ -61,7 +61,7 @@ class UpdateProducts extends AbstractProductSyncerJob implements StartOnHookInte
 			throw JobException::item_not_provided( 'Array of WooCommerce Product IDs' );
 		}
 
-		if ( $this->can_start( [ $ids ] ) ) {
+		if ( $this->can_schedule( [ $ids ] ) ) {
 			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), [ $ids ] );
 		}
 	}

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -289,7 +289,7 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 	 */
 	protected function validate_merchant_center_setup(): void {
 		if ( ! $this->merchant_center->is_connected() ) {
-			do_action( 'woocommerce_gla_error', 'Can not sync any products before setting up Google Merchant Center.', __METHOD__ );
+			do_action( 'woocommerce_gla_error', 'Cannot sync any products before setting up Google Merchant Center.', __METHOD__ );
 
 			throw new ProductSyncerException( __( 'Google Merchant Center has not been set up correctly. Please review your configuration.', 'google-listings-and-ads' ) );
 		}

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -288,7 +288,7 @@ class ProductSyncer implements Service, MerchantCenterAwareInterface {
 	 * @throws ProductSyncerException If Google Merchant Center is not set up and connected.
 	 */
 	protected function validate_merchant_center_setup(): void {
-		if ( ! $this->merchant_center->is_setup_complete() ) {
+		if ( ! $this->merchant_center->is_connected() ) {
 			do_action( 'woocommerce_gla_error', 'Can not sync any products before setting up Google Merchant Center.', __METHOD__ );
 
 			throw new ProductSyncerException( __( 'Google Merchant Center has not been set up correctly. Please review your configuration.', 'google-listings-and-ads' ) );

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -168,12 +168,12 @@ class SyncerHooks implements Service, Registerable, MerchantCenterAwareInterface
 			}
 
 			$this->product_helper->mark_as_pending( $product );
-			$this->update_products_job->start( [ $product_ids ] );
+			$this->update_products_job->schedule( [ $product_ids ] );
 			$this->set_already_scheduled( $product_id );
 		} elseif ( $this->product_helper->is_product_synced( $product ) ) {
 			// Delete the product from Google Merchant Center if it's already synced BUT it is not sync ready after the edit.
 			$request_entries = $this->batch_helper->generate_delete_request_entries( [ $product ] );
-			$this->delete_products_job->start( [ BatchProductIDRequestEntry::convert_to_id_map( $request_entries )->get() ] );
+			$this->delete_products_job->schedule( [ BatchProductIDRequestEntry::convert_to_id_map( $request_entries )->get() ] );
 			$this->set_already_scheduled( $product_id );
 
 			do_action(
@@ -195,7 +195,7 @@ class SyncerHooks implements Service, Registerable, MerchantCenterAwareInterface
 		if ( isset( $this->delete_requests_map[ $product_id ] ) ) {
 			$product_id_map = BatchProductIDRequestEntry::convert_to_id_map( $this->delete_requests_map[ $product_id ] )->get();
 			if ( ! empty( $product_id_map ) ) {
-				$this->delete_products_job->start( [ $product_id_map ] );
+				$this->delete_products_job->schedule( [ $product_id_map ] );
 				$this->set_already_scheduled( $product_id );
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR confirms that the Merchant Center is both setup and connected before trying to sync products. This also relies on the Google Account remaining connected. If either is disconnected the scheduled job will fail with the message:
> Google Merchant Center has not been set up correctly. Please review your configuration.

The function `can_start` and `start` were renamed to `can_schedule` and `schedule`, as the intention of these functions was to schedule a task and not start it directly.

### Detailed test instructions:

1. Test with a site with a large amount of products that will span across several batches (or lower the batch size with a snippet)
```php
add_filter(
	'woocommerce_gla_batched_job_size',
	function( $size ) {
		return 5;
	}
);
```
2. Make sure both the Google Account and the Merchant Setup has been completed
3. Add a code snippet which will disconnect the Google connection after the first scheduled task
```php
add_action(
	'gla/jobs/update_all_products/process_item',
	function() {
		$options = woogle_get_container()->get( 'Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface' );
		$options->update( 'google_connected', false );
	},
	9999
);
```
4. On the connection test page schedule an async action to update all the products
5. In WooCommerce > Status > Scheduled Actions observe the initial task `gla/jobs/update_all_products/process_item` completes, and the following ones fail with an error: `Google Merchant Center has not been set up correctly. Please review your configuration.`
6. If there are more then 5 batches we might also receive the error: `The "update_all_products" job was stopped because it's failure rate is above the allowed threshold.` for the latter tasks
7. Check WooCommerce > Status > Logs > gla-log-file and confirm we see an error like: `ERROR Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer::validate_merchant_center_setup Can not sync any products before setting up Google Merchant Center.`
8. Set the option `gla_google_connected` back to 1 in the DB so it no longer blocks other requests


### Changelog entry
* Tweak - Stop syncing products if the Merchant or Google accounts are no longer connected.