### PR TITLE
Check for WC_VERSION constant before using it

### DIFF
--- a/src/Exception/InvalidVersion.php
+++ b/src/Exception/InvalidVersion.php
@@ -37,4 +37,23 @@ class InvalidVersion extends RuntimeException implements GoogleListingsAndAdsExc
 			)
 		);
 	}
+
+	/**
+	 * Create a new instance of the exception when a requirement is missing.
+	 *
+	 * @param string $requirement
+	 * @param string $minimum_version
+	 *
+	 * @return InvalidVersion
+	 */
+	public static function requirement_missing( string $requirement, string $minimum_version ): InvalidVersion {
+		return new static(
+			sprintf(
+				/* translators: 1 is the required component, 2 is the minimum required version */
+				__( 'Google Listings and Ads requires %1$s version %2$s or higher.', 'google-listings-and-ads' ),
+				$requirement,
+				$minimum_version
+			)
+		);
+	}
 }

--- a/src/Internal/Requirements/PluginValidator.php
+++ b/src/Internal/Requirements/PluginValidator.php
@@ -31,6 +31,7 @@ class PluginValidator {
 	public static function validate(): bool {
 		$validated = true;
 
+		/** @var RequirementValidator $plugin */
 		foreach ( self::PLUGINS as $plugin ) {
 			if ( ! $plugin::instance()->validate() ) {
 				$validated = false;

--- a/src/Internal/Requirements/WCValidator.php
+++ b/src/Internal/Requirements/WCValidator.php
@@ -35,6 +35,10 @@ class WCValidator extends RequirementValidator {
 	 * @throws InvalidVersion When the WooCommerce version does not meet the minimum version.
 	 */
 	protected function validate_wc_version() {
+		if ( ! defined( 'WC_VERSION' ) ) {
+			throw InvalidVersion::requirement_missing( 'WooCommerce', WC_GLA_MIN_WC_VER );
+		}
+
 		if ( ! version_compare( WC_VERSION, WC_GLA_MIN_WC_VER, '>=' ) ) {
 			throw InvalidVersion::from_requirement( 'WooCommerce', WC_VERSION, WC_GLA_MIN_WC_VER );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #965 .

This creates a separate check for the `WC_VERSION` constant before using it, to prevent situations where a fatal error could be triggered.

### Detailed test instructions:

1. Install the plugin manually or via the WooCommerce Setup Wizard (Business Details step)
2. Disable WooCommerce, then try to enable Google Listings and Ads
3. There should be no fatal error 


### Changelog entry

> Fix a potential fatal error when WooCommerce isn't active while activating Google Listings and Ads
