### PR TITLE
Silently log exception when checking MC contact info

### DIFF
--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
@@ -322,7 +323,17 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			'address'      => false,
 		];
 
-		$contact_info = $this->container->get( ContactInformation::class )->get_contact_information();
+		try {
+			$contact_info = $this->container->get( ContactInformation::class )->get_contact_information();
+		} catch ( MerchantApiException $exception ) {
+			do_action(
+				'woocommerce_gla_debug_message',
+				'Error retrieving Merchant Center account\'s business information.',
+				__METHOD__
+			);
+
+			return false;
+		}
 
 		if ( $contact_info instanceof AccountBusinessInformation ) {
 			$is_setup['phone_number'] = ! empty( $contact_info->getPhoneNumber() );

--- a/src/Notes/ContactInformation.php
+++ b/src/Notes/ContactInformation.php
@@ -88,7 +88,7 @@ class ContactInformation implements Deactivateable, Service, Registerable, Optio
 			return false;
 		}
 
-		if ( ! $this->merchant_center->is_setup_complete() ) {
+		if ( ! $this->merchant_center->is_connected() ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

We check if Merchant Center contact information is set up on `admin_init` (`\Automattic\WooCommerce\GoogleListingsAndAds\Notes\ContactInformation`) so that we can add a WC Note to the admin. This was causing a fatal error for some users when they upgraded to v1.4.0 if they didn't have their MC account connected.

Related support thread: https://wordpress.org/support/topic/fatal-error-unable-to-retrieve-merchant-center-account/

### Detailed test instructions:

1. Disconnect your Google MC account
2. Deactivate and then activate the plugin
3. There should not be any fatal errors when activating the plugin


### Changelog entry

> Fix - Fatal error when activating plugin with no Merchant Center account connected.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->