### PR TITLE
Replace "Wordpress.com" with "WordPress.com"

### DIFF
--- a/js/src/settings/disconnect-accounts/index.js
+++ b/js/src/settings/disconnect-accounts/index.js
@@ -72,7 +72,7 @@ export default function DisconnectAccounts() {
 		<Section
 			title={ __( 'Linked accounts', 'google-listings-and-ads' ) }
 			description={ __(
-				'A Wordpress.com account, Google account, and Google Merchant Center account are required to use this extension in WooCommerce.',
+				'A WordPress.com account, Google account, and Google Merchant Center account are required to use this extension in WooCommerce.',
 				'google-listings-and-ads'
 			) }
 		>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -45,7 +45,7 @@ const SetupAccounts = ( props ) => {
 					'google-listings-and-ads'
 				) }
 				description={ __(
-					'Connect your Wordpress.com account, Google account, and Google Merchant Center account to use Google Listings & Ads.',
+					'Connect your WordPress.com account, Google account, and Google Merchant Center account to use Google Listings & Ads.',
 					'google-listings-and-ads'
 				) }
 			/>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There are two locations in our code where "WordPress.com" has a typo with a lowercase "P". This corrects those typos.


### Screenshots:

<img width="911" alt="Screen Shot 2021-09-20 at 14 13 37" src="https://user-images.githubusercontent.com/871924/134053149-f5e6ef35-c7d1-4dfe-8669-59c3493252b2.png">

### Changelog entry

> Fix - correct spelling/capitalization of "WordPress.com"