### PR TITLE
Add few more e2e tests, with browser-mocked Jetpack and Google connection

### DIFF
--- a/tests/e2e/specs/get-started.test.js
+++ b/tests/e2e/specs/get-started.test.js
@@ -1,11 +1,16 @@
-const { merchant } = require( '@woocommerce/e2e-utils' );
+/**
+ * External dependencies
+ */
+import {
+	merchant, // eslint-disable-line import/named
+} from '@woocommerce/e2e-utils';
 
 describe( 'Merchant who is getting started', () => {
 	beforeAll( async () => {
 		await merchant.login();
 	} );
 
-	it( 'Clicks on the Marketing > GLA link, clicks on the call-to-action setup button to go to the Setup MC page', async () => {
+	it( 'Clicks on the Marketing > GLA link, clicks on the call-to-action setup button to go to the Setup MC page, should get to the accounts setup', async () => {
 		// hover at the marketing link to open popup submenu.
 		const marketingLink = (
 			await page.$x( "//a[contains(., 'Marketing')]" )
@@ -26,8 +31,9 @@ describe( 'Merchant who is getting started', () => {
 		await glaLink.click();
 
 		await page.waitForNavigation();
-		const pageTitle = await page.title();
-		expect( pageTitle ).toContain( 'Google Listings & Ads' );
+		await expect( page.title() ).resolves.toContain(
+			'Google Listings & Ads'
+		);
 
 		// click on the call-to-action button.
 		const setupButton = (
@@ -36,19 +42,20 @@ describe( 'Merchant who is getting started', () => {
 		await setupButton.click();
 		await page.waitForNavigation();
 
-		// check we are in the Setup MC Step 1 page.
-		const topBarText = (
-			await page.$x(
+		// Check we are in the Setup MC page.
+		await expect(
+			page.waitForXPath(
 				"//*[text()='Get started with Google Listings & Ads']"
 			)
-		 )[ 0 ];
-		expect( topBarText ).toBeTruthy();
+		).resolves.toBeTruthy();
 
-		// there are some API calls running in the page before the steps are displayed.
-		// wait for the text in Step 1 to show up.
-		const step1Text = await page.waitForXPath(
-			"//*[text()='Set up your accounts']"
-		);
-		expect( step1Text ).toBeTruthy();
+		// There are some API calls running in the page before the steps are displayed.
+		// Assert we eventually see the setup page Step 1 header.
+		await expect(
+			page.waitForXPath( "//*[text()='Set up your accounts']" )
+		).resolves.toBeTruthy();
+
+		// Expect to land on the setup page URL.
+		expect( page.url() ).toMatch( /path=%2Fgoogle%2Fsetup-mc/ );
 	} );
 } );

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -1,0 +1,187 @@
+/**
+ * External dependencies
+ */
+import {
+	merchant, // eslint-disable-line import/named
+} from '@woocommerce/e2e-utils';
+/**
+ * Internal dependencies
+ */
+import { createURL } from '../../utils/create-url';
+import { visitGLAPage } from '../../utils/visit-gla-page';
+import { RequestMock } from '../../utils/request-mock';
+
+const requestMock = new RequestMock();
+
+describe( 'At setup page', () => {
+	beforeAll( async () => {
+		await merchant.login();
+	} );
+	afterAll( () => {
+		requestMock.disconnect();
+	} );
+
+	afterEach( async function goToSetup() {
+		requestMock.restore();
+	} );
+
+	describe( 'Merchant who is getting started', () => {
+		beforeEach( async function goToSetup() {
+			// Go to the setup page short way - directly via URL.
+			await visitGLAPage( { path: '/google/setup-mc' } );
+		} );
+
+		it( 'should see accounts step header, "Connect your WordPress.com account" & connect button', async () => {
+			// Wait for API calls and the page to render.
+			await expect(
+				page.waitForXPath( "//*[text()='Set up your accounts']" )
+			).resolves.toBeTruthy();
+
+			await expect(
+				page.waitForXPath(
+					"//*[text()='Connect your WordPress.com account']"
+				)
+			).resolves.toBeTruthy();
+
+			expect(
+				page.$x( "//button[text()='Connect'][not(@disabled)]" )
+			).toBeTruthy();
+		} );
+
+		describe( 'after clicking the "Connect your WordPress.com account" button', () => {
+			let jetpackConnectMock;
+
+			beforeEach( async function mockJetpackConnect() {
+				await requestMock.observe( page );
+
+				jetpackConnectMock = requestMock
+					// Match "connect" not "connected".
+					.mock( /%2Fwc%2Fgla%2Fjetpack%2Fconnect\b/ )
+					.mockImplementation( ( interceptedRequest ) => {
+						// Mock connected
+						interceptedRequest.respond( {
+							content: 'application/json',
+							headers: { 'Access-Control-Allow-Origin': '*' },
+							body: JSON.stringify( {
+								url: createURL( '/auth/url/' ),
+							} ),
+						} );
+						return true;
+					} );
+			} );
+
+			it( 'should sent an API request to connect Jetpack, and redirect to the returned URL', async () => {
+				// Wait for enabled button.
+				const connectWPButton = await page.waitForXPath(
+					"//button[text()='Connect'][not(@disabled)]"
+				);
+
+				// Click the button.
+				await connectWPButton.click();
+
+				// Wait for all XHRs and redirects.
+				await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+
+				// Expect Jetpack call to be executed.
+				expect( jetpackConnectMock ).toBeCalled();
+				// Expect the user to be redirected
+				expect( page.url() ).toEqual( createURL( '/auth/url/' ) );
+			} );
+		} );
+	} );
+	describe( 'Merchant who has their Jetpack connected, but Google not yet connected', () => {
+		beforeEach( async function goToSetup() {
+			// Mock Jetpack as connected
+			await requestMock.observe( page );
+			requestMock
+				.mock( /%2Fwc%2Fgla%2Fjetpack%2Fconnected\b/ )
+				.mockImplementation( ( interceptedRequest ) => {
+					interceptedRequest.respond( {
+						content: 'application/json',
+						headers: { 'Access-Control-Allow-Origin': '*' },
+						body: JSON.stringify( {
+							active: 'yes',
+							owner: 'yes',
+							displayName: 'testUser',
+							email: 'mail@example.com',
+						} ),
+					} );
+					return true;
+				} );
+
+			// Mock google as not connected.
+			// When pending even WPORG will not render yet.
+			// If not mocked will fail and render nothing,
+			// as Jetpack is mocked only on the client-side.
+			requestMock
+				.mock( /%2Fwc%2Fgla%2Fgoogle%2Fconnected\b/ )
+				.mockImplementation( ( interceptedRequest ) => {
+					interceptedRequest.respond( {
+						content: 'application/json',
+						headers: { 'Access-Control-Allow-Origin': '*' },
+						body: JSON.stringify( {
+							active: 'no',
+							email: '',
+						} ),
+					} );
+
+					return true;
+				} );
+
+			// Go to the setup page short way - directly via URL.
+			await visitGLAPage( { path: '/google/setup-mc' } );
+			// Wait for API calls and the page to render.
+			await page.waitForXPath( "//*[text()='Set up your accounts']" );
+		} );
+
+		it( 'should see their WPORG email, "Connect your Google account" text & connect button', async () => {
+			await expect(
+				page.waitForXPath( "//*[text()='mail@example.com']" )
+			).resolves.toBeTruthy();
+
+			await expect(
+				page.waitForXPath( "//*[text()='Connect your Google account']" )
+			).resolves.toBeTruthy();
+
+			await expect(
+				page.$x( "//button[text()='Connect'][not(@disabled)]" )
+			).resolves.toBeTruthy();
+		} );
+
+		describe( 'after clicking the "Connect your Google account" button', () => {
+			let googleConnectMock;
+			beforeEach( async function mockJetpackConnect() {
+				// Spy on Google connection request.
+				googleConnectMock = requestMock
+					.mock( /%2Fwc%2Fgla%2Fgoogle%2Fconnect\b/ )
+					.mockImplementation( ( interceptedRequest ) => {
+						interceptedRequest.respond( {
+							content: 'application/json',
+							headers: { 'Access-Control-Allow-Origin': '*' },
+							body: JSON.stringify( {
+								url: createURL( '/google/auth/' ),
+							} ),
+						} );
+						return true;
+					} );
+			} );
+
+			it( 'should sent an API request to connect Jetpack, and redirect to the returned URL', async () => {
+				const connectWPButton = await page.waitForXPath(
+					"//button[text()='Connect'][not(@disabled)]"
+				);
+
+				// Click the button
+				await connectWPButton.click();
+
+				// Wait for all XHRs and redirects.
+				await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+
+				// Expect Google call to be executed.
+				expect( googleConnectMock ).toBeCalled();
+				// Expect the user to be redirected
+				expect( page.url() ).toEqual( createURL( '/google/auth/' ) );
+			} );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -150,7 +150,7 @@ describe( 'At setup page', () => {
 
 		describe( 'after clicking the "Connect your Google account" button', () => {
 			let googleConnectMock;
-			beforeEach( async function mockJetpackConnect() {
+			beforeEach( async function mockGoogleConnect() {
 				// Spy on Google connection request.
 				googleConnectMock = requestMock
 					.mock( /%2Fwc%2Fgla%2Fgoogle%2Fconnect\b/ )
@@ -166,13 +166,13 @@ describe( 'At setup page', () => {
 					} );
 			} );
 
-			it( 'should sent an API request to connect Jetpack, and redirect to the returned URL', async () => {
-				const connectWPButton = await page.waitForXPath(
+			it( 'should sent an API request to connect Google account, and redirect to the returned URL', async () => {
+				const connectGoogleButton = await page.waitForXPath(
 					"//button[text()='Connect'][not(@disabled)]"
 				);
 
 				// Click the button
-				await connectWPButton.click();
+				await connectGoogleButton.click();
 
 				// Wait for all XHRs and redirects.
 				await page.waitForNavigation( { waitUntil: 'networkidle0' } );

--- a/tests/e2e/utils/create-url.js
+++ b/tests/e2e/utils/create-url.js
@@ -11,9 +11,10 @@ import { createURL as originalCreateUrl } from '@woocommerce/e2e-utils'; // esli
 const WP_BASE_URL = originalCreateUrl( '' );
 
 /**
- * Creates new URL by parsing given WPPath and query params, relative to the WP base.
+ * Creates new absolute (full) URL string by parsing given
+ * `url` and `query` relative to the WP base.
  *
- * Given `query` params are merged with the ones already present in the path.
+ * Given `query` params are merged with the ones already present in the `url`.
  * Any overlapping ones will be overwritten.
  *
  * @example
@@ -23,20 +24,20 @@ const WP_BASE_URL = originalCreateUrl( '' );
  * // "http://localhost:8889/foo?a=b&bar=baz&fiz=a%2Fb%2Fc"
  * ```
  *
- * @param {string}              [WPPath=''] String to be serialized as pathname.
+ * @param {string}              [url=''] A valid URL string, usually a relative path, but could contain as well contain query, fragment or be absolute.
  * @param {string|Object|Array} [query]     Query parameters in any format supported by {@link https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams | URLSearchParams}.
- * @return {string} String which represents full URL.
+ * @return {string} String which represents the full, absolute URL.
  */
-export function createURL( WPPath = '', query = '' ) {
-	const url = new URL( WPPath, WP_BASE_URL );
+export function createURL( url = '', query = '' ) {
+	const fullUrl = new URL( url, WP_BASE_URL );
 
 	// Merge query params if any.
 	if ( query ) {
 		for ( const [ key, value ] of new URLSearchParams( query ) ) {
 			// Overwrite any params if already present.
-			url.searchParams.set( key, value );
+			fullUrl.searchParams.set( key, value );
 		}
 	}
 
-	return url.href;
+	return fullUrl.href;
 }

--- a/tests/e2e/utils/create-url.js
+++ b/tests/e2e/utils/create-url.js
@@ -1,0 +1,42 @@
+/**
+ * This is an enhanced/fixed version of `@wordpress/e2e-utils.createURL`,
+ * the original one has not so usable API.
+ * The PR to upstream nad tests are pending at
+ * https://github.com/WordPress/gutenberg/pull/34051
+ */
+/**
+ * External dependencies
+ */
+import { createURL as originalCreateUrl } from '@woocommerce/e2e-utils'; // eslint-disable-line import/named
+const WP_BASE_URL = originalCreateUrl( '' );
+
+/**
+ * Creates new URL by parsing given WPPath and query params, relative to the WP base.
+ *
+ * Given `query` params are merged with the ones already present in the path.
+ * Any overlapping ones will be overwritten.
+ *
+ * @example
+ *
+ * ```js
+ * createURL( '/foo?a=b&bar=f', { bar: 'baz', fiz: 'a/b/c' } );
+ * // "http://localhost:8889/foo?a=b&bar=baz&fiz=a%2Fb%2Fc"
+ * ```
+ *
+ * @param {string}              [WPPath=''] String to be serialized as pathname.
+ * @param {string|Object|Array} [query]     Query parameters in any format supported by {@link https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams | URLSearchParams}.
+ * @return {string} String which represents full URL.
+ */
+export function createURL( WPPath = '', query = '' ) {
+	const url = new URL( WPPath, WP_BASE_URL );
+
+	// Merge query params if any.
+	if ( query ) {
+		for ( const [ key, value ] of new URLSearchParams( query ) ) {
+			// Overwrite any params if already present.
+			url.searchParams.set( key, value );
+		}
+	}
+
+	return url.href;
+}

--- a/tests/e2e/utils/request-mock.js
+++ b/tests/e2e/utils/request-mock.js
@@ -1,0 +1,103 @@
+/**
+ * Observer to listen and mock puppeteer page requests.
+ */
+export class RequestMock {
+	/**
+	 * Map of mock functions to URL patters they should apply to.
+	 *
+	 * @type {Map<jest.Mock, RegExp>}
+	 */
+	#mocks;
+	/**
+	 * The instance of a page being observed.
+	 *
+	 * @type {import("puppeteer").Page}
+	 */
+	#observedPage;
+
+	constructor() {
+		this.#mocks = new Map();
+		this.#callMocksOnThis = this.#callMocks.bind( this );
+	}
+
+	/**
+	 * Get the mock to stub/mock/observe requests for a URL matching the given `pattern`.
+	 *
+	 * @param {RegExp} pattern Pattern for an URL(s) to mock.
+	 * @return {jest.Mock<import("puppeteer").Request>} New jest mock, will be called with an intercepted request. If the mock returns:
+	 * 	- `undefined` - the original request will be passed through, unless already handled.
+	 *  - falsy - the request will be aborted
+	 *  - truthy - no action will be taken
+	 */
+	mock( pattern ) {
+		const mock = jest.fn().mockName( 'mocked request' );
+		this.#mocks.set( mock, pattern );
+		return mock;
+	}
+
+	/**
+	 * Stop applying all or the given mock.
+	 *
+	 * @param {jest.Mock} [mock] Mock to be restored/unobserved. If not given all will be restored.
+	 */
+	restore( mock ) {
+		if ( mock ) {
+			this.#mocks.delete( mock );
+		} else {
+			this.#mocks.clear();
+		}
+	}
+
+	/**
+	 * Start oberving/intercepting requests for the given `page`.
+	 *
+	 * @param {import("puppeteer").Page} page
+	 */
+	async observe( page ) {
+		// Unobserve the previous page.
+		this.disconnect();
+
+		this.#observedPage = page;
+		await page.setRequestInterception( true );
+		page.on( 'request', this.#callMocksOnThis );
+	}
+	/**
+	 * Stop observing.
+	 */
+	disconnect() {
+		if ( this.#observedPage ) {
+			this.#observedPage.off( 'request', this.#callMocksOnThis );
+			this.#observedPage = undefined;
+		}
+	}
+
+	/**
+	 * Call a matching mock, if any.
+	 *
+	 * @param {import("puppeteer").Request} interceptedRequest
+	 */
+	#callMocks( interceptedRequest ) {
+		const url = interceptedRequest.url();
+		// Find a matching mock.
+		for ( const [ mock, pattern ] of this.#mocks ) {
+			if ( url.match( pattern ) ) {
+				const result = mock( interceptedRequest );
+
+				if ( result === undefined ) {
+					interceptedRequest.continue();
+				} else if ( ! result ) {
+					interceptedRequest.abort();
+				}
+				return;
+			}
+		}
+		// Pass through non-matching requests.
+		if ( ! interceptedRequest._interceptionHandled ) {
+			interceptedRequest.continue();
+		}
+	}
+	/**
+	 * @alias RequestMock#callMocks
+	 */
+	#callMocksOnThis; // Needed because `Page#addEventListener` does not take {@link https://developer.mozilla.org/en-US/docs/Web/API/EventListener | `EventListener`s}.
+}

--- a/tests/e2e/utils/visit-gla-page.js
+++ b/tests/e2e/utils/visit-gla-page.js
@@ -1,0 +1,51 @@
+/**
+ * A GLA specific version of `@wordpress/e2e-utils.visitAdminPage`,
+ * as the original is not quite usefull for us.
+ * See https://github.com/WordPress/gutenberg/issues/34044
+ */
+/* global page */
+/**
+ * External dependencies
+ */
+import {
+	WP_ADMIN_WC_HOME, // eslint-disable-line import/named
+	isCurrentURL,
+	loginUser,
+	getPageError,
+} from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import { createURL } from './create-url';
+
+/**
+ * Visits admin page; if user is not logged in then it logging in it first, then visits admin page.
+ *
+ * @param {string|Object|Array} [query]     	Search query params, in the format acceptable by `SearchParams`.
+ * @param {string} 				[query.path]  	Path to the page.
+ * @return {string} Full URL of the destination.
+ */
+export async function visitGLAPage( query ) {
+	const fullURL = createURL( WP_ADMIN_WC_HOME, query );
+	await page.goto( fullURL );
+
+	// Handle upgrade required screen
+	if ( isCurrentURL( 'wp-admin/upgrade.php' ) ) {
+		// Click update
+		await page.click( '.button.button-large.button-primary' );
+		// Click continue
+		await page.click( '.button.button-large' );
+	}
+
+	if ( isCurrentURL( 'wp-login.php' ) ) {
+		await loginUser();
+		await visitGLAPage( query );
+	}
+
+	const error = await getPageError();
+	if ( error ) {
+		throw new Error( 'Unexpected error in page content: ' + error );
+	}
+	return fullURL;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a baby step towards #886.

- Add tests for a part of step 1 of MC onboarding. (2878bcd)
	```
  At setup page
    Merchant who is getting started
      ✓ should see accounts step header, "Connect your WordPress.com account" & connect button (1325ms)
      after clicking the "Connect your WordPress.com account" button
        ✓ should sent an API request to connect Jetpack, and redirect to the returned URL (2295ms)
    Merchant who has their Jetpack connected, but Google not yet connected
      ✓ should see their WPORG email, "Connect your Google account" text & connect button (1226ms)
      after clicking the "Connect your Google account" button
        ✓ should sent an API request to connect Jetpack, and redirect to the returned URL (2302ms)
	```
	Mock Jetpack and Google connection requests on the browser level. Later we could improve it by mocking on PHP/WCS level.

	Shorten the landing page tests. The details are now tested in `setup-mc/` tests.


- Add improved version of `createURL`. (e800471)
	as the `@wordpress/e2e-utils`/`@woocommerce/e2e-utils` is not helpful for absolute paths from `@woocommerce/e2e-utils` and merging `searchParams` which we'd need everytime.

	We should keep it until WordPress/gutenberg#34051 is merged or WordPress/gutenberg#34044 otherwise fixed.
- Add an improved version of `visitAdminPage`. (549f938)
	as the `@wordpress/e2e-utils`/`@woocommerce/e2e-utils` one is not helpful for absolute paths from `@woocommerce/e2e-utils` and merging `searchParams` which we'd need everytime.

	Could be simplified after WordPress/gutenberg#34051 is merged or WordPress/gutenberg#34044 otherwise fixed.

- Add a helper to mock XHR requests in e2e tests. (74f7b3d)
	Wrap Puppeteer's `page.setRequestInterception` and `page.on` with some sugar, to simplify mocking individual URLs.




### Screenshots:
![Animations of tests being run in browser](https://user-images.githubusercontent.com/17435/130120500-50eff190-f1f4-43cd-bb46-f20a65dcdf4f.gif)



### Detailed test instructions:

1. Checkout this branch, 
2. `npm run docker:up`
3. `npm run test:e2e`
4. `npm run test:e2e-dev` - to see what's happening, and to test a slightly different browser setup :confused: 

### Additional notes:

1. There are still plenty of tests to be written
2. This PR mocks Jetpack nad Google request on a browser level, it has a number of downsides:
	- Does not test -to-end
	- It requires even more mocking, as the server-side still lacks the connected state, so the following requests may fail
	
	But this is at least a small step forward, so we could:
	- write more tests, to avoid purely JS-based bugs, like https://github.com/woocommerce/google-listings-and-ads/issues/884
	- iteratively mock deeper, add similar helpers to mock WCS, etc.
3. I believe, that even once we will mock Jetpack and Google calls deeper, the `RequestMock` util could be helpful for spying on those requests and responses.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Added a few more e2e tests and utils.

