### PR TITLE
Fix a bug that calling `split()` on `null` value in the useStoreAddress hook

### DIFF
--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -52,18 +52,18 @@ export default function useStoreAddress() {
 
 	if ( loaded && contact ) {
 		const {
-			wc_address: {
-				country: countryCode,
-				locality: city,
-				postal_code: postcode,
-				region: state,
-				street_address: streetAddress,
-			},
+			wc_address: wcAddress,
 			is_mc_address_different: isMCAddressDifferent,
 		} = contact;
 
+		// Handle fallback for `null` fields to make sure the returned data types are consistent.
+		const streetAddress = wcAddress.street_address || '';
+		const city = wcAddress.locality || '';
+		const state = wcAddress.region || '';
+		const postcode = wcAddress.postal_code || '';
+
 		const [ address, address2 = '' ] = streetAddress.split( '\n' );
-		const country = countryNameDict[ countryCode ];
+		const country = countryNameDict[ wcAddress.country ];
 		const isAddressFilled = !! ( address && city && country && postcode );
 
 		data = {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fix a bug that calling `split()` on `null` value in the **useStoreAddress** hook.
- Make sure the returned data types of **useStoreAddress** hook are consistent.

![image](https://user-images.githubusercontent.com/17420811/128458121-2631f968-38f8-4069-a573-be1a654112a5.png)

### Detailed test instructions:

1. Clear store address via the WC Settings page or SQL:
    ![image](https://user-images.githubusercontent.com/17420811/128457775-1b52ebdf-6047-4113-b550-64f7c4a0dba0.png)
    ```SQL
    DELETE FROM `wp_options` WHERE `option_name` IN ('woocommerce_store_address', 'woocommerce_store_address_2', 'woocommerce_store_city', 'woocommerce_default_country', 'woocommerce_store_postcode');
    ```
2. Go to GLA's MC setup or settings pages.
3. It should be able to render pages without the `Cannot read property 'split' of null` error.
4. The returned fields in the `data` property of **useStoreAddress** hook should always be string types.


### Changelog entry
