### PR TITLE
Add fourth MC Setup step value: 'store_requirements'

### DIFF
--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -139,7 +139,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			return true;
 		}
 
-		// Additional check for users that have already gone through onboarding.
+		// Additional check for users that have already gone through on-boarding.
 		if ( $this->is_setup_complete() ) {
 			$is_mc_setup = $this->is_mc_contact_information_setup();
 			$this->options->update( OptionsInterface::CONTACT_INFO_SETUP, $is_mc_setup );
@@ -340,8 +340,8 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 		return $is_setup['phone_number'] && $is_setup['address'];
 	}
-	
-	/*
+
+	/**
 	 * Check if the taxes + shipping rate and time + free shipping settings have been saved.
 	 *
 	 * @return bool If all required settings have been provided.

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -362,15 +362,15 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			return false;
 		}
 
-		// Shipping options saved if: 'manual' OR 'flat' + records for all countries
-		if ( 'manual' === ( $merchant_center_settings['shipping_time'] ?? 'flat' ) ) {
+		// Shipping options saved if: 'manual' OR records for all countries
+		if ( isset( $merchant_center_settings['shipping_time'] ) && 'manual' === $merchant_center_settings['shipping_time'] ) {
 			$saved_shipping_time = true;
 		} else {
 			$shipping_time_rows  = $this->container->get( ShippingTimeQuery::class )->get_count();
 			$saved_shipping_time = $shipping_time_rows === count( $target_countries );
 		}
 
-		if ( 'manual' === ( $merchant_center_settings['shipping_rate'] ?? 'flat' ) ) {
+		if ( isset( $merchant_center_settings['shipping_rate'] ) && 'manual' === $merchant_center_settings['shipping_rate'] ) {
 			$saved_shipping_rate = true;
 		} else {
 			$shipping_rate_rows  = $this->container->get( ShippingRateQuery::class )->get_count();

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -358,7 +358,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		}
 
 		// Free shipping saved if: not offered, OR offered and threshold not null
-		if ( ! empty( $merchant_center_settings['offers_free_shipping'] ) && is_null( $merchant_center_settings['free_shipping_threshold'] ) ) {
+		if ( ! empty( $merchant_center_settings['offers_free_shipping'] ) && ! isset( $merchant_center_settings['free_shipping_threshold'] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Goes with #927 .

This adds a fourth `step` value to the possible replies from `GET /wc/gla/mc/step`: `store_requirements`.

This value is returned when shipping rate, shipping time, tax rate and free shipping threshold values are all deemed to have been completed:
- Tax rate: US isn't a target country, or the `tax_rate` setting isn't empty
- Offers Free Shipping: not offered (`offers_free_shipping` is `false`), or offered and `free_shipping_threshold` set (can be `0`, just not null)
- Shipping Rate: `shipping_rate` setting set to `manual` OR one row in `wp_gla_shipping_rates` table for each target country
- Shipping time: same as shipping rate

### Detailed test instructions:

1. Go through MC Onboarding steps
2. After each step, make a `GET /gla/mc/setup` request and confirm that the `step` value is as expected
3. For shipping at settings, try different configurations to confirm that the values are correct:
    - If Shipping Rate and Time set to "Set in MC": `store_requirements`
    - If Shipping Rate and Time set to _manual_, but no values added: `shipping_and_taxes`
    - If Shipping Rate and Time set to _manual_, with values: `store_requirements`
    - Store has US as target country, but no option selected for taxes: `shipping_and_taxes`
    - Store has US as target country, _EITHER_ option selected for taxes: `store_requirements`
    - Store has free shipping for some orders selected, empty value for the threshold: `shipping_and_taxes`
    - Store has free shipping for some orders selected, any value for the threshold (including `0` 🤷🏻 ): `store_requirements`

(Changelog added with frontend changes).

### Changelog entry
