### PR TITLE
Implement `PhoneNumberCard` and `ContactInformation` components for contact info

### DIFF
--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Flex, FlexItem, FlexBlock } from '@wordpress/components';
+import GridiconPhone from 'gridicons/dist/phone';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ const googleLogoURL =
  */
 export const APPEARANCE = {
 	GOOGLE: 'google',
+	PHONE: 'phone',
 };
 
 const appearanceDict = {
@@ -39,6 +41,10 @@ const appearanceDict = {
 			/>
 		),
 		title: __( 'Google account', 'google-listings-and-ads' ),
+	},
+	[ APPEARANCE.PHONE ]: {
+		icon: <GridiconPhone size={ 32 } />,
+		title: __( 'Phone number', 'google-listings-and-ads' ),
 	},
 };
 

--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { Flex, FlexItem, FlexBlock } from '@wordpress/components';
 
 /**
@@ -29,7 +30,7 @@ export const APPEARANCE = {
 
 const appearanceDict = {
 	[ APPEARANCE.GOOGLE ]: {
-		logo: (
+		icon: (
 			<img
 				src={ googleLogoURL }
 				alt={ __( 'Google Logo', 'google-listings-and-ads' ) }
@@ -45,24 +46,28 @@ const appearanceDict = {
  * Renders a Card component with account info and status.
  *
  * @param {Object} props React props.
+ * @param {string} [props.className] Additional CSS class name to be appended.
  * @param {APPEARANCE} props.appearance Kind of account to indicate the card appearance.
  * @param {JSX.Element} props.description Content below the card title.
+ * @param {boolean} [props.hideIcon=false] Whether hide the leading icon.
  * @param {JSX.Element} [props.indicator] Indicator of actions or status on the right side of the card.
  * @param {Array<JSX.Element>} [props.children] Children to be rendered if needs more content within the card.
  */
 export default function AccountCard( {
+	className,
 	appearance,
 	description,
+	hideIcon = false,
 	indicator,
 	children,
 } ) {
-	const { logo, title } = appearanceDict[ appearance ];
+	const { icon, title } = appearanceDict[ appearance ];
 
 	return (
-		<Section.Card className="gla-account-card">
+		<Section.Card className={ classnames( 'gla-account-card', className ) }>
 			<Section.Card.Body>
 				<Flex gap={ 4 }>
-					<FlexItem>{ logo }</FlexItem>
+					{ ! hideIcon && <FlexItem>{ icon }</FlexItem> }
 					<FlexBlock>
 						<Subsection.Title>{ title }</Subsection.Title>
 						<div>{ description }</div>

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -53,6 +53,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 			{ phone.loaded ? (
 				<VerticalGapLayout size="large">
 					<PhoneNumberCard
+						phoneNumber={ phone }
 						initEditing={ initEditing }
 						onPhoneNumberChange={ onPhoneNumberChange }
 					/>

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
+import Section from '.~/wcdl/section';
+import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import AppSpinner from '.~/components/app-spinner';
+import PhoneNumberCard from './phone-number-card';
+
+const description = __(
+	'Your contact information is required by Google for verification purposes. It will be shared with the Google Merchant Center and will not be displayed to customers.',
+	'google-listings-and-ads'
+);
+
+const mcTitle = __( 'Enter contact information', 'google-listings-and-ads' );
+const settingsTitle = __( 'Contact information', 'google-listings-and-ads' );
+
+export default function ContactInformation( { view, onPhoneNumberChange } ) {
+	const phone = useGoogleMCPhoneNumber();
+	const isSetupMC = view === 'setup-mc';
+
+	const initEditing = isSetupMC ? ! phone.data.isValid : true;
+	const title = isSetupMC ? mcTitle : settingsTitle;
+	const trackContext = isSetupMC
+		? 'setup-mc-contact-information'
+		: 'settings-contact-information';
+
+	return (
+		<Section
+			title={ title }
+			description={
+				<div>
+					<p>{ description }</p>
+					<p>
+						<AppDocumentationLink
+							context={ trackContext }
+							linkId="contact-information-read-more"
+							// TODO: [lite-contact-info] add link
+							href="https://example.com/"
+						>
+							{ __( 'Learn more', 'google-listings-and-ads' ) }
+						</AppDocumentationLink>
+					</p>
+				</div>
+			}
+		>
+			{ phone.loaded ? (
+				<VerticalGapLayout size="large">
+					<PhoneNumberCard
+						initEditing={ initEditing }
+						onPhoneNumberChange={ onPhoneNumberChange }
+					/>
+					<div>TODO: add store address card</div>
+				</VerticalGapLayout>
+			) : (
+				<AppSpinner />
+			) }
+		</Section>
+	);
+}

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -11,7 +11,6 @@ import { Spinner } from '@woocommerce/components';
  * Internal dependencies
  */
 import useCountryCallingCodeOptions from '.~/hooks/useCountryCallingCodeOptions';
-import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import Section from '.~/wcdl/section';
 import SelectControl from '.~/wcdl/select-control';
 import AppInputControl from '.~/components/app-input-control';
@@ -79,13 +78,14 @@ function PhoneNumberContent( {
 }
 
 export default function PhoneNumberCard( {
+	phoneNumber,
 	isPreview,
 	initEditing,
 	onEditClick,
 	onPhoneNumberChange = noop,
 } ) {
 	const [ isEditing, setEditing ] = useState( initEditing );
-	const { loaded, data } = useGoogleMCPhoneNumber();
+	const { loaded, data } = phoneNumber;
 
 	const editButton = isEditing ? null : (
 		<AppButton

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import { getCountryCallingCode } from 'libphonenumber-js';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Flex, FlexItem, FlexBlock, CardDivider } from '@wordpress/components';
+import { Spinner } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import useCountryCallingCodes from '.~/hooks/useCountryCallingCodes';
+import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
+import Section from '.~/wcdl/section';
+import SelectControl from '.~/wcdl/select-control';
+import AppInputControl from '.~/components/app-input-control';
+import AccountCard, { APPEARANCE } from '.~/components/account-card';
+import AppButton from '.~/components/app-button';
+import AppSpinner from '.~/components/app-spinner';
+import './phone-number-card.scss';
+
+const noop = () => {};
+
+function PhoneNumberContent( {
+	initCountry,
+	initNationalNumber,
+	onPhoneNumberChange,
+} ) {
+	const countryCallingCodes = useCountryCallingCodes( 'select-options' );
+	const [ country, setCountry ] = useState( initCountry );
+	const [ number, setNumber ] = useState( initNationalNumber );
+
+	const handleChange = ( nextCountry, nextNumber ) => {
+		if ( nextCountry !== country ) {
+			setCountry( nextCountry );
+		}
+		if ( nextNumber !== number ) {
+			setNumber( nextNumber );
+		}
+
+		const countryCallingCode = nextCountry
+			? getCountryCallingCode( nextCountry )
+			: '';
+		onPhoneNumberChange( countryCallingCode, nextNumber, nextCountry );
+	};
+
+	const handleCountryChange = ( v ) => handleChange( v, number );
+	const handleNumberChange = ( v ) => handleChange( country, v );
+
+	return (
+		<Section.Card.Body>
+			<Flex gap={ 4 }>
+				<FlexItem>
+					<SelectControl
+						label={ __(
+							'Country code',
+							'google-listings-and-ads'
+						) }
+						isSearchable
+						excludeSelectedOptions={ false }
+						options={ countryCallingCodes }
+						selected={ country }
+						onChange={ handleCountryChange }
+					/>
+				</FlexItem>
+				<FlexBlock>
+					<AppInputControl
+						label={ __(
+							'Phone number',
+							'google-listings-and-ads'
+						) }
+						value={ number }
+						onChange={ handleNumberChange }
+					/>
+				</FlexBlock>
+			</Flex>
+		</Section.Card.Body>
+	);
+}
+
+export default function PhoneNumberCard( {
+	isPreview,
+	initEditing,
+	onEditClick,
+	onPhoneNumberChange = noop,
+} ) {
+	const [ isEditing, setEditing ] = useState( initEditing );
+	const { loaded, data } = useGoogleMCPhoneNumber();
+
+	const editButton = isEditing ? null : (
+		<AppButton
+			isSecondary
+			onClick={ () => {
+				if ( onEditClick ) {
+					onEditClick();
+				} else {
+					setEditing( true );
+				}
+			} }
+		>
+			{ __( 'Edit', 'google-listings-and-ads' ) }
+		</AppButton>
+	);
+
+	let description = null;
+	let phoneNumberContent = null;
+
+	if ( isEditing ) {
+		description = __(
+			'Please enter a phone number to be used for verification.',
+			'google-listings-and-ads'
+		);
+
+		if ( loaded ) {
+			phoneNumberContent = (
+				<>
+					<CardDivider />
+					<PhoneNumberContent
+						initCountry={ data.country }
+						initNationalNumber={ data.nationalNumber }
+						onPhoneNumberChange={ onPhoneNumberChange }
+					/>
+				</>
+			);
+		} else {
+			phoneNumberContent = <AppSpinner />;
+		}
+	} else {
+		description = loaded ? data.display : <Spinner />;
+	}
+
+	return (
+		<AccountCard
+			className="gla-phone-number-card"
+			appearance={ APPEARANCE.PHONE }
+			description={ description }
+			hideIcon={ isPreview }
+			indicator={ editButton }
+		>
+			{ phoneNumberContent }
+		</AccountCard>
+	);
+}

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -32,12 +32,8 @@ function PhoneNumberContent( {
 	const [ number, setNumber ] = useState( initNationalNumber );
 
 	const handleChange = ( nextCountry, nextNumber ) => {
-		if ( nextCountry !== country ) {
-			setCountry( nextCountry );
-		}
-		if ( nextNumber !== number ) {
-			setNumber( nextNumber );
-		}
+		setCountry( nextCountry );
+		setNumber( nextNumber );
 
 		const countryCallingCode = nextCountry
 			? getCountryCallingCode( nextCountry )
@@ -45,8 +41,11 @@ function PhoneNumberContent( {
 		onPhoneNumberChange( countryCallingCode, nextNumber, nextCountry );
 	};
 
-	const handleCountryChange = ( v ) => handleChange( v, number );
-	const handleNumberChange = ( v ) => handleChange( country, v );
+	const handleCountryChange = ( nextCountry ) =>
+		handleChange( nextCountry, number );
+
+	const handleNumberChange = ( nextNumber ) =>
+		handleChange( country, nextNumber );
 
 	return (
 		<Section.Card.Body>

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -10,7 +10,7 @@ import { Spinner } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import useCountryCallingCodes from '.~/hooks/useCountryCallingCodes';
+import useCountryCallingCodeOptions from '.~/hooks/useCountryCallingCodeOptions';
 import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import Section from '.~/wcdl/section';
 import SelectControl from '.~/wcdl/select-control';
@@ -27,7 +27,7 @@ function PhoneNumberContent( {
 	initNationalNumber,
 	onPhoneNumberChange,
 } ) {
-	const countryCallingCodes = useCountryCallingCodes( 'select-options' );
+	const countryCallingCodeOptions = useCountryCallingCodeOptions();
 	const [ country, setCountry ] = useState( initCountry );
 	const [ number, setNumber ] = useState( initNationalNumber );
 
@@ -58,7 +58,7 @@ function PhoneNumberContent( {
 						) }
 						isSearchable
 						excludeSelectedOptions={ false }
-						options={ countryCallingCodes }
+						options={ countryCallingCodeOptions }
 						selected={ country }
 						onChange={ handleCountryChange }
 					/>

--- a/js/src/components/contact-information/phone-number-card.scss
+++ b/js/src/components/contact-information/phone-number-card.scss
@@ -1,0 +1,42 @@
+.gla-phone-number-card {
+	// Country code selector
+	.wcdl-select-control {
+		.wcdl-select-control__input {
+			margin-bottom: 0;
+		}
+
+		.woocommerce-select-control {
+			.components-base-control {
+				height: 36px;
+				border-color: $gray-600;
+			}
+
+			.woocommerce-select-control__control-input {
+				font-size: 13px;
+				color: $gray-900;
+			}
+
+			.woocommerce-select-control__listbox {
+				top: 37px;
+			}
+
+			.woocommerce-select-control__option {
+				min-height: 36px;
+				font-size: 13px;
+			}
+		}
+	}
+
+	// Phone number input
+	.components-input-control .components-input-control__container {
+		.components-input-control__input {
+			height: 36px;
+			font-size: 13px;
+			color: $gray-900;
+		}
+
+		.components-input-control__backdrop {
+			border-color: $gray-600;
+		}
+	}
+}

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -106,6 +106,10 @@ export function* getExistingGoogleAdsAccounts() {
 	yield fetchExistingGoogleAdsAccounts();
 }
 
+export function* getGoogleMCPhoneNumber() {
+	// TODO: [lite-contact-info] integrate with API
+}
+
 export function* getCountries() {
 	yield fetchCountries();
 }

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -68,6 +68,15 @@ export const getExistingGoogleAdsAccounts = ( state ) => {
 	return state.mc.accounts.existing_ads;
 };
 
+const mockPhoneNumber = Math.random() > 0.5 ? '+12133734253' : '';
+export const getGoogleMCPhoneNumber = () => {
+	// TODO: [lite-contact-info] integrate with API
+	return {
+		id: '123456789',
+		phone_number: mockPhoneNumber,
+	};
+};
+
 export const getCountries = ( state ) => {
 	return state.mc.countries;
 };

--- a/js/src/hooks/useCountryCallingCodeOptions.js
+++ b/js/src/hooks/useCountryCallingCodeOptions.js
@@ -9,30 +9,25 @@ import { getCountries, getCountryCallingCode } from 'libphonenumber-js';
  */
 import useCountryKeyNameMap from './useCountryKeyNameMap';
 
-const toData = ( country, countryCallingCode, countryName ) => ( {
-	country,
-	countryCallingCode,
-	countryName,
-} );
-
 const toOption = ( country, countryCallingCode, countryName ) => ( {
 	key: country,
 	keywords: [ countryName, countryCallingCode, country ],
 	label: `${ countryName } (+${ countryCallingCode })`,
 } );
 
-export default function useCountryCallingCodes( as ) {
+export default function useCountryCallingCodeOptions() {
 	const countryNameDict = useCountryKeyNameMap();
 
 	return useMemo( () => {
 		return getCountries().reduce( ( acc, country ) => {
 			const countryName = countryNameDict[ country ];
 			if ( countryName ) {
-				const fn = as === 'select-options' ? toOption : toData;
 				const countryCallingCode = getCountryCallingCode( country );
-				acc.push( fn( country, countryCallingCode, countryName ) );
+				acc.push(
+					toOption( country, countryCallingCode, countryName )
+				);
 			}
 			return acc;
 		}, [] );
-	}, [ as, countryNameDict ] );
+	}, [ countryNameDict ] );
 }

--- a/js/src/hooks/useCountryCallingCodes.js
+++ b/js/src/hooks/useCountryCallingCodes.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { getCountries, getCountryCallingCode } from 'libphonenumber-js';
+
+/**
+ * Internal dependencies
+ */
+import useCountryKeyNameMap from './useCountryKeyNameMap';
+
+const toData = ( country, countryCallingCode, countryName ) => ( {
+	country,
+	countryCallingCode,
+	countryName,
+} );
+
+const toOption = ( country, countryCallingCode, countryName ) => ( {
+	key: country,
+	keywords: [ countryName, countryCallingCode, country ],
+	label: `${ countryName } (+${ countryCallingCode })`,
+} );
+
+export default function useCountryCallingCodes( as ) {
+	const countryNameDict = useCountryKeyNameMap();
+
+	return useMemo( () => {
+		return getCountries().reduce( ( acc, country ) => {
+			const countryName = countryNameDict[ country ];
+			if ( countryName ) {
+				const fn = as === 'select-options' ? toOption : toData;
+				const countryCallingCode = getCountryCallingCode( country );
+				acc.push( fn( country, countryCallingCode, countryName ) );
+			}
+			return acc;
+		}, [] );
+	}, [ as, countryNameDict ] );
+}

--- a/js/src/hooks/useCountryKeyNameMap.js
+++ b/js/src/hooks/useCountryKeyNameMap.js
@@ -4,6 +4,18 @@
 import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 
+/*
+ * Examples:
+ * - Cura&ccedil;ao                             -> Curaçao
+ * - Saint Barth&eacute;lemy                    -> Saint Barthélemy
+ * - S&atilde;o Tom&eacute; and Pr&iacute;ncipe -> São Tomé and Príncipe
+ */
+function replaceHtmlEntities( countryName ) {
+	const el = document.createElement( 'span' );
+	el.innerHTML = countryName;
+	return el.textContent;
+}
+
 /**
  * Get a country key-name map object. Used for getting complete country name based on country code.
  *
@@ -18,10 +30,19 @@ import { useSelect } from '@wordpress/data';
  */
 const useCountryKeyNameMap = () => {
 	return useSelect( ( select ) => {
-		return select( SETTINGS_STORE_NAME ).getSetting(
-			'wc_admin',
-			'countries'
-		);
+		const { getSetting } = select( SETTINGS_STORE_NAME );
+		const countries = {
+			...getSetting( 'wc_admin', 'countries' ),
+		};
+
+		Object.keys( countries ).forEach( ( key ) => {
+			const name = countries[ key ];
+			if ( /&[^;]+;/.test( name ) ) {
+				countries[ key ] = replaceHtmlEntities( name );
+			}
+		} );
+
+		return countries;
 	}, [] );
 };
 

--- a/js/src/hooks/useCountryKeyNameMap.js
+++ b/js/src/hooks/useCountryKeyNameMap.js
@@ -3,18 +3,7 @@
  */
 import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
-
-/*
- * Examples:
- * - Cura&ccedil;ao                             -> Curaçao
- * - Saint Barth&eacute;lemy                    -> Saint Barthélemy
- * - S&atilde;o Tom&eacute; and Pr&iacute;ncipe -> São Tomé and Príncipe
- */
-function replaceHtmlEntities( countryName ) {
-	const el = document.createElement( 'span' );
-	el.innerHTML = countryName;
-	return el.textContent;
-}
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Get a country key-name map object. Used for getting complete country name based on country code.
@@ -35,11 +24,15 @@ const useCountryKeyNameMap = () => {
 			...getSetting( 'wc_admin', 'countries' ),
 		};
 
+		/*
+		 * There are HTML entities in some country names.
+		 * Examples:
+		 * - Cura&ccedil;ao                             -> Curaçao
+		 * - Saint Barth&eacute;lemy                    -> Saint Barthélemy
+		 * - S&atilde;o Tom&eacute; and Pr&iacute;ncipe -> São Tomé and Príncipe
+		 */
 		Object.keys( countries ).forEach( ( key ) => {
-			const name = countries[ key ];
-			if ( /&[^;]+;/.test( name ) ) {
-				countries[ key ] = replaceHtmlEntities( name );
-			}
+			countries[ key ] = decodeEntities( countries[ key ] );
 		} );
 
 		return countries;

--- a/js/src/hooks/useGoogleMCPhoneNumber.js
+++ b/js/src/hooks/useGoogleMCPhoneNumber.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { parsePhoneNumberFromString as parsePhoneNumber } from 'libphonenumber-js';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '.~/data/constants';
+
+const selectorName = 'getGoogleMCPhoneNumber';
+const emptyData = {
+	country: '',
+	countryCallingCode: '',
+	nationalNumber: '',
+	isValid: false,
+	display: '',
+};
+
+export default function useGoogleMCPhoneNumber() {
+	return useSelect( ( select ) => {
+		const selector = select( STORE_KEY );
+		const phone = selector[ selectorName ]();
+		let data = emptyData;
+
+		if ( phone ) {
+			const parsed = parsePhoneNumber( phone.phone_number );
+			if ( parsed ) {
+				data = {
+					...parsed,
+					isValid: parsed.isValid(),
+					display: parsed.formatInternational(),
+				};
+				delete data.metadata;
+			}
+		}
+
+		return {
+			loaded: selector.hasFinishedResolution( selectorName ),
+			data,
+		};
+	}, [] );
+}

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -15,6 +15,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
+import ContactInformation from '.~/components/contact-information';
 import AppButton from '.~/components/app-button';
 
 export default function StoreRequirements() {
@@ -25,6 +26,11 @@ export default function StoreRequirements() {
 	const handleValidate = () => {
 		// TODO: [lite-contact-info] add validation
 		return {};
+	};
+
+	const handlePhoneNumberChange = ( countryCallingCode, nationalNumber ) => {
+		// TODO: [lite-contact-info] handle the onChange callback of phone number
+		console.log( countryCallingCode, nationalNumber ); // eslint-disable-line
 	};
 
 	const handleSubmitCallback = async () => {
@@ -83,7 +89,10 @@ export default function StoreRequirements() {
 
 					return (
 						<>
-							<div>TODO: implement contact information setup</div>
+							<ContactInformation
+								view="setup-mc"
+								onPhoneNumberChange={ handlePhoneNumberChange }
+							/>
 							<div>TODO: move pre-lauch checklist to here</div>
 							<StepContentFooter>
 								<AppButton

--- a/package-lock.json
+++ b/package-lock.json
@@ -5668,6 +5668,14 @@
 						"@babel/runtime": "^7.13.10"
 					}
 				},
+				"@wordpress/html-entities": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.7.0.tgz",
+					"integrity": "sha512-OmHZFHDl1Ai0LmRlqehRAt0broGigW1QCnRS1K82nurCFi9kz8x13C7GWv7wshA9TC4Qp/PLP9SEl/nzcJyIYg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
 				"@wordpress/i18n": {
 					"version": "3.11.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.11.0.tgz",
@@ -7272,11 +7280,11 @@
 			}
 		},
 		"@wordpress/html-entities": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.7.0.tgz",
-			"integrity": "sha512-OmHZFHDl1Ai0LmRlqehRAt0broGigW1QCnRS1K82nurCFi9kz8x13C7GWv7wshA9TC4Qp/PLP9SEl/nzcJyIYg==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.2.1.tgz",
+			"integrity": "sha512-DHuIQ7MMyAcmkMM/VY8RibIcLiIcstk6Og09f4EWQegOgage6yMgnG7eI0nf2LBe65mttnda1EL51slc7XjaXg==",
 			"requires": {
-				"@babel/runtime": "^7.9.2"
+				"@babel/runtime": "^7.13.10"
 			}
 		},
 		"@wordpress/i18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20882,6 +20882,11 @@
 				"type-check": "~0.3.2"
 			}
 		},
+		"libphonenumber-js": {
+			"version": "1.9.22",
+			"resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.22.tgz",
+			"integrity": "sha512-nE0aF0wrNq09ewF36s9FVqRW73hmpw6cobVDlbexmsu1432LEfuN24BCudNuRx4t2rElSeK/N0JbedzRW/TC4A=="
+		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 		"@wordpress/dom": "^3.1.1",
 		"@wordpress/element": "^2.18.0",
 		"@wordpress/hooks": "^3.1.1",
+		"@wordpress/html-entities": "^3.2.1",
 		"@wordpress/i18n": "^4.1.1",
 		"@wordpress/icons": ">=2.9.1 <3.0.0",
 		"@wordpress/primitives": ">=1.12.3 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"@wordpress/url": "^2.22.2",
 		"classnames": "^2.3.1",
 		"gridicons": "^3.3.1",
+		"libphonenumber-js": "^1.9.22",
 		"lodash": "^4.17.20",
 		"md5": "^2.3.0",
 		"prop-types": "^15.7.2",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Partial of #863 and based on #914

- Add `libphonenumber-js` to dependencies
- Add hooks to get all supported country calling codes and user's MC phone number
- Add phone number appearance and 'hideIcon' prop to **AccountCard**, and make its className extendable
- Decode HTML entities within country names
- Implement the shared components of **PhoneNumberCard** and **ContactInformation** section

💡  Please note that this PR doesn't include the API integration.

### Screenshots:

#### 🎥 . When the phone number got from Google MC is empty

https://user-images.githubusercontent.com/17420811/127475223-8cfbcb18-4d78-4d6b-86f5-fb4f2f1ee3e2.mp4

#### 🎥 . When the phone number got from Google MC has already exist

https://user-images.githubusercontent.com/17420811/127475258-e8a300b1-3d40-401e-9867-671a4506b80d.mp4

#### 📷 . The preview mode of PhoneNumberCard will be used in the Setting page later

![image](https://user-images.githubusercontent.com/17420811/127476444-28217c95-a4a0-40a3-9cb7-678cfc810a89.png)

### Detailed test instructions:

For easier testing, there is a mock phone number that is 50% chance for an empty phone number and 50% for an existed phone number when every time reload the page.

https://github.com/woocommerce/google-listings-and-ads/blob/4df92ad07f4c6f156a33988fe7be2115169f7f6b/js/src/data/selectors.js#L71-L78

1. Go to the MC setup flow and proceed to the "Confirm store requirements" step
2. The phone number card should be able to interact
3. The country calling code and national number should be printed on DevTool console when changing it via UI 
    ![image](https://user-images.githubusercontent.com/17420811/127476932-d15eac24-04d1-483b-80b1-db7691bfaa2f.png)

### Changelog entry
