### PR TITLE
Check whether the GMC address is filled at the main Settings page

### DIFF
--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -9,6 +9,7 @@ import { getHistory } from '@woocommerce/navigation';
  */
 import { getEditContactInformationUrl } from '.~/utils/urls';
 import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
+import useStoreAddress from '.~/hooks/useStoreAddress';
 import Section from '.~/wcdl/section';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AppDocumentationLink from '.~/components/app-documentation-link';
@@ -31,6 +32,7 @@ const settingsTitle = __( 'Contact information', 'google-listings-and-ads' );
 
 export function ContactInformationPreview() {
 	const phone = useGoogleMCPhoneNumber();
+	const address = useStoreAddress( 'mc' );
 
 	const handleEditClick = () => {
 		getHistory().push( getEditContactInformationUrl() );
@@ -38,8 +40,8 @@ export function ContactInformationPreview() {
 
 	let sectionContent = <SpinnerCard />;
 
-	if ( phone.loaded ) {
-		if ( phone.data.isValid ) {
+	if ( phone.loaded && address.loaded ) {
+		if ( phone.data.isValid && address.data.isAddressFilled ) {
 			sectionContent = (
 				<VerticalGapLayout size="overlap">
 					<PhoneNumberCard

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -59,13 +59,13 @@ export default function useStoreAddress( source = 'wc' ) {
 			source === 'wc' ? contact.wc_address : contact.mc_address;
 
 		// Handle fallback for `null` fields to make sure the returned data types are consistent.
-		const streetAddress = storeAddress.street_address || '';
-		const city = storeAddress.locality || '';
-		const state = storeAddress.region || '';
-		const postcode = storeAddress.postal_code || '';
+		const streetAddress = storeAddress?.street_address || '';
+		const city = storeAddress?.locality || '';
+		const state = storeAddress?.region || '';
+		const postcode = storeAddress?.postal_code || '';
 
 		const [ address, address2 = '' ] = streetAddress.split( '\n' );
-		const country = countryNameDict[ storeAddress.country ];
+		const country = countryNameDict[ storeAddress?.country ];
 		const isAddressFilled = !! ( address && city && country && postcode );
 
 		data = {

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -37,9 +37,12 @@ const emptyData = {
 /**
  * Get store address data and refectch function.
  *
+ * @param {'wc'|'mc'} [source='wc'] The data source of store address. 'wc' by default.
+ *     'wc': get from WooCommerce Settings.
+ *     'mc': get from Google Merchant Center.
  * @return {StoreAddressResult} Store address result.
  */
-export default function useStoreAddress() {
+export default function useStoreAddress( source = 'wc' ) {
 	const {
 		data: contact,
 		hasFinishedResolution: loaded,
@@ -51,19 +54,18 @@ export default function useStoreAddress() {
 	let data = emptyData;
 
 	if ( loaded && contact ) {
-		const {
-			wc_address: wcAddress,
-			is_mc_address_different: isMCAddressDifferent,
-		} = contact;
+		const { is_mc_address_different: isMCAddressDifferent } = contact;
+		const storeAddress =
+			source === 'wc' ? contact.wc_address : contact.mc_address;
 
 		// Handle fallback for `null` fields to make sure the returned data types are consistent.
-		const streetAddress = wcAddress.street_address || '';
-		const city = wcAddress.locality || '';
-		const state = wcAddress.region || '';
-		const postcode = wcAddress.postal_code || '';
+		const streetAddress = storeAddress.street_address || '';
+		const city = storeAddress.locality || '';
+		const state = storeAddress.region || '';
+		const postcode = storeAddress.postal_code || '';
 
 		const [ address, address2 = '' ] = streetAddress.split( '\n' );
-		const country = countryNameDict[ wcAddress.country ];
+		const country = countryNameDict[ storeAddress.country ];
 		const isAddressFilled = !! ( address && city && country && postcode );
 
 		data = {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's based on #936 to prevent code conflicts.

- Check whether the GMC address is filled at the main Settings page.

### Detailed test instructions:

1. Have a saved phone number, and remove address from [Google Merchant Center](https://merchants.google.com/mc/merchantprofile/businessinfo)
    ![image](https://user-images.githubusercontent.com/17420811/128483327-8f50289a-a1db-4324-90ec-10044df3c29c.png)
3. Go to the GLA Settings page, and it should display the no contact information notice
    ![image](https://user-images.githubusercontent.com/17420811/128483552-fc227c8f-dd15-4351-87b9-6ddeb839ca66.png)

### Additional note

💡  If proceeding to the edit contact info page with fulfilled WC store address data, you might found that the "Save detail" button is disabled. This problem was fixed by #937.

### Changelog entry
