### PR TITLE
Remove file autoloads for namespaced packages

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -171,7 +171,7 @@ function remove_file_autoloads( string $file, array $composer_json, string $pack
 		foreach( $package['autoload']['files'] as $autoload_file ) {
 
 			// Confirm we already include this autoload in the main composer file.
-			$filename = 'vendor/' . $package['name'] . '/' . $autoload_file;
+			$filename = "vendor/{$package['name']}/{$autoload_file}";
 			if ( in_array( $filename, $composer_json['autoload']['files'] ?? [], true ) ) {
 				continue;
 			}

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -111,6 +111,15 @@ foreach ( $replacements as $namespace => $path ) {
 	);
 }
 
+/**
+ * Find a list of PHP files for this package, and append a list of dependent
+ * files that use the package.
+ *
+ * @since 1.1.0
+ *
+ * @param string $path Package path
+ * @return array Merged list of files
+ */
 function find_files( string $path ): array {
 	global $vendor_dir, $dependencies;
 
@@ -136,6 +145,15 @@ function find_files( string $path ): array {
 	return $files;
 }
 
+/**
+ * Replace namespace strings with a JSON file.
+ *
+ * @since 1.2.0
+ *
+ * @param string $file          Filename to replace the strings
+ * @param string $namespace     Namespace to search for
+ * @param string $new_namespace Namespace to replace with
+ */
 function replace_in_json_file( string $file, string $namespace, string $new_namespace ) {
 	if ( ! file_exists( $file ) ) {
 		return;
@@ -152,6 +170,18 @@ function replace_in_json_file( string $file, string $namespace, string $new_name
 	);
 }
 
+/**
+ * Removes any autoload files from a package, and confirms they are loaded from the main composer.json file.
+ * This ensures that the generated file vendor/composer/autoload_files.php will only autoload the files once,
+ * using the new namespace. Autoloading the files from our main composer.json ensures we use a unique hash so
+ * we don't conflict with other extensions autoloading the same files.
+ *
+ * @since x.x.x
+ *
+ * @param string $file              Generated file containing information about all the installed packages
+ * @param array  $composer_autoload List of autoloaded files in composer.json
+ * @param string $package_name      Name of the package we are replacing
+ */
 function remove_file_autoloads( string $file, array $composer_autoload, string $package_name ) {
 	if ( ! file_exists( $file ) ) {
 		return;

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -71,8 +71,8 @@ foreach ( $replacements as $namespace => $path ) {
 		);
 
 		if ( ! empty( $direct_replacements[ $path ] ) ) {
-			foreach( $direct_replacements[ $path ] as $replace ) {
-				$replace = preg_quote( $replace, '#' );
+			foreach ( $direct_replacements[ $path ] as $replace ) {
+				$replace  = preg_quote( $replace, '#' );
 				$contents =	preg_replace(
 					"#({$replace})#m",
 					"{$new_namespace}\\\\\$1",
@@ -118,7 +118,7 @@ function find_files( string $path ): array {
 	);
 
 	if ( ! empty( $dependencies[ $path ] ) ) {
-		foreach( $dependencies[ $path ] as $dependency ) {
+		foreach ( $dependencies[ $path ] as $dependency ) {
 			$dependent_files = array_filter(
 				explode(
 					"\n",
@@ -159,7 +159,7 @@ function remove_file_autoloads( string $file, array $composer_json, string $pack
 	}
 
 	$modified = false;
-	foreach( $json['packages'] as $key => $package ) {
+	foreach ( $json['packages'] as $key => $package ) {
 		if ( 0 !== strpos( $package['name'], $package_name ) ) {
 			continue;
 		}
@@ -168,7 +168,7 @@ function remove_file_autoloads( string $file, array $composer_json, string $pack
 			continue;
 		}
 
-		foreach( $package['autoload']['files'] as $autoload_file ) {
+		foreach ( $package['autoload']['files'] as $autoload_file ) {
 
 			// Confirm we already include this autoload in the main composer file.
 			$filename = "vendor/{$package['name']}/{$autoload_file}";

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -104,7 +104,11 @@ foreach ( $replacements as $namespace => $path ) {
 	replace_in_json_file( "{$vendor_dir}/composer/installed.json", $namespace, $new_namespace );
 
 	// Remove file autoloads from vendor/composer/installed.json
-	remove_file_autoloads( "{$vendor_dir}/composer/installed.json", $composer_json, $path );
+	remove_file_autoloads(
+		"{$vendor_dir}/composer/installed.json",
+		$composer_json['autoload']['files'] ?? [],
+		$path
+	);
 }
 
 function find_files( string $path ): array {
@@ -148,7 +152,7 @@ function replace_in_json_file( string $file, string $namespace, string $new_name
 	);
 }
 
-function remove_file_autoloads( string $file, array $composer_json, string $package_name ) {
+function remove_file_autoloads( string $file, array $composer_autoload, string $package_name ) {
 	if ( ! file_exists( $file ) ) {
 		return;
 	}
@@ -172,7 +176,7 @@ function remove_file_autoloads( string $file, array $composer_json, string $pack
 
 			// Confirm we already include this autoload in the main composer file.
 			$filename = "vendor/{$package['name']}/{$autoload_file}";
-			if ( in_array( $filename, $composer_json['autoload']['files'] ?? [], true ) ) {
+			if ( in_array( $filename, $composer_autoload, true ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We added the loading of the function_includes files directly to our [composer.json](https://github.com/woocommerce/google-listings-and-ads/blob/1.4.0/composer.json#L35-L39) file. Note that we need to load these files directly to support deprecated functions. The Google Ads library > GAX relies on some deprecated functions, so until that's updated we will need to resolve the conflict with any other plugins/themes that use deprecated functions.

The technique we use works great for `google-listings-and-ads` to enforce that the re-named versions are loaded. However loading from the main composer.json file, actually adds the files a second time to the `vendor/composer/autoload_files.php` file. The hash is generated with `package name + file path`, so even if it's already loaded by another plugin, we still load it with our GLA package name.
In the case of a theme (or a plugin which is loaded after ours) they are loaded later, so we claim both the hash `guzzlehttp/guzzle ... functions_include.php` and `woocommerce/google-listings-and-ads ... functions_include.php` which both load our namespaced versions. So any call to a deprecated function using the original namespace (GuzzleHttp) will fail.

So to summarize our method works if a plugin loads guzzle first and we load our namespaced version after, but the other way around, and the deprecated functions are missing (only loaded for our new namespace name).

Note: The scope of conflicts here is limited because both of the following requirements must be true.
- Plugin / theme is loaded after the `google-listings-and-ads` extension
- Plugin / theme uses deprecated Guzzle functions

What this PR does is update the file `vendor/composer/installed.json` and removes any `autoload > files`. In addition to this it checks to confirm that the file is included in the main composer.json file, if it is not it will fail with an error which must be fixed before composer install can be run.

Closes #952

Example theme which uses a deprecated function:
[storefront-child.zip](https://github.com/woocommerce/google-listings-and-ads/files/6975492/storefront-child.zip)

With `google-listings-and-ads` activated this child theme will fail with the error:

```
[12-Aug-2021 12:14:24 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function GuzzleHttp\choose_handler() in wp-content/themes/storefront-child/functions.php:14
```

If we deactivate `google-listings-and-ads` it doesn't give any issues.

### Detailed test instructions:

1. Deactivate the `google-listings-and-ads` extension
2. Install the example child theme (needs storefront installed)
3. Run `composer install` within the child theme directory
4. Activate `google-listings-and-ads` and observe the fatal error
5. Checkout this PR
6. Run `rm -rf vendor && composer install`
7. Reactivate `google-listings-and-ads` and confirm that the fatal no longer occurs
8. Test some requests from the Connection Test page and confirm they complete without errors
9. In particular test the request "Get Campaigns from Google Ads" as this uses some deprecated functions from the Guzzle package

### Changelog entry
* Fix - Remove file autoloads for namespaced packages.
