### PR TITLE
Fix margin/padding styles for the `<AppButton>` when having spinner/icon/text

### DIFF
--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -60,7 +60,7 @@ const AppButton = ( props ) => {
 		text.push( passedInText );
 
 		if ( rest.icon ) {
-			classes.push( 'app-button--fix-padding' );
+			classes.push( 'app-button--icon-with-text' );
 		}
 		if ( rest.iconPosition === 'right' ) {
 			classes.push( 'app-button--icon-position-right' );

--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -36,7 +36,7 @@ const AppButton = ( props ) => {
 		loading,
 		eventName,
 		eventProps,
-		children,
+		text: passedInText,
 		onClick = () => {},
 		...rest
 	} = props;
@@ -49,21 +49,32 @@ const AppButton = ( props ) => {
 		onClick( ...args );
 	};
 
+	const text = [];
 	const classes = [ 'app-button', className ];
-	if ( rest.iconPosition === 'right' ) {
-		classes.push( 'app-button--fix-icon-position-right' );
+
+	if ( loading ) {
+		text.push( <Spinner /> );
+	}
+
+	if ( passedInText ) {
+		text.push( passedInText );
+
+		if ( rest.icon ) {
+			classes.push( 'app-button--fix-padding' );
+		}
+		if ( rest.iconPosition === 'right' ) {
+			classes.push( 'app-button--icon-position-right' );
+		}
 	}
 
 	return (
 		<Button
 			className={ classnames( ...classes ) }
 			disabled={ disabled || loading }
+			text={ text.length ? text : undefined }
 			onClick={ handleClick }
 			{ ...rest }
-		>
-			{ loading && <Spinner /> }
-			{ children }
-		</Button>
+		/>
 	);
 };
 

--- a/js/src/components/app-button/index.scss
+++ b/js/src/components/app-button/index.scss
@@ -22,7 +22,7 @@
 	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L292
 	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L15
 	 */
-	&--fix-padding.has-icon {
+	&--icon-with-text.has-icon {
 		padding: 6px 12px;
 	}
 }

--- a/js/src/components/app-button/index.scss
+++ b/js/src/components/app-button/index.scss
@@ -10,12 +10,19 @@
 		}
 	}
 
-	/**
-	 * Fix that the SVG icon gap to text should be on the left side.
-	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L309-L311
-	 */
-	&--fix-icon-position-right.has-icon.has-text svg {
-		margin-right: 0;
+	// Add a gap between the SVG icon and text when the icon is on the right side.
+	// `:last-child` is to prevent this style apply on the loading <Spinner>.
+	&--icon-position-right.has-icon svg:last-child {
 		margin-left: 8px;
+	}
+
+	/**
+	 * Reset the padding when a button contains both text and icon.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L292
+	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L15
+	 */
+	&--fix-padding.has-icon {
+		padding: 6px 12px;
 	}
 }

--- a/js/src/components/contact-information/store-address-card.scss
+++ b/js/src/components/contact-information/store-address-card.scss
@@ -5,14 +5,6 @@
 		bottom: 0;
 		margin: auto;
 
-		&.has-icon.has-text {
-			justify-content: center;
-
-			svg {
-				margin: 0;
-			}
-		}
-
 		.gridicons-refresh {
 			fill: var(--wp-admin-theme-color);
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up fix from #918.

- Reset to the original `padding` when a `<AppButton>` contains both text and icon. 
    - https://github.com/woocommerce/google-listings-and-ads/pull/918#pullrequestreview-720450325
- Change the appending logic of loading spinner to prevent `<Button>` adding the unsuitable style to SVG icon. 
    - https://github.com/woocommerce/google-listings-and-ads/pull/918#discussion_r681924240

### Screenshots:

Revised button styles are shown on the left side. The right side is the current **trunk** version.

![Kapture 2021-08-17 at 18 00 33](https://user-images.githubusercontent.com/17420811/129707258-aec94f34-44a7-4d2e-beb0-cbb1d33b7fe1.gif)

💡  Please note that I added some examples in the demo GIF to show the difference. But currently, we don't have a use case that has text, icon, and loading state at the same time, such as the loading "Edit in Settings" button shown in the GIF. 

![Kapture 2021-08-17 at 17 40 04](https://user-images.githubusercontent.com/17420811/129711528-e14c611f-1a9e-4317-877a-ee9388471324.gif)

### Detailed test instructions:

1. Browse around to see if buttons are displayed properly.
2. Go to the edit contact info page in GLA Settings to see if:
    1. the refresh icon should be at the center of the clickable area
    ![image](https://user-images.githubusercontent.com/17420811/129710154-5281d8a3-88d8-4889-9aef-76cb65271975.png)
    2. there is a gap between the "Edit in Settings" text and the External Icon, and no `margin-right: 8px` on the icon.
    3. the padding of the "Edit in Settings" button should look nicer than before.
    ![image](https://user-images.githubusercontent.com/17420811/129709887-1e5a7875-2e28-41ef-a214-b56c584a2c04.png)

### Changelog entry

> Fix - Fix margin/padding styles for the AppButton when having spinner/icon/text
