### PR TITLE
Retry account creation after invalid terms

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidTerm;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -82,22 +83,51 @@ class Proxy implements OptionsAwareInterface {
 	/**
 	 * Create a new Merchant Center account.
 	 *
-	 * @return int
+	 * @return int Created merchant account ID
+	 *
 	 * @throws Exception When an Exception is caught or we receive an invalid response.
 	 */
 	public function create_merchant_account(): int {
+		$user = wp_get_current_user();
+		$tos  = $this->mark_tos_accepted( 'google-mc', $user->user_email );
+		if ( ! $tos->accepted() ) {
+			throw new Exception( __( 'Unable to log accepted TOS', 'google-listings-and-ads' ) );
+		}
+
+		$site_url = esc_url_raw( $this->get_site_url() );
+		if ( ! wc_is_valid_url( $site_url ) ) {
+			throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
+		}
+
 		try {
-			$user = wp_get_current_user();
-			$tos  = $this->mark_tos_accepted( 'google-mc', $user->user_email );
-			if ( ! $tos->accepted() ) {
-				throw new Exception( __( 'Unable to log accepted TOS', 'google-listings-and-ads' ) );
-			}
+			return $this->create_merchant_account_request(
+				$this->new_account_name(),
+				$site_url
+			);
+		} catch ( InvalidTerm $e ) {
+			// Try again with a default account name.
+			return $this->create_merchant_account_request(
+				$this->default_account_name(),
+				$site_url
+			);
+		}
+	}
 
-			$site_url = esc_url_raw( $this->get_site_url() );
-			if ( ! wc_is_valid_url( $site_url ) ) {
-				throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
-			}
-
+	/**
+	 * Send a request to create a merchant account.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $name     Site name
+	 * @param string $site_url Website URL
+	 *
+	 * @return int Created merchant account ID
+	 *
+	 * @throws Exception   When an Exception is caught or we receive an invalid response.
+	 * @throws InvalidTerm When the account name contains invalid terms.
+	 */
+	protected function create_merchant_account_request( string $name, string $site_url ): int {
+		try {
 			/** @var Client $client */
 			$client = $this->container->get( Client::class );
 			$result = $client->post(
@@ -105,7 +135,7 @@ class Proxy implements OptionsAwareInterface {
 				[
 					'body' => json_encode(
 						[
-							'name'       => $this->new_account_name(),
+							'name'       => $name,
 							'websiteUrl' => $site_url,
 						]
 					),
@@ -125,12 +155,14 @@ class Proxy implements OptionsAwareInterface {
 			$error = $response['message'] ?? __( 'Invalid response when creating account', 'google-listings-and-ads' );
 			throw new Exception( $error, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
-			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+			$message = $this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) );
 
-			throw new Exception(
-				$this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) ),
-				$e->getCode()
-			);
+			if ( preg_match( '/terms?.* are|is not allowed/', $message ) ) {
+				throw InvalidTerm::contains_invalid_terms( $name );
+			}
+
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+			throw new Exception( $message, $e->getCode() );
 		}
 	}
 
@@ -599,11 +631,26 @@ class Proxy implements OptionsAwareInterface {
 
 	/**
 	 * Generate a descriptive name for a new account.
+	 * Use site name if available.
 	 *
 	 * @return string
 	 */
 	protected function new_account_name(): string {
-		return get_bloginfo( 'name' );
+		$site_name = get_bloginfo( 'name' );
+		return ! empty( $site_name ) ? $site_name : $this->default_account_name();
+	}
+
+	/**
+	 * Generate a default account name based on the date.
+	 *
+	 * @return string
+	 */
+	protected function default_account_name(): string {
+		return sprintf(
+			/* translators: 1: current date in the format Y-m-d */
+			__( 'Account %1$s', 'google-listings-and-ads' ),
+			( new DateTime() )->format( 'Y-m-d' )
+		);
 	}
 
 	/**

--- a/src/Exception/InvalidTerm.php
+++ b/src/Exception/InvalidTerm.php
@@ -1,0 +1,27 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
+
+use InvalidArgumentException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class InvalidTerm
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
+ */
+class InvalidTerm extends InvalidArgumentException implements GoogleListingsAndAdsException {
+
+	/**
+	 * Create a new instance of the exception when a text contains invalid terms.
+	 *
+	 * @param string $text
+	 *
+	 * @return InvalidTerm
+	 */
+	public static function contains_invalid_terms( string $text ): InvalidTerm {
+		return new static( sprintf( 'The text "%s" contains invalid terms.', $text ) );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When creating a new merchant account we originally used just the site name, however there are various cases where that can return an error. This PR resolves two of those cases:

1. Empty site_name, the account name is a required field so we must pass a value. To prevent this we generate a default name in the format `Account Y-m-d`
2. If a forbidden term(s) is used, Google returns an error with the explicit terms which can't be used. We catch the error and try the request again using the same default name in the point above

Closes #956 
Closes #969 

### Detailed test instructions:

Test in combination with PR: 1816-gh-Automattic/woocommerce-connect-server

1. Disconnect Merchant Center account (Connection Test page)
2. Change the site name (Settings > General) to a name containing forbidden terms
3. Send a request to create a new Merchant Account (Connection Test page or onboarding)
4. Check the requests in your local WCS and confirm that the request `/google/manager/create-merchant` was sent twice. The first time should have failed with a 400 error containing a message like:
```
{"message":"[name] These terms are not allowed: 'xxx', 'yyy'","domain":"global","reason":"invalid"}
```
5. Check the created account ID in https://merchants.google.com and confirm that the account name is something like "Account 2021-08-17"
6. In the same dashboard any created test accounts can be removed

### Changelog entry
* Fix - Retry Merchant account creation after detecting invalid terms.