### PR TITLE
Handle all loading states within the `PhoneNumberCard` component

### DIFF
--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -44,7 +44,6 @@ export function ContactInformationPreview() {
 				<VerticalGapLayout size="overlap">
 					<PhoneNumberCard
 						isPreview
-						initEditing={ false }
 						phoneNumber={ phone }
 						onEditClick={ handleEditClick }
 					/>
@@ -73,7 +72,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 	const phone = useGoogleMCPhoneNumber();
 	const isSetupMC = view === 'setup-mc';
 
-	const initEditing = isSetupMC ? ! phone.data.isValid : true;
+	const initEditing = isSetupMC ? null : true;
 	const title = isSetupMC ? mcTitle : settingsTitle;
 	const trackContext = isSetupMC
 		? 'setup-mc-contact-information'
@@ -97,21 +96,14 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 				</div>
 			}
 		>
-			{ phone.loaded ? (
-				<VerticalGapLayout size="large">
-					<PhoneNumberCard
-						phoneNumber={ phone }
-						initEditing={ initEditing }
-						onPhoneNumberChange={ onPhoneNumberChange }
-					/>
-					<StoreAddressCard />
-				</VerticalGapLayout>
-			) : (
-				<VerticalGapLayout size="large">
-					<SpinnerCard />
-					<SpinnerCard />
-				</VerticalGapLayout>
-			) }
+			<VerticalGapLayout size="large">
+				<PhoneNumberCard
+					phoneNumber={ phone }
+					initEditing={ initEditing }
+					onPhoneNumberChange={ onPhoneNumberChange }
+				/>
+				<StoreAddressCard />
+			</VerticalGapLayout>
 		</Section>
 	);
 }

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -131,14 +131,11 @@ function PhoneNumberContent( {
 function EditPhoneNumberCard( { phoneNumber, onPhoneNumberChange } ) {
 	const { loaded, data } = phoneNumber;
 	const phoneNumberContent = loaded ? (
-		<>
-			<CardDivider />
-			<PhoneNumberContent
-				initCountry={ data.country }
-				initNationalNumber={ data.nationalNumber }
-				onPhoneNumberChange={ onPhoneNumberChange }
-			/>
-		</>
+		<PhoneNumberContent
+			initCountry={ data.country }
+			initNationalNumber={ data.nationalNumber }
+			onPhoneNumberChange={ onPhoneNumberChange }
+		/>
 	) : (
 		<AppSpinner />
 	);
@@ -151,6 +148,7 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberChange } ) {
 				'google-listings-and-ads'
 			) }
 		>
+			<CardDivider />
 			{ phoneNumberContent }
 		</AccountCard>
 	);

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -29,6 +29,23 @@ const basePhoneNumberCardProps = {
 	appearance: APPEARANCE.PHONE,
 };
 
+/**
+ * @typedef { import(".~/hooks/useGoogleMCPhoneNumber").PhoneNumber } PhoneNumber
+ * @typedef { import(".~/hooks/useGoogleMCPhoneNumber").PhoneNumberData } PhoneNumberData
+ */
+
+/**
+ * @typedef {Object} ExtraPhoneNumberData
+ * @property {boolean} isDirty Whether the phone number data contain unsaved changes.
+ *
+ * @typedef {PhoneNumberData & ExtraPhoneNumberData} CallbackPhoneNumberData
+ */
+
+/**
+ * @callback onPhoneNumberChange
+ * @param {CallbackPhoneNumberData} phoneNumberData The changed phone number data.
+ */
+
 function PhoneNumberContent( {
 	initCountry,
 	initNationalNumber,
@@ -69,6 +86,7 @@ function PhoneNumberContent( {
 				isDirty,
 				countryCallingCode,
 				nationalNumber: nextNumber,
+				country: nextCountry,
 			} );
 		}
 	};
@@ -138,6 +156,20 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberChange } ) {
 	);
 }
 
+/**
+ * Renders phone number data in Card UI and is able to edit.
+ *
+ * @param {Object} props React props.
+ * @param {PhoneNumber} props.phoneNumber Phone number data.
+ * @param {boolean} [props.isPreview=false] Whether to display as preview UI.
+ * @param {boolean|null} [props.initEditing=null] Specify the inital UI state. This prop would be ignored if `isPreview` is true.
+ *     `true`: initialize with the editing UI.
+ *     `false`: initialize with the viewing UI.
+ *     `null`: determine the initial UI state according to the `data.isValid` after the `phoneNumber` loaded.
+ * @param {Function} [props.onEditClick] Called when clicking on "Edit" button.
+ *     If this callback is omitted, it will enter edit mode when clicking on "Edit" button.
+ * @param {onPhoneNumberChange} [props.onPhoneNumberChange] Called when inputs of phone number are changed in edit mode.
+ */
 export default function PhoneNumberCard( {
 	phoneNumber,
 	isPreview = false,

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -208,7 +208,7 @@ export default function PhoneNumberCard( {
 	}
 
 	let description = null;
-	let indicator = null;
+	let indicator = <Spinner />;
 
 	if ( loaded ) {
 		description = data.display;
@@ -226,8 +226,6 @@ export default function PhoneNumberCard( {
 				{ __( 'Edit', 'google-listings-and-ads' ) }
 			</AppButton>
 		);
-	} else {
-		indicator = <Spinner />;
 	}
 
 	return (

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -180,6 +180,8 @@ export default function PhoneNumberCard( {
 		isPreview ? false : initEditing
 	);
 
+	// Handle the initial UI state of `initEditing = null`.
+	// The `isEditing` state is on hold. Determine it after the `phoneNumber` loaded.
 	useEffect( () => {
 		if ( loaded && isEditing === null ) {
 			setEditing( ! data.isValid );

--- a/js/src/hooks/useGoogleMCPhoneNumber.js
+++ b/js/src/hooks/useGoogleMCPhoneNumber.js
@@ -17,6 +17,26 @@ const emptyData = {
 	display: '',
 };
 
+/**
+ * @typedef {Object} PhoneNumber
+ * @property {boolean} loaded Whether the data have been loaded.
+ * @property {PhoneNumberData} data User's phone number data fetched from Google Merchant Center.
+ */
+
+/**
+ * @typedef {Object} PhoneNumberData
+ * @property {string} country The country code. Example: 'US'.
+ * @property {string} countryCallingCode The country calling code. Example: '1'.
+ * @property {string} nationalNumber The national (significant) number. Example: '2133734253'.
+ * @property {boolean} isValid Whether the phone number is valid.
+ * @property {string} display The phone number string in international format. Example: '+1 213 373 4253'.
+ */
+
+/**
+ * A hook to load user's phone number data from Google Merchant Center.
+ *
+ * @return {PhoneNumber} [description]
+ */
 export default function useGoogleMCPhoneNumber() {
 	return useSelect( ( select ) => {
 		const { getGoogleMCPhoneNumber } = select( STORE_KEY );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up for https://github.com/woocommerce/google-listings-and-ads/pull/917#discussion_r681624815.

- Handle all loading states within the `PhoneNumberCard` component to show more card content as soon as possible.

❗  **This's a refactor PR and didn't affect the functionality of the Contact Information feature. It could be reviewed and (maybe) merged after the Contact Information is released.**

### Screenshots:

#### MC setup

- When the phone number is empty
    ![Kapture 2021-08-05 at 12 19 19](https://user-images.githubusercontent.com/17420811/128292736-97181dff-c072-4505-8be8-caf9cda3f6f3.gif)
- When the phone number exists
    ![Kapture 2021-08-05 at 12 21 30](https://user-images.githubusercontent.com/17420811/128292716-8d0b87ab-dc3f-47f2-ac86-a3c597f8ffd9.gif)

#### Settings

- When refreshing the edit contact info page
    ![Kapture 2021-08-05 at 12 23 15](https://user-images.githubusercontent.com/17420811/128292694-d5cd29bd-121f-4dec-b0ae-ff6bc5d5954b.gif)

### Detailed test instructions:

To enter the MC setup step 4 directly, it could replace [this line in js/src/setup-mc/setup-stepper/saved-setup-stepper.js](https://github.com/woocommerce/google-listings-and-ads/blob/b377bf8e85fceb4bb48e0537150e65c62e97054e/js/src/setup-mc/setup-stepper/saved-setup-stepper.js#L21) by 

```js
const [ step, setStep ] = useState( '4' );
```

To mock the API response of phone number and add more delay to view the loading state, it could add PHP snippet in **google-listings-and-ads.php**.

```php
add_filter(
	'woocommerce_gla_prepared_response_mc-contact-information',
	function( $response ) {
		sleep( 1 );
		return [
			'is_mc_address_different' => false,
			'phone_number' => '+12133734253',
			'wc_address' => [
				'street_address' => '',
			],
		];
	},
);
```

1. Go to the MC setup and settings pages with empty/existed phone number
2. Check the loading spinner is shown within the `PhoneNumberCard` component instead of the parent layer for all cases

### Changelog entry
