### PR TITLE
Bump WordPress tested version to 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,13 @@ env:
     - WP_DIR=/tmp/wordpress
     - WP_CORE_DIR="${WP_DIR}/src"
     - WP_TESTS_DIR="${WP_DIR}/tests/phpunit"
-    - WP_LATEST=5.7
+    - WP_LATEST=5.8
     - WC_LATEST=trunk
   matrix:
     - WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}"
     - WP_VERSION="${WP_LATEST}" WC_VERSION=5.2
+    - WP_VERSION=5.7 WC_VERSION=5.2
     - WP_VERSION=5.6 WC_VERSION=5.2
-    - WP_VERSION=5.5 WC_VERSION=5.2
 
 # Additional tests
 matrix:

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
  * Requires at least: 5.5
- * Tested up to: 5.7
+ * Tested up to: 5.8
  * Requires PHP: 7.3
  *
  * WC requires at least: 5.2

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -8,6 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
  * Requires at least: 5.5
+ * Tested up to: 5.7
  * Requires PHP: 7.3
  *
  * WC requires at least: 5.2

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, listings, ads
 Requires at least: 5.5
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 7.3
 Stable tag: 1.2.1
 License: GPLv3


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #900 .

This PR bumps the WordPress tested version up to 5.8, as per #900. 

This would address the "untested" warnings as shown in the images below:

![image](https://user-images.githubusercontent.com/417342/127042725-508f633c-fd68-4e91-8a0d-f1fd78686cbf.png)

![image](https://user-images.githubusercontent.com/417342/127042753-c113b72b-e7bc-4713-a871-c2028d8e67cc.png)

### Detailed test instructions:

I think this can only be tested after deploying to https://wordpress.org/plugins/google-listings-and-ads/.

### Changelog entry

Fix - Bump WordPress tested version to 5.8.
