### PR TITLE
Add unit tests for functions within `.~/reports/utils.js`

### DIFF
--- a/js/src/reports/utils.js
+++ b/js/src/reports/utils.js
@@ -119,6 +119,8 @@ export function sumToPerformance(
 					MISSING_FREE_LISTINGS_DATA.FOR_REQUEST;
 			} else {
 				// There is free listings data, sum with paid one.
+				// `freeTotals` doesn't have fallback because it will only be number or undefined type,
+				// and the undefined has been checked above.
 				value = ( paidTotals[ key ] || 0 ) + freeTotals[ key ];
 			}
 		}

--- a/js/src/reports/utils.js
+++ b/js/src/reports/utils.js
@@ -146,8 +146,7 @@ export function addBaseToPerformance( performance, base ) {
 			[ key ]: fieldsToPerformance(
 				performance[ key ].value,
 				base[ key ]?.value,
-				performance[ key ].missingFreeListingsData ||
-					base[ key ].missingFreeListingsData
+				performance[ key ].missingFreeListingsData
 			),
 		} ),
 		{}

--- a/js/src/reports/utils.js
+++ b/js/src/reports/utils.js
@@ -54,12 +54,12 @@ function sumProperies( metrics, totals1 = {}, totals2 = {} ) {
  *
  * @param {Array<IntervalsData>} [intervals1]
  * @param {Array<IntervalsData>} [intervals2]
- * @return {Array<IntervalsData>} Aggregated intervals.
+ * @return {Array<IntervalsData>|null} Aggregated intervals. `null` if both intervals are not provided.
  */
 export function aggregateIntervals( intervals1, intervals2 ) {
 	// Return early if there is nothing to merge.
 	if ( ! intervals2 ) {
-		return intervals1;
+		return intervals1 || null;
 	} else if ( ! intervals1 ) {
 		return intervals2;
 	}

--- a/js/src/reports/utils.js
+++ b/js/src/reports/utils.js
@@ -119,7 +119,7 @@ export function sumToPerformance(
 					MISSING_FREE_LISTINGS_DATA.FOR_REQUEST;
 			} else {
 				// There is free listings data, sum with paid one.
-				value = ( paidTotals[ key ] || 0 ) + freeTotals[ key ];
+				value = ( paidTotals[ key ] || 0 ) + ( freeTotals[ key ] || 0 );
 			}
 		}
 

--- a/js/src/reports/utils.js
+++ b/js/src/reports/utils.js
@@ -119,7 +119,7 @@ export function sumToPerformance(
 					MISSING_FREE_LISTINGS_DATA.FOR_REQUEST;
 			} else {
 				// There is free listings data, sum with paid one.
-				value = ( paidTotals[ key ] || 0 ) + ( freeTotals[ key ] || 0 );
+				value = ( paidTotals[ key ] || 0 ) + freeTotals[ key ];
 			}
 		}
 

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -87,6 +87,8 @@ describe( 'aggregateIntervals', () => {
 			[ '2021-06' ],
 			[ '2021-08' ]
 		);
+
+		const result = aggregateIntervals( intervals1, intervals2 );
 		const expectedIntervals = toIntervals(
 			[ '2021-01' ],
 			[ '2021-02' ],
@@ -97,8 +99,6 @@ describe( 'aggregateIntervals', () => {
 			[ '2021-07' ],
 			[ '2021-08' ]
 		);
-
-		const result = aggregateIntervals( intervals1, intervals2 );
 
 		expectedIntervals.forEach( ( item, i ) => {
 			expect( result[ i ] ).toMatchObject( item );
@@ -114,12 +114,12 @@ describe( 'aggregateIntervals', () => {
 			[ '2021-01', 56, 78 ],
 			[ '2021-02', 78, 90 ]
 		);
+
+		const result = aggregateIntervals( intervals1, intervals2 );
 		const expectedIntervals = toIntervals(
 			[ '2021-01', 68, 112 ],
 			[ '2021-02', 112, 146 ]
 		);
-
-		const result = aggregateIntervals( intervals1, intervals2 );
 
 		expect( result ).toHaveLength( expectedIntervals.length );
 		expectedIntervals.forEach( ( item, i ) => {
@@ -130,12 +130,12 @@ describe( 'aggregateIntervals', () => {
 	it( "should merge two given intervals' items to a union result by `interval`", () => {
 		const intervals1 = toIntervals( [ '2021-01', 12 ] );
 		const intervals2 = toIntervals( [ '2021-02', 34 ] );
+
+		const result = aggregateIntervals( intervals1, intervals2 );
 		const expectedIntervals = toIntervals(
 			[ '2021-01', 12 ],
 			[ '2021-02', 34 ]
 		);
-
-		const result = aggregateIntervals( intervals1, intervals2 );
 
 		expect( result ).toHaveLength( expectedIntervals.length );
 		expectedIntervals.forEach( ( item, i ) => {
@@ -146,9 +146,9 @@ describe( 'aggregateIntervals', () => {
 	it( 'When any metric in `paidFields` does not exist in `subtotals`, should fill its value with 0', () => {
 		const intervals1 = toIntervals( [ '2021-01', , 1, , 3 ] );
 		const intervals2 = toIntervals( [ '2021-01', , , 2, , 4 ] );
-		const expectedIntervals = toIntervals( [ '2021-01', 0, 1, 2, 3, 4 ] );
 
 		const result = aggregateIntervals( intervals1, intervals2 );
+		const expectedIntervals = toIntervals( [ '2021-01', 0, 1, 2, 3, 4 ] );
 
 		expectedIntervals.forEach( ( item, i ) => {
 			expect( result[ i ] ).toMatchObject( item );
@@ -173,6 +173,7 @@ describe( 'sumToPerformance', () => {
 	it( 'should be able to sum paid `totals` to performance only', () => {
 		const paid = toPaidTotals( 123 );
 		const free = undefined;
+
 		const performance = sumToPerformance( paid, free );
 
 		expect( performance ).toMatchObject( {
@@ -187,6 +188,7 @@ describe( 'sumToPerformance', () => {
 	it( 'should be able to sum free `totals` to performance only', () => {
 		const paid = undefined;
 		const free = toFreeTotals( 456 );
+
 		const performance = sumToPerformance( paid, free, freeFields );
 
 		expect( performance ).toMatchObject( {
@@ -202,6 +204,7 @@ describe( 'sumToPerformance', () => {
 		const sameFields = [ 'ranks' ];
 		const paid = toTotals( sameFields, 123 );
 		const free = toTotals( sameFields, 456 );
+
 		const performance = sumToPerformance( paid, free, sameFields );
 
 		expect( performance ).toMatchObject( {
@@ -218,6 +221,7 @@ describe( 'sumToPerformance', () => {
 		const expectedFreeFields = [ 'views' ];
 		const paid = toTotals( paidOnlyFields, 1 );
 		const free = toTotals( expectedFreeFields, 1 );
+
 		const performance = sumToPerformance( paid, free, expectedFreeFields );
 
 		expect( performance ).toMatchObject( {
@@ -231,6 +235,7 @@ describe( 'sumToPerformance', () => {
 		const expectedFields = [ 'ranks' ];
 		const paid = toTotals( expectedFields, 1 );
 		const free = toTotals( expectedFields );
+
 		const performance = sumToPerformance( paid, free, expectedFields );
 
 		expect( performance ).toMatchObject( {
@@ -267,6 +272,7 @@ describe( 'addBaseToPerformance', () => {
 			clicks: { value: 10 },
 			sales: { value: 10 },
 		};
+
 		const result = addBaseToPerformance( performance, base );
 
 		expect( result ).toEqual( {

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -221,27 +221,6 @@ describe( 'sumToPerformance', () => {
 			} );
 		} );
 
-		it( 'When it able to sum but any fields value is `null`, should consider `null` as 0', () => {
-			const sameFields = [ 'ranks' ];
-			const paid = toTotals( sameFields, 123 );
-			const free = toTotals( sameFields, 456 );
-			const nullField = toTotals( sameFields, null );
-
-			// Paid `totals` have null value
-			let performance = sumToPerformance( nullField, free, sameFields );
-
-			expect( performance ).toMatchObject( {
-				[ sameFields[ 0 ] ]: { value: 456 },
-			} );
-
-			// Free `totals` have null value
-			performance = sumToPerformance( paid, nullField, sameFields );
-
-			expect( performance ).toMatchObject( {
-				[ sameFields[ 0 ] ]: { value: 123 },
-			} );
-		} );
-
 		it( 'When a paid field is not (yet) available in API, should flag the data is not available', () => {
 			const paidOnlyFields = [ 'ranks' ];
 			const expectedFreeFields = [ 'views' ];

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -6,7 +6,12 @@ import {
 	paidFields,
 	MISSING_FREE_LISTINGS_DATA,
 } from '.~/data/utils';
-import { getIdsFromQuery, aggregateIntervals, sumToPerformance } from './utils';
+import {
+	getIdsFromQuery,
+	aggregateIntervals,
+	sumToPerformance,
+	addBaseToPerformance,
+} from './utils';
 
 // Copied from https://github.com/woocommerce/woocommerce-admin/blob/b35156dcf17b44b3a81ea4b4528445b432917fd5/packages/navigation/src/test/index.js#L184-L221
 describe( 'getIdsFromQuery', () => {
@@ -240,6 +245,51 @@ describe( 'sumToPerformance', () => {
 		expect( performance ).toMatchObject( {
 			[ expectedFields[ 0 ] ]: {
 				missingFreeListingsData: MISSING_FREE_LISTINGS_DATA.FOR_REQUEST,
+			},
+		} );
+	} );
+} );
+
+describe( 'addBaseToPerformance', () => {
+	it( 'Should iterate fields according to the data properties of `performance`', () => {
+		// Still in loading
+		const base = { clicks: {}, sales: {} };
+		let performance = {};
+		let result = addBaseToPerformance( performance, base );
+
+		expect( result ).toEqual( {} );
+
+		// Loaded
+		performance = { clicks: {}, sales: {} };
+		result = addBaseToPerformance( performance, base );
+
+		expect( result ).toHaveProperty( 'clicks' );
+		expect( result ).toHaveProperty( 'sales' );
+	} );
+
+	it( 'should calculate the final performance data', () => {
+		const performance = {
+			clicks: { value: 13, missingFreeListingsData: 0 },
+			sales: { value: 5, missingFreeListingsData: 2 },
+		};
+		const base = {
+			clicks: { value: 10 },
+			sales: { value: 10 },
+		};
+		const result = addBaseToPerformance( performance, base );
+
+		expect( result ).toEqual( {
+			clicks: {
+				value: 13,
+				prevValue: 10,
+				delta: 30,
+				missingFreeListingsData: 0,
+			},
+			sales: {
+				value: 5,
+				prevValue: 10,
+				delta: -50,
+				missingFreeListingsData: 2,
 			},
 		} );
 	} );

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -244,17 +244,21 @@ describe( 'sumToPerformance', () => {
 } );
 
 describe( 'addBaseToPerformance', () => {
-	it( 'Should iterate fields according to the data properties of `performance`', () => {
-		// Still in loading
+	it( 'When `performance` is still in loading, should return an empty object', () => {
+		// In our use cases, the passed-in `performance` in loading status would be an empty object.
+		const performance = {};
 		const base = { clicks: {}, sales: {} };
-		let performance = {};
-		let result = addBaseToPerformance( performance, base );
+
+		const result = addBaseToPerformance( performance, base );
 
 		expect( result ).toEqual( {} );
+	} );
 
-		// Loaded
-		performance = { clicks: {}, sales: {} };
-		result = addBaseToPerformance( performance, base );
+	it( 'When `performance` is loaded, should iterate fields according to its data properties', () => {
+		const performance = { clicks: {}, sales: {} };
+		const base = {};
+
+		const result = addBaseToPerformance( performance, base );
 
 		expect( result ).toHaveProperty( 'clicks' );
 		expect( result ).toHaveProperty( 'sales' );

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -105,62 +105,53 @@ describe( 'aggregateIntervals', () => {
 		} );
 	} );
 
-	describe( 'aggregate intervals', () => {
-		it( "should merge two given intervals' items by the same `interval`, and the `subtotals` from the same `interval` items should be aggregated by summation of each its metric", () => {
-			const intervals1 = toIntervals(
-				[ '2021-01', 12, 34 ],
-				[ '2021-02', 34, 56 ]
-			);
-			const intervals2 = toIntervals(
-				[ '2021-01', 56, 78 ],
-				[ '2021-02', 78, 90 ]
-			);
-			const expectedIntervals = toIntervals(
-				[ '2021-01', 68, 112 ],
-				[ '2021-02', 112, 146 ]
-			);
+	it( "should merge two given intervals' items by the same `interval`, and the `subtotals` from the same `interval` items should be aggregated by summation of each its metric", () => {
+		const intervals1 = toIntervals(
+			[ '2021-01', 12, 34 ],
+			[ '2021-02', 34, 56 ]
+		);
+		const intervals2 = toIntervals(
+			[ '2021-01', 56, 78 ],
+			[ '2021-02', 78, 90 ]
+		);
+		const expectedIntervals = toIntervals(
+			[ '2021-01', 68, 112 ],
+			[ '2021-02', 112, 146 ]
+		);
 
-			const result = aggregateIntervals( intervals1, intervals2 );
+		const result = aggregateIntervals( intervals1, intervals2 );
 
-			expect( result ).toHaveLength( expectedIntervals.length );
-			expectedIntervals.forEach( ( item, i ) => {
-				expect( result[ i ] ).toMatchObject( item );
-			} );
+		expect( result ).toHaveLength( expectedIntervals.length );
+		expectedIntervals.forEach( ( item, i ) => {
+			expect( result[ i ] ).toMatchObject( item );
 		} );
+	} );
 
-		it( "should merge two given intervals' items to a union result by `interval`", () => {
-			const intervals1 = toIntervals( [ '2021-01', 12 ] );
-			const intervals2 = toIntervals( [ '2021-02', 34 ] );
-			const expectedIntervals = toIntervals(
-				[ '2021-01', 12 ],
-				[ '2021-02', 34 ]
-			);
+	it( "should merge two given intervals' items to a union result by `interval`", () => {
+		const intervals1 = toIntervals( [ '2021-01', 12 ] );
+		const intervals2 = toIntervals( [ '2021-02', 34 ] );
+		const expectedIntervals = toIntervals(
+			[ '2021-01', 12 ],
+			[ '2021-02', 34 ]
+		);
 
-			const result = aggregateIntervals( intervals1, intervals2 );
+		const result = aggregateIntervals( intervals1, intervals2 );
 
-			expect( result ).toHaveLength( expectedIntervals.length );
-			expectedIntervals.forEach( ( item, i ) => {
-				expect( result[ i ] ).toMatchObject( item );
-			} );
+		expect( result ).toHaveLength( expectedIntervals.length );
+		expectedIntervals.forEach( ( item, i ) => {
+			expect( result[ i ] ).toMatchObject( item );
 		} );
+	} );
 
-		it( 'When any metric in `paidFields` does not exist in `subtotals`, should fill its value with 0', () => {
-			const intervals1 = toIntervals( [ '2021-01', , 1, , 3 ] );
-			const intervals2 = toIntervals( [ '2021-01', , , 2, , 4 ] );
-			const expectedIntervals = toIntervals( [
-				'2021-01',
-				0,
-				1,
-				2,
-				3,
-				4,
-			] );
+	it( 'When any metric in `paidFields` does not exist in `subtotals`, should fill its value with 0', () => {
+		const intervals1 = toIntervals( [ '2021-01', , 1, , 3 ] );
+		const intervals2 = toIntervals( [ '2021-01', , , 2, , 4 ] );
+		const expectedIntervals = toIntervals( [ '2021-01', 0, 1, 2, 3, 4 ] );
 
-			const result = aggregateIntervals( intervals1, intervals2 );
+		const result = aggregateIntervals( intervals1, intervals2 );
 
-			expectedIntervals.forEach( ( item, i ) => {
-				expect( result[ i ] ).toMatchObject( item );
-			} );
+		expectedIntervals.forEach( ( item, i ) => {
+			expect( result[ i ] ).toMatchObject( item );
 		} );
 	} );
 } );

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { getIdsFromQuery } from './utils';
+import { paidFields } from '.~/data/utils';
+import { getIdsFromQuery, aggregateIntervals } from './utils';
 
 // Copied from https://github.com/woocommerce/woocommerce-admin/blob/b35156dcf17b44b3a81ea4b4528445b432917fd5/packages/navigation/src/test/index.js#L184-L221
 describe( 'getIdsFromQuery', () => {
@@ -39,6 +40,118 @@ describe( 'getIdsFromQuery', () => {
 				8,
 				9,
 			] );
+		} );
+	} );
+} );
+
+describe( 'aggregateIntervals', () => {
+	function toIntervals( ...tuples ) {
+		return tuples.map( ( [ interval, ...values ] ) => ( {
+			interval,
+			subtotals: values.reduce(
+				( acc, value, i ) => ( {
+					...acc,
+					[ paidFields[ i ] ]: value,
+				} ),
+				{}
+			),
+		} ) );
+	}
+
+	it( 'if both `intervals` parameters are not provided, should return null', () => {
+		expect( aggregateIntervals() ).toBeNull();
+		expect( aggregateIntervals( null ) ).toBeNull();
+		expect( aggregateIntervals( null, null ) ).toBeNull();
+		expect( aggregateIntervals( undefined, null ) ).toBeNull();
+	} );
+
+	it( 'should sort aggregated intervals in ascending order of string code by `interval`', () => {
+		const intervals1 = toIntervals(
+			[ '2021-01' ],
+			[ '2021-03' ],
+			[ '2021-05' ],
+			[ '2021-07' ]
+		);
+		const intervals2 = toIntervals(
+			[ '2021-02' ],
+			[ '2021-04' ],
+			[ '2021-06' ],
+			[ '2021-08' ]
+		);
+		const expectedIntervals = toIntervals(
+			[ '2021-01' ],
+			[ '2021-02' ],
+			[ '2021-03' ],
+			[ '2021-04' ],
+			[ '2021-05' ],
+			[ '2021-06' ],
+			[ '2021-07' ],
+			[ '2021-08' ]
+		);
+
+		const result = aggregateIntervals( intervals1, intervals2 );
+
+		expectedIntervals.forEach( ( item, i ) => {
+			expect( result[ i ] ).toMatchObject( item );
+		} );
+	} );
+
+	describe( 'aggregate intervals', () => {
+		it( "should merge two given intervals' items by the same `interval`, and the `subtotals` from the same `interval` items should be aggregated by summation of each its metric", () => {
+			const intervals1 = toIntervals(
+				[ '2021-01', 12, 34 ],
+				[ '2021-02', 34, 56 ]
+			);
+			const intervals2 = toIntervals(
+				[ '2021-01', 56, 78 ],
+				[ '2021-02', 78, 90 ]
+			);
+			const expectedIntervals = toIntervals(
+				[ '2021-01', 68, 112 ],
+				[ '2021-02', 112, 146 ]
+			);
+
+			const result = aggregateIntervals( intervals1, intervals2 );
+
+			expect( result ).toHaveLength( expectedIntervals.length );
+			expectedIntervals.forEach( ( item, i ) => {
+				expect( result[ i ] ).toMatchObject( item );
+			} );
+		} );
+
+		it( "should merge two given intervals' items to a union result by `interval`", () => {
+			const intervals1 = toIntervals( [ '2021-01', 12 ] );
+			const intervals2 = toIntervals( [ '2021-02', 34 ] );
+			const expectedIntervals = toIntervals(
+				[ '2021-01', 12 ],
+				[ '2021-02', 34 ]
+			);
+
+			const result = aggregateIntervals( intervals1, intervals2 );
+
+			expect( result ).toHaveLength( expectedIntervals.length );
+			expectedIntervals.forEach( ( item, i ) => {
+				expect( result[ i ] ).toMatchObject( item );
+			} );
+		} );
+
+		it( 'When any metric in `paidFields` does not exist in `subtotals`, should fill its value with 0', () => {
+			const intervals1 = toIntervals( [ '2021-01', , 1, , 3 ] );
+			const intervals2 = toIntervals( [ '2021-01', , , 2, , 4 ] );
+			const expectedIntervals = toIntervals( [
+				'2021-01',
+				0,
+				1,
+				2,
+				3,
+				4,
+			] );
+
+			const result = aggregateIntervals( intervals1, intervals2 );
+
+			expectedIntervals.forEach( ( item, i ) => {
+				expect( result[ i ] ).toMatchObject( item );
+			} );
 		} );
 	} );
 } );

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -67,11 +67,18 @@ describe( 'aggregateIntervals', () => {
 		} ) );
 	}
 
-	it( 'if both `intervals` parameters are not provided, should return null', () => {
+	it( 'If both `intervals` parameters are not given, should return null', () => {
 		expect( aggregateIntervals() ).toBeNull();
 		expect( aggregateIntervals( null ) ).toBeNull();
 		expect( aggregateIntervals( null, null ) ).toBeNull();
 		expect( aggregateIntervals( undefined, null ) ).toBeNull();
+	} );
+
+	it( 'If one of `intervals` parameters is not given, should return another early', () => {
+		const intervals = toIntervals();
+
+		expect( aggregateIntervals( intervals ) ).toBe( intervals );
+		expect( aggregateIntervals( null, intervals ) ).toBe( intervals );
 	} );
 
 	it( 'should sort aggregated intervals in ascending order of string code by `interval`', () => {

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -167,7 +167,7 @@ describe( 'sumToPerformance', () => {
 		);
 	}
 
-	it( 'should be able to sum paid `totals` to performance only', () => {
+	it( 'When only paid `totals` is given, should still map it to performance data', () => {
 		const paid = toTotals( paidFields, 123 );
 		const free = undefined;
 
@@ -182,7 +182,7 @@ describe( 'sumToPerformance', () => {
 		} );
 	} );
 
-	it( 'should be able to sum free `totals` to performance only', () => {
+	it( 'When paid `totals` is not given, should still be able to calculate performance data', () => {
 		const paid = undefined;
 		const free = toTotals( freeFields, 456 );
 
@@ -197,48 +197,56 @@ describe( 'sumToPerformance', () => {
 		} );
 	} );
 
-	it( 'should sum the same field from paid `totals` and free `totals` to performance', () => {
-		const sameFields = [ 'ranks' ];
-		const paid = toTotals( sameFields, 123 );
-		const free = toTotals( sameFields, 456 );
+	describe( 'When paid and free `totals` are given', () => {
+		it( 'should sum the same fields from paid and free `totals` to performance', () => {
+			const sameFields = [ 'ranks' ];
+			const paid = toTotals( sameFields, 123 );
+			const free = toTotals( sameFields, 456 );
 
-		const performance = sumToPerformance( paid, free, sameFields );
+			const performance = sumToPerformance( paid, free, sameFields );
 
-		expect( performance ).toMatchObject( {
-			[ sameFields[ 0 ] ]: {
-				value: 579,
-				delta: null,
-				missingFreeListingsData: MISSING_FREE_LISTINGS_DATA.NONE,
-			},
+			expect( performance ).toMatchObject( {
+				[ sameFields[ 0 ] ]: {
+					value: 579,
+					delta: null,
+					missingFreeListingsData: MISSING_FREE_LISTINGS_DATA.NONE,
+				},
+			} );
 		} );
-	} );
 
-	it( 'When a paid field is not (yet) available in API, should flag the data is not available', () => {
-		const paidOnlyFields = [ 'ranks' ];
-		const expectedFreeFields = [ 'views' ];
-		const paid = toTotals( paidOnlyFields, 1 );
-		const free = toTotals( expectedFreeFields, 1 );
+		it( 'When a paid field is not (yet) available in API, should flag the data is not available', () => {
+			const paidOnlyFields = [ 'ranks' ];
+			const expectedFreeFields = [ 'views' ];
+			const paid = toTotals( paidOnlyFields, 1 );
+			const free = toTotals( expectedFreeFields, 1 );
 
-		const performance = sumToPerformance( paid, free, expectedFreeFields );
+			const performance = sumToPerformance(
+				paid,
+				free,
+				expectedFreeFields
+			);
 
-		expect( performance ).toMatchObject( {
-			[ paidOnlyFields[ 0 ] ]: {
-				missingFreeListingsData: MISSING_FREE_LISTINGS_DATA.FOR_METRIC,
-			},
+			expect( performance ).toMatchObject( {
+				[ paidOnlyFields[ 0 ] ]: {
+					missingFreeListingsData:
+						MISSING_FREE_LISTINGS_DATA.FOR_METRIC,
+				},
+			} );
 		} );
-	} );
 
-	it( `When an expected free field doesn't exist, should flag anticipated data is not returned from API`, () => {
-		const expectedFields = [ 'ranks' ];
-		const paid = toTotals( expectedFields, 1 );
-		const free = toTotals( expectedFields );
+		it( `When an expected free field doesn't exist, should flag anticipated data is not returned from API`, () => {
+			const expectedFields = [ 'ranks' ];
+			const paid = toTotals( expectedFields, 1 );
+			const free = toTotals( expectedFields );
 
-		const performance = sumToPerformance( paid, free, expectedFields );
+			const performance = sumToPerformance( paid, free, expectedFields );
 
-		expect( performance ).toMatchObject( {
-			[ expectedFields[ 0 ] ]: {
-				missingFreeListingsData: MISSING_FREE_LISTINGS_DATA.FOR_REQUEST,
-			},
+			expect( performance ).toMatchObject( {
+				[ expectedFields[ 0 ] ]: {
+					missingFreeListingsData:
+						MISSING_FREE_LISTINGS_DATA.FOR_REQUEST,
+				},
+			} );
 		} );
 	} );
 } );

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -167,11 +167,8 @@ describe( 'sumToPerformance', () => {
 		);
 	}
 
-	const toFreeTotals = toTotals.bind( null, freeFields );
-	const toPaidTotals = toTotals.bind( null, paidFields );
-
 	it( 'should be able to sum paid `totals` to performance only', () => {
-		const paid = toPaidTotals( 123 );
+		const paid = toTotals( paidFields, 123 );
 		const free = undefined;
 
 		const performance = sumToPerformance( paid, free );
@@ -187,7 +184,7 @@ describe( 'sumToPerformance', () => {
 
 	it( 'should be able to sum free `totals` to performance only', () => {
 		const paid = undefined;
-		const free = toFreeTotals( 456 );
+		const free = toTotals( freeFields, 456 );
 
 		const performance = sumToPerformance( paid, free, freeFields );
 

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { getIdsFromQuery } from './utils';
+
+// Copied from https://github.com/woocommerce/woocommerce-admin/blob/b35156dcf17b44b3a81ea4b4528445b432917fd5/packages/navigation/src/test/index.js#L184-L221
+describe( 'getIdsFromQuery', () => {
+	it( 'if the given query is empty, should return an empty array', () => {
+		expect( getIdsFromQuery( '' ) ).toEqual( [] );
+	} );
+
+	it( 'if the given query is undefined, should return an empty array', () => {
+		expect( getIdsFromQuery( undefined ) ).toEqual( [] );
+	} );
+
+	it( 'if the given query is does not contain any coma-separated numbers, should return an empty array', () => {
+		expect( getIdsFromQuery( 'foo123,bar,baz1.' ) ).toEqual( [] );
+	} );
+
+	describe( 'if the given query contains numbers', () => {
+		it( 'should return an array of them', () => {
+			expect( getIdsFromQuery( '77,8,-1' ) ).toEqual( [ 77, 8, -1 ] );
+		} );
+		it( 'should consider `0` a valid id', () => {
+			expect( getIdsFromQuery( '0' ) ).toEqual( [ 0 ] );
+			expect( getIdsFromQuery( '77,0,1' ) ).toEqual( [ 77, 0, 1 ] );
+		} );
+		it( 'should map floats to integers', () => {
+			expect( getIdsFromQuery( '77,8.54' ) ).toEqual( [ 77, 8 ] );
+		} );
+		it( 'should ignore duplicates', () => {
+			expect( getIdsFromQuery( '77,8,8' ) ).toEqual( [ 77, 8 ] );
+			// Consider two floats that maps to the same integer a duplicate.
+			expect( getIdsFromQuery( '77,8.5,8.4' ) ).toEqual( [ 77, 8 ] );
+		} );
+		it( 'should ignore non numbers entries in the coma-separated list', () => {
+			expect( getIdsFromQuery( '77,,8,foo,null,9' ) ).toEqual( [
+				77,
+				8,
+				9,
+			] );
+		} );
+	} );
+} );

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -221,6 +221,27 @@ describe( 'sumToPerformance', () => {
 			} );
 		} );
 
+		it( 'When it able to sum but any fields value is `null`, should consider `null` as 0', () => {
+			const sameFields = [ 'ranks' ];
+			const paid = toTotals( sameFields, 123 );
+			const free = toTotals( sameFields, 456 );
+			const nullField = toTotals( sameFields, null );
+
+			// Paid `totals` have null value
+			let performance = sumToPerformance( nullField, free, sameFields );
+
+			expect( performance ).toMatchObject( {
+				[ sameFields[ 0 ] ]: { value: 456 },
+			} );
+
+			// Free `totals` have null value
+			performance = sumToPerformance( paid, nullField, sameFields );
+
+			expect( performance ).toMatchObject( {
+				[ sameFields[ 0 ] ]: { value: 123 },
+			} );
+		} );
+
 		it( 'When a paid field is not (yet) available in API, should flag the data is not available', () => {
 			const paidOnlyFields = [ 'ranks' ];
 			const expectedFreeFields = [ 'views' ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add unit tests for functions within `.~/reports/utils.js`

- Copy test cases from woocommerce-admin repo for `getIdsFromQuery` function
- Add test cases for `aggregateIntervals`, `sumToPerformance`, and `addBaseToPerformance` functions
- Add a fallback `null` for `aggregateIntervals` function to make the returned invalid value consistent
- Remove the unneeded `missingFreeListingsData` fallback from `addBaseToPerformance` function

### Detailed test instructions:

1. Run `npm run test-unit` and make sure all these tests pass
2. The programs reports page should work well as before

### Changelog entry
