### PR TITLE
Clarify "otherwise" in PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,6 @@ Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
 > Tweak - I made a small change.
 > Update - I made big changes to something that wasn't broken.
 
-Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
+Or leave the "Changelog entry" header in place completely empty, without any summary and **without this comment** if no changelog entry is needed.  
 If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.  
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,5 +33,5 @@ Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
 > Update - I made big changes to something that wasn't broken.
 
 Or leave the "Changelog entry" header in place without any summary if no changelog entry is needed.  
-Otherwise, the title of Pull Request will be used as the changelog entry.  
+If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.  
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,10 +19,6 @@ _Replace this with a good description of your changes & reasoning._
 3. 
 
 
-### Changelog entry
-
-> 
-
 <!--
 Optional.
 Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
@@ -32,6 +28,9 @@ Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
 > Tweak - I made a small change.
 > Update - I made big changes to something that wasn't broken.
 
-Or leave the "Changelog entry" header in place completely empty, without any summary and **without this comment** if no changelog entry is needed.
+Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
 If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
 -->
+### Changelog entry
+
+>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,13 +25,13 @@ _Replace this with a good description of your changes & reasoning._
 
 <!--
 Optional.
-Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. 
+Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
 Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
 > Fix - I took care of something that wasn't working.
 > Add - I added something new that's pretty cool.
 > Tweak - I made a small change.
 > Update - I made big changes to something that wasn't broken.
 
-Or leave the "Changelog entry" header in place completely empty, without any summary and **without this comment** if no changelog entry is needed.  
-If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.  
+Or leave the "Changelog entry" header in place completely empty, without any summary and **without this comment** if no changelog entry is needed.
+If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
 -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Clarify "otherwise" in PR template.

	Personally, I was not sure what "otherwise" in the sentence "Enter something here…, or leave it empty…, otherwise." means.
	Reading the `woorlease` code, I get that it means "remove the section".
- Describe how to get no changelog entry in PR template.
	Somewhat workaround 322-gh-woocommerce/woorelease
	//cc @ecgan, @nima-karimi 
Helps to avoid changelog entries like:
```
* Fix - <!--.
* Fix - Each line should start with `(Fix|Add|Tweak|Update) - `, for example:.
* Fix - Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted. .
* Fix - Optional.
```

### Detailed test instructions:

1. Create new PR, to see the template
2. Make a release :feelsgood: to see how the changelog is parsed.


### Changelog entry
<!-- test 323-gh-woocommerce/woorelease -->
### <!--Test 323-gh-woocommerce/woorelease-->