### PR TITLE
Implement `StoreAddressCard` component for contact info

### DIFF
--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Flex, FlexItem, FlexBlock } from '@wordpress/components';
 import GridiconPhone from 'gridicons/dist/phone';
+import { Icon, store as storeIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ const googleLogoURL =
 export const APPEARANCE = {
 	GOOGLE: 'google',
 	PHONE: 'phone',
+	ADDRESS: 'address',
 };
 
 const appearanceDict = {
@@ -45,6 +47,10 @@ const appearanceDict = {
 	[ APPEARANCE.PHONE ]: {
 		icon: <GridiconPhone size={ 32 } />,
 		title: __( 'Phone number', 'google-listings-and-ads' ),
+	},
+	[ APPEARANCE.ADDRESS ]: {
+		icon: <Icon icon={ storeIcon } size={ 32 } />,
+		title: __( 'Store address', 'google-listings-and-ads' ),
 	},
 };
 

--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -51,7 +51,7 @@ const AppButton = ( props ) => {
 
 	const classes = [ 'app-button', className ];
 	if ( rest.iconPosition === 'right' ) {
-		classes.push( 'gla-app-button--fix-icon-position' );
+		classes.push( 'app-button--fix-icon-position-right' );
 	}
 
 	return (

--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -49,9 +49,14 @@ const AppButton = ( props ) => {
 		onClick( ...args );
 	};
 
+	const classes = [ 'app-button', className ];
+	if ( rest.iconPosition === 'right' ) {
+		classes.push( 'gla-app-button--fix-icon-position' );
+	}
+
 	return (
 		<Button
-			className={ classnames( 'app-button', className ) }
+			className={ classnames( ...classes ) }
 			disabled={ disabled || loading }
 			onClick={ handleClick }
 			{ ...rest }

--- a/js/src/components/app-button/index.scss
+++ b/js/src/components/app-button/index.scss
@@ -9,14 +9,12 @@
 			stroke: currentColor;
 		}
 	}
-}
 
-.gla-app-button {
 	/**
 	 * Fix that the SVG icon gap to text should be on the left side.
 	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L309-L311
 	 */
-	&--fix-icon-position.has-icon.has-text svg {
+	&--fix-icon-position-right.has-icon.has-text svg {
 		margin-right: 0;
 		margin-left: 8px;
 	}

--- a/js/src/components/app-button/index.scss
+++ b/js/src/components/app-button/index.scss
@@ -2,13 +2,22 @@
 	white-space: nowrap;
 
 	svg {
-		width: inherit;
-		height: inherit;
 		max-width: inherit;
 		max-height: inherit;
 
 		circle {
 			stroke: currentColor;
 		}
+	}
+}
+
+.gla-app-button {
+	/**
+	 * Fix that the SVG icon gap to text should be on the left side.
+	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L309-L311
+	 */
+	&--fix-icon-position.has-icon.has-text svg {
+		margin-right: 0;
+		margin-left: 8px;
 	}
 }

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -12,6 +12,7 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import AppSpinner from '.~/components/app-spinner';
 import PhoneNumberCard from './phone-number-card';
+import StoreAddressCard from './store-address-card';
 
 const description = __(
 	'Your contact information is required by Google for verification purposes. It will be shared with the Google Merchant Center and will not be displayed to customers.',
@@ -56,7 +57,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 						initEditing={ initEditing }
 						onPhoneNumberChange={ onPhoneNumberChange }
 					/>
-					<div>TODO: add store address card</div>
+					<StoreAddressCard />
 				</VerticalGapLayout>
 			) : (
 				<AppSpinner />

--- a/js/src/components/contact-information/store-address-card.js
+++ b/js/src/components/contact-information/store-address-card.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { CardDivider } from '@wordpress/components';
+import { Spinner } from '@woocommerce/components';
+import { external as externalIcon } from '@wordpress/icons';
+import GridiconRefresh from 'gridicons/dist/refresh';
+
+/**
+ * Internal dependencies
+ */
+import useStoreAddress from '.~/hooks/useStoreAddress';
+import Section from '.~/wcdl/section';
+import Subsection from '.~/wcdl/subsection';
+import AccountCard, { APPEARANCE } from '.~/components/account-card';
+import AppButton from '.~/components/app-button';
+import './store-address-card.scss';
+
+export default function StoreAddressCard( { isPreview } ) {
+	const { loaded, data, refetch } = useStoreAddress();
+	const editButton = (
+		<AppButton
+			isSecondary
+			icon={ externalIcon }
+			iconSize={ 16 }
+			iconPosition="right"
+			target="_blank"
+			href="admin.php?page=wc-settings"
+			text={ __( 'Edit in Settings', 'google-listings-and-ads' ) }
+		/>
+	);
+
+	let addressContent;
+	let description = '';
+
+	if ( ! isPreview ) {
+		description = __(
+			'Please confirm your store address for verification.',
+			'google-listings-and-ads'
+		);
+	}
+
+	if ( loaded ) {
+		const { address, address2, city, state, country, postcode } = data;
+		const stateAndCountry = state ? `${ state } - ${ country }` : country;
+
+		if ( isPreview ) {
+			description = [ address, address2, city, stateAndCountry, postcode ]
+				.filter( Boolean )
+				.join( ', ' );
+		} else {
+			const rest = [ city, stateAndCountry, postcode ]
+				.filter( Boolean )
+				.join( ', ' );
+
+			addressContent = (
+				<div>
+					<div>{ address }</div>
+					{ address2 && <div>{ address2 }</div> }
+					<div>{ rest }</div>
+				</div>
+			);
+		}
+	} else {
+		addressContent = <Spinner />;
+	}
+
+	return (
+		<AccountCard
+			appearance={ APPEARANCE.ADDRESS }
+			description={ description }
+			hideIcon={ isPreview }
+			indicator={ editButton }
+		>
+			{ ! isPreview && (
+				<>
+					<CardDivider />
+					<Section.Card.Body>
+						<Subsection.Title>
+							{ __( 'Store address', 'google-listings-and-ads' ) }
+							<AppButton
+								className="gla-store-address__refresh-button"
+								icon={ GridiconRefresh }
+								iconSize={ 16 }
+								onClick={ refetch }
+								disabled={ ! loaded }
+							/>
+						</Subsection.Title>
+						{ addressContent }
+					</Section.Card.Body>
+				</>
+			) }
+		</AccountCard>
+	);
+}

--- a/js/src/components/contact-information/store-address-card.scss
+++ b/js/src/components/contact-information/store-address-card.scss
@@ -1,0 +1,12 @@
+.gla-store-address {
+	&__refresh-button {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		margin: auto;
+
+		.gridicons-refresh {
+			fill: var(--wp-admin-theme-color);
+		}
+	}
+}

--- a/js/src/components/contact-information/store-address-card.scss
+++ b/js/src/components/contact-information/store-address-card.scss
@@ -5,6 +5,14 @@
 		bottom: 0;
 		margin: auto;
 
+		&.has-icon.has-text {
+			justify-content: center;
+
+			svg {
+				margin: 0;
+			}
+		}
+
 		.gridicons-refresh {
 			fill: var(--wp-admin-theme-color);
 		}

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { SETTINGS_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
+
+const optionNames = [
+	'woocommerce_store_address',
+	'woocommerce_store_address_2',
+	'woocommerce_store_city',
+	'woocommerce_default_country',
+	'woocommerce_store_postcode',
+];
+
+const selectorName = 'getOption';
+
+/**
+ * @typedef {Object} StoreAddress
+ * @property {string} address Store address line 1.
+ * @property {string} address2 Address line 2.
+ * @property {string} city Store city.
+ * @property {string} state Store country state if available.
+ * @property {string} country Store country.
+ * @property {string} postcode Store postcode.
+ */
+/**
+ * @typedef {Object} StoreAddressResult
+ * @property {Function} refetch Dispatch a refetch action to reload store address.
+ * @property {boolean} loaded Whether the data have been loaded.
+ * @property {StoreAddress} data Store address data.
+ */
+/**
+ * Get store address data and refectch function.
+ *
+ * @return {StoreAddressResult} Store address result.
+ */
+export default function useStoreAddress() {
+	const { invalidateResolution } = useDispatch( OPTIONS_STORE_NAME );
+	const refetch = useCallback( () => {
+		optionNames.forEach( ( name ) =>
+			invalidateResolution( selectorName, [ name ] )
+		);
+	}, [ invalidateResolution ] );
+
+	return useSelect(
+		( select ) => {
+			const selector = select( OPTIONS_STORE_NAME );
+			const { hasFinishedResolution } = selector;
+
+			const [
+				address,
+				address2,
+				city,
+				countryAndState,
+				postcode,
+			] = optionNames.map( ( name ) => selector[ selectorName ]( name ) );
+
+			const loaded = optionNames
+				.map( ( name ) =>
+					hasFinishedResolution( selectorName, [ name ] )
+				)
+				.every( Boolean );
+
+			let country = '';
+			let state = '';
+
+			if ( loaded ) {
+				const { getSetting } = select( SETTINGS_STORE_NAME );
+				const { countries } = getSetting( 'wc_admin', 'dataEndpoints' );
+				const [ countryCode, stateCode ] = countryAndState.split( ':' );
+
+				const countryMeta = countries.find(
+					( el ) => el.code === countryCode
+				);
+				if ( countryMeta ) {
+					country = countryMeta.name;
+
+					const stateMeta = countryMeta.states.find(
+						( el ) => el.code === stateCode
+					);
+					if ( stateMeta ) {
+						state = stateMeta.name;
+					}
+				}
+			}
+
+			return {
+				refetch,
+				loaded,
+				data: {
+					address,
+					address2,
+					city,
+					state,
+					country,
+					postcode,
+				},
+			};
+		},
+		[ refetch ]
+	);
+}

--- a/js/src/wcdl/subsection/title/index.scss
+++ b/js/src/wcdl/subsection/title/index.scss
@@ -1,4 +1,5 @@
 .wcdl-subsection-title {
+	position: relative;
 	font-size: 14px;
 	font-style: normal;
 	font-weight: 600;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Partial of #863 and based on #917

- Add a hook to get store address via the core options API
- Add new appearance to **AccountCard** for store address
- Implement the shared **StoreAddressCard** component
- For the **Button** component, fix icon size, and gap between icon and text when icon on right side

💡 Please note that this PR doesn't include the API integration.

### Screenshots:

#### 🎥 . Display store address and refresh

https://user-images.githubusercontent.com/17420811/127481139-34d68d9a-723c-429b-ae75-093183aa853f.mp4

#### 📷 . The preview mode of StoreAddressCard will be used in the Setting page later

![image](https://user-images.githubusercontent.com/17420811/127481897-76d71521-f61b-4d27-8e32-3ae787e8df18.png)

### Detailed test instructions:

1. Go to the MC setup flow and proceed to the "Confirm store requirements" step
2. The store address card should be able to interact
3. Change store address from WC setting page and back to opened MC setup page, the address should be up-to-date after clicking on the refresh icon

### Changelog entry
