### PR TITLE
Add phone verification API endpoints

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ResponseFromExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
@@ -26,6 +27,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
 class ContactInformationController extends BaseOptionsController {
+
+	use ResponseFromExceptionTrait;
 
 	/**
 	 * @var ContactInformation $contact_information
@@ -93,7 +96,7 @@ class ContactInformationController extends BaseOptionsController {
 					$request
 				);
 			} catch ( MerchantApiException $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -115,7 +118,7 @@ class ContactInformationController extends BaseOptionsController {
 					$request
 				);
 			} catch ( MerchantApiException $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -44,25 +44,34 @@ class PhoneVerificationController extends BaseOptionsController {
 	public function register_routes(): void {
 		$verification_method = [
 			'description'       => __( 'Method used to verify the phone number.', 'google-listings-and-ads' ),
+			'enum'              => [
+				PhoneVerification::VERIFICATION_METHOD_SMS,
+				PhoneVerification::VERIFICATION_METHOD_PHONE_CALL,
+			],
+			'required'          => true,
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
-			'required'          => true,
 		];
 
 		$this->register_route(
 			'/mc/phone-verification/request',
 			[
 				[
-					'method'              => TransportMethods::CREATABLE,
+					'methods'              => TransportMethods::CREATABLE,
 					'callback'            => $this->get_request_phone_verification_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => [
-						'context'             => $this->get_context_param( [ 'default' => 'view' ] ),
+						'phone_region_code' => [
+							'description'       => __( 'Two-letter country code (ISO 3166-1 alpha-2) for the phone number.', 'google-listings-and-ads' ),
+							'required'          => true,
+							'type'              => 'string',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
 						'phone_number'        => [
 							'description'       => __( 'The phone number to verify.', 'google-listings-and-ads' ),
+							'required'          => true,
 							'type'              => [ 'integer', 'string' ],
 							'validate_callback' => 'rest_validate_request_arg',
-							'required'          => true,
 						],
 						'verification_method' => $verification_method,
 					],
@@ -74,22 +83,21 @@ class PhoneVerificationController extends BaseOptionsController {
 			'/mc/phone-verification/verify',
 			[
 				[
-					'method'              => TransportMethods::CREATABLE,
+					'methods'              => TransportMethods::CREATABLE,
 					'callback'            => $this->get_verify_phone_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => [
-						'context'                   => $this->get_context_param( [ 'default' => 'view' ] ),
 						'verification_id'           => [
 							'description'       => __( 'The verification ID returned by the /request call.', 'google-listings-and-ads' ),
+							'required'          => true,
 							'type'              => 'string',
 							'validate_callback' => 'rest_validate_request_arg',
-							'required'          => true,
 						],
 						'verification_code' => [
 							'description'       => __( 'The verification code that was sent to the phone number for validation.', 'google-listings-and-ads' ),
+							'required'          => true,
 							'type'              => 'string',
 							'validate_callback' => 'rest_validate_request_arg',
-							'required'          => true,
 						],
 						'verification_method' => $verification_method,
 					],

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\PhoneNumber;
 use Exception;
 use WP_REST_Request as Request;
+use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -146,6 +147,7 @@ class PhoneVerificationController extends BaseOptionsController {
 					$request->get_param( 'verification_code' ),
 					$request->get_param( 'verification_method' ),
 				);
+				return new Response( [], 204 );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -62,11 +62,11 @@ class PhoneVerificationController extends BaseOptionsController {
 			'/mc/phone-verification/request',
 			[
 				[
-					'methods'              => TransportMethods::CREATABLE,
+					'methods'             => TransportMethods::CREATABLE,
 					'callback'            => $this->get_request_phone_verification_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => [
-						'phone_region_code' => [
+						'phone_region_code'   => [
 							'description'       => __( 'Two-letter country code (ISO 3166-1 alpha-2) for the phone number.', 'google-listings-and-ads' ),
 							'required'          => true,
 							'type'              => 'string',
@@ -80,7 +80,7 @@ class PhoneVerificationController extends BaseOptionsController {
 						],
 						'verification_method' => $verification_method,
 					],
-				]
+				],
 			]
 		);
 
@@ -88,17 +88,17 @@ class PhoneVerificationController extends BaseOptionsController {
 			'/mc/phone-verification/verify',
 			[
 				[
-					'methods'              => TransportMethods::CREATABLE,
+					'methods'             => TransportMethods::CREATABLE,
 					'callback'            => $this->get_verify_phone_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => [
-						'verification_id'           => [
+						'verification_id'     => [
 							'description'       => __( 'The verification ID returned by the /request call.', 'google-listings-and-ads' ),
 							'required'          => true,
 							'type'              => 'string',
 							'validate_callback' => 'rest_validate_request_arg',
 						],
-						'verification_code' => [
+						'verification_code'   => [
 							'description'       => __( 'The verification code that was sent to the phone number for validation.', 'google-listings-and-ads' ),
 							'required'          => true,
 							'type'              => 'string',
@@ -106,7 +106,7 @@ class PhoneVerificationController extends BaseOptionsController {
 						],
 						'verification_method' => $verification_method,
 					],
-				]
+				],
 			]
 		);
 	}
@@ -125,10 +125,9 @@ class PhoneVerificationController extends BaseOptionsController {
 					$request->get_param( 'verification_method' ),
 				);
 				return [
-					'verification_id' => $verification_id
+					'verification_id' => $verification_id,
 				];
-			}
-			catch ( Exception $e ) {
+			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}
 		};
@@ -147,8 +146,7 @@ class PhoneVerificationController extends BaseOptionsController {
 					$request->get_param( 'verification_code' ),
 					$request->get_param( 'verification_method' ),
 				);
-			}
-			catch ( Exception $e ) {
+			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}
 		};

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -76,7 +76,7 @@ class PhoneVerificationController extends BaseOptionsController {
 						'phone_number'        => [
 							'description'       => __( 'The phone number to verify.', 'google-listings-and-ads' ),
 							'required'          => true,
-							'type'              => [ 'integer', 'string' ],
+							'type'              => 'string',
 							'validate_callback' => 'rest_validate_request_arg',
 						],
 						'verification_method' => $verification_method,
@@ -122,7 +122,7 @@ class PhoneVerificationController extends BaseOptionsController {
 			try {
 				$verification_id = $this->phone_verification->request_phone_verification(
 					$request->get_param( 'phone_region_code' ),
-					new PhoneNumber( (string) $request->get_param( 'phone_number' ) ),
+					new PhoneNumber( $request->get_param( 'phone_number' ) ),
 					$request->get_param( 'verification_method' ),
 				);
 				return [

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -1,0 +1,127 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class PhoneVerificationController
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
+ */
+class PhoneVerificationController extends BaseOptionsController {
+
+	use EmptySchemaPropertiesTrait;
+
+	/**
+	 * @var PhoneVerification
+	 */
+	protected $phone_verification;
+
+	/**
+	 * ContactInformationController constructor.
+	 *
+	 * @param RESTServer        $server
+	 * @param PhoneVerification $phone_verification
+	 */
+	public function __construct( RESTServer $server, PhoneVerification $phone_verification ) {
+		parent::__construct( $server );
+		$this->phone_verification = $phone_verification;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$verification_method = [
+			'description'       => __( 'Method used to verify the phone number.', 'google-listings-and-ads' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+			'required'          => true,
+		];
+
+		$this->register_route(
+			'/mc/phone-verification/request',
+			[
+				[
+					'method'              => TransportMethods::CREATABLE,
+					'callback'            => $this->get_request_phone_verification_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => [
+						'context'             => $this->get_context_param( [ 'default' => 'view' ] ),
+						'phone_number'        => [
+							'description'       => __( 'The phone number to verify.', 'google-listings-and-ads' ),
+							'type'              => [ 'integer', 'string' ],
+							'validate_callback' => 'rest_validate_request_arg',
+							'required'          => true,
+						],
+						'verification_method' => $verification_method,
+					],
+				]
+			]
+		);
+
+		$this->register_route(
+			'/mc/phone-verification/verify',
+			[
+				[
+					'method'              => TransportMethods::CREATABLE,
+					'callback'            => $this->get_verify_phone_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => [
+						'context'                   => $this->get_context_param( [ 'default' => 'view' ] ),
+						'verification_id'           => [
+							'description'       => __( 'The verification ID returned by the /request call.', 'google-listings-and-ads' ),
+							'type'              => 'string',
+							'validate_callback' => 'rest_validate_request_arg',
+							'required'          => true,
+						],
+						'verification_code' => [
+							'description'       => __( 'The verification code that was sent to the phone number for validation.', 'google-listings-and-ads' ),
+							'type'              => 'string',
+							'validate_callback' => 'rest_validate_request_arg',
+							'required'          => true,
+						],
+						'verification_method' => $verification_method,
+					],
+				]
+			]
+		);
+	}
+
+	/**
+	 * Get callback for requesting phone verification endpoint.
+	 *
+	 * @return callable
+	 */
+	protected function get_request_phone_verification_callback() {
+
+	}
+
+	/**
+	 * Get callback for verifying a phone number.
+	 *
+	 * @return callable
+	 */
+	protected function get_verify_phone_callback() {
+
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'phone_verification';
+	}
+}

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -142,8 +142,22 @@ class PhoneVerificationController extends BaseOptionsController {
 	 *
 	 * @return callable
 	 */
-	protected function get_verify_phone_callback() {
-
+	protected function get_verify_phone_callback(): callable {
+		return function( Request $request ) {
+			try {
+				$this->phone_verification->verify_phone_number(
+					$request->get_param( 'verification_id' ),
+					$request->get_param( 'verification_code' ),
+					$request->get_param( 'verification_method' ),
+				);
+			}
+			catch ( InvalidValue $e ) {
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+			}
+			catch ( PhoneVerificationException $e ) {
+				return new Response( [ 'code' => $e->get_reason(), 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+			}
+		};
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -5,14 +5,13 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ResponseFromExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerificationException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\PhoneNumber;
+use Exception;
 use WP_REST_Request as Request;
-use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -26,6 +25,7 @@ defined( 'ABSPATH' ) || exit;
 class PhoneVerificationController extends BaseOptionsController {
 
 	use EmptySchemaPropertiesTrait;
+	use ResponseFromExceptionTrait;
 
 	/**
 	 * @var PhoneVerification
@@ -128,11 +128,8 @@ class PhoneVerificationController extends BaseOptionsController {
 					'verification_id' => $verification_id
 				];
 			}
-			catch ( InvalidValue $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
-			}
-			catch ( PhoneVerificationException $e ) {
-				return new Response( [ 'code' => $e->get_reason(), 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+			catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -151,11 +148,8 @@ class PhoneVerificationController extends BaseOptionsController {
 					$request->get_param( 'verification_method' ),
 				);
 			}
-			catch ( InvalidValue $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
-			}
-			catch ( PhoneVerificationException $e ) {
-				return new Response( [ 'code' => $e->get_reason(), 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+			catch ( Exception $e ) {
+				$this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -149,7 +149,7 @@ class PhoneVerificationController extends BaseOptionsController {
 				);
 			}
 			catch ( Exception $e ) {
-				$this->response_from_exception( $e );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -33,10 +33,10 @@ class PhoneVerificationController extends BaseOptionsController {
 	protected $phone_verification;
 
 	/**
-	 * ContactInformationController constructor.
+	 * PhoneVerificationController constructor.
 	 *
 	 * @param RESTServer        $server
-	 * @param PhoneVerification $phone_verification
+	 * @param PhoneVerification $phone_verification Phone verification service.
 	 */
 	public function __construct( RESTServer $server, PhoneVerification $phone_verification ) {
 		parent::__construct( $server );

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -147,7 +147,7 @@ class PhoneVerificationController extends BaseOptionsController {
 					$request->get_param( 'verification_code' ),
 					$request->get_param( 'verification_method' ),
 				);
-				return new Response( [], 204 );
+				return new Response( null, 204 );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/API/Site/Controllers/MerchantCenter/ReportsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ReportsController.php
@@ -5,10 +5,10 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseReportsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ResponseFromExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Exception;
 use WP_REST_Request as Request;
-use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -18,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
 class ReportsController extends BaseReportsController {
+
+	use ResponseFromExceptionTrait;
 
 	/**
 	 * Register rest routes with WordPress.
@@ -63,7 +65,7 @@ class ReportsController extends BaseReportsController {
 				$data     = $merchant->get_report_data( 'free_listings', $this->prepare_query_arguments( $request ) );
 				return $this->prepare_item_for_response( $data, $request );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -81,7 +83,7 @@ class ReportsController extends BaseReportsController {
 				$data     = $merchant->get_report_data( 'products', $this->prepare_query_arguments( $request ) );
 				return $this->prepare_item_for_response( $data, $request );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/ResponseFromExceptionTrait.php
+++ b/src/API/Site/Controllers/ResponseFromExceptionTrait.php
@@ -1,0 +1,36 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Exception;
+use WP_REST_Response as Response;
+
+/**
+ * Trait ResponseFromExceptionTrait
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers
+ *
+ * @since x.x.x
+ */
+trait ResponseFromExceptionTrait {
+
+	/**
+	 * Get REST response from an exception.
+	 *
+	 * @param Exception $exception
+	 *
+	 * @return Response
+	 */
+	protected function response_from_exception( Exception $exception ): Response {
+		$code = $exception->getCode();
+		$status = $code && is_numeric( $code ) ? $code : 400;
+
+		if ( $exception instanceof ExceptionWithResponseData ) {
+			return new Response( $exception->get_response_data( true ), $status );
+		}
+
+		return new Response( [ 'message' => $exception->getMessage() ], $status );
+	}
+}

--- a/src/API/Site/Controllers/ResponseFromExceptionTrait.php
+++ b/src/API/Site/Controllers/ResponseFromExceptionTrait.php
@@ -24,7 +24,7 @@ trait ResponseFromExceptionTrait {
 	 * @return Response
 	 */
 	protected function response_from_exception( Exception $exception ): Response {
-		$code = $exception->getCode();
+		$code   = $exception->getCode();
 		$status = $code && is_numeric( $code ) ? $code : 400;
 
 		if ( $exception instanceof ExceptionWithResponseData ) {

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -20,6 +20,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Jetpack\Acc
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController as MerchantCenterAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\IssuesController as MerchantCenterIssuesController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ContactInformationController as MerchantCenterContactInformationController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\PhoneVerificationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductStatisticsController as MerchantCenterProductStatsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ProductFeedController as MerchantCenterProductFeedController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ConnectionController;
@@ -39,6 +40,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -87,6 +89,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( MerchantCenterProductVisibilityController::class, ProductHelper::class, MerchantIssueQuery::class );
 		$this->share( MerchantCenterContactInformationController::class, ContactInformation::class, Settings::class, AddressUtility::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class, Middleware::class );
+		$this->share( PhoneVerificationController::class, PhoneVerification::class );
 		$this->share_with_container( MerchantCenterAccountController::class );
 		$this->share_with_container( MerchantCenterReportsController::class );
 		$this->share_with_container( ShippingRateBatchController::class );

--- a/src/MerchantCenter/PhoneVerification.php
+++ b/src/MerchantCenter/PhoneVerification.php
@@ -148,6 +148,6 @@ class PhoneVerification implements Service {
 			$reason  = $error['reason'] ?? '';
 		}
 
-		return new PhoneVerificationException( $message, $code, $exception, $reason );
+		return new PhoneVerificationException( $message, $code, $exception, [ 'reason' => $reason ] );
 	}
 }

--- a/src/MerchantCenter/PhoneVerificationException.php
+++ b/src/MerchantCenter/PhoneVerificationException.php
@@ -3,9 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
-use Exception;
-use Throwable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -16,40 +14,4 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since x.x.x
  */
-class PhoneVerificationException extends Exception implements GoogleListingsAndAdsException {
-	/**
-	 * @var string
-	 */
-	protected $reason;
-
-	/**
-	 * PhoneVerificationException constructor.
-	 *
-	 * @param string         $message
-	 * @param int            $code
-	 * @param Throwable|null $previous
-	 * @param string         $reason
-	 */
-	public function __construct( string $message = '', int $code = 0, Throwable $previous = null, string $reason = '' ) {
-		parent::__construct( $message, $code, $previous );
-		$this->reason = $reason;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function get_reason(): string {
-		return $this->reason;
-	}
-
-	/**
-	 * @param string $reason
-	 *
-	 * @return PhoneVerificationException
-	 */
-	public function set_reason( string $reason ): PhoneVerificationException {
-		$this->reason = $reason;
-
-		return $this;
-	}
-}
+class PhoneVerificationException extends ExceptionWithResponseData {}

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -80,7 +80,7 @@ abstract class RESTControllerUnitTest extends UnitTest {
 	 * @return Response
 	 */
 	protected function do_request( string $endpoint, string $type = 'GET', array $params = [] ): object {
-		$request = new Request( $type, untrailingslashit( $endpoint ) );
+		$request = new Request( $type, $endpoint );
 		'GET' === $type ? $request->set_query_params( $params ) : $request->set_body_params( $params );
 		return $this->server->dispatch_request( $request );
 	}

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -1,0 +1,88 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+use WP_Test_Spy_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class RESTControllerUnitTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework
+ *
+ * @property RESTServer $server
+ */
+abstract class RESTControllerUnitTest extends UnitTest {
+
+	/**
+	 * Controller we are testing.
+	 *
+	 * @var BaseController
+	 */
+	protected $controller;
+
+	/**
+	 * @var RESTServer
+	 */
+	protected $server;
+
+	/**
+	 * User variable.
+	 *
+	 * @var \WP_User
+	 */
+	protected static $user;
+
+	/**
+	 * Setup once before running tests.
+	 *
+	 * @param object $factory Factory object.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user = $factory->user->create( [ 'role' => 'administrator' ] );
+	}
+
+	/**
+	 * Setup our test server.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_Test_Spy_REST_Server();
+		$this->server   = new RESTServer( $wp_rest_server );
+		wp_set_current_user( self::$user );
+	}
+
+	/**
+	 * Unset the server.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		unset( $this->server );
+	}
+
+	/**
+	 * Perform a request and return the status and returned data.
+	 *
+	 * @param string  $endpoint Endpoint to hit.
+	 * @param string  $type     Type of request e.g GET or POST.
+	 * @param array   $params   Request body or query.
+	 *
+	 * @return Response
+	 */
+	protected function do_request( string $endpoint, string $type = 'GET', array $params = [] ): object {
+		$request = new Request( $type, untrailingslashit( $endpoint ) );
+		'GET' === $type ? $request->set_query_params( $params ) : $request->set_body_params( $params );
+		return $this->server->dispatch_request( $request );
+	}
+
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
@@ -74,7 +74,7 @@ class PhoneVerificationControllerTest extends RESTControllerUnitTest {
 		$this->phone_verification->expects( $this->once() )
 		                         ->method( 'request_phone_verification' )
 		                         ->willThrowException(
-		                         	new PhoneVerificationException( 'oops', 429, null, 'rateLimitExceeded' )
+		                         	new PhoneVerificationException( 'oops', 429, null, [ 'reason' => 'rateLimitExceeded' ] )
 		                         );
 
 		$response = $this->do_request( self::ROUTE_REQUEST_VERIFICATION, 'POST', self::TEST_REQUEST_VERIFICATION_ARGS );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\PhoneVerificationController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerificationException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\PhoneNumber;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class PhoneNumberControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
+ *
+ * @property RESTServer                   $rest_server
+ * @property PhoneVerification|MockObject $phone_verification
+ */
+class PhoneVerificationControllerTest extends RESTControllerUnitTest {
+
+	protected const ROUTE_REQUEST_VERIFICATION     = '/wc/gla/mc/phone-verification/request';
+	protected const ROUTE_VERIFY_PHONE             = '/wc/gla/mc/phone-verification/verify';
+	protected const TEST_PHONE_NUMBER              = '0412 123 123';
+	protected const TEST_VERIFICATION_ID           = 'test_verification_id';
+	protected const TEST_REQUEST_VERIFICATION_ARGS = [
+		'phone_region_code'   => 'AU',
+		'phone_number'        => self::TEST_PHONE_NUMBER,
+		'verification_method' => 'SMS',
+	];
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->phone_verification = $this->createMock( PhoneVerification::class );
+		$this->controller         = new PhoneVerificationController( $this->server, $this->phone_verification );
+		$this->controller->register();
+	}
+
+	public function test_request_phone_verification() {
+		$this->phone_verification->expects( $this->once() )
+		                         ->method( 'request_phone_verification' )
+		                         ->with( 'AU', new PhoneNumber( self::TEST_PHONE_NUMBER ), 'SMS' )
+		                         ->willReturn( self::TEST_VERIFICATION_ID );
+
+		$response = $this->do_request( self::ROUTE_REQUEST_VERIFICATION, 'POST', self::TEST_REQUEST_VERIFICATION_ARGS );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [ 'verification_id' => self::TEST_VERIFICATION_ID ], $response->get_data() );
+	}
+
+	public function test_request_phone_verification_missing_args() {
+		$response = $this->do_request( self::ROUTE_REQUEST_VERIFICATION, 'POST' );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'rest_missing_callback_param', $response->get_data()['code'] );
+		$this->assertCount( 3, $response->get_data()['data']['params'], 'All 3 params should be required.' );
+	}
+
+	public function test_request_phone_verification_with_invalid_value_exception() {
+		$this->phone_verification->expects( $this->once() )
+		                         ->method( 'request_phone_verification' )
+		                         ->willThrowException( new InvalidValue( 'oops' ) );
+
+		$response = $this->do_request( self::ROUTE_REQUEST_VERIFICATION, 'POST', self::TEST_REQUEST_VERIFICATION_ARGS );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'oops', $response->get_data()['message'] );
+	}
+
+	public function test_request_phone_verification_with_phone_verification_exception() {
+		$this->phone_verification->expects( $this->once() )
+		                         ->method( 'request_phone_verification' )
+		                         ->willThrowException(
+		                         	new PhoneVerificationException( 'oops', 429, null, 'rateLimitExceeded' )
+		                         );
+
+		$response = $this->do_request( self::ROUTE_REQUEST_VERIFICATION, 'POST', self::TEST_REQUEST_VERIFICATION_ARGS );
+
+		$this->assertEquals( 429, $response->get_status() );
+		$this->assertEquals( 'rateLimitExceeded', $response->get_data()['code'] );
+		$this->assertEquals( 'oops', $response->get_data()['message'] );
+	}
+
+
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
@@ -101,7 +101,7 @@ class PhoneVerificationControllerTest extends RESTControllerUnitTest {
 
 		$response = $this->do_request( self::ROUTE_VERIFY_PHONE, 'POST', self::TEST_VERIFY_PHONE_ARGS );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 204, $response->get_status() );
 		$this->assertNull( $response->get_data() );
 	}
 

--- a/tests/Unit/MerchantCenter/PhoneVerificationTest.php
+++ b/tests/Unit/MerchantCenter/PhoneVerificationTest.php
@@ -92,7 +92,7 @@ class PhoneVerificationTest extends UnitTest {
 		try {
 			$this->phone_verification->request_phone_verification( 'US', new PhoneNumber( '8772733049' ), PhoneVerification::VERIFICATION_METHOD_SMS );
 		} catch ( PhoneVerificationException $exception ) {
-			$this->assertEquals( 'rateLimitExceeded', $exception->get_reason() );
+			$this->assertEquals( 'rateLimitExceeded', $exception->get_response_data()['reason'] );
 			throw $exception;
 		}
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,7 @@ require_once $wc_tests_dir . '/includes/wp-http-testcase.php';
 require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-product.php';
 require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-shipping.php';
 require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-customer.php';
+require_once $wc_tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php';
 
 /**
  * Load WooCommerce for testing


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Closes #982.
Requires PR #998 to be finished first.

We need two new API endpoints that allow requesting a phone verification code from Google (and sending the code to the user's phone), and verifying the user-provided code.

I chose to create a new controller to handle phone verification rather than use the `ContactInformationController` because it seemed cleaner to me and there wasn't much commonality with the contact info schema.

### Change to `PhoneVerificationException`

This PR also changes `PhoneVerificationException` (introduced in #998) so it extends the pre-existing `ExceptionWithResponseData` class. My thinking was that since this `ExceptionWithResponseData` is being used in other areas to send REST error response data it makes sense to use it here also.

### Screenshots:

<img width="745" alt="Screen Shot 2021-09-10 at 11 38 36 am" src="https://user-images.githubusercontent.com/1892137/132789123-648e1821-139d-4cf0-baf2-f29bba395c72.png">

<img width="647" alt="Screen Shot 2021-09-10 at 11 47 08 am" src="https://user-images.githubusercontent.com/1892137/132789112-7234fd5b-d4c0-4c26-9ba2-e9c00986db59.png">

### Detailed test instructions:

1. Make a request to `POST /wc/gla/mc/phone-verification/request`. See `OPTIONS /wc/gla/mc/phone-verification/request` for params.
2. Save the response
3. Wait for the your verification code to come through
3. Make a request to `POST /wc/gla/mc/phone-verification/verify`. See `OPTIONS /wc/gla/mc/phone-verification/verify` for params. Use the `verification_id` value from the previous response.

### Changelog entry

