### PR TITLE
Filters for adjusting description

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -177,7 +177,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		// Strip out active shortcodes and HTML tags.
 		$description = strip_shortcodes( wp_strip_all_tags( $description ) );
 
-		return apply_filters( 'woocommerce_gla_synced_product_description', $description, $this->wc_product );
+		return apply_filters( 'woocommerce_gla_product_attribute_value_description', $description, $this->wc_product );
 	}
 
 	/**

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -152,13 +152,15 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 * @return string
 	 */
 	protected function get_wc_product_description(): string {
-		$description = ! empty( $this->wc_product->get_description() ) ?
+		$use_short_description = apply_filters( 'woocommerce_gla_use_short_description', false );
+
+		$description = ! empty( $this->wc_product->get_description() ) && ! $use_short_description ?
 			$this->wc_product->get_description() :
 			$this->wc_product->get_short_description();
 
 		// prepend the parent product description to the variation product
 		if ( $this->is_variation() ) {
-			$parent_description = ! empty( $this->parent_wc_product->get_description() ) ?
+			$parent_description = ! empty( $this->parent_wc_product->get_description() ) && ! $use_short_description ?
 				$this->parent_wc_product->get_description() :
 				$this->parent_wc_product->get_short_description();
 			$new_line           = ! empty( $description ) && ! empty( $parent_description ) ? PHP_EOL : '';
@@ -172,7 +174,10 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			$description
 		);
 
-		return strip_shortcodes( wp_strip_all_tags( $description ) );
+		// Strip out active shortcodes and HTML tags.
+		$description = strip_shortcodes( wp_strip_all_tags( $description ) );
+
+		return apply_filters( 'woocommerce_gla_synced_product_description', $description, $this->wc_product );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/google-listings-and-ads/issues/782#issuecomment-876889791 we decided to go with using the full description and fallback to short description if it's not available.

However this doesn't resolve the issue for sites where there are theme shortcodes within the description. We only filter out "active" shortcodes which means that if the theme hasn't registered the shortcodes at the time of the sync then they won't be filtered out. Since we currently don't want to change the defaults, this PR offers those merchants some flexibility to be able to use a filter to influence the way the description is synced.

1. Always use the short description with the code snippet:
```php
add_filter( 'woocommerce_gla_use_short_description', '__return_true' );
```
2. Use the filter `woocommerce_gla_product_attribute_value_description` which will pass both the description and the product so it can be modified as needed.

Closes #784

### Detailed test instructions:

1. Use a code snippet to log the synced description:
```php
add_filter(
	'woocommerce_gla_product_attribute_value_description',
	function( $description, $product ) {
		do_action(
			'woocommerce_gla_debug_message',
			sprintf( 'Description for product %d: %s', $product->get_id(), $description ),
			'code snippet'
		);

		return $description;
	},
	999,
	2
);
```
2. Edit a product and save it with no description and a short description
3. Sync the product by ID on the connection test page and confirm the log entry shows the short description
4. Edit a product and save it with a description and a short description
5. Sync the product by ID on the connection test page and confirm the log entry shows the description
6. Enable the code snippet to always use short description
```php
add_filter( 'woocommerce_gla_use_short_description', '__return_true' );
```
7. Sync the product by ID on the connection test page and confirm the log entry shows the short description
8. Use a filter to modify the description
```php
add_filter(
	'woocommerce_gla_product_attribute_value_description',
	function( $description, $product ) {
		return sprintf( 'Custom description for %d', $product->get_id() );
	},
	10,
	2
);
```
9. Sync the product by ID on the connection test page and confirm the log entry shows the custom description
10. Wait for the product to be updated in the Merchant Center and confirm it shows the last used description:
![image](https://user-images.githubusercontent.com/11388669/125421090-b7418331-20b3-4ee5-ba80-058180ef4ec1.png)


### Changelog entry
* Tweak - Add filters for adjusting description.