### PR TITLE
Add contact information section and its edit subpage to the settings page

### DIFF
--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -12,7 +12,6 @@ import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import Section from '.~/wcdl/section';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AppDocumentationLink from '.~/components/app-documentation-link';
-import AppSpinner from '.~/components/app-spinner';
 import SpinnerCard from '.~/components/spinner-card';
 import PhoneNumberCard from './phone-number-card';
 import StoreAddressCard from './store-address-card';
@@ -59,9 +58,7 @@ export function ContactInformationPreview() {
 			);
 		}
 	} else {
-		sectionContent = (
-			<SpinnerCard />
-		);
+		sectionContent = <SpinnerCard />;
 	}
 
 	return (

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -13,6 +13,7 @@ import Section from '.~/wcdl/section';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import AppSpinner from '.~/components/app-spinner';
+import SpinnerCard from '.~/components/spinner-card';
 import PhoneNumberCard from './phone-number-card';
 import StoreAddressCard from './store-address-card';
 import NoContactInformationCard from './no-contact-information-card';
@@ -109,7 +110,10 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 					<StoreAddressCard />
 				</VerticalGapLayout>
 			) : (
-				<AppSpinner />
+				<VerticalGapLayout size="large">
+					<SpinnerCard />
+					<SpinnerCard />
+				</VerticalGapLayout>
 			) }
 		</Section>
 	);

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -45,6 +45,7 @@ export function ContactInformationPreview() {
 					<PhoneNumberCard
 						isPreview
 						initEditing={ false }
+						phoneNumber={ phone }
 						onEditClick={ handleEditClick }
 					/>
 					<StoreAddressCard isPreview />

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -18,8 +18,8 @@ import PhoneNumberCard from './phone-number-card';
 import StoreAddressCard from './store-address-card';
 import NoContactInformationCard from './no-contact-information-card';
 
-// TODO: [lite-contact-info] add link
-const learnMoreUrl = 'https://example.com/';
+const learnMoreUrl =
+	'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information';
 
 const description = __(
 	'Your contact information is required by Google for verification purposes. It will be shared with the Google Merchant Center and will not be displayed to customers.',

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -2,10 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import { getEditContactInformationUrl } from '.~/utils/urls';
 import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import Section from '.~/wcdl/section';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
@@ -13,6 +15,10 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import AppSpinner from '.~/components/app-spinner';
 import PhoneNumberCard from './phone-number-card';
 import StoreAddressCard from './store-address-card';
+import NoContactInformationCard from './no-contact-information-card';
+
+// TODO: [lite-contact-info] add link
+const learnMoreUrl = 'https://example.com/';
 
 const description = __(
 	'Your contact information is required by Google for verification purposes. It will be shared with the Google Merchant Center and will not be displayed to customers.',
@@ -21,6 +27,50 @@ const description = __(
 
 const mcTitle = __( 'Enter contact information', 'google-listings-and-ads' );
 const settingsTitle = __( 'Contact information', 'google-listings-and-ads' );
+
+export function ContactInformationPreview() {
+	const phone = useGoogleMCPhoneNumber();
+
+	const handleEditClick = () => {
+		getHistory().push( getEditContactInformationUrl() );
+	};
+
+	let sectionContent;
+
+	if ( phone.loaded ) {
+		if ( phone.data.isValid ) {
+			sectionContent = (
+				<VerticalGapLayout size="overlap">
+					<PhoneNumberCard
+						isPreview
+						initEditing={ false }
+						onEditClick={ handleEditClick }
+					/>
+					<StoreAddressCard isPreview />
+				</VerticalGapLayout>
+			);
+		} else {
+			sectionContent = (
+				<NoContactInformationCard
+					onEditClick={ handleEditClick }
+					learnMoreUrl={ learnMoreUrl }
+				/>
+			);
+		}
+	} else {
+		sectionContent = (
+			<Section.Card>
+				<AppSpinner />
+			</Section.Card>
+		);
+	}
+
+	return (
+		<Section title={ settingsTitle } description={ description }>
+			{ sectionContent }
+		</Section>
+	);
+}
 
 export default function ContactInformation( { view, onPhoneNumberChange } ) {
 	const phone = useGoogleMCPhoneNumber();
@@ -42,8 +92,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 						<AppDocumentationLink
 							context={ trackContext }
 							linkId="contact-information-read-more"
-							// TODO: [lite-contact-info] add link
-							href="https://example.com/"
+							href={ learnMoreUrl }
 						>
 							{ __( 'Learn more', 'google-listings-and-ads' ) }
 						</AppDocumentationLink>

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -60,9 +60,7 @@ export function ContactInformationPreview() {
 		}
 	} else {
 		sectionContent = (
-			<Section.Card>
-				<AppSpinner />
-			</Section.Card>
+			<SpinnerCard />
 		);
 	}
 

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -35,7 +35,7 @@ export function ContactInformationPreview() {
 		getHistory().push( getEditContactInformationUrl() );
 	};
 
-	let sectionContent;
+	let sectionContent = <SpinnerCard />;
 
 	if ( phone.loaded ) {
 		if ( phone.data.isValid ) {
@@ -57,8 +57,6 @@ export function ContactInformationPreview() {
 				/>
 			);
 		}
-	} else {
-		sectionContent = <SpinnerCard />;
 	}
 
 	return (

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -17,6 +17,7 @@ import PhoneNumberCard from './phone-number-card';
 import StoreAddressCard from './store-address-card';
 import NoContactInformationCard from './no-contact-information-card';
 
+const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
 	'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information';
 
@@ -54,6 +55,7 @@ export function ContactInformationPreview() {
 				<NoContactInformationCard
 					onEditClick={ handleEditClick }
 					learnMoreUrl={ learnMoreUrl }
+					learnMoreLinkId={ learnMoreLinkId }
 				/>
 			);
 		}
@@ -85,7 +87,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 					<p>
 						<AppDocumentationLink
 							context={ trackContext }
-							linkId="contact-information-read-more"
+							linkId={ learnMoreLinkId }
 							href={ learnMoreUrl }
 						>
 							{ __( 'Learn more', 'google-listings-and-ads' ) }

--- a/js/src/components/contact-information/no-contact-information-card.js
+++ b/js/src/components/contact-information/no-contact-information-card.js
@@ -31,7 +31,7 @@ export default function NoContactInformationCard( {
 					</Subsection.Title>
 					<Subsection.Body>
 						{ __(
-							'Google requires the phone number and store address for all stores using Google Merchant Center. This is required to verify that you are the owner of the business.',
+							'Google requires the phone number and store address for all stores using Google Merchant Center.',
 							'google-listings-and-ads'
 						) }
 					</Subsection.Body>

--- a/js/src/components/contact-information/no-contact-information-card.js
+++ b/js/src/components/contact-information/no-contact-information-card.js
@@ -15,6 +15,7 @@ import './no-contact-information-card.scss';
 export default function NoContactInformationCard( {
 	onEditClick,
 	learnMoreUrl,
+	learnMoreLinkId,
 } ) {
 	return (
 		<Section.Card className="gla-no-contact-information-card">
@@ -47,6 +48,13 @@ export default function NoContactInformationCard( {
 						<AppButton
 							isTertiary
 							target="_blank"
+							eventName="gla_google_mc_link_click"
+							eventProps={ {
+								context:
+									'settings-no-contact-information-notice',
+								link_id: learnMoreLinkId,
+								href: learnMoreUrl,
+							} }
 							href={ learnMoreUrl }
 						>
 							{ __( 'Learn more', 'google-listings-and-ads' ) }

--- a/js/src/components/contact-information/no-contact-information-card.js
+++ b/js/src/components/contact-information/no-contact-information-card.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import GridiconNotice from 'gridicons/dist/notice';
+
+/**
+ * Internal dependencies
+ */
+import Subsection from '.~/wcdl/subsection';
+import Section from '.~/wcdl/section';
+import AppButton from '.~/components/app-button';
+import './no-contact-information-card.scss';
+
+export default function NoContactInformationCard( {
+	onEditClick,
+	learnMoreUrl,
+} ) {
+	return (
+		<Section.Card className="gla-no-contact-information-card">
+			<Section.Card.Body>
+				<Subsection>
+					<Subsection.Title>
+						<div>
+							<GridiconNotice />
+						</div>
+						{ __(
+							'Please add your contact information',
+							'google-listings-and-ads'
+						) }
+					</Subsection.Title>
+					<Subsection.Body>
+						{ __(
+							'Google requires the phone number and store address for all stores using Google Merchant Center. This is required to verify that you are the owner of the business.',
+							'google-listings-and-ads'
+						) }
+					</Subsection.Body>
+				</Subsection>
+				<Subsection>
+					<Subsection.Body>
+						<AppButton isPrimary onClick={ onEditClick }>
+							{ __(
+								'Add information',
+								'google-listings-and-ads'
+							) }
+						</AppButton>
+						<AppButton
+							isTertiary
+							target="_blank"
+							href={ learnMoreUrl }
+						>
+							{ __( 'Learn more', 'google-listings-and-ads' ) }
+						</AppButton>
+					</Subsection.Body>
+				</Subsection>
+			</Section.Card.Body>
+		</Section.Card>
+	);
+}

--- a/js/src/components/contact-information/no-contact-information-card.scss
+++ b/js/src/components/contact-information/no-contact-information-card.scss
@@ -1,0 +1,17 @@
+.gla-no-contact-information-card {
+	.wcdl-subsection-title > div {
+		margin-bottom: 8px;
+	}
+
+	.wcdl-subsection-body {
+		color: $gray-700;
+	}
+
+	.gridicons-notice {
+		fill: $alert-red;
+	}
+
+	.components-button {
+		margin-right: $grid-unit-30;
+	}
+}

--- a/js/src/components/vertical-gap-layout/index.js
+++ b/js/src/components/vertical-gap-layout/index.js
@@ -1,16 +1,28 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import './index.scss';
 
+const sizeClassName = {
+	large: 'gla-vertical-gap-layout__large',
+	overlap: 'gla-vertical-gap-layout__overlap',
+};
+
 const VerticalGapLayout = ( props ) => {
-	const { className = '', size = '', ...rest } = props;
+	const { className, size = '', ...rest } = props;
 
 	return (
 		<div
-			className={ `gla-vertical-gap-layout ${
-				size === 'large' ? 'gla-vertical-gap-layout__large' : ''
-			} ${ className }` }
+			className={ classnames(
+				'gla-vertical-gap-layout',
+				sizeClassName[ size ],
+				className
+			) }
 			{ ...rest }
 		/>
 	);

--- a/js/src/components/vertical-gap-layout/index.scss
+++ b/js/src/components/vertical-gap-layout/index.scss
@@ -6,4 +6,12 @@
 	&.gla-vertical-gap-layout__large {
 		gap: calc(var(--large-gap) / 2);
 	}
+
+	&.gla-vertical-gap-layout__overlap {
+		gap: 0;
+
+		> *:not(:first-child) {
+			margin-top: -1px;
+		}
+	}
 }

--- a/js/src/settings/disconnect-accounts/index.js
+++ b/js/src/settings/disconnect-accounts/index.js
@@ -17,7 +17,7 @@ import useJetpackAccount from '.~/hooks/useJetpackAccount';
 import useGoogleAccount from '.~/hooks/useGoogleAccount';
 import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import AppSpinner from '.~/components/app-spinner';
+import SpinnerCard from '.~/components/spinner-card';
 import Section from '.~/wcdl/section';
 import AccountSubsection from './account-subsection';
 import DisconnectModal, {
@@ -83,76 +83,69 @@ export default function DisconnectAccounts() {
 					disconnectTarget={ openedModal }
 				/>
 			) }
-			<Section.Card>
-				{ isLoading ? (
-					<AppSpinner />
-				) : (
-					<>
-						<Section.Card.Body>
-							<AccountSubsection
-								title={ __(
-									'WordPress.com',
-									'google-listings-and-ads'
-								) }
-								info={ getConnectedJetpackInfo( jetpack ) }
-								helperContent={ requiredText }
-							/>
-							<AccountSubsection
-								title={ __(
-									'Google',
-									'google-listings-and-ads'
-								) }
-								info={ google.email }
-								helperContent={ requiredText }
-							/>
-							<AccountSubsection
-								title={ __(
-									'Google Merchant Center',
-									'google-listings-and-ads'
-								) }
-								info={ toAccountText( googleMCAccount.id ) }
-								helperContent={ requiredText }
-							/>
-							{ hasAdsAccount && (
-								<AccountSubsection
-									title={ __(
-										'Google Ads',
-										'google-listings-and-ads'
-									) }
-									info={ toAccountText(
-										googleAdsAccount.id
-									) }
-									helperContent={
-										<Button
-											isDestructive
-											isLink
-											onClick={
-												openDisconnectAdsAccountModal
-											}
-										>
-											{ __(
-												'Disconnect Google Ads account only',
-												'google-listings-and-ads'
-											) }
-										</Button>
-									}
-								/>
+			{ isLoading ? (
+				<SpinnerCard />
+			) : (
+				<Section.Card>
+					<Section.Card.Body>
+						<AccountSubsection
+							title={ __(
+								'WordPress.com',
+								'google-listings-and-ads'
 							) }
-						</Section.Card.Body>
-						<Section.Card.Footer>
-							<Button
-								isDestructive
-								onClick={ openDisconnectAllAccountsModal }
-							>
-								{ __(
-									'Disconnect all accounts',
+							info={ getConnectedJetpackInfo( jetpack ) }
+							helperContent={ requiredText }
+						/>
+						<AccountSubsection
+							title={ __( 'Google', 'google-listings-and-ads' ) }
+							info={ google.email }
+							helperContent={ requiredText }
+						/>
+						<AccountSubsection
+							title={ __(
+								'Google Merchant Center',
+								'google-listings-and-ads'
+							) }
+							info={ toAccountText( googleMCAccount.id ) }
+							helperContent={ requiredText }
+						/>
+						{ hasAdsAccount && (
+							<AccountSubsection
+								title={ __(
+									'Google Ads',
 									'google-listings-and-ads'
 								) }
-							</Button>
-						</Section.Card.Footer>
-					</>
-				) }
-			</Section.Card>
+								info={ toAccountText( googleAdsAccount.id ) }
+								helperContent={
+									<Button
+										isDestructive
+										isLink
+										onClick={
+											openDisconnectAdsAccountModal
+										}
+									>
+										{ __(
+											'Disconnect Google Ads account only',
+											'google-listings-and-ads'
+										) }
+									</Button>
+								}
+							/>
+						) }
+					</Section.Card.Body>
+					<Section.Card.Footer>
+						<Button
+							isDestructive
+							onClick={ openDisconnectAllAccountsModal }
+						>
+							{ __(
+								'Disconnect all accounts',
+								'google-listings-and-ads'
+							) }
+						</Button>
+					</Section.Card.Footer>
+				</Section.Card>
+			) }
 		</Section>
 	);
 }

--- a/js/src/settings/edit-contact-information/index.js
+++ b/js/src/settings/edit-contact-information/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Flex } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { getSettingsUrl } from '.~/utils/urls';
+import FullContainer from '.~/components/full-container';
+import TopBar from '.~/components/stepper/top-bar';
+import HelpIconButton from '.~/components/help-icon-button';
+import Section from '.~/wcdl/section';
+import AppButton from '.~/components/app-button';
+import ContactInformation from '.~/components/contact-information';
+
+export default function EditContactInformation() {
+	const handlePhoneNumberChange = ( countryCallingCode, nationalNumber ) => {
+		// TODO: [lite-contact-info] handle the onChange callback of phone number
+		console.log( countryCallingCode, nationalNumber ); // eslint-disable-line
+	};
+
+	const handleSaveClick = () => {
+		// TODO: [lite-contact-info] POST phone number to API if it has changed
+		// TODO: [lite-contact-info] POST address to API
+	};
+
+	return (
+		<FullContainer>
+			<TopBar
+				title={ __(
+					'Add contact information',
+					'google-listings-and-ads'
+				) }
+				helpButton={
+					<HelpIconButton eventContext="edit-contact-information" />
+				}
+				backHref={ getSettingsUrl() }
+			/>
+			<div className="gla-settings">
+				<ContactInformation
+					view="settings"
+					onPhoneNumberChange={ handlePhoneNumberChange }
+				/>
+				<Section>
+					<Flex justify="flex-end">
+						<AppButton isPrimary onClick={ handleSaveClick }>
+							{ __( 'Save details', 'google-listings-and-ads' ) }
+						</AppButton>
+					</Flex>
+				</Section>
+			</div>
+		</FullContainer>
+	);
+}

--- a/js/src/settings/index.js
+++ b/js/src/settings/index.js
@@ -10,13 +10,17 @@ import { getQuery, getHistory } from '@woocommerce/navigation';
 import useGoogleAccount from '.~/hooks/useGoogleAccount';
 import { subpaths, getReconnectAccountsUrl } from '.~/utils/urls';
 import NavigationClassic from '.~/components/navigation-classic';
+import { ContactInformationPreview } from '.~/components/contact-information';
 import DisconnectAccounts from './disconnect-accounts';
 import ReconnectAccounts from './reconnect-accounts';
+import EditContactInformation from './edit-contact-information';
 import './index.scss';
 
 const Settings = () => {
 	const { subpath } = getQuery();
 	const { google } = useGoogleAccount();
+	const isEditContactInformationPage =
+		subpath === subpaths.editContactInformation;
 	const isReconnectAccountsPage = subpath === subpaths.reconnectAccounts;
 
 	// This page wouldn't get any 401 response when losing Google account access,
@@ -27,6 +31,10 @@ const Settings = () => {
 		}
 	}, [ isReconnectAccountsPage, google ] );
 
+	if ( isEditContactInformationPage ) {
+		return <EditContactInformation />;
+	}
+
 	if ( isReconnectAccountsPage ) {
 		return <ReconnectAccounts />;
 	}
@@ -35,6 +43,7 @@ const Settings = () => {
 		<div className="gla-settings">
 			<NavigationClassic />
 			<DisconnectAccounts />
+			<ContactInformationPreview />
 		</div>
 	);
 };

--- a/js/src/settings/index.scss
+++ b/js/src/settings/index.scss
@@ -1,7 +1,12 @@
 .gla-settings {
 	.wcdl-section {
 		max-width: 780px;
-		margin: 0 auto;
+		margin-left: auto;
+		margin-right: auto;
+
+		&:first-child {
+			margin-top: var(--large-gap);
+		}
 	}
 
 	.wcdl-subsection-helper-text {

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -10,6 +10,7 @@ export const subpaths = {
 	editFreeListings: '/free-listings/edit',
 	editCampaign: '/campaigns/edit',
 	createCampaign: '/campaigns/create',
+	editContactInformation: '/edit-contact-information',
 	reconnectAccounts: '/reconnect-accounts',
 };
 
@@ -30,6 +31,18 @@ export const getCreateCampaignUrl = () => {
 
 export const getDashboardUrl = () => {
 	return getNewPath( null, dashboardPath, null );
+};
+
+export const getSettingsUrl = () => {
+	return getNewPath( null, settingsPath, null );
+};
+
+export const getEditContactInformationUrl = () => {
+	return getNewPath(
+		{ subpath: subpaths.editContactInformation },
+		settingsPath,
+		null
+	);
 };
 
 export const getReconnectAccountsUrl = () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Partial of #863 and based on #918

- Add URLs to utils for settings and edit contact info pages
- Implement the preview section and edit subpage of contact information, and add them to the settings page

💡 Please note that this PR doesn't include the API integration.

### Screenshots:

#### 🎥 . When the phone number got from Google MC is empty

https://user-images.githubusercontent.com/17420811/127619456-9d5d8c83-d353-43e5-be62-0a8bbd1ed803.mp4

#### 🎥 . When the phone number got from Google MC has already exist

https://user-images.githubusercontent.com/17420811/127619741-ae09b9fa-dd57-4378-8950-840fdf131f5d.mp4

### Detailed test instructions:

For easier testing, there is a mock phone number that is 50% chance for an empty phone number and 50% for an existed phone number when every time reload the page.

https://github.com/woocommerce/google-listings-and-ads/blob/4f5eb4e9cb8d13f943c164bb9e1d0b1d22ab84f5/js/src/data/selectors.js#L71-L78

1. Go to the settings page.
2. The "Contact information" should show up with
    - a warning section that prompts users to add information if the phone data is empty.
    - a folded section that displays phone number and store address if the phone data is not empty.
3. Click on "Add information" or "Edit" button, and it should bring you to contact info edit page.
4. In the contact info edit page,
    - the implementations are the same as the previous PRs. Please refer to #917 and #918 if want to test them further.
    - click on "<" icon at the top-left side, and it should bring you back to settings page.

### Changelog entry
