### PR TITLE
Remove all "STEP [NUMBER]" texts from step headers

### DIFF
--- a/js/src/components/free-listings/choose-audience/index.js
+++ b/js/src/components/free-listings/choose-audience/index.js
@@ -21,13 +21,11 @@ import '.~/components/free-listings/choose-audience/index.scss';
  * Copied from {@link .~/setup-mc/setup-stepper/choose-audience/index.js}.
  *
  * @param {Object} props
- * @param {string} props.stepHeader Header text to indicate the step number.
  * @param {string} [props.initialData] Target audience data, if not given AppSinner will be rendered.
  * @param {(change: {name, value}, values: Object) => void} props.onChange Callback called with form data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
  * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked.
  */
 export default function ChooseAudience( {
-	stepHeader,
 	initialData,
 	onChange = () => {},
 	onContinue = () => {},
@@ -60,7 +58,6 @@ export default function ChooseAudience( {
 		<div className="gla-choose-audience">
 			<StepContent>
 				<StepContentHeader
-					step={ stepHeader }
 					title={ __(
 						'Choose your audience',
 						'google-listings-and-ads'

--- a/js/src/components/free-listings/configure-product-listings/hero/index.js
+++ b/js/src/components/free-listings/configure-product-listings/hero/index.js
@@ -12,16 +12,12 @@ import './index.scss';
 
 /**
  * Hero element for free listing configuration.
- *
- * @param {Object} props
- * @param {string} props.stepHeader Header text to indicate the step number.
  */
-const Hero = ( { stepHeader } ) => {
+const Hero = () => {
 	return (
 		<div className="gla-setup-free-listing-hero">
 			<StepContentHeader
 				className="hero-text"
-				step={ stepHeader }
 				title={ __(
 					'Configure your product listings',
 					'google-listings-and-ads'

--- a/js/src/components/stepper/step-content-header/index.js
+++ b/js/src/components/stepper/step-content-header/index.js
@@ -4,11 +4,10 @@
 import './index.scss';
 
 const StepContentHeader = ( props ) => {
-	const { className = '', step, title, description } = props;
+	const { className = '', title, description } = props;
 
 	return (
 		<header className={ `gla-step-content-header ${ className }` }>
-			<p className="step">{ step }</p>
 			<h1>{ title }</h1>
 			<div className="description">{ description }</div>
 		</header>

--- a/js/src/components/stepper/step-content-header/index.scss
+++ b/js/src/components/stepper/step-content-header/index.scss
@@ -8,12 +8,6 @@
 	gap: 12px;
 	margin-bottom: var(--large-gap);
 
-	.step {
-		font-size: 14px;
-		font-weight: 600;
-		margin: 0;
-	}
-
 	h1 {
 		font-size: 32px;
 		font-weight: 400;

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -240,10 +240,6 @@ export default function EditFreeCampaign() {
 						),
 						content: (
 							<ChooseAudience
-								stepHeader={ __(
-									'STEP ONE',
-									'google-listings-and-ads'
-								) }
 								initialData={ targetAudience }
 								onChange={ ( change, newTargetAudience ) =>
 									updateTargetAudience( newTargetAudience )
@@ -261,10 +257,6 @@ export default function EditFreeCampaign() {
 						),
 						content: (
 							<SetupFreeListings
-								stepHeader={ __(
-									'STEP TWO',
-									'google-listings-and-ads'
-								) }
 								countries={ getFinalCountries(
 									targetAudience
 								) }

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -25,7 +25,6 @@ import FormContent from './form-content';
  * without any save strategy, this is to be bound externaly.
  *
  * @param {Object} props
- * @param {string} props.stepHeader Header text to indicate the step number.
  * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to FormContent.
  * @param {Object} props.settings Settings data, if not given AppSpinner will be rendered.
  * @param {(change: {name, value}, values: Object) => void} props.onSettingsChange Callback called with new data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
@@ -37,7 +36,6 @@ import FormContent from './form-content';
  * @param {string} [props.submitLabel] Submit button label, to be forwarded to `FormContent`.
  */
 const SetupFreeListings = ( {
-	stepHeader,
 	countries,
 	settings,
 	onSettingsChange = () => {},
@@ -96,7 +94,7 @@ const SetupFreeListings = ( {
 
 	return (
 		<div className="gla-setup-free-listings">
-			<Hero stepHeader={ stepHeader } />
+			<Hero />
 			<Form
 				initialValues={ {
 					shipping_rate: settings.shipping_rate,

--- a/js/src/setup-ads/ads-stepper/create-campaign/index.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/index.js
@@ -21,7 +21,6 @@ const CreateCampaign = ( props ) => {
 	return (
 		<StepContent>
 			<StepContentHeader
-				step={ __( 'STEP TWO', 'google-listings-and-ads' ) }
 				title={ __(
 					'Create your paid campaign',
 					'google-listings-and-ads'

--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.js
@@ -30,7 +30,6 @@ const SetupAccounts = ( props ) => {
 	return (
 		<StepContent>
 			<StepContentHeader
-				step={ __( 'STEP ONE', 'google-listings-and-ads' ) }
 				title={ __(
 					'Set up your accounts',
 					'google-listings-and-ads'

--- a/js/src/setup-ads/ads-stepper/setup-billing/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-billing/index.js
@@ -31,7 +31,6 @@ const SetupBilling = ( props ) => {
 	return (
 		<StepContent>
 			<StepContentHeader
-				step={ __( 'STEP THREE', 'google-listings-and-ads' ) }
 				title={ __( 'Set up billing', 'google-listings-and-ads' ) }
 				description={
 					billingStatus.status === 'approved'

--- a/js/src/setup-mc/setup-stepper/choose-audience/index.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/index.js
@@ -58,7 +58,6 @@ const ChooseAudience = ( props ) => {
 		<div className="gla-choose-audience">
 			<StepContent>
 				<StepContentHeader
-					step={ __( 'STEP TWO', 'google-listings-and-ads' ) }
 					title={ __(
 						'Choose your audience',
 						'google-listings-and-ads'

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -40,7 +40,6 @@ const SetupAccounts = ( props ) => {
 	return (
 		<StepContent>
 			<StepContentHeader
-				step={ __( 'STEP ONE', 'google-listings-and-ads' ) }
 				title={ __(
 					'Set up your accounts',
 					'google-listings-and-ads'

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -65,9 +65,7 @@ const SetupFreeListings = ( props ) => {
 
 	return (
 		<div className="gla-setup-free-listings">
-			<Hero
-				stepHeader={ __( 'STEP THREE', 'google-listings-and-ads' ) }
-			/>
+			<Hero />
 			<Form
 				initialValues={ {
 					shipping_rate: settings.shipping_rate,

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -83,7 +83,6 @@ export default function StoreRequirements() {
 	return (
 		<StepContent>
 			<StepContentHeader
-				step={ __( 'STEP FOUR', 'google-listings-and-ads' ) }
 				title={ __(
 					'Confirm store requirements',
 					'google-listings-and-ads'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #923.

Remove all "STEP [NUMBER]" texts from step headers on these pages:

- onboarding setup
- paid campaign setup
- free listings edit

### Screenshots:

- Onboarding setup
    ![Kapture 2021-08-19 at 11 52 47](https://user-images.githubusercontent.com/17420811/130007142-f7d2faab-0fdd-436e-9173-428207211598.gif)
- Paid campaign setup
    ![Kapture 2021-08-19 at 12 07 19](https://user-images.githubusercontent.com/17420811/130007184-32d0de2e-9ab7-4d0d-ac07-e72e23f9e7fb.gif)
- Free listings edit
    ![Kapture 2021-08-19 at 12 00 41](https://user-images.githubusercontent.com/17420811/130007174-8e9a6b84-87a7-474c-ab7e-2fbf03a7e6e1.gif)

### Detailed test instructions:

Go to the above pages to see if the "STEP [NUMBER]" texts have been removed. 

### Changelog entry

> Tweak - Remove all "STEP [NUMBER]" texts from step headers on the onboarding setup, paid campaign setup, and free listings edit pages.
