### PR TITLE
Run Travis-CI on all branches,

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ services:
 notifications:
   email: false
 
-# Safelist (only test pushes/merges with these branches)
-branches:
-  only:
-    - trunk
-    - develop
-
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Run Travis-CI on all branches,
Remove safelist, to go with the default allow all, except `gh-pages`.

I believe this or a similar change would be useful as we started working on a `feature/*`  branch for contact info.
With the current setup, none of our Travis & bundlewatch checks are being run there.

I would say we run quite a limited [number of branches](https://github.com/woocommerce/google-listings-and-ads/branches) and we are now public repo, so hopefully hitting Travis minutes won't be an issue. The benefit we will gain:
1. Checks on the contact info feature branch.
2. Checks for  PRs to PRs (which we use from time to time, even for `trunk`)
3. Check for experiment/proposal branches without a PR yet.

### Screenshots:

#### PRs to `feature/contact-info` branch
like https://github.com/woocommerce/google-listings-and-ads/pull/914
![image](https://user-images.githubusercontent.com/17435/127700649-b0d6f370-d914-433d-a0b0-2c3796dbe1b6.png)

#### PRs to PRs
like https://github.com/woocommerce/google-listings-and-ads/pull/918
![image](https://user-images.githubusercontent.com/17435/127700739-8a13217b-b2c6-44d4-8dcb-f6af179c46c1.png)



### Detailed test instructions:

1. Merge this branch :wink: :shipit: 
2. Check the Travis checks for them all


### Changelog entry

> 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->

### Additional notes:

- Alternatively, we could just safelist `feature/contact-info` or `/^feature/.*$/`
- @jconroy, was there a specific reason I missed, for safe listing only `trunk` and `develop` initially?