### PR TITLE
Change expiry to after 25 days

### DIFF
--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -270,7 +270,7 @@ class ProductRepository implements Service {
 				[
 					'key'     => ProductMetaHandler::KEY_SYNCED_AT,
 					'compare' => '<',
-					'value'   => strtotime( '-28 days' ),
+					'value'   => strtotime( '-25 days' ),
 				],
 			],
 		];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the expiry of products to after 25 days, which will trigger them to be resubmitted earlier to avoid confusing "expiring soon messages".

Closes #877

### Detailed test instructions:

1. Change the expiry date by [modifying the timestamp](https://www.epochconverter.com/) in the postmeta `_wc_gla_synced_at` 
2. Set one product to -24 days and another to -26 days
3. Go to `WooCommerce > Status > Scheduled Actions > Pending` and trigger the `resubmit_expiring_products` job to run
4. Check the completed actions (after a minute) and confirm we see an action `gla/jobs/resubmit_expiring_products/process_item` with the ID of the product we set to -26 days in the arguments column
![image](https://user-images.githubusercontent.com/11388669/125411772-23da6380-e3b6-11eb-9d11-ce935dc65fd3.png)

### Changelog entry
* Tweak - Change product expiry to after 25 days.