### PR TITLE
Hide product attributes and channel visibility for subscription products

### DIFF
--- a/src/Admin/Input/Form.php
+++ b/src/Admin/Input/Form.php
@@ -209,11 +209,11 @@ class Form implements FormInterface {
 	 * @return array
 	 */
 	public function get_view_data(): array {
-		$view_data = [];
-
-		$view_data['name'] = $this->get_view_name();
-
-		$view_data['is_root'] = $this->is_root();
+		$view_data = [
+			'name'     => $this->get_view_name(),
+			'is_root'  => $this->is_root(),
+			'children' => [],
+		];
 
 		foreach ( $this->get_children() as $index => $form ) {
 			$view_data['children'][ $index ] = $form->get_view_data();

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -92,14 +92,21 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	 * @return array
 	 */
 	public function get_classes(): array {
-		$supported_types = ProductSyncer::get_supported_product_types();
-
-		return array_map(
+		$shown_types = array_map(
 			function ( string $product_type ) {
-				return "show_if_{$product_type}";
+				return "show_if_${product_type}";
 			},
-			$supported_types
+			ProductSyncer::get_supported_product_types()
 		);
+
+		$hidden_types = array_map(
+			function ( string $product_type ) {
+				return "hide_if_${product_type}";
+			},
+			ProductSyncer::get_hidden_product_types()
+		);
+
+		return array_merge( $shown_types, $hidden_types );
 	}
 
 	/**

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
@@ -86,12 +87,25 @@ class AttributesTab implements Service, Registerable, Conditional {
 	 * @return array An array with product tabs with the Yoast SEO tab added.
 	 */
 	private function add_tab( array $tabs ): array {
-		$product_types   = $this->get_applicable_product_types();
-		$show_if_classes = ! empty( $product_types ) ? ' show_if_' . join( ' show_if_', $product_types ) : '';
+		$shown_types = array_map(
+			function ( string $product_type ) {
+				return "show_if_${product_type}";
+			},
+			$this->get_applicable_product_types()
+		);
+
+		$hidden_types = array_map(
+			function ( string $product_type ) {
+				return "hide_if_${product_type}";
+			},
+			ProductSyncer::get_hidden_product_types()
+		);
+
+		$classes = array_merge( [ 'gla' ], $shown_types, $hidden_types );
 
 		$tabs['gla_attributes'] = [
 			'label'  => 'Google Listings and Ads',
-			'class'  => 'gla' . $show_if_classes,
+			'class'  => join( ' ', $classes ),
 			'target' => 'gla_attributes',
 		];
 

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -81,7 +81,8 @@ class VariationsAttributes implements Service, Registerable, Conditional {
 		$data = $this->get_form( $product, $variation_index )->get_view_data();
 
 		// Do not render the form if it doesn't contain any child attributes.
-		if ( empty( $data['children'] ) || empty( $data['children'][0]['children'] ) ) {
+		$attributes = reset( $data['children'] );
+		if ( empty( $data['children'] ) || empty( $attributes['children'] ) ) {
 			return;
 		}
 

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -78,8 +78,15 @@ class VariationsAttributes implements Service, Registerable, Conditional {
 		 */
 		$product = wc_get_product( $variation->ID );
 
+		$data = $this->get_form( $product, $variation_index )->get_view_data();
+
+		// Do not render the form if it doesn't contain any child attributes.
+		if ( empty( $data['children'] ) || empty( $data['children'][0]['children'] ) ) {
+			return;
+		}
+
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo $this->admin->get_view( 'attributes/variations-form', $this->get_form( $product, $variation_index )->get_view_data() );
+		echo $this->admin->get_view( 'attributes/variations-form', $data );
 	}
 
 	/**

--- a/src/Integration/WooCommerceSubscriptions.php
+++ b/src/Integration/WooCommerceSubscriptions.php
@@ -8,6 +8,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class WooCommerceSubscriptions
  *
+ * @since x.x.x
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Integration
  */
 class WooCommerceSubscriptions implements IntegrationInterface {

--- a/src/Integration/WooCommerceSubscriptions.php
+++ b/src/Integration/WooCommerceSubscriptions.php
@@ -1,0 +1,41 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Integration;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WooCommerceSubscriptions
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Integration
+ */
+class WooCommerceSubscriptions implements IntegrationInterface {
+
+	protected const VALUE_KEY = 'woocommerce_subscriptions';
+
+	/**
+	 * Returns whether the integration is active or not.
+	 *
+	 * @return bool
+	 */
+	public function is_active(): bool {
+		return defined( 'WCS_INIT_TIMESTAMP' );
+	}
+
+	/**
+	 * Initializes the integration (e.g. by registering the required hooks, filters, etc.).
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_filter(
+			'woocommerce_gla_hidden_product_types',
+			function ( array $product_types ) {
+				$product_types[] = 'subscription';
+				$product_types[] = 'variable-subscription';
+				return $product_types;
+			}
+		);
+	}
+}

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInitializ
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceBrands;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceProductBundles;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceSubscriptions;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
@@ -42,6 +43,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( YoastWooCommerceSeo::class );
 		$this->share_with_tags( WooCommerceBrands::class, WP::class );
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
+		$this->share_with_tags( WooCommerceSubscriptions::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -231,6 +231,8 @@ class ProductSyncer implements Service {
 	/**
 	 * Return the list of product types we will hide functionality for (default none).
 	 *
+	 * @since x.x.x
+	 *
 	 * @return array
 	 */
 	public static function get_hidden_product_types(): array {

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -229,6 +229,15 @@ class ProductSyncer implements Service {
 	}
 
 	/**
+	 * Return the list of product types we will hide functionality for (default none).
+	 *
+	 * @return array
+	 */
+	public static function get_hidden_product_types(): array {
+		return (array) apply_filters( 'woocommerce_gla_hidden_product_types', [] );
+	}
+
+	/**
 	 * @param BatchInvalidProductEntry[] $invalid_products
 	 */
 	protected function handle_update_errors( array $invalid_products ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We show the tab and meta box based on classes such as `show_if_simple` or `show_if_variable`. However subscriptions also displays the fields/meta boxes based on these types. This PR adds a list of product types where we hide the functionality for, which will add a class like `hide_if_subscription`.

In addition to this the variations form was modified to only render if it has a list of children attributes. When we create a subscription variation we don't support any of the product attributes so it remains an empty form.

Closes #787

### Detailed test instructions:

1. Install and activate WooCommerce Subscriptions
2. Create a new product
3. Switch to both subscription and variable subscription for the product type
4. Confirm that the product attributes tab and channel visibility is not shown for those types
5. Switch to simple or variable
6. Confirm that the product attributes tab and channel visibility is shown for those types
7. Create a variable subscription product and add at least one variation
8. Confirm that the attributes form is not shown per variation and doesn't generate any errors


### Changelog entry
* Fix - Hide product attributes and channel visibility for subscription products.
