### PR TITLE
Trim product descriptions to 5000 characters

### DIFF
--- a/src/Polyfills/MBString.php
+++ b/src/Polyfills/MBString.php
@@ -210,4 +210,41 @@ final class MBString {
 
 		return $encoding;
 	}
+
+	/**
+	 * Get part of string.
+	 *
+	 * @param string      $string
+	 * @param int         $start
+	 * @param int|null    $length
+	 * @param string|null $encoding
+	 *
+	 * @return string
+	 *
+	 * @since x.x.x
+	 */
+	public static function mb_substr( $string, $start, $length = null, $encoding = null ) {
+		$encoding = self::get_encoding( $encoding );
+		if ( 'CP850' === $encoding || 'ASCII' === $encoding ) {
+			return (string) substr( $string, $start, null === $length ? 2147483647 : $length );
+		}
+
+		if ( $start < 0 ) {
+			$start = \iconv_strlen( $string, $encoding ) + $start;
+			if ( $start < 0 ) {
+				$start = 0;
+			}
+		}
+
+		if ( null === $length ) {
+			$length = 2147483647;
+		} elseif ( $length < 0 ) {
+			$length = \iconv_strlen( $string, $encoding ) + $length - $start;
+			if ( $length < 0 ) {
+				return '';
+			}
+		}
+
+		return (string) \iconv_substr( $string, $start, $length, $encoding );
+	}
 }

--- a/src/Polyfills/bootstrap.php
+++ b/src/Polyfills/bootstrap.php
@@ -40,3 +40,21 @@ if ( ! function_exists( 'mb_strlen' ) ) {
 		return MBString::mb_strlen( $string, $encoding );
 	}
 }
+
+if ( ! function_exists( 'mb_substr' ) ) {
+	/**
+	 * Get part of string.
+	 *
+	 * @param string      $string
+	 * @param int         $start
+	 * @param int|null    $length
+	 * @param string|null $encoding
+	 *
+	 * @return string
+	 *
+	 * @since x.x.x
+	 */
+	function mb_substr( $string, $start, $length = null, $encoding = null ) {
+		return MBString::mb_substr( $string, $start, $length, $encoding );
+	}
+}

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -215,14 +215,6 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			$description        = $parent_description . $new_line . $description;
 		}
 
-		// Strip out invalid unicode.
-		$description = mb_convert_encoding( $description, 'UTF-8', 'UTF-8' );
-		$description = preg_replace(
-			'/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u',
-			'',
-			$description
-		);
-
 		/**
 		 * Filters whether the shortcodes should be applied for product descriptions when syncing a product or be stripped out.
 		 *
@@ -239,6 +231,14 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			// Strip out active shortcodes
 			$description = strip_shortcodes( $description );
 		}
+
+		// Strip out invalid unicode.
+		$description = mb_convert_encoding( $description, 'UTF-8', 'UTF-8' );
+		$description = preg_replace(
+			'/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u',
+			'',
+			$description
+		);
 
 		// Strip out invalid HTML tags (e.g. script, style, canvas, etc.) along with attributes of all tags.
 		$valid_html_tags   = array_keys( wp_kses_allowed_html( 'post' ) );

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -245,6 +245,9 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$kses_allowed_tags = array_fill_keys( $valid_html_tags, [] );
 		$description       = wp_kses( $description, $kses_allowed_tags );
 
+		// Trim the description if it's more than 5000 characters.
+		$description = mb_substr( $description, 0, 5000, 'utf-8' );
+
 		/**
 		 * Filters the product's description.
 		 *

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -148,9 +148,9 @@ class WCProductAdapterTest extends UnitTest {
 		add_filter(
 			'woocommerce_gla_product_attribute_values',
 			function ( array $attributes, WC_Product $product, WCProductAdapter $google_product ) {
-				$attributes['imageLink'] = 'https://example.com/image_overide.png?prev=' . $google_product->getImageLink();
+				$attributes['imageLink']   = 'https://example.com/image_overide.png?prev=' . $google_product->getImageLink();
 				$attributes['description'] = 'Overridden description!';
-				$attributes['id'] = 'override_' . $product->get_id();
+				$attributes['id']          = 'override_' . $product->get_id();
 
 				return $attributes;
 			},
@@ -423,7 +423,7 @@ class WCProductAdapterTest extends UnitTest {
 		$product         = WC_Helper_Product::create_simple_product(
 			false,
 			[
-				'description'       => 'Long description.',
+				'description' => 'Long description.',
 			]
 		);
 		$adapted_product = new WCProductAdapter(
@@ -434,6 +434,26 @@ class WCProductAdapterTest extends UnitTest {
 		);
 
 		$this->assertEquals( 'Modified description!', $adapted_product->getDescription() );
+	}
+
+	public function test_description_is_trimmed_if_more_than_5000_chars() {
+		$long_description = rand_long_str( 10000 );
+
+		$product         = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'description' => $long_description,
+			]
+		);
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		$this->assertEquals( 5000, mb_strlen( $adapted_product->getDescription(), 'utf-8' ) );
+		$this->assertEquals( mb_substr( $long_description, 0, 5000, 'utf-8' ), $adapted_product->getDescription() );
 	}
 
 	public function test_parent_description_is_included_in_variation_description() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #932 .

In order to prevent issues with large attributes, this PR trims the products' descriptions to 5000 characters. Google also [limits the description attribute to 5k characters](https://support.google.com/merchants/answer/6324468?hl=en) and automatically trimmed them when synced. However, if the product had [more than 10kb of data](https://support.google.com/merchants/answer/1139283?hl=en) in any attribute then sync would fail completely because of the following error:

```
Request too large: Attribute too large.
```

A new ployfill for the `mb_substr` function is also added to the MBString ployfills we have.

### Detailed test instructions:

1. Create a product with a description of more then 10k bytes of [lorem ipsum](https://www.lipsum.com/)
2. Add a title, price and image to make sure the product is eligible for syncing
3. Wait for the product to be synced (check action scheduler)
4. Confirm that the product is synced and its description is already trimmed to 5k characters


### Changelog entry

> Tweak - Limit the product descriptions to 5000 characters when syncing.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->