### PR TITLE
Quote path to allow for spaces in vendor directory

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -85,7 +85,7 @@ foreach ( $replacements as $namespace => $path ) {
 	$composer_files = array_filter(
 		explode(
 			"\n",
-			`find {$vendor_dir}/{$path} -iname 'composer.json'`
+			`find "{$vendor_dir}/{$path}" -iname 'composer.json'`
 		)
 	);
 
@@ -107,7 +107,7 @@ function find_files( string $path ): array {
 	$files = array_filter(
 		explode(
 			"\n",
-			`find {$vendor_dir}/{$path} -iname '*.php'`
+			`find "{$vendor_dir}/{$path}" -iname '*.php'`
 		)
 	);
 
@@ -116,7 +116,7 @@ function find_files( string $path ): array {
 			$dependent_files = array_filter(
 				explode(
 					"\n",
-					`find {$vendor_dir}/{$dependency} -iname '*.php'`
+					`find "{$vendor_dir}/{$dependency}" -iname '*.php'`
 				)
 			);
 			$files = array_merge( $files, $dependent_files );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Place path in double quotes so we can search within a path containing spaces.

Closes #929

### Detailed test instructions:

1. Clone this branch into a folder with spaces
```
git clone --branch fix/929-prefix-vendor-spaces-in-path git@github.com:woocommerce/google-listings-and-ads.git "google listings and ads"
```
2. Run `composer install` to prefix vendor namespaces
```
cd google\ listings\ and\ ads && composer install
```
3. Confirm that there are no PHP errors
4. Confirm that replacements were done, for example in file `vendor/google/auth/composer.json`


### Changelog entry
* Fix - Allow spaces in paths when prefixing vendor namespaces.