### PR TITLE
Fix that it's unable to save if user only changes address in the edit contact info page

### DIFF
--- a/js/src/settings/edit-contact-information/index.js
+++ b/js/src/settings/edit-contact-information/index.js
@@ -23,8 +23,11 @@ export default function EditContactInformation() {
 	const { updateGoogleMCContactInformation } = useAppDispatch();
 	const { data: address } = useStoreAddress();
 	const [ isSaving, setSaving ] = useState( false );
+
+	// The initial `isValid: true` is to avoid blocking the submission when only the store address is changed.
+	// And the prevention of saving invalid phone number can be checked by initial `isDirty: false`.
 	const [ phoneNumber, setPhoneNumber ] = useState( {
-		isValid: false,
+		isValid: true,
 		isDirty: false,
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fix that it's unable to save if user only changes address in the edit contact info page

### Screenshots:

![Kapture 2021-08-06 at 15 20 56](https://user-images.githubusercontent.com/17420811/128472593-9335b693-ccd0-49ba-8861-c1539d01ef81.gif)

### Detailed test instructions:

1. Go to the edit contact info page under Settings with an existed valid phone number.
2. Make some changes to store address via the WC Settings.
3. Back to edit contact info page and click on the refresh button, the "Save detail" button should be enabled for click.

### Changelog entry
