### PR TITLE
Add a warning when Ads' currency is different

### DIFF
--- a/js/src/components/different-currency-notice.js
+++ b/js/src/components/different-currency-notice.js
@@ -16,9 +16,11 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
  * Shows warning {@link Notice}
  * when the store's currency is different than the one set in Google Ads account.
  *
+ * @param {Object} props React props.
+ * @param {string} props.context Context or page on which the notice is shown, to be forwarded to the link's track event.
  * @return {JSX.Element} {@link Notice} element with the warning message and the link to the documentation.
  */
-export default function DifferentCurrencyNotice() {
+export default function DifferentCurrencyNotice( { context } ) {
 	const { googleAdsAccount } = useGoogleAdsAccount();
 	const { code: storeCurrency } = useStoreCurrency();
 
@@ -48,7 +50,7 @@ export default function DifferentCurrencyNotice() {
 							className="gla-different-currency-notice__link"
 							href="https://support.google.com/google-ads/answer/9841530"
 							eventName="gla_different_currency_notice_link_click"
-							context="dashboard"
+							context={ context }
 							linkId="setting-up-currency"
 						/>
 					),

--- a/js/src/components/different-currency-notice.js
+++ b/js/src/components/different-currency-notice.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
+import useStoreCurrency from '.~/hooks/useStoreCurrency';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+
+/**
+ * Shows warning {@link Notice}
+ * when the store's currency is different than the one set in Google Ads account.
+ *
+ * @return {JSX.Element} {@link Notice} element with the warning message and the link to the documentation.
+ */
+export default function DifferentCurrencyNotice() {
+	const { googleAdsAccount } = useGoogleAdsAccount();
+	const { code: storeCurrency } = useStoreCurrency();
+
+	// Do not render if data is not available, or the same currencies are used.
+	if ( ! googleAdsAccount || googleAdsAccount.currency === storeCurrency ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			className="gla-different-currency-notice"
+			status="warning"
+			isDismissible={ false }
+		>
+			{ createInterpolateElement(
+				__(
+					'Note: The currency set in your Google Ads account is <adsCurrency />, which is different from your store currency, <storeCurrency />. <readMoreLink>Read more</readMoreLink>',
+					'google-listings-and-ads'
+				),
+				{
+					adsCurrency: <strong>{ googleAdsAccount.currency }</strong>,
+					storeCurrency: <strong>{ storeCurrency }</strong>,
+					// `ExternalIcon` is not addd here as that should be done uniformly across all `AppDocumentationLink`s:
+					// https://github.com/woocommerce/google-listings-and-ads/issues/984
+					readMoreLink: (
+						<AppDocumentationLink
+							className="gla-different-currency-notice__link"
+							href="https://support.google.com/google-ads/answer/9841530"
+							eventName="gla_different_currency_notice_link_click"
+							context="dashboard"
+							linkId="setting-up-currency"
+						/>
+					),
+				}
+			) }
+		</Notice>
+	);
+}

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -8,6 +8,7 @@ import { getNewPath, getQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import DifferentCurrencyNotice from '.~/components/different-currency-notice';
 import NavigationClassic from '.~/components/navigation-classic';
 import AppDateRangeFilterPicker from './app-date-range-filter-picker';
 import SummarySection from './summary-section';
@@ -44,6 +45,7 @@ const Dashboard = () => {
 
 	return (
 		<div className="gla-dashboard">
+			<DifferentCurrencyNotice />
 			<NavigationClassic />
 			<div className="gla-dashboard__filter">
 				<AppDateRangeFilterPicker

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -45,7 +45,7 @@ const Dashboard = () => {
 
 	return (
 		<div className="gla-dashboard">
-			<DifferentCurrencyNotice />
+			<DifferentCurrencyNotice context="dashboard" />
 			<NavigationClassic />
 			<div className="gla-dashboard__filter">
 				<AppDateRangeFilterPicker

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -117,7 +117,7 @@ const ProductsReportPage = () => {
 
 	return (
 		<>
-			<DifferentCurrencyNotice />
+			<DifferentCurrencyNotice context="reports-products" />
 			<NavigationClassic />
 			<ReportsNavigation />
 			{ loaded ? (

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -16,6 +16,7 @@ import {
 import useProductsReport from './useProductsReport';
 import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
 import AppSpinner from '.~/components/app-spinner';
+import DifferentCurrencyNotice from '.~/components/different-currency-notice';
 import NavigationClassic from '.~/components/navigation-classic';
 import ProductsReportFilters from './products-report-filters';
 import SummarySection from '../summary-section';
@@ -116,6 +117,7 @@ const ProductsReportPage = () => {
 
 	return (
 		<>
+			<DifferentCurrencyNotice />
 			<NavigationClassic />
 			<ReportsNavigation />
 			{ loaded ? (

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -8,6 +8,7 @@ import { getQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import useProgramsReport, { usePerformanceReport } from './useProgramsReport';
+import DifferentCurrencyNotice from '.~/components/different-currency-notice';
 import NavigationClassic from '.~/components/navigation-classic';
 import ProgramsReportFilters from './programs-report-filters';
 import SummarySection from '../summary-section';
@@ -88,6 +89,7 @@ const ProgramsReport = () => {
 
 	return (
 		<>
+			<DifferentCurrencyNotice />
 			<NavigationClassic />
 			<ReportsNavigation />
 			<ProgramsReportFilters

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -89,7 +89,7 @@ const ProgramsReport = () => {
 
 	return (
 		<>
-			<DifferentCurrencyNotice />
+			<DifferentCurrencyNotice context={ trackEventId } />
 			<NavigationClassic />
 			<ReportsNavigation />
 			<ProgramsReportFilters


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Add a warning when Ads' currency is different than the store's one.

Addresses https://github.com/woocommerce/google-listings-and-ads/issues/363#issuecomment-876309170.


### Screenshots:

<!--- Optional --->
![warning](https://user-images.githubusercontent.com/17435/132068374-26823d52-a516-4ec8-ac8b-d64f9b245cd9.gif)



### Detailed test instructions:

1. Setup Ads account with a currency - _X_ (PLN)
3. Change the store currency to _Y_ (EUR)
4. Go to the 
	- Dashboard ([`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard) )
	- Program reports ([`/wp-admin/admin.php?page=wc-admin&reportKey=programs&path=%2Fgoogle%2Freports`](https://gla1.test/wp-admin/admin.php?page=wc-admin&reportKey=programs&path=%2Fgoogle%2Freports))
	- Product report ([`/wp-admin/admin.php?page=wc-admin&reportKey=products&path=%2Fgoogle%2Freports`](https://gla1.test/wp-admin/admin.php?page=wc-admin&reportKey=products&path=%2Fgoogle%2Freports)
5. Check the warning that will eventually appear.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Warning notice when the Ads' currency is different from the store's one.

### Additional notes:
- There is no external link icon at "Read more" as I'd add it in a separate PR for all the external/documentation links. See https://github.com/woocommerce/google-listings-and-ads/issues/984, woocommerce/woocommerce#32236
