### PR TITLE
Skip orphaned variations instead of throwing errors when syncing products

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -104,6 +104,8 @@ class IssuesController extends BaseOptionsController {
 						sprintf( 'Merchant Center product ID %s not found in this WooCommerce store.', $issue['product_id'] ),
 						__METHOD__,
 					);
+
+					continue;
 				}
 			}
 

--- a/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php
@@ -179,9 +179,9 @@ class ProductVisibilityController extends BaseController {
 	 */
 	protected function change_product_visibility( int $product_id, bool $new_visibility ): bool {
 		try {
-			$product_id = $this->product_helper->maybe_swap_for_parent_id( $product_id );
+			$product = $this->product_helper->get_wc_product( $product_id );
+			$product = $this->product_helper->maybe_swap_for_parent( $product );
 			// Use $product->save() instead of ProductMetaHandler to trigger MC sync.
-			$product = wc_get_product( $product_id );
 			$product->update_meta_data(
 				$this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY ),
 				$new_visibility ? ChannelVisibility::SYNC_AND_SHOW : ChannelVisibility::DONT_SYNC_AND_SHOW
@@ -190,6 +190,8 @@ class ProductVisibilityController extends BaseController {
 
 			return true;
 		} catch ( Exception $e ) {
+			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
+
 			return false;
 		}
 	}

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -118,7 +118,7 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	 * @return array
 	 */
 	protected function get_view_context( WP_Post $post, array $args ): array {
-		$product_id = $post->ID;
+		$product_id = absint( $post->ID );
 		$product    = $this->product_helper->get_wc_product( $product_id );
 
 		return [

--- a/src/Product/ProductFactory.php
+++ b/src/Product/ProductFactory.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -47,6 +48,8 @@ class ProductFactory {
 	 * @param string     $target_country
 	 *
 	 * @return WCProductAdapter
+	 *
+	 * @throws InvalidValue When the product is a variation and its parent does not exist.
 	 */
 	public function create( WC_Product $product, string $target_country ): WCProductAdapter {
 		// We do not support syncing the parent variable product. Each variation is synced individually instead.

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -249,12 +249,13 @@ class ProductHelper implements Service {
 	/**
 	 * Get WooCommerce product
 	 *
-	 * @param int|false $product_id
+	 * @param int $product_id
 	 *
 	 * @return WC_Product
+	 *
 	 * @throws InvalidValue If the given ID doesn't reference a valid product.
 	 */
-	public function get_wc_product( $product_id ): WC_Product {
+	public function get_wc_product( int $product_id ): WC_Product {
 		return $this->wc->get_product( $product_id );
 	}
 

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -246,6 +246,7 @@ class ProductHelper implements Service {
 		if ( ! preg_match( $pattern, $mc_product_id, $matches ) ) {
 			return 0;
 		}
+
 		return intval( $matches[1] );
 	}
 
@@ -456,6 +457,7 @@ class ProductHelper implements Service {
 	 * Combines errors for variable products, which have a variation-indexed array of errors.
 	 *
 	 * @param WC_Product $product
+	 *
 	 * @return array
 	 */
 	public function get_validation_errors( WC_Product $product ): array {

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -79,8 +79,13 @@ class ProductHelper implements Service {
 		}
 
 		// mark the parent product as synced if it's a variation
-		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
-			$parent_product = $this->get_wc_product( $product->get_parent_id() );
+		if ( $product instanceof WC_Product_Variation ) {
+			try {
+				$parent_product = $this->get_wc_product( $product->get_parent_id() );
+			} catch ( InvalidValue $exception ) {
+				return;
+			}
+
 			$this->mark_as_synced( $parent_product, $google_product );
 		}
 	}
@@ -97,8 +102,13 @@ class ProductHelper implements Service {
 		$this->meta_handler->delete_sync_failed_at( $product );
 
 		// mark the parent product as un-synced if it's a variation
-		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
-			$parent_product = $this->get_wc_product( $product->get_parent_id() );
+		if ( $product instanceof WC_Product_Variation ) {
+			try {
+				$parent_product = $this->get_wc_product( $product->get_parent_id() );
+			} catch ( InvalidValue $exception ) {
+				return;
+			}
+
 			$this->mark_as_unsynced( $parent_product );
 		}
 	}
@@ -157,9 +167,12 @@ class ProductHelper implements Service {
 		}
 
 		// mark the parent product as invalid if it's a variation
-		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
-			$wc_parent_id   = $product->get_parent_id();
-			$parent_product = $this->get_wc_product( $wc_parent_id );
+		if ( $product instanceof WC_Product_Variation ) {
+			try {
+				$parent_product = $this->get_wc_product( $product->get_parent_id() );
+			} catch ( InvalidValue $exception ) {
+				return;
+			}
 
 			$parent_errors = ! empty( $this->meta_handler->get_errors( $parent_product ) ) ?
 				$this->meta_handler->get_errors( $parent_product ) :
@@ -182,9 +195,13 @@ class ProductHelper implements Service {
 		$this->meta_handler->update_sync_status( $product, SyncStatus::PENDING );
 
 		// mark the parent product as pending if it's a variation
-		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
-			$wc_parent_id   = $product->get_parent_id();
-			$parent_product = $this->get_wc_product( $wc_parent_id );
+		if ( $product instanceof WC_Product_Variation ) {
+			try {
+				$parent_product = $this->get_wc_product( $product->get_parent_id() );
+			} catch ( InvalidValue $exception ) {
+				return;
+			}
+
 			$this->mark_as_pending( $parent_product );
 		}
 	}

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -285,9 +285,20 @@ class ProductHelper implements Service {
 		$product_visibility = $product->is_visible();
 		$product_status     = $product->get_status();
 
-		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
+		if ( $product instanceof WC_Product_Variation ) {
 			// Check the post status of the parent product if it's a variation
-			$parent         = $this->get_wc_product( $product->get_parent_id() );
+			try {
+				$parent = $this->get_wc_product( $product->get_parent_id() );
+			} catch ( InvalidValue $exception ) {
+				do_action(
+					'woocommerce_gla_error',
+					sprintf( 'Cannot sync an orphaned variation (ID: %s).', $product->get_id() ),
+					__METHOD__
+				);
+
+				return false;
+			}
+
 			$product_status = $parent->get_status();
 
 			/**

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -409,15 +409,15 @@ class ProductHelper implements Service {
 	/**
 	 * If the provided product has a parent, return its ID. Otherwise, return the given (valid product) ID.
 	 *
-	 * @param int $product WooCommerce product ID.
+	 * @param int $product_id WooCommerce product ID.
 	 *
 	 * @return int The parent ID or product ID of it doesn't have a parent.
 	 *
 	 * @throws InvalidValue If a given ID doesn't reference a valid product. Or if a variation product does not have a
 	 *                      valid parent ID (i.e. it's an orphan).
 	 */
-	public function maybe_swap_for_parent_id( int $product ): int {
-		$product = $this->get_wc_product( $product );
+	public function maybe_swap_for_parent_id( int $product_id ): int {
+		$product = $this->get_wc_product( $product_id );
 
 		return $this->maybe_swap_for_parent( $product )->get_id();
 	}

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -73,12 +73,13 @@ class WC {
 	/**
 	 * Get a WooCommerce product and confirm it exists.
 	 *
-	 * @param int|false $product_id
+	 * @param int $product_id
 	 *
 	 * @return WC_Product
+	 *
 	 * @throws InvalidValue When the product does not exist.
 	 */
-	public function get_product( $product_id ): WC_Product {
+	public function get_product( int $product_id ): WC_Product {
 		$product = wc_get_product( $product_id );
 		if ( ! $product instanceof WC_Product ) {
 			throw InvalidValue::not_valid_product_id( $product_id );

--- a/uninstall.php
+++ b/uninstall.php
@@ -5,7 +5,7 @@
  * Uninstalling Google Listings and Ads unschedules any pending jobs, deletes its custom tables, related transients,
  * options, and product metadata.
  *
- * @version x.x.x
+ * @since x.x.x
  */
 
 declare( strict_types=1 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #888.
Closes #887.

This PR adds error handling and fault tolerance to the methods and classes related to product syncing functionality so that it doesn't fail when an exception is thrown while creating and validating products.

`try ... catch` blocks are added to catch the exceptions thrown by `WC::get_product` and silently log them. In some cases (like `is_sync_ready`), a default value is returned when this exception is thrown so that the product can be skipped without disrupting the syncing process.

The `product_id` argument of `WC::get_product` and `ProductHelper::get_wc_product` is also changed to always except an `int`. These methods were never called with a `false` argument and I think it's just safer to type-hint them.


### Detailed test instructions:

1. Edit one of the variations in the DB and change the `post_parent` to a non-existing product like 9999999
1. Update all products (async) on the Connection test page
1. Go to `WooCommerce > Status > Scheduled Actions` and check the failed actions
1. The syncing should not fail
1. The orphan variation should not be synced to MC but other products are synced

Also, run `phpunit` and make sure all the tests pass.

### Changelog entry

> Fix - Skip orphaned variations instead of throwing errors when syncing products.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->