### PR TITLE
Allow backorder product availability

### DIFF
--- a/js/src/product-attributes/index.scss
+++ b/js/src/product-attributes/index.scss
@@ -36,7 +36,8 @@
 	}
 }
 
-.gla-channel-visibility-box select {
+#channel_visibility .gla-channel-visibility-box select {
 	display: block;
 	margin: $grid-unit-10 0;
+	max-width: 100%;
 }

--- a/src/API/Site/Controllers/BaseReportsController.php
+++ b/src/API/Site/Controllers/BaseReportsController.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use DateTime;
 use DateTimeZone;
 use Psr\Container\ContainerInterface;
@@ -152,7 +153,9 @@ abstract class BaseReportsController extends BaseController {
 	 * @param array $query_args Array of query arguments.
 	 */
 	protected function normalize_timezones( &$query_args ) {
-		$local_tz = new DateTimeZone( wc_timezone_string() );
+		/** @var WP $wp */
+		$wp       = $this->container->get( WP::class );
+		$local_tz = new DateTimeZone( $wp->wp_timezone_string() );
 
 		foreach ( [ 'before', 'after' ] as $query_arg_key ) {
 			if ( isset( $query_args[ $query_arg_key ] ) && is_string( $query_args[ $query_arg_key ] ) ) {

--- a/src/Admin/Input/DateTime.php
+++ b/src/Admin/Input/DateTime.php
@@ -1,0 +1,98 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input;
+
+use DateTimeZone;
+use Exception;
+use WC_DateTime;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class DateTime
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input
+ *
+ * @since x.x.x
+ */
+class DateTime extends Input {
+	/**
+	 * DateTime constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'datetime' );
+	}
+
+	/**
+	 * Return the data used for the input's view.
+	 *
+	 * @return array
+	 */
+	public function get_view_data(): array {
+		$view_data = parent::get_view_data();
+
+		if ( ! empty( $this->get_value() ) ) {
+			try {
+				// Display the time in site's local timezone.
+				$datetime = new WC_DateTime( $this->get_value(), new DateTimeZone( 'UTC' ) );
+				$datetime->setTimezone( new DateTimeZone( $this->get_local_tz_string() ) );
+				$view_data['value'] = $datetime->format( 'Y-m-d H:i:s' );
+				$view_data['date']  = $datetime->format( 'Y-m-d' );
+				$view_data['time']  = $datetime->format( 'H:i' );
+			} catch ( Exception $e ) {
+				do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
+
+				$view_data['value'] = '';
+				$view_data['date']  = '';
+				$view_data['time']  = '';
+			}
+		}
+
+		return $view_data;
+	}
+
+	/**
+	 * Set the form's data.
+	 *
+	 * @param mixed $data
+	 *
+	 * @return void
+	 */
+	public function set_data( $data ): void {
+		if ( is_array( $data ) ) {
+			if ( ! empty( $data['date'] ) ) {
+				$date = $data['date'] ?? '';
+				$time = $data['time'] ?? '';
+				$data = sprintf( '%s%s', $date, $time );
+			} else {
+				$data = '';
+			}
+		}
+
+		if ( ! empty( $data ) ) {
+			try {
+				// Store the time in UTC.
+				$datetime = new WC_DateTime( $data, new DateTimeZone( $this->get_local_tz_string() ) );
+				$datetime->setTimezone( new DateTimeZone( 'UTC' ) );
+				$data = (string) $datetime;
+			} catch ( Exception $e ) {
+				do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
+
+				$data = '';
+			}
+		}
+
+		parent::set_data( $data );
+	}
+
+	/**
+	 * Get site's local timezone string from WordPress settings.
+	 *
+	 * @return string
+	 */
+	protected function get_local_tz_string(): string {
+		return wp_timezone_string();
+	}
+
+}

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -127,6 +127,16 @@ class AttributesTab implements Service, Registerable, Conditional {
 	 * @param WC_Product $product
 	 */
 	private function handle_update_product( WC_Product $product ) {
+		/**
+		 * Array of `true` values for each product IDs already handled by this method. Used to prevent double submission.
+		 *
+		 * @var bool[] $already_updated
+		 */
+		static $already_updated = [];
+		if ( isset( $already_updated[ $product->get_id() ] ) ) {
+			return;
+		}
+
 		$form           = $this->get_form( $product );
 		$form_view_data = $form->get_view_data();
 
@@ -140,6 +150,8 @@ class AttributesTab implements Service, Registerable, Conditional {
 
 		$form->submit( $submitted_data );
 		$this->update_data( $product, $form->get_data() );
+
+		$already_updated[ $product->get_id() ] = true;
 	}
 
 	/**

--- a/src/Admin/Product/Attributes/Input/AdultInput.php
+++ b/src/Admin/Product/Attributes/Input/AdultInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\BooleanSelect;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Adult
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class AdultInput extends BooleanSelect {
+
+	/**
+	 * AdultInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Adult content', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'Whether the product contains nudity or sexually suggestive content', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/AgeGroupInput.php
+++ b/src/Admin/Product/Attributes/Input/AgeGroupInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Select;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AgeGroup
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class AgeGroupInput extends Select {
+
+	/**
+	 * AgeGroupInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Age Group', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'Target age group of the item.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/AttributeInputInterface.php
+++ b/src/Admin/Product/Attributes/Input/AttributeInputInterface.php
@@ -1,0 +1,40 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AttributeInputInterface
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input
+ *
+ * @since x.x.x
+ */
+interface AttributeInputInterface {
+
+	/**
+	 * Returns a name for the attribute input.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string;
+
+	/**
+	 * Returns a short description for the attribute input.
+	 *
+	 * @return string
+	 */
+	public static function get_description(): string;
+
+	/**
+	 * Returns the input class used for the attribute input.
+	 *
+	 * Must be an instance of `InputInterface`.
+	 *
+	 * @return string
+	 */
+	public static function get_input_type(): string;
+
+}

--- a/src/Admin/Product/Attributes/Input/AvailabilityDateInput.php
+++ b/src/Admin/Product/Attributes/Input/AvailabilityDateInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\DateTime;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AvailabilityDate
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class AvailabilityDateInput extends DateTime {
+
+	/**
+	 * AvailabilityDateInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Availability Date', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'The date a preordered or backordered product becomes available for delivery. Required if product availability is preorder or backorder', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/BrandInput.php
+++ b/src/Admin/Product/Attributes/Input/BrandInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Text;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Brand
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class BrandInput extends Text {
+
+	/**
+	 * BrandInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Brand', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'Brand of the product.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/ColorInput.php
+++ b/src/Admin/Product/Attributes/Input/ColorInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Text;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Color
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class ColorInput extends Text {
+
+	/**
+	 * ColorInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Color', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'Color of the product.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/ConditionInput.php
+++ b/src/Admin/Product/Attributes/Input/ConditionInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Select;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Condition
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class ConditionInput extends Select {
+
+	/**
+	 * ConditionInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Condition', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'Condition or state of the item.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/GTINInput.php
+++ b/src/Admin/Product/Attributes/Input/GTINInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Text;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class GTIN
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class GTINInput extends Text {
+
+	/**
+	 * GTINInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Global Trade Item Number (GTIN)', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'Global Trade Item Number (GTIN) for your item. These identifiers include UPC (in North America), EAN (in Europe), JAN (in Japan), and ISBN (for books)', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/GenderInput.php
+++ b/src/Admin/Product/Attributes/Input/GenderInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Select;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Gender
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class GenderInput extends Select {
+
+	/**
+	 * GenderInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Gender', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'The gender for which your product is intended.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/IsBundleInput.php
+++ b/src/Admin/Product/Attributes/Input/IsBundleInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\BooleanSelect;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class IsBundle
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class IsBundleInput extends BooleanSelect {
+
+	/**
+	 * IsBundleInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Is Bundle?', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'Whether the item is a bundle of products. A bundle is a custom grouping of different products sold by a merchant for a single price.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/MPNInput.php
+++ b/src/Admin/Product/Attributes/Input/MPNInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Text;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MPN
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class MPNInput extends Text {
+
+	/**
+	 * MPNInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Manufacturer Part Number (MPN)', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'This code uniquely identifies the product to its manufacturer.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/MaterialInput.php
+++ b/src/Admin/Product/Attributes/Input/MaterialInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Text;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Material
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class MaterialInput extends Text {
+
+	/**
+	 * MaterialInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Material', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'The material of which the item is made.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/MultipackInput.php
+++ b/src/Admin/Product/Attributes/Input/MultipackInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Integer;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Multipack
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class MultipackInput extends Integer {
+
+	/**
+	 * MultipackInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Multipack', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/PatternInput.php
+++ b/src/Admin/Product/Attributes/Input/PatternInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Text;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Pattern
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class PatternInput extends Text {
+
+	/**
+	 * PatternInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Pattern', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'The item\'s pattern (e.g. polka dots).', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/SizeInput.php
+++ b/src/Admin/Product/Attributes/Input/SizeInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Text;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Size
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class SizeInput extends Text {
+
+	/**
+	 * SizeInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Size', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'Size of the product.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/SizeSystemInput.php
+++ b/src/Admin/Product/Attributes/Input/SizeSystemInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Select;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SizeSystem
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class SizeSystemInput extends Select {
+
+	/**
+	 * SizeInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Size system', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'System in which the size is specified. Recommended for apparel items.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/Input/SizeTypeInput.php
+++ b/src/Admin/Product/Attributes/Input/SizeTypeInput.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Select;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SizeType
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class SizeTypeInput extends Select {
+
+	/**
+	 * SizeTypeInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Size type', 'google-listings-and-ads' ) );
+		$this->set_description( __( 'The cut of the item. Recommended for apparel items.', 'google-listings-and-ads' ) );
+	}
+
+}

--- a/src/Integration/WooCommercePreOrders.php
+++ b/src/Integration/WooCommercePreOrders.php
@@ -1,0 +1,71 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Integration;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
+use WC_Pre_Orders_Product;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WooCommercePreOrders
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Integration
+ *
+ * @link https://woocommerce.com/products/woocommerce-pre-orders/
+ *
+ * @since x.x.x
+ */
+class WooCommercePreOrders implements IntegrationInterface {
+
+	/**
+	 * Returns whether the integration is active or not.
+	 *
+	 * @return bool
+	 */
+	public function is_active(): bool {
+		return defined( 'WC_PRE_ORDERS_VERSION' );
+	}
+
+	/**
+	 * Initializes the integration (e.g. by registering the required hooks, filters, etc.).
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_filter(
+			'woocommerce_gla_product_attribute_values',
+			function ( array $attributes, WC_Product $product ) {
+				return $this->maybe_set_preorder_availability( $attributes, $product );
+			},
+			2,
+			10
+		);
+	}
+
+	/**
+	 * Sets the product's availability to "preorder" if it's in-stock and can be pre-ordered.
+	 *
+	 * @param array      $attributes
+	 * @param WC_Product $product
+	 *
+	 * @return array
+	 */
+	protected function maybe_set_preorder_availability( array $attributes, WC_Product $product ): array {
+		if ( $product->is_in_stock() && WC_Pre_Orders_Product::product_can_be_pre_ordered( $product ) ) {
+			$attributes['availability'] = WCProductAdapter::AVAILABILITY_PREORDER;
+
+			$timestamp = WC_Pre_Orders_Product::get_localized_availability_datetime_timestamp( $product );
+			if ( ! empty( $timestamp ) ) {
+				// Convert the timestamp back to UTC.
+				// The localized offset is already applied to timestamp by WC_Pre_Orders_Product.
+				$utc_timestamp                  = $timestamp - wc_timezone_offset();
+				$attributes['availabilityDate'] = gmdate( 'c', intval( $utc_timestamp ) );
+			}
+		}
+
+		return $attributes;
+	}
+}

--- a/src/Integration/WooCommercePreOrders.php
+++ b/src/Integration/WooCommercePreOrders.php
@@ -117,6 +117,9 @@ class WooCommercePreOrders implements IntegrationInterface {
 	/**
 	 * Triggers an update job for the product to be synced with Merchant Center.
 	 *
+	 * This is required because WooCommerce Pre-orders updates the product's metadata via `update_post_meta`, which
+	 * does not automatically trigger a sync.
+	 *
 	 * @hooked wc_pre_orders_pre_orders_disabled_for_product
 	 *
 	 * @param mixed $product_id

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -78,6 +78,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Tracks;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\TracksAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\TracksInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\AddressUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -103,6 +104,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		CompleteSetup::class          => true,
 		CompleteSetupNote::class      => true,
 		Dashboard::class              => true,
+		DateTimeUtility::class        => true,
 		EventTracking::class          => true,
 		GetStarted::class             => true,
 		GlobalSiteTag::class          => true,
@@ -192,6 +194,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Share utility classes
 		$this->share_with_tags( AddressUtility::class );
+		$this->share_with_tags( DateTimeUtility::class );
 
 		// Share our regular service classes.
 		$this->conditionally_share_with_tags(

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceProductBu
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceSubscriptions;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 defined( 'ABSPATH' ) || exit;
@@ -45,7 +46,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceBrands::class, WP::class );
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommerceSubscriptions::class );
-		$this->share_with_tags( WooCommercePreOrders::class );
+		$this->share_with_tags( WooCommercePreOrders::class, ProductHelper::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceBrands;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommercePreOrders;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceProductBundles;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceSubscriptions;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
@@ -44,6 +45,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceBrands::class, WP::class );
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommerceSubscriptions::class );
+		$this->share_with_tags( WooCommercePreOrders::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Product/Attributes/Adult.php
+++ b/src/Product/Attributes/Adult.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\AdultInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,24 +28,6 @@ class Adult extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Adult content', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'Whether the product contains nudity or sexually suggestive content', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
@@ -63,4 +47,16 @@ class Adult extends AbstractAttribute {
 		return 'boolean';
 	}
 
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return AdultInput::class;
+	}
 }

--- a/src/Product/Attributes/AgeGroup.php
+++ b/src/Product/Attributes/AgeGroup.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\AgeGroupInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -23,24 +25,6 @@ class AgeGroup extends AbstractAttribute implements WithValueOptionsInterface {
 	 */
 	public static function get_id(): string {
 		return 'ageGroup';
-	}
-
-	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Age Group', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'Target age group of the item.', 'google-listings-and-ads' );
 	}
 
 	/**
@@ -67,6 +51,19 @@ class AgeGroup extends AbstractAttribute implements WithValueOptionsInterface {
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return AgeGroupInput::class;
 	}
 
 }

--- a/src/Product/Attributes/AttributeInterface.php
+++ b/src/Product/Attributes/AttributeInterface.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\AttributeInputInterface;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -24,13 +26,6 @@ interface AttributeInterface {
 	public static function get_id(): string;
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string;
-
-	/**
 	 * Return the attribute's value type. Must be a valid PHP type.
 	 *
 	 * @return string
@@ -40,11 +35,15 @@ interface AttributeInterface {
 	public static function get_value_type(): string;
 
 	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
 	 *
 	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
 	 */
-	public static function get_description(): string;
+	public static function get_input_type(): string;
 
 	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -37,6 +37,7 @@ class AttributeManager implements Service {
 		AgeGroup::class,
 		Multipack::class,
 		IsBundle::class,
+		AvailabilityDate::class,
 		Adult::class,
 	];
 

--- a/src/Product/Attributes/AvailabilityDate.php
+++ b/src/Product/Attributes/AvailabilityDate.php
@@ -1,0 +1,70 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\AvailabilityDateInput;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AvailabilityDate
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ *
+ * @since x.x.x
+ */
+class AvailabilityDate extends AbstractAttribute {
+
+	/**
+	 * Returns the attribute ID.
+	 *
+	 * Must be the same as a Google product's property name to be set automatically.
+	 *
+	 * @return string
+	 *
+	 * @see \Google\Service\ShoppingContent\Product for the list of properties.
+	 */
+	public static function get_id(): string {
+		return 'availabilityDate';
+	}
+
+	/**
+	 * Returns a name for the attribute. Used in attribute's input.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Availability Date', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns a short description for the attribute. Used in attribute's input.
+	 *
+	 * @return string
+	 */
+	public static function get_description(): string {
+		return __( 'The date a preordered or backordered product becomes available for delivery. Required if product availability is preorder or backorder', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Return an array of WooCommerce product types that this attribute can be applied to.
+	 *
+	 * @return array
+	 */
+	public static function get_applicable_product_types(): array {
+		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 */
+	public static function get_input_type(): string {
+		return AvailabilityDateInput::class;
+	}
+
+}

--- a/src/Product/Attributes/Brand.php
+++ b/src/Product/Attributes/Brand.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\BrandInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,30 +28,25 @@ class Brand extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Brand', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'Brand of the product', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variable' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return BrandInput::class;
 	}
 
 }

--- a/src/Product/Attributes/Color.php
+++ b/src/Product/Attributes/Color.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\ColorInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,30 +28,25 @@ class Color extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Color', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'Color of the product', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return ColorInput::class;
 	}
 
 }

--- a/src/Product/Attributes/Condition.php
+++ b/src/Product/Attributes/Condition.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\ConditionInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -23,24 +25,6 @@ class Condition extends AbstractAttribute implements WithValueOptionsInterface {
 	 */
 	public static function get_id(): string {
 		return 'condition';
-	}
-
-	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Condition', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'Condition or state of the item.', 'google-listings-and-ads' );
 	}
 
 	/**
@@ -66,4 +50,18 @@ class Condition extends AbstractAttribute implements WithValueOptionsInterface {
 			'used'        => __( 'Used', 'google-listings-and-ads' ),
 		];
 	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return ConditionInput::class;
+	}
+
 }

--- a/src/Product/Attributes/GTIN.php
+++ b/src/Product/Attributes/GTIN.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\GTINInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,30 +28,25 @@ class GTIN extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Global Trade Item Number (GTIN)', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'Global Trade Item Number (GTIN) for your item. These identifiers include UPC (in North America), EAN (in Europe), JAN (in Japan), and ISBN (for books)', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return GTINInput::class;
 	}
 
 }

--- a/src/Product/Attributes/Gender.php
+++ b/src/Product/Attributes/Gender.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\GenderInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -23,24 +25,6 @@ class Gender extends AbstractAttribute implements WithValueOptionsInterface {
 	 */
 	public static function get_id(): string {
 		return 'gender';
-	}
-
-	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Gender', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'The gender for which your product is intended', 'google-listings-and-ads' );
 	}
 
 	/**
@@ -65,6 +49,19 @@ class Gender extends AbstractAttribute implements WithValueOptionsInterface {
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return GenderInput::class;
 	}
 
 }

--- a/src/Product/Attributes/IsBundle.php
+++ b/src/Product/Attributes/IsBundle.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\IsBundleInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,24 +28,6 @@ class IsBundle extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Is Bundle?', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'Whether the item is a bundle of products. A bundle is a custom grouping of different products sold by a merchant for a single price.', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
@@ -61,6 +45,19 @@ class IsBundle extends AbstractAttribute {
 	 */
 	public static function get_value_type(): string {
 		return 'boolean';
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return IsBundleInput::class;
 	}
 
 }

--- a/src/Product/Attributes/MPN.php
+++ b/src/Product/Attributes/MPN.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\MPNInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,30 +28,25 @@ class MPN extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Manufacturer Part Number (MPN)', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'This code uniquely identifies the product to its manufacturer', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return MPNInput::class;
 	}
 
 }

--- a/src/Product/Attributes/Material.php
+++ b/src/Product/Attributes/Material.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\MaterialInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,30 +28,25 @@ class Material extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Material', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'The material of which the item is made.', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return MaterialInput::class;
 	}
 
 }

--- a/src/Product/Attributes/Multipack.php
+++ b/src/Product/Attributes/Multipack.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\MultipackInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,24 +28,6 @@ class Multipack extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Multipack', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
@@ -61,6 +45,19 @@ class Multipack extends AbstractAttribute {
 	 */
 	public static function get_value_type(): string {
 		return 'integer';
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return MultipackInput::class;
 	}
 
 }

--- a/src/Product/Attributes/Pattern.php
+++ b/src/Product/Attributes/Pattern.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\PatternInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,30 +28,25 @@ class Pattern extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Pattern', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'The item\'s pattern (e.g. polka dots).', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return PatternInput::class;
 	}
 
 }

--- a/src/Product/Attributes/Size.php
+++ b/src/Product/Attributes/Size.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\SizeInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,30 +28,25 @@ class Size extends AbstractAttribute {
 	}
 
 	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Size', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'Size of the product', 'google-listings-and-ads' );
-	}
-
-	/**
 	 * Return an array of WooCommerce product types that this attribute can be applied to.
 	 *
 	 * @return array
 	 */
 	public static function get_applicable_product_types(): array {
 		return [ 'simple', 'variation' ];
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return SizeInput::class;
 	}
 
 }

--- a/src/Product/Attributes/SizeSystem.php
+++ b/src/Product/Attributes/SizeSystem.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\SizeSystemInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -23,24 +25,6 @@ class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface 
 	 */
 	public static function get_id(): string {
 		return 'sizeSystem';
-	}
-
-	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Size system', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'System in which the size is specified. Recommended for apparel items.', 'google-listings-and-ads' );
 	}
 
 	/**
@@ -74,4 +58,18 @@ class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface 
 			'MEX' => __( 'MEX', 'google-listings-and-ads' ),
 		];
 	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return SizeSystemInput::class;
+	}
+
 }

--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\SizeTypeInput;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -23,24 +25,6 @@ class SizeType extends AbstractAttribute implements WithValueOptionsInterface {
 	 */
 	public static function get_id(): string {
 		return 'sizeType';
-	}
-
-	/**
-	 * Returns a name for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_name(): string {
-		return __( 'Size type', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns a short description for the attribute. Used in attribute's input.
-	 *
-	 * @return string
-	 */
-	public static function get_description(): string {
-		return __( 'The cut of the item. Recommended for apparel items.', 'google-listings-and-ads' );
 	}
 
 	/**
@@ -69,4 +53,18 @@ class SizeType extends AbstractAttribute implements WithValueOptionsInterface {
 			'maternity'    => __( 'Maternity', 'google-listings-and-ads' ),
 		];
 	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 *
+	 * @since x.x.x
+	 */
+	public static function get_input_type(): string {
+		return SizeTypeInput::class;
+	}
+
 }

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -429,8 +429,7 @@ class ProductHelper implements Service {
 	 *
 	 * @return WC_Product The parent product object or the given product object of it doesn't have a parent.
 	 *
-	 * @throws InvalidValue If a given ID doesn't reference a valid product. Or if a variation product does not have a
-	 *                      valid parent ID (i.e. it's an orphan).
+	 * @throws InvalidValue If a variation product does not have a valid parent ID (i.e. it's an orphan).
 	 *
 	 * @since 1.3.0
 	 */

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -427,7 +427,7 @@ class ProductHelper implements Service {
 	 *
 	 * @param WC_Product $product WooCommerce product object.
 	 *
-	 * @return WC_Product The parent product object or the given product object of it doesn't have a parent.
+	 * @return WC_Product The parent product object or the given product object if it doesn't have a parent.
 	 *
 	 * @throws InvalidValue If a variation product does not have a valid parent ID (i.e. it's an orphan).
 	 *

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -680,6 +680,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$metadata->addGetterConstraint( 'salePrice', new GooglePriceConstraint() );
 
 		$metadata->addConstraint( new Assert\Callback( 'validate_item_group_id' ) );
+		$metadata->addConstraint( new Assert\Callback( 'validate_availability' ) );
 
 		$metadata->addPropertyConstraint( 'gtin', new Assert\Regex( '/^\d{8}(?:\d{4,6})?$/' ) );
 		$metadata->addPropertyConstraint( 'mpn', new Assert\Type( 'alnum' ) ); // alphanumeric
@@ -723,6 +724,19 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		if ( $this->is_variation() && empty( $this->getItemGroupId() ) ) {
 			$context->buildViolation( 'ItemGroupId needs to be set for variable products.' )
 					->atPath( 'itemGroupId' )
+					->addViolation();
+		}
+	}
+
+	/**
+	 * Used by the validator to check if the availability date is set for product available as `backorder`.
+	 *
+	 * @param ExecutionContextInterface $context
+	 */
+	public function validate_availability( ExecutionContextInterface $context ) {
+		if ( self::AVAILABILITY_BACKORDER === $this->getAvailability() && empty( $this->getAvailabilityDate() ) ) {
+			$context->buildViolation( 'Availability date is required if you set the product\'s availability to backorder.' )
+					->atPath( 'availabilityDate' )
 					->addViolation();
 		}
 	}

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -40,6 +40,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	public const AVAILABILITY_IN_STOCK     = 'in stock';
 	public const AVAILABILITY_OUT_OF_STOCK = 'out of stock';
 	public const AVAILABILITY_BACKORDER    = 'backorder';
+	public const AVAILABILITY_PREORDER     = 'preorder';
 
 	public const IMAGE_SIZE_FULL = 'full';
 
@@ -308,7 +309,6 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 * @return $this
 	 */
 	protected function map_wc_availability() {
-		// todo: include 'preorder' status (maybe a new field for products / or using an extension?)
 		if ( ! $this->wc_product->is_in_stock() ) {
 			$availability = self::AVAILABILITY_OUT_OF_STOCK;
 		} elseif ( $this->wc_product->is_on_backorder( 1 ) ) {

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -39,6 +39,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 
 	public const AVAILABILITY_IN_STOCK     = 'in stock';
 	public const AVAILABILITY_OUT_OF_STOCK = 'out of stock';
+	public const AVAILABILITY_BACKORDER    = 'backorder';
 
 	public const IMAGE_SIZE_FULL = 'full';
 
@@ -308,7 +309,14 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 */
 	protected function map_wc_availability() {
 		// todo: include 'preorder' status (maybe a new field for products / or using an extension?)
-		$availability = $this->wc_product->is_in_stock() ? self::AVAILABILITY_IN_STOCK : self::AVAILABILITY_OUT_OF_STOCK;
+		if ( ! $this->wc_product->is_in_stock() ) {
+			$availability = self::AVAILABILITY_OUT_OF_STOCK;
+		} elseif ( $this->wc_product->is_on_backorder( 1 ) ) {
+			$availability = self::AVAILABILITY_BACKORDER;
+		} else {
+			$availability = self::AVAILABILITY_IN_STOCK;
+		}
+
 		$this->setAvailability( $availability );
 
 		return $this;

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -729,13 +729,17 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	}
 
 	/**
-	 * Used by the validator to check if the availability date is set for product available as `backorder`.
+	 * Used by the validator to check if the availability date is set for product available as `backorder` or
+	 * `preorder`.
 	 *
 	 * @param ExecutionContextInterface $context
 	 */
 	public function validate_availability( ExecutionContextInterface $context ) {
-		if ( self::AVAILABILITY_BACKORDER === $this->getAvailability() && empty( $this->getAvailabilityDate() ) ) {
-			$context->buildViolation( 'Availability date is required if you set the product\'s availability to backorder.' )
+		if (
+			( self::AVAILABILITY_BACKORDER === $this->getAvailability() || self::AVAILABILITY_PREORDER === $this->getAvailability() ) &&
+			empty( $this->getAvailabilityDate() )
+		) {
+			$context->buildViolation( 'Availability date is required if you set the product\'s availability to backorder or pre-order.' )
 					->atPath( 'availabilityDate' )
 					->addViolation();
 		}

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -115,4 +115,18 @@ class WP {
 	public function is_wp_error( $thing ): bool {
 		return is_wp_error( $thing );
 	}
+
+	/**
+	 * Retrieves the timezone from site settings as a string.
+	 *
+	 * Uses the `timezone_string` option to get a proper timezone if available,
+	 * otherwise falls back to an offset.
+	 *
+	 * @return string PHP timezone string or a ±HH:MM offset.
+	 *
+	 * @since x.x.x
+	 */
+	public function wp_timezone_string(): string {
+		return wp_timezone_string();
+	}
 }

--- a/src/Utility/DateTimeUtility.php
+++ b/src/Utility/DateTimeUtility.php
@@ -1,0 +1,47 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use DateTime;
+use DateTimeZone;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class DateTimeUtility
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Utility
+ *
+ * @since x.x.x
+ */
+class DateTimeUtility implements Service {
+
+	/**
+	 * Convert a timezone offset to the closest matching timezone string.
+	 *
+	 * @param string $timezone
+	 *
+	 * @return string
+	 *
+	 * @throws Exception If the DateTime instantiation fails.
+	 */
+	public function maybe_convert_tz_string( string $timezone ): string {
+		if ( false !== strpos( $timezone, ':' ) ) {
+			[ $hours, $minutes ] = explode( ':', $timezone );
+
+			$dst      = (int) ( new DateTime( 'now', new DateTimeZone( $timezone ) ) )->format( 'I' );
+			$seconds  = $hours * 60 * 60 + $minutes * 60;
+			$tz_name  = timezone_name_from_abbr( '', $seconds, $dst );
+			$timezone = $tz_name !== false ? $tz_name : date_default_timezone_get();
+		}
+
+		if ( 'UTC' === $timezone ) {
+			$timezone = 'Etc/GMT';
+		}
+
+		return $timezone;
+	}
+}

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -602,6 +602,23 @@ DESCRIPTION;
 		$this->assertEquals( WCProductAdapter::AVAILABILITY_IN_STOCK, $adapted_product->getAvailability() );
 	}
 
+	public function test_availability_is_set_to_backorder_if_0_stock_and_backorder_enabled() {
+		$product = WC_Helper_Product::create_simple_product( false );
+		$product->set_manage_stock( true );
+
+		$product->set_stock_status( 'instock' );
+		$product->set_backorders( 'yes' );
+		$product->set_stock_quantity( 0 );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+		$this->assertEquals( WCProductAdapter::AVAILABILITY_BACKORDER, $adapted_product->getAvailability() );
+	}
+
 	public function test_shipping_country_is_set_based_on_target_country() {
 		$product = WC_Helper_Product::create_simple_product( false );
 

--- a/views/inputs/datetime.php
+++ b/views/inputs/datetime.php
@@ -19,28 +19,18 @@ defined( 'ABSPATH' ) || exit;
 $input = $this->input;
 
 $input['class']         = $input['class'] ?? '';
-$input['placeholder']   = $input['placeholder'] ?? '';
-$input['style']         = $input['style'] ?? '';
 $input['wrapper_class'] = $input['wrapper_class'] ?? '';
 $input['name']          = $input['name'] ?? $input['id'];
 $input['desc_tip']      = $input['desc_tip'] ?? false;
 $input['date']          = $input['date'] ?? '';
 $input['time']          = $input['time'] ?? '';
 
-// Custom attribute handling
-$custom_attributes = [];
-if ( ! empty( $input['custom_attributes'] ) && is_array( $input['custom_attributes'] ) ) {
-	foreach ( $input['custom_attributes'] as $attribute => $value ) {
-		$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
-	}
-}
-
 echo '<p class="form-field ' . esc_attr( $input['id'] ) . '_field gla-input-datetime ' . esc_attr( $input['wrapper_class'] ) . '">
 		<label for="' . esc_attr( $input['id'] ) . '_date">' . wp_kses_post( $input['label'] ) . '</label>';
 
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-echo '<input type="date" pattern="\d{4}-\d{2}-\d{2}" class="' . esc_attr( $input['class'] ) . '" style="' . esc_attr( $input['style'] ) . '" name="' . esc_attr( $input['name'] ) . '[date]" id="' . esc_attr( $input['id'] ) . '_date" value="' . esc_attr( $input['date'] ) . '" placeholder="' . esc_attr( $input['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
-echo '<input type="time" pattern="[0-9]{2}:[0-9]{2}" class="' . esc_attr( $input['class'] ) . '" style="' . esc_attr( $input['style'] ) . '" name="' . esc_attr( $input['name'] ) . '[time]" id="' . esc_attr( $input['id'] ) . '_time" value="' . esc_attr( $input['time'] ) . '" placeholder="' . esc_attr( $input['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
+echo '<input type="date" pattern="\d{4}-\d{2}-\d{2}" class="' . esc_attr( $input['class'] ) . '" name="' . esc_attr( $input['name'] ) . '[date]" id="' . esc_attr( $input['id'] ) . '_date" value="' . esc_attr( $input['date'] ) . '" /> ';
+echo '<input type="time" pattern="[0-9]{2}:[0-9]{2}" class="' . esc_attr( $input['class'] ) . '" name="' . esc_attr( $input['name'] ) . '[time]" id="' . esc_attr( $input['id'] ) . '_time" value="' . esc_attr( $input['time'] ) . '" /> ';
 // phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 if ( ! empty( $input['description'] ) && false !== $input['desc_tip'] ) {

--- a/views/inputs/datetime.php
+++ b/views/inputs/datetime.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Datetime input template
+ *
+ * @since x.x.x
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @var \Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView $this
+ */
+
+/**
+ * @var array $input
+ */
+$input = $this->input;
+
+$input['class']         = $input['class'] ?? '';
+$input['placeholder']   = $input['placeholder'] ?? '';
+$input['style']         = $input['style'] ?? '';
+$input['wrapper_class'] = $input['wrapper_class'] ?? '';
+$input['name']          = $input['name'] ?? $input['id'];
+$input['desc_tip']      = $input['desc_tip'] ?? false;
+$input['date']          = $input['date'] ?? '';
+$input['time']          = $input['time'] ?? '';
+
+// Custom attribute handling
+$custom_attributes = [];
+if ( ! empty( $input['custom_attributes'] ) && is_array( $input['custom_attributes'] ) ) {
+	foreach ( $input['custom_attributes'] as $attribute => $value ) {
+		$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
+	}
+}
+
+echo '<p class="form-field ' . esc_attr( $input['id'] ) . '_field gla-input-datetime ' . esc_attr( $input['wrapper_class'] ) . '">
+		<label for="' . esc_attr( $input['id'] ) . '_date">' . wp_kses_post( $input['label'] ) . '</label>';
+
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+echo '<input type="date" pattern="\d{4}-\d{2}-\d{2}" class="' . esc_attr( $input['class'] ) . '" style="' . esc_attr( $input['style'] ) . '" name="' . esc_attr( $input['name'] ) . '[date]" id="' . esc_attr( $input['id'] ) . '_date" value="' . esc_attr( $input['date'] ) . '" placeholder="' . esc_attr( $input['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
+echo '<input type="time" pattern="[0-9]{2}:[0-9]{2}" class="' . esc_attr( $input['class'] ) . '" style="' . esc_attr( $input['style'] ) . '" name="' . esc_attr( $input['name'] ) . '[time]" id="' . esc_attr( $input['id'] ) . '_time" value="' . esc_attr( $input['time'] ) . '" placeholder="' . esc_attr( $input['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
+// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
+
+if ( ! empty( $input['description'] ) && false !== $input['desc_tip'] ) {
+	echo wc_help_tip( $input['description'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+
+if ( ! empty( $input['description'] ) && false === $input['desc_tip'] ) {
+	echo '<span class="description">' . wp_kses_post( $input['description'] ) . '</span>';
+}
+
+echo '</p>';

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -72,6 +72,7 @@ if ( $input_disabled ) {
 				ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
 			],
 			'custom_attributes' => $custom_attributes,
+			'wrapper_class'     => 'form-row form-row-full',
 		]
 	);
 	?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

As part of #738.

This PR adds a `backorder` availability for the products when back-ordering is enabled for a product and its stock status is on backorder (less than or equal to zero).

This also includes some refactoring, mainly applied to the admin inputs and attributes. A new set of input classes are created that each represents the input for an attribute. This way, the attribute's label, and description are defined in their input, which seems more logical given that they're only used in the Admin and not anywhere else the attributes are used.

A new DateTime input type is introduced that uses a set of two HTML inputs (`input type="date"` and `input type="time"`) to get the availability date and time from the user. I first tried to use a third-party DateTime picker library for this but decided to go native HTML instead because these inputs are supported by most modern browsers and by using them we avoid adding yet another library (albeit small) to our package.

This DateTime input assumes that the time entered by the user is based on the site's local timezone and not the browser's; therefore, the time is always converted to UTC when stored in the database and then back to the site's timezone when displaying to the user.

### Compatibility with [WooCommerce Pre-Orders](https://woocommerce.com/products/woocommerce-pre-orders/)

Note that since this PR was the base for the Pre-Order PR (https://github.com/woocommerce/google-listings-and-ads/pull/959) and the other one got merged, any code related to Pre-Orders is previously reviewed and can be safely ignored. Although it would be a good idea to test these two functionalities together. 

For example, since the pre-orders integration hooks into the `woocommerce_gla_product_attribute_values` action, it will override the availability date set by the user in the GLA section if pre-orders is enabled for the product and an availability date value is set in the Pre-Orders extension.

### Detailed test instructions:

1. Create a new product or edit an existing one
2. From `Inventory` enable `Manage Stock?` and `Allow Backorders?` for that product
3. Make sure it has a negative or zero stock quantity
4. Under the GLA tab of the product edit page, set the availability date to a valid date. You can also set the time but it's optional. Time is set in the site's timezone but stored in DB in UTC, so please check that the timezone conversion applies correctly.
5. Update the product and wait for it to be synced to Merchant Center
6. Confirm that the product's availability in MC is now set to "Backorder" instead of "In Stock" and the availability date and time are set correctly (also check the timezone).
7. Remove the availability date and update the product
8. Confirm that the availability date is deleted from product metadata and MC

**Test compatibility with WooCommerce Pre-Orders**

1. Install and activate [WooCommerce Pre-Orders](https://woocommerce.com/products/woocommerce-pre-orders/)
2. Enable pre-orders for the product and set an availability date via the Pre-Orders extension
3. Set a different availability date in the GLA section and also allow back orders for the product
4. Update the product and wait for it to sync
5. Confirm that the product availability is now set to "preorder" and its availability date is the one set via the Pre-Orders extension


### Changelog entry

> Add - Allow backorder stock availability for products

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->