### PR TITLE
Check if fetched Google ids is an array before processing

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -229,6 +229,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$all_google_ids       = $product_meta_query_helper->get_all_values( ProductMetaHandler::KEY_GOOGLE_IDS );
 		$filtered_google_ids  = [];
 		foreach ( array_intersect_key( $all_google_ids, $filtered_product_ids ) as $product_ids ) {
+			if ( empty( $product_ids ) || ! is_array( $product_ids ) ) {
+				// Skip if empty or not an array
+				continue;
+			}
+
 			$filtered_google_ids = array_merge( $filtered_google_ids, array_values( $product_ids ) );
 		}
 		return $filtered_google_ids;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #908.

Just added a small check to the `MerchantStatuses::get_synced_google_ids` method to make sure the fetched `product_ids` is an array before proceeding with filtering it.


### Detailed test instructions:

1. Reset one of the values in `postmeta` with the key `_wc_gla_google_ids` and set the value to an empty string
2. Refresh the Product Feed page (clear the cache on the connection test page if needed)
3. Make sure there are no errors


### Changelog entry

> Fix - Invalid Google IDs meta value causing fatal failure.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->