### PR TITLE
Type to filter countries in Setup Ads

### DIFF
--- a/js/src/components/paid-ads/audience-section.js
+++ b/js/src/components/paid-ads/audience-section.js
@@ -41,7 +41,6 @@ const AudienceSection = ( props ) => {
 							'google-listings-and-ads'
 						) }
 						helperText={ countrySelectHelperText }
-						isSearchable={ false }
 						inlineTags={ false }
 						{ ...inputProps }
 					/>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #954 .

This PR allows users to type to search / filter countries in the Setup Ads Step 2 page.

### Screenshots:

Demo video: (https://d.pr/v/A1LKld)

https://user-images.githubusercontent.com/417342/130123744-df62444b-4d21-4c8a-b4ab-59ba0c355cf6.mp4

### Detailed test instructions:

1. Open Setup Ads page: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads`
2. Proceed to Step 2.
3. In the "Select one country" field, you should be able to type to search / filter the list of countries in the select dropdown.

### Changelog entry

> Fix - Make audience country searchable in Setup Ads.
