### PR TITLE
Hotfix for PR #987 Hide channel visibiliy and attributes tab if GLA not set up 

### DIFF
--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -21,6 +23,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 
+	use PluginHelper;
+
 	/**
 	 * @var ProductMetaHandler
 	 */
@@ -32,15 +36,22 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	protected $product_helper;
 
 	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
 	 * ChannelVisibilityMetaBox constructor.
 	 *
-	 * @param Admin              $admin
-	 * @param ProductMetaHandler $meta_handler
-	 * @param ProductHelper      $product_helper
+	 * @param Admin                 $admin
+	 * @param ProductMetaHandler    $meta_handler
+	 * @param ProductHelper         $product_helper
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( Admin $admin, ProductMetaHandler $meta_handler, ProductHelper $product_helper ) {
-		$this->meta_handler   = $meta_handler;
-		$this->product_helper = $product_helper;
+	public function __construct( Admin $admin, ProductMetaHandler $meta_handler, ProductHelper $product_helper, MerchantCenterService $merchant_center ) {
+		$this->meta_handler    = $meta_handler;
+		$this->product_helper  = $product_helper;
+		$this->merchant_center = $merchant_center;
 		parent::__construct( $admin );
 	}
 
@@ -128,6 +139,8 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 			'channel_visibility' => $this->product_helper->get_channel_visibility( $product ),
 			'sync_status'        => $this->meta_handler->get_sync_status( $product ),
 			'issues'             => $this->product_helper->get_validation_errors( $product ),
+			'is_setup_complete'  => $this->merchant_center->is_setup_complete(),
+			'get_started_url'    => $this->get_start_url(),
 		];
 	}
 

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use WC_Product;
@@ -34,20 +35,32 @@ class AttributesTab implements Service, Registerable, Conditional {
 	protected $attribute_manager;
 
 	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
 	 * AttributesTab constructor.
 	 *
-	 * @param Admin            $admin
-	 * @param AttributeManager $attribute_manager
+	 * @param Admin                 $admin
+	 * @param AttributeManager      $attribute_manager
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( Admin $admin, AttributeManager $attribute_manager ) {
+	public function __construct( Admin $admin, AttributeManager $attribute_manager, MerchantCenterService $merchant_center ) {
 		$this->admin             = $admin;
 		$this->attribute_manager = $attribute_manager;
+		$this->merchant_center   = $merchant_center;
 	}
 
 	/**
 	 * Register a service.
 	 */
 	public function register(): void {
+		// Register the hooks only if Merchant Center is set up.
+		if ( ! $this->merchant_center->is_setup_complete() ) {
+			return;
+		}
+
 		add_action(
 			'woocommerce_new_product',
 			function ( int $product_id, WC_Product $product ) {

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use WC_Product_Variation;
 use WP_Post;
@@ -35,19 +36,31 @@ class VariationsAttributes implements Service, Registerable, Conditional {
 	protected $attribute_manager;
 
 	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
 	 * VariationsAttributes constructor.
 	 *
-	 * @param Admin            $admin
-	 * @param AttributeManager $attribute_manager
+	 * @param Admin                 $admin
+	 * @param AttributeManager      $attribute_manager
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( Admin $admin, AttributeManager $attribute_manager ) {
+	public function __construct( Admin $admin, AttributeManager $attribute_manager, MerchantCenterService $merchant_center ) {
 		$this->admin             = $admin;
 		$this->attribute_manager = $attribute_manager;
+		$this->merchant_center   = $merchant_center;
 	}
 	/**
 	 * Register a service.
 	 */
 	public function register(): void {
+		// Register the hooks only if Merchant Center is set up.
+		if ( ! $this->merchant_center->is_setup_complete() ) {
+			return;
+		}
+
 		add_action(
 			'woocommerce_product_after_variable_attributes',
 			function ( int $variation_index, array $variation_data, WP_Post $variation ) {

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -228,8 +228,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Product attributes
 		$this->conditionally_share_with_tags( AttributeManager::class );
-		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class );
-		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class );
+		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
+		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 
 		$this->share_with_tags( AdsAccountState::class );
 		$this->share_with_tags( MerchantAccountState::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -263,7 +263,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			 ->invokeMethod( 'set_tracks', [ TracksInterface::class ] );
 
 		// Share admin meta boxes
-		$this->conditionally_share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class );
+		$this->conditionally_share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( MetaBoxInitializer::class, Admin::class, MetaBoxInterface::class );
 
 		$this->share_with_tags( PHPViewFactory::class );

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -7,29 +7,23 @@ use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
 
 defined( 'ABSPATH' ) || exit;
 
-/**
- * @var PHPView $this
- */
+/** @var PHPView $this */
 
-/**
- * @var int $product_id
- */
+/** @var int $product_id */
 $product_id = $this->product_id;
-/**
- * @var WC_Product $product
- */
+/** @var WC_Product $product */
 $product = $this->product;
 
 $channel_visibility = $this->channel_visibility;
 
-/**
- * @var string
- */
+/** @var string */
 $field_id = $this->field_id;
+/** @var string */
+$is_setup_complete = $this->is_setup_complete;
+/** @var string */
+$get_started_url = $this->get_started_url;
 
-/**
- * @var string $sync_status
- */
+/** @var string $sync_status */
 if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
 	$sync_status = __( 'Issues detected', 'google-listings-and-ads' );
 } elseif ( ! is_null( $this->sync_status ) ) {
@@ -37,9 +31,7 @@ if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
 }
 $show_status = ! empty( $sync_status ) && $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
 
-/**
- * @var array $issues
- */
+/** @var array $issues */
 $issues     = $this->issues;
 $has_issues = ! empty( $issues );
 
@@ -59,36 +51,43 @@ if ( $input_disabled ) {
 ?>
 
 <div class="gla-channel-visibility-box">
-	<?php
-	woocommerce_wp_select(
-		[
-			'id'                => $field_id,
-			'value'             => $channel_visibility,
-			'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
-			'description'       => $input_description,
-			'desc_tip'          => false,
-			'options'           => [
-				ChannelVisibility::SYNC_AND_SHOW      => __( 'Sync and show', 'google-listings-and-ads' ),
-				ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
-			],
-			'custom_attributes' => $custom_attributes,
-		]
-	);
-	?>
-	<?php if ( $show_status ) : ?>
-	<div class="sync-status notice-alt notice-large notice-warning" style="border-left-style: solid">
-		<p><strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong></p>
-		<p><?php echo esc_html( $sync_status ); ?></p>
-		<?php if ( $has_issues ) : ?>
-			<div class="gla-product-issues">
-				<p><strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong></p>
-				<ul>
-					<?php foreach ( $issues as $issue ) : ?>
-					<li><?php echo esc_html( $issue ); ?></li>
-					<?php endforeach; ?>
-				</ul>
+	<?php if ( $is_setup_complete ) : ?>
+		<?php
+		woocommerce_wp_select(
+			[
+				'id'                => $field_id,
+				'value'             => $channel_visibility,
+				'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
+				'description'       => $input_description,
+				'desc_tip'          => false,
+				'options'           => [
+					ChannelVisibility::SYNC_AND_SHOW      => __( 'Sync and show', 'google-listings-and-ads' ),
+					ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
+				],
+				'custom_attributes' => $custom_attributes,
+			]
+		);
+		?>
+		<?php if ( $show_status ) : ?>
+			<div class="sync-status notice-alt notice-large notice-warning" style="border-left-style: solid">
+				<p><strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong></p>
+				<p><?php echo esc_html( $sync_status ); ?></p>
+				<?php if ( $has_issues ) : ?>
+					<div class="gla-product-issues">
+						<p><strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong></p>
+						<ul>
+							<?php foreach ( $issues as $issue ) : ?>
+							<li><?php echo esc_html( $issue ); ?></li>
+							<?php endforeach; ?>
+						</ul>
+					</div>
+				<?php endif; ?>
 			</div>
 		<?php endif; ?>
-	</div>
+	<?php else : ?>
+		<p><strong><?php esc_html_e( 'Google Listings & Ads', 'google-listings-and-ads' ); ?></strong></p>
+		<p><?php esc_html_e( 'Integrate with Google to list your products for free and launch paid ad campaigns.', 'google-listings-and-ads' ); ?></p>
+		<a href="<?php echo esc_attr( $get_started_url ); ?>"
+		   class="button button-primary"><?php esc_html_e( 'Get Started', 'google-listings-and-ads' ); ?></a>
 	<?php endif; ?>
 </div>

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -18,7 +18,7 @@ $channel_visibility = $this->channel_visibility;
 
 /** @var string */
 $field_id = $this->field_id;
-/** @var string */
+/** @var bool */
 $is_setup_complete = $this->is_setup_complete;
 /** @var string */
 $get_started_url = $this->get_started_url;

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -35,7 +35,7 @@ if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
 } elseif ( ! is_null( $this->sync_status ) ) {
 	$sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
 }
-$show_status = $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
+$show_status = ! empty( $sync_status ) && $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
 
 /**
  * @var array $issues

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -86,8 +86,8 @@ if ( $input_disabled ) {
 		<?php endif; ?>
 	<?php else : ?>
 		<p><strong><?php esc_html_e( 'Google Listings & Ads', 'google-listings-and-ads' ); ?></strong></p>
-		<p><?php esc_html_e( 'Integrate with Google to list your products for free and launch paid ad campaigns.', 'google-listings-and-ads' ); ?></p>
+		<p><?php esc_html_e( 'Complete setup to get your products listed on Google for free.', 'google-listings-and-ads' ); ?></p>
 		<a href="<?php echo esc_attr( $get_started_url ); ?>"
-		   class="button button-primary"><?php esc_html_e( 'Get Started', 'google-listings-and-ads' ); ?></a>
+		   class="button"><?php esc_html_e( 'Complete setup', 'google-listings-and-ads' ); ?></a>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Closes #986.

This is essentially the same PR as #987, but meant to be released as a hotfix. This PR's target base branch is `hotfix/1.4.3`, which is based off from tag `1.4.2`.

For more PR details, please refer to #987.

### Changelog entry

> Tweak - Hide channel visibility box and attributes tab if the setup is not completed.


