### PR TITLE
Load deprecated functions from guzzlehttp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,12 @@
 	"autoload": {
 		"psr-4": {
 			"Automattic\\WooCommerce\\GoogleListingsAndAds\\": "src/"
-		}
+		},
+		"files": [
+			"vendor/guzzlehttp/guzzle/src/functions_include.php",
+			"vendor/guzzlehttp/promises/src/functions_include.php",
+			"vendor/guzzlehttp/psr7/src/functions_include.php"
+		]
 	},
 	"autoload-dev": {
 		"psr-4": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After updating the Google Merchant Center library in #830 we took advantage of the fact that it no longer used any deprecated functions from the Guzzle library. This was important because we change the namespace for this library and the deprecated functions are loaded directly within it's `composer.json` file. It turns out that the GAX library still uses some of these deprecated functions `uri_for` in particular. This is a dependency of the Google Ads library and at the moment there is no [updated version available](https://github.com/googleapis/gax-php/releases).

To get around this we need to load the deprecated versions directly from our main composer.json so it can correctly load them with the changed namespace.

Closes #845 

### Detailed test instructions:

1. Start with a copy of trunk
2. Get an older copy of the Brizzy Pro plugin from 4179454-zen
3. Install the main Brizzy plugin version 2.2.6 (needed to match the pro version) from [WordPress.org](https://wordpress.org/plugins/brizy/advanced/)
4. Activate both plugins and go to the Connection Test page
5. Make sure we have an ads account connected and click the Get Campaigns from Google Ads button
6. Confirm we see the fatal error
7. Checkout this PR and run `composer install`
8. Repeat the same request in step 5
9. Confirm this time we get a valid response without the fatal error

### Changelog entry
* Fix - Load deprecated functions from Guzzle which are required for the GAX library.