### PR TITLE
Add integration with WooCommerce Pre Orders extension

### DIFF
--- a/src/Integration/WooCommercePreOrders.php
+++ b/src/Integration/WooCommercePreOrders.php
@@ -1,0 +1,71 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Integration;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
+use WC_Pre_Orders_Product;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WooCommercePreOrders
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Integration
+ *
+ * @link https://woocommerce.com/products/woocommerce-pre-orders/
+ *
+ * @since x.x.x
+ */
+class WooCommercePreOrders implements IntegrationInterface {
+
+	/**
+	 * Returns whether the integration is active or not.
+	 *
+	 * @return bool
+	 */
+	public function is_active(): bool {
+		return defined( 'WC_PRE_ORDERS_VERSION' );
+	}
+
+	/**
+	 * Initializes the integration (e.g. by registering the required hooks, filters, etc.).
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_filter(
+			'woocommerce_gla_product_attribute_values',
+			function ( array $attributes, WC_Product $product ) {
+				return $this->maybe_set_preorder_availability( $attributes, $product );
+			},
+			2,
+			10
+		);
+	}
+
+	/**
+	 * Sets the product's availability to "preorder" if it's in-stock and can be pre-ordered.
+	 *
+	 * @param array      $attributes
+	 * @param WC_Product $product
+	 *
+	 * @return array
+	 */
+	protected function maybe_set_preorder_availability( array $attributes, WC_Product $product ): array {
+		if ( $product->is_in_stock() && WC_Pre_Orders_Product::product_can_be_pre_ordered( $product ) ) {
+			$attributes['availability'] = WCProductAdapter::AVAILABILITY_PREORDER;
+
+			$timestamp = WC_Pre_Orders_Product::get_localized_availability_datetime_timestamp( $product );
+			if ( ! empty( $timestamp ) ) {
+				// Convert the timestamp back to UTC.
+				// The localized offset is already applied to timestamp by WC_Pre_Orders_Product.
+				$utc_timestamp                  = $timestamp - wc_timezone_offset();
+				$attributes['availabilityDate'] = gmdate( 'c', intval( $utc_timestamp ) );
+			}
+		}
+
+		return $attributes;
+	}
+}

--- a/src/Integration/WooCommercePreOrders.php
+++ b/src/Integration/WooCommercePreOrders.php
@@ -117,6 +117,9 @@ class WooCommercePreOrders implements IntegrationInterface {
 	/**
 	 * Triggers an update job for the product to be synced with Merchant Center.
 	 *
+	 * This is required because WooCommerce Pre-orders updates the product's metadata via `update_post_meta`, which
+	 * does not automatically trigger a sync.
+	 *
 	 * @hooked wc_pre_orders_pre_orders_disabled_for_product
 	 *
 	 * @param mixed $product_id

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceProductBu
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceSubscriptions;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 defined( 'ABSPATH' ) || exit;
@@ -45,7 +46,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceBrands::class, WP::class );
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommerceSubscriptions::class );
-		$this->share_with_tags( WooCommercePreOrders::class );
+		$this->share_with_tags( WooCommercePreOrders::class, ProductHelper::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceBrands;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommercePreOrders;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceProductBundles;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WooCommerceSubscriptions;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
@@ -44,6 +45,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceBrands::class, WP::class );
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommerceSubscriptions::class );
+		$this->share_with_tags( WooCommercePreOrders::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -429,8 +429,7 @@ class ProductHelper implements Service {
 	 *
 	 * @return WC_Product The parent product object or the given product object of it doesn't have a parent.
 	 *
-	 * @throws InvalidValue If a given ID doesn't reference a valid product. Or if a variation product does not have a
-	 *                      valid parent ID (i.e. it's an orphan).
+	 * @throws InvalidValue If a variation product does not have a valid parent ID (i.e. it's an orphan).
 	 *
 	 * @since 1.3.0
 	 */

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -427,7 +427,7 @@ class ProductHelper implements Service {
 	 *
 	 * @param WC_Product $product WooCommerce product object.
 	 *
-	 * @return WC_Product The parent product object or the given product object of it doesn't have a parent.
+	 * @return WC_Product The parent product object or the given product object if it doesn't have a parent.
 	 *
 	 * @throws InvalidValue If a variation product does not have a valid parent ID (i.e. it's an orphan).
 	 *

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -40,6 +40,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	public const AVAILABILITY_IN_STOCK     = 'in stock';
 	public const AVAILABILITY_OUT_OF_STOCK = 'out of stock';
 	public const AVAILABILITY_BACKORDER    = 'backorder';
+	public const AVAILABILITY_PREORDER     = 'preorder';
 
 	public const IMAGE_SIZE_FULL = 'full';
 
@@ -308,7 +309,6 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 * @return $this
 	 */
 	protected function map_wc_availability() {
-		// todo: include 'preorder' status (maybe a new field for products / or using an extension?)
 		if ( ! $this->wc_product->is_in_stock() ) {
 			$availability = self::AVAILABILITY_OUT_OF_STOCK;
 		} elseif ( $this->wc_product->is_on_backorder( 1 ) ) {

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -729,13 +729,17 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	}
 
 	/**
-	 * Used by the validator to check if the availability date is set for product available as `backorder`.
+	 * Used by the validator to check if the availability date is set for product available as `backorder` or
+	 * `preorder`.
 	 *
 	 * @param ExecutionContextInterface $context
 	 */
 	public function validate_availability( ExecutionContextInterface $context ) {
-		if ( self::AVAILABILITY_BACKORDER === $this->getAvailability() && empty( $this->getAvailabilityDate() ) ) {
-			$context->buildViolation( 'Availability date is required if you set the product\'s availability to backorder.' )
+		if (
+			( self::AVAILABILITY_BACKORDER === $this->getAvailability() || self::AVAILABILITY_PREORDER === $this->getAvailability() ) &&
+			empty( $this->getAvailabilityDate() )
+		) {
+			$context->buildViolation( 'Availability date is required if you set the product\'s availability to backorder or pre-order.' )
 					->atPath( 'availabilityDate' )
 					->addViolation();
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

As part of #738.

This PR will add support for the `preorder` product availability if the [WooCommerce Pre-Orders](https://woocommerce.com/products/woocommerce-pre-orders/) extension is installed and activated. 

If a product has pre-orders enabled then we set its availability to `preorder`. However, once a `preorder` product goes out-of-stock and doesn't allow back ordering then we set it to `out-of-stock instead of `preorder`. This is to mimic the functionality of Pre Orders extension because the out-of-stock products are not available for pre-order.

Even though the usage of `availabilityDate` for pre-order products [is required in Google](https://support.google.com/merchants/answer/6324470), [WooCommerce Pre-Orders](https://woocommerce.com/products/woocommerce-pre-orders/) doesn't enforce that and has made it optional. To get around this, there is a new validation constraint for products that checks the availabilityDate has been set if the product is on backorder or pre-order.


### Detailed test instructions:

1. Install and configure [WooCommerce Pre-Orders](https://woocommerce.com/products/woocommerce-pre-orders/)
2. Edit a product and enabled pre-orders for it but do not set an availability date
3. Update the product and confirm that it has not synced and there is a pre-sync validation error for availabilityDate.
4. Set the availability date for the product
5. Update and sync the product again
6. This time the product should be synced successfully to MC and its availability and availabilityDate must be set accordingly
7. Check that the timezone is calculated correctly for the availability date by setting a different timezone on your store and checking the availability time in MC


### Changelog entry

> Add - Set pre-order availability for products using the WooCommerce Pre-Orders extension.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
Otherwise, the title of Pull Request will be used as the changelog entry.  
-->