### PR TITLE
Unit tests for the Ads account controller

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -60,30 +60,30 @@ set -ex
 
 install_wp() {
 
-  if [ -d $WP_CORE_DIR ]; then
+  if [ -d "$WP_CORE_DIR" ]; then
     return
   fi
 
-  mkdir -p $WP_CORE_DIR
+  mkdir -p "$WP_CORE_DIR"
 
   if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-    mkdir -p $TMPDIR/wordpress-trunk
-    rm -rf $TMPDIR/wordpress-trunk/*
-    svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
-    mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
+    mkdir -p "$TMPDIR"/wordpress-trunk
+    rm -rf "$TMPDIR"/wordpress-trunk/*
+    svn export --quiet https://core.svn.wordpress.org/trunk "$TMPDIR"/wordpress-trunk/wordpress
+    mv "$TMPDIR"/wordpress-trunk/wordpress/* "$WP_CORE_DIR"
   else
     if [ $WP_VERSION == 'latest' ]; then
       local ARCHIVE_NAME='latest'
     elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
       # https serves multiple offers, whereas http serves single.
-      download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+      download https://api.wordpress.org/core/version-check/1.7/ "$TMPDIR"/wp-latest.json
       if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
         # version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
         LATEST_VERSION=${WP_VERSION%??}
       else
         # otherwise, scan the releases and get the most up to date minor version of the major release
         local VERSION_ESCAPED=$(echo $WP_VERSION | sed 's/\./\\\\./g')
-        LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+        LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' "$TMPDIR"/wp-latest.json | sed 's/"version":"//' | head -1)
       fi
       if [[ -z "$LATEST_VERSION" ]]; then
         local ARCHIVE_NAME="wordpress-$WP_VERSION"
@@ -93,11 +93,11 @@ install_wp() {
     else
       local ARCHIVE_NAME="wordpress-$WP_VERSION"
     fi
-    download https://wordpress.org/${ARCHIVE_NAME}.tar.gz $TMPDIR/wordpress.tar.gz
-    tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+    download https://wordpress.org/${ARCHIVE_NAME}.tar.gz "$TMPDIR"/wordpress.tar.gz
+    tar --strip-components=1 -zxmf "$TMPDIR"/wordpress.tar.gz -C "$WP_CORE_DIR"
   fi
 
-  download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+  download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR"/wp-content/db.php
 }
 
 install_test_suite() {
@@ -109,12 +109,12 @@ install_test_suite() {
   fi
 
   # set up testing suite if it doesn't yet exist
-  if [ ! -d $WP_TESTS_DIR ]; then
+  if [ ! -d "$WP_TESTS_DIR" ]; then
     # set up testing suite
-    mkdir -p $WP_TESTS_DIR
-    rm -rf $WP_TESTS_DIR/{includes,data}
-    svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-    svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+    mkdir -p "$WP_TESTS_DIR"
+    rm -rf "$WP_TESTS_DIR"/{includes,data}
+    svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ "$WP_TESTS_DIR"/includes
+    svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ "$WP_TESTS_DIR"/data
   fi
 
   if [ ! -f wp-tests-config.php ]; then
@@ -180,12 +180,19 @@ install_db() {
 }
 
 install_wc() {
-  if [ ! -d $WC_DIR ]; then
+  if [ ! -d "$WC_DIR" ]; then
     # set up testing suite
-    mkdir -p $WC_DIR
+    mkdir -p "$WC_DIR"
     echo "Installing WooCommerce ($WC_VERSION)."
     # Grab the necessary plugins.
-    git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${WC_DIR}"
+    if [ $WC_VERSION == 'trunk' ]; then
+      rm -rf "$TMPDIR"/woocommerce-trunk
+      git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${TMPDIR}/woocommerce-trunk"
+      mv "$TMPDIR"/woocommerce-trunk/plugins/woocommerce/* "$WC_DIR"
+    else
+      echo "Test with specified WooCommerce version ${WC_VERSION} is not yet supported."
+      exit 1
+    fi
 
     # Install composer for WooCommerce
     cd "${WC_DIR}"

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -269,7 +269,7 @@ class AccountController extends BaseOptionsController {
 	 * @throws Exception If there is already an Ads account ID.
 	 */
 	private function use_existing_account( int $account_id ) {
-		$ads_id = $this->options->get( OptionsInterface::ADS_ID );
+		$ads_id = $this->options->get_ads_id();
 		if ( $ads_id && $ads_id !== $account_id ) {
 			throw new Exception(
 				/* translators: 1: is a numeric account ID */
@@ -302,7 +302,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	private function setup_account(): array {
 		$state   = $this->account_state->get();
-		$ads_id  = $this->options->get( OptionsInterface::ADS_ID );
+		$ads_id  = $this->options->get_ads_id();
 		$account = [ 'id' => $ads_id ];
 
 		foreach ( $state as $name => &$step ) {

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -44,6 +44,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -44,7 +44,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -4,6 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
@@ -41,6 +44,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
@@ -79,7 +83,15 @@ class RESTServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$this->share( SettingsController::class );
 		$this->share( ConnectionController::class );
-		$this->share_with_container( AdsAccountController::class );
+		$this->share(
+			AdsAccountController::class,
+			Middleware::class,
+			Ads::class,
+			AdsAccountState::class,
+			AdsService::class,
+			AdsConversionAction::class,
+			Merchant::class
+		);
 		$this->share_with_container( AdsCampaignController::class );
 		$this->share_with_container( AdsReportsController::class );
 		$this->share( GoogleAccountController::class, Connection::class );

--- a/tests/Framework/MockRESTServer.php
+++ b/tests/Framework/MockRESTServer.php
@@ -10,8 +10,6 @@ defined( 'ABSPATH' ) || exit;
  * Class MockRESTServer
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework
- *
- * @since   x.x.x
  */
 class MockRESTServer extends WP_REST_Server {
 	/**

--- a/tests/Framework/MockRESTServer.php
+++ b/tests/Framework/MockRESTServer.php
@@ -10,6 +10,8 @@ defined( 'ABSPATH' ) || exit;
  * Class MockRESTServer
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework
+ *
+ * @since   x.x.x
  */
 class MockRESTServer extends WP_REST_Server {
 	/**

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -86,6 +86,7 @@ abstract class RESTControllerUnitTest extends UnitTest {
 
 	/**
 	 * Validate that the returned API schema matches what is expected.
+
 	 */
 	public function test_schema_properties() {
 		$request    = new Request( 'OPTIONS', $this->routes[0] );

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BillingSetupStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ *
+ * @property MockObject|Middleware          $middleware
+ * @property MockObject|Ads                 $ads,
+ * @property MockObject|AdsService          $ads_service,
+ * @property MockObject|AdsConversionAction $ads_conversion_action,
+ * @property MockObject|Merchant            $merchant
+ * @property MockObject|OptionsInterface    $options
+ * @property AccountController              $controller
+ * @property AdsAccountState                $account_state
+ */
+class AccountControllerTest extends RESTControllerUnitTest {
+
+	/**
+	 * Routes that this endpoint creates.
+	 *
+	 * @var array
+	 */
+	protected $routes = [
+		'/wc/gla/ads/accounts',
+		'/wc/gla/ads/connection',
+		'/wc/gla/ads/billing-status',
+	];
+
+	/**
+	 * The endpoint schema.
+	 *
+	 * @var array Keys are property names, values are supported context.
+	 */
+	protected $properties = [
+		'id'          => [ 'view', 'edit' ],
+		'billing_url' => [ 'view', 'edit' ],
+	];
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->middleware            = $this->createMock( Middleware::class );
+		$this->ads                   = $this->createMock( Ads::class );
+		$this->ads_service           = $this->createMock( AdsService::class );
+		$this->ads_conversion_action = $this->createMock( AdsConversionAction::class );
+		$this->merchant              = $this->createMock( Merchant::class );
+		$this->options               = $this->createMock( OptionsInterface::class );
+
+		$this->account_state = new AdsAccountState();
+		$this->account_state->set_options_object( $this->options );
+
+		$this->controller = new AccountController(
+			$this->server,
+			$this->middleware,
+			$this->ads,
+			$this->account_state,
+			$this->ads_service,
+			$this->ads_conversion_action,
+			$this->merchant
+		);
+		$this->controller->set_options_object( $this->options );
+
+		$this->register_test_routes();
+	}
+
+	public function test_get_accounts() {
+		$accounts = [
+			12345,
+			23456,
+		];
+
+		$this->middleware->expects( $this->any() )
+			->method( 'get_ads_account_ids' )
+			->willReturn( $accounts );
+
+		$response = $this->do_request( '/wc/gla/ads/accounts', 'GET' );
+	 	$this->assertExpectedResponse( $response, 200 );
+	 	$this->assertEquals( $accounts, $response->data );
+	}
+
+	public function test_unable_to_get_accounts() {
+		$this->middleware->expects( $this->any() )
+	 		->method( 'get_ads_account_ids' )
+	 		->will(
+				$this->throwException( new Exception( 'Error', 403 ) )
+			);
+
+		$response = $this->do_request( '/wc/gla/ads/accounts', 'GET' );
+		$this->assertExpectedResponse( $response, 403 );
+	}
+
+	public function test_create_new_account() {
+		$ads_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->willReturn( 0 );
+
+		$this->middleware->expects( $this->any() )
+			->method( 'create_ads_account' )
+			->willReturn(
+				[
+					'id'          => $ads_id,
+					'billing_url' => 'https://billingurl.test',
+				]
+			);
+
+		$response = $this->do_request( '/wc/gla/ads/accounts', 'POST' );
+		$this->assertExpectedResponse( $response, 428 );
+		$this->assertEquals( BillingSetupStatus::UNKNOWN, $response->data['billing_status'] );
+	}
+
+	public function test_continue_create_new_account() {
+		$ads_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->willReturn( $ads_id );
+
+		$this->ads->expects( $this->any() )
+			->method( 'get_billing_status' )
+			->willReturn( BillingSetupStatus::APPROVED );
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 23456 );
+
+		$this->expected_account_state(
+			[
+				'set_id'            => [
+					'status' => AdsAccountState::STEP_DONE,
+				],
+				'billing'           => [
+					'status' => AdsAccountState::STEP_PENDING,
+				],
+				'link_merchant'     => [
+					'status' => AdsAccountState::STEP_PENDING,
+				],
+				'conversion_action' => [
+					'status' => AdsAccountState::STEP_PENDING,
+				],
+			],
+		);
+
+		$response = $this->do_request( '/wc/gla/ads/accounts', 'POST' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( $ads_id, $response->data['id'] );
+	}
+
+	public function test_link_existing_account() {
+		$ads_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->will( $this->onConsecutiveCalls( 0, $ads_id, $ads_id, $ads_id ) );
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 23456 );
+
+		$this->expected_account_state(
+			[
+				[
+					'set_id'  => [
+						'status' => AdsAccountState::STEP_PENDING,
+					],
+					'billing' => [
+						'status' => AdsAccountState::STEP_PENDING,
+					],
+				],
+				[
+					'set_id'            => [
+						'status' => AdsAccountState::STEP_DONE,
+					],
+					'billing'           => [
+						'status' => AdsAccountState::STEP_DONE,
+					],
+					'link_merchant'     => [
+						'status' => AdsAccountState::STEP_PENDING,
+					],
+					'conversion_action' => [
+						'status' => AdsAccountState::STEP_PENDING,
+					],
+				],
+			],
+			true
+		);
+
+		$response = $this->do_request(
+			'/wc/gla/ads/accounts',
+			'POST',
+			[
+				'id' => $ads_id,
+			]
+		);
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( $ads_id, $response->data['id'] );
+	}
+
+	public function test_link_invalid_merchant() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->expected_account_state(
+			[
+				'set_id'        => [
+					'status' => AdsAccountState::STEP_DONE,
+				],
+				'billing'       => [
+					'status' => AdsAccountState::STEP_DONE,
+				],
+				'link_merchant' => [
+					'status' => AdsAccountState::STEP_PENDING,
+				],
+			]
+		);
+
+		$response = $this->do_request( '/wc/gla/ads/accounts', 'POST' );
+		$this->assertExpectedResponse( $response, 400 );
+	}
+
+	public function test_invalid_step() {
+	 	$ads_id = 12345;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->willReturn( $ads_id );
+
+		$this->expected_account_state(
+			[
+				'invalid' => [
+					'status' => AdsAccountState::STEP_PENDING,
+				],
+			]
+		);
+
+		$response = $this->do_request( '/wc/gla/ads/accounts', 'POST' );
+		$this->assertExpectedResponse( $response, 400 );
+	}
+
+	public function test_account_already_connected() {
+		$ads_id       = 12345;
+		$connected_id = 23456;
+
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->willReturn( $connected_id );
+
+		$response = $this->do_request(
+			'/wc/gla/ads/accounts',
+			'POST',
+			[
+				'id' => $ads_id,
+			]
+		);
+		$this->assertExpectedResponse( $response, 400 );
+		$this->assertStringContainsString( $connected_id, $response->data['message'] );
+	}
+
+	public function test_connection_status() {
+		$status = [
+			'id'       => '12345',
+			'currency' => 'USD',
+			'status'   => 'connected',
+		];
+		$this->middleware->expects( $this->any() )
+			->method( 'get_connected_ads_account' )
+			->willReturn( $status );
+
+		$response = $this->do_request( '/wc/gla/ads/connection', 'GET' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( $status, $response->data );
+	}
+
+	public function test_disconnect() {
+		$response = $this->do_request( '/wc/gla/ads/connection', 'DELETE' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( 'success', $response->data['status'] );
+	}
+
+	public function test_billing_status_approved() {
+		$this->ads->expects( $this->any() )
+			->method( 'get_billing_status' )
+			->willReturn( BillingSetupStatus::APPROVED );
+
+		$response = $this->do_request( '/wc/gla/ads/billing-status', 'GET' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( BillingSetupStatus::APPROVED, $response->data['status'] );
+	}
+
+	public function test_billing_status_pending() {
+		$billing_url = 'https://billingurl.test';
+
+		$this->ads->expects( $this->any() )
+			->method( 'get_billing_status' )
+			->willReturn( BillingSetupStatus::PENDING );
+
+		$this->options->expects( $this->any() )
+			->method( 'get' )
+			->will(
+				$this->returnCallback(
+					function( $arg ) use ( $billing_url ) {
+						if ( OptionsInterface::ADS_BILLING_URL === $arg ) {
+							return $billing_url;
+						}
+					}
+				)
+			);
+
+		$response = $this->do_request( '/wc/gla/ads/billing-status', 'GET' );
+		$this->assertExpectedResponse( $response, 200 );
+		$this->assertEquals( BillingSetupStatus::PENDING, $response->data['status'] );
+		$this->assertEquals( $billing_url, $response->data['billing_url'] );
+	}
+
+	public function test_billing_status_failure() {
+		$this->ads->expects( $this->any() )
+			->method( 'get_billing_status' )
+	 		->will(
+				$this->throwException( new Exception( 'Error', 403 ) )
+			);
+
+		$response = $this->do_request( '/wc/gla/ads/billing-status', 'GET' );
+		$this->assertExpectedResponse( $response, 403 );
+	}
+
+	/**
+	 * Mock the ads account state to return specific state values.
+	 * Parameter $state must contain states with a numeric index if $consecutive_states is true.
+	 *
+	 * @param array $state              Expected state values to return.
+	 * @param bool  $consecutive_states If we expect consecutive states.
+	 */
+	protected function expected_account_state( array $state, bool $consecutive_states = false ) {
+		$callback = function( $arg ) use ( $state, $consecutive_states ) {
+			static $consecutive_index = 0;
+			if ( OptionsInterface::ADS_ACCOUNT_STATE === $arg ) {
+				return $consecutive_states ? $state[ $consecutive_index++ ] : $state;
+			}
+		};
+
+		$this->options->expects( $this->any() )
+			->method( 'get' )
+			->will( $this->returnCallback( $callback ) );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds unit tests for the Ads account controller. This re-uses the `RESTControllerUnitTest` which from #973.

Like the previous PR we also change the controller to receive it's dependencies directly in the constructor (instead of through the container). This makes it easier to test and pass mocked services.

See comments from https://github.com/woocommerce/google-listings-and-ads/pull/973#issuecomment-907075512
Issue #388 needs to be addressed before we can refine these tests.

### Detailed test instructions:

1. Run the unit tests and confirm that they all pass.

### Changelog entry

* Add - Unit tests for the Ads account controller.