### PR TITLE
Don't sync invisible products to MC

### DIFF
--- a/js/src/product-attributes/index.scss
+++ b/js/src/product-attributes/index.scss
@@ -35,3 +35,8 @@
 		}
 	}
 }
+
+#gla_channel_visibility_visibility {
+	display: block;
+	margin: $grid-unit-10 0;
+}

--- a/js/src/product-attributes/index.scss
+++ b/js/src/product-attributes/index.scss
@@ -36,7 +36,7 @@
 	}
 }
 
-#gla_channel_visibility_visibility {
+.gla-channel-visibility-box select {
 	display: block;
 	margin: $grid-unit-10 0;
 }

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -122,12 +122,12 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 		$product    = $this->product_helper->get_wc_product( $product_id );
 
 		return [
-			'field_id'    => $this->get_visibility_field_id(),
-			'product_id'  => $product_id,
-			'product'     => $product,
-			'visibility'  => $this->product_helper->get_channel_visibility( $product ),
-			'sync_status' => $this->meta_handler->get_sync_status( $product ),
-			'issues'      => $this->product_helper->get_validation_errors( $product ),
+			'field_id'           => $this->get_visibility_field_id(),
+			'product_id'         => $product_id,
+			'product'            => $product,
+			'channel_visibility' => $this->product_helper->get_channel_visibility( $product ),
+			'sync_status'        => $this->meta_handler->get_sync_status( $product ),
+			'issues'             => $this->product_helper->get_validation_errors( $product ),
 		];
 	}
 

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -125,7 +125,7 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 			'field_id'    => $this->get_visibility_field_id(),
 			'product_id'  => $product_id,
 			'product'     => $product,
-			'visibility'  => $this->product_helper->get_visibility( $product ),
+			'visibility'  => $this->product_helper->get_channel_visibility( $product ),
 			'sync_status' => $this->meta_handler->get_sync_status( $product ),
 			'issues'      => $this->product_helper->get_validation_errors( $product ),
 		];

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -90,7 +90,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 			$products[ $id ] = [
 				'id'      => $id,
 				'title'   => $product->get_name(),
-				'visible' => $product_helper->get_visibility( $product ) !== ChannelVisibility::DONT_SYNC_AND_SHOW,
+				'visible' => $product_helper->get_channel_visibility( $product ) !== ChannelVisibility::DONT_SYNC_AND_SHOW,
 				'status'  => $product_helper->get_mc_status( $product ) ?: $product_helper->get_sync_status( $product ),
 				'errors'  => array_values( $errors ),
 			];

--- a/src/HelperTraits/ViewHelperTrait.php
+++ b/src/HelperTraits/ViewHelperTrait.php
@@ -39,6 +39,7 @@ trait ViewHelperTrait {
 			'name'             => true,
 			'selected'         => true,
 			'type'             => true,
+			'disabled'         => true,
 		];
 
 		return array_merge(

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -276,8 +276,7 @@ class ProductHelper implements Service {
 	 * @return bool
 	 */
 	public function is_sync_ready( WC_Product $product ): bool {
-		$hide_out_of_stock  = 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' );
-		$product_visibility = ! $hide_out_of_stock || $product->is_in_stock();
+		$product_visibility = $product->is_visible();
 		$product_status     = $product->get_status();
 
 		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -295,7 +295,7 @@ class ProductHelper implements Service {
 			}
 		}
 
-		return ( ChannelVisibility::DONT_SYNC_AND_SHOW !== $this->get_visibility( $product ) ) &&
+		return ( ChannelVisibility::DONT_SYNC_AND_SHOW !== $this->get_channel_visibility( $product ) ) &&
 			   ( in_array( $product->get_type(), ProductSyncer::get_supported_product_types(), true ) ) &&
 			   ( 'publish' === $product_status ) &&
 			   $product_visibility;
@@ -325,7 +325,7 @@ class ProductHelper implements Service {
 	 *
 	 * @return string|null
 	 */
-	public function get_visibility( WC_Product $wc_product ): ?string {
+	public function get_channel_visibility( WC_Product $wc_product ): ?string {
 		$visibility = $this->meta_handler->get_visibility( $wc_product );
 		if ( $wc_product instanceof WC_Product_Variation ) {
 			// todo: we might need to define visibility per variation later.

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -216,21 +216,21 @@ trait ProductTrait {
 
 		$variations = [];
 
-		$variations[] = WC_Helper_Product::create_product_variation_object(
+		$variations[] = $this->create_product_variation_object(
 			$product->get_id(),
 			'DUMMY SKU VARIABLE SMALL',
 			10,
 			[ 'pa_size' => 'small' ]
 		);
 
-		$variations[] = WC_Helper_Product::create_product_variation_object(
+		$variations[] = $this->create_product_variation_object(
 			$product->get_id(),
 			'DUMMY SKU VARIABLE LARGE',
 			15,
 			[ 'pa_size' => 'large' ]
 		);
 
-		$variations[] = WC_Helper_Product::create_product_variation_object(
+		$variations[] = $this->create_product_variation_object(
 			$product->get_id(),
 			'DUMMY SKU VARIABLE HUGE',
 			15,
@@ -250,6 +250,36 @@ trait ProductTrait {
 		$product->set_children( $variation_ids );
 
 		return $product;
+	}
+
+	/**
+	 * Creates an instance of WC_Product_Variation with the supplied parameters, optionally persisting it to the
+	 * database.
+	 *
+	 * @param string $parent_id  Parent product id.
+	 * @param string $sku        SKU for the variation.
+	 * @param int    $price      Price of the variation.
+	 * @param array  $attributes Attributes that define the variation, e.g. ['pa_color'=>'red'].
+	 * @param bool   $save       If true, the object will be saved to the database after being created and configured.
+	 *
+	 * @return WC_Product_Variation The created object.
+	 */
+	protected function create_product_variation_object( $parent_id, $sku, $price, $attributes, $save = true ) {
+		$variation = new WC_Product_Variation();
+		$variation->set_props(
+			[
+				'parent_id'     => $parent_id,
+				'sku'           => $sku,
+				'regular_price' => $price,
+			]
+		);
+		$variation->set_parent_data( [ 'catalog_visibility' => 'visible' ] );
+		$variation->set_attributes( $attributes );
+		if ( $save ) {
+			$variation->save();
+		}
+
+		return $variation;
 	}
 
 	/**

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -582,6 +582,20 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertFalse( $this->product_helper->is_sync_ready( $variation ) );
 	}
 
+	public function test_is_sync_ready_variation_parent_hidden_in_catalog() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$parent->set_status( 'publish' );
+		$parent->set_catalog_visibility( 'hidden' );
+		$parent->save();
+		$this->product_meta->update_visibility( $parent, ChannelVisibility::SYNC_AND_SHOW );
+
+		$variation = $this->wc->get_product( $parent->get_children()[0] );
+		$variation->set_status( 'publish' );
+		$variation->save();
+		$this->product_meta->update_visibility( $variation, ChannelVisibility::SYNC_AND_SHOW );
+		$this->assertFalse( $this->product_helper->is_sync_ready( $variation ) );
+	}
+
 	/**
 	 * @param WC_Product $product
 	 *

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -620,18 +620,18 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	 *
 	 * @dataProvider return_blank_test_products
 	 */
-	public function test_get_visibility( WC_Product $product ) {
+	public function test_get_channel_visibility( WC_Product $product ) {
 		$this->product_meta->update_visibility( $product, ChannelVisibility::DONT_SYNC_AND_SHOW );
-		$result = $this->product_helper->get_visibility( $product );
+		$result = $this->product_helper->get_channel_visibility( $product );
 		$this->assertEquals( ChannelVisibility::DONT_SYNC_AND_SHOW, $result );
 	}
 
-	public function test_get_visibility_variation_product_inherits_from_parent() {
+	public function test_get_channel_visibility_variation_product_inherits_from_parent() {
 		$parent    = WC_Helper_Product::create_variation_product();
 		$variation = $this->wc->get_product( $parent->get_children()[0] );
 		$this->product_meta->update_visibility( $parent, ChannelVisibility::DONT_SYNC_AND_SHOW );
 		$this->product_meta->update_visibility( $variation, ChannelVisibility::SYNC_AND_SHOW );
-		$this->assertEquals( ChannelVisibility::DONT_SYNC_AND_SHOW, $this->product_helper->get_visibility( $variation ) );
+		$this->assertEquals( ChannelVisibility::DONT_SYNC_AND_SHOW, $this->product_helper->get_channel_visibility( $variation ) );
 	}
 
 	/**

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -41,7 +41,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_mark_as_synced( WC_Product $product ) {
 		$google_product = $this->generate_google_product_mock();
@@ -69,7 +69,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_mark_as_synced_keeps_existing_google_ids( WC_Product $product ) {
 		$google_product = $this->generate_google_product_mock();
@@ -89,7 +89,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_mark_as_synced_doesnt_delete_errors_unless_all_target_countries_synced( WC_Product $product ) {
 		$google_product = $this->generate_google_product_mock();
@@ -156,7 +156,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_mark_as_unsynced( WC_Product $product ) {
 		// First mark the product as synced to update its meta data
@@ -173,7 +173,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_mark_as_unsynced_updates_both_variation_and_parent() {
 		$parent = WC_Helper_Product::create_variation_product();
@@ -200,7 +200,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_remove_google_id( WC_Product $product ) {
 		$this->product_meta->update_google_ids(
@@ -219,7 +219,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_remove_google_id_marks_as_unsynced_if_empty_ids( WC_Product $product ) {
 		$this->product_meta->update_google_ids( $product, [ 'US' => 'online:en:US:gla_1', ] );
@@ -233,7 +233,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_mark_as_invalid( WC_Product $product ) {
 		$errors = [
@@ -257,7 +257,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_mark_as_invalid_updates_failed_sync_attempts_if_internal_error_exists( WC_Product $product ) {
 		$errors = [
@@ -314,7 +314,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_mark_as_pending( WC_Product $product ) {
 		$this->product_helper->mark_as_pending( $product );
@@ -338,7 +338,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_get_synced_google_product_ids( WC_Product $product ) {
 		$this->product_meta->update_google_ids( $product, [ 'US' => 'online:en:US:gla_1' ] );
@@ -386,7 +386,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_product_synced( WC_Product $product ) {
 		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
@@ -397,7 +397,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_product_synced_return_false_if_no_google_id( WC_Product $product ) {
 		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
@@ -409,7 +409,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_product_synced_return_false_if_no_synced_at( WC_Product $product ) {
 		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
@@ -421,7 +421,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_sync_ready_visible_published( WC_Product $product ) {
 		$product->set_status( 'publish' );
@@ -434,7 +434,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_sync_ready_not_visible_published( WC_Product $product ) {
 		$product->set_status( 'publish' );
@@ -447,7 +447,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_sync_ready_visible_not_published( WC_Product $product ) {
 		$product->set_status( 'draft' );
@@ -585,7 +585,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_sync_failed_recently( WC_Product $product ) {
 		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD + 5 );
@@ -596,7 +596,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_sync_failed_recently_less_than_threshold( WC_Product $product ) {
 		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD - 1 );
@@ -607,7 +607,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_is_sync_failed_recently_old_failure_but_more_than_threshold( WC_Product $product ) {
 		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD + 5 );
@@ -618,7 +618,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_get_channel_visibility( WC_Product $product ) {
 		$this->product_meta->update_visibility( $product, ChannelVisibility::DONT_SYNC_AND_SHOW );
@@ -637,7 +637,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_get_sync_status( WC_Product $product ) {
 		$this->product_meta->update_sync_status( $product, SyncStatus::SYNCED );
@@ -647,7 +647,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_get_mc_status( WC_Product $product ) {
 		$this->product_meta->update_mc_status( $product, MCStatus::APPROVED );
@@ -684,7 +684,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_get_validation_errors( WC_Product $product ) {
 		$errors = [
@@ -718,7 +718,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @param WC_Product $product
 	 *
-	 * @dataProvider return_blank_test_products
+	 * @dataProvider return_test_products
 	 */
 	public function test_get_validation_errors_returns_as_is_if_keys_arent_product_ids( WC_Product $product ) {
 		$errors = [
@@ -747,7 +747,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * @return array
 	 */
-	public function return_blank_test_products(): array {
+	public function return_test_products(): array {
 		// variation products are provided separately to related tests
 		return [
 			[ WC_Helper_Product::create_simple_product() ],

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -81,12 +81,12 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_adding_variation_schedules_update_job() {
-		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product = $this->create_variation_product();
 
 		$this->update_products_job->expects( $this->once() )
 								  ->method( 'schedule' );
 
-		WC_Helper_Product::create_product_variation_object(
+		$this->create_product_variation_object(
 			$variable_product->get_id(),
 			'DUMMY SKU VARIABLE SMALL BLUE 2',
 			10,
@@ -131,7 +131,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_trashing_synced_variable_schedules_delete_job_for_all_variations() {
-		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product = $this->create_variation_product();
 		foreach ( $variable_product->get_children() as $variation_id ) {
 			$variation = wc_get_product( $variation_id );
 			$this->product_helper->mark_as_synced( $variation, $this->generate_google_product_mock() );
@@ -144,7 +144,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_force_deleting_synced_variable_schedules_delete_job_for_all_variations() {
-		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product = $this->create_variation_product();
 		foreach ( $variable_product->get_children() as $variation_id ) {
 			$variation = wc_get_product( $variation_id );
 			$this->product_helper->mark_as_synced( $variation, $this->generate_google_product_mock() );
@@ -157,7 +157,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_trashing_synced_variation_schedules_delete_job() {
-		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product = $this->create_variation_product();
 		foreach ( $variable_product->get_children() as $variation_id ) {
 			$variation = wc_get_product( $variation_id );
 			$this->product_helper->mark_as_synced( $variation, $this->generate_google_product_mock( 'online:en:US:gla_' . $variation_id ) );
@@ -172,7 +172,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_force_deleting_synced_variation_schedules_delete_job() {
-		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product = $this->create_variation_product();
 		foreach ( $variable_product->get_children() as $variation_id ) {
 			$variation = wc_get_product( $variation_id );
 			$this->product_helper->mark_as_synced( $variation, $this->generate_google_product_mock( 'online:en:US:gla_' . $variation_id ) );

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -47,6 +47,7 @@ $input_description = '';
 $input_disabled    = false;
 if ( ! $product->is_visible() ) {
 	$channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
+	$show_status        = false;
 	$input_disabled     = true;
 	$input_description  = __( 'This product cannot be shown on any channel because it is hidden from your store catalog.', 'google-listings-and-ads' );
 }

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -50,6 +50,11 @@ if ( ! $product->is_visible() ) {
 	$input_disabled     = true;
 	$input_description  = __( 'This product cannot be shown on any channel because it is hidden from your store catalog.', 'google-listings-and-ads' );
 }
+
+$custom_attributes = [];
+if ( $input_disabled ) {
+	$custom_attributes['disabled'] = 'disabled';
+}
 ?>
 
 <div class="gla-channel-visibility-box">
@@ -65,9 +70,7 @@ if ( ! $product->is_visible() ) {
 				ChannelVisibility::SYNC_AND_SHOW      => __( 'Sync and show', 'google-listings-and-ads' ),
 				ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
 			],
-			'custom_attributes' => [
-				'disabled' => 'disabled',
-			],
+			'custom_attributes' => $custom_attributes,
 		]
 	);
 	?>

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -20,7 +20,7 @@ $product_id = $this->product_id;
  */
 $product = $this->product;
 
-$visibility = $this->visibility;
+$channel_visibility = $this->channel_visibility;
 
 /**
  * @var string
@@ -35,25 +35,38 @@ if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
 } elseif ( ! is_null( $this->sync_status ) ) {
 	$sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
 }
-$show_status = $visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
+$show_status = $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
 
 /**
  * @var array $issues
  */
 $issues     = $this->issues;
 $has_issues = ! empty( $issues );
+
+$input_description = '';
+$input_disabled    = false;
+if ( ! $product->is_visible() ) {
+	$channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
+	$input_disabled     = true;
+	$input_description  = __( 'This product cannot be shown on any channel because it is hidden from your store catalog.', 'google-listings-and-ads' );
+}
 ?>
 
 <div class="gla-channel-visibility-box">
 	<?php
 	woocommerce_wp_select(
 		[
-			'id'      => $field_id,
-			'value'   => $visibility,
-			'label'   => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
-			'options' => [
+			'id'                => $field_id,
+			'value'             => $channel_visibility,
+			'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
+			'description'       => $input_description,
+			'desc_tip'          => false,
+			'options'           => [
 				ChannelVisibility::SYNC_AND_SHOW      => __( 'Sync and show', 'google-listings-and-ads' ),
 				ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
+			],
+			'custom_attributes' => [
+				'disabled' => 'disabled',
 			],
 		]
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR modifies the `ProductHelper::is_sync_ready` method so that it also checks the product's visibility. In addition to the previous conditions, it now returns false for a product when:
 - `woocommerce_hide_out_of_stock_items` option is enabled and the product is out of stock
 - If it's an invisible variation (i.e. have no price or it's disabled)

The WooCommerce core `woocommerce_hide_invisible_variations` filter is also used here to check whether the variation should be displayed even if it's invisible.

These conditions were already checked for variations in `SyncerHooks` class and a few other places where the method accepts a variable product and tries to fetch its "available" variations via the `\WC_Product_Variable::get_available_variations` method. By adding these conditions to `ProductHelper::is_sync_ready` we'll also check for the "availability" (or visibility) of all other product types just like we do for variations and make things more consistent.

One major effect of this change is that if the user has enabled the `woocommerce_hide_out_of_stock_items` we no longer sync the `out-of-stock` products to Merchant Center and also remove the previously synced products once the product goes out of stock. 

However, if the user already has some out-of-stock products and then enables the `woocommerce_hide_out_of_stock_items` option, we do not remove anything. This should probably be done by watching the WooCommerce events and trigger a refresh job if any settings change. I didn't include this part in the PR because we also don't do this for any other settings changes (e.g. country, language, etc.) and I first wanted to discuss whether we need to.

### Detailed test instructions:

1. Create an out-of-stock product
2. Check the `Out of stock visibility` option  under "WooCommerce > Settings > Products > Inventory"
3. Sync the out of stock product via Connect Test page and check that it's NOT synced to MC
4. Uncheck the `Out of stock visibility` option  under "WooCommerce > Settings > Products > Inventory"
5. Sync the out of stock product via Connect Test page and check that it's synced to MC
6. Repeat the above with a variation product
7. Disable a variation by unchecking the "Enabled" option
8. Sync it via Connect Test page and check that it's NOT synced to MC
9. Remove the variation price
10. Sync it via Connect Test page and check that it's NOT synced to MC
11. Add the following filter and then disable a variation
     ```
     add_filter( 
	     'woocommerce_hide_invisible_variations', 
	     function () {
		     return false;
	     }
     );
     ```
12. Sync it via Connect Test page and check that it's synced to MC
13. Run phpunit and make sure all the tests pass


### Changelog entry

> Update - Stop syncing invisible products and variations

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->