### PR TITLE
Clean up `Note` classes

### DIFF
--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -18,10 +18,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class CompleteSetup extends Note implements OptionsAwareInterface, MerchantCenterAwareInterface {
+class CompleteSetup extends Note implements MerchantCenterAwareInterface {
 
 	use MerchantCenterAwareTrait;
-	use OptionsAwareTrait;
 	use PluginHelper;
 	use Utilities;
 

--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -15,6 +15,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Class CompleteSetup
  *

--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -3,12 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
-use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -22,25 +18,20 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwareInterface, MerchantCenterAwareInterface {
+class CompleteSetup extends Note implements OptionsAwareInterface, MerchantCenterAwareInterface {
 
 	use MerchantCenterAwareTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;
 	use Utilities;
 
-	public const NOTE_NAME = 'gla-complete-setup';
-
 	/**
-	 * Register a service.
+	 * Get the note's unique name.
+	 *
+	 * @return string
 	 */
-	public function register(): void {
-		add_action(
-			'admin_init',
-			function() {
-				$this->possibly_add_note();
-			}
-		);
+	public function get_note_name(): string {
+		return 'gla-complete-setup';
 	}
 
 	/**
@@ -51,14 +42,14 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 			return;
 		}
 
-		$note = new Note();
+		$note = new NoteEntry();
 		$note->set_title( __( 'Complete your setup on Google', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'Finish setting up Google Listings & Ads to list your products on Google for free and promote them with paid ads.', 'google-listings-and-ads' ) );
 		$note->set_content_data( (object) [] );
-		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_layout( 'plain' );
 		$note->set_image( '' );
-		$note->set_name( self::NOTE_NAME );
+		$note->set_name( $this->get_note_name() );
 		$note->set_source( $this->get_slug() );
 		$note->add_action(
 			'complete-setup',
@@ -79,14 +70,7 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 	 * @return bool
 	 */
 	public function can_add_note(): bool {
-		if ( ! class_exists( '\WC_Data_Store' ) ) {
-			return false;
-		}
-
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-
-		if ( ! empty( $note_ids ) ) {
+		if ( $this->has_been_added() ) {
 			return false;
 		}
 
@@ -99,18 +83,5 @@ class CompleteSetup implements Deactivateable, Service, Registerable, OptionsAwa
 		}
 
 		return true;
-	}
-
-	/**
-	 * Deactivate the service.
-	 *
-	 * @return void
-	 */
-	public function deactivate(): void {
-		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
-			return;
-		}
-
-		Notes::delete_notes_with_name( self::NOTE_NAME );
 	}
 }

--- a/src/Notes/ContactInformation.php
+++ b/src/Notes/ContactInformation.php
@@ -3,12 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
-use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -24,25 +20,20 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.4.0
  */
-class ContactInformation implements Deactivateable, Service, Registerable, OptionsAwareInterface, MerchantCenterAwareInterface {
+class ContactInformation extends Note implements OptionsAwareInterface, MerchantCenterAwareInterface {
 
 	use MerchantCenterAwareTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;
 	use Utilities;
 
-	public const NOTE_NAME = 'gla-contact-information';
-
 	/**
-	 * Register a service.
+	 * Get the note's unique name.
+	 *
+	 * @return string
 	 */
-	public function register(): void {
-		add_action(
-			'admin_init',
-			function() {
-				$this->possibly_add_note();
-			}
-		);
+	public function get_note_name(): string {
+		return 'gla-contact-information';
 	}
 
 	/**
@@ -53,14 +44,14 @@ class ContactInformation implements Deactivateable, Service, Registerable, Optio
 			return;
 		}
 
-		$note = new Note();
+		$note = new NoteEntry();
 		$note->set_title( __( 'Please add your contact information', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'Google requires the phone number and store address for all stores using Google Merchant Center. This is required to verify your store, and it will not be shown to customers. If you do not add your contact information, your listings may not appear on Google.', 'google-listings-and-ads' ) );
 		$note->set_content_data( (object) [] );
-		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_layout( 'plain' );
 		$note->set_image( '' );
-		$note->set_name( self::NOTE_NAME );
+		$note->set_name( $this->get_note_name() );
 		$note->set_source( $this->get_slug() );
 		$note->add_action(
 			'contact-information',
@@ -79,14 +70,7 @@ class ContactInformation implements Deactivateable, Service, Registerable, Optio
 	 * @return bool
 	 */
 	public function can_add_note(): bool {
-		if ( ! class_exists( '\WC_Data_Store' ) ) {
-			return false;
-		}
-
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-
-		if ( ! empty( $note_ids ) ) {
+		if ( $this->has_been_added() ) {
 			return false;
 		}
 
@@ -101,16 +85,4 @@ class ContactInformation implements Deactivateable, Service, Registerable, Optio
 		return true;
 	}
 
-	/**
-	 * Deactivate the service.
-	 *
-	 * @return void
-	 */
-	public function deactivate(): void {
-		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
-			return;
-		}
-
-		Notes::delete_notes_with_name( self::NOTE_NAME );
-	}
 }

--- a/src/Notes/ContactInformation.php
+++ b/src/Notes/ContactInformation.php
@@ -7,8 +7,6 @@ use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
@@ -20,10 +18,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.4.0
  */
-class ContactInformation extends Note implements OptionsAwareInterface, MerchantCenterAwareInterface {
+class ContactInformation extends Note implements MerchantCenterAwareInterface {
 
 	use MerchantCenterAwareTrait;
-	use OptionsAwareTrait;
 	use PluginHelper;
 	use Utilities;
 

--- a/src/Notes/ContactInformation.php
+++ b/src/Notes/ContactInformation.php
@@ -15,6 +15,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Class ContactInformation
  *

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -31,7 +31,7 @@ abstract class Note implements Service, Registerable, Deactivateable {
 	/**
 	 * Possibly add the note
 	 */
-	abstract function possibly_add_note(): void;
+	abstract public function possibly_add_note(): void;
 
 	/**
 	 * Register a service.

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -59,9 +59,9 @@ abstract class Note implements Service, Registerable, Deactivateable {
 	/**
 	 * Get note data store.
 	 *
-	 * @return DataStore
+	 * @return WC_Data_Store
 	 */
-	protected function get_data_store(): DataStore {
+	protected function get_data_store(): WC_Data_Store {
 		return WC_Data_Store::load( 'admin-note' );
 	}
 

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -1,0 +1,79 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
+
+use Automattic\WooCommerce\Admin\Notes\DataStore;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use WC_Data_Store;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Note base class.
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
+ */
+abstract class Note implements Service, Registerable, Deactivateable {
+
+	/**
+	 * Get the note's unique name.
+	 *
+	 * @return string
+	 */
+	abstract protected function get_note_name(): string;
+
+	/**
+	 * Possibly add the note
+	 */
+	abstract function possibly_add_note(): void;
+
+	/**
+	 * Register a service.
+	 */
+	public function register(): void {
+		add_action(
+			'admin_init',
+			function() {
+				$this->possibly_add_note();
+			}
+		);
+	}
+
+	/**
+	 * Deactivate the service.
+	 */
+	public function deactivate(): void {
+		if ( ! class_exists( Notes::class ) ) {
+			return;
+		}
+
+		Notes::delete_notes_with_name( $this->get_note_name() );
+	}
+
+	/**
+	 * Get note data store.
+	 *
+	 * @return DataStore
+	 */
+	protected function get_data_store(): DataStore {
+		return WC_Data_Store::load( 'admin-note' );
+	}
+
+	/**
+	 * Check if the note has already been added.
+	 *
+	 * @return bool
+	 */
+	protected function has_been_added(): bool {
+		$note_ids = $this->get_data_store()->get_notes_with_name( $this->get_note_name() );
+
+		return ! empty( $note_ids );
+	}
+
+}

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
-use Automattic\WooCommerce\Admin\Notes\DataStore;
 use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -16,6 +16,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use WC_Data_Store;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Class SetupCampaign
  *

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaign extends Note implements OptionsAwareInterface, AdsAwareInterface {
+class SetupCampaign extends Note implements AdsAwareInterface {
 
 	use AdsAwareTrait;
 	use PluginHelper;

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -3,18 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
-use Automattic\WooCommerce\Admin\Notes\DataStore;
-use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
-use WC_Data_Store;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -23,24 +17,19 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwareInterface, AdsAwareInterface {
+class SetupCampaign extends Note implements OptionsAwareInterface, AdsAwareInterface {
 
 	use AdsAwareTrait;
 	use PluginHelper;
 	use Utilities;
 
-	public const NOTE_NAME = 'gla-setup-campaign';
-
 	/**
-	 * Register a service.
+	 * Get the note's unique name.
+	 *
+	 * @return string
 	 */
-	public function register(): void {
-		add_action(
-			'admin_init',
-			function() {
-				$this->possibly_add_note();
-			}
-		);
+	public function get_note_name(): string {
+		return 'gla-setup-campaign';
 	}
 
 	/**
@@ -51,14 +40,14 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 			return;
 		}
 
-		$note = new Note();
+		$note = new NoteEntry();
 		$note->set_title( __( 'Create your first campaign to boost sales', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'Leverage the power of paid ads to list products on Google Search, Shopping, YouTube, Gmail and the Display Network and drive sales.', 'google-listings-and-ads' ) );
 		$note->set_content_data( (object) [] );
-		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_layout( 'plain' );
 		$note->set_image( '' );
-		$note->set_name( self::NOTE_NAME );
+		$note->set_name( $this->get_note_name() );
 		$note->set_source( $this->get_slug() );
 		$note->add_action(
 			'setup-campaign',
@@ -78,15 +67,7 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 	 * @return bool
 	 */
 	public function can_add_note(): bool {
-		if ( ! class_exists( WC_Data_Store::class ) ) {
-			return false;
-		}
-
-		/** @var DataStore $data_store */
-		$data_store = WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-
-		if ( ! empty( $note_ids ) ) {
+		if ( $this->has_been_added() ) {
 			return false;
 		}
 
@@ -101,16 +82,4 @@ class SetupCampaign implements Deactivateable, Service, Registerable, OptionsAwa
 		return true;
 	}
 
-	/**
-	 * Deactivate the service.
-	 *
-	 * @return void
-	 */
-	public function deactivate(): void {
-		if ( ! class_exists( Notes::class ) ) {
-			return;
-		}
-
-		Notes::delete_notes_with_name( self::NOTE_NAME );
-	}
 }

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -3,18 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
-use Automattic\WooCommerce\Admin\Notes\DataStore;
-use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
-use WC_Data_Store;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -23,24 +17,19 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaignTwoWeeks implements Deactivateable, Service, Registerable, OptionsAwareInterface, AdsAwareInterface {
+class SetupCampaignTwoWeeks extends Note implements OptionsAwareInterface, AdsAwareInterface {
 
 	use AdsAwareTrait;
 	use PluginHelper;
 	use Utilities;
 
-	public const NOTE_NAME = 'gla-setup-campaign-two-weeks';
-
 	/**
-	 * Register a service.
+	 * Get the note's unique name.
+	 *
+	 * @return string
 	 */
-	public function register(): void {
-		add_action(
-			'admin_init',
-			function() {
-				$this->possibly_add_note();
-			}
-		);
+	public function get_note_name(): string {
+		return 'gla-setup-campaign-two-weeks';
 	}
 
 	/**
@@ -51,14 +40,14 @@ class SetupCampaignTwoWeeks implements Deactivateable, Service, Registerable, Op
 			return;
 		}
 
-		$note = new Note();
+		$note = new NoteEntry();
 		$note->set_title( __( 'Launch your first ad in a few steps', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'You’re just a few steps away from reaching new shoppers across Google. Create your first paid ad campaign today.', 'google-listings-and-ads' ) );
 		$note->set_content_data( (object) [] );
-		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_layout( 'plain' );
 		$note->set_image( '' );
-		$note->set_name( self::NOTE_NAME );
+		$note->set_name( $this->get_note_name() );
 		$note->set_source( $this->get_slug() );
 		$note->add_action(
 			'setup-campaign',
@@ -78,15 +67,7 @@ class SetupCampaignTwoWeeks implements Deactivateable, Service, Registerable, Op
 	 * @return bool
 	 */
 	public function can_add_note(): bool {
-		if ( ! class_exists( WC_Data_Store::class ) ) {
-			return false;
-		}
-
-		/** @var DataStore $data_store */
-		$data_store = WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-
-		if ( ! empty( $note_ids ) ) {
+		if ( $this->has_been_added() ) {
 			return false;
 		}
 
@@ -99,18 +80,5 @@ class SetupCampaignTwoWeeks implements Deactivateable, Service, Registerable, Op
 		}
 
 		return true;
-	}
-
-	/**
-	 * Deactivate the service.
-	 *
-	 * @return void
-	 */
-	public function deactivate(): void {
-		if ( ! class_exists( Notes::class ) ) {
-			return;
-		}
-
-		Notes::delete_notes_with_name( self::NOTE_NAME );
 	}
 }

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -16,6 +16,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use WC_Data_Store;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Class SetupCampaignTwoWeeks
  *

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaignTwoWeeks extends Note implements OptionsAwareInterface, AdsAwareInterface {
+class SetupCampaignTwoWeeks extends Note implements AdsAwareInterface {
 
 	use AdsAwareTrait;
 	use PluginHelper;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We need to add some more inbox notifications (#860) and while I was looking into it there seemed to be a number of duplicated lines in each of the `Automattic\WooCommerce\GoogleListingsAndAds\Notes\*` classes. Before adding any new notes classes I wanted to clean this up.

This PR also prevents direct access to these files.

**Question:** I don't see that these classes are using `OptionsAwareInterface` at all. Am I missing something?

### Testing

This is a little tricky since each note has different criteria. Deleting your existing notes `DELETE FROM wp_wc_admin_notes WHERE name LIKE 'gla-%'` would be the first step.

### Changelog entry

>
