### PR TITLE
Add track event for saving contact information in Settings page

### DIFF
--- a/js/src/settings/edit-contact-information/index.js
+++ b/js/src/settings/edit-contact-information/index.js
@@ -69,6 +69,7 @@ export default function EditContactInformation() {
 							isPrimary
 							loading={ isSaving }
 							disabled={ ! isReadyToSave }
+							eventName="gla_contact_information_save_button_click"
 							onClick={ handleSaveClick }
 						>
 							{ __( 'Save details', 'google-listings-and-ads' ) }

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -45,6 +45,8 @@ All event names are prefixed by `wcadmin_gla_`.
     -   `report`: name of the report (e.g. `"reports-programs" | "reports-products"`)
     -   `context`: metric key of the clicked tab (e.g. `"sales" | "conversions" | "clicks" | "impressions" | "spend"`).
 
+-   `contact_information_save_button_click` - Triggered when the save button in contact information page is clicked.
+
 -   `datepicker_update` - Triggered when datepicker (date ranger picker) is updated
 
     -   `report`: name of the report (e.g. `"dashboard" | "reports-programs" | "reports-products" | "product-feed"`)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds track event for clicking save button in contact information page.

### Screenshots:

![image](https://user-images.githubusercontent.com/417342/128749910-2db12442-608c-450a-bb45-79e3016707b1.png)

### Detailed test instructions:

1. Go to Edit contact info page: /wp-admin/admin.php?page=wc-admin&subpath=%2Fedit-contact-information&path=%2Fgoogle%2Fsettings
2. Make some changes and click on Save details button.
3. There should be a track event recorded, as per the above screenshot.

### Changelog entry

> Add - track event for saving contact information.
