### PR TITLE
Change MC setup flow to have four steps

### DIFF
--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -32,7 +32,7 @@ const SavedSetupStepper = ( props ) => {
 	};
 
 	const handleStepClick = ( stepKey ) => {
-		if ( stepKey <= savedStep ) {
+		if ( Number( stepKey ) <= Number( savedStep ) ) {
 			setStep( stepKey );
 		}
 	};

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -12,6 +12,7 @@ import { recordSetupMCEvent } from '.~/utils/recordEvent';
 import SetupAccounts from './setup-accounts';
 import SetupFreeListings from './setup-free-listings';
 import ChooseAudience from './choose-audience';
+import StoreRequirements from './store-requirements';
 import './index.scss';
 import stepNameKeyMap from './stepNameKeyMap';
 
@@ -28,6 +29,12 @@ const SavedSetupStepper = ( props ) => {
 	const handleChooseAudienceContinue = () => {
 		recordSetupMCEvent( 'step2_continue' );
 		setStep( stepNameKeyMap.shipping_and_taxes );
+		onRefetchSavedStep();
+	};
+
+	const handleSetupListingsContinue = () => {
+		recordSetupMCEvent( 'step3_continue' );
+		setStep( stepNameKeyMap.store_requirements );
 		onRefetchSavedStep();
 	};
 
@@ -74,7 +81,20 @@ const SavedSetupStepper = ( props ) => {
 						'Configure your product listings',
 						'google-listings-and-ads'
 					),
-					content: <SetupFreeListings />,
+					content: (
+						<SetupFreeListings
+							onContinue={ handleSetupListingsContinue }
+						/>
+					),
+					onClick: handleStepClick,
+				},
+				{
+					key: stepNameKeyMap.store_requirements,
+					label: __(
+						'Confirm store requirements',
+						'google-listings-and-ads'
+					),
+					content: <StoreRequirements />,
 					onClick: handleStepClick,
 				},
 			] }

--- a/js/src/setup-mc/setup-stepper/stepNameKeyMap.js
+++ b/js/src/setup-mc/setup-stepper/stepNameKeyMap.js
@@ -1,7 +1,9 @@
 const stepNameKeyMap = {
-	accounts: 1,
-	target_audience: 2,
-	shipping_and_taxes: 3,
+	accounts: '1',
+	target_audience: '2',
+	shipping_and_taxes: '3',
+	// TODO: [lite-contact-info] double-check this key with backend dev.
+	store_requirements: '4',
 };
 
 export default stepNameKeyMap;

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { Form } from '@woocommerce/components';
+import { getNewPath } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import useAdminUrl from '.~/hooks/useAdminUrl';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import StepContent from '.~/components/stepper/step-content';
+import StepContentHeader from '.~/components/stepper/step-content-header';
+import StepContentFooter from '.~/components/stepper/step-content-footer';
+import AppButton from '.~/components/app-button';
+
+export default function StoreRequirements() {
+	const adminUrl = useAdminUrl();
+	const { createNotice } = useDispatchCoreNotices();
+	const [ completing, setCompleting ] = useState( false );
+
+	const handleValidate = () => {
+		// TODO: [lite-contact-info] add validation
+		return {};
+	};
+
+	const handleSubmitCallback = async () => {
+		try {
+			setCompleting( true );
+
+			// TODO: [lite-contact-info] POST phone number to API if it has changed
+
+			// TODO: [lite-contact-info] POST address to API
+
+			await apiFetch( {
+				path: '/wc/gla/mc/settings/sync',
+				method: 'POST',
+			} );
+
+			// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
+			const path = getNewPath(
+				{ guide: 'submission-success' },
+				'/google/product-feed'
+			);
+			window.location.href = adminUrl + path;
+		} catch ( error ) {
+			setCompleting( false );
+
+			createNotice(
+				'error',
+				__(
+					'Unable to complete your setup. Please try again later.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+	};
+
+	return (
+		<StepContent>
+			<StepContentHeader
+				step={ __( 'STEP FOUR', 'google-listings-and-ads' ) }
+				title={ __(
+					'Confirm store requirements',
+					'google-listings-and-ads'
+				) }
+				description={ __(
+					'Review and confirm that your store meets Google Merchant Center requirements.',
+					'google-listings-and-ads'
+				) }
+			/>
+			<Form
+				initialValues={ {} }
+				validate={ handleValidate }
+				onSubmitCallback={ handleSubmitCallback }
+				onSubmit={ handleSubmitCallback }
+			>
+				{ ( formProps ) => {
+					const { handleSubmit, isValidForm } = formProps;
+
+					return (
+						<>
+							<div>TODO: implement contact information setup</div>
+							<div>TODO: move pre-lauch checklist to here</div>
+							<StepContentFooter>
+								<AppButton
+									isPrimary
+									loading={ completing }
+									disabled={ ! isValidForm }
+									onClick={ handleSubmit }
+								>
+									{ __(
+										'Complete setup',
+										'google-listings-and-ads'
+									) }
+								</AppButton>
+							</StepContentFooter>
+						</>
+					);
+				} }
+			</Form>
+		</StepContent>
+	);
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Partial of #863 

- Add the fourth step page (layout only) for MC setup flow
- Change values of MC steps to string type and add the fourth step key/value
- Change MC setup flow to have four steps

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/127460261-cd44bfc2-255f-4aaa-b1a8-7591b46befe9.png)

### Detailed test instructions:

1. Go to the MC setup flow and it should have four steps
2. The button text of the third step should be "Continue", and click on it should move forward to the "Confirm store requirements" step

### Changelog entry
