### PR TITLE
Add `admin-e2e-tests`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ languages
 node_modules
 vendor
 legacy
+tests/e2e/specs/wc-admin

--- a/package-lock.json
+++ b/package-lock.json
@@ -2528,6 +2528,43 @@
 				}
 			}
 		},
+		"@jest/environment": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+			"integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"jest-mock": "^26.6.2"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+			"integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"@sinonjs/fake-timers": "^6.0.1",
+				"@types/node": "*",
+				"jest-message-util": "^26.6.2",
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2"
+			}
+		},
+		"@jest/globals": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+			"integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"expect": "^26.6.2"
+			}
+		},
 		"@jest/reporters": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
@@ -4309,6 +4346,15 @@
 				"type-detect": "4.0.8"
 			}
 		},
+		"@sinonjs/fake-timers": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
+			}
+		},
 		"@slack/logger": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-2.0.0.tgz",
@@ -4922,6 +4968,12 @@
 			"integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
 			"dev": true
 		},
+		"@types/stack-utils": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+			"dev": true
+		},
 		"@types/tapable": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.7.tgz",
@@ -5303,6 +5355,28 @@
 				"@webassemblyjs/ast": "1.9.0",
 				"@webassemblyjs/wast-parser": "1.9.0",
 				"@xtuc/long": "4.2.2"
+			}
+		},
+		"@woocommerce/admin-e2e-tests": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/admin-e2e-tests/-/admin-e2e-tests-0.1.0.tgz",
+			"integrity": "sha512-QpKLiS6ShIMO0Eb7FbblMwyhYVzV29v+QWIslUizduuzVQxH9i1ow3IZ966xC8b+a1fF7hI/zQp4NNp1CaHNmw==",
+			"dev": true,
+			"requires": {
+				"@jest/globals": "^26.4.2",
+				"@types/jest": "26.0.23",
+				"config": "3.3.6"
+			},
+			"dependencies": {
+				"config": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/config/-/config-3.3.6.tgz",
+					"integrity": "sha512-Hj5916C5HFawjYJat1epbyY2PlAgLpBtDUlr0MxGLgo3p5+7kylyvnRY18PqJHgnNWXcdd0eWDemT7eYWuFgwg==",
+					"dev": true,
+					"requires": {
+						"json5": "^2.1.1"
+					}
+				}
 			}
 		},
 		"@woocommerce/api": {
@@ -13733,6 +13807,46 @@
 				"os-homedir": "^1.0.1"
 			}
 		},
+		"expect": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+			"integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"ansi-styles": "^4.0.0",
+				"jest-get-type": "^26.3.0",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-regex-util": "^26.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				}
+			}
+		},
 		"expect-puppeteer": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz",
@@ -19379,6 +19493,147 @@
 				}
 			}
 		},
+		"jest-matcher-utils": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+			"integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^26.6.2",
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.6.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-message-util": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+			"integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/types": "^26.6.2",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
+				"micromatch": "^4.0.2",
+				"pretty-format": "^26.6.2",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-mock": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+			"integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"@types/node": "*"
+			}
+		},
 		"jest-pnp-resolver": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
@@ -19394,6 +19649,12 @@
 				"expect-puppeteer": "^4.4.0",
 				"jest-environment-puppeteer": "^4.4.0"
 			}
+		},
+		"jest-regex-util": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+			"dev": true
 		},
 		"jest-resolve": {
 			"version": "24.9.0",
@@ -20334,6 +20595,71 @@
 					"requires": {
 						"is-number": "^3.0.0",
 						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
+		"jest-util": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+			"integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
+				"is-ci": "^2.0.0",
+				"micromatch": "^4.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -26002,6 +26328,23 @@
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
 			"dev": true
+		},
+		"stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				}
+			}
 		},
 		"state-toggle": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"@testing-library/react-hooks": "^5.1.1",
 		"@types/jest": "^26.0.23",
 		"@types/puppeteer": "^5.4.3",
+		"@woocommerce/admin-e2e-tests": "^0.1.0",
 		"@woocommerce/api": "^0.2.0",
 		"@woocommerce/e2e-environment": "^0.2.2",
 		"@woocommerce/e2e-utils": "^0.1.5",

--- a/tests/e2e/specs/wc-admin/README.md
+++ b/tests/e2e/specs/wc-admin/README.md
@@ -1,0 +1,6 @@
+# WooCommerce Admin E2E test
+
+:warning: These files and folders are copied from
+[woocommerce/woocommerce/tests/e2e/specs](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/specs)
+to run [`@woocommerce/admin-e2e-tests`](https://www.npmjs.com/package/@woocommerce/admin-e2e-tests) as suggested in
+the release post (pcShBQ-6A-p2).

--- a/tests/e2e/specs/wc-admin/activate-and-setup/basic-setup.test.js
+++ b/tests/e2e/specs/wc-admin/activate-and-setup/basic-setup.test.js
@@ -1,0 +1,3 @@
+const { testAdminBasicSetup } = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminBasicSetup();

--- a/tests/e2e/specs/wc-admin/activate-and-setup/complete-onboarding-wizard.test.js
+++ b/tests/e2e/specs/wc-admin/activate-and-setup/complete-onboarding-wizard.test.js
@@ -1,0 +1,7 @@
+const {
+	testAdminOnboardingWizard,
+	testSelectiveBundleWCPay,
+} = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminOnboardingWizard();
+testSelectiveBundleWCPay();

--- a/tests/e2e/specs/wc-admin/activate-and-setup/setup-onboarding.js
+++ b/tests/e2e/specs/wc-admin/activate-and-setup/setup-onboarding.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runSetupOnboardingTests } = require( '@woocommerce/e2e-core-tests' );
+
+runSetupOnboardingTests();

--- a/tests/e2e/specs/wc-admin/admin-analytics/analytics-overview.test.js
+++ b/tests/e2e/specs/wc-admin/admin-analytics/analytics-overview.test.js
@@ -1,0 +1,3 @@
+const { testAdminAnalyticsOverview } = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminAnalyticsOverview();

--- a/tests/e2e/specs/wc-admin/admin-analytics/analytics.test.js
+++ b/tests/e2e/specs/wc-admin/admin-analytics/analytics.test.js
@@ -1,0 +1,3 @@
+const { testAdminAnalyticsPages } = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminAnalyticsPages();

--- a/tests/e2e/specs/wc-admin/admin-marketing/coupons.test.js
+++ b/tests/e2e/specs/wc-admin/admin-marketing/coupons.test.js
@@ -1,0 +1,3 @@
+const { testAdminCouponsPage } = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminCouponsPage();

--- a/tests/e2e/specs/wc-admin/admin-tasks/payment.test.tsx
+++ b/tests/e2e/specs/wc-admin/admin-tasks/payment.test.tsx
@@ -1,0 +1,3 @@
+const { testAdminPaymentSetupTask } = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminPaymentSetupTask();

--- a/tests/e2e/specs/wc-admin/imported.test.js
+++ b/tests/e2e/specs/wc-admin/imported.test.js
@@ -1,0 +1,3 @@
+const { testAdminBasicSetup } = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminBasicSetup();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add `admin-e2e-tests`
to make sure our plugin does not break WooCommerce Admin.
Add `@woocommerce/admin-e2e-tests` dependency,
clone test suites from https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/specs as suggested in the release post (pcShBQ-6A-p2).

It seems valuable, as we actually fail on two:
```
 FAIL  ../../../tests/e2e/specs/wc-admin/admin-analytics/analytics-overview.test.js (37.502s)
  Analytics pages
    ✓ a user should see 3 sections by default - Performance, Charts, and Leaderboards (157ms)
    ✓ should allow a user to remove a section (248ms)
    ✓ should allow a user to add a section back in (199ms)
    moving sections
      ✕ should not display move up for the top, or move down for the bottom section (95ms)
      ✕ should allow a user to move a section down (30012ms)
      ✕ should allow a user to move a section up (203ms)
```


### Screenshots:

![image](https://user-images.githubusercontent.com/17435/131215953-b09389be-8cf5-42a6-aff2-a6650baae8c3.png)



### Detailed test instructions:

1. Checkout this branch
2. ```sh
 	npm i
	npm run docker:up
	npm run test:e2e
	```


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - WooCommerce Admin tests suite.
