### PR TITLE
Fetch the product from DB when hooking to create product actions

### DIFF
--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -127,16 +127,16 @@ class SyncerHooks implements Service, Registerable {
 			$this->handle_delete_product( $product_id );
 		};
 
-		// when a product is added / updated, schedule a update job.
-		add_action( 'woocommerce_new_product', $update_by_object, 90, 2 );
+		// when a product is added / updated, schedule an "update" job.
+		add_action( 'woocommerce_new_product', $update_by_id, 90 );
+		add_action( 'woocommerce_new_product_variation', $update_by_id, 90 );
 		add_action( 'woocommerce_update_product', $update_by_object, 90, 2 );
-		add_action( 'woocommerce_new_product_variation', $update_by_object, 90, 2 );
 		add_action( 'woocommerce_update_product_variation', $update_by_object, 90, 2 );
 
 		// if we don't attach to these we miss product gallery updates.
 		add_action( 'woocommerce_process_product_meta', $update_by_id, 90 );
 
-		// when a product is trashed or removed, schedule a delete job.
+		// when a product is trashed or removed, schedule a "delete" job.
 		add_action( 'wp_trash_post', $pre_delete, 90 );
 		add_action( 'before_delete_post', $pre_delete, 90 );
 		add_action( 'woocommerce_before_delete_product_variation', $pre_delete, 90 );
@@ -145,10 +145,10 @@ class SyncerHooks implements Service, Registerable {
 		add_action( 'woocommerce_delete_product_variation', $delete, 90 );
 		add_action( 'woocommerce_trash_product_variation', $delete, 90 );
 
-		// when a product is restored from the trash, schedule a update job.
+		// when a product is restored from the trash, schedule an "update" job.
 		add_action( 'untrashed_post', $update_by_id, 90 );
 
-		// exclude the sync meta data when duplicating the product
+		// exclude the sync metadata when duplicating the product
 		add_action(
 			'woocommerce_duplicate_product_exclude_meta',
 			function ( array $exclude_meta ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #988 .

Instead of relying on the product object that WooCommerce provides to the callbacks of `woocommerce_new_product` and `woocommerce_new_product_variation` functions, make a call to the database and fetch the product using its ID.

Some product attributes seem to be only set in the `WP_Product` object once WooCommerce persists the product into the database or when the `WP_Product` is created by fetching the product data from the database.

For example, the `catalog_visibility` attribute was not set for the `WC_Product` object returned by the `woocommerce_new_product_variation` action.

This was causing a notice to appear in the debug logs whenever a new product variation was created:

```
PHP Notice:  Undefined index: catalog_visibility in ./woocommerce/includes/class-wc-product-variation.php on line 419
```


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Install GLA and complete the Merchant Center onboarding.
2. [Activate the WP debug log](https://codex.wordpress.org/WP_DEBUG#WP_DEBUG_LOG) by setting `WP_DEBUG_LOG` constant to `true` in `wp-config.php`
2. Add or edit a variable product.
3. Use "Product data" > "Variations" > "Add Variation" > "Go" to add a variation.
4. Confirm the notice does not appear in the WP `debug.log`.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - PHP notice when creating a product variation.
