### PR TITLE
Fold build in travis log for bundlewatch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,13 @@ matrix:
       script: npm run lint
     - name: "Bundle size"
       php: 7.4
-      env: WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}" WP_TRAVISCI=cs WP_MULTISITE=0 CI_BRANCH_BASE="${TRAVIS_BRANCH}"
+      env: WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}" WP_TRAVISCI=bs WP_MULTISITE=0 CI_BRANCH_BASE="${TRAVIS_BRANCH}"
       # We run the production build, to watch also .zip size.
-      script: npm run build && npx bundlewatch
+      script:
+        - echo 'Build production bundles' && echo -en "travis_fold:start:Build\r"
+        - npm run build
+        - echo -en 'travis_fold:end:Build\r'
+        - npx bundlewatch
 
 before_install:
   - if [[ "${WP_TRAVISCI}" != "jest" ]]; then composer self-update --1; fi
@@ -71,7 +75,7 @@ before_script:
   - if [[ "${WP_TRAVISCI}" != "jest" ]]; then composer install; fi
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - npm ci
-  - npm run dev
+  - if [[ "${WP_TRAVISCI}" != "bs" ]]; then npm run dev; fi
 
 script:
   - composer test-unit


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Folded the entire `npm run build`. It had almost 14000 lines and was not the crucial part of bundlewatch report itself.
- Removed redundant `npm run dev` build for bundle size job.


### Screenshots:

![Folded travis log](https://user-images.githubusercontent.com/17435/125807185-e78401df-cfd7-4647-a1e6-2ad801857cf7.png)


### Detailed test instructions:

1. Check Travis log https://travis-ci.com/github/woocommerce/google-listings-and-ads/jobs/524706938#L806

### Additional notes:

I could have also moved the build to the `before_install` section, as we already have a conditional build there. But I wanted to reduce the bloat that's there, plus this way we can have a custom label on the right side. 

### Changelog entry

> 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->