### PR TITLE
Unit tests for the MerchantCenter account controller

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -123,7 +123,7 @@ class Merchant implements OptionsAwareInterface {
 	 * @return AccountStatus The user's Merchant Center account status.
 	 * @throws Exception If the account can't be retrieved.
 	 */
-	public function get_accountstatus( int $id = 0 ): AccountStatus {
+	protected function get_accountstatus( int $id = 0 ): AccountStatus {
 		$id = $id ?: $this->options->get_merchant_id();
 
 		try {
@@ -133,6 +133,31 @@ class Merchant implements OptionsAwareInterface {
 			throw new Exception( __( 'Unable to retrieve Merchant Center account status.', 'google-listings-and-ads' ), $e->getCode() );
 		}
 		return $mc_account_status;
+	}
+
+	/**
+	 * Check if the account website has been claimed.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param integer $merchant_id Merchant Account ID.
+	 * @return bool
+	 * @throws Exception If the account can't be retrieved.
+	 */
+	public function is_website_claimed( int $merchant_id ): bool {
+		return $this->get_accountstatus( $merchant_id )->getWebsiteClaimed();
+	}
+
+	/**
+	 * Return list of account level issues from the account status.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array
+	 * @throws Exception If the account can't be retrieved.
+	 */
+	public function get_account_level_issues(): array {
+		return $this->get_accountstatus()->getAccountLevelIssues();
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -445,6 +445,7 @@ class AccountController extends BaseOptionsController {
 				if ( 'claim' === $name && 403 === $e->getCode() ) {
 					$data = [
 						'id'          => $merchant_id,
+						'step'        => $name,
 						'website_url' => $this->strip_url_protocol(
 							esc_url_raw( $this->get_site_url() )
 						),

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -382,7 +382,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function setup_merchant_account() {
 		$state       = $this->account_state->get();
-		$merchant_id = intval( $this->options->get( OptionsInterface::MERCHANT_ID ) );
+		$merchant_id = $this->options->get_merchant_id();
 
 		foreach ( $state as $name => &$step ) {
 			if ( MerchantAccountState::STEP_DONE === $step['status'] ) {

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -364,9 +364,8 @@ class AccountController extends BaseOptionsController {
 	 * @return Response
 	 */
 	protected function prepare_error_response( array $data, int $code = null ): Response {
-		$merchant_id = $this->options->get_merchant_id();
-		if ( $merchant_id ) {
-			$data['id'] = $merchant_id;
+		if ( ! isset( $data['id'] ) && $this->options->get_merchant_id() ) {
+			$data['id'] = $this->options->get_merchant_id();
 		}
 		return new Response( $data, $code ?: 400 );
 

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -416,7 +416,7 @@ class AccountController extends BaseOptionsController {
 					case 'claim':
 						// At this step, the website URL is assumed to be correct.
 						// If the URL is already claimed, no claim should be attempted.
-						if ( $this->merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed() ) {
+						if ( $this->merchant->is_website_claimed( $merchant_id ) ) {
 							break;
 						}
 
@@ -602,7 +602,7 @@ class AccountController extends BaseOptionsController {
 
 		if ( untrailingslashit( $site_website_url ) !== untrailingslashit( $account_website_url ) ) {
 
-			$is_website_claimed = $this->merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed();
+			$is_website_claimed = $this->merchant->is_website_claimed( $merchant_id );
 
 			if ( ! empty( $account_website_url ) && $is_website_claimed && ! $this->allow_switch_url ) {
 				$state                              = $this->account_state->get();

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
@@ -37,8 +38,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -87,7 +90,14 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( MerchantCenterProductVisibilityController::class, ProductHelper::class, MerchantIssueQuery::class );
 		$this->share( MerchantCenterContactInformationController::class, ContactInformation::class, Settings::class, AddressUtility::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class, Middleware::class );
-		$this->share_with_container( MerchantCenterAccountController::class );
+		$this->share(
+			MerchantCenterAccountController::class,
+			Middleware::class,
+			Merchant::class,
+			MerchantAccountState::class,
+			MerchantCenterService::class,
+			SiteVerification::class
+		);
 		$this->share_with_container( MerchantCenterReportsController::class );
 		$this->share_with_container( ShippingRateBatchController::class );
 		$this->share_with_container( ShippingRateController::class );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -371,7 +371,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$merchant       = $this->container->get( Merchant::class );
 		$account_issues = [];
 		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
-		foreach ( $merchant->get_accountstatus()->getAccountLevelIssues() as $issue ) {
+		foreach ( $merchant->get_account_level_issues() as $issue ) {
 			$account_issues[] = [
 				'product_id' => 0,
 				'product'    => __( 'All products', 'google-listings-and-ads' ),

--- a/src/Options/AccountState.php
+++ b/src/Options/AccountState.php
@@ -58,7 +58,7 @@ abstract class AccountState implements Service, OptionsAwareInterface {
 			$this->update( $state );
 		}
 
-		return $state;
+		return $state ?: [];
 	}
 
 	/**

--- a/tests/Framework/MockRESTServer.php
+++ b/tests/Framework/MockRESTServer.php
@@ -10,8 +10,6 @@ defined( 'ABSPATH' ) || exit;
  * Class MockRESTServer
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework
- *
- * @since   x.x.x
  */
 class MockRESTServer extends WP_REST_Server {
 	/**

--- a/tests/Framework/MockRESTServer.php
+++ b/tests/Framework/MockRESTServer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework;
+
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MockRESTServer
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework
+ *
+ * @since   x.x.x
+ */
+class MockRESTServer extends WP_REST_Server {
+	/**
+	 * Get the raw $endpoints data from the server
+	 *
+	 * @return array
+	 */
+	public function get_raw_endpoint_data() {
+		return $this->endpoints;
+	}
+
+	/**
+	 * Allow calling protected methods from tests
+	 *
+	 * @param string $method Method to call
+	 * @param array $args Arguments to pass to the method
+	 * @return mixed
+	 */
+	public function __call( $method, $args ) {
+		return call_user_func_array( array( $this, $method ), $args );
+	}
+
+	/**
+	 * Call dispatch() with the rest_post_dispatch filter
+	 */
+	public function dispatch( $request ) {
+		$result = parent::dispatch( $request );
+		$result = rest_ensure_response( $result );
+		if ( is_wp_error( $result ) ) {
+			$result = $this->error_to_response( $result );
+		}
+		return apply_filters( 'rest_post_dispatch', rest_ensure_response( $result ), $this, $request );
+	}
+}

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -86,8 +86,6 @@ abstract class RESTControllerUnitTest extends UnitTest {
 
 	/**
 	 * Validate that the returned API schema matches what is expected.
-	 *
-	 * @return void
 	 */
 	public function test_schema_properties() {
 		$request    = new Request( 'OPTIONS', $this->routes[0] );
@@ -129,16 +127,16 @@ abstract class RESTControllerUnitTest extends UnitTest {
 	 * @param array   $params   Request body or query.
 	 * @return object
 	 */
-	protected function do_request( $endpoint, $type = 'GET', $params = [] ) {
+	protected function do_request( string $endpoint, string $type = 'GET', array $params = [] ): object {
 		$request = new Request( $type, untrailingslashit( $endpoint ) );
 		'GET' === $type ? $request->set_query_params( $params ) : $request->set_body_params( $params );
 		$response = $this->server->dispatch_request( $request );
 
-		return (object) array(
+		return (object) [
 			'status' => $response->get_status(),
 			'data'   => json_decode( wp_json_encode( $response->get_data() ), true ),
 			'raw'    => $response->get_data(),
-		);
+		];
 	}
 
 	/**

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -13,8 +13,6 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework
  *
- * @since   x.x.x
- *
  * @property RESTServer $server
  */
 abstract class RESTControllerUnitTest extends UnitTest {

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use WP_REST_Request as Request;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class RESTControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework
+ *
+ * @since   x.x.x
+ *
+ * @property RESTServer $server
+ */
+abstract class RESTControllerUnitTest extends UnitTest {
+
+	/**
+	 * Controller we are testing.
+	 *
+	 * @var mixed
+	 */
+	protected $controller;
+
+	/**
+	 * Routes that this controller creates.
+	 *
+	 * @var array
+	 */
+	protected $routes = [];
+
+	/**
+	 * The endpoint schema.
+	 *
+	 * @var array Keys are property names, values are supported context.
+	 */
+	protected $properties = [];
+
+	/**
+	 * @var RESTServer
+	 */
+	protected $server;
+
+	/**
+	 * User variable.
+	 *
+	 * @var WP_User
+	 */
+	protected static $user;
+
+	/**
+	 * Setup once before running tests.
+	 *
+	 * @param object $factory Factory object.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user = $factory->user->create( [ 'role' => 'administrator' ] );
+	}
+
+	/**
+	 * Setup our test server.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new MockRESTServer();
+		$this->server   = new RESTServer( $wp_rest_server );
+		$wp_rest_server;
+		wp_set_current_user( self::$user );
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+	 	$actual_routes   = $this->server->get_routes();
+	 	$expected_routes = $this->routes;
+
+	 	foreach ( $expected_routes as $expected_route ) {
+	 		$this->assertArrayHasKey( $expected_route, $actual_routes );
+	 	}
+	}
+
+	/**
+	 * Validate that the returned API schema matches what is expected.
+	 *
+	 * @return void
+	 */
+	public function test_schema_properties() {
+		$request    = new Request( 'OPTIONS', $this->routes[0] );
+		$response   = $this->server->dispatch_request( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( count( array_keys( $this->properties ) ), count( $properties ), print_r( array_diff( array_keys( $properties ), array_keys( $this->properties ) ), true ) );
+
+		foreach ( array_keys( $this->properties ) as $property ) {
+			$this->assertArrayHasKey( $property, $properties );
+			$this->assertEquals( $this->properties[ $property ], $properties[ $property ]['context'] );
+		}
+	}
+
+	/**
+	 * Unset the server.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		unset( $this->server );
+	}
+
+	/**
+	 * Register routes for the controller we are testing.
+	 */
+	protected function register_test_routes() {
+		$this->controller->register_routes();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Perform a request and return the status and returned data.
+	 *
+	 * @param string  $endpoint Endpoint to hit.
+	 * @param string  $type     Type of request e.g GET or POST.
+	 * @param array   $params   Request body or query.
+	 * @return object
+	 */
+	protected function do_request( $endpoint, $type = 'GET', $params = [] ) {
+		$request = new Request( $type, untrailingslashit( $endpoint ) );
+		'GET' === $type ? $request->set_query_params( $params ) : $request->set_body_params( $params );
+		$response = $this->server->dispatch_request( $request );
+
+		return (object) array(
+			'status' => $response->get_status(),
+			'data'   => json_decode( wp_json_encode( $response->get_data() ), true ),
+			'raw'    => $response->get_data(),
+		);
+	}
+
+	/**
+	 * Test the request/response matched the data we sent.
+	 *
+	 * @param array $response    Array of response data from do_request above.
+	 * @param int   $status_code Expected status code.
+	 * @param array $data        Array of expected data.
+	 */
+	protected function assertExpectedResponse( $response, $status_code = 200, $data = array() ) {
+		$this->assertObjectHasAttribute( 'status', $response );
+		$this->assertObjectHasAttribute( 'data', $response );
+		$this->assertEquals( $status_code, $response->status, print_r( $response->data, true ) );
+
+		if ( ! $data ) {
+			return;
+		}
+
+		foreach ( $data as $key => $value ) {
+			if ( ! isset( $response->data[ $key ] ) ) {
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				$this->assertArraySubset( $value, $response->data[ $key ] );
+			} else {
+				$this->assertEquals( $value, $response->data[ $key ] );
+			}
+		}
+	}
+
+}

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -142,32 +142,15 @@ abstract class RESTControllerUnitTest extends UnitTest {
 	}
 
 	/**
-	 * Test the request/response matched the data we sent.
+	 * Test the response matches the expected status code and contains data.
 	 *
-	 * @param array $response    Array of response data from do_request above.
-	 * @param int   $status_code Expected status code.
-	 * @param array $data        Array of expected data.
+	 * @param object $response    Response object from do_request above.
+	 * @param int    $status_code Expected status code.
 	 */
-	protected function assertExpectedResponse( $response, $status_code = 200, $data = array() ) {
+	protected function assertExpectedResponse( object $response, int $status_code = 200 ) {
 		$this->assertObjectHasAttribute( 'status', $response );
 		$this->assertObjectHasAttribute( 'data', $response );
-		$this->assertEquals( $status_code, $response->status, print_r( $response->data, true ) );
-
-		if ( ! $data ) {
-			return;
-		}
-
-		foreach ( $data as $key => $value ) {
-			if ( ! isset( $response->data[ $key ] ) ) {
-				continue;
-			}
-
-			if ( is_array( $value ) ) {
-				$this->assertArraySubset( $value, $response->data[ $key ] );
-			} else {
-				$this->assertEquals( $value, $response->data[ $key ] );
-			}
-		}
+		$this->assertEquals( $status_code, $response->status );
 	}
 
 }

--- a/tests/Tools/HelperTrait/MerchantTrait.php
+++ b/tests/Tools/HelperTrait/MerchantTrait.php
@@ -46,4 +46,8 @@ trait MerchantTrait {
 
 		return $account;
 	}
+
+	protected function clean_site_url(): string {
+		return preg_replace( '#^https?://#', '', untrailingslashit( site_url() ) );
+	}
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -13,6 +13,7 @@ use Google\Service\ShoppingContent;
 use Google\Service\ShoppingContent\Account;
 use Google\Service\ShoppingContent\AccountAdsLink;
 use Google\Service\ShoppingContent\AccountStatus;
+use Google\Service\ShoppingContent\AccountStatusAccountLevelIssue;
 use Google\Service\ShoppingContent\AccountUser;
 use Google\Service\ShoppingContent\Product;
 use Google\Service\ShoppingContent\ProductsListResponse;
@@ -188,8 +189,15 @@ class MerchantTest extends UnitTest {
 		$this->merchant->get_account();
 	}
 
-	public function test_get_accountstatuses() {
+	public function test_get_account_level_issues() {
+		$issues = [
+			$this->createMock( AccountStatusAccountLevelIssue::class ),
+			$this->createMock( AccountStatusAccountLevelIssue::class ),
+		];
 		$account_status = $this->createMock( AccountStatus::class );
+		$account_status->expects( $this->once() )
+			->method( 'getAccountLevelIssues' )
+			->willReturn( $issues );
 
 		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
 		$this->service->accountstatuses->expects( $this->once() )
@@ -197,10 +205,10 @@ class MerchantTest extends UnitTest {
 			->with( $this->merchant_id, $this->merchant_id )
 			->willReturn( $account_status );
 
-		$this->assertEquals( $account_status, $this->merchant->get_accountstatus() );
+		$this->assertEquals( $issues, $this->merchant->get_account_level_issues() );
 	}
 
-	public function test_get_accountstatus_failure() {
+	public function test_get_account_level_issues_failure() {
 		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
 		$this->service->accountstatuses->expects( $this->once() )
 			->method( 'get' )
@@ -213,7 +221,7 @@ class MerchantTest extends UnitTest {
 
 		$this->expectException( Exception::class );
         $this->expectExceptionCode( 400 );
-		$this->merchant->get_accountstatus();
+		$this->merchant->get_account_level_issues();
 	}
 
 	public function test_get_productstatuses_batch() {

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -189,6 +189,37 @@ class MerchantTest extends UnitTest {
 		$this->merchant->get_account();
 	}
 
+	public function test_is_website_claimed() {
+		$account_status = $this->createMock( AccountStatus::class );
+		$account_status->expects( $this->once() )
+			->method( 'getWebsiteClaimed' )
+			->willReturn( true );
+
+		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
+		$this->service->accountstatuses->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
+			->willReturn( $account_status );
+
+		$this->assertTrue( $this->merchant->is_website_claimed( $this->merchant_id ) );
+	}
+
+	public function test_is_website_claimed_failure() {
+		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
+		$this->service->accountstatuses->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
+			->will(
+				$this->throwException(
+					new GoogleException( 'error', 400 )
+				)
+			);
+
+		$this->expectException( Exception::class );
+        $this->expectExceptionCode( 400 );
+		$this->merchant->is_website_claimed( $this->merchant_id );
+	}
+
 	public function test_get_account_level_issues() {
 		$issues = [
 			$this->createMock( AccountStatusAccountLevelIssue::class ),

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -368,6 +368,57 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( $merchant_id, $response->data['id'] );
 	}
 
+	public function test_invalid_switch_url() {
+		$merchant_id = 12345;
+
+		$response = $this->do_request(
+			'/wc/gla/mc/accounts/switch-url',
+			'POST',
+			[
+				'id' => $merchant_id,
+			]
+		);
+		$this->assertExpectedResponse( $response, 400 );
+	}
+
+	public function test_switch_url() {
+		$merchant_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get' )
+			->will(
+            	$this->returnCallback(
+					function( $arg ) {
+                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
+							return [
+								'set_id' => [
+									'status'  => $this->onConsecutiveCalls( 0, 1 ),
+									'message' => '',
+									'data'    => [
+										'old_url' => 'oldurl.test',
+									],
+								],
+							];
+    	    	        }
+            		}
+				)
+			);
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( $merchant_id );
+
+		$response = $this->do_request(
+			'/wc/gla/mc/accounts/switch-url',
+			'POST',
+			[
+				'id' => $merchant_id,
+			]
+		);
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( $merchant_id, $response->data['id'] );
+	}
+
 	protected function clean_site_url(): string {
 		return preg_replace( '#^https?://#', '', untrailingslashit( site_url() ) );
 	}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -418,6 +418,11 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( $status, $response->data );
 	}
 
+	/**
+	 * Mock the merchant account state to return specific state values.
+	 *
+	 * @param array $state Expected state values to return.
+	 */
 	protected function expected_account_state( array $state ) {
 		$this->options->expects( $this->any() )
 			->method( 'get' )

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -276,6 +276,27 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertArrayHasKey( 'retry_after', $response->data );
 	}
 
+	public function test_invalid_step() {
+		$merchant_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( $merchant_id );
+
+		$this->expected_account_state(
+			[
+				'invalid' => [
+					'status'  => MerchantAccountState::STEP_PENDING,
+					'message' => '',
+					'data'    => [],
+				],
+			]
+		);
+
+		$response = $this->do_request( '/wc/gla/mc/accounts', 'POST' );
+		$this->assertExpectedResponse( $response, 400 );
+	}
+
 	public function test_account_already_connected() {
 		$merchant_id = 12345;
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -377,10 +377,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->expected_account_state(
 			[
 				'set_id' => [
-					'status'  => $this->onConsecutiveCalls(
-						MerchantAccountState::STEP_PENDING,
-						MerchantAccountState::STEP_DONE
-					),
+					'status'  => MerchantAccountState::STEP_PENDING,
 					'message' => '',
 					'data'    => [
 						'old_url' => 'oldurl.test',

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -22,8 +22,6 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
  *
- * @since   x.x.x
- *
  * @property MockObject|Middleware            $middleware
  * @property MockObject|Merchant              $merchant
  * @property MockObject|MerchantCenterService $mc_service

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -22,10 +23,11 @@ defined( 'ABSPATH' ) || exit;
  *
  * @property MockObject|Middleware            $middleware
  * @property MockObject|Merchant              $merchant
- * @property MockObject|MerchantAccountState  $account_state
  * @property MockObject|MerchantCenterService $mc_service
  * @property MockObject|SiteVerification      $site_verification
+ * @property MockObject|OptionsInterface      $options
  * @property AccountController                $controller
+ * @property MerchantAccountState             $account_state
  */
 class AccountControllerTest extends RESTControllerUnitTest {
 
@@ -60,9 +62,12 @@ class AccountControllerTest extends RESTControllerUnitTest {
 
 		$this->middleware        = $this->createMock( Middleware::class );
 		$this->merchant          = $this->createMock( Merchant::class );
-		$this->account_state     = $this->createMock( MerchantAccountState::class );
 		$this->mc_service        = $this->createMock( MerchantCenterService::class );
 		$this->site_verification = $this->createMock( SiteVerification::class );
+		$this->options           = $this->createMock( OptionsInterface::class );
+
+		$this->account_state = new MerchantAccountState();
+		$this->account_state->set_options_object( $this->options );
 
 		$this->controller = new AccountController(
 			$this->server,
@@ -72,6 +77,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			$this->mc_service,
 			$this->site_verification
 		);
+		$this->controller->set_options_object( $this->options );
 
 		$this->register_test_routes();
 	}
@@ -90,11 +96,43 @@ class AccountControllerTest extends RESTControllerUnitTest {
 
 		$this->middleware->expects( $this->any() )
 			->method( 'get_merchant_ids' )
-			->willReturn(  $accounts );
+			->willReturn( $accounts );
 
 		$response = $this->do_request( '/wc/gla/mc/accounts', 'GET' );
 	 	$this->assertExpectedResponse( $response, 200 );
 	 	$this->assertEquals( $accounts, $response->data );
+	}
+
+	public function test_create_new_account() {
+		$merchant_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->middleware->expects( $this->any() )
+			->method( 'create_merchant_account' )
+			->willReturn( $merchant_id );
+
+		$this->site_verification->expects( $this->any() )
+			->method( 'insert' )
+			->willReturn( true );
+
+		$this->options->expects( $this->any() )
+			->method( 'get' )
+			->will(
+            	$this->returnCallback(
+					function( $arg ) {
+                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
+							return [];
+    	            	}
+            		}
+				)
+			);
+
+		$response = $this->do_request( '/wc/gla/mc/accounts', 'POST' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( $merchant_id, $response->data['id'] );
 	}
 
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -162,7 +162,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
                 		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
 							return [
 								'claim' => [
-									'status'  => 0,
+									'status'  => MerchantAccountState::STEP_PENDING,
 									'message' => '',
 									'data'    => [],
 								],
@@ -199,14 +199,14 @@ class AccountControllerTest extends RESTControllerUnitTest {
                 		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
 							return [
 								'set_id' => [
-									'status'  => 1,
+									'status'  => MerchantAccountState::STEP_DONE,
 									'message' => '',
 									'data'    => [
 										'from_mca' => false,
 									],
 								],
 								'claim' => [
-									'status'  => 0,
+									'status'  => MerchantAccountState::STEP_PENDING,
 									'message' => '',
 									'data'    => [],
 								],
@@ -276,7 +276,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
                 		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
 							return [
 								'link' => [
-									'status'  => 0,
+									'status'  => MerchantAccountState::STEP_PENDING,
 									'message' => '',
 									'data'    => [],
 								],
@@ -338,10 +338,10 @@ class AccountControllerTest extends RESTControllerUnitTest {
                 		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
 							return [
 								'set_id' => [
-									'status'  => 1,
+									'status'  => MerchantAccountState::STEP_DONE,
 								],
 								'claim' => [
-									'status'  => 0,
+									'status'  => MerchantAccountState::STEP_PENDING,
 									'message' => '',
 									'data'    => [
 										'overwrite_required' => true,
@@ -392,7 +392,10 @@ class AccountControllerTest extends RESTControllerUnitTest {
                 		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
 							return [
 								'set_id' => [
-									'status'  => $this->onConsecutiveCalls( 0, 1 ),
+									'status'  => $this->onConsecutiveCalls(
+										MerchantAccountState::STEP_PENDING,
+										MerchantAccountState::STEP_DONE
+									),
 									'message' => '',
 									'data'    => [
 										'old_url' => 'oldurl.test',

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -135,4 +135,38 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( $merchant_id, $response->data['id'] );
 	}
 
+	public function test_link_existing_account() {
+		$merchant_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->will( $this->onConsecutiveCalls( 0, $merchant_id ) );
+
+		$this->site_verification->expects( $this->any() )
+			->method( 'insert' )
+			->willReturn( true );
+
+		$this->options->expects( $this->any() )
+			->method( 'get' )
+			->will(
+            	$this->returnCallback(
+					function( $arg ) {
+                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
+							return [];
+    	    	        }
+            		}
+				)
+			);
+
+		$response = $this->do_request(
+			'/wc/gla/mc/accounts',
+			'POST',
+			[
+				'id' => $merchant_id,
+			]
+		);
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( $merchant_id, $response->data['id'] );
+	}
+
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -154,23 +154,15 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->method( 'get_merchant_id' )
 			->will( $this->onConsecutiveCalls( 0, $merchant_id ) );
 
-		$this->options->expects( $this->any() )
-			->method( 'get' )
-			->will(
-            	$this->returnCallback(
-					function( $arg ) {
-                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
-							return [
-								'claim' => [
-									'status'  => MerchantAccountState::STEP_PENDING,
-									'message' => '',
-									'data'    => [],
-								],
-							];
-    	    	        }
-            		}
-				)
-			);
+		$this->expected_account_state(
+			[
+				'claim' => [
+					'status'  => MerchantAccountState::STEP_PENDING,
+					'message' => '',
+					'data'    => [],
+				],
+			]
+		);
 
 		$this->merchant->expects( $this->any() )
 			->method( 'claimwebsite' )
@@ -191,30 +183,22 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->method( 'get_merchant_id' )
 			->will( $this->onConsecutiveCalls( 0, $merchant_id ) );
 
-		$this->options->expects( $this->any() )
-			->method( 'get' )
-			->will(
-            	$this->returnCallback(
-					function( $arg ) {
-                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
-							return [
-								'set_id' => [
-									'status'  => MerchantAccountState::STEP_DONE,
-									'message' => '',
-									'data'    => [
-										'from_mca' => false,
-									],
-								],
-								'claim' => [
-									'status'  => MerchantAccountState::STEP_PENDING,
-									'message' => '',
-									'data'    => [],
-								],
-							];
-    	    	        }
-            		}
-				)
-			);
+		$this->expected_account_state(
+			[
+				'set_id' => [
+					'status'  => MerchantAccountState::STEP_DONE,
+					'message' => '',
+					'data'    => [
+						'from_mca' => false,
+					],
+				],
+				'claim' => [
+					'status'  => MerchantAccountState::STEP_PENDING,
+					'message' => '',
+					'data'    => [],
+				],
+			]
+		);
 
 		$this->merchant->expects( $this->any() )
 			->method( 'claimwebsite' )
@@ -268,23 +252,15 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->method( 'get_merchant_id' )
 			->willReturn( 0 );
 
-		$this->options->expects( $this->any() )
-			->method( 'get' )
-			->will(
-            	$this->returnCallback(
-					function( $arg ) {
-                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
-							return [
-								'link' => [
-									'status'  => MerchantAccountState::STEP_PENDING,
-									'message' => '',
-									'data'    => [],
-								],
-							];
-    	    	        }
-            		}
-				)
-			);
+		$this->expected_account_state(
+			[
+				'link' => [
+					'status'  => MerchantAccountState::STEP_PENDING,
+					'message' => '',
+					'data'    => [],
+				],
+			]
+		);
 
 		$this->middleware->expects( $this->any() )
 			->method( 'link_merchant_to_mca' )
@@ -330,28 +306,20 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	public function test_claim_overwrite() {
 		$merchant_id = 12345;
 
-		$this->options->expects( $this->any() )
-			->method( 'get' )
-			->will(
-            	$this->returnCallback(
-					function( $arg ) {
-                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
-							return [
-								'set_id' => [
-									'status'  => MerchantAccountState::STEP_DONE,
-								],
-								'claim' => [
-									'status'  => MerchantAccountState::STEP_PENDING,
-									'message' => '',
-									'data'    => [
-										'overwrite_required' => true,
-									],
-								],
-							];
-    	    	        }
-            		}
-				)
-			);
+		$this->expected_account_state(
+			[
+				'set_id' => [
+					'status'  => MerchantAccountState::STEP_DONE,
+				],
+				'claim' => [
+					'status'  => MerchantAccountState::STEP_PENDING,
+					'message' => '',
+					'data'    => [
+						'overwrite_required' => true,
+					],
+				],
+			]
+		);
 
 		$this->options->expects( $this->any() )
 			->method( 'get_merchant_id' )
@@ -384,28 +352,20 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	public function test_switch_url() {
 		$merchant_id = 12345;
 
-		$this->options->expects( $this->any() )
-			->method( 'get' )
-			->will(
-            	$this->returnCallback(
-					function( $arg ) {
-                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
-							return [
-								'set_id' => [
-									'status'  => $this->onConsecutiveCalls(
-										MerchantAccountState::STEP_PENDING,
-										MerchantAccountState::STEP_DONE
-									),
-									'message' => '',
-									'data'    => [
-										'old_url' => 'oldurl.test',
-									],
-								],
-							];
-    	    	        }
-            		}
-				)
-			);
+		$this->expected_account_state(
+			[
+				'set_id' => [
+					'status'  => $this->onConsecutiveCalls(
+						MerchantAccountState::STEP_PENDING,
+						MerchantAccountState::STEP_DONE
+					),
+					'message' => '',
+					'data'    => [
+						'old_url' => 'oldurl.test',
+					],
+				],
+			]
+		);
 
 		$this->options->expects( $this->any() )
 			->method( 'get_merchant_id' )
@@ -424,5 +384,19 @@ class AccountControllerTest extends RESTControllerUnitTest {
 
 	protected function clean_site_url(): string {
 		return preg_replace( '#^https?://#', '', untrailingslashit( site_url() ) );
+	}
+
+	protected function expected_account_state( array $state ) {
+		$this->options->expects( $this->any() )
+			->method( 'get' )
+			->will(
+				$this->returnCallback(
+					function( $arg ) use ( $state ) {
+						if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
+							return $state;
+						}
+					}
+				)
+			);
 	}
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterSer
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
 use Exception;
 use Google\Service\ShoppingContent\Account;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -32,6 +33,8 @@ defined( 'ABSPATH' ) || exit;
  * @property MerchantAccountState             $account_state
  */
 class AccountControllerTest extends RESTControllerUnitTest {
+
+	use MerchantTrait;
 
 	/**
 	 * Routes that this endpoint creates.
@@ -413,10 +416,6 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( '/wc/gla/mc/setup', 'GET' );
 		$this->assertExpectedResponse( $response, 200 );
 		$this->assertEquals( $status, $response->data );
-	}
-
-	protected function clean_site_url(): string {
-		return preg_replace( '#^https?://#', '', untrailingslashit( site_url() ) );
 	}
 
 	protected function expected_account_state( array $state ) {

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
+ *
+ * @since   x.x.x
+ *
+ * @property MockObject|Middleware            $middleware
+ * @property MockObject|Merchant              $merchant
+ * @property MockObject|MerchantAccountState  $account_state
+ * @property MockObject|MerchantCenterService $mc_service
+ * @property MockObject|SiteVerification      $site_verification
+ * @property AccountController                $controller
+ */
+class AccountControllerTest extends RESTControllerUnitTest {
+
+	/**
+	 * Routes that this endpoint creates.
+	 *
+	 * @var array
+	 */
+	protected $routes = [
+		'/wc/gla/mc/accounts',
+		'/wc/gla/mc/accounts/claim-overwrite',
+		'/wc/gla/mc/accounts/switch-url',
+		'/wc/gla/mc/connection',
+		'/wc/gla/mc/setup',
+	];
+
+	/**
+	 * The endpoint schema.
+	 *
+	 * @var array Keys are property names, values are supported context.
+	 */
+	protected $properties = [
+		'id'         => [ 'view', 'edit' ],
+		'subaccount' => [ 'view' ],
+	];
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->middleware        = $this->createMock( Middleware::class );
+		$this->merchant          = $this->createMock( Merchant::class );
+		$this->account_state     = $this->createMock( MerchantAccountState::class );
+		$this->mc_service        = $this->createMock( MerchantCenterService::class );
+		$this->site_verification = $this->createMock( SiteVerification::class );
+
+		$this->controller = new AccountController(
+			$this->server,
+			$this->middleware,
+			$this->merchant,
+			$this->account_state,
+			$this->mc_service,
+			$this->site_verification
+		);
+
+		$this->register_test_routes();
+	}
+
+	public function test_get_accounts() {
+		$accounts = [
+			[
+				'id'         => 12345,
+				'subaccount' => true,
+			],
+			[
+				'id'         => 23456,
+				'subaccount' => false,
+			],
+		];
+
+		$this->middleware->expects( $this->any() )
+			->method( 'get_merchant_ids' )
+			->willReturn(  $accounts );
+
+		$response = $this->do_request( '/wc/gla/mc/accounts', 'GET' );
+	 	$this->assertExpectedResponse( $response, 200 );
+	 	$this->assertEquals( $accounts, $response->data );
+	}
+
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -169,4 +169,21 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( $merchant_id, $response->data['id'] );
 	}
 
+	public function test_account_already_connected() {
+		$merchant_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( $merchant_id );
+
+		$this->mc_service->expects( $this->any() )
+			->method( 'is_setup_complete' )
+			->willReturn( true );
+
+		$response = $this->do_request( '/wc/gla/mc/accounts', 'POST' );
+		$this->assertExpectedResponse( $response, 400 );
+		$this->assertEquals( $merchant_id, $response->data['id'] );
+		$this->assertArrayHasKey( 'message', $response->data );
+	}
+
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -382,6 +382,26 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( $merchant_id, $response->data['id'] );
 	}
 
+	public function test_connection_status() {
+		$status = [
+			'id'     => '12345',
+			'status' => 'connected',
+		];
+		$this->mc_service->expects( $this->any() )
+			->method( 'get_connected_status' )
+			->willReturn( $status );
+
+		$response = $this->do_request( '/wc/gla/mc/connection', 'GET' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( $status, $response->data );
+	}
+
+	public function test_disconnect() {
+		$response = $this->do_request( '/wc/gla/mc/connection', 'DELETE' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( 'success', $response->data['status'] );
+	}
+
 	protected function clean_site_url(): string {
 		return preg_replace( '#^https?://#', '', untrailingslashit( site_url() ) );
 	}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -120,18 +120,6 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->method( 'insert' )
 			->willReturn( true );
 
-		$this->options->expects( $this->any() )
-			->method( 'get' )
-			->will(
-            	$this->returnCallback(
-					function( $arg ) {
-                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
-							return [];
-    	            	}
-            		}
-				)
-			);
-
 		$response = $this->do_request( '/wc/gla/mc/accounts', 'POST' );
 		$this->assertExpectedResponse( $response, 200 );
 		$this->assertEquals( $merchant_id, $response->data['id'] );
@@ -147,18 +135,6 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->site_verification->expects( $this->any() )
 			->method( 'insert' )
 			->willReturn( true );
-
-		$this->options->expects( $this->any() )
-			->method( 'get' )
-			->will(
-            	$this->returnCallback(
-					function( $arg ) {
-                		if ( OptionsInterface::MERCHANT_ACCOUNT_STATE === $arg ) {
-							return [];
-    	    	        }
-            		}
-				)
-			);
 
 		$response = $this->do_request(
 			'/wc/gla/mc/accounts',

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -402,6 +402,19 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'success', $response->data['status'] );
 	}
 
+	public function test_is_setup() {
+		$status = [
+			'status' => 'complete',
+		];
+		$this->mc_service->expects( $this->any() )
+			->method( 'get_setup_status' )
+			->willReturn( $status );
+
+		$response = $this->do_request( '/wc/gla/mc/setup', 'GET' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( $status, $response->data );
+	}
+
 	protected function clean_site_url(): string {
 		return preg_replace( '#^https?://#', '', untrailingslashit( site_url() ) );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds unit tests for the MerchantCenter account controller. Since we didn't have any framework for testing controllers, we include the `RESTControllerUnitTest` which can be used for testing controllers. By default this test will check if all the routes are registered, and if the schema matches what is expected. It also provides helper functions for sending and testing responses for an API controller request (this has been based on examples in WooCommerce)

### Detailed test instructions:

1. Run the unit tests and confirm that they all pass.

### Changelog entry

* Add - Unit tests for the MerchantCenter account controller.