### PR TITLE
Add root files and directories to version replace path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ wp-cli.local.yml
 # Files allowed to be overridden with a local version
 phpcs.xml
 phpunit.xml
+
+# Do not include backup PHP files
+*.php.bak

--- a/package.json
+++ b/package.json
@@ -91,7 +91,11 @@
 	"config": {
 		"wp_org_slug": "google-listings-and-ads",
 		"version_replace_paths": [
-			"src"
+			"src",
+			"views",
+			"bin",
+			"uninstall.php",
+			"google-listings-and-ads.php"
 		]
 	},
 	"bundlewatch": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #940 .

This change is needed for woorelease to be able to pick up these files and replace the `@since x.x.x` version string in them to the actual version string used for the release.

So far we only included the `./src` folder, which meant that if we had a new function or class in any other directory, woorelease wouldn't had replaced their `@since` tags with the right version.

This caused a minor issue with the last release where the `uninstall.php` file was not updated with the latest version string (#940).

### Detailed test instructions:

The main thing to test here is that whether woorelease is also able to accept file paths in the `version_replace_paths` along with directory paths.

`woorelease` runs the following `find` command when replacing version strings for a file called `uninstall.php` and a version `1.3.0`:

```
find ./uninstall.php -iname '*.php' -exec sed -i.bak -e "s/@since\( \{1,\}\)x.x.x/@since\11.3.0/g;s/@version\( \{1,\}\)x.x.x/@version\11.3.0/g" {} \;
```

https://github.com/woocommerce/woorelease/blob/7d04098d099975d60dc8be5f0571b4fc2f279ec1/includes/tools/class-version-replace.php#L45-L54

I think it would safe to just run the command above and check if your `uninstall.php` file that contains a `@since x.x.x` text is modified to contain `@since 1.3.0`.

### Changelog entry

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->