### PR TITLE
Add unit tests for PHPView and DateTimeUtility

### DIFF
--- a/src/Infrastructure/ViewFactory.php
+++ b/src/Infrastructure/ViewFactory.php
@@ -13,11 +13,11 @@ defined( 'ABSPATH' ) || exit;
 interface ViewFactory {
 
 	/**
-	 * Create a new view object for a given relative path.
+	 * Create a new view object.
 	 *
-	 * @param string $relative_path Relative path to create the view for.
+	 * @param string $path Path to the view file to render.
 	 *
 	 * @return View Instantiated view object.
 	 */
-	public function create( string $relative_path ): View;
+	public function create( string $path ): View;
 }

--- a/src/Utility/DateTimeUtility.php
+++ b/src/Utility/DateTimeUtility.php
@@ -4,9 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
-use DateTime;
-use DateTimeZone;
-use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -25,16 +22,15 @@ class DateTimeUtility implements Service {
 	 * @param string $timezone
 	 *
 	 * @return string
-	 *
-	 * @throws Exception If the DateTime instantiation fails.
 	 */
 	public function maybe_convert_tz_string( string $timezone ): string {
-		if ( false !== strpos( $timezone, ':' ) ) {
-			[ $hours, $minutes ] = explode( ':', $timezone );
+		if ( preg_match( '/^([+-]\d{1,2}):?(\d{1,2})$/', $timezone, $matches ) ) {
+			[ $timezone, $hours, $minutes ] = $matches;
 
-			$dst      = (int) ( new DateTime( 'now', new DateTimeZone( $timezone ) ) )->format( 'I' );
-			$seconds  = $hours * 60 * 60 + $minutes * 60;
-			$tz_name  = timezone_name_from_abbr( '', $seconds, $dst );
+			$sign    = (int) $hours >= 0 ? 1 : - 1;
+			$seconds = $sign * ( absint( $hours ) * 60 * 60 + absint( $minutes ) * 60 );
+			$tz_name = timezone_name_from_abbr( '', $seconds, 0 );
+
 			$timezone = $tz_name !== false ? $tz_name : date_default_timezone_get();
 		}
 

--- a/src/View/PHPViewFactory.php
+++ b/src/View/PHPViewFactory.php
@@ -17,15 +17,15 @@ defined( 'ABSPATH' ) || exit;
 final class PHPViewFactory implements Service, ViewFactory {
 
 	/**
-	 * Create a new view object for a given relative path.
+	 * Create a new view object.
 	 *
-	 * @param string $relative_path Relative path to create the view for.
+	 * @param string $path Path to the view file to render.
 	 *
 	 * @return View Instantiated view object.
 	 *
 	 * @throws ViewException If an invalid path was passed into the View.
 	 */
-	public function create( string $relative_path ): View {
-		return new PHPView( $relative_path, $this );
+	public function create( string $path ): View {
+		return new PHPView( $path, $this );
 	}
 }

--- a/tests/Unit/Utility/DateTimeUtilityTest.php
+++ b/tests/Unit/Utility/DateTimeUtilityTest.php
@@ -1,0 +1,39 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
+
+/**
+ * Class DateTimeUtilityTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
+ *
+ * @property DateTimeUtility $datetime_utility
+ */
+class DateTimeUtilityTest extends UnitTest {
+
+	public function test_returns_tz_as_is_if_not_offset() {
+		$this->assertEquals( 'Europe/London', $this->datetime_utility->maybe_convert_tz_string( 'Europe/London' ) );
+	}
+
+	public function test_returns_tz_as_gmt_if_utc_provided() {
+		$this->assertEquals( 'Etc/GMT', $this->datetime_utility->maybe_convert_tz_string( 'UTC' ) );
+	}
+
+	public function test_returns_tz_name_by_offset() {
+		$this->assertEquals( 'America/New_York', $this->datetime_utility->maybe_convert_tz_string( '-5:00' ) );
+		$this->assertEquals( 'Europe/London', $this->datetime_utility->maybe_convert_tz_string( '+00:00' ) );
+		$this->assertEquals( 'Asia/Dubai', $this->datetime_utility->maybe_convert_tz_string( '+04:00' ) );
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->datetime_utility = new DateTimeUtility();
+	}
+}

--- a/tests/Unit/View/PHPViewFactoryTest.php
+++ b/tests/Unit/View/PHPViewFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\View;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\DataTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
+use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
+use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
+
+/**
+ * Class PHPViewFactoryTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
+ *
+ * @property PHPViewFactory $view_factory
+ */
+class PHPViewFactoryTest extends UnitTest {
+
+	use DataTrait;
+
+	public function test_create_view() {
+		$view = $this->view_factory->create( $this->get_data_file_path( 'test-php-view.php' ) );
+
+		$this->assertInstanceOf( PHPView::class, $view );
+	}
+
+	public function test_create_view_fails_if_non_existing_view_file() {
+		$this->expectException( ViewException::class );
+		$this->view_factory->create( '/tmp/imaginary-folder/non-existing-view' . md5( (string) rand() ) );
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->view_factory = new PHPViewFactory();
+	}
+
+}

--- a/tests/Unit/View/PHPViewTest.php
+++ b/tests/Unit/View/PHPViewTest.php
@@ -1,0 +1,72 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\View;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\DataTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
+use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
+use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
+
+/**
+ * Class PHPViewTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
+ *
+ * @property PHPViewFactory $view_factory
+ */
+class PHPViewTest extends UnitTest {
+
+	use DataTrait;
+
+	public function test_view_construct_fails_if_non_existing_view_file() {
+		$this->expectException( ViewException::class );
+		new PHPView( '/tmp/imaginary-folder/non-existing-view' . md5( (string) rand() ), $this->view_factory );
+	}
+
+	public function test_view_render_with_partial() {
+		$view = new PHPView( $this->get_data_file_path( 'test-php-view.php' ), $this->view_factory );
+
+		$expected = <<<VIEW
+Variable value is: Test
+Raw variable value is: <strong>Test Raw HTML</strong>
+Boolean variable value is: 1
+Array variable value is: Value 1, Value 2
+Partial variable value is: Test partial
+Partial with no context:
+Partial variable value is: Test
+VIEW;
+
+		$this->assertEquals(
+			$expected,
+			$view->render(
+				[
+					'some_variable'  => '<strong>Test</strong>%30',
+					'raw_variable'   => '<strong>Test Raw HTML</strong>',
+					'bool_variable'  => true,
+					'array_variable' => [
+						'<p>Value 1</p>',
+						'<p>Value 2</p>',
+					],
+					'partial_path'   => $this->get_data_file_path( 'test-php-view-partial.php' ),
+				]
+			)
+		);
+	}
+
+	public function test_view_render_fails_if_context_variable_missing() {
+		$view = new PHPView( $this->get_data_file_path( 'test-php-view.php' ), $this->view_factory );
+		$this->expectException( ViewException::class );
+		$view->render();
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->view_factory = new PHPViewFactory();
+	}
+
+}

--- a/tests/data/test-php-view-partial.php
+++ b/tests/data/test-php-view-partial.php
@@ -1,0 +1,15 @@
+<?php
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @var PHPView $this
+ */
+
+/** @var string $some_variable */
+$some_variable = $this->some_variable;
+?>
+Partial variable value is: <?php echo $some_variable; ?>

--- a/tests/data/test-php-view.php
+++ b/tests/data/test-php-view.php
@@ -1,0 +1,39 @@
+<?php
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @var PHPView $this
+ */
+
+/** @var string $some_variable */
+$some_variable = $this->some_variable;
+/** @var string $raw_variable */
+$raw_variable = $this->raw( 'raw_variable' );
+/** @var bool $bool_variable */
+$bool_variable = $this->bool_variable;
+/** @var array $array_variable */
+$array_variable = $this->array_variable;
+
+/** @var string $partial_path */
+$partial_path = $this->partial_path;
+?>
+Variable value is: <?php echo $some_variable; ?>
+
+Raw variable value is: <?php echo $raw_variable; ?>
+
+Boolean variable value is: <?php echo true === $bool_variable ? '1' : '0' ; ?>
+
+Array variable value is: <?php echo implode( ', ', $array_variable ); ?>
+
+<?php
+echo $this->render_partial( $partial_path, [ 'some_variable' => 'Test partial' ] );
+?>
+
+Partial with no context:
+<?php
+echo $this->render_partial( $partial_path );
+?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR adds unit tests for the `DateTimeUtility`, `PHPView`, and `PHPViewFactory` classes.

#### Refactoring `DateTimeUtility::maybe_convert_tz_string`

It includes some modifications to this method so that it uses regex to detect a UTC offset instead of `strpos`. 

The DST calculations are removed from this method because the PHP `DateTime` class always returned `0` if an offset is provided as `DateTimeZone`, meaning that it was not being used as part of the calculation. So I decided to use a hard-coded zero instead. For some reason, the `timezone_name_from_abbr` method didn't return any values if no `isDST` arg is provided.

I don't think there is any way to guess if DST is enabled because WordPress sets the PHP default timezone to `UTC` in `wp-settings.php`, so even the `date( 'I' )` method (used by WooCommerce and other plugins) won't work because UTC doesn't have DST.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Run PHP unit and make sure all tests pass

The `maybe_convert_tz_string` method is only used when creating a new Google Ads account where it sets the customer's timezone. To test if it works as expected:

1. Set the WP timezone to an offset (instead of a city or region)
2. Create a new Ads account through GLA
3. Confirm that the new account's timezone is guessed correctly


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

