### PR TITLE
Allow safe HTML tags for product descriptions

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -179,8 +179,13 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			$description
 		);
 
-		// Strip out active shortcodes and HTML tags.
-		$description = strip_shortcodes( wp_strip_all_tags( $description ) );
+		// Strip out invalid HTML tags (e.g. script, style, canvas, etc.) along with attributes of all tags.
+		$valid_html_tags   = array_keys( wp_kses_allowed_html( 'post' ) );
+		$kses_allowed_tags = array_fill_keys( $valid_html_tags, [] );
+		$description       = wp_kses( $description, $kses_allowed_tags );
+
+		// Strip out active shortcodes
+		$description = strip_shortcodes( $description );
 
 		return apply_filters( 'woocommerce_gla_product_attribute_value_description', $description, $this->wc_product );
 	}

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -234,7 +234,7 @@ class WCProductAdapterTest extends UnitTest {
 				'description'       =>
 					'<h1>Sample product</h1> description with some valid ⏰⌛⊗⊝Ɋ❤😍 and <strong data-title="what?">invalid</strong> unicode chars' . $invalid_chars .
 					' and some registered short code like [video mp4="source.mp4"] and [gallery order="DESC" orderby="ID"] that ' .
-					'will get <i>striped out</i>, along with an unregistered short code [some-test-short-code id=1] that will remain intact.' .
+					'will get <i>stripped out</i>, along with an unregistered short code [some-test-short-code id=1] that will remain intact.' .
 					'<script>window.alert("this should be plain text!")</script><style>h1 {font-size: 2em;}</style>'
 				,
 				'short_description' => 'Short description.',
@@ -249,7 +249,7 @@ class WCProductAdapterTest extends UnitTest {
 
 		$expected_description = '<h1>Sample product</h1> description with some valid ⏰⌛⊗⊝Ɋ❤😍 and <strong>invalid</strong> unicode chars  and some registered short code like ' .
 								' and  that ' .
-								'will get <i>striped out</i>, along with an unregistered short code [some-test-short-code id=1] that will remain intact.' .
+								'will get <i>stripped out</i>, along with an unregistered short code [some-test-short-code id=1] that will remain intact.' .
 								'window.alert("this should be plain text!")h1 {font-size: 2em;}';
 
 		$this->assertEquals( $expected_description, $adapted_product->getDescription() );

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -232,10 +232,10 @@ class WCProductAdapterTest extends UnitTest {
 			false,
 			[
 				'description'       =>
-					'<h1>Sample product</h1> description with some valid ⏰⌛⊗⊝Ɋ❤😍 and <strong>invalid</strong> unicode chars' . $invalid_chars .
+					'<h1>Sample product</h1> description with some valid ⏰⌛⊗⊝Ɋ❤😍 and <strong data-title="what?">invalid</strong> unicode chars' . $invalid_chars .
 					' and some registered short code like [video mp4="source.mp4"] and [gallery order="DESC" orderby="ID"] that ' .
-					'will get <strike>striped out</strike>, along with an unregistered short code [some-test-short-code id=1] that will remain intact.' .
-					'<script>window.alert("this should be removed!")</script><style>h1 {font-size: 2em;}</style>'
+					'will get <i>striped out</i>, along with an unregistered short code [some-test-short-code id=1] that will remain intact.' .
+					'<script>window.alert("this should be plain text!")</script><style>h1 {font-size: 2em;}</style>'
 				,
 				'short_description' => 'Short description.',
 			]
@@ -247,10 +247,10 @@ class WCProductAdapterTest extends UnitTest {
 			]
 		);
 
-		$expected_description = 'Sample product description with some valid ⏰⌛⊗⊝Ɋ❤😍 and invalid unicode chars  and some registered short code like ' .
+		$expected_description = '<h1>Sample product</h1> description with some valid ⏰⌛⊗⊝Ɋ❤😍 and <strong>invalid</strong> unicode chars  and some registered short code like ' .
 								' and  that ' .
-								'will get striped out, along with an unregistered short code [some-test-short-code id=1] that will remain intact.' .
-								'';
+								'will get <i>striped out</i>, along with an unregistered short code [some-test-short-code id=1] that will remain intact.' .
+								'window.alert("this should be plain text!")h1 {font-size: 2em;}';
 
 		$this->assertEquals( $expected_description, $adapted_product->getDescription() );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR uses `wp_kses` to sanitize the product's description. So instead of removing all HTML tags, any tag allowed in a WordPress post is now also allowed to be set as a product's description. 

[Google allows basic HTML tags to be set as product descriptions](https://support.google.com/merchants/answer/6324468?hl=en) but prevents unsafe tags and all attributes. Therefore, Unsafe tags such as <script> and <style> are removed along with attributes of all tags.

Note that the content of unsafe tags are not removed just the tag itself. So `My product! <script>//something</script>` will become `My product! //something`.

### Detailed test instructions:

1. Use HTML to write a product's description with both valid (e.g. `<b>`, `<ul>`, etc.) and invalid tags (such as `<script>`).
2. Sync the product and wait for it to be updated in Merchant Center
3. Check the synced product's description in Merchant Center and confirm that the valid HTML tags are present but invalid tags and any attributes on all HTML tags are removed.


### Changelog entry

> Tweak - Allow safe HTML tags for product descriptions

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->