### PR TITLE
Add filter to optionally apply shortcodes in product descriptions

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -156,6 +156,11 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 * @return string
 	 */
 	protected function get_wc_product_description(): string {
+		/**
+		 * Filters whether the short product description should be used for the synced product.
+		 *
+		 * @param bool $use_short_description
+		 */
 		$use_short_description = apply_filters( 'woocommerce_gla_use_short_description', false );
 
 		$description = ! empty( $this->wc_product->get_description() ) && ! $use_short_description ?
@@ -179,14 +184,32 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			$description
 		);
 
+		/**
+		 * Filters whether the shortcodes should be applied for product descriptions when syncing a product or be stripped out.
+		 *
+		 * @param bool       $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
+		 * @param WC_Product $wc_product       WooCommerce product object.
+		 */
+		$apply_shortcodes = apply_filters( 'woocommerce_gla_product_description_apply_shortcodes', false, $this->wc_product );
+		if ( $apply_shortcodes ) {
+			// Apply active shortcodes
+			$description = do_shortcode( $description );
+		} else {
+			// Strip out active shortcodes
+			$description = strip_shortcodes( $description );
+		}
+
 		// Strip out invalid HTML tags (e.g. script, style, canvas, etc.) along with attributes of all tags.
 		$valid_html_tags   = array_keys( wp_kses_allowed_html( 'post' ) );
 		$kses_allowed_tags = array_fill_keys( $valid_html_tags, [] );
 		$description       = wp_kses( $description, $kses_allowed_tags );
 
-		// Strip out active shortcodes
-		$description = strip_shortcodes( $description );
-
+		/**
+		 * Filters the product's description.
+		 *
+		 * @param string     $description Product description.
+		 * @param WC_Product $wc_product  WooCommerce product object.
+		 */
 		return apply_filters( 'woocommerce_gla_product_attribute_value_description', $description, $this->wc_product );
 	}
 

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -187,6 +187,8 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		/**
 		 * Filters whether the shortcodes should be applied for product descriptions when syncing a product or be stripped out.
 		 *
+		 * @since x.x.x
+		 *
 		 * @param bool       $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
 		 * @param WC_Product $wc_product       WooCommerce product object.
 		 */

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -309,6 +309,31 @@ class WCProductAdapterTest extends UnitTest {
 		$this->assertEquals( 'Short description.', $adapted_product->getDescription() );
 	}
 
+	public function test_short_description_is_set_if_filter_used() {
+		add_filter(
+			'woocommerce_gla_use_short_description',
+			function () {
+				return true;
+			}
+		);
+
+		$product         = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'description'       => 'Long description.',
+				'short_description' => 'Short description.',
+			]
+		);
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		$this->assertEquals( 'Short description.', $adapted_product->getDescription() );
+	}
+
 	public function test_parent_description_is_included_in_variation_description() {
 		$variable = WC_Helper_Product::create_variation_product();
 		$variable->set_description( 'Parent description.' );
@@ -1370,6 +1395,7 @@ DESCRIPTION;
 		remove_all_filters( 'wc_tax_enabled' );
 		remove_all_filters( 'woocommerce_prices_include_tax' );
 		remove_all_filters( 'woocommerce_gla_product_description_apply_shortcodes' );
+		remove_all_filters( 'woocommerce_gla_use_short_description' );
 
 		// remove added shortcodes
 		remove_shortcode( 'wc_gla_sample_test_shortcode' );

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -255,6 +255,42 @@ class WCProductAdapterTest extends UnitTest {
 		$this->assertEquals( $expected_description, $adapted_product->getDescription() );
 	}
 
+	public function test_description_shortcodes_are_applied() {
+		add_filter(
+			'woocommerce_gla_product_description_apply_shortcodes',
+			function () {
+				return true;
+			}
+		);
+
+		// add a sample shortcode to test
+		add_shortcode(
+			'wc_gla_sample_test_shortcode',
+			function () {
+				return 'sample-shortcode-rendered-result';
+			}
+		);
+
+		$product         = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'description' => 'This product has a shortcode like [wc_gla_sample_test_shortcode] that will not get stripped out, ' .
+								 'along with an unregistered short code [some-test-short-code id=1] that will also remain intact.',
+			]
+		);
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		$expected_description = 'This product has a shortcode like sample-shortcode-rendered-result that will not get stripped out, ' .
+								'along with an unregistered short code [some-test-short-code id=1] that will also remain intact.';
+
+		$this->assertEquals( $expected_description, $adapted_product->getDescription() );
+	}
+
 	public function test_short_description_is_set_if_description_empty() {
 		$product         = WC_Helper_Product::create_simple_product(
 			false,
@@ -1333,5 +1369,9 @@ DESCRIPTION;
 		remove_all_filters( 'woocommerce_gla_product_attribute_value_sale_price' );
 		remove_all_filters( 'wc_tax_enabled' );
 		remove_all_filters( 'woocommerce_prices_include_tax' );
+		remove_all_filters( 'woocommerce_gla_product_description_apply_shortcodes' );
+
+		// remove added shortcodes
+		remove_shortcode( 'wc_gla_sample_test_shortcode' );
 	}
 }

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -334,6 +334,30 @@ class WCProductAdapterTest extends UnitTest {
 		$this->assertEquals( 'Short description.', $adapted_product->getDescription() );
 	}
 
+	public function test_description_can_be_modified_using_filter() {
+		add_filter(
+			'woocommerce_gla_product_attribute_value_description',
+			function () {
+				return 'Modified description!';
+			}
+		);
+
+		$product         = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'description'       => 'Long description.',
+			]
+		);
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		$this->assertEquals( 'Modified description!', $adapted_product->getDescription() );
+	}
+
 	public function test_parent_description_is_included_in_variation_description() {
 		$variable = WC_Helper_Product::create_variation_product();
 		$variable->set_description( 'Parent description.' );
@@ -1396,6 +1420,7 @@ DESCRIPTION;
 		remove_all_filters( 'woocommerce_prices_include_tax' );
 		remove_all_filters( 'woocommerce_gla_product_description_apply_shortcodes' );
 		remove_all_filters( 'woocommerce_gla_use_short_description' );
+		remove_all_filters( 'woocommerce_gla_product_attribute_value_description' );
 
 		// remove added shortcodes
 		remove_shortcode( 'wc_gla_sample_test_shortcode' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #907 .

This PR adds a new filter called `woocommerce_gla_product_description_apply_shortcodes` that allows the user to specify whether they want to apply the shortcodes to their product's descriptions or not. If a `false` value is returned by this filter, we strip the shortcodes out (this happens by default if the filter isn't used).

The argument for stripping the shortcodes by default (and only applying them if the filter is used) was that in most cases users would want a simple description without all the formatting, etc. applied by third-party plugins to be sent to Google Merchant Center. We could also have a separate option in our settings that enables or disables this but I think this filter could work as a quick solution until we implement the settings.

A few unit tests are also added to cover some of the filters used when processing the product's description.

### Detailed test instructions:

1. Edit a product and add shortcodes to its description
2. Sync the product and make sure that shortcodes are stripped out from its description
3. Add the following filter: `add_filter( 'woocommerce_gla_product_description_apply_shortcodes', '__return_true' );`
4. Sync the product and make sure the shortcode is applied when viewing the product's description in MC


### Changelog entry

> Add - Filter to allow applying shortcodes to product description.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->