### PR TITLE
Fix some edge cases and add unit tests for `checkErrors` function

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
+++ b/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is not set, should not pass 1`] = `"Please specify tax rate option."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 1`] = `"Please check the requirement."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 2`] = `"Please check the requirement."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 3`] = `"Please check the requirement."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 4`] = `"Please check the requirement."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 5`] = `"Please check the requirement."`;
+
+exports[`checkErrors Shipping rates For flat type When the free shipping threshold is < 0, should not pass 1`] = `"Please specify a valid minimum order price for free shipping"`;
+
+exports[`checkErrors Shipping rates For flat type When there are any selected countries' shipping rates is not set, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;
+
+exports[`checkErrors Shipping rates For flat type When there are any shipping rates is < 0, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;
+
+exports[`checkErrors Shipping rates When the type of shipping rate is not set, should not pass 1`] = `"Please select a shipping rate option."`;
+
+exports[`checkErrors Shipping times For flat type When there are any selected countries' shipping times is not set, should not pass 1`] = `"Please specify shipping times for all the countries. And the estimated shipping time cannot be less than 0."`;
+
+exports[`checkErrors Shipping times For flat type When there are any shipping times is < 0, should not pass 1`] = `"Please specify shipping times for all the countries. And the estimated shipping time cannot be less than 0."`;
+
+exports[`checkErrors Shipping times When the type of shipping time is not set, should not pass 1`] = `"Please select a shipping time option."`;

--- a/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
+++ b/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is not set, should not pass 1`] = `"Please specify tax rate option."`;
+exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value, should not pass 1`] = `"Please specify tax rate option."`;
+
+exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value, should not pass 2`] = `"Please specify tax rate option."`;
+
+exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value, should not pass 3`] = `"Please specify tax rate option."`;
 
 exports[`checkErrors Requirements When there are any requirements are not true, should not pass 1`] = `"Please check the requirement."`;
 
@@ -12,16 +16,38 @@ exports[`checkErrors Requirements When there are any requirements are not true, 
 
 exports[`checkErrors Requirements When there are any requirements are not true, should not pass 5`] = `"Please check the requirement."`;
 
-exports[`checkErrors Shipping rates For flat type When the free shipping threshold is < 0, should not pass 1`] = `"Please specify a valid minimum order price for free shipping"`;
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 6`] = `"Please check the requirement."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 7`] = `"Please check the requirement."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 8`] = `"Please check the requirement."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 9`] = `"Please check the requirement."`;
+
+exports[`checkErrors Requirements When there are any requirements are not true, should not pass 10`] = `"Please check the requirement."`;
+
+exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value, should not pass 1`] = `"Please specify a valid minimum order price for free shipping"`;
+
+exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value, should not pass 2`] = `"Please specify a valid minimum order price for free shipping"`;
+
+exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value, should not pass 3`] = `"Please specify a valid minimum order price for free shipping"`;
 
 exports[`checkErrors Shipping rates For flat type When there are any selected countries' shipping rates is not set, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;
 
 exports[`checkErrors Shipping rates For flat type When there are any shipping rates is < 0, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;
 
-exports[`checkErrors Shipping rates When the type of shipping rate is not set, should not pass 1`] = `"Please select a shipping rate option."`;
+exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value, should not pass 1`] = `"Please select a shipping rate option."`;
+
+exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value, should not pass 2`] = `"Please select a shipping rate option."`;
+
+exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value, should not pass 3`] = `"Please select a shipping rate option."`;
 
 exports[`checkErrors Shipping times For flat type When there are any selected countries' shipping times is not set, should not pass 1`] = `"Please specify shipping times for all the countries. And the estimated shipping time cannot be less than 0."`;
 
 exports[`checkErrors Shipping times For flat type When there are any shipping times is < 0, should not pass 1`] = `"Please specify shipping times for all the countries. And the estimated shipping time cannot be less than 0."`;
 
-exports[`checkErrors Shipping times When the type of shipping time is not set, should not pass 1`] = `"Please select a shipping time option."`;
+exports[`checkErrors Shipping times When the type of shipping time is an invalid value, should not pass 1`] = `"Please select a shipping time option."`;
+
+exports[`checkErrors Shipping times When the type of shipping time is an invalid value, should not pass 2`] = `"Please select a shipping time option."`;
+
+exports[`checkErrors Shipping times When the type of shipping time is an invalid value, should not pass 3`] = `"Please select a shipping time option."`;

--- a/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
+++ b/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value, should not pass 1`] = `"Please specify tax rate option."`;
+exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value or missing, should not pass 1`] = `"Please specify tax rate option."`;
 
-exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value, should not pass 2`] = `"Please specify tax rate option."`;
+exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value or missing, should not pass 2`] = `"Please specify tax rate option."`;
 
-exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value, should not pass 3`] = `"Please specify tax rate option."`;
+exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value or missing, should not pass 3`] = `"Please specify tax rate option."`;
 
 exports[`checkErrors Requirements When there are any requirements are not true, should not pass 1`] = `"Please check the requirement."`;
 
@@ -26,28 +26,28 @@ exports[`checkErrors Requirements When there are any requirements are not true, 
 
 exports[`checkErrors Requirements When there are any requirements are not true, should not pass 10`] = `"Please check the requirement."`;
 
-exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value, should not pass 1`] = `"Please specify a valid minimum order price for free shipping"`;
+exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value or missing, should not pass 1`] = `"Please specify a valid minimum order price for free shipping"`;
 
-exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value, should not pass 2`] = `"Please specify a valid minimum order price for free shipping"`;
+exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value or missing, should not pass 2`] = `"Please specify a valid minimum order price for free shipping"`;
 
-exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value, should not pass 3`] = `"Please specify a valid minimum order price for free shipping"`;
+exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value or missing, should not pass 3`] = `"Please specify a valid minimum order price for free shipping"`;
 
-exports[`checkErrors Shipping rates For flat type When there are any selected countries' shipping rates is not set, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;
+exports[`checkErrors Shipping rates For flat type When there are any selected countries with shipping rates not set, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;
 
 exports[`checkErrors Shipping rates For flat type When there are any shipping rates is < 0, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;
 
-exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value, should not pass 1`] = `"Please select a shipping rate option."`;
+exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value or missing, should not pass 1`] = `"Please select a shipping rate option."`;
 
-exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value, should not pass 2`] = `"Please select a shipping rate option."`;
+exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value or missing, should not pass 2`] = `"Please select a shipping rate option."`;
 
-exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value, should not pass 3`] = `"Please select a shipping rate option."`;
+exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value or missing, should not pass 3`] = `"Please select a shipping rate option."`;
 
 exports[`checkErrors Shipping times For flat type When there are any selected countries' shipping times is not set, should not pass 1`] = `"Please specify shipping times for all the countries. And the estimated shipping time cannot be less than 0."`;
 
 exports[`checkErrors Shipping times For flat type When there are any shipping times is < 0, should not pass 1`] = `"Please specify shipping times for all the countries. And the estimated shipping time cannot be less than 0."`;
 
-exports[`checkErrors Shipping times When the type of shipping time is an invalid value, should not pass 1`] = `"Please select a shipping time option."`;
+exports[`checkErrors Shipping times When the type of shipping time is an invalid value or missing, should not pass 1`] = `"Please select a shipping time option."`;
 
-exports[`checkErrors Shipping times When the type of shipping time is an invalid value, should not pass 2`] = `"Please select a shipping time option."`;
+exports[`checkErrors Shipping times When the type of shipping time is an invalid value or missing, should not pass 2`] = `"Please select a shipping time option."`;
 
-exports[`checkErrors Shipping times When the type of shipping time is an invalid value, should not pass 3`] = `"Please select a shipping time option."`;
+exports[`checkErrors Shipping times When the type of shipping time is an invalid value or missing, should not pass 3`] = `"Please select a shipping time option."`;

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -3,6 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 
+const validShippingSet = new Set( [ 'flat', 'manual' ] );
+const validTaxRateSet = new Set( [ 'destination', 'manual' ] );
+
 const checkErrors = (
 	values,
 	shippingRates,
@@ -14,7 +17,7 @@ const checkErrors = (
 	/**
 	 * Check shipping rates.
 	 */
-	if ( ! values.shipping_rate ) {
+	if ( ! validShippingSet.has( values.shipping_rate ) ) {
 		errors.shipping_rate = __(
 			'Please select a shipping rate option.',
 			'google-listings-and-ads'
@@ -32,10 +35,12 @@ const checkErrors = (
 		);
 	}
 
+	// When set up from scratch, the initial value of `free_shipping_threshold` is null.
+	const threshold = values.free_shipping_threshold;
 	if (
 		values.shipping_rate === 'flat' &&
 		values.offers_free_shipping &&
-		values.free_shipping_threshold < 0
+		( ! Number.isFinite( threshold ) || threshold < 0 )
 	) {
 		errors.free_shipping_threshold = __(
 			'Please specify a valid minimum order price for free shipping',
@@ -46,7 +51,7 @@ const checkErrors = (
 	/**
 	 * Check shipping times.
 	 */
-	if ( ! values.shipping_time ) {
+	if ( ! validShippingSet.has( values.shipping_time ) ) {
 		errors.shipping_time = __(
 			'Please select a shipping time option.',
 			'google-listings-and-ads'
@@ -67,7 +72,10 @@ const checkErrors = (
 	/**
 	 * Check tax rate (required for U.S. only).
 	 */
-	if ( finalCountryCodes.includes( 'US' ) && ! values.tax_rate ) {
+	if (
+		finalCountryCodes.includes( 'US' ) &&
+		! validTaxRateSet.has( values.tax_rate )
+	) {
 		errors.tax_rate = __(
 			'Please specify tax rate option.',
 			'google-listings-and-ads'
@@ -77,35 +85,35 @@ const checkErrors = (
 	/**
 	 * Pre-launch checklist.
 	 */
-	if ( ! values.website_live ) {
+	if ( values.website_live !== true ) {
 		errors.website_live = __(
 			'Please check the requirement.',
 			'google-listings-and-ads'
 		);
 	}
 
-	if ( ! values.checkout_process_secure ) {
+	if ( values.checkout_process_secure !== true ) {
 		errors.checkout_process_secure = __(
 			'Please check the requirement.',
 			'google-listings-and-ads'
 		);
 	}
 
-	if ( ! values.payment_methods_visible ) {
+	if ( values.payment_methods_visible !== true ) {
 		errors.payment_methods_visible = __(
 			'Please check the requirement.',
 			'google-listings-and-ads'
 		);
 	}
 
-	if ( ! values.refund_tos_visible ) {
+	if ( values.refund_tos_visible !== true ) {
 		errors.refund_tos_visible = __(
 			'Please check the requirement.',
 			'google-listings-and-ads'
 		);
 	}
 
-	if ( ! values.contact_info_visible ) {
+	if ( values.contact_info_visible !== true ) {
 		errors.contact_info_visible = __(
 			'Please check the requirement.',
 			'google-listings-and-ads'

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -1,0 +1,273 @@
+/**
+ * Internal dependencies
+ */
+import checkErrors from './checkErrors';
+
+function toRates( ...tuples ) {
+	return tuples.map( ( [ countryCode, rate ] ) => ( {
+		countryCode,
+		rate,
+	} ) );
+}
+
+function toTimes( ...tuples ) {
+	return tuples.map( ( [ countryCode, time ] ) => ( {
+		countryCode,
+		time,
+	} ) );
+}
+
+describe( 'checkErrors', () => {
+	describe( 'Shipping rates', () => {
+		let flatShipping;
+		let manualShipping;
+
+		beforeEach( () => {
+			flatShipping = { shipping_rate: 'flat' };
+			manualShipping = { shipping_rate: 'manual' };
+		} );
+
+		it( 'When the type of shipping rate is not set, should not pass', () => {
+			const errors = checkErrors( {}, [], [], [] );
+
+			expect( errors ).toHaveProperty( 'shipping_rate' );
+			expect( errors.shipping_rate ).toMatchSnapshot();
+		} );
+
+		it( 'When the type of shipping rate is set, should pass', () => {
+			// Selected flat
+			let errors = checkErrors( flatShipping, [], [], [] );
+
+			expect( errors ).not.toHaveProperty( 'shipping_rate' );
+
+			// Selected manual
+			errors = checkErrors( manualShipping, [], [], [] );
+
+			expect( errors ).not.toHaveProperty( 'shipping_rate' );
+		} );
+
+		describe( 'For flat type', () => {
+			it( `When there are any selected countries' shipping rates is not set, should not pass`, () => {
+				const rates = toRates( [ 'US', 10.5 ], [ 'FR', 12.8 ] );
+				const codes = [ 'US', 'JP', 'FR' ];
+
+				const errors = checkErrors( flatShipping, rates, [], codes );
+
+				expect( errors ).toHaveProperty( 'shipping_rate' );
+				expect( errors.shipping_rate ).toMatchSnapshot();
+			} );
+
+			it( `When all selected countries' shipping rates are set, should pass`, () => {
+				const rates = toRates( [ 'US', 10.5 ], [ 'FR', 12.8 ] );
+				const codes = [ 'US', 'FR' ];
+
+				const errors = checkErrors( flatShipping, rates, [], codes );
+
+				expect( errors ).not.toHaveProperty( 'shipping_rate' );
+			} );
+
+			it( `When there are any shipping rates is < 0, should not pass`, () => {
+				const rates = toRates( [ 'US', 10.5 ], [ 'JP', -0.01 ] );
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( flatShipping, rates, [], codes );
+
+				expect( errors ).toHaveProperty( 'shipping_rate' );
+				expect( errors.shipping_rate ).toMatchSnapshot();
+			} );
+
+			it( `When all shipping rates are ≥ 0, should pass`, () => {
+				const rates = toRates( [ 'US', 1 ], [ 'JP', 0 ] );
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( flatShipping, rates, [], codes );
+
+				expect( errors ).not.toHaveProperty( 'shipping_rate' );
+			} );
+
+			it( 'When the free shipping threshold is < 0, should not pass', () => {
+				const freeShipping = {
+					...flatShipping,
+					offers_free_shipping: true,
+					free_shipping_threshold: -0.01,
+				};
+				const rates = toRates( [ 'JP', 2 ] );
+				const codes = [ 'JP' ];
+
+				const errors = checkErrors( freeShipping, rates, [], codes );
+
+				expect( errors ).toHaveProperty( 'free_shipping_threshold' );
+				expect( errors.free_shipping_threshold ).toMatchSnapshot();
+			} );
+
+			it( 'When the free shipping threshold ≥ 0, should pass', () => {
+				// Free threshold is 0
+				let freeShipping = {
+					...flatShipping,
+					offers_free_shipping: true,
+					free_shipping_threshold: 0,
+				};
+				const rates = toRates( [ 'JP', 2 ] );
+				const codes = [ 'JP' ];
+
+				let errors = checkErrors( freeShipping, rates, [], codes );
+
+				expect( errors ).not.toHaveProperty(
+					'free_shipping_threshold'
+				);
+
+				// Free threshold is a positive number
+				freeShipping = {
+					...flatShipping,
+					offers_free_shipping: true,
+					free_shipping_threshold: 0.01,
+				};
+
+				errors = checkErrors( freeShipping, rates, [], codes );
+
+				expect( errors ).not.toHaveProperty(
+					'free_shipping_threshold'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'Shipping times', () => {
+		let flatShipping;
+		let manualShipping;
+
+		beforeEach( () => {
+			flatShipping = { shipping_time: 'flat' };
+			manualShipping = { shipping_time: 'manual' };
+		} );
+
+		it( 'When the type of shipping time is not set, should not pass', () => {
+			const errors = checkErrors( {}, [], [], [] );
+
+			expect( errors ).toHaveProperty( 'shipping_time' );
+			expect( errors.shipping_time ).toMatchSnapshot();
+		} );
+
+		it( 'When the type of shipping time is set, should pass', () => {
+			// Selected flat
+			let errors = checkErrors( flatShipping, [], [], [] );
+
+			expect( errors ).not.toHaveProperty( 'shipping_time' );
+
+			// Selected manual
+			errors = checkErrors( manualShipping, [], [], [] );
+
+			expect( errors ).not.toHaveProperty( 'shipping_time' );
+		} );
+
+		describe( 'For flat type', () => {
+			it( `When there are any selected countries' shipping times is not set, should not pass`, () => {
+				const times = toTimes( [ 'US', 7 ], [ 'FR', 16 ] );
+				const codes = [ 'US', 'JP', 'FR' ];
+
+				const errors = checkErrors( flatShipping, [], times, codes );
+
+				expect( errors ).toHaveProperty( 'shipping_time' );
+				expect( errors.shipping_time ).toMatchSnapshot();
+			} );
+
+			it( `When all selected countries' shipping times are set, should pass`, () => {
+				const times = toTimes( [ 'US', 7 ], [ 'FR', 16 ] );
+				const codes = [ 'US', 'FR' ];
+
+				const errors = checkErrors( flatShipping, [], times, codes );
+
+				expect( errors ).not.toHaveProperty( 'shipping_time' );
+			} );
+
+			it( `When there are any shipping times is < 0, should not pass`, () => {
+				const times = toTimes( [ 'US', 10 ], [ 'JP', -1 ] );
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( flatShipping, [], times, codes );
+
+				expect( errors ).toHaveProperty( 'shipping_time' );
+				expect( errors.shipping_time ).toMatchSnapshot();
+			} );
+
+			it( `When all shipping times are ≥ 0, should pass`, () => {
+				const times = toTimes( [ 'US', 1 ], [ 'JP', 0 ] );
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( flatShipping, [], times, codes );
+
+				expect( errors ).not.toHaveProperty( 'shipping_time' );
+			} );
+		} );
+	} );
+
+	describe( `For tax rate, if selected country codes include 'US'`, () => {
+		let codes;
+
+		beforeEach( () => {
+			codes = [ 'US' ];
+		} );
+
+		it( `When the tax rate option is not set, should not pass`, () => {
+			const errors = checkErrors( {}, [], [], codes );
+
+			expect( errors ).toHaveProperty( 'tax_rate' );
+			expect( errors.tax_rate ).toMatchSnapshot();
+		} );
+
+		it( 'When the tax rate option is set, should pass', () => {
+			// Selected destination
+			const destinationTaxRate = { tax_rate: 'destination' };
+
+			let errors = checkErrors( destinationTaxRate, [], [], codes );
+
+			expect( errors ).not.toHaveProperty( 'tax_rate' );
+
+			// Selected manual
+			const manualTaxRate = { tax_rate: 'manual' };
+
+			errors = checkErrors( manualTaxRate, [], [], codes );
+
+			expect( errors ).not.toHaveProperty( 'tax_rate' );
+		} );
+	} );
+
+	describe( 'Requirements', () => {
+		it( 'When there are any requirements are not true, should not pass', () => {
+			const errors = checkErrors( {}, [], [], [] );
+
+			expect( errors ).toHaveProperty( 'website_live' );
+			expect( errors.website_live ).toMatchSnapshot();
+
+			expect( errors ).toHaveProperty( 'checkout_process_secure' );
+			expect( errors.checkout_process_secure ).toMatchSnapshot();
+
+			expect( errors ).toHaveProperty( 'payment_methods_visible' );
+			expect( errors.payment_methods_visible ).toMatchSnapshot();
+
+			expect( errors ).toHaveProperty( 'refund_tos_visible' );
+			expect( errors.refund_tos_visible ).toMatchSnapshot();
+
+			expect( errors ).toHaveProperty( 'contact_info_visible' );
+			expect( errors.contact_info_visible ).toMatchSnapshot();
+		} );
+
+		it( 'When all requirements are true, should pass', () => {
+			const values = {
+				website_live: true,
+				checkout_process_secure: true,
+				payment_methods_visible: true,
+				refund_tos_visible: true,
+				contact_info_visible: true,
+			};
+
+			const errors = checkErrors( values, [], [], [] );
+
+			expect( errors ).not.toHaveProperty( 'website_live' );
+			expect( errors ).not.toHaveProperty( 'checkout_process_secure' );
+			expect( errors ).not.toHaveProperty( 'payment_methods_visible' );
+			expect( errors ).not.toHaveProperty( 'refund_tos_visible' );
+			expect( errors ).not.toHaveProperty( 'contact_info_visible' );
+		} );
+	} );
+} );

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -26,6 +26,36 @@ function toTimes( ...tuples ) {
  * should not pass - returned object should contain respective property with an error message.
  */
 describe( 'checkErrors', () => {
+	it( 'When all checks are passed, should return an empty object', () => {
+		const values = {
+			shipping_rate: 'flat',
+			shipping_time: 'flat',
+			offers_free_shipping: true,
+			free_shipping_threshold: 100,
+			tax_rate: 'manual',
+			website_live: true,
+			checkout_process_secure: true,
+			payment_methods_visible: true,
+			refund_tos_visible: true,
+			contact_info_visible: true,
+		};
+		const rates = toRates( [ 'US', 10 ], [ 'JP', 30 ] );
+		const times = toTimes( [ 'US', 3 ], [ 'JP', 10 ] );
+		const codes = [ 'US', 'JP' ];
+
+		const errors = checkErrors( values, rates, times, codes );
+
+		expect( errors ).toStrictEqual( {} );
+	} );
+
+	it( 'should indicate multiple unpassed checks by setting properties in the returned object', () => {
+		const errors = checkErrors( {}, [], [], [] );
+
+		expect( errors ).toHaveProperty( 'shipping_rate' );
+		expect( errors ).toHaveProperty( 'shipping_time' );
+		expect( errors ).toHaveProperty( 'website_live' );
+	} );
+
 	describe( 'Shipping rates', () => {
 		let flatShipping;
 		let manualShipping;

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -27,14 +27,27 @@ describe( 'checkErrors', () => {
 			manualShipping = { shipping_rate: 'manual' };
 		} );
 
-		it( 'When the type of shipping rate is not set, should not pass', () => {
-			const errors = checkErrors( {}, [], [], [] );
+		it( 'When the type of shipping rate is an invalid value, should not pass', () => {
+			// Not set yet
+			let errors = checkErrors( {}, [], [], [] );
+
+			expect( errors ).toHaveProperty( 'shipping_rate' );
+			expect( errors.shipping_rate ).toMatchSnapshot();
+
+			// Invalid value
+			errors = checkErrors( { shipping_rate: true }, [], [], [] );
+
+			expect( errors ).toHaveProperty( 'shipping_rate' );
+			expect( errors.shipping_rate ).toMatchSnapshot();
+
+			// Invalid value
+			errors = checkErrors( { shipping_rate: 'automatic' }, [], [], [] );
 
 			expect( errors ).toHaveProperty( 'shipping_rate' );
 			expect( errors.shipping_rate ).toMatchSnapshot();
 		} );
 
-		it( 'When the type of shipping rate is set, should pass', () => {
+		it( 'When the type of shipping rate is a valid value, should pass', () => {
 			// Selected flat
 			let errors = checkErrors( flatShipping, [], [], [] );
 
@@ -47,6 +60,14 @@ describe( 'checkErrors', () => {
 		} );
 
 		describe( 'For flat type', () => {
+			function createFreeShipping( threshold ) {
+				return {
+					...flatShipping,
+					offers_free_shipping: true,
+					free_shipping_threshold: threshold,
+				};
+			}
+
 			it( `When there are any selected countries' shipping rates is not set, should not pass`, () => {
 				const rates = toRates( [ 'US', 10.5 ], [ 'FR', 12.8 ] );
 				const codes = [ 'US', 'JP', 'FR' ];
@@ -85,16 +106,29 @@ describe( 'checkErrors', () => {
 				expect( errors ).not.toHaveProperty( 'shipping_rate' );
 			} );
 
-			it( 'When the free shipping threshold is < 0, should not pass', () => {
-				const freeShipping = {
-					...flatShipping,
-					offers_free_shipping: true,
-					free_shipping_threshold: -0.01,
-				};
+			it( 'When the free shipping threshold is an invalid value, should not pass', () => {
+				// Not set yet
+				let freeShipping = createFreeShipping( null );
 				const rates = toRates( [ 'JP', 2 ] );
 				const codes = [ 'JP' ];
 
-				const errors = checkErrors( freeShipping, rates, [], codes );
+				let errors = checkErrors( freeShipping, rates, [], codes );
+
+				expect( errors ).toHaveProperty( 'free_shipping_threshold' );
+				expect( errors.free_shipping_threshold ).toMatchSnapshot();
+
+				// Invalid value
+				freeShipping = createFreeShipping( true );
+
+				errors = checkErrors( freeShipping, rates, [], codes );
+
+				expect( errors ).toHaveProperty( 'free_shipping_threshold' );
+				expect( errors.free_shipping_threshold ).toMatchSnapshot();
+
+				// Invalid range
+				freeShipping = createFreeShipping( -0.01 );
+
+				errors = checkErrors( freeShipping, rates, [], codes );
 
 				expect( errors ).toHaveProperty( 'free_shipping_threshold' );
 				expect( errors.free_shipping_threshold ).toMatchSnapshot();
@@ -102,11 +136,7 @@ describe( 'checkErrors', () => {
 
 			it( 'When the free shipping threshold ≥ 0, should pass', () => {
 				// Free threshold is 0
-				let freeShipping = {
-					...flatShipping,
-					offers_free_shipping: true,
-					free_shipping_threshold: 0,
-				};
+				let freeShipping = createFreeShipping( 0 );
 				const rates = toRates( [ 'JP', 2 ] );
 				const codes = [ 'JP' ];
 
@@ -117,11 +147,7 @@ describe( 'checkErrors', () => {
 				);
 
 				// Free threshold is a positive number
-				freeShipping = {
-					...flatShipping,
-					offers_free_shipping: true,
-					free_shipping_threshold: 0.01,
-				};
+				freeShipping = createFreeShipping( 0.01 );
 
 				errors = checkErrors( freeShipping, rates, [], codes );
 
@@ -141,14 +167,27 @@ describe( 'checkErrors', () => {
 			manualShipping = { shipping_time: 'manual' };
 		} );
 
-		it( 'When the type of shipping time is not set, should not pass', () => {
-			const errors = checkErrors( {}, [], [], [] );
+		it( 'When the type of shipping time is an invalid value, should not pass', () => {
+			// Not set yet
+			let errors = checkErrors( {}, [], [], [] );
+
+			expect( errors ).toHaveProperty( 'shipping_time' );
+			expect( errors.shipping_time ).toMatchSnapshot();
+
+			// Invalid value
+			errors = checkErrors( { shipping_time: true }, [], [], [] );
+
+			expect( errors ).toHaveProperty( 'shipping_time' );
+			expect( errors.shipping_time ).toMatchSnapshot();
+
+			// Invalid value
+			errors = checkErrors( { shipping_time: 'automatic' }, [], [], [] );
 
 			expect( errors ).toHaveProperty( 'shipping_time' );
 			expect( errors.shipping_time ).toMatchSnapshot();
 		} );
 
-		it( 'When the type of shipping time is set, should pass', () => {
+		it( 'When the type of shipping time is a valid value, should pass', () => {
 			// Selected flat
 			let errors = checkErrors( flatShipping, [], [], [] );
 
@@ -208,14 +247,27 @@ describe( 'checkErrors', () => {
 			codes = [ 'US' ];
 		} );
 
-		it( `When the tax rate option is not set, should not pass`, () => {
-			const errors = checkErrors( {}, [], [], codes );
+		it( `When the tax rate option is an invalid value, should not pass`, () => {
+			// Not set yet
+			let errors = checkErrors( {}, [], [], codes );
+
+			expect( errors ).toHaveProperty( 'tax_rate' );
+			expect( errors.tax_rate ).toMatchSnapshot();
+
+			// Invalid value
+			errors = checkErrors( { tax_rate: true }, [], [], codes );
+
+			expect( errors ).toHaveProperty( 'tax_rate' );
+			expect( errors.tax_rate ).toMatchSnapshot();
+
+			// Invalid value
+			errors = checkErrors( { tax_rate: 'automatic' }, [], [], codes );
 
 			expect( errors ).toHaveProperty( 'tax_rate' );
 			expect( errors.tax_rate ).toMatchSnapshot();
 		} );
 
-		it( 'When the tax rate option is set, should pass', () => {
+		it( 'When the tax rate option is a valid value, should pass', () => {
 			// Selected destination
 			const destinationTaxRate = { tax_rate: 'destination' };
 
@@ -234,7 +286,34 @@ describe( 'checkErrors', () => {
 
 	describe( 'Requirements', () => {
 		it( 'When there are any requirements are not true, should not pass', () => {
-			const errors = checkErrors( {}, [], [], [] );
+			// Not set yet
+			let errors = checkErrors( {}, [], [], [] );
+
+			expect( errors ).toHaveProperty( 'website_live' );
+			expect( errors.website_live ).toMatchSnapshot();
+
+			expect( errors ).toHaveProperty( 'checkout_process_secure' );
+			expect( errors.checkout_process_secure ).toMatchSnapshot();
+
+			expect( errors ).toHaveProperty( 'payment_methods_visible' );
+			expect( errors.payment_methods_visible ).toMatchSnapshot();
+
+			expect( errors ).toHaveProperty( 'refund_tos_visible' );
+			expect( errors.refund_tos_visible ).toMatchSnapshot();
+
+			expect( errors ).toHaveProperty( 'contact_info_visible' );
+			expect( errors.contact_info_visible ).toMatchSnapshot();
+
+			// Invalid value
+			const values = {
+				website_live: false,
+				checkout_process_secure: 1,
+				payment_methods_visible: 'true',
+				refund_tos_visible: [],
+				contact_info_visible: {},
+			};
+
+			errors = checkErrors( values, [], [], [] );
 
 			expect( errors ).toHaveProperty( 'website_live' );
 			expect( errors.website_live ).toMatchSnapshot();

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -146,6 +146,7 @@ describe( 'checkErrors', () => {
 
 			it( 'When the free shipping threshold is an invalid value or missing, should not pass', () => {
 				// Not set yet
+				// When set up from scratch, the initial value of `free_shipping_threshold` is null.
 				let freeShipping = createFreeShipping( null );
 				const rates = toRates( [ 'JP', 2 ] );
 				const codes = [ 'JP' ];

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -17,6 +17,14 @@ function toTimes( ...tuples ) {
 	} ) );
 }
 
+/**
+ * checkErrors function returns an object, and if any checks are not passed,
+ * set properties respectively with an error message to indicate it.
+ *
+ * To test each cases separately, the meaning of "should (not) pass" in test descriptions are:
+ * should pass - returned object should not contain respective property.
+ * should not pass - returned object should contain respective property with an error message.
+ */
 describe( 'checkErrors', () => {
 	describe( 'Shipping rates', () => {
 		let flatShipping;
@@ -27,7 +35,7 @@ describe( 'checkErrors', () => {
 			manualShipping = { shipping_rate: 'manual' };
 		} );
 
-		it( 'When the type of shipping rate is an invalid value, should not pass', () => {
+		it( 'When the type of shipping rate is an invalid value or missing, should not pass', () => {
 			// Not set yet
 			let errors = checkErrors( {}, [], [], [] );
 
@@ -106,7 +114,7 @@ describe( 'checkErrors', () => {
 				expect( errors ).not.toHaveProperty( 'shipping_rate' );
 			} );
 
-			it( 'When the free shipping threshold is an invalid value, should not pass', () => {
+			it( 'When the free shipping threshold is an invalid value or missing, should not pass', () => {
 				// Not set yet
 				let freeShipping = createFreeShipping( null );
 				const rates = toRates( [ 'JP', 2 ] );
@@ -167,7 +175,7 @@ describe( 'checkErrors', () => {
 			manualShipping = { shipping_time: 'manual' };
 		} );
 
-		it( 'When the type of shipping time is an invalid value, should not pass', () => {
+		it( 'When the type of shipping time is an invalid value or missing, should not pass', () => {
 			// Not set yet
 			let errors = checkErrors( {}, [], [], [] );
 
@@ -247,7 +255,7 @@ describe( 'checkErrors', () => {
 			codes = [ 'US' ];
 		} );
 
-		it( `When the tax rate option is an invalid value, should not pass`, () => {
+		it( `When the tax rate option is an invalid value or missing, should not pass`, () => {
 			// Not set yet
 			let errors = checkErrors( {}, [], [], codes );
 

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -68,7 +68,7 @@ describe( 'checkErrors', () => {
 				};
 			}
 
-			it( `When there are any selected countries' shipping rates is not set, should not pass`, () => {
+			it( `When there are any selected countries with shipping rates not set, should not pass`, () => {
 				const rates = toRates( [ 'US', 10.5 ], [ 'FR', 12.8 ] );
 				const codes = [ 'US', 'JP', 'FR' ];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

For the `checkErrors` functions at `.~/components/free-listings/configure-product-listings/checkErrors.js`

- Add unit tests
- Fix some edge cases to make sure the merchant settings data called to API will not contain invalid values

### Screenshots

https://user-images.githubusercontent.com/17420811/125068092-a548a200-e0e7-11eb-9619-c541a328387f.mp4

### Detailed test instructions:

1. Run `npm run test-unit` and make sure all these tests pass
2. Delete or move out the `gla_merchant_center` WP options to load the initial MC onboarding setup from scratch
3. Proceed to step 3
    - The "Complete setup" button should be disabled if the free shipping threshold is not yet entered
    - Other checks should work as before

### Changelog entry

> Fix - Disable the "Complete setup" button if the free shipping price is not yet entered when setting up Merchant Center for the first time
