### PR TITLE
Remove since tags from tests

### DIFF
--- a/tests/Tools/HelperTrait/MerchantTrait.php
+++ b/tests/Tools/HelperTrait/MerchantTrait.php
@@ -12,8 +12,6 @@ use Google\Service\ShoppingContent\AccountBusinessInformation;
  * Trait MerchantTrait
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait
- *
- * @since x.x.x
  */
 trait MerchantTrait {
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ContactInformationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ContactInformationControllerTest.php
@@ -20,7 +20,6 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
  *
- * @since   x.x.x
  * @property MockObject|ContactInformation $contact_information
  * @property MockObject|Settings           $google_settings
  * @property MockObject|Merchant           $merchant

--- a/tests/Unit/MerchantCenter/ContactInformationTest.php
+++ b/tests/Unit/MerchantCenter/ContactInformationTest.php
@@ -18,8 +18,6 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
  *
- * @since x.x.x
- *
  * @property  MockObject|Merchant $merchant
  * @property  MockObject|Settings $google_settings
  * @property  ContactInformation  $contact_information


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is just to clean up some of the test files which have `@since` tags added.

> our tests and related utility classes are not meant to be extended or re-used by third-parties

We also don't replace them with WooRelease so it's not useful to keep them there.