### PR TITLE
Update `@since` tag for the `uninstall.php` file

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -5,7 +5,7 @@
  * Uninstalling Google Listings and Ads unschedules any pending jobs, deletes its custom tables, related transients,
  * options, and product metadata.
  *
- * @since x.x.x
+ * @since 1.3.0
  */
 
 declare( strict_types=1 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `uninstall.php` file is already released as part of [v1.3.0](https://github.com/woocommerce/google-listings-and-ads/releases/tag/1.3.0) but For some reason this tag was not updated during the release. Maybe woorelease doesn't look for this tag in all php files?

Related to https://github.com/woocommerce/google-listings-and-ads/pull/892

### Changelog entry
