### PR TITLE
Set `CI_BRANCH_BASE` for `bundlewatch` on push events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       script: npm run lint
     - name: "Bundle size"
       php: 7.4
-      env: WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}" WP_TRAVISCI=cs WP_MULTISITE=0
+      env: WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}" WP_TRAVISCI=cs WP_MULTISITE=0 CI_BRANCH_BASE="${TRAVIS_BRANCH}"
       # We run the production build, to watch also .zip size.
       script: npm run build && npx bundlewatch
 

--- a/package.json
+++ b/package.json
@@ -115,8 +115,8 @@
 				"compression": "none"
 			}
 		],
-        "ci": {
-            "trackBranches": ["trunk", "develop"]
-        }
+		"ci": {
+			"trackBranches": ["trunk", "develop"]
+		}
 	}
 }


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Set `BRANCH_BASE` for `bundlewatch` on push events,
workaround https://github.com/bundlewatch/bundlewatch/issues/423.

Previously if no base was given, it was using hardcoded `master` which does not exist in our repo.
See https://app.travis-ci.com/github/woocommerce/google-listings-and-ads/jobs/522666112#L14735
```
[ERROR] Unable to fetch fileDetails for baseBranch=master from https://service.bundlewatch.io/store code=Request failed with status code 404
[INFO] master !== trunk, no results saved
[INFO] Saving results
```

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Run buildwatch with those changes on push event  - with our current setup, this means run them in `trunk` :|


### Changelog entry

> 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->