### PR TITLE
Google Product Feed incompatibility account-level issue

### DIFF
--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -1,0 +1,70 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExtensionRequirementException;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class GoogleProductFeedValidator
+ *
+ * @package AutomatticWooCommerceGoogleListingsAndAdsInternalRequirements
+ */
+class GoogleProductFeedValidator extends RequirementValidator {
+
+	/**
+	 * Validate all requirements for the plugin to function properly.
+	 *
+	 * @return bool
+	 */
+	public function validate(): bool {
+		try {
+			$this->validate_google_product_feed_inactive();
+		} catch ( ExtensionRequirementException $e ) {
+			add_filter(
+				'woocommerce_gla_account_issues',
+				function( $arr ) {
+					foreach ( $arr as &$issue ) {
+						// Make sure all issues have the source attribute to avoid erros.
+						if ( ! empty( $issue['source'] ) ) {
+							continue;
+						}
+						$issue['source'] = 'mc';
+					}
+
+					array_push(
+						$arr,
+						[
+							'product_id' => '0',
+							'product'    => 'All products',
+							'code'       => 'incompatible_google_product_feed',
+							'issue'      => 'The Google Product Feed plugin may cause conflicts or unexpected results.',
+							'action'     => 'Delete or deactivate the Google Product Feed plugin from your store',
+							'action_url' => 'https://developers.google.com/shopping-content/guides/best-practices#do-not-use-api-and-feeds',
+							'created_at' => date_format( date_create(), 'Y-m-d H:i:s' ),
+							'type'       => MerchantStatuses::TYPE_ACCOUNT,
+							'severity'   => 'error',
+							'source'     => 'filter',
+						]
+					);
+					return $arr;
+				}
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Validate that Google Product Feed isn't enabled.
+	 *
+	 * @throws ExtensionRequirementException When Google Product Feed is active.
+	 */
+	protected function validate_google_product_feed_inactive() {
+		if ( defined( 'WOOCOMMERCE_GPF_VERSION' ) ) {
+			throw ExtensionRequirementException::incompatible_plugin( 'Google Product Feed' );
+		}
+	}
+}

--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -68,11 +68,11 @@ class GoogleProductFeedValidator extends RequirementValidator {
 	 * to the array of issues to be saved in the database.
 	 *
 	 * @param array    $issues The current array of account-level issues
-	 * @param DateTime $current_time The time of the cache/issues generation.
+	 * @param DateTime $cache_created_time The time of the cache/issues generation.
 	 *
 	 * @return array The issues with the new conflict issue included
 	 */
-	protected function add_conflict_issue( array $issues, DateTime $current_time ): array {
+	protected function add_conflict_issue( array $issues, DateTime $cache_created_time ): array {
 		foreach ( $issues as &$issue ) {
 			// Make sure all issues have the source attribute to avoid errors.
 			if ( ! empty( $issue['source'] ) ) {
@@ -88,7 +88,7 @@ class GoogleProductFeedValidator extends RequirementValidator {
 			'issue'      => __( 'The Google Product Feed plugin may cause conflicts or unexpected results.', 'google-listings-and-ads' ),
 			'action'     => __( 'Deactivate the Google Product Feed plugin from your store', 'google-listings-and-ads' ),
 			'action_url' => 'https://developers.google.com/shopping-content/guides/best-practices#do-not-use-api-and-feeds',
-			'created_at' => $current_time->format( 'Y-m-d H:i:s' ),
+			'created_at' => $cache_created_time->format( 'Y-m-d H:i:s' ),
 			'type'       => MerchantStatuses::TYPE_ACCOUNT,
 			'severity'   => 'error',
 			'source'     => 'filter',

--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExtensionRequirementEx
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use DateTime;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -33,9 +34,11 @@ class GoogleProductFeedValidator extends RequirementValidator {
 
 			add_filter(
 				'woocommerce_gla_account_issues',
-				function( $issues ) {
-					return $this->add_conflict_issue( $issues );
-				}
+				function( $issues, $current_time ) {
+					return $this->add_conflict_issue( $issues, $current_time );
+				},
+				10,
+				2
 			);
 
 			add_filter(
@@ -65,11 +68,12 @@ class GoogleProductFeedValidator extends RequirementValidator {
 	 * Add an account-level issue regarding the plugin conflict
 	 * to the array of issues to be saved in the database.
 	 *
-	 * @param array $issues The current array of account-level issues
+	 * @param array    $issues The current array of account-level issues
+	 * @param DateTime $current_time The time of the cache/issues generation.
 	 *
 	 * @return array The issues with the new conflict issue included
 	 */
-	protected function add_conflict_issue( array $issues ): array {
+	protected function add_conflict_issue( array $issues, DateTime $current_time ): array {
 		foreach ( $issues as &$issue ) {
 			// Make sure all issues have the source attribute to avoid errors.
 			if ( ! empty( $issue['source'] ) ) {
@@ -85,7 +89,7 @@ class GoogleProductFeedValidator extends RequirementValidator {
 			'issue'      => 'The Google Product Feed plugin may cause conflicts or unexpected results.',
 			'action'     => 'Delete or deactivate the Google Product Feed plugin from your store',
 			'action_url' => 'https://developers.google.com/shopping-content/guides/best-practices#do-not-use-api-and-feeds',
-			'created_at' => date_format( date_create(), 'Y-m-d H:i:s' ),
+			'created_at' => $current_time->format( 'Y-m-d H:i:s' ),
 			'type'       => MerchantStatuses::TYPE_ACCOUNT,
 			'severity'   => 'error',
 			'source'     => 'filter',

--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -45,7 +45,7 @@ class GoogleProductFeedValidator extends RequirementValidator {
 				'deactivated_plugin',
 				function( $plugin ) {
 					if ( 'woocommerce-product-feeds/woocommerce-gpf.php' === $plugin ) {
-						delete_transient( $this->get_slug() . '_' . TransientsInterface::MC_STATUSES );
+						woogle_get_container()->get( MerchantStatuses::class )->clear_cache();
 					}
 				}
 			);

--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExtensionRequirementException;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use DateTime;
 
@@ -83,11 +82,11 @@ class GoogleProductFeedValidator extends RequirementValidator {
 		}
 
 		$issues[] = [
-			'product_id' => '0',
+			'product_id' => 0,
 			'product'    => 'All products',
 			'code'       => 'incompatible_google_product_feed',
-			'issue'      => 'The Google Product Feed plugin may cause conflicts or unexpected results.',
-			'action'     => 'Delete or deactivate the Google Product Feed plugin from your store',
+			'issue'      => __( 'The Google Product Feed plugin may cause conflicts or unexpected results.', 'google-listings-and-ads' ),
+			'action'     => __( 'Deactivate the Google Product Feed plugin from your store', 'google-listings-and-ads' ),
 			'action_url' => 'https://developers.google.com/shopping-content/guides/best-practices#do-not-use-api-and-feeds',
 			'created_at' => $current_time->format( 'Y-m-d H:i:s' ),
 			'type'       => MerchantStatuses::TYPE_ACCOUNT,

--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -41,7 +41,7 @@ class GoogleProductFeedValidator extends RequirementValidator {
 				2
 			);
 
-			add_filter(
+			add_action(
 				'deactivated_plugin',
 				function( $plugin ) {
 					if ( 'woocommerce-product-feeds/woocommerce-gpf.php' === $plugin ) {

--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -44,7 +44,11 @@ class GoogleProductFeedValidator extends RequirementValidator {
 				'deactivated_plugin',
 				function( $plugin ) {
 					if ( 'woocommerce-product-feeds/woocommerce-gpf.php' === $plugin ) {
-						woogle_get_container()->get( MerchantStatuses::class )->clear_cache();
+						/** @var MerchantStatuses $merchant_statuses */
+						$merchant_statuses = woogle_get_container()->get( MerchantStatuses::class );
+						if ( $merchant_statuses instanceof MerchantStatuses ) {
+							$merchant_statuses->clear_cache();
+						}
 					}
 				}
 			);

--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -32,7 +32,7 @@ class GoogleProductFeedValidator extends RequirementValidator {
 		} catch ( ExtensionRequirementException $e ) {
 
 			add_filter(
-				'woocommerce_gla_account_issues',
+				'woocommerce_gla_custom_merchant_issues',
 				function( $issues, $current_time ) {
 					return $this->add_conflict_issue( $issues, $current_time );
 				},

--- a/src/Internal/Requirements/PluginValidator.php
+++ b/src/Internal/Requirements/PluginValidator.php
@@ -20,6 +20,7 @@ class PluginValidator {
 	private const PLUGINS = [
 		WCAdminValidator::class,
 		WCValidator::class,
+		GoogleProductFeedValidator::class,
 	];
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -188,6 +188,9 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		// Update pre-sync product validation issues.
 		$this->refresh_presync_product_issues();
 
+		// Include any custom merchant issues.
+		$this->refresh_custom_merchant_issues();
+
 		// Delete stale issues.
 		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
 	}
@@ -370,16 +373,26 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			];
 		}
 
-		/**
-		 * Account-level issues can be added the merchant issues table.
-		 *
-		 * @since x.x.x
-		 */
-		$account_issues = apply_filters( 'woocommerce_gla_account_issues', $account_issues, $this->cache_created_time );
-
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 		$issue_query->update_or_insert( $account_issues );
+	}
+
+	/**
+	 * Custom issues can be added to the merchant issues table.
+	 *
+	 * @since x.x.x
+	 */
+	protected function refresh_custom_merchant_issues() {
+		$custom_issues = apply_filters( 'woocommerce_gla_custom_merchant_issues', [], $this->cache_created_time );
+
+		if ( empty( $custom_issues ) ) {
+			return;
+		}
+
+		/** @var MerchantIssueQuery $issue_query */
+		$issue_query = $this->container->get( MerchantIssueQuery::class );
+		$issue_query->update_or_insert( $custom_issues );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -189,9 +189,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$this->refresh_presync_product_issues();
 
 		// Delete stale issues.
-		$delete_before = clone $this->current_time;
-		$delete_before->modify( '-' . $this->get_status_lifetime() . ' seconds' );
-		$this->container->get( MerchantIssueTable::class )->delete_stale( $delete_before );
+		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->current_time );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -372,6 +372,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			];
 		}
 
+		/**
+		 * Account-level issues can be added the merchant issues table.
+		 *
+		 * @since x.x.x
+		 */
+		$account_issues = apply_filters( 'woocommerce_gla_account_issues', $account_issues );
+
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 		$issue_query->update_or_insert( $account_issues );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -62,9 +62,9 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	public const SEVERITY_ERROR   = 'error';
 
 	/**
-	 * @var DateTime $current_time For cache age operations.
+	 * @var DateTime $cache_created_time For cache age operations.
 	 */
-	protected $current_time;
+	protected $cache_created_time;
 
 	/**
 	 * @var array Reference array of countries associated to each product+issue combo.
@@ -93,7 +93,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 * MerchantStatuses constructor.
 	 */
 	public function __construct() {
-		$this->current_time = new DateTime();
+		$this->cache_created_time = new DateTime();
 	}
 
 	/**
@@ -189,7 +189,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$this->refresh_presync_product_issues();
 
 		// Delete stale issues.
-		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->current_time );
+		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
 	}
 
 	/**
@@ -355,7 +355,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		/** @var Merchant $merchant */
 		$merchant       = $this->container->get( Merchant::class );
 		$account_issues = [];
-		$created_at     = $this->current_time->format( 'Y-m-d H:i:s' );
+		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
 		foreach ( $merchant->get_accountstatus()->getAccountLevelIssues() as $issue ) {
 			$account_issues[] = [
 				'product_id' => 0,
@@ -375,7 +375,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		 *
 		 * @since x.x.x
 		 */
-		$account_issues = apply_filters( 'woocommerce_gla_account_issues', $account_issues, $this->current_time );
+		$account_issues = apply_filters( 'woocommerce_gla_account_issues', $account_issues, $this->cache_created_time );
 
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
@@ -392,7 +392,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$product_helper = $this->container->get( ProductHelper::class );
 
 		$product_issues = [];
-		$created_at     = $this->current_time->format( 'Y-m-d H:i:s' );
+		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
 		foreach ( $validated_mc_statuses as $product ) {
 			$wc_product_id = $product_helper->get_wc_product_id( $product->getProductId() );
 
@@ -458,7 +458,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	protected function refresh_presync_product_issues(): void {
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query  = $this->container->get( MerchantIssueQuery::class );
-		$created_at   = $this->current_time->format( 'Y-m-d H:i:s' );
+		$created_at   = $this->cache_created_time->format( 'Y-m-d H:i:s' );
 		$issue_action = __( 'Update this attribute in your product data', 'google-listings-and-ads' );
 
 		/** @var ProductMetaQueryHelper $product_meta_query_helper */
@@ -559,7 +559,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$product_statistics[ MCStatus::NOT_SYNCED ] = count( $product_repository->find_mc_not_synced_product_ids() );
 
 		$this->mc_statuses = [
-			'timestamp'  => $this->current_time->getTimestamp(),
+			'timestamp'  => $this->cache_created_time->getTimestamp(),
 			'statistics' => $product_statistics,
 		];
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -375,7 +375,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		 *
 		 * @since x.x.x
 		 */
-		$account_issues = apply_filters( 'woocommerce_gla_account_issues', $account_issues );
+		$account_issues = apply_filters( 'woocommerce_gla_account_issues', $account_issues, $this->current_time );
 
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #774.

This PR adds an account-level issue to the "Issues to resolve" list when the [Google Product Feed](https://woocommerce.com/products/google-product-feed/) plugin is detected.
- The filter `woocommerce_gla_custom_merchant_issues` is added, allowing custom issues (both account and product) to be added to the merchant issues table.
- In the `GoogleProductFeedValidator`, if the plugin is detected, then instead of showing a notice and preventing GLA from loading, the new filter is used to add an account-level issue.
- If the plugin is detected, then the `deactivated_plugin` hook is used to delete the `MC_STATUSES` cache when the plugin is deactivated, to prevent a stale issue from displaying.
    - This is done using `woogle_get_container` as the validation is performed before any services are registered (so `Transient`/`TransientInterface`/`MerchantStatus` aren't available yet).

#### Notes
- _Should_ GLA be prevented from loading (or a more visible notice be added to /wp-admin/)? In this case, a user won't see the incompatibility notice until they've already set up their Merchant Center account (which could mean they've already made a mess of their feed).
- There's a small change to the stale merchant issues removal process - now all issues that aren't explicitly updated/added during generation, are deleted. This prevents stale issues that are younger than the `STATUS_LIFETIME`, but are actually no longer valid, from persisting in the table. (An example is this Google Product Feed issue: when the plugin is deactivated, the status transient is cleared, but the issues table isn't truncated. When the cache is regenerated, all issues are update-or-inserted, and issues older than 1 hour are removed. But if the plugin was deactivated less than 60 minutes ago, it's no longer valid *AND* still younger than one hour, so it persists, incorrectly).

### Screenshots:
![image](https://user-images.githubusercontent.com/228780/124575679-e3299a00-de4b-11eb-95ba-5d7d907c093a.png)


### Detailed test instructions:
1. Go through Merchant Center onboarding.
2. In the Product Feed page, check that "Issues to resolve" is populated.
3. Activate the Google Product Feed plugin.
4. Clear the merchant status cache (from Connection Test).
5. Reload or revisit the Product Feed page.
    - Check that the incompatibility notice is visible in the "Issues to resolve".
6. Disable the Google Product Feed plugin, 
    - *Don't* clear the merchant status cache - it should be done automatically on deactivation.
    - Check the cache transient no longer exists:
    ``SELECT *  FROM `wp_options` WHERE `option_name` LIKE '%gla_mc_statuses'``
5. Reload or revisit the Product Feed page.
    - Check that the incompatibility notice is **NOT** visible in the "Issues to resolve".


### Changelog entry

> Add - Incompatibility warning for Google Product Feed plugin.