### PR TITLE
Track event for phone number existence

### DIFF
--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -119,6 +119,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 		>
 			<VerticalGapLayout size="large">
 				<PhoneNumberCard
+					view={ view }
 					phoneNumber={ phone }
 					initEditing={ initEditing }
 					onPhoneNumberChange={ onPhoneNumberChange }

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -82,7 +82,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 		? 'setup-mc-contact-information'
 		: 'settings-contact-information';
 
-	usePhoneNumberCheckTrackEventEffect( view, phone );
+	usePhoneNumberCheckTrackEventEffect( phone );
 
 	return (
 		<Section

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getHistory } from '@woocommerce/navigation';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,7 +17,7 @@ import SpinnerCard from '.~/components/spinner-card';
 import PhoneNumberCard from './phone-number-card';
 import StoreAddressCard from './store-address-card';
 import NoContactInformationCard from './no-contact-information-card';
-import recordEvent from '.~/utils/recordEvent';
+import usePhoneNumberCheckTrackEventEffect from './usePhoneNumberCheckTrackEventEffect';
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
@@ -82,22 +81,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 		? 'setup-mc-contact-information'
 		: 'settings-contact-information';
 
-	const {
-		loaded,
-		data: { display, isValid },
-	} = phone;
-	const exist = !! display;
-	useEffect( () => {
-		if ( ! loaded ) {
-			return;
-		}
-
-		recordEvent( 'gla_mc_phone_number_check', {
-			view,
-			exist,
-			isValid,
-		} );
-	}, [ exist, isValid, loaded, view ] );
+	usePhoneNumberCheckTrackEventEffect( view, phone );
 
 	return (
 		<Section

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -46,6 +46,7 @@ export function ContactInformationPreview() {
 			sectionContent = (
 				<VerticalGapLayout size="overlap">
 					<PhoneNumberCard
+						view="settings"
 						isPreview
 						phoneNumber={ phone }
 						onEditClick={ handleEditClick }

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getHistory } from '@woocommerce/navigation';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import SpinnerCard from '.~/components/spinner-card';
 import PhoneNumberCard from './phone-number-card';
 import StoreAddressCard from './store-address-card';
 import NoContactInformationCard from './no-contact-information-card';
+import recordEvent from '.~/utils/recordEvent';
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
@@ -79,6 +81,23 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 	const trackContext = isSetupMC
 		? 'setup-mc-contact-information'
 		: 'settings-contact-information';
+
+	const {
+		loaded,
+		data: { display, isValid },
+	} = phone;
+	const exist = !! display;
+	useEffect( () => {
+		if ( ! loaded ) {
+			return;
+		}
+
+		recordEvent( 'gla_mc_phone_number_check', {
+			view,
+			exist,
+			isValid,
+		} );
+	}, [ exist, isValid, loaded, view ] );
 
 	return (
 		<Section

--- a/js/src/components/contact-information/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card.js
@@ -158,6 +158,7 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberChange } ) {
  * Renders phone number data in Card UI and is able to edit.
  *
  * @param {Object} props React props.
+ * @param {string} props.view The view the card is in.
  * @param {PhoneNumber} props.phoneNumber Phone number data.
  * @param {boolean} [props.isPreview=false] Whether to display as preview UI.
  * @param {boolean|null} [props.initEditing=null] Specify the inital UI state. This prop would be ignored if `isPreview` is true.
@@ -169,6 +170,7 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberChange } ) {
  * @param {onPhoneNumberChange} [props.onPhoneNumberChange] Called when inputs of phone number are changed in edit mode.
  */
 export default function PhoneNumberCard( {
+	view,
 	phoneNumber,
 	isPreview = false,
 	initEditing = null,
@@ -215,6 +217,10 @@ export default function PhoneNumberCard( {
 		indicator = (
 			<AppButton
 				isSecondary
+				eventName="gla_mc_phone_number_edit_button_click"
+				eventProps={ {
+					view,
+				} }
 				onClick={ () => {
 					if ( onEditClick ) {
 						onEditClick();

--- a/js/src/components/contact-information/usePhoneNumberCheckTrackEventEffect.js
+++ b/js/src/components/contact-information/usePhoneNumberCheckTrackEventEffect.js
@@ -2,18 +2,20 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
+import { getPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
 import recordEvent from '.~/utils/recordEvent';
 
-const usePhoneNumberCheckTrackEventEffect = ( view, phone ) => {
+const usePhoneNumberCheckTrackEventEffect = ( phone ) => {
 	const {
 		loaded,
 		data: { display, isValid },
 	} = phone;
 	const exist = !! display;
+	const path = getPath();
 
 	useEffect( () => {
 		if ( ! loaded ) {
@@ -21,11 +23,11 @@ const usePhoneNumberCheckTrackEventEffect = ( view, phone ) => {
 		}
 
 		recordEvent( 'gla_mc_phone_number_check', {
-			view,
+			path,
 			exist,
 			isValid,
 		} );
-	}, [ exist, isValid, loaded, view ] );
+	}, [ exist, isValid, loaded, path ] );
 };
 
 export default usePhoneNumberCheckTrackEventEffect;

--- a/js/src/components/contact-information/usePhoneNumberCheckTrackEventEffect.js
+++ b/js/src/components/contact-information/usePhoneNumberCheckTrackEventEffect.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import recordEvent from '.~/utils/recordEvent';
+
+const usePhoneNumberCheckTrackEventEffect = ( view, phone ) => {
+	const {
+		loaded,
+		data: { display, isValid },
+	} = phone;
+	const exist = !! display;
+
+	useEffect( () => {
+		if ( ! loaded ) {
+			return;
+		}
+
+		recordEvent( 'gla_mc_phone_number_check', {
+			view,
+			exist,
+			isValid,
+		} );
+	}, [ exist, isValid, loaded, view ] );
+};
+
+export default usePhoneNumberCheckTrackEventEffect;

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -129,6 +129,16 @@ All event names are prefixed by `wcadmin_gla_`.
 
 -   `mc_account_reclaim_url_button_click` - Clicking on the button to reclaim URL for a Google Merchant Center account.
 
+-   `mc_phone_number_check` - Whether the phone number for Merchant Center exists or not.
+
+    -   `view`: which view the check is in. Possible values: `setup-mc`, `settings`.
+    -   `exist`: whether the phone number exists or not.
+    -   `isValid`: whether the phone number is valid or not.
+
+-   `mc_phone_number_edit_button_click` - Clicking on the Merchant Center phone number edit button.
+
+    -   `view`: which view the edit button is in. Possible values: `setup-mc`, `settings`.
+
 -   `mc_url_switch`
 
     -   `action` property is `required`: the Merchant Center account has a different, claimed URL and needs to be changed

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -129,9 +129,9 @@ All event names are prefixed by `wcadmin_gla_`.
 
 -   `mc_account_reclaim_url_button_click` - Clicking on the button to reclaim URL for a Google Merchant Center account.
 
--   `mc_phone_number_check` - Whether the phone number for Merchant Center exists or not.
+-   `mc_phone_number_check` - Check for whether the phone number for Merchant Center exists or not.
 
-    -   `view`: which view the check is in. Possible values: `setup-mc`, `settings`.
+    -   `path`: the path where the check is in.
     -   `exist`: whether the phone number exists or not.
     -   `isValid`: whether the phone number is valid or not.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/google-listings-and-ads/issues/863.

This PR adds track event for when phone number is added or edited - "need to be able to track even when phone number is initially added vs already existing on an account".

### Screenshots:

When phone number does not exist in Setup MC flow:

![image](https://user-images.githubusercontent.com/417342/128732736-61afab96-2b6f-4f58-a9d6-34d1fc614c22.png)

When phone number exists in Setup MC flow:

![image](https://user-images.githubusercontent.com/417342/128732751-a9fb5214-5ec0-46d4-9c9b-1cbf9c651180.png)

When phone number exists in settings page:

![image](https://user-images.githubusercontent.com/417342/128732759-c50e28b0-374c-4f3e-ab28-06925a7c8215.png)

Clicking on phone number edit button:

![image](https://user-images.githubusercontent.com/417342/128736088-d15451ea-83f0-41fe-811f-f807aa3390b3.png)


### Detailed test instructions:

Open dev tools, call `localStorage.setItem( 'debug', 'wc-admin:*' );` to see the tracking events in the log.

1. In Setup MC, connect to a Google Merchant Center that does not have a phone number, and proceed to Step 4. You should see the first screenshot above in your console.
2. In Setup MC, connect to a Google Merchant Center that has a phone number, and proceed to Step 4. You should see the second screenshot above in your console. 
3. Go to the plugin settings page, and click the edit button to go to the edit phone number page. You should see the third screenshot above in your console.
4. When you click on the phone number edit button, you should see the fourth screenshot above in your console.

### Changelog entry

> Add - Track events to check whether phone number exists or not, and when phone number is edited.
