### PR TITLE
Hide channel visibiliy and attributes tab if GLA not set up 

### DIFF
--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -21,6 +23,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 
+	use PluginHelper;
+
 	/**
 	 * @var ProductMetaHandler
 	 */
@@ -32,15 +36,22 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	protected $product_helper;
 
 	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
 	 * ChannelVisibilityMetaBox constructor.
 	 *
-	 * @param Admin              $admin
-	 * @param ProductMetaHandler $meta_handler
-	 * @param ProductHelper      $product_helper
+	 * @param Admin                 $admin
+	 * @param ProductMetaHandler    $meta_handler
+	 * @param ProductHelper         $product_helper
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( Admin $admin, ProductMetaHandler $meta_handler, ProductHelper $product_helper ) {
-		$this->meta_handler   = $meta_handler;
-		$this->product_helper = $product_helper;
+	public function __construct( Admin $admin, ProductMetaHandler $meta_handler, ProductHelper $product_helper, MerchantCenterService $merchant_center ) {
+		$this->meta_handler    = $meta_handler;
+		$this->product_helper  = $product_helper;
+		$this->merchant_center = $merchant_center;
 		parent::__construct( $admin );
 	}
 
@@ -128,6 +139,8 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 			'channel_visibility' => $this->product_helper->get_channel_visibility( $product ),
 			'sync_status'        => $this->meta_handler->get_sync_status( $product ),
 			'issues'             => $this->product_helper->get_validation_errors( $product ),
+			'is_setup_complete'  => $this->merchant_center->is_setup_complete(),
+			'get_started_url'    => $this->get_start_url(),
 		];
 	}
 

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use WC_Product;
@@ -34,20 +35,32 @@ class AttributesTab implements Service, Registerable, Conditional {
 	protected $attribute_manager;
 
 	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
 	 * AttributesTab constructor.
 	 *
-	 * @param Admin            $admin
-	 * @param AttributeManager $attribute_manager
+	 * @param Admin                 $admin
+	 * @param AttributeManager      $attribute_manager
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( Admin $admin, AttributeManager $attribute_manager ) {
+	public function __construct( Admin $admin, AttributeManager $attribute_manager, MerchantCenterService $merchant_center ) {
 		$this->admin             = $admin;
 		$this->attribute_manager = $attribute_manager;
+		$this->merchant_center   = $merchant_center;
 	}
 
 	/**
 	 * Register a service.
 	 */
 	public function register(): void {
+		// Register the hooks only if Merchant Center is set up.
+		if ( ! $this->merchant_center->is_setup_complete() ) {
+			return;
+		}
+
 		add_action(
 			'woocommerce_new_product',
 			function ( int $product_id, WC_Product $product ) {

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use WC_Product_Variation;
 use WP_Post;
@@ -35,19 +36,31 @@ class VariationsAttributes implements Service, Registerable, Conditional {
 	protected $attribute_manager;
 
 	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
 	 * VariationsAttributes constructor.
 	 *
-	 * @param Admin            $admin
-	 * @param AttributeManager $attribute_manager
+	 * @param Admin                 $admin
+	 * @param AttributeManager      $attribute_manager
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( Admin $admin, AttributeManager $attribute_manager ) {
+	public function __construct( Admin $admin, AttributeManager $attribute_manager, MerchantCenterService $merchant_center ) {
 		$this->admin             = $admin;
 		$this->attribute_manager = $attribute_manager;
+		$this->merchant_center   = $merchant_center;
 	}
 	/**
 	 * Register a service.
 	 */
 	public function register(): void {
+		// Register the hooks only if Merchant Center is set up.
+		if ( ! $this->merchant_center->is_setup_complete() ) {
+			return;
+		}
+
 		add_action(
 			'woocommerce_product_after_variable_attributes',
 			function ( int $variation_index, array $variation_data, WP_Post $variation ) {

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -266,7 +266,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			 ->invokeMethod( 'set_tracks', [ TracksInterface::class ] );
 
 		// Share admin meta boxes
-		$this->conditionally_share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class );
+		$this->conditionally_share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( MetaBoxInitializer::class, Admin::class, MetaBoxInterface::class );
 
 		$this->share_with_tags( PHPViewFactory::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -231,8 +231,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Product attributes
 		$this->conditionally_share_with_tags( AttributeManager::class );
-		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class );
-		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class );
+		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
+		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 
 		$this->share_with_tags( AdsAccountState::class );
 		$this->share_with_tags( MerchantAccountState::class );

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -7,29 +7,23 @@ use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
 
 defined( 'ABSPATH' ) || exit;
 
-/**
- * @var PHPView $this
- */
+/** @var PHPView $this */
 
-/**
- * @var int $product_id
- */
+/** @var int $product_id */
 $product_id = $this->product_id;
-/**
- * @var WC_Product $product
- */
+/** @var WC_Product $product */
 $product = $this->product;
 
 $channel_visibility = $this->channel_visibility;
 
-/**
- * @var string
- */
+/** @var string */
 $field_id = $this->field_id;
+/** @var string */
+$is_setup_complete = $this->is_setup_complete;
+/** @var string */
+$get_started_url = $this->get_started_url;
 
-/**
- * @var string $sync_status
- */
+/** @var string $sync_status */
 if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
 	$sync_status = __( 'Issues detected', 'google-listings-and-ads' );
 } elseif ( ! is_null( $this->sync_status ) ) {
@@ -37,9 +31,7 @@ if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
 }
 $show_status = ! empty( $sync_status ) && $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
 
-/**
- * @var array $issues
- */
+/** @var array $issues */
 $issues     = $this->issues;
 $has_issues = ! empty( $issues );
 
@@ -59,37 +51,44 @@ if ( $input_disabled ) {
 ?>
 
 <div class="gla-channel-visibility-box">
-	<?php
-	woocommerce_wp_select(
-		[
-			'id'                => $field_id,
-			'value'             => $channel_visibility,
-			'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
-			'description'       => $input_description,
-			'desc_tip'          => false,
-			'options'           => [
-				ChannelVisibility::SYNC_AND_SHOW      => __( 'Sync and show', 'google-listings-and-ads' ),
-				ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
-			],
-			'custom_attributes' => $custom_attributes,
-			'wrapper_class'     => 'form-row form-row-full',
-		]
-	);
-	?>
-	<?php if ( $show_status ) : ?>
-	<div class="sync-status notice-alt notice-large notice-warning" style="border-left-style: solid">
-		<p><strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong></p>
-		<p><?php echo esc_html( $sync_status ); ?></p>
-		<?php if ( $has_issues ) : ?>
-			<div class="gla-product-issues">
-				<p><strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong></p>
-				<ul>
-					<?php foreach ( $issues as $issue ) : ?>
-					<li><?php echo esc_html( $issue ); ?></li>
-					<?php endforeach; ?>
-				</ul>
+	<?php if ( $is_setup_complete ) : ?>
+		<?php
+		woocommerce_wp_select(
+			[
+				'id'                => $field_id,
+				'value'             => $channel_visibility,
+				'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
+				'description'       => $input_description,
+				'desc_tip'          => false,
+				'options'           => [
+					ChannelVisibility::SYNC_AND_SHOW      => __( 'Sync and show', 'google-listings-and-ads' ),
+					ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
+				],
+				'custom_attributes' => $custom_attributes,
+				'wrapper_class'     => 'form-row form-row-full',
+			]
+		);
+		?>
+		<?php if ( $show_status ) : ?>
+			<div class="sync-status notice-alt notice-large notice-warning" style="border-left-style: solid">
+				<p><strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong></p>
+				<p><?php echo esc_html( $sync_status ); ?></p>
+				<?php if ( $has_issues ) : ?>
+					<div class="gla-product-issues">
+						<p><strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong></p>
+						<ul>
+							<?php foreach ( $issues as $issue ) : ?>
+								<li><?php echo esc_html( $issue ); ?></li>
+							<?php endforeach; ?>
+						</ul>
+					</div>
+				<?php endif; ?>
 			</div>
 		<?php endif; ?>
-	</div>
+	<?php else : ?>
+		<p><strong><?php esc_html_e( 'Google Listings & Ads', 'google-listings-and-ads' ); ?></strong></p>
+		<p><?php esc_html_e( 'Integrate with Google to list your products for free and launch paid ad campaigns.', 'google-listings-and-ads' ); ?></p>
+		<a href="<?php echo esc_attr( $get_started_url ); ?>"
+		   class="button button-primary"><?php esc_html_e( 'Get Started', 'google-listings-and-ads' ); ?></a>
 	<?php endif; ?>
 </div>

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -18,7 +18,7 @@ $channel_visibility = $this->channel_visibility;
 
 /** @var string */
 $field_id = $this->field_id;
-/** @var string */
+/** @var bool */
 $is_setup_complete = $this->is_setup_complete;
 /** @var string */
 $get_started_url = $this->get_started_url;

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -35,7 +35,7 @@ if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
 } elseif ( ! is_null( $this->sync_status ) ) {
 	$sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
 }
-$show_status = $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
+$show_status = ! empty( $sync_status ) && $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
 
 /**
  * @var array $issues

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -87,8 +87,8 @@ if ( $input_disabled ) {
 		<?php endif; ?>
 	<?php else : ?>
 		<p><strong><?php esc_html_e( 'Google Listings & Ads', 'google-listings-and-ads' ); ?></strong></p>
-		<p><?php esc_html_e( 'Integrate with Google to list your products for free and launch paid ad campaigns.', 'google-listings-and-ads' ); ?></p>
+		<p><?php esc_html_e( 'Complete setup to get your products listed on Google for free.', 'google-listings-and-ads' ); ?></p>
 		<a href="<?php echo esc_attr( $get_started_url ); ?>"
-		   class="button button-primary"><?php esc_html_e( 'Get Started', 'google-listings-and-ads' ); ?></a>
+		   class="button"><?php esc_html_e( 'Complete setup', 'google-listings-and-ads' ); ?></a>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #986 .

This PR resolves an error thrown in the product edit page if GLA was not set up. The `sync_status` variable was being printed without first checking if it exists.

As an extra measure, the channel visibility meta box is modified to display a message instead of the usual form in case GLA has not been set up yet. This message includes a link to the `Get started` page:

![image](https://user-images.githubusercontent.com/73110514/131669776-feb7f4f9-0a0e-49c8-bede-415505119ba1.png)

I copied over the text from the Get started page, but we might want to use a different text or no text at all here. The other option would be to simply hide the `Channel Visiblity` meta box altogether but I think having some call-to-action there in the edit product page might be helpful.  (cc: @j111q)

The GLA attributes tab is also hidden from the product data tab of the edit product page if GLA is not set up. I didn't add the Get Started button there since it's already displayed on the page and didn't want to add duplicates.


### Detailed test instructions:

1. Activate GLA and WooCommerce plugins on a new site or DB
2. Do **not** go through the GLA onboarding
3. Edit a product and confirm no error is displayed
4. Confirm that the channel visibility box is similar to the screenshot and the Get Started button works
5. Confirm that the GLA attributes tab is hidden
6. Go through GLA onboarding and connect to Merchant Center
7. Edit a product again and confirm that both channel visibility meta box and GLA attributes are visible and working as expected


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Hide channel visibility box and attributes tab if the setup is not completed.
