### PR TITLE
Fix pre sync errors being skipped in the issues table

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -496,6 +496,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$chunk_size     = apply_filters( 'woocommerce_gla_merchant_status_presync_issues_chunk', 500 );
 		$product_issues = [];
 		foreach ( $all_errors as $product_id => $presync_errors ) {
+			// Don't create issues with empty descriptions
+			// or for variable parents (they contain issues of all children).
+			$error = $presync_errors[ array_key_first( $presync_errors ) ];
+			if ( empty( $error ) || ! is_string( $error ) ) {
+				continue;
+			}
+
 			$product = get_post( $product_id );
 			// Don't store pre-sync errors for unpublished (draft, trashed) products.
 			if ( 'publish' !== get_post_status( $product ) ) {
@@ -503,11 +510,6 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			}
 
 			foreach ( $presync_errors as $text ) {
-				// Don't create issues with empty descriptions or for variable parents (they contain issues of all children).
-				if ( empty( $text ) || ! is_string( $text ) ) {
-					continue;
-				}
-
 				$issue_parts      = $this->parse_presync_issue_text( $text );
 				$product_issues[] = [
 					'product'              => $product->post_title,

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -498,7 +498,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		foreach ( $all_errors as $product_id => $presync_errors ) {
 			// Don't create issues with empty descriptions
 			// or for variable parents (they contain issues of all children).
-			if ( empty( $presync_errors[0] ) ) {
+			if ( empty( $presync_errors[ array_key_first( $presync_errors ) ] ) ) {
 				continue;
 			}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -496,12 +496,6 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$chunk_size     = apply_filters( 'woocommerce_gla_merchant_status_presync_issues_chunk', 500 );
 		$product_issues = [];
 		foreach ( $all_errors as $product_id => $presync_errors ) {
-			// Don't create issues with empty descriptions
-			// or for variable parents (they contain issues of all children).
-			if ( empty( $presync_errors[ array_key_first( $presync_errors ) ] ) ) {
-				continue;
-			}
-
 			$product = get_post( $product_id );
 			// Don't store pre-sync errors for unpublished (draft, trashed) products.
 			if ( 'publish' !== get_post_status( $product ) ) {
@@ -509,6 +503,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			}
 
 			foreach ( $presync_errors as $text ) {
+				// Don't create issues with empty descriptions or for variable parents (they contain issues of all children).
+				if ( empty( $text ) || ! is_string( $text ) ) {
+					continue;
+				}
+
 				$issue_parts      = $this->parse_presync_issue_text( $text );
 				$product_issues[] = [
 					'product'              => $product->post_title,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #933.

This PR fixes an issue with the pre-sync merchant center issues being skipped if they are provided as an associative array with a non-integer key. For example:

```
[
  request_too_large: "Request too large: Attribute too large."
]
```

To resolve this, we check the first array key instead of index 0. This way if an associative array is provided as the $presync_errors we wouldn't skip it because it has no `0` index.


### Detailed test instructions:

1. Create a pre-sync error (such as a product description larger than 10k). To cause this error, you could comment the `mb_substr` line from `WCProductAdapter::get_wc_product_description` so that we no longer trim the description.
2. Wait for the product to sync and store the sync errors
3. Clear the statuses transient on the Connection Test
4. Refresh the product feed page and confirm that this specific error shows up in the issues table


### Changelog entry

> Fix - Some pre-sync errors being skipped in the product issues table.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->