### PR TITLE
Add filter to allow overriding all product attributes

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -152,7 +152,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		 *
 		 * @since x.x.x
 		 */
-		$attributes = apply_filters( 'woocommerce_gla_override_product_attribute_values', [], $this->wc_product, $this );
+		$attributes = apply_filters( 'woocommerce_gla_product_attribute_values', [], $this->wc_product, $this );
 
 		if ( ! empty( $attributes ) ) {
 			parent::mapTypes( $attributes );
@@ -742,16 +742,16 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 				 * set for the product through WooCommerce's edit product page
 				 *
 				 * In order to override all product attributes and/or set new ones for the product use the
-				 * `woocommerce_gla_override_product_attribute_values` filter.
+				 * `woocommerce_gla_product_attribute_values` filter.
 				 *
-				 * Note that the `woocommerce_gla_override_product_attribute_values` filter takes precedence over
+				 * Note that the `woocommerce_gla_product_attribute_values` filter takes precedence over
 				 * this filter, and it can be used to override any values defined here.
 				 *
 				 * @param mixed      $attribute_value The attribute's current value
 				 * @param WC_Product $wc_product      The WooCommerce product object.
 				 *
 				 * @see AttributeManager::ATTRIBUTES for the list of attributes that their values can be modified using this filter.
-				 * @see WCProductAdapter::override_attributes for the docuemntation of the `woocommerce_gla_override_product_attribute_values` filter.
+				 * @see WCProductAdapter::override_attributes for the docuemntation of the `woocommerce_gla_product_attribute_values` filter.
 				 */
 				$gla_attributes[ $attribute_id ] = apply_filters( "woocommerce_gla_product_attribute_value_{$attribute_id}", $attribute_value, $this->get_wc_product() );
 			}

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -97,6 +97,9 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		parent::mapTypes( $array );
 
 		$this->map_woocommerce_product();
+
+		// Allow users to override the product's attributes using a WordPress filter.
+		$this->override_attributes();
 	}
 
 	/**
@@ -118,6 +121,37 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			 ->map_wc_prices();
 
 		$this->setIdentifierExists( ! empty( $this->getGtin() ) || ! empty( $this->getMpn() ) );
+	}
+
+	/**
+	 * Overrides the product attributes by applying a filter and setting the provided values.
+	 *
+	 * @since x.x.x
+	 */
+	protected function override_attributes() {
+		/**
+		 * Filters the list of overridden attributes to set for this product.
+		 *
+		 * @param array            $attributes An array of values for the product properties. All properties of the
+		 *                                     `\Google\Service\ShoppingContent\Product` class can be set by providing
+		 *                                     the property name as key and its value as array item.
+		 *                                     For example:
+		 *                                     [ 'imageLink' => 'https://example.com/image.jpg' ] overrides the product's
+		 *                                     main image.
+		 *
+		 * @param WC_Product       $wc_product The WooCommerce product object.
+		 * @param WCProductAdapter $this       The Adapted Google product object. All WooCommerce product properties
+		 *                                     are already mapped to this object.
+		 *
+		 * @see \Google\Service\ShoppingContent\Product for the list of product properties that can be overriden.
+		 *
+		 * @since x.x.x
+		 */
+		$attributes = apply_filters( 'woocommerce_gla_override_product_attribute_values', [], $this->wc_product, $this );
+
+		if ( ! empty( $attributes ) ) {
+			parent::mapTypes( $attributes );
+		}
 	}
 
 	/**

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -147,8 +147,8 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		 *                                     are already mapped to this object.
 		 *
 		 * @see \Google\Service\ShoppingContent\Product for the list of product properties that can be overriden.
-		 * @see self::map_gla_attributes where another filter is defined (`woocommerce_gla_product_attribute_value_{$attribute_id}`)
-		 *                               that allows modifying some attributes such as GTIN, MPN, Brand, etc.
+		 * @see WCProductAdapter::map_gla_attributes for the docuementation of `woocommerce_gla_product_attribute_value_{$attribute_id}`
+		 *                                           filter, which allows modifying some attributes such as GTIN, MPN, etc.
 		 *
 		 * @since x.x.x
 		 */

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -150,6 +150,7 @@ class WCProductAdapterTest extends UnitTest {
 			function ( array $attributes, WC_Product $product, WCProductAdapter $google_product ) {
 				$attributes['imageLink'] = 'https://example.com/image_overide.png?prev=' . $google_product->getImageLink();
 				$attributes['description'] = 'Overridden description!';
+				$attributes['id'] = 'override_' . $product->get_id();
 
 				return $attributes;
 			},
@@ -183,6 +184,41 @@ class WCProductAdapterTest extends UnitTest {
 			'Overridden description!',
 			$adapted_product->getDescription()
 		);
+		$this->assertEquals(
+			'override_' . $product->get_id(),
+			$adapted_product->getId()
+		);
+	}
+
+	public function test_attribute_values_filter_takes_precedence() {
+
+		add_filter(
+			'woocommerce_gla_product_attribute_value_gtin',
+			function () {
+				return '1234';
+			}
+		);
+
+		add_filter(
+			'woocommerce_gla_product_attribute_values',
+			function ( array $attributes ) {
+				$attributes['gtin'] = '56789';
+
+				return $attributes;
+			}
+		);
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'     => WC_Helper_Product::create_simple_product( false ),
+				'gla_attributes' => [
+					Brand::get_id() => 'Google',
+				],
+				'targetCountry'  => 'US',
+			]
+		);
+
+		$this->assertEquals( '56789', $adapted_product->getGtin() );
 	}
 
 	public function test_channel_is_always_set_to_online() {

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -146,7 +146,7 @@ class WCProductAdapterTest extends UnitTest {
 
 	public function test_basic_attributes_can_be_overridden_via_filter() {
 		add_filter(
-			'woocommerce_gla_override_product_attribute_values',
+			'woocommerce_gla_product_attribute_values',
 			function ( array $attributes, WC_Product $product, WCProductAdapter $google_product ) {
 				$attributes['imageLink'] = 'https://example.com/image_overide.png?prev=' . $google_product->getImageLink();
 				$attributes['description'] = 'Overridden description!';
@@ -1463,7 +1463,7 @@ DESCRIPTION;
 		remove_all_filters( 'woocommerce_gla_product_description_apply_shortcodes' );
 		remove_all_filters( 'woocommerce_gla_use_short_description' );
 		remove_all_filters( 'woocommerce_gla_product_attribute_value_description' );
-		remove_all_filters( 'woocommerce_gla_override_product_attribute_values' );
+		remove_all_filters( 'woocommerce_gla_product_attribute_values' );
 
 		// remove added shortcodes
 		remove_shortcode( 'wc_gla_sample_test_shortcode' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR introduces a new filter called `woocommerce_gla_product_attribute_values` to allow overriding all product properties.

The filter accepts a list of key => values containing Google product properties. Basically, any property of the `\Google\Service\ShoppingContent\Product` class can be overridden and set using this filter now. This allows for more customization in cases where our mapping is not working as expected for users.


### Detailed test instructions:

1. Use the following filter configuration to provide a test value for `description`:
```
add_filter(
  'woocommerce_gla_product_attribute_values',
  function ( array $attributes, WC_Product $product, WCProductAdapter $google_product ) {
    $attributes['description'] = 'Overridden description! Previously set to: ' . $product->get_description();

    return $attributes;
  },
  10,
  3
);
```
2. Sync a product and make sure the description of the synced product in MC is now set to the value provided by the filter

Note: We already provide filters for setting custom attribute values like `GTIN`, `MPN`, etc. However, those filters do now allow setting basic attributes such as image link or description. My aim was to allow overriding any and all attributes when mapping a WooCommerce product so that third parties have more flexibility for integration. Not sure if we should remove those now that we have this filter because this one overlaps with those filters and overrides any value set by those filters.

### Changelog entry

> Add `woocommerce_gla_product_attribute_values` filter to allow overriding all product attributes.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->