### PR TITLE
Process all batches when updating products

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -1043,7 +1043,7 @@ class ConnectionTest implements Service, Registerable {
 				$product_repository = $this->container->get( ProductRepository::class );
 
 				try {
-					$products = $product_repository->find_sync_ready_products();
+					$products = $product_repository->find_sync_ready_products()->get();
 
 					$result = $product_syncer->update( $products );
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -55,6 +55,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFilter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -119,6 +120,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		ProductMetaHandler::class     => true,
 		SiteVerificationMeta::class   => true,
 		BatchProductHelper::class     => true,
+		ProductFilter::class          => true,
 		ProductRepository::class      => true,
 		MetaBoxInterface::class       => true,
 		MetaBoxInitializer::class     => true,
@@ -221,7 +223,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( MerchantStatuses::class );
 		$this->share_with_tags( ProductMetaHandler::class );
 		$this->share( ProductHelper::class, ProductMetaHandler::class, WC::class, MerchantCenterService::class );
-		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class, ProductHelper::class );
+		$this->share_with_tags( ProductFilter::class, ProductHelper::class );
+		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class, ProductFilter::class );
 		$this->share_with_tags( ProductFactory::class, AttributeManager::class, WC::class );
 		$this->share_with_tags(
 			BatchProductHelper::class,

--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -67,15 +67,18 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 		$this->monitor->validate_failure_rate( $this );
 
 		$items = $this->get_batch( $batch_number );
+		$count = $this->unfiltered_count ?? count( $items );
 
-		if ( empty( $items ) ) {
+		if ( 0 === $count ) {
 			// if no more items the job is complete
 			$this->handle_complete( $batch_number );
 		} else {
 			// if items, schedule the process action
-			$this->schedule_process_action( $items );
+			if ( ! empty( $items ) ) {
+				$this->schedule_process_action( $items );
+			}
 
-			if ( count( $items ) >= $this->get_batch_size() ) {
+			if ( $count >= $this->get_batch_size() ) {
 				// if there might be more items, add another "create_batch" action to handle them
 				$this->schedule_create_batch_action( $batch_number + 1 );
 			}

--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -67,18 +67,15 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 		$this->monitor->validate_failure_rate( $this );
 
 		$items = $this->get_batch( $batch_number );
-		$count = $this->unfiltered_count ?? count( $items );
 
-		if ( 0 === $count ) {
+		if ( empty( $items ) ) {
 			// if no more items the job is complete
 			$this->handle_complete( $batch_number );
 		} else {
 			// if items, schedule the process action
-			if ( ! empty( $items ) ) {
-				$this->schedule_process_action( $items );
-			}
+			$this->schedule_process_action( $items );
 
-			if ( $count >= $this->get_batch_size() ) {
+			if ( count( $items ) >= $this->get_batch_size() ) {
 				// if there might be more items, add another "create_batch" action to handle them
 				$this->schedule_create_batch_action( $batch_number + 1 );
 			}

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -37,7 +37,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 * @return array
 	 */
 	public function get_batch( int $batch_number ): array {
-		return $this->get_filtered_batch()->get();
+		return $this->get_filtered_batch( $batch_number )->get();
 	}
 
 	/**

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -35,7 +35,10 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 * @return array
 	 */
 	public function get_batch( int $batch_number ): array {
-		return $this->product_repository->find_sync_ready_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) )->get();
+		$list = $this->product_repository->find_sync_ready_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+
+		$this->unfiltered_count = $list->get_unfiltered_count();
+		return $list->get();
 	}
 
 	/**

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -45,6 +45,8 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
 	 *
 	 * @return FilteredProductList
@@ -60,6 +62,8 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * Schedules an action to run immediately for the items in the batch.
 	 * Uses the unfiltered count to check if there are additional batches.
+	 *
+	 * @since x.x.x
 	 *
 	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
 	 *

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -3,7 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\FilteredProductList;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncerException;
+use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -35,10 +37,54 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 * @return array
 	 */
 	public function get_batch( int $batch_number ): array {
-		$list = $this->product_repository->find_sync_ready_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+		return $this->get_filtered_batch()->get();
+	}
 
-		$this->unfiltered_count = $list->get_unfiltered_count();
-		return $list->get();
+	/**
+	 * Get a single filtered batch of items.
+	 *
+	 * If no items are returned the job will stop.
+	 *
+	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 *
+	 * @return FilteredProductList
+	 */
+	protected function get_filtered_batch( int $batch_number ): FilteredProductList {
+		return $this->product_repository->find_sync_ready_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Handles batch creation action hook.
+	 *
+	 * @hooked gla/jobs/{$job_name}/create_batch
+	 *
+	 * Schedules an action to run immediately for the items in the batch.
+	 * Uses the unfiltered count to check if there are additional batches.
+	 *
+	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 *
+	 * @throws Exception If an error occurs.
+	 * @throws JobException If the job failure rate is too high.
+	 */
+	public function handle_create_batch_action( int $batch_number ) {
+		$this->monitor->validate_failure_rate( $this );
+
+		$items = $this->get_filtered_batch( $batch_number );
+
+		if ( 0 === $items->get_unfiltered_count() ) {
+			// if no more items the job is complete
+			$this->handle_complete( $batch_number );
+		} else {
+			// if items, schedule the process action
+			if ( count( $items ) ) {
+				$this->schedule_process_action( $items->get() );
+			}
+
+			if ( $items->get_unfiltered_count() >= $this->get_batch_size() ) {
+				// if there might be more items, add another "create_batch" action to handle them
+				$this->schedule_create_batch_action( $batch_number + 1 );
+			}
+		}
 	}
 
 	/**

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -35,7 +35,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 * @return array
 	 */
 	public function get_batch( int $batch_number ): array {
-		return $this->product_repository->find_sync_ready_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+		return $this->product_repository->find_sync_ready_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) )->get();
 	}
 
 	/**

--- a/src/Jobs/UpdateProducts.php
+++ b/src/Jobs/UpdateProducts.php
@@ -37,7 +37,7 @@ class UpdateProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 */
 	public function process_items( array $product_ids ) {
 		$args     = [ 'include' => $product_ids ];
-		$products = $this->product_repository->find_sync_ready_products( $args );
+		$products = $this->product_repository->find_sync_ready_products( $args )->get();
 
 		if ( empty( $products ) ) {
 			throw JobException::item_not_found();

--- a/src/Product/FilteredProductList.php
+++ b/src/Product/FilteredProductList.php
@@ -39,7 +39,7 @@ class FilteredProductList implements Countable {
 	 * @param WC_Product[]|int[] $products         List of filtered products.
 	 * @param int                $unfiltered_count Product count before filtering.
 	 */
-	public function __construct( $products, $unfiltered_count ) {
+	public function __construct( $products, int $unfiltered_count ) {
 		$this->products         = $products ?? [];
 		$this->unfiltered_count = $unfiltered_count;
 	}

--- a/src/Product/FilteredProductList.php
+++ b/src/Product/FilteredProductList.php
@@ -36,8 +36,8 @@ class FilteredProductList implements Countable {
 	/**
 	 * FilteredProductList constructor.
 	 *
-	 * @param array $products         List of filtered products.
-	 * @param array $unfiltered_count Product count before filtering.
+	 * @param WC_Product[]|int[] $products         List of filtered products.
+	 * @param int                $unfiltered_count Product count before filtering.
 	 */
 	public function __construct( $products, $unfiltered_count ) {
 		$this->products         = $products ?? [];

--- a/src/Product/FilteredProductList.php
+++ b/src/Product/FilteredProductList.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
+use Countable;
 use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
@@ -16,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
  */
-class FilteredProductList {
+class FilteredProductList implements Countable {
 
 	/**
 	 * List of product objects or IDs.
@@ -76,5 +77,14 @@ class FilteredProductList {
 	 */
 	public function get_unfiltered_count(): int {
 		return $this->unfiltered_count;
+	}
+
+	/**
+	 * Count products for Countable.
+	 *
+	 * @return int
+	 */
+	public function count(): int {
+		return count( $this->products );
 	}
 }

--- a/src/Product/FilteredProductList.php
+++ b/src/Product/FilteredProductList.php
@@ -1,0 +1,80 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
+
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class FilteredProductList
+ *
+ * A list of filtered products and their total count before filtering.
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
+ */
+class FilteredProductList {
+
+	/**
+	 * List of product objects or IDs.
+	 *
+	 * @var WC_Product[]|int[]
+	 */
+	protected $products;
+
+	/**
+	 * Count before filtering.
+	 *
+	 * @var int
+	 */
+	protected $unfiltered_count;
+
+	/**
+	 * FilteredProductList constructor.
+	 *
+	 * @param array $products         List of filtered products.
+	 * @param array $unfiltered_count Product count before filtering.
+	 */
+	public function __construct( $products, $unfiltered_count ) {
+		$this->products         = $products ?? [];
+		$this->unfiltered_count = $unfiltered_count;
+	}
+
+	/**
+	 * Get the list of products.
+	 *
+	 * @return array
+	 */
+	public function get(): array {
+		return $this->products;
+	}
+
+	/**
+	 * Get product IDs.
+	 *
+	 * @return int[]
+	 */
+	public function get_product_ids(): array {
+		return array_map(
+			function ( $product ) {
+				if ( $product instanceof WC_Product ) {
+					return $product->get_id();
+				}
+				return $product;
+			},
+			$this->products
+		);
+	}
+
+	/**
+	 * Get the unfiltered amount of results.
+	 *
+	 * @return int
+	 */
+	public function get_unfiltered_count(): int {
+		return $this->unfiltered_count;
+	}
+}

--- a/src/Product/ProductFilter.php
+++ b/src/Product/ProductFilter.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use WC_Product;
+
+/**
+ * Class ProductFilter
+ *
+ * Filters a list of products retrieved from the repository.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
+ */
+class ProductFilter implements Service {
+
+	/**
+	 * @var ProductHelper
+	 */
+	protected $product_helper;
+
+	/**
+	 * ProductRepository constructor.
+	 *
+	 * @param ProductHelper $product_helper
+	 */
+	public function __construct( ProductHelper $product_helper ) {
+		$this->product_helper = $product_helper;
+	}
+
+	/**
+	 * Filters and returns a list of products that are ready to be submitted to Google Merchant Center.
+	 *
+	 * @param WC_Product[] $products
+	 * @param bool         $return_ids
+	 *
+	 * @return FilteredProductList
+	 */
+	public function filter_sync_ready_products( array $products, bool $return_ids = false ): FilteredProductList {
+		$unfiltered_count = count( $products );
+
+		/**
+		 * Filters the list of products ready to be synced (before applying filters to check failures and sync-ready status).
+		 *
+		 * @param WC_Product[] $products Sync-ready WooCommerce products
+		 */
+		$products = apply_filters( 'woocommerce_gla_get_sync_ready_products_pre_filter', $products );
+
+		$results = [];
+		foreach ( $products as $product ) {
+			// skip if it's not sync ready or if syncing has recently failed
+			if ( ! $this->product_helper->is_sync_ready( $product ) || $this->product_helper->is_sync_failed_recently( $product ) ) {
+				continue;
+			}
+
+			$results[] = $return_ids ? $product->get_id() : $product;
+		}
+
+		/**
+		 * Filters the list of products ready to be synced (after applying filters to check failures and sync-ready status).
+		 *
+		 * @param WC_Product[] $results Sync-ready WooCommerce products
+		 */
+		$results = apply_filters( 'woocommerce_gla_get_sync_ready_products_filter', $results );
+
+		return new FilteredProductList( $results, $unfiltered_count );
+	}
+}

--- a/src/Product/ProductFilter.php
+++ b/src/Product/ProductFilter.php
@@ -10,6 +10,8 @@ use WC_Product;
  *
  * Filters a list of products retrieved from the repository.
  *
+ * @since x.x.x
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
  */
 class ProductFilter implements Service {

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -28,19 +28,19 @@ class ProductRepository implements Service {
 	protected $meta_handler;
 
 	/**
-	 * @var ProductHelper
+	 * @var ProductFilter
 	 */
-	protected $product_helper;
+	protected $product_filter;
 
 	/**
 	 * ProductRepository constructor.
 	 *
 	 * @param ProductMetaHandler $meta_handler
-	 * @param ProductHelper      $product_helper
+	 * @param ProductFilter      $product_filter
 	 */
-	public function __construct( ProductMetaHandler $meta_handler, ProductHelper $product_helper ) {
+	public function __construct( ProductMetaHandler $meta_handler, ProductFilter $product_filter ) {
 		$this->meta_handler   = $meta_handler;
-		$this->product_helper = $product_helper;
+		$this->product_filter = $product_filter;
 	}
 
 	/**
@@ -143,12 +143,12 @@ class ProductRepository implements Service {
 	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
 	 * @param int   $offset Amount to offset product results.
 	 *
-	 * @return WC_Product[] Array of WooCommerce product objects
+	 * @return FilteredProductList List of WooCommerce product objects after filtering.
 	 */
-	public function find_sync_ready_products( array $args = [], int $limit = - 1, int $offset = 0 ): array {
+	public function find_sync_ready_products( array $args = [], int $limit = - 1, int $offset = 0 ): FilteredProductList {
 		$results = $this->find( $this->get_sync_ready_products_query_args( $args ), $limit, $offset );
 
-		return $this->filter_sync_ready_products( $results, false );
+		return $this->product_filter->filter_sync_ready_products( $results, false );
 	}
 
 	/**
@@ -158,46 +158,12 @@ class ProductRepository implements Service {
 	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
 	 * @param int   $offset Amount to offset product results.
 	 *
-	 * @return int[] Array of WooCommerce product IDs
+	 * @return FilteredProductList List of WooCommerce product IDs after filtering.
 	 */
-	public function find_sync_ready_product_ids( array $args = [], int $limit = - 1, int $offset = 0 ): array {
+	public function find_sync_ready_product_ids( array $args = [], int $limit = - 1, int $offset = 0 ): FilteredProductList {
 		$results = $this->find( $this->get_sync_ready_products_query_args( $args ), $limit, $offset );
 
-		return $this->filter_sync_ready_products( $results, true );
-	}
-
-	/**
-	 * Filters and returns a list of products that are ready to be submitted to Google Merchant Center.
-	 *
-	 * @param WC_Product[] $products
-	 * @param bool         $return_ids
-	 *
-	 * @return WC_Product[]
-	 */
-	protected function filter_sync_ready_products( array $products, bool $return_ids = false ): array {
-		/**
-		 * Filters the list of products ready to be synced (before applying filters to check failures and sync-ready status).
-		 *
-		 * @param WC_Product[] $products Sync-ready WooCommerce products
-		 */
-		$products = apply_filters( 'woocommerce_gla_get_sync_ready_products_pre_filter', $products );
-
-		$results = [];
-		foreach ( $products as $product ) {
-			// skip if it's not sync ready or if syncing has recently failed
-			if ( ! $this->product_helper->is_sync_ready( $product ) || $this->product_helper->is_sync_failed_recently( $product ) ) {
-				continue;
-			}
-
-			$results[] = $return_ids ? $product->get_id() : $product;
-		}
-
-		/**
-		 * Filters the list of products ready to be synced (after applying filters to check failures and sync-ready status).
-		 *
-		 * @param WC_Product[] $results Sync-ready WooCommerce products
-		 */
-		return apply_filters( 'woocommerce_gla_get_sync_ready_products_filter', $results );
+		return $this->product_filter->filter_sync_ready_products( $results, true );
 	}
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
@@ -6,8 +7,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Class ProductRepository

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\FilteredProductList;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -194,21 +195,16 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		}
 
 		$results = $this->product_repository->find_sync_ready_products();
+		$this->assertInstanceOf( FilteredProductList::class, $results );
 
 		// compare the IDs because the objects might not be identical
-		$result_ids = array_map(
-			function ( WC_Product $product ) {
-				return $product->get_id();
-			},
-			$results
+		$this->assertEquals(
+			array_merge( [ $simple_product->get_id() ], $variable_product->get_children() ),
+			$results->get_product_ids()
 		);
 		$this->assertEquals(
 			array_merge( [ $simple_product->get_id() ], $variable_product->get_children() ),
-			$result_ids
-		);
-		$this->assertEquals(
-			array_merge( [ $simple_product->get_id() ], $variable_product->get_children() ),
-			$this->product_repository->find_sync_ready_product_ids()
+			$this->product_repository->find_sync_ready_product_ids()->get()
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the responses returned by the ProductRepository class to return an instance of ProductList. A ProductList can contain both a set of products/ids as well as the count before filtering. We use this count to confirm that we need to process additional batches of products.

Initially I was planning to use the `paginate = true` option to `wc_get_products` however in the end I decided to simplify it to only store the unfiltered count. Using the pagination option could lead to additional DB queries and resource usage.

Closes #861

### Detailed test instructions:

1. Start with trunk
2. Set some variable products to "Do not Sync and Show" (preferably ones with a lower product ID)
3. Confirm we have more products / variations then default batch size of 100, otherwise use the code snippet to decrease it:
```
add_filter(
	'woocommerce_gla_batched_job_size',
	function( $size ) {
		return 10;
	}
);
```
4. Sync all the products (async) on the Connection test page
5. Check WooCommerce > Status > Scheduled Actions and view the completed actions
6. Confirm that as soon as we encounter a batch containing less then batch size products, no new batch is scheduled
7. Checkout PR and repeat steps 2 to 5
8. Confirm that even if we encounter a batch containing less then batch size products batches are continued to be scheduled
9. Confirm unit test for unfiltered_count passes in PR

### Changelog entry
* Fix - Process all batches when updating products.