### PR TITLE
Optionally clean up plugin data on uninstall

### DIFF
--- a/src/DB/Installer.php
+++ b/src/DB/Installer.php
@@ -3,43 +3,31 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\DB;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\FirstInstallInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class DBController
+ * Class Installer
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\DB
  */
 class Installer implements Service, FirstInstallInterface, InstallableInterface {
 
-	use ValidateInterface;
-
 	/**
-	 * @var OptionsInterface
+	 * @var TableManager
 	 */
-	protected $options;
+	protected $table_manager;
 
 	/**
-	 * @var Table[]
-	 */
-	protected $tables;
-
-	/**
-	 * DBController constructor.
+	 * Installer constructor.
 	 *
-	 * @param Table[]          $tables
-	 * @param OptionsInterface $options
+	 * @param TableManager $table_manager
 	 */
-	public function __construct( array $tables, OptionsInterface $options ) {
-		$this->tables  = $tables;
-		$this->options = $options;
-		$this->validate_table_controllers();
+	public function __construct( TableManager $table_manager ) {
+		$this->table_manager = $table_manager;
 	}
 
 	/**
@@ -49,7 +37,7 @@ class Installer implements Service, FirstInstallInterface, InstallableInterface 
 	 * @param string $new_version Current version after updating.
 	 */
 	public function install( string $old_version, string $new_version ): void {
-		foreach ( $this->tables as $table ) {
+		foreach ( $this->table_manager->get_tables() as $table ) {
 			$table->install();
 		}
 	}
@@ -58,19 +46,10 @@ class Installer implements Service, FirstInstallInterface, InstallableInterface 
 	 * Logic to run when the plugin is first installed.
 	 */
 	public function first_install(): void {
-		foreach ( $this->tables as $table ) {
+		foreach ( $this->table_manager->get_tables() as $table ) {
 			if ( $table instanceof FirstInstallInterface ) {
 				$table->first_install();
 			}
-		}
-	}
-
-	/**
-	 * Set up each of the table controllers.
-	 */
-	protected function validate_table_controllers() {
-		foreach ( $this->tables as $table ) {
-			$this->validate_instanceof( $table, Table::class );
 		}
 	}
 }

--- a/src/DB/Table.php
+++ b/src/DB/Table.php
@@ -10,9 +10,12 @@ use wpdb;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class DBTable
+ * Class Table
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\DB
+ *
+ * @see TableManager::VALID_TABLES contains a list of table classes that will be installed.
+ * @see \Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer::install for installing tables.
  */
 abstract class Table implements TableInterface {
 
@@ -25,7 +28,7 @@ abstract class Table implements TableInterface {
 	protected $wpdb;
 
 	/**
-	 * DBTable constructor.
+	 * Table constructor.
 	 *
 	 * @param WP   $wp   The WP proxy object.
 	 * @param wpdb $wpdb The wpdb object.
@@ -59,7 +62,7 @@ abstract class Table implements TableInterface {
 	 * Delete the Database table.
 	 */
 	public function delete(): void {
-		$this->wpdb->query( "DROP TABLE `{$this->get_sql_safe_name()}`" ); // phpcs:ignore WordPress.DB.PreparedSQL
+		$this->wpdb->query( "DROP TABLE IF EXISTS `{$this->get_sql_safe_name()}`" ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 
 	/**

--- a/src/DB/Table.php
+++ b/src/DB/Table.php
@@ -124,5 +124,5 @@ abstract class Table implements TableInterface {
 	 *
 	 * @return string
 	 */
-	abstract protected function get_raw_name(): string;
+	abstract public static function get_raw_name(): string;
 }

--- a/src/DB/Table/BudgetRecommendationTable.php
+++ b/src/DB/Table/BudgetRecommendationTable.php
@@ -48,7 +48,7 @@ SQL;
 		// phpcs:ignore WordPress.DB.PreparedSQL
 		$result = $this->wpdb->get_row( "SELECT COUNT(*) AS count FROM `{$this->get_sql_safe_name()}`" );
 		if ( empty( $result->count ) ) {
-			 $this->load_initial_data();
+			$this->load_initial_data();
 		}
 	}
 
@@ -86,7 +86,7 @@ SQL;
 		$chunk_size = 500;
 
 		if ( file_exists( $path ) ) {
-			$csv     = array_map( 'str_getcsv', file( $path ) );
+			$csv = array_map( 'str_getcsv', file( $path ) );
 			if ( empty( $csv ) ) {
 				return;
 			}

--- a/src/DB/Table/BudgetRecommendationTable.php
+++ b/src/DB/Table/BudgetRecommendationTable.php
@@ -57,7 +57,7 @@ SQL;
 	 *
 	 * @return string
 	 */
-	protected function get_raw_name(): string {
+	public static function get_raw_name(): string {
 		return 'budget_recommendations';
 	}
 
@@ -87,7 +87,6 @@ SQL;
 
 		if ( file_exists( $path ) ) {
 			$csv     = array_map( 'str_getcsv', file( $path ) );
-			$headers = array_shift( $csv );
 			if ( empty( $csv ) ) {
 				return;
 			}

--- a/src/DB/Table/BudgetRecommendationTable.php
+++ b/src/DB/Table/BudgetRecommendationTable.php
@@ -87,6 +87,10 @@ SQL;
 
 		if ( file_exists( $path ) ) {
 			$csv = array_map( 'str_getcsv', file( $path ) );
+
+			// Remove the headers
+			array_shift( $csv );
+
 			if ( empty( $csv ) ) {
 				return;
 			}

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -48,7 +48,7 @@ SQL;
 	 *
 	 * @return string
 	 */
-	protected function get_raw_name(): string {
+	public static function get_raw_name(): string {
 		return 'merchant_issues';
 	}
 

--- a/src/DB/Table/ShippingRateTable.php
+++ b/src/DB/Table/ShippingRateTable.php
@@ -40,7 +40,7 @@ SQL;
 	 *
 	 * @return string
 	 */
-	protected function get_raw_name(): string {
+	public static function get_raw_name(): string {
 		return 'shipping_rates';
 	}
 

--- a/src/DB/Table/ShippingTimeTable.php
+++ b/src/DB/Table/ShippingTimeTable.php
@@ -38,7 +38,7 @@ SQL;
 	 *
 	 * @return string
 	 */
-	protected function get_raw_name(): string {
+	public static function get_raw_name(): string {
 		return 'shipping_times';
 	}
 

--- a/src/DB/TableManager.php
+++ b/src/DB/TableManager.php
@@ -1,0 +1,86 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\DB;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\BudgetRecommendationTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class TableManager
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\DB
+ */
+class TableManager {
+
+	use ValidateInterface;
+
+	protected const VALID_TABLES = [
+		BudgetRecommendationTable::class => true,
+		MerchantIssueTable::class        => true,
+		ShippingRateTable::class         => true,
+		ShippingTimeTable::class         => true,
+	];
+
+	/**
+	 * @var Table[]
+	 */
+	protected $tables;
+
+	/**
+	 * TableManager constructor.
+	 *
+	 * @param Table[] $tables
+	 */
+	public function __construct( array $tables ) {
+		$this->setup_tables( $tables );
+	}
+
+	/**
+	 * @return Table[]
+	 *
+	 * @see \Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer::install for installing these tables.
+	 */
+	public function get_tables(): array {
+		return $this->tables;
+	}
+
+	/**
+	 * Returns a list of table names to be installed.
+	 *
+	 * @return string[] Table names
+	 *
+	 * @see TableManager::VALID_TABLES for the list of valid table classes.
+	 */
+	public static function get_all_table_names(): array {
+		$tables = [];
+		foreach ( array_keys( self::VALID_TABLES ) as $table_class ) {
+			$table_name = call_user_func( [ $table_class, 'get_raw_name' ] );
+
+			$tables[ $table_name ] = $table_name;
+		}
+
+		return $tables;
+	}
+
+	/**
+	 * Set up each of the table controllers.
+	 *
+	 * @param Table[] $tables
+	 */
+	protected function setup_tables( array $tables ) {
+		foreach ( $tables as $table ) {
+			$this->validate_instanceof( $table, Table::class );
+
+			// only include tables from the installable tables list.
+			if ( isset( self::VALID_TABLES[ get_class( $table ) ] ) ) {
+				$this->tables[] = $table;
+			}
+		}
+	}
+}

--- a/src/DB/TableManager.php
+++ b/src/DB/TableManager.php
@@ -15,6 +15,8 @@ defined( 'ABSPATH' ) || exit;
  * Class TableManager
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\DB
+ *
+ * @since x.x.x
  */
 class TableManager {
 

--- a/src/Integration/WooCommerceProductBundles.php
+++ b/src/Integration/WooCommerceProductBundles.php
@@ -101,7 +101,7 @@ class WooCommerceProductBundles implements IntegrationInterface {
 	 */
 	protected function init_product_types(): void {
 		// every attribute that applies to simple products also applies to bundle products.
-		foreach ( AttributeManager::ATTRIBUTES as $attribute_type ) {
+		foreach ( AttributeManager::get_available_attribute_types() as $attribute_type ) {
 			$attribute_id     = call_user_func( [ $attribute_type, 'get_id' ] );
 			$applicable_types = call_user_func( [ $attribute_type, 'get_applicable_product_types' ] );
 			if ( ! in_array( 'simple', $applicable_types, true ) ) {

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Variati
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer as DBInstaller;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\TableManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Event\ClearProductStatsCache;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\ActivationRedirect;
@@ -109,6 +110,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		SetupMerchantCenter::class    => true,
 		SetupCampaignNote::class      => true,
 		SetupCampaign2Note::class     => true,
+		TableManager::class           => true,
 		TrackerSnapshot::class        => true,
 		Tracks::class                 => true,
 		TracksInterface::class        => true,
@@ -256,13 +258,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( InstallTimestamp::class );
 		$this->conditionally_share_with_tags( ClearProductStatsCache::class, MerchantStatuses::class );
 
-		// The DB Controller has some extra setup required.
-		$db_definition = $this->share_with_tags( DBInstaller::class, 'db_table', OptionsInterface::class );
-		$db_definition->setConcrete(
-			function( ...$arguments ) {
-				return new DBInstaller( ...$arguments );
-			}
-		);
+		$this->share_with_tags( TableManager::class, 'db_table' );
+		$this->share_with_tags( DBInstaller::class, TableManager::class );
 
 		$this->share_with_tags( DeprecatedFilters::class );
 	}

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -57,7 +57,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		ActionSchedulerInterface::class  => true,
 		AsyncActionRunner::class         => true,
 		ActionSchedulerJobMonitor::class => true,
-		PluginUpdateJobs::class          => true,
+		PluginUpdate::class              => true,
 		ProductSyncStats::class          => true,
 		SyncerHooks::class               => true,
 		Service::class                   => true,

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -8,7 +8,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\CastableValueInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\PositiveInteger;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ValueInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -21,34 +20,6 @@ defined( 'ABSPATH' ) || exit;
 final class Options implements OptionsInterface, Service {
 
 	use PluginHelper;
-
-	private const VALID_OPTIONS = [
-		self::ADS_ACCOUNT_CURRENCY   => true,
-		self::ADS_ACCOUNT_STATE      => true,
-		self::ADS_BILLING_URL        => true,
-		self::ADS_ID                 => true,
-		self::ADS_CONVERSION_ACTION  => true,
-		self::ADS_SETUP_COMPLETED_AT => true,
-		self::DB_VERSION             => true,
-		self::FILE_VERSION           => true,
-		self::GOOGLE_CONNECTED       => true,
-		self::INSTALL_TIMESTAMP      => true,
-		self::MC_SETUP_COMPLETED_AT  => true,
-		self::MERCHANT_ACCOUNT_STATE => true,
-		self::MERCHANT_CENTER        => true,
-		self::MERCHANT_ID            => true,
-		self::SHIPPING_RATES         => true,
-		self::SHIPPING_TIMES         => true,
-		self::REDIRECT_TO_ONBOARDING => true,
-		self::SITE_VERIFICATION      => true,
-		self::TARGET_AUDIENCE        => true,
-		self::WP_TOS_ACCEPTED        => true,
-	];
-
-	private const OPTION_TYPES = [
-		self::ADS_ID      => PositiveInteger::class,
-		self::MERCHANT_ID => PositiveInteger::class,
-	];
 
 	/**
 	 * Array of options that we have loaded.
@@ -154,6 +125,15 @@ final class Options implements OptionsInterface, Service {
 		// TODO: Remove overriding with default once ConnectionTest is removed.
 		$default = intval( $_GET['merchant_id'] ?? 0 ); // phpcs:ignore WordPress.Security
 		return $default ?: $this->get( self::MERCHANT_ID );
+	}
+
+	/**
+	 * Returns all available option keys.
+	 *
+	 * @return array
+	 */
+	public static function get_all_option_keys(): array {
+		return array_keys( self::VALID_OPTIONS );
 	}
 
 	/**

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\PositiveInteger;
+
 /**
  * Interface OptionsInterface
  *
@@ -30,6 +32,34 @@ interface OptionsInterface {
 	public const SITE_VERIFICATION      = 'site_verification';
 	public const TARGET_AUDIENCE        = 'target_audience';
 	public const WP_TOS_ACCEPTED        = 'wp_tos_accepted';
+
+	public const VALID_OPTIONS = [
+		self::ADS_ACCOUNT_CURRENCY   => true,
+		self::ADS_ACCOUNT_STATE      => true,
+		self::ADS_BILLING_URL        => true,
+		self::ADS_ID                 => true,
+		self::ADS_CONVERSION_ACTION  => true,
+		self::ADS_SETUP_COMPLETED_AT => true,
+		self::DB_VERSION             => true,
+		self::FILE_VERSION           => true,
+		self::GOOGLE_CONNECTED       => true,
+		self::INSTALL_TIMESTAMP      => true,
+		self::MC_SETUP_COMPLETED_AT  => true,
+		self::MERCHANT_ACCOUNT_STATE => true,
+		self::MERCHANT_CENTER        => true,
+		self::MERCHANT_ID            => true,
+		self::SHIPPING_RATES         => true,
+		self::SHIPPING_TIMES         => true,
+		self::REDIRECT_TO_ONBOARDING => true,
+		self::SITE_VERIFICATION      => true,
+		self::TARGET_AUDIENCE        => true,
+		self::WP_TOS_ACCEPTED        => true,
+	];
+
+	public const OPTION_TYPES = [
+		self::ADS_ID      => PositiveInteger::class,
+		self::MERCHANT_ID => PositiveInteger::class,
+	];
 
 	/**
 	 * Get an option.
@@ -76,6 +106,13 @@ interface OptionsInterface {
 	 * @return int
 	 */
 	public function get_merchant_id(): int;
+
+	/**
+	 * Returns all available option keys.
+	 *
+	 * @return array
+	 */
+	public static function get_all_option_keys(): array;
 
 	/**
 	 * Helper function to retrieve the Ads Account ID.

--- a/src/Options/Transients.php
+++ b/src/Options/Transients.php
@@ -19,10 +19,6 @@ final class Transients implements TransientsInterface, Service {
 
 	use PluginHelper;
 
-	private const VALID_OPTIONS = [
-		self::MC_STATUSES => true,
-	];
-
 	/**
 	 * Array of transients that we have loaded.
 	 *
@@ -87,6 +83,15 @@ final class Transients implements TransientsInterface, Service {
 		unset( $this->transients[ $name ] );
 
 		return boolval( delete_transient( $this->prefix_name( $name ) ) );
+	}
+
+	/**
+	 * Returns all available transient keys.
+	 *
+	 * @return array
+	 */
+	public static function get_all_transient_keys(): array {
+		return array_keys( self::VALID_OPTIONS );
 	}
 
 	/**

--- a/src/Options/Transients.php
+++ b/src/Options/Transients.php
@@ -89,6 +89,8 @@ final class Transients implements TransientsInterface, Service {
 	 * Returns all available transient keys.
 	 *
 	 * @return array
+	 *
+	 * @since x.x.x
 	 */
 	public static function get_all_transient_keys(): array {
 		return array_keys( self::VALID_OPTIONS );

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -12,6 +12,10 @@ interface TransientsInterface {
 
 	public const MC_STATUSES = 'mc_statuses';
 
+	public const VALID_OPTIONS = [
+		self::MC_STATUSES => true,
+	];
+
 	/**
 	 * Get a transient.
 	 *
@@ -41,4 +45,11 @@ interface TransientsInterface {
 	 * @return bool
 	 */
 	public function delete( string $name ): bool;
+
+	/**
+	 * Returns all available transient keys.
+	 *
+	 * @return array
+	 */
+	public static function get_all_transient_keys(): array;
 }

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -50,6 +50,8 @@ interface TransientsInterface {
 	 * Returns all available transient keys.
 	 *
 	 * @return array
+	 *
+	 * @since x.x.x
 	 */
 	public static function get_all_transient_keys(): array;
 }

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -45,6 +45,7 @@ trait PluginHelper {
 	 * @return string
 	 */
 	protected function get_slug(): string {
+		// This value is also hard-coded in uninstall.php
 		return 'gla';
 	}
 
@@ -74,6 +75,7 @@ trait PluginHelper {
 	 * @return string
 	 */
 	protected function get_meta_key_prefix(): string {
+		// This value is also hard-coded in uninstall.php
 		return "_wc_{$this->get_slug()}";
 	}
 

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -22,7 +22,7 @@ class AttributeManager implements Service {
 	use PluginHelper;
 	use ValidateInterface;
 
-	public const ATTRIBUTES = [
+	protected const ATTRIBUTES = [
 		GTIN::class,
 		MPN::class,
 		Brand::class,
@@ -208,6 +208,22 @@ class AttributeManager implements Service {
 	}
 
 	/**
+	 * Return an array of all available attribute class names.
+	 *
+	 * @return string[] Attribute class names
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_available_attribute_types(): array {
+		/**
+		 * Filters the list of available product attributes.
+		 *
+		 * @param string[] $attributes Array of attribute class names (FQN)
+		 */
+		return apply_filters( 'woocommerce_gla_product_attribute_types', self::ATTRIBUTES );
+	}
+
+	/**
 	 * Returns an array of attribute types for all product types
 	 *
 	 * @return string[][] of attribute classes mapped to product types
@@ -243,10 +259,8 @@ class AttributeManager implements Service {
 	 * @throws InvalidClass If any of the given attribute classes do not implement the AttributeInterface.
 	 */
 	protected function map_attribute_types(): void {
-		$available_attributes = apply_filters( 'woocommerce_gla_product_attribute_types', self::ATTRIBUTES );
-
 		$this->attribute_types_map = [];
-		foreach ( $available_attributes as $attribute_type ) {
+		foreach ( self::get_available_attribute_types() as $attribute_type ) {
 			$this->validate_interface( $attribute_type, AttributeInterface::class );
 
 			$attribute_id     = call_user_func( [ $attribute_type, 'get_id' ] );

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -208,6 +208,25 @@ class AttributeManager implements Service {
 	}
 
 	/**
+	 * Returns all available attribute IDs.
+	 *
+	 * @return array
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_available_attribute_ids(): array {
+		$attributes = [];
+		foreach ( self::get_available_attribute_types() as $attribute_type ) {
+			if ( method_exists( $attribute_type, 'get_id' ) ) {
+				$attribute_id                = call_user_func( [ $attribute_type, 'get_id' ] );
+				$attributes[ $attribute_id ] = $attribute_id;
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
 	 * Return an array of all available attribute class names.
 	 *
 	 * @return string[] Attribute class names

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -292,4 +292,12 @@ class ProductMetaHandler implements Service, Registerable {
 		return $updated_queries;
 	}
 
+	/**
+	 * Returns all available meta keys.
+	 *
+	 * @return array
+	 */
+	public static function get_all_meta_keys(): array {
+		return array_keys( self::TYPES );
+	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Autoloader;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\TableManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
@@ -61,5 +62,10 @@ if ( defined( 'WC_GLA_REMOVE_ALL_DATA' ) && true === WC_GLA_REMOVE_ALL_DATA ) {
 	// delete products metadata
 	foreach ( ProductMetaHandler::get_all_meta_keys() as $meta_key ) {
 		delete_post_meta_by_key( WC_GLA_METAKEY_PREFIX . "_{$meta_key}" );
+	}
+
+	// delete products attributes
+	foreach ( AttributeManager::get_available_attribute_ids() as $attribute_id ) {
+		delete_post_meta_by_key( WC_GLA_METAKEY_PREFIX . "_{$attribute_id}" );
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -40,7 +40,7 @@ if ( defined( 'WC_GLA_REMOVE_ALL_DATA' ) && true === WC_GLA_REMOVE_ALL_DATA ) {
 
 	// un-schedule all ActionScheduler jobs for GLA
 	if ( function_exists( 'as_unschedule_all_actions' ) ) {
-		as_unschedule_all_actions( null, null, 'gla' );
+		as_unschedule_all_actions( null, null, WC_GLA_SLUG );
 	}
 
 	// drop custom tables

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Google Listings and Ads Uninstall
+ *
+ * Uninstalling Google Listings and Ads unschedules any pending jobs, deletes its custom tables, related transients,
+ * options, and product metadata.
+ *
+ * @version x.x.x
+ */
+
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Autoloader;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\TableManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
+
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+/** @see \Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper::get_slug() */
+define( 'WC_GLA_SLUG', 'gla' );
+
+/** @see \Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper::get_meta_key_prefix() */
+define( 'WC_GLA_METAKEY_PREFIX', '_wc_gla' );
+
+/*
+ * Only remove ALL plugin data if WC_GLA_REMOVE_ALL_DATA constant is set to true in user's
+ * wp-config.php. This is to prevent data loss when deleting the plugin from the backend
+ * and to ensure only the site owner can perform this action.
+ */
+if ( defined( 'WC_GLA_REMOVE_ALL_DATA' ) && true === WC_GLA_REMOVE_ALL_DATA ) {
+	// Load and initialize the autoloader.
+	require_once __DIR__ . '/src/Autoloader.php';
+	if ( ! Autoloader::init() ) {
+		return;
+	}
+
+	global $wpdb;
+
+	// un-schedule all ActionScheduler jobs for GLA
+	if ( function_exists( 'as_unschedule_all_actions' ) ) {
+		as_unschedule_all_actions( null, null, 'gla' );
+	}
+
+	// drop custom tables
+	foreach ( TableManager::get_all_table_names() as $table ) {
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . WC_GLA_SLUG . "_{$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL
+	}
+
+	// delete options
+	foreach ( Options::get_all_option_keys() as $option ) {
+		delete_option( WC_GLA_SLUG . "_{$option}" );
+	}
+
+	// delete transients
+	foreach ( Transients::get_all_transient_keys() as $transient ) {
+		delete_transient( WC_GLA_SLUG . "_{$transient}" );
+	}
+
+	// delete products metadata
+	foreach ( ProductMetaHandler::get_all_meta_keys() as $meta_key ) {
+		delete_post_meta_by_key( WC_GLA_METAKEY_PREFIX . "_{$meta_key}" );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #883.

This PR adds an `uninstall.php` file that WordPress runs when the plugin is being uninstalled. We check for a constant called `WC_GLA_REMOVE_ALL_DATA` before removing any data in order to prevent data loss.

The data that gets removed includes:

- Custom tables
- Options
- Transients
- Product metadata

Any pending ActionScheduler jobs are also canceled.

Since we don't have access to any of our classes in the `uninstall.php` file, I tried to mostly use native WordPress functions to do the operations and not call any of our services to reduce the dependency. However, I had to initialize the autoloader in order to have access to a bunch of helper methods and constants that were defined in our classes (table names, options, meta keys, etc.).

The only raw query used here is for dropping database tables. Options, transients, and product metadata are all deleted using WordPress native methods.

I'm a little bit worried about the performance of the `delete_post_meta_by_key` function because it runs at least two queries internally and if the number of products is large, it could slow things down and even lead to timeout for the uninstall process. 

I originally intended to use a `DELETE ... LIKE '_wc_gla_%` raw query to delete the posts' metadata but since that has also its own disadvantages (long-running query, not explicitly defining the meta key to delete), I went with the WordPress native functions.

Also for deleting Options and Transients, instead of running raw delete queries (which would be similar to `DELETE ... LIKE 'gla_%`), I went with getting the list of all keys and then deleting them one by one. This is the only way to be sure that we don't delete anything we shouldn't have.

All ActionScheduler jobs using the `gla` group are also unscheduled by using ActionScheduler's own API (`as_unschedule_all_actions`) if the method exists.

A few refactorings are included here too:

- Introduced a new `TableManager` class that keeps a list of all valid custom tables that we add. This was required because `uninstall.php` needed a static list of tables instead of getting them from the container
- Renamed a possible typo (`PluginUpdateJobs`) in `JobServiceProvider`
- Made the `get_raw_name` of `Table` classes static and public. The raw name of a table never changes during the lifetime of any Table class; therefore it made sense for them to be static
- Moved the Options and Transients keys into their interface classes. The keys were all defined in interfaces, so it made sense to also have the list defined there
- Added `get_all_***_keys` to Options, Transients, and ProductMetaHandler classes to return the list of all valid keys they use


### Detailed test instructions:

(It would be best to test this on a separate test site or somewhere that you don't care about losing the data.)

1. Define the `WC_GLA_REMOVE_ALL_DATA` constant in your wp-config.php file and set it to boolean `true`
2. Uninstall the plugin via `WordPress > Plugins`
3. Check that all plugin data is removed and there are no pending GLA action scheduler jobs


### Changelog entry

> Update - Optionally clean up plugin data on uninstall.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->