### PR TITLE
Track "edit store address button clicked" event,

### DIFF
--- a/js/src/components/contact-information/store-address-card.js
+++ b/js/src/components/contact-information/store-address-card.js
@@ -6,6 +6,7 @@ import { CardDivider } from '@wordpress/components';
 import { Spinner } from '@woocommerce/components';
 import { external as externalIcon } from '@wordpress/icons';
 import GridiconRefresh from 'gridicons/dist/refresh';
+import { getPath, getQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -17,8 +18,27 @@ import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import AppButton from '.~/components/app-button';
 import './store-address-card.scss';
 
+/**
+ * "Edit MC store address" Tracking event
+ *
+ * @event gla_edit_mc_store_address
+ * @type {Object} TrackingEvent
+ * @property {string} path A page from which the link was clicked.
+ * @property {string|undefined} [subpath] A subpage from which the link was clicked.
+ */
+
+/**
+ * Renders a component with a given store address.
+ *
+ * @fires gla_edit_mc_store_address Whenever "Edit in Settings" is clicked.
+ *
+ * @param {Object} props React props
+ * @param {boolean} props.isPreview Is that a short preview or more formatted view?
+ * @return {JSX.Element} Filled AccountCard component.
+ */
 export default function StoreAddressCard( { isPreview } ) {
 	const { loaded, data, refetch } = useStoreAddress();
+	const { subpath } = getQuery();
 	const editButton = (
 		<AppButton
 			isSecondary
@@ -28,6 +48,8 @@ export default function StoreAddressCard( { isPreview } ) {
 			target="_blank"
 			href="admin.php?page=wc-settings"
 			text={ __( 'Edit in Settings', 'google-listings-and-ads' ) }
+			eventName="gla_edit_mc_store_address"
+			eventProps={ { path: getPath(), subpath } }
 		/>
 	);
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -65,6 +65,11 @@ All event names are prefixed by `wcadmin_gla_`.
     -   `context`: indicate which link is clicked
     -   `href`: link's URL
 
+-   `edit_mc_store_address` - Trigger when edit links are clicked from product feed table
+
+    - `path`: The path used in the page, e.g. `"/google/settings"`.
+    - `subpath`: The subpath used in the page, e.g. `"/edit-contact-information"`.
+
 -   `edit_product_click` - Trigger when edit links are clicked from product feed table
 
     -   `status`: `("approved" | "partially_approved" | "expiring" | "pending" | "disapproved" | "not_synced")`

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -65,10 +65,10 @@ All event names are prefixed by `wcadmin_gla_`.
     -   `context`: indicate which link is clicked
     -   `href`: link's URL
 
--   `edit_mc_store_address` - Trigger when edit links are clicked from product feed table
+-   `edit_mc_store_address` - Trigger when store address edit button is clicked.
 
     - `path`: The path used in the page, e.g. `"/google/settings"`.
-    - `subpath`: The subpath used in the page, e.g. `"/edit-contact-information"`.
+    - `subpath`: The subpath used in the page, e.g. `"/edit-contact-information"` or `undefined` when there is no subpath.
 
 -   `edit_product_click` - Trigger when edit links are clicked from product feed table
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Track "edit store address button clicked" event,
Implements part of https://github.com/woocommerce/google-listings-and-ads/issues/863.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

#### Edit flow
1. Go to the GLA Settings page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings)
3. Open dev tools, call `localStorage.setItem( 'debug', 'wc-admin:*' );` to see the tracking events in the log
3. Click "Edit in Settings"
3. Go back to GLA tab, check the events
![edit in settings with address](https://user-images.githubusercontent.com/17435/128729696-307bccf2-f5de-4bc7-b331-20b88f924159.gif)

You should see 
```js
'wcadmin_gla_edit_mc_store_address'
{
	  path: "/google/settings"
	  subpath: undefined
}
```

#### Edit flow2
0. Remove address info from your MC account https://merchants.google.com/mc/merchantprofile/businessinfo
1. Go to the GLA Settings page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings)
2. Click "Add information"
3. Open dev tools, call `localStorage.setItem( 'debug', 'wc-admin:*' );` to see the tracking events in the log
3. Click "Edit in Settings"
3. Go back to GLA tab, check the events
![Edit in settings](https://user-images.githubusercontent.com/17435/128729391-67a01f51-4a9e-4b45-8b41-f1d146265aea.gif)

You should see 
```js
'wcadmin_gla_edit_mc_store_address'
{
	  path: "/google/settings"
	  subpath: "/edit-contact-information"
}
```

#### Setup flow
0. Go to the GLA Settings page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings)
1. Click "Disconnect all accounts" and approve.
2. In Setup flow, proceeded to step 4.
3. Open dev tools, call `localStorage.setItem( 'debug', 'wc-admin:*' );` to see the tracking events in the log
3. Click "Edit in Settings"
3. Go back to GLA tab, check the events
![Edit in setup](https://user-images.githubusercontent.com/17435/128729245-21e1b8e1-6266-4fb1-b4bb-906cce223df9.gif)

You should see 
```js
'wcadmin_gla_edit_mc_store_address'
{
	  path: "/google/setup-mc"
	  subpath: undefined
}
```



### Changelog entry

> Add - Track "edit store address button clicked" event.
