### PR TITLE
Unit tests for the Merchant Google Service class

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -13,7 +13,6 @@ use Google\Service\ShoppingContent\AccountAdsLink;
 use Google\Service\ShoppingContent\AccountStatus;
 use Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
 use Google\Service\ShoppingContent\ProductstatusesCustomBatchRequest;
-use Google\Service\ShoppingContent\ProductstatusesListResponse;
 use Google\Service\ShoppingContent\Product;
 use Exception;
 
@@ -134,22 +133,6 @@ class Merchant implements OptionsAwareInterface {
 			throw new Exception( __( 'Unable to retrieve Merchant Center account status.', 'google-listings-and-ads' ), $e->getCode() );
 		}
 		return $mc_account_status;
-	}
-
-	/**
-	 * Retrieve a page of the user's Merchant Center product statuses.
-	 *
-	 * @param string|null $page_token
-	 *
-	 * @return ProductstatusesListResponse A page of the Merchant Center product statuses.
-	 */
-	public function get_productstatuses( ?string $page_token ): ProductstatusesListResponse {
-		$merchant_id = $this->options->get_merchant_id();
-		$opt_params  = [ 'maxResults' => 250 ];
-		if ( ! empty( $page_token ) ) {
-			$opt_params['pageToken'] = $page_token;
-		}
-		return $this->service->productstatuses->listProductstatuses( $merchant_id, $opt_params );
 	}
 
 	/**

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -163,16 +163,18 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_get_account() {
-		$this->service->accounts->expects( $this->any() )
+		$this->service->accounts->expects( $this->once() )
 			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
 			->willReturn( $this->createMock( Account::class ) );
 
 		$this->assertInstanceOf( Account::class, $this->merchant->get_account() );
 	}
 
 	public function test_get_account_failure() {
-		$this->service->accounts->expects( $this->any() )
+		$this->service->accounts->expects( $this->once() )
 			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
 			->will(
 				$this->throwException(
 					new GoogleException( 'error', 400 )
@@ -186,8 +188,9 @@ class MerchantTest extends UnitTest {
 
 	public function test_get_accountstatuses() {
 		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
-		$this->service->accountstatuses->expects( $this->any() )
+		$this->service->accountstatuses->expects( $this->once() )
 			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
 			->willReturn( $this->createMock( AccountStatus::class ) );
 
 		$this->assertInstanceOf( AccountStatus::class, $this->merchant->get_accountstatus() );
@@ -195,8 +198,9 @@ class MerchantTest extends UnitTest {
 
 	public function test_get_accountstatus_failure() {
 		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
-		$this->service->accountstatuses->expects( $this->any() )
+		$this->service->accountstatuses->expects( $this->once() )
 			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
 			->will(
 				$this->throwException(
 					new GoogleException( 'error', 400 )
@@ -211,7 +215,7 @@ class MerchantTest extends UnitTest {
 	public function test_get_productstatuses_batch() {
 		$this->service->productstatuses = $this->createMock( Productstatuses::class );
 
-		$this->service->productstatuses->expects( $this->any() )
+		$this->service->productstatuses->expects( $this->once() )
 			->method( 'custombatch' )
 			->willReturn( $this->createMock( ProductstatusesCustomBatchResponse::class ) );
 

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -6,9 +6,12 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Exception;
+use Google\Exception as GoogleException;
 use Google\Service\ShoppingContent;
 use Google\Service\ShoppingContent\Product;
 use Google\Service\ShoppingContent\ProductsListResponse;
+use Google\Service\ShoppingContent\Resource\Accounts;
 use Google\Service\ShoppingContent\Resource\Products;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -30,15 +33,17 @@ class MerchantTest extends UnitTest {
 	 */
 	public function setUp() {
 		parent::setUp();
-		$this->service  = $this->createMock( ShoppingContent::class );
+		$this->service           = $this->createMock( ShoppingContent::class );
+		$this->service->accounts = $this->createMock( Accounts::class );
+		$this->service->products = $this->createMock( Products::class );
+
 		$this->options  = $this->createMock( OptionsInterface::class );
 		$this->merchant = new Merchant( $this->service );
 		$this->merchant->set_options_object( $this->options );
 	}
 
 	public function test_get_products_empty_list() {
-		$this->service->products = $this->createMock( Products::class );
-		$list_response           = $this->createMock( ProductsListResponse::class );
+		$list_response = $this->createMock( ProductsListResponse::class );
 
 		$this->service->products->expects( $this->any() )
 			->method( 'listProducts' )
@@ -49,8 +54,7 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_get_products() {
-		$this->service->products = $this->createMock( Products::class );
-		$list_response           = $this->createMock( ProductsListResponse::class );
+		$list_response = $this->createMock( ProductsListResponse::class );
 
 		$product_list = [
 			$this->createMock( Product::class ),
@@ -73,8 +77,7 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_get_products_multiple_pages() {
-		$this->service->products = $this->createMock( Products::class );
-		$list_response           = $this->createMock( ProductsListResponse::class );
+		$list_response = $this->createMock( ProductsListResponse::class );
 
 		$product_list = [
 			$this->createMock( Product::class ),
@@ -103,4 +106,34 @@ class MerchantTest extends UnitTest {
 		$this->assertCount( count( $product_list ) * 2, $products );
 	}
 
+	public function test_claim_website() {
+		$this->assertTrue( $this->merchant->claimwebsite() );
+	}
+
+	public function test_claimwebsite_error() {
+		$this->service->accounts->expects( $this->any() )
+			->method( 'claimwebsite' )
+			->will(
+				$this->throwException(
+					new GoogleException()
+				)
+			);
+
+		$this->expectException( Exception::class );
+		$this->merchant->claimwebsite();
+	}
+
+	public function test_website_already_claimed() {
+		$this->service->accounts->expects( $this->any() )
+			->method( 'claimwebsite' )
+			->will(
+				$this->throwException(
+					new GoogleException( 'claimed', 403 )
+				)
+			);
+
+		$this->expectException( Exception::class );
+        $this->expectExceptionCode( 403 );
+		$this->merchant->claimwebsite();
+	}
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -13,6 +13,7 @@ use Google\Service\ShoppingContent;
 use Google\Service\ShoppingContent\Account;
 use Google\Service\ShoppingContent\AccountAdsLink;
 use Google\Service\ShoppingContent\AccountStatus;
+use Google\Service\ShoppingContent\AccountUser;
 use Google\Service\ShoppingContent\Product;
 use Google\Service\ShoppingContent\ProductsListResponse;
 use Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
@@ -272,6 +273,48 @@ class MerchantTest extends UnitTest {
 
 		$this->assertFalse(
 			$this->merchant->link_ads_id( $ads_id )
+		);
+	}
+
+	public function test_has_access_to_account() {
+		$account = $this->createMock( Account::class );
+		$user    = $this->createMock( AccountUser::class );
+		$email   = 'john@doe.email';
+
+		$user->expects( $this->any() )
+			->method( 'getEmailAddress' )
+			->willReturn( $email );
+
+		$user->expects( $this->any() )
+			->method( 'getAdmin' )
+			->willReturn( true );
+
+		$account->expects( $this->any() )
+			->method( 'getUsers' )
+			->willReturn( [ $user ] );
+
+		$this->service->accounts->expects( $this->any() )
+			->method( 'get' )
+			->willReturn( $account );
+
+		$this->assertTrue(
+			$this->merchant->has_access( $email )
+		);
+	}
+
+	public function test_no_access_to_account() {
+		$email = 'john@doe.email';
+
+		$this->service->accounts->expects( $this->any() )
+			->method( 'get' )
+			->will(
+				$this->throwException(
+					new GoogleException( 'no access', 403 )
+				)
+			);
+
+		$this->assertFalse(
+			$this->merchant->has_access( $email )
 		);
 	}
 

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -11,6 +11,7 @@ use Exception;
 use Google\Exception as GoogleException;
 use Google\Service\ShoppingContent;
 use Google\Service\ShoppingContent\Account;
+use Google\Service\ShoppingContent\AccountAdsLink;
 use Google\Service\ShoppingContent\AccountStatus;
 use Google\Service\ShoppingContent\Product;
 use Google\Service\ShoppingContent\ProductsListResponse;
@@ -229,6 +230,49 @@ class MerchantTest extends UnitTest {
 		$this->expectException( MerchantApiException::class );
         $this->expectExceptionCode( 400 );
 		$this->merchant->update_account( $account );
+	}
+
+	public function test_link_ads_id() {
+		$account = $this->createMock( Account::class );
+		$ads_id  = 12345;
+
+		$account->expects( $this->any() )
+			->method( 'getAdsLinks' )
+			->willReturn( [] );
+
+		$this->service->accounts->expects( $this->any() )
+			->method( 'get' )
+			->willReturn( $account );
+
+		$this->service->accounts->expects( $this->any() )
+			->method( 'update' )
+			->willReturn( $account );
+
+		$this->assertTrue(
+			$this->merchant->link_ads_id( $ads_id )
+		);
+	}
+
+	public function test_ads_id_already_linked() {
+		$account  = $this->createMock( Account::class );
+		$ads_link = $this->createMock( AccountAdsLink::class );
+		$ads_id   = 12345;
+
+		$ads_link->expects( $this->any() )
+			->method( 'getAdsId' )
+			->willReturn( $ads_id );
+
+		$account->expects( $this->any() )
+			->method( 'getAdsLinks' )
+			->willReturn( [ $ads_link ] );
+
+		$this->service->accounts->expects( $this->any() )
+			->method( 'get' )
+			->willReturn( $account );
+
+		$this->assertFalse(
+			$this->merchant->link_ads_id( $ads_id )
+		);
 	}
 
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -340,8 +340,9 @@ class MerchantTest extends UnitTest {
 			->method( 'getUsers' )
 			->willReturn( [ $user ] );
 
-		$this->service->accounts->expects( $this->any() )
+		$this->service->accounts->expects( $this->once() )
 			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
 			->willReturn( $account );
 
 		$this->assertTrue(
@@ -352,8 +353,9 @@ class MerchantTest extends UnitTest {
 	public function test_no_access_to_account() {
 		$email = 'john@doe.email';
 
-		$this->service->accounts->expects( $this->any() )
+		$this->service->accounts->expects( $this->once() )
 			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
 			->will(
 				$this->throwException(
 					new GoogleException( 'no access', 403 )

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -4,11 +4,13 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Exception;
 use Google\Exception as GoogleException;
 use Google\Service\ShoppingContent;
+use Google\Service\ShoppingContent\Account;
 use Google\Service\ShoppingContent\Product;
 use Google\Service\ShoppingContent\ProductsListResponse;
 use Google\Service\ShoppingContent\Resource\Accounts;
@@ -135,5 +137,27 @@ class MerchantTest extends UnitTest {
 		$this->expectException( Exception::class );
         $this->expectExceptionCode( 403 );
 		$this->merchant->claimwebsite();
+	}
+
+	public function test_get_account() {
+		$this->service->accounts->expects( $this->any() )
+			->method( 'get' )
+			->willReturn( $this->createMock( Account::class ) );
+
+		$this->assertInstanceOf( Account::class, $this->merchant->get_account() );
+	}
+
+	public function test_get_account_failure() {
+		$this->service->accounts->expects( $this->any() )
+			->method( 'get' )
+			->will(
+				$this->throwException(
+					new GoogleException( 'error', 400 )
+				)
+			);
+
+		$this->expectException( MerchantApiException::class );
+        $this->expectExceptionCode( 400 );
+		$this->merchant->get_account();
 	}
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -202,4 +202,33 @@ class MerchantTest extends UnitTest {
 		);
 	}
 
+	public function test_update_account() {
+		$account = $this->createMock( Account::class );
+
+		$this->service->accounts->expects( $this->any() )
+			->method( 'update' )
+			->willReturn( $account );
+
+		$this->assertInstanceOf(
+			Account::class,
+			$this->merchant->update_account( $account )
+		);
+	}
+
+	public function test_update_account_failure() {
+		$account = $this->createMock( Account::class );
+
+		$this->service->accounts->expects( $this->any() )
+			->method( 'update' )
+			->will(
+				$this->throwException(
+					new GoogleException( 'error', 400 )
+				)
+			);
+
+		$this->expectException( MerchantApiException::class );
+        $this->expectExceptionCode( 400 );
+		$this->merchant->update_account( $account );
+	}
+
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -16,6 +16,7 @@ use Google\Service\ShoppingContent\AccountStatus;
 use Google\Service\ShoppingContent\AccountUser;
 use Google\Service\ShoppingContent\Product;
 use Google\Service\ShoppingContent\ProductsListResponse;
+use Google\Service\ShoppingContent\ProductstatusesCustomBatchRequest;
 use Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
 use Google\Service\ShoppingContent\Resource\Accounts;
 use Google\Service\ShoppingContent\Resource\Accountstatuses;
@@ -217,6 +218,23 @@ class MerchantTest extends UnitTest {
 
 		$this->service->productstatuses->expects( $this->once() )
 			->method( 'custombatch' )
+			->with(
+				$this->callback(
+					function( ProductstatusesCustomBatchRequest $request ) {
+						$this->assertEquals(
+							[
+								'batchId'    => 3,
+								'productId'  => 3,
+								'method'     => 'GET',
+								'merchantId' => $this->merchant_id,
+							],
+							$request->getEntries()[2]
+						);
+
+						return true;
+					}
+				)
+			)
 			->willReturn( $this->createMock( ProductstatusesCustomBatchResponse::class ) );
 
 		$this->assertInstanceOf(

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -127,12 +127,16 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_claim_website() {
+		$this->service->accounts->expects( $this->once() )
+			->method( 'claimwebsite' )
+			->with( $this->merchant_id, $this->merchant_id, [] );
 		$this->assertTrue( $this->merchant->claimwebsite() );
 	}
 
 	public function test_claimwebsite_error() {
-		$this->service->accounts->expects( $this->any() )
+		$this->service->accounts->expects( $this->once() )
 			->method( 'claimwebsite' )
+			->with( $this->merchant_id, $this->merchant_id, [] )
 			->will(
 				$this->throwException(
 					new GoogleException()
@@ -144,8 +148,9 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_website_already_claimed() {
-		$this->service->accounts->expects( $this->any() )
+		$this->service->accounts->expects( $this->once() )
 			->method( 'claimwebsite' )
+			->with( $this->merchant_id, $this->merchant_id, [] )
 			->will(
 				$this->throwException(
 					new GoogleException( 'claimed', 403 )

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -11,9 +11,11 @@ use Exception;
 use Google\Exception as GoogleException;
 use Google\Service\ShoppingContent;
 use Google\Service\ShoppingContent\Account;
+use Google\Service\ShoppingContent\AccountStatus;
 use Google\Service\ShoppingContent\Product;
 use Google\Service\ShoppingContent\ProductsListResponse;
 use Google\Service\ShoppingContent\Resource\Accounts;
+use Google\Service\ShoppingContent\Resource\Accountstatuses;
 use Google\Service\ShoppingContent\Resource\Products;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -160,4 +162,29 @@ class MerchantTest extends UnitTest {
         $this->expectExceptionCode( 400 );
 		$this->merchant->get_account();
 	}
+
+	public function test_get_accountstatuses() {
+		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
+		$this->service->accountstatuses->expects( $this->any() )
+			->method( 'get' )
+			->willReturn( $this->createMock( AccountStatus::class ) );
+
+		$this->assertInstanceOf( AccountStatus::class, $this->merchant->get_accountstatus() );
+	}
+
+	public function test_get_accountstatus_failure() {
+		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
+		$this->service->accountstatuses->expects( $this->any() )
+			->method( 'get' )
+			->will(
+				$this->throwException(
+					new GoogleException( 'error', 400 )
+				)
+			);
+
+		$this->expectException( Exception::class );
+        $this->expectExceptionCode( 400 );
+		$this->merchant->get_accountstatus();
+	}
+
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -226,23 +226,31 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_update_account() {
-		$account = $this->createMock( Account::class );
+		$account_id = uniqid();
+		$account    = $this->createMock( Account::class );
 
-		$this->service->accounts->expects( $this->any() )
+		$account->method( 'getId' )->willReturn( $account_id );
+
+		$this->service->accounts->expects( $this->once() )
 			->method( 'update' )
+			->with( $account_id, $account_id, $account )
 			->willReturn( $account );
 
-		$this->assertInstanceOf(
-			Account::class,
+		$this->assertEquals(
+			$account,
 			$this->merchant->update_account( $account )
 		);
 	}
 
 	public function test_update_account_failure() {
-		$account = $this->createMock( Account::class );
+		$account_id = uniqid();
+		$account    = $this->createMock( Account::class );
 
-		$this->service->accounts->expects( $this->any() )
+		$account->method( 'getId' )->willReturn( $account_id );
+
+		$this->service->accounts->expects( $this->once() )
 			->method( 'update' )
+			->with( $account_id, $account_id, $account )
 			->will(
 				$this->throwException(
 					new GoogleException( 'error', 400 )

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -57,7 +57,7 @@ class MerchantTest extends UnitTest {
 	public function test_get_products_empty_list() {
 		$list_response = $this->createMock( ProductsListResponse::class );
 
-		$this->service->products->expects( $this->any() )
+		$this->service->products->expects( $this->once() )
 			->method( 'listProducts' )
 			->with( $this->merchant_id )
 			->willReturn( $list_response );
@@ -78,16 +78,15 @@ class MerchantTest extends UnitTest {
 			->method( 'getResources' )
 			->willReturn( $product_list );
 
-		$this->service->products->expects( $this->any() )
+		$this->service->products->expects( $this->once() )
 			->method( 'listProducts' )
 			->with( $this->merchant_id )
 			->willReturn( $list_response );
 
-		$products = $this->merchant->get_products();
-		$this->assertCount( count( $product_list ), $products );
-		foreach ( $products as $product ) {
-			$this->assertInstanceOf( Product::class, $product );
-		}
+		$this->assertEquals(
+			$product_list,
+			$this->merchant->get_products()
+		);
 	}
 
 	public function test_get_products_multiple_pages() {
@@ -328,11 +327,11 @@ class MerchantTest extends UnitTest {
 			->method( 'getAdsId' )
 			->willReturn( $ads_id );
 
-		$account->expects( $this->any() )
+		$account->expects( $this->once() )
 			->method( 'getAdsLinks' )
 			->willReturn( [ $ads_link ] );
 
-		$this->service->accounts->expects( $this->any() )
+		$this->service->accounts->expects( $this->once() )
 			->method( 'get' )
 			->with( $this->merchant_id, $this->merchant_id )
 			->willReturn( $account );
@@ -347,15 +346,15 @@ class MerchantTest extends UnitTest {
 		$user    = $this->createMock( AccountUser::class );
 		$email   = 'john@doe.email';
 
-		$user->expects( $this->any() )
+		$user->expects( $this->once() )
 			->method( 'getEmailAddress' )
 			->willReturn( $email );
 
-		$user->expects( $this->any() )
+		$user->expects( $this->once() )
 			->method( 'getAdmin' )
 			->willReturn( true );
 
-		$account->expects( $this->any() )
+		$account->expects( $this->once() )
 			->method( 'getUsers' )
 			->willReturn( [ $user ] );
 

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -14,9 +14,11 @@ use Google\Service\ShoppingContent\Account;
 use Google\Service\ShoppingContent\AccountStatus;
 use Google\Service\ShoppingContent\Product;
 use Google\Service\ShoppingContent\ProductsListResponse;
+use Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
 use Google\Service\ShoppingContent\Resource\Accounts;
 use Google\Service\ShoppingContent\Resource\Accountstatuses;
 use Google\Service\ShoppingContent\Resource\Products;
+use Google\Service\ShoppingContent\Resource\Productstatuses;
 use PHPUnit\Framework\MockObject\MockObject;
 
 defined( 'ABSPATH' ) || exit;
@@ -185,6 +187,19 @@ class MerchantTest extends UnitTest {
 		$this->expectException( Exception::class );
         $this->expectExceptionCode( 400 );
 		$this->merchant->get_accountstatus();
+	}
+
+	public function test_get_productstatuses_batch() {
+		$this->service->productstatuses = $this->createMock( Productstatuses::class );
+
+		$this->service->productstatuses->expects( $this->any() )
+			->method( 'custombatch' )
+			->willReturn( $this->createMock( ProductstatusesCustomBatchResponse::class ) );
+
+		$this->assertInstanceOf(
+			ProductstatusesCustomBatchResponse::class,
+			$this->merchant->get_productstatuses_batch( [ 1, 2, 3 ] )
+		);
 	}
 
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -288,15 +288,29 @@ class MerchantTest extends UnitTest {
 		$account = $this->createMock( Account::class );
 		$ads_id  = 12345;
 
-		$account->expects( $this->any() )
+		$account->expects( $this->once() )
 			->method( 'getAdsLinks' )
 			->willReturn( [] );
 
-		$this->service->accounts->expects( $this->any() )
+		$account->expects( $this->once() )
+			->method( 'setAdsLinks' )
+			->with(
+				$this->callback(
+					function( array $links ) use ( $ads_id ) {
+						$this->assertEquals( $ads_id, $links[0]->getAdsId() );
+						$this->assertEquals( 'active', $links[0]->getStatus() );
+
+						return true;
+					}
+				)
+			);
+
+		$this->service->accounts->expects( $this->once() )
 			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
 			->willReturn( $account );
 
-		$this->service->accounts->expects( $this->any() )
+		$this->service->accounts->expects( $this->once() )
 			->method( 'update' )
 			->willReturn( $account );
 
@@ -320,6 +334,7 @@ class MerchantTest extends UnitTest {
 
 		$this->service->accounts->expects( $this->any() )
 			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
 			->willReturn( $account );
 
 		$this->assertFalse(

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -164,12 +164,14 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_get_account() {
+		$account = $this->createMock( Account::class );
+
 		$this->service->accounts->expects( $this->once() )
 			->method( 'get' )
 			->with( $this->merchant_id, $this->merchant_id )
-			->willReturn( $this->createMock( Account::class ) );
+			->willReturn( $account );
 
-		$this->assertInstanceOf( Account::class, $this->merchant->get_account() );
+		$this->assertEquals( $account, $this->merchant->get_account() );
 	}
 
 	public function test_get_account_failure() {
@@ -188,13 +190,15 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_get_accountstatuses() {
+		$account_status = $this->createMock( AccountStatus::class );
+
 		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
 		$this->service->accountstatuses->expects( $this->once() )
 			->method( 'get' )
 			->with( $this->merchant_id, $this->merchant_id )
-			->willReturn( $this->createMock( AccountStatus::class ) );
+			->willReturn( $account_status );
 
-		$this->assertInstanceOf( AccountStatus::class, $this->merchant->get_accountstatus() );
+		$this->assertEquals( $account_status, $this->merchant->get_accountstatus() );
 	}
 
 	public function test_get_accountstatus_failure() {

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -1,0 +1,106 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Google\Service\ShoppingContent;
+use Google\Service\ShoppingContent\Product;
+use Google\Service\ShoppingContent\ProductsListResponse;
+use Google\Service\ShoppingContent\Resource\Products;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MerchantTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ *
+ * @property  MockObject|ShoppingContent  $service
+ * @property  MockObject|OptionsInterface $options
+ * @property  Merchant                    $merchant
+ */
+class MerchantTest extends UnitTest {
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->service  = $this->createMock( ShoppingContent::class );
+		$this->options  = $this->createMock( OptionsInterface::class );
+		$this->merchant = new Merchant( $this->service );
+		$this->merchant->set_options_object( $this->options );
+	}
+
+	public function test_get_products_empty_list() {
+		$this->service->products = $this->createMock( Products::class );
+		$list_response           = $this->createMock( ProductsListResponse::class );
+
+		$this->service->products->expects( $this->any() )
+			->method( 'listProducts' )
+			->willReturn( $list_response );
+
+		$products = $this->merchant->get_products();
+		$this->assertEquals( $products, [] );
+	}
+
+	public function test_get_products() {
+		$this->service->products = $this->createMock( Products::class );
+		$list_response           = $this->createMock( ProductsListResponse::class );
+
+		$product_list = [
+			$this->createMock( Product::class ),
+			$this->createMock( Product::class ),
+		];
+
+		$list_response->expects( $this->any() )
+			->method( 'getResources' )
+			->willReturn( $product_list );
+
+		$this->service->products->expects( $this->any() )
+			->method( 'listProducts' )
+			->willReturn( $list_response );
+
+		$products = $this->merchant->get_products();
+		$this->assertCount( count( $product_list ), $products );
+		foreach ( $products as $product ) {
+			$this->assertInstanceOf( Product::class, $product );
+		}
+	}
+
+	public function test_get_products_multiple_pages() {
+		$this->service->products = $this->createMock( Products::class );
+		$list_response           = $this->createMock( ProductsListResponse::class );
+
+		$product_list = [
+			$this->createMock( Product::class ),
+			$this->createMock( Product::class ),
+		];
+
+		$list_response->expects( $this->any() )
+			->method( 'getResources' )
+			->willReturn( $product_list );
+
+		$list_response->expects( $this->any() )
+			->method( 'getNextPageToken' )
+			->will(
+				$this->onConsecutiveCalls(
+					'token',
+					'token',
+					null
+				)
+			);
+
+		$this->service->products->expects( $this->any() )
+			->method( 'listProducts' )
+			->willReturn( $list_response );
+
+		$products = $this->merchant->get_products();
+		$this->assertCount( count( $product_list ) * 2, $products );
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR adds unit tests for the Google API Merchant class which is a wrapper for some of the services from the Google Content API.

The function `get_productstatuses` is no longer used by the code since we switched to retrieving these in batches. This PR removes the function, if we need it again at a later stage we can bring it back.

### Detailed test instructions:

1. Run the unit tests and confirm that they all pass.

### Changelog entry

* Add - Unit tests for the Merchant Google Service class.