### PR TITLE
Allow connection test page for other admin users

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -186,7 +186,6 @@ class ConnectionTest implements Service, Registerable {
 							<p>
 								<code><?php echo Jetpack_Options::get_option( 'id' ); ?></code>
 							</p>
-							<!--<pre><?php var_dump( $blog_token ); ?></pre>-->
 						</td>
 					</tr>
 				<?php } ?>
@@ -198,7 +197,6 @@ class ConnectionTest implements Service, Registerable {
 							<p>
 								<code><?php echo $user_data['ID']; ?></code>
 							</p>
-							<!--<pre><?php var_dump( $user_token ); ?></pre>-->
 						</td>
 					</tr>
 				<?php } elseif ( $blog_token ) { ?>

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -201,9 +201,14 @@ class ConnectionTest implements Service, Registerable {
 							<!--<pre><?php var_dump( $user_token ); ?></pre>-->
 						</td>
 					</tr>
+				<?php } elseif ( $blog_token ) { ?>
+					<tr>
+						<th><label>User:</label></th>
+						<td><p>Connected with another user account</p></td>
+					</tr>
 				<?php } ?>
 
-				<?php if ( $blog_token && $user_token ) { ?>
+				<?php if ( $blog_token ) { ?>
 				<tr>
 					<th>Test Authenticated WCS Request:</th>
 					<td>
@@ -217,10 +222,9 @@ class ConnectionTest implements Service, Registerable {
 				<tr>
 					<th>Toggle Connection:</th>
 					<td>
-						<?php if ( ! $blog_token || ! $user_token ) { ?>
+						<?php if ( ! $blog_token ) { ?>
 							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'connect' ], $url ), 'connect' ) ); ?>">Connect to Jetpack</a></p>
-						<?php } ?>
-						<?php if ( $blog_token && $user_token ) { ?>
+						<?php } else { ?>
 							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'disconnect' ], $url ), 'disconnect' ) ); ?>">Disconnect Jetpack</a></p>
 						<?php } ?>
 					</td>
@@ -230,7 +234,7 @@ class ConnectionTest implements Service, Registerable {
 
 			<hr />
 
-			<?php if ( $blog_token && $user_token ) { ?>
+			<?php if ( $blog_token ) { ?>
 
 				<h2 class="title">Google Account</h2>
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The changes in this PR allow the Connection Test page to be usable whenever we have a valid blog token. A user token is linked to the specific admin user that made the initial Jetpack connection, which means other admin users aren't able to send test requests. Here we remove this requirement and rely only on the blog token, when a different user is connected we show the user as "Connected with another user account".

Closes #931

### Detailed test instructions:

1. Connect Jetpack and Google accounts
2. Create a second WordPress user as an administrator
3. Login as the second administrator and visit the Connection Test page `admin.php?page=connection-test-admin-page`
4. Observe the Jetpack user shows up with "Connected with another user account"
5. Test a request to the Merchant or Ads Account
6. Confirm that we are able to complete the requests without any problems
7. Additional test: Create a user with a Shop Manager role
8. Try to visit the Connection Test page and confirm they do not have sufficient permissions

### Changelog entry
* Fix - Allow connection test page for other admin users.
