### PR TITLE
Use WordPress date & time format for product feed

### DIFF
--- a/js/src/product-feed/product-statistics/status-box.js
+++ b/js/src/product-feed/product-statistics/status-box.js
@@ -12,6 +12,7 @@ import GridiconSync from 'gridicons/dist/sync';
  */
 import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
 import { ISSUE_TABLE_PER_PAGE } from '../constants';
+import { glaData } from '.~/constants';
 
 function getUnsolvedStatusText( totalUnsolvedIssues ) {
 	if ( ! Number.isInteger( totalUnsolvedIssues ) ) {
@@ -71,7 +72,10 @@ function getSyncResult( {
 				totalSynced,
 				'google-listings-and-ads'
 			),
-			formatDate( 'j F Y, h:ia', new Date( timestamp * 1000 ) ),
+			formatDate(
+				glaData.dateFormat + ', '  + glaData.timeFormat,
+				new Date( timestamp * 1000 )
+			),
 			totalSynced
 		),
 	};

--- a/js/src/product-feed/product-statistics/status-box.js
+++ b/js/src/product-feed/product-statistics/status-box.js
@@ -73,7 +73,7 @@ function getSyncResult( {
 				'google-listings-and-ads'
 			),
 			formatDate(
-				glaData.dateFormat + ', ' + glaData.timeFormat,
+				glaData.dateFormat + ( glaData.timeFormat ? ', ' + glaData.timeFormat : '' ),
 				new Date( timestamp * 1000 )
 			),
 			totalSynced

--- a/js/src/product-feed/product-statistics/status-box.js
+++ b/js/src/product-feed/product-statistics/status-box.js
@@ -73,7 +73,11 @@ function getSyncResult( {
 				'google-listings-and-ads'
 			),
 			formatDate(
-				glaData.dateFormat + ( glaData.timeFormat ? ', ' + glaData.timeFormat : '' ),
+				glaData.dateFormat +
+					( glaData.dateFormat.trim() && glaData.timeFormat.trim()
+						? ', '
+						: '' ) +
+					glaData.timeFormat,
 				new Date( timestamp * 1000 )
 			),
 			totalSynced

--- a/js/src/product-feed/product-statistics/status-box.js
+++ b/js/src/product-feed/product-statistics/status-box.js
@@ -73,7 +73,7 @@ function getSyncResult( {
 				'google-listings-and-ads'
 			),
 			formatDate(
-				glaData.dateFormat + ', '  + glaData.timeFormat,
+				glaData.dateFormat + ', ' + glaData.timeFormat,
 				new Date( timestamp * 1000 )
 			),
 			totalSynced

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -115,6 +115,8 @@ class Admin implements Service, Registerable, Conditional {
 				'mcSupportedLanguage' => $this->merchant_center->is_language_supported(),
 				'adsSetupComplete'    => $this->ads->is_setup_complete(),
 				'enableReports'       => $this->enableReports(),
+				'dateFormat'          => get_option( 'date_format' ),
+				'timeFormat'          => get_option( 'time_format' ),
 			]
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #805.

This passes the site's date and time formats (set in `/wp-admin/options-general.php`) in the `glaData` object, and then uses them in the Product Feed `Sync with Google` info box:

![image](https://user-images.githubusercontent.com/228780/126617307-3aabdb78-c496-4cfa-b170-1455f76067a9.png)


### Detailed test instructions:

1. `npm run dev`
2. Visit the Product Feed page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed`
    - Confirm the date and time formats match the WordPress settings
3. Change the WordPress date and time formats (`/wp-admin/options-general.php`)
4. Visit the Product Feed page again.
    - Confirm the date and time formats match the changed WordPress settings


### Changelog entry

> Tweak - Use the WordPress date and time formats on the Product Feed page.