### PR TITLE
Add SVG to the .zip (redo #897)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,6 @@
 		"exclude": [
 			"!/js/build",
 			"!/vendor/*",
-			"!/js/src/**/*.svg",
 			"!/languages"
 		]
 	},

--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -7,16 +7,10 @@ import { Flex, FlexItem, FlexBlock } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
 import Section from '.~/wcdl/section';
 import Subsection from '.~/wcdl/subsection';
+import googleLogoURL from './gogole-g-logo.svg';
 import './index.scss';
-
-/**
- * Full URL to the Google G logo image.
- */
-const googleLogoURL =
-	glaData.assetsURL + 'js/src/components/account-card/gogole-g-logo.svg';
 
 /**
  * Enum of account card appearances.

--- a/js/src/components/free-listings/configure-product-listings/hero/index.js
+++ b/js/src/components/free-listings/configure-product-listings/hero/index.js
@@ -6,16 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
 import StepContentHeader from '.~/components/stepper/step-content-header';
+import heroImageURL from './google-free-listing.svg';
 import './index.scss';
-
-/**
- * Full URL to the hero image.
- */
-const heroImageURL =
-	glaData.assetsURL +
-	'js/src/components/free-listings/configure-product-listings/hero/google-free-listing.svg';
 
 /**
  * Hero element for free listing configuration.

--- a/js/src/dashboard/campaign-creation-success-guide/index.js
+++ b/js/src/dashboard/campaign-creation-success-guide/index.js
@@ -10,23 +10,16 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
 import { getCreateCampaignUrl } from '.~/utils/urls';
 import AppModal from '.~/components/app-modal';
 import GuidePageContent, {
 	ContentLink,
 } from '.~/components/guide-page-content';
+import headerImageURL from './header.svg';
 import './index.scss';
 
 const GUIDE_NAME = 'campaign-creation-success';
 const CTA_CREATE_ANOTHER_CAMPAIGN = 'create-another-campaign';
-
-/**
- * Full URL to the header image.
- */
-const headerImageURL =
-	glaData.assetsURL +
-	'js/src/dashboard/campaign-creation-success-guide/header.svg';
 
 const handleCloseWithAction = ( e, specifiedAction ) => {
 	const action = specifiedAction || e.currentTarget.dataset.action;

--- a/js/src/get-started-page/features-card/index.js
+++ b/js/src/get-started-page/features-card/index.js
@@ -12,13 +12,10 @@ import {
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
+import connectionImageURL from './img-connection.svg';
+import freeListingsImageURL from './img-free-listings.svg';
+import googleAdsImageURL from './img-google-ads.svg';
 import './index.scss';
-
-/**
- * Full URL to the feature images folder.
- */
-const imagesURL = glaData.assetsURL + 'js/src/get-started-page/features-card/';
 
 const FeaturesCard = () => {
 	return (
@@ -26,7 +23,7 @@ const FeaturesCard = () => {
 			<Flex>
 				<FlexBlock>
 					<img
-						src={ imagesURL + 'img-connection.svg' }
+						src={ connectionImageURL }
 						alt={ __(
 							'Drawing of jigsaw puzzles connecting together',
 							'google-listings-and-ads'
@@ -55,7 +52,7 @@ const FeaturesCard = () => {
 				</FlexBlock>
 				<FlexBlock>
 					<img
-						src={ imagesURL + 'img-free-listings.svg' }
+						src={ freeListingsImageURL }
 						alt={ __(
 							'Drawing of a person looking at their mobile',
 							'google-listings-and-ads'
@@ -84,7 +81,7 @@ const FeaturesCard = () => {
 				</FlexBlock>
 				<FlexBlock>
 					<img
-						src={ imagesURL + 'img-google-ads.svg' }
+						src={ googleAdsImageURL }
 						alt={ __(
 							'Drawing of a bar and line charts heading up',
 							'google-listings-and-ads'

--- a/js/src/get-started-page/get-started-card/index.js
+++ b/js/src/get-started-page/get-started-card/index.js
@@ -17,14 +17,9 @@ import { getNewPath } from '@woocommerce/navigation';
  */
 import { glaData } from '.~/constants';
 import AppDocumentationLink from '.~/components/app-documentation-link';
+import motivationImageURL from './image.svg';
 import './index.scss';
 import AppButton from '.~/components/app-button';
-
-/**
- * Full URL to the header image.
- */
-const motivationImageURL =
-	glaData.assetsURL + 'js/src/get-started-page/get-started-card/image.svg';
 
 const GetStartedCard = () => {
 	const disableNextStep = ! glaData.mcSupportedLanguage;

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -7,6 +7,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
+import './public-path';
 import './css/index.scss';
 import GetStartedPage from './get-started-page';
 import SetupMC from './setup-mc';

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -14,27 +14,18 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
 import Guide from '.~/external-components/wordpress/guide';
 import GuidePageContent, {
 	ContentLink,
 } from '.~/components/guide-page-content';
 import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
+import wooLogoURL from './woocommerce-logo.svg';
+import googleLogoURL from './google-logo.svg';
 import './index.scss';
 
 const GUIDE_NAME = 'submission-success';
 const EVENT_NAME = 'gla_modal_closed';
 const LATER_BUTTON_CLASS = 'components-guide__finish-button';
-
-/**
- * Full URL to the logo images.
- */
-const wooLogoURL =
-	glaData.assetsURL +
-	'js/src/product-feed/submission-success-guide/woocommerce-logo.svg';
-const googleLogoURL =
-	glaData.assetsURL +
-	'js/src/product-feed/submission-success-guide/google-logo.svg';
 
 const productFeedPath = getNewPath(
 	{ guide: undefined },

--- a/js/src/public-path.js
+++ b/js/src/public-path.js
@@ -1,0 +1,8 @@
+/**
+ * This is needed in Webpack < 5, as we cannot use eiither
+ * `import.meta` or `publicPath: 'auto'`,
+ * but we do need Webpack's `publicPath` for `file-loader` to create accurate URLs.
+ */
+const url = new URL( document.currentScript.src ).href;
+// eslint-disable-next-line camelcase, no-undef
+__webpack_public_path__ = url.slice( 0, url.lastIndexOf( '/' ) + 1 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -14088,6 +14088,35 @@
 				"flat-cache": "^2.0.1"
 			}
 		},
+		"file-loader": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+			"integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^3.0.0"
+			},
+			"dependencies": {
+				"@types/json-schema": {
+					"version": "7.0.8",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+					"integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.8",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
+					}
+				}
+			}
+		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"bundlewatch": "^0.3.2",
 		"eslint-import-resolver-webpack": "^0.13.1",
 		"eslint-plugin-import": "^2.23.4",
+		"file-loader": "^6.2.0",
 		"h2o2": "^8.2.0",
 		"prettier": "npm:wp-prettier@^2.0.5"
 	},

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -110,7 +110,6 @@ class Admin implements Service, Registerable, Conditional {
 		) )->add_inline_script(
 			'glaData',
 			[
-				'assetsURL'           => plugin_dir_url( $this->get_main_file() ),
 				'mcSetupComplete'     => $this->merchant_center->is_setup_complete(),
 				'mcSupportedCountry'  => $this->merchant_center->is_country_supported(),
 				'mcSupportedLanguage' => $this->merchant_center->is_language_supported(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,9 +50,6 @@ const webpackConfig = {
 					loader: 'file-loader',
 					options: {
 						name: 'images/[path]/[contenthash].[name].[ext]',
-						// FIXME: for production build, for some reason `__webpack_public_path__` is empty.
-						// Making default publicPath empty.
-						// postTransformPublicPath: (p) => `__webpack_public_path__ + ${p}`,
 					},
 				},
 				// Prevent Webpack 5 from procesing files again.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,9 +31,35 @@ const requestToHandle = ( request ) => {
 
 	return wcHandleMap[ request ];
 };
+const exceptSVGRule = ( rule ) => {
+	return ! rule.test.toString().match( /svg/i );
+};
 
 const webpackConfig = {
 	...defaultConfig,
+	module: {
+		...defaultConfig.module,
+		// Expose image assets as files.
+		// In Webpack 5 we would use Asset Modules and `asset/resource`
+		rules: [
+			// Remove `@wordpress/` rules for SVGs.
+			...defaultConfig.module.rules.filter( exceptSVGRule ),
+			{
+				test: /\.(svg|png|jpe?g|gif)$/i,
+				use: {
+					loader: 'file-loader',
+					options: {
+						name: 'images/[path]/[contenthash].[name].[ext]',
+						// FIXME: for production build, for some reason `__webpack_public_path__` is empty.
+						// Making default publicPath empty.
+						// postTransformPublicPath: (p) => `__webpack_public_path__ + ${p}`,
+					},
+				},
+				// Prevent Webpack 5 from procesing files again.
+				type: 'javascript/auto',
+			},
+		],
+	},
 	resolve: {
 		...defaultConfig.resolve,
 		alias: {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use `file-loader` to expose image assets from `js/src/` to `js/build`.
Redo https://github.com/woocommerce/google-listings-and-ads/pull/897/

Fixes https://github.com/woocommerce/google-listings-and-ads/issues/498
and adds `.svg`s to the `.zip`  package https://github.com/woocommerce/google-listings-and-ads/pull/897#issuecomment-888246189

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. `npm run build`
2. Redo tests from https://github.com/woocommerce/google-listings-and-ads/pull/897#issue-694550944

### Additional notes:

1. This PR tries to implement the idea to use Webpack's `file-loader` suggested at https://github.com/woocommerce/google-listings-and-ads/pull/897#issuecomment-888246189

	It almost works, but, for some reason `file-loader` cannot pickup `__webpack_public_path__` and the paths gets rendered as `images/{path}/{hash}.{name}.{ext}` whereas we need `{path_to_build_folder}/images/{path}/{hash}.{name}.{ext}`
	
	Is that achievable via Webpack, to do we need to add it as before with `glaData.assetsURL`?
	
	@ecgan @eason9487 Do you have any advice?

2. We could tweak the `file-loader`'s setup a little and make it will serve the files directly from `js/src/` folder for the development environment. So, we will not need to rebuild the package when files change. I'm not sure how often we would use that. If it's worth the bloat in the config, and the fact we will be testing not the production result.

### Changelog entry
