### PR TITLE
Update contributor guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,8 @@ Please see [SECURITY.md](./SECURITY.md).
 Feature requests can be submitted to our [ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=403986). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
 
 ## Getting started
-* [Git Flow](https://github.com/woocommerce/google-listings-and-ads/wiki/Git-Flow)
-* [Writing Code & Requesting a Review](https://github.com/woocommerce/google-listings-and-ads/wiki/Working-With-Code#writing-code-and-requesting-a-review)
-* [Reviewing Code](https://github.com/woocommerce/google-listings-and-ads/wiki/Working-With-Code#reviewing-code)
-* [Development Docs, Guides & Best Practices](https://github.com/woocommerce/google-listings-and-ads/wiki/Development-Docs,-Guides-&-Best-Practices)
+
+-   [Git Flow](https://github.com/woocommerce/google-listings-and-ads/wiki/Git-Flow)
+-   [Writing Code & Requesting a Review](https://github.com/woocommerce/google-listings-and-ads/wiki/Working-With-Code#writing-code-and-requesting-a-review)
+-   [Reviewing Code](https://github.com/woocommerce/google-listings-and-ads/wiki/Working-With-Code#reviewing-code)
+-   [Development Docs, Guides & Best Practices](https://github.com/woocommerce/google-listings-and-ads/wiki/Development-Docs,-Guides-&-Best-Practices)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,6 +6,20 @@ Thanks for your interest in contributing to Google Listings and Ads!
 
 Like the WooCommerce project, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
+If you wish to contribute code, please read the information in the sections below. Then [fork](https://help.github.com/articles/fork-a-repo/) Google Listings & Ads, commit your changes, and [submit a pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) 🎉
+
+Google Listings & Ads is licensed under the GPLv3+, and all contributions to the project will be released under the same license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv3+ license.
+
 ## Reporting Security Issues
 
 Please see [SECURITY.md](./SECURITY.md).
+
+## Feature Requests
+
+Feature requests can be submitted to our [ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=403986). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+
+## Getting started
+* [Git Flow](https://github.com/woocommerce/google-listings-and-ads/wiki/Git-Flow)
+* [Writing Code & Requesting a Review](https://github.com/woocommerce/google-listings-and-ads/wiki/Working-With-Code#writing-code-and-requesting-a-review)
+* [Reviewing Code](https://github.com/woocommerce/google-listings-and-ads/wiki/Working-With-Code#reviewing-code)
+* [Development Docs, Guides & Best Practices](https://github.com/woocommerce/google-listings-and-ads/wiki/Development-Docs,-Guides-&-Best-Practices)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates contributor guidelines, pointing to Wiki articles we can tweak/maintain as needed.

Preparing for contributions from outside of the Woo Ventures team so that we have a common understanding (based on some of our internal docs)