### PR TITLE
Workaround `onSubmitCallback` being ignored by `@woocommerce/components.Form`

### DIFF
--- a/js/src/components/free-listings/choose-audience/index.js
+++ b/js/src/components/free-listings/choose-audience/index.js
@@ -80,6 +80,7 @@ export default function ChooseAudience( {
 						} }
 						validate={ handleValidate }
 						onSubmitCallback={ onContinue }
+						onSubmit={ onContinue }
 						onChangeCallback={ onChange }
 					>
 						{ ( formProps ) => {

--- a/js/src/components/free-listings/choose-audience/index.js
+++ b/js/src/components/free-listings/choose-audience/index.js
@@ -23,7 +23,7 @@ import '.~/components/free-listings/choose-audience/index.scss';
  * @param {Object} props
  * @param {string} props.stepHeader Header text to indicate the step number.
  * @param {string} [props.initialData] Target audience data, if not given AppSinner will be rendered.
- * @param {(change: {name, value}, values: Object) => void} props.onChange Callback called with form data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback}
+ * @param {(change: {name, value}, values: Object) => void} props.onChange Callback called with form data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
  * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked.
  */
 export default function ChooseAudience( {
@@ -82,6 +82,7 @@ export default function ChooseAudience( {
 						onSubmitCallback={ onContinue }
 						onSubmit={ onContinue }
 						onChangeCallback={ onChange }
+						onChange={ onChange }
 					>
 						{ ( formProps ) => {
 							return <FormContent formProps={ formProps } />;

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -59,6 +59,7 @@ const AddRateModal = ( { countries, onRequestClose, onSubmit } ) => {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmitCallback }
+			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {
 				const { getInputProps, isValidForm, handleSubmit } = formProps;

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-form.js
@@ -14,7 +14,7 @@ import getCountriesPriceArray from './getCountriesPriceArray';
  * @param {Array<ShippingRateFromServerSide>} props.value Array of individual shipping rates to be used as the initial values of the form.
  * @param {string} props.currencyCode Shop's currency code.
  * @param {Array<CountryCode>} props.audienceCountries Array of country codes of all audience countries.
- * @param {(newValue: Object) => void} props.onChange Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChangeCallback}
+ * @param {(newValue: Object) => void} props.onChange Callback called with new data once shipping rates are changed.
  */
 export default function ShippingCountriesForm( {
 	value: shippingRates,

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -78,6 +78,7 @@ const EditRateModal = ( {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmitCallback }
+			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {
 				const {

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -55,6 +55,7 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmitCallback }
+			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {
 				const { getInputProps, isValidForm, handleSubmit } = formProps;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -19,7 +19,7 @@ import getCountriesTimeArray from './getCountriesTimeArray';
  * @param {Object} props
  * @param {Array<ShippingTime>} props.value Array of individual shipping times to be used as the initial values of the form.
  * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
- * @param {(newValue: Object) => void} props.onChange Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChangeCallback}
+ * @param {(newValue: Object) => void} props.onChange Callback called with new data once shipping times are changed.
  */
 export default function ShippingCountriesForm( {
 	value: shippingTimes,

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -77,6 +77,7 @@ const EditTimeModal = ( {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmitCallback }
+			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {
 				const { getInputProps, isValidForm, handleSubmit } = formProps;

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -114,6 +114,7 @@ const SetupFreeListings = ( {
 				} }
 				validate={ handleValidate }
 				onSubmitCallback={ handleSubmit }
+				onSubmit={ handleSubmit }
 			>
 				{ ( formProps ) => {
 					return (

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -28,11 +28,11 @@ import FormContent from './form-content';
  * @param {string} props.stepHeader Header text to indicate the step number.
  * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to FormContent.
  * @param {Object} props.settings Settings data, if not given AppSpinner will be rendered.
- * @param {(change: {name, value}, values: Object) => void} props.onSettingsChange Callback called with new data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback}
+ * @param {(change: {name, value}, values: Object) => void} props.onSettingsChange Callback called with new data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
  * @param {Array<ShippingRateFromServerSide>} props.shippingRates Shipping rates data, if not given AppSpinner will be rendered.
- * @param {(newValue: Object) => void} props.onShippingRatesChange Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChangeCallback}
+ * @param {(newValue: Object) => void} props.onShippingRatesChange Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
  * @param {Array<ShippingTime>} props.shippingTimes Shipping times data, if not given AppSpinner will be rendered.
- * @param {(newValue: Object) => void} props.onShippingTimesChange Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChangeCallback}
+ * @param {(newValue: Object) => void} props.onShippingTimesChange Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
  * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked. Could be async. While it's being resolved the form would turn into a saving state.
  * @param {string} [props.submitLabel] Submit button label, to be forwarded to `FormContent`.
  */
@@ -74,6 +74,26 @@ const SetupFreeListings = ( {
 		setSaving( false );
 	};
 
+	const handleChange = ( change, newVals ) => {
+		// Un-glue form data.
+		const {
+			shipping_country_rates: newShippingRates,
+			shipping_country_times: newShippingTimes,
+			...newSettings
+		} = newVals;
+
+		switch ( change.name ) {
+			case 'shipping_country_rates':
+				onShippingRatesChange( newShippingRates );
+				break;
+			case 'shipping_country_times':
+				onShippingTimesChange( newShippingTimes );
+				break;
+			default:
+				onSettingsChange( change, newSettings );
+		}
+	};
+
 	return (
 		<div className="gla-setup-free-listings">
 			<Hero stepHeader={ stepHeader } />
@@ -93,25 +113,8 @@ const SetupFreeListings = ( {
 					shipping_country_rates: shippingRates,
 					shipping_country_times: shippingTimes,
 				} }
-				onChangeCallback={ ( change, newVals ) => {
-					// Un-glue form data.
-					const {
-						shipping_country_rates: newShippingRates,
-						shipping_country_times: newShippingTimes,
-						...newSettings
-					} = newVals;
-
-					switch ( change.name ) {
-						case 'shipping_country_rates':
-							onShippingRatesChange( newShippingRates );
-							break;
-						case 'shipping_country_times':
-							onShippingTimesChange( newShippingTimes );
-							break;
-						default:
-							onSettingsChange( change, newSettings );
-					}
-				} }
+				onChangeCallback={ handleChange }
+				onChange={ handleChange }
 				validate={ handleValidate }
 				onSubmitCallback={ handleSubmit }
 				onSubmit={ handleSubmit }

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -74,6 +74,7 @@ const CreatePaidAdsCampaignForm = () => {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmit }
+			onSubmit={ handleSubmit }
 		>
 			{ ( formProps ) => {
 				const {

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -68,6 +68,7 @@ const EditPaidAdsCampaignForm = ( props ) => {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmit }
+			onSubmit={ handleSubmit }
 		>
 			{ ( formProps ) => {
 				const {

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -67,13 +67,16 @@ const SetupAdsForm = () => {
 		} );
 	};
 
+	const handleChange = ( _, values ) => {
+		setEditedValues( values );
+	};
+
 	return (
 		<Form
 			initialValues={ initialValues }
 			validate={ handleValidate }
-			onChangeCallback={ ( _, values ) => {
-				setEditedValues( values );
-			} }
+			onChangeCallback={ handleChange }
+			onChange={ handleChange }
 			onSubmitCallback={ handleSubmit }
 			onSubmit={ handleSubmit }
 		>

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -56,6 +56,17 @@ const SetupAdsForm = () => {
 		shouldPreventLeave
 	);
 
+	const handleSubmit = ( values ) => {
+		const { amount, country: countryArr } = values;
+		const country = countryArr && countryArr[ 0 ];
+
+		recordLaunchPaidCampaignClickEvent( amount, country );
+
+		handleSetupComplete( amount, country, () => {
+			setSubmitted( true );
+		} );
+	};
+
 	return (
 		<Form
 			initialValues={ initialValues }
@@ -63,16 +74,8 @@ const SetupAdsForm = () => {
 			onChangeCallback={ ( _, values ) => {
 				setEditedValues( values );
 			} }
-			onSubmitCallback={ ( values ) => {
-				const { amount, country: countryArr } = values;
-				const country = countryArr && countryArr[ 0 ];
-
-				recordLaunchPaidCampaignClickEvent( amount, country );
-
-				handleSetupComplete( amount, country, () => {
-					setSubmitted( true );
-				} );
-			} }
+			onSubmitCallback={ handleSubmit }
+			onSubmit={ handleSubmit }
 		>
 			{ ( formProps ) => {
 				const mixedFormProps = {

--- a/js/src/setup-mc/setup-stepper/choose-audience/index.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/index.js
@@ -78,6 +78,7 @@ const ChooseAudience = ( props ) => {
 						} }
 						validate={ handleValidate }
 						onSubmitCallback={ handleSubmitCallback }
+						onSubmit={ handleSubmitCallback }
 					>
 						{ ( formProps ) => {
 							return <FormContent formProps={ formProps } />;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -112,6 +112,7 @@ const SetupFreeListings = () => {
 				} }
 				validate={ handleValidate }
 				onSubmitCallback={ handleSubmitCallback }
+				onSubmit={ handleSubmitCallback }
 			>
 				{ ( formProps ) => {
 					const { values, handleSubmit } = formProps;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -63,6 +63,7 @@ const AddRateModal = ( props ) => {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmitCallback }
+			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {
 				const { getInputProps, isValidForm, handleSubmit } = formProps;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -81,6 +81,7 @@ const EditRateModal = ( props ) => {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmitCallback }
+			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {
 				const {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -54,6 +54,7 @@ const AddTimeModal = ( props ) => {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmitCallback }
+			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {
 				const { getInputProps, isValidForm, handleSubmit } = formProps;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -74,6 +74,7 @@ const EditTimeModal = ( props ) => {
 			} }
 			validate={ handleValidate }
 			onSubmitCallback={ handleSubmitCallback }
+			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {
 				const { getInputProps, isValidForm, handleSubmit } = formProps;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Workaround `onSubmitCallback` & `onChangeCallback` being ignored by `@woocommerce/components.Form`.

Addresses https://github.com/woocommerce/google-listings-and-ads/issues/884
Works around https://github.com/woocommerce/woocommerce-admin/issues/7351.

In the long-term we should remove deprecated `onSubmitCallback` & `onChangeCallback`.


### Screenshots:

![Submit](https://user-images.githubusercontent.com/17435/125662099-589d85e8-86c0-4c3e-a510-d0ed2c9d60b3.gif)


### Detailed test instructions:

#### Original issue

1. Install WC 5.5 or at least >=https://github.com/woocommerce/woocommerce-admin/releases/tag/v2.4.0
2. Disconnect MC account to restart onboarding
2. Go to onboarding flow [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc) step 2
3. Click "Continue"

#### Other forms

- Edit audience countries in MC setup & edit free listings
- Edit shipping rate & time in setup and edit flows
- Submitting paid campaign in Ads setup & edit flow


### Changelog entry

> Fix - Made Forms submit and change behavior work with WC >= 5.5 (WooCommerce Admin >= 2.4.0).

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->

### Additional notes:
- :scroll: it would be nice to have e2e test for onboarding flow. It's tricky as we need to have e2e test for account connection first https://github.com/woocommerce/google-listings-and-ads/issues/886