### PR TITLE
Feature/coupon syncer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,83 +1,77 @@
 {
-	"name": "woocommerce/google-listings-and-ads",
-	"type": "wordpress-plugin",
-	"description": "Native integration with Google that allows merchants to easily display their products across Google’s network.",
-	"prefer-stable": true,
-	"minimum-stability": "dev",
-	"require": {
-		"php": ">=7.3",
-		"automattic/jetpack-autoloader": "^2.4",
-		"automattic/jetpack-config": "^1.4",
-		"automattic/jetpack-connection": "^1.20",
-		"google/apiclient": "^2.10.1",
-		"google/apiclient-services": "~0.210.0",
-		"googleads/google-ads-php": "^10.0",
-		"league/container": "^3.3",
-		"league/iso3166": "^3.0",
-		"phpseclib/bcmath_compat": "^2.0",
-		"psr/container": "^1.0",
-		"symfony/validator": "^5.2",
-		"ext-json": "*"
+	"name" : "woocommerce/google-listings-and-ads",
+	"type" : "wordpress-plugin",
+	"description" : "Native integration with Google that allows merchants to easily display their products across Google\u2019s network.",
+	"prefer-stable" : true,
+	"minimum-stability" : "dev",
+	"require" : {
+		"php" : ">=7.3",
+		"automattic/jetpack-autoloader" : "^2.4",
+		"automattic/jetpack-config" : "^1.4",
+		"automattic/jetpack-connection" : "^1.20",
+		"google/apiclient" : "~2.10",
+		"google/apiclient-services" : "~0.211",
+		"googleads/google-ads-php" : "^10.0",
+		"league/container" : "^3.3",
+		"league/iso3166" : "^3.0",
+		"phpseclib/bcmath_compat" : "^2.0",
+		"psr/container" : "^1.0",
+		"symfony/validator" : "^5.2",
+		"ext-json" : "*"
 	},
-	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^v0.7",
-		"phpunit/phpunit": "^7.5",
-		"wp-cli/i18n-command": "^2.2",
-		"wp-coding-standards/wpcs": "^2.3"
+	"require-dev" : {
+		"dealerdirect/phpcodesniffer-composer-installer" : "^v0.7",
+		"phpunit/phpunit" : "^7.5",
+		"wp-cli/i18n-command" : "^2.2",
+		"wp-coding-standards/wpcs" : "^2.3"
 	},
-	"replace": {
-		"symfony/polyfill-mbstring": "*"
+	"replace" : {
+		"symfony/polyfill-mbstring" : "*"
 	},
-	"license": "GPL-3.0",
-	"autoload": {
-		"psr-4": {
-			"Automattic\\WooCommerce\\GoogleListingsAndAds\\": "src/"
+	"license" : "GPL-3.0",
+	"autoload" : {
+		"psr-4" : {
+			"Automattic\\WooCommerce\\GoogleListingsAndAds\\" : "src/"
 		},
-		"files": [
+		"files" : [
 			"vendor/guzzlehttp/guzzle/src/functions_include.php",
 			"vendor/guzzlehttp/promises/src/functions_include.php",
 			"vendor/guzzlehttp/psr7/src/functions_include.php"
 		]
 	},
-	"autoload-dev": {
-		"psr-4": {
-			"Automattic\\WooCommerce\\GoogleListingsAndAds\\Tests\\": "tests/"
+	"autoload-dev" : {
+		"psr-4" : {
+			"Automattic\\WooCommerce\\GoogleListingsAndAds\\Tests\\" : "tests/"
 		}
 	},
-	"config": {
-		"platform": {
-			"php": "7.3.27"
+	"config" : {
+		"platform" : {
+			"php" : "7.3.27"
 		},
-		"sort-packages": true
+		"sort-packages" : true
 	},
-	"scripts": {
-		"install-scripts": [
+	"scripts" : {
+		"install-scripts" : [
 			"Google\\Task\\Composer::cleanup",
 			"php ./bin/prefix-vendor-namespace.php",
 			"composer run-script remove-google-ads-api-version-support -- 6 7",
 			"bash ./bin/cleanup-vendor-files.sh",
 			"composer dump-autoload"
 		],
-		"post-install-cmd": [
-			"@install-scripts"
-		],
-		"post-update-cmd": [
-			"@install-scripts"
-		],
-		"remove-google-ads-api-version-support": [
-			"Google\\Ads\\GoogleAds\\Util\\ApiVersionSupport::remove"
-		],
-		"test-unit": "./vendor/bin/phpunit"
+		"post-install-cmd" : "@install-scripts",
+		"post-update-cmd" : "@install-scripts",
+		"remove-google-ads-api-version-support" : "Google\\Ads\\GoogleAds\\Util\\ApiVersionSupport::remove",
+		"test-unit" : "./vendor/bin/phpunit"
 	},
-	"archive": {
-		"exclude": [
+	"archive" : {
+		"exclude" : [
 			"!/js/build",
 			"!/vendor/*",
 			"!/languages"
 		]
 	},
-	"extra": {
-		"google/apiclient-services": [
+	"extra" : {
+		"google/apiclient-services" : [
 			"ShoppingContent",
 			"SiteVerification"
 		]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "902bfa2e74fb573ba14edfac05054c24",
+    "content-hash": "df199488590330a8b54c36a716131d34",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -692,7 +692,7 @@
         },
         {
             "name": "google/apiclient",
-            "version": "v2.10.1",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
@@ -5120,5 +5120,5 @@
     "platform-overrides": {
         "php": "7.3.27"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,28 +4,36 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20773c0eb40754596a49e0af2f484e21",
+    "content-hash": "902bfa2e74fb573ba14edfac05054c24",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
-            "version": "1.4.1",
+            "version": "v1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-a8c-mc-stats.git",
-                "reference": "b2f6b20aa3046848391593e6a18f87ae3797e888"
+                "reference": "5307c1526b153520bad42d459dcf42074cf28f5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/b2f6b20aa3046848391593e6a18f87ae3797e888",
-                "reference": "b2f6b20aa3046848391593e6a18f87ae3797e888",
+                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/5307c1526b153520bad42d459dcf42074cf28f5c",
+                "reference": "5307c1526b153520bad42d459dcf42074cf28f5c",
                 "shasum": ""
             },
             "require-dev": {
-                "yoast/phpunit-polyfills": "0.2.0"
+                "automattic/jetpack-changelogger": "^1.2",
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-a8c-mc-stats"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-a8c-mc-stats",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -38,34 +46,42 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/1.4.1"
+                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/v1.4.5"
             },
-            "time": "2021-02-05T19:06:50+00:00"
+            "time": "2021-08-30T14:18:51+00:00"
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "v1.11.2",
+            "version": "v1.11.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-assets.git",
-                "reference": "833a6840b5f39ef05b2a65def8a1e61dc7c45a7a"
+                "reference": "66772f66b59dbec3320d917a490ca2b4f10c86f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/833a6840b5f39ef05b2a65def8a1e61dc7c45a7a",
-                "reference": "833a6840b5f39ef05b2a65def8a1e61dc7c45a7a",
+                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/66772f66b59dbec3320d917a490ca2b4f10c86f9",
+                "reference": "66772f66b59dbec3320d917a490ca2b4f10c86f9",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-constants": "1.6.2"
+                "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "0.2.0"
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-assets"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-assets",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.11.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -78,34 +94,42 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-assets/tree/v1.11.2"
+                "source": "https://github.com/Automattic/jetpack-assets/tree/v1.11.6"
             },
-            "time": "2021-02-23T14:58:20+00:00"
+            "time": "2021-08-30T14:19:15+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.10.0",
+            "version": "v2.10.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "6409c42b32ed82aff50869fd0a6a2e5c7a96fbd6"
+                "reference": "ec66177eefa1126d5319f3135ff3a7185e21a0ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/6409c42b32ed82aff50869fd0a6a2e5c7a96fbd6",
-                "reference": "6409c42b32ed82aff50869fd0a6a2e5c7a96fbd6",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/ec66177eefa1126d5319f3135ff3a7185e21a0ba",
+                "reference": "ec66177eefa1126d5319f3135ff3a7185e21a0ba",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
-                "yoast/phpunit-polyfills": "0.2.0"
+                "automattic/jetpack-changelogger": "^1.2",
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "composer-plugin",
             "extra": {
+                "autotagger": true,
                 "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
-                "mirror-repo": "Automattic/jetpack-autoloader"
+                "mirror-repo": "Automattic/jetpack-autoloader",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -121,27 +145,37 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.10.0"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.10.5"
             },
-            "time": "2021-02-09T18:24:48+00:00"
+            "time": "2021-08-31T17:20:29+00:00"
         },
         {
             "name": "automattic/jetpack-config",
-            "version": "v1.4.3",
+            "version": "v1.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-config.git",
-                "reference": "6bc77aa73d90510c9488e2d8fdaad4b056d3a066"
+                "reference": "219ec1addd3f9e28f3ec3aa8b55d8a4e031bc955"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/6bc77aa73d90510c9488e2d8fdaad4b056d3a066",
-                "reference": "6bc77aa73d90510c9488e2d8fdaad4b056d3a066",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/219ec1addd3f9e28f3ec3aa8b55d8a4e031bc955",
+                "reference": "219ec1addd3f9e28f3ec3aa8b55d8a4e031bc955",
                 "shasum": ""
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-config"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-config",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -154,40 +188,54 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-config/tree/v1.4.3"
+                "source": "https://github.com/Automattic/jetpack-config/tree/v1.4.7"
             },
-            "time": "2021-01-19T14:25:05+00:00"
+            "time": "2021-08-31T17:20:32+00:00"
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "v1.24.0",
+            "version": "v1.30.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "5ffc22ecc7210cb229ab4a9833e2ba1def817ff8"
+                "reference": "81e3762de3eb3478c6f29491b198141a10eee21f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/5ffc22ecc7210cb229ab4a9833e2ba1def817ff8",
-                "reference": "5ffc22ecc7210cb229ab4a9833e2ba1def817ff8",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/81e3762de3eb3478c6f29491b198141a10eee21f",
+                "reference": "81e3762de3eb3478c6f29491b198141a10eee21f",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-constants": "1.6.2",
-                "automattic/jetpack-heartbeat": "1.3.3",
-                "automattic/jetpack-options": "1.11.2",
-                "automattic/jetpack-roles": "1.4.2",
-                "automattic/jetpack-status": "1.7.2",
-                "automattic/jetpack-tracking": "1.13.2"
+                "automattic/jetpack-a8c-mc-stats": "^1.4",
+                "automattic/jetpack-constants": "^1.6",
+                "automattic/jetpack-heartbeat": "^1.3",
+                "automattic/jetpack-options": "^1.13",
+                "automattic/jetpack-redirect": "^1.7",
+                "automattic/jetpack-roles": "^1.4",
+                "automattic/jetpack-status": "^1.8",
+                "automattic/jetpack-terms-of-service": "^1.9",
+                "automattic/jetpack-tracking": "^1.13"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
                 "automattic/wordbless": "@dev",
-                "brain/monkey": "^2.6",
-                "yoast/phpunit-polyfills": "0.2.0"
+                "brain/monkey": "2.6.0",
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-connection"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-connection",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.30.x-dev"
+                }
             },
             "autoload": {
                 "files": [
@@ -204,31 +252,39 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-connection/tree/v1.24.0"
+                "source": "https://github.com/Automattic/jetpack-connection/tree/v1.30.4"
             },
-            "time": "2021-02-23T15:05:16+00:00"
+            "time": "2021-09-02T21:19:22+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "v1.6.2",
+            "version": "v1.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "84c8f09c5a6467104094243912fdcfe8eaed945b"
+                "reference": "f72c4292cd5a31ec1acb65e9f7656ba2378ef7cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/84c8f09c5a6467104094243912fdcfe8eaed945b",
-                "reference": "84c8f09c5a6467104094243912fdcfe8eaed945b",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/f72c4292cd5a31ec1acb65e9f7656ba2378ef7cf",
+                "reference": "f72c4292cd5a31ec1acb65e9f7656ba2378ef7cf",
                 "shasum": ""
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "0.2.0"
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-constants"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-constants",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-constants/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -241,31 +297,41 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.6.2"
+                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.6.6"
             },
-            "time": "2021-02-05T19:07:24+00:00"
+            "time": "2021-08-30T14:18:59+00:00"
         },
         {
             "name": "automattic/jetpack-heartbeat",
-            "version": "v1.3.3",
+            "version": "v1.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-heartbeat.git",
-                "reference": "d6e906c15a539bee5f52957126ba1b43d11e63da"
+                "reference": "caade9254cbde292b62b3959547a30a0d80b90da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-heartbeat/zipball/d6e906c15a539bee5f52957126ba1b43d11e63da",
-                "reference": "d6e906c15a539bee5f52957126ba1b43d11e63da",
+                "url": "https://api.github.com/repos/Automattic/jetpack-heartbeat/zipball/caade9254cbde292b62b3959547a30a0d80b90da",
+                "reference": "caade9254cbde292b62b3959547a30a0d80b90da",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-a8c-mc-stats": "1.4.1",
-                "automattic/jetpack-options": "1.11.2"
+                "automattic/jetpack-a8c-mc-stats": "^1.4",
+                "automattic/jetpack-options": "^1.13"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-heartbeat"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-heartbeat",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-heartbeat/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -278,33 +344,41 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-heartbeat/tree/v1.3.3"
+                "source": "https://github.com/Automattic/jetpack-heartbeat/tree/v1.3.10"
             },
-            "time": "2021-02-23T15:01:22+00:00"
+            "time": "2021-09-03T16:20:06+00:00"
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "v1.11.2",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-options.git",
-                "reference": "1889f3648782b5ceaac255f2a5ee96c1de8cca1e"
+                "reference": "fd3d213bc4d7597ea2d5f24adbf111028db46496"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/1889f3648782b5ceaac255f2a5ee96c1de8cca1e",
-                "reference": "1889f3648782b5ceaac255f2a5ee96c1de8cca1e",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/fd3d213bc4d7597ea2d5f24adbf111028db46496",
+                "reference": "fd3d213bc4d7597ea2d5f24adbf111028db46496",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-constants": "1.6.2"
+                "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "yoast/phpunit-polyfills": "0.2.0"
+                "automattic/jetpack-changelogger": "^1.2",
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-options"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-options",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-options/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.13.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -317,31 +391,87 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-options/tree/v1.11.2"
+                "source": "https://github.com/Automattic/jetpack-options/tree/v1.13.1"
             },
-            "time": "2021-02-23T15:00:26+00:00"
+            "time": "2021-08-30T14:19:17+00:00"
         },
         {
-            "name": "automattic/jetpack-roles",
-            "version": "v1.4.2",
+            "name": "automattic/jetpack-redirect",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/jetpack-roles.git",
-                "reference": "ad4e0c4483945b24db10c09696558a2f381236ee"
+                "url": "https://github.com/Automattic/jetpack-redirect.git",
+                "reference": "1607360c2f8b4e14d97cb3a22aee8e1565d96f80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/ad4e0c4483945b24db10c09696558a2f381236ee",
-                "reference": "ad4e0c4483945b24db10c09696558a2f381236ee",
+                "url": "https://api.github.com/repos/Automattic/jetpack-redirect/zipball/1607360c2f8b4e14d97cb3a22aee8e1565d96f80",
+                "reference": "1607360c2f8b4e14d97cb3a22aee8e1565d96f80",
                 "shasum": ""
             },
+            "require": {
+                "automattic/jetpack-status": "^1.8"
+            },
             "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "0.2.0"
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-roles"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-redirect",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-redirect/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-redirect/tree/v1.7.1"
+            },
+            "time": "2021-08-30T14:19:19+00:00"
+        },
+        {
+            "name": "automattic/jetpack-roles",
+            "version": "v1.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-roles.git",
+                "reference": "1b67fb3d17842d54ee6242fbd665417ce9b3d497"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/1b67fb3d17842d54ee6242fbd665417ce9b3d497",
+                "reference": "1b67fb3d17842d54ee6242fbd665417ce9b3d497",
+                "shasum": ""
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
+                "brain/monkey": "2.6.0",
+                "yoast/phpunit-polyfills": "1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-roles",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-roles/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -354,31 +484,39 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-roles/tree/v1.4.2"
+                "source": "https://github.com/Automattic/jetpack-roles/tree/v1.4.6"
             },
-            "time": "2021-02-05T19:07:59+00:00"
+            "time": "2021-08-30T14:19:09+00:00"
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "v1.7.2",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-status.git",
-                "reference": "a0f1f7450f045afc2669135ba576632ca0889506"
+                "reference": "f3f26d5effc09709e5b52290cc7e3dd2c5861b14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/a0f1f7450f045afc2669135ba576632ca0889506",
-                "reference": "a0f1f7450f045afc2669135ba576632ca0889506",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/f3f26d5effc09709e5b52290cc7e3dd2c5861b14",
+                "reference": "f3f26d5effc09709e5b52290cc7e3dd2c5861b14",
                 "shasum": ""
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "0.2.0"
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-status"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-status",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -391,35 +529,43 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-status/tree/v1.7.2"
+                "source": "https://github.com/Automattic/jetpack-status/tree/v1.8.1"
             },
-            "time": "2021-02-05T19:08:03+00:00"
+            "time": "2021-08-30T14:19:10+00:00"
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "v1.9.3",
+            "version": "v1.9.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
-                "reference": "f8435228d918a5bd32912339b1124d35911efde1"
+                "reference": "96667ee94d2a1b47a3a054af0af909ba7d4b0707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/f8435228d918a5bd32912339b1124d35911efde1",
-                "reference": "f8435228d918a5bd32912339b1124d35911efde1",
+                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/96667ee94d2a1b47a3a054af0af909ba7d4b0707",
+                "reference": "96667ee94d2a1b47a3a054af0af909ba7d4b0707",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-options": "1.11.2",
-                "automattic/jetpack-status": "1.7.2"
+                "automattic/jetpack-options": "^1.13",
+                "automattic/jetpack-status": "^1.8"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "0.2.0"
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-terms-of-service"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-terms-of-service",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-terms-of-service/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.9.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -432,36 +578,44 @@
             ],
             "description": "Everything need to manage the terms of service state",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-terms-of-service/tree/v1.9.3"
+                "source": "https://github.com/Automattic/jetpack-terms-of-service/tree/v1.9.9"
             },
-            "time": "2021-02-23T15:02:14+00:00"
+            "time": "2021-08-30T14:19:27+00:00"
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "v1.13.2",
+            "version": "v1.13.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-tracking.git",
-                "reference": "b2dc6688098798111e21bd7d5d052fb828fa0932"
+                "reference": "fe019c0cee900559e21d7a98d564177a373b1016"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/b2dc6688098798111e21bd7d5d052fb828fa0932",
-                "reference": "b2dc6688098798111e21bd7d5d052fb828fa0932",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/fe019c0cee900559e21d7a98d564177a373b1016",
+                "reference": "fe019c0cee900559e21d7a98d564177a373b1016",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-assets": "1.11.2",
-                "automattic/jetpack-options": "1.11.2",
-                "automattic/jetpack-status": "1.7.2",
-                "automattic/jetpack-terms-of-service": "1.9.3"
+                "automattic/jetpack-assets": "^1.11",
+                "automattic/jetpack-options": "^1.13",
+                "automattic/jetpack-status": "^1.8",
+                "automattic/jetpack-terms-of-service": "^1.9"
             },
             "require-dev": {
-                "yoast/phpunit-polyfills": "0.2.0"
+                "automattic/jetpack-changelogger": "^1.2",
+                "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",
             "extra": {
-                "mirror-repo": "Automattic/jetpack-tracking"
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-tracking",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-tracking/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.13.x-dev"
+                }
             },
             "autoload": {
                 "classmap": [
@@ -475,9 +629,9 @@
             ],
             "description": "Tracking for Jetpack",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-tracking/tree/v1.13.2"
+                "source": "https://github.com/Automattic/jetpack-tracking/tree/v1.13.9"
             },
-            "time": "2021-02-23T15:03:25+00:00"
+            "time": "2021-08-30T14:19:28+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -607,16 +761,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.210.0",
+            "version": "v0.212.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "2be187c5c7c6b6325ddc99015ac6b00ebb8ec764"
+                "reference": "2c4bd512502ad9cdfec8ea711ea1592c79d345e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/2be187c5c7c6b6325ddc99015ac6b00ebb8ec764",
-                "reference": "2be187c5c7c6b6325ddc99015ac6b00ebb8ec764",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/2c4bd512502ad9cdfec8ea711ea1592c79d345e5",
+                "reference": "2c4bd512502ad9cdfec8ea711ea1592c79d345e5",
                 "shasum": ""
             },
             "require": {
@@ -645,28 +799,28 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.210.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.212.0"
             },
-            "time": "2021-08-29T11:20:24+00:00"
+            "time": "2021-09-12T11:18:27+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.16.0",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "c747738d2dd450f541f09f26510198fbedd1c8a0"
+                "reference": "21dd478e77b0634ed9e3a68613f74ed250ca9347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/c747738d2dd450f541f09f26510198fbedd1c8a0",
-                "reference": "c747738d2dd450f541f09f26510198fbedd1c8a0",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/21dd478e77b0634ed9e3a68613f74ed250ca9347",
+                "reference": "21dd478e77b0634ed9e3a68613f74ed250ca9347",
                 "shasum": ""
             },
             "require": {
                 "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
                 "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7.0",
-                "guzzlehttp/psr7": "^1.2",
+                "guzzlehttp/psr7": "^1.7|^2.0",
                 "php": ">=5.4",
                 "psr/cache": "^1.0|^2.0",
                 "psr/http-message": "^1.0"
@@ -676,8 +830,7 @@
                 "kelvinmo/simplejwt": "^0.2.5|^0.5.1",
                 "phpseclib/phpseclib": "^2.0.31",
                 "phpunit/phpunit": "^4.8.36|^5.7",
-                "sebastian/comparator": ">=1.2.3",
-                "squizlabs/php_codesniffer": "^3.5"
+                "sebastian/comparator": ">=1.2.3"
             },
             "suggest": {
                 "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings or for token management. Please require version ^2."
@@ -702,22 +855,22 @@
             "support": {
                 "docs": "https://googleapis.github.io/google-auth-library-php/master/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.16.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.18.0"
             },
-            "time": "2021-06-22T18:06:03+00:00"
+            "time": "2021-08-24T18:03:18+00:00"
         },
         {
             "name": "google/common-protos",
-            "version": "1.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/common-protos-php.git",
-                "reference": "535f489ff1c3433c0ea64cd5aa0560f926949ac5"
+                "reference": "c348d1545fbeac7df3c101fdc687aba35f49811f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/535f489ff1c3433c0ea64cd5aa0560f926949ac5",
-                "reference": "535f489ff1c3433c0ea64cd5aa0560f926949ac5",
+                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/c348d1545fbeac7df3c101fdc687aba35f49811f",
+                "reference": "c348d1545fbeac7df3c101fdc687aba35f49811f",
                 "shasum": ""
             },
             "require": {
@@ -745,32 +898,32 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/common-protos-php/issues",
-                "source": "https://github.com/googleapis/common-protos-php/tree/1.3"
+                "source": "https://github.com/googleapis/common-protos-php/tree/1.3.1"
             },
-            "time": "2020-08-26T16:05:09+00:00"
+            "time": "2021-06-29T15:42:12+00:00"
         },
         {
             "name": "google/gax",
-            "version": "v1.7.1",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/gax-php.git",
-                "reference": "48cd41dbea7b8fece8c41100022786d149de64ca"
+                "reference": "30ca2be6125c8936e74ad17ec2b495bb26697a59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/48cd41dbea7b8fece8c41100022786d149de64ca",
-                "reference": "48cd41dbea7b8fece8c41100022786d149de64ca",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/30ca2be6125c8936e74ad17ec2b495bb26697a59",
+                "reference": "30ca2be6125c8936e74ad17ec2b495bb26697a59",
                 "shasum": ""
             },
             "require": {
-                "google/auth": "^1.2.0",
+                "google/auth": "^1.18.0",
                 "google/common-protos": "^1.0",
                 "google/grpc-gcp": "^0.1.0",
                 "google/protobuf": "^3.12.2",
                 "grpc/grpc": "^1.13",
                 "guzzlehttp/promises": "^1.3",
-                "guzzlehttp/psr7": "^1.2",
+                "guzzlehttp/psr7": "^1.7.0|^2",
                 "php": ">=5.5"
             },
             "conflict": {
@@ -798,9 +951,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/gax-php/issues",
-                "source": "https://github.com/googleapis/gax-php/tree/v1.7.1"
+                "source": "https://github.com/googleapis/gax-php/tree/v1.9.0"
             },
-            "time": "2021-03-22T22:27:35+00:00"
+            "time": "2021-09-01T16:16:42+00:00"
         },
         {
             "name": "google/grpc-gcp",
@@ -849,16 +1002,16 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v3.17.3",
+            "version": "v3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "ae9282cf11dd2933b7e71a611f9590f07d53d3f3"
+                "reference": "24fed401306c943be38a1371ca2f3db2cd8137fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/ae9282cf11dd2933b7e71a611f9590f07d53d3f3",
-                "reference": "ae9282cf11dd2933b7e71a611f9590f07d53d3f3",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/24fed401306c943be38a1371ca2f3db2cd8137fb",
+                "reference": "24fed401306c943be38a1371ca2f3db2cd8137fb",
                 "shasum": ""
             },
             "require": {
@@ -888,22 +1041,22 @@
             ],
             "support": {
                 "issues": "https://github.com/protocolbuffers/protobuf-php/issues",
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.17.3"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.18.0"
             },
-            "time": "2021-06-08T14:59:41+00:00"
+            "time": "2021-09-15T17:41:56+00:00"
         },
         {
             "name": "googleads/google-ads-php",
-            "version": "v10.0.0",
+            "version": "v10.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleads/google-ads-php.git",
-                "reference": "630dacbdbc295a4acad99b9fa44b36ddc1188ccf"
+                "reference": "9762537c97f009e9c622b14e394a2a68b6c2ff7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleads/google-ads-php/zipball/630dacbdbc295a4acad99b9fa44b36ddc1188ccf",
-                "reference": "630dacbdbc295a4acad99b9fa44b36ddc1188ccf",
+                "url": "https://api.github.com/repos/googleads/google-ads-php/zipball/9762537c97f009e9c622b14e394a2a68b6c2ff7d",
+                "reference": "9762537c97f009e9c622b14e394a2a68b6c2ff7d",
                 "shasum": ""
             },
             "require": {
@@ -947,22 +1100,22 @@
             "homepage": "https://github.com/googleads/google-ads-php",
             "support": {
                 "issues": "https://github.com/googleads/google-ads-php/issues",
-                "source": "https://github.com/googleads/google-ads-php/tree/v10.0.0"
+                "source": "https://github.com/googleads/google-ads-php/tree/v10.1.0"
             },
-            "time": "2021-06-16T04:54:25+00:00"
+            "time": "2021-07-02T15:35:18+00:00"
         },
         {
             "name": "grpc/grpc",
-            "version": "1.38.0",
+            "version": "1.39.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grpc/grpc-php.git",
-                "reference": "e1687963fb0b087d0c70e75d3bfff9062eaeb215"
+                "reference": "101485614283d1ecb6b2ad1d5b95dc82495931db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/e1687963fb0b087d0c70e75d3bfff9062eaeb215",
-                "reference": "e1687963fb0b087d0c70e75d3bfff9062eaeb215",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/101485614283d1ecb6b2ad1d5b95dc82495931db",
+                "reference": "101485614283d1ecb6b2ad1d5b95dc82495931db",
                 "shasum": ""
             },
             "require": {
@@ -991,9 +1144,9 @@
                 "rpc"
             ],
             "support": {
-                "source": "https://github.com/grpc/grpc-php/tree/v1.38.0"
+                "source": "https://github.com/grpc/grpc-php/tree/v1.39.0"
             },
-            "time": "2021-05-24T20:45:41+00:00"
+            "time": "2021-07-23T23:04:53+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1230,21 +1383,21 @@
         },
         {
             "name": "league/container",
-            "version": "3.3.5",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/container.git",
-                "reference": "048ab87810f508dbedbcb7ae941b606eb8ee353b"
+                "reference": "84ecbc2dbecc31bd23faf759a0e329ee49abddbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/container/zipball/048ab87810f508dbedbcb7ae941b606eb8ee353b",
-                "reference": "048ab87810f508dbedbcb7ae941b606eb8ee353b",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/84ecbc2dbecc31bd23faf759a0e329ee49abddbd",
+                "reference": "84ecbc2dbecc31bd23faf759a0e329ee49abddbd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/container": "^1.0.0 || ^2.0.0"
+                "psr/container": "^1.0.0"
             },
             "provide": {
                 "psr/container-implementation": "^1.0"
@@ -1253,8 +1406,8 @@
                 "orno/di": "~2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0",
-                "roave/security-advisories": "dev-master",
+                "phpunit/phpunit": "^6.0 || ^7.0",
+                "roave/security-advisories": "dev-latest",
                 "scrutinizer/ocular": "^1.8",
                 "squizlabs/php_codesniffer": "^3.5"
             },
@@ -1297,7 +1450,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/container/issues",
-                "source": "https://github.com/thephpleague/container/tree/3.3.5"
+                "source": "https://github.com/thephpleague/container/tree/3.4.1"
             },
             "funding": [
                 {
@@ -1305,7 +1458,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-16T09:42:56+00:00"
+            "time": "2021-07-09T08:23:52+00:00"
         },
         {
             "name": "league/iso3166",
@@ -1366,24 +1519,24 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.2.0",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084"
+                "reference": "437e7a1c50044b92773b361af77620efb76fff59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
-                "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437e7a1c50044b92773b361af77620efb76fff59",
+                "reference": "437e7a1c50044b92773b361af77620efb76fff59",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "psr/log": "^1.0.1"
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "1.0.0"
+                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
             },
             "require-dev": {
                 "aws/aws-sdk-php": "^2.4.9 || ^3.0",
@@ -1394,11 +1547,11 @@
                 "php-amqplib/php-amqplib": "~2.4",
                 "php-console/php-console": "^3.1.3",
                 "phpspec/prophecy": "^1.6.1",
-                "phpstan/phpstan": "^0.12.59",
+                "phpstan/phpstan": "^0.12.91",
                 "phpunit/phpunit": "^8.5",
                 "predis/predis": "^1.1",
                 "rollbar/rollbar": "^1.3",
-                "ruflin/elastica": ">=0.90 <7.0.1",
+                "ruflin/elastica": ">=0.90@dev",
                 "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
@@ -1406,8 +1559,11 @@
                 "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                 "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
                 "ext-mbstring": "Allow to work properly with unicode symbols",
                 "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                 "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
                 "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
@@ -1446,7 +1602,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.2.0"
+                "source": "https://github.com/Seldaek/monolog/tree/2.3.4"
             },
             "funding": [
                 {
@@ -1458,7 +1614,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-14T13:15:25+00:00"
+            "time": "2021-09-15T11:27:21+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -1632,20 +1788,25 @@
                 "math",
                 "polyfill"
             ],
+            "support": {
+                "email": "terrafrost@php.net",
+                "issues": "https://github.com/phpseclib/bcmath_compat/issues",
+                "source": "https://github.com/phpseclib/bcmath_compat"
+            },
             "time": "2020-12-22T16:38:51+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.9",
+            "version": "3.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "a127a5133804ff2f47ae629dd529b129da616ad7"
+                "reference": "62fcc5a94ac83b1506f52d7558d828617fac9187"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/a127a5133804ff2f47ae629dd529b129da616ad7",
-                "reference": "a127a5133804ff2f47ae629dd529b129da616ad7",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/62fcc5a94ac83b1506f52d7558d828617fac9187",
+                "reference": "62fcc5a94ac83b1506f52d7558d828617fac9187",
                 "shasum": ""
             },
             "require": {
@@ -1727,7 +1888,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.9"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.10"
             },
             "funding": [
                 {
@@ -1743,7 +1904,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-14T06:54:45+00:00"
+            "time": "2021-08-16T04:24:45+00:00"
         },
         {
             "name": "psr/cache",
@@ -2043,16 +2204,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
                 "shasum": ""
             },
             "require": {
@@ -2061,7 +2222,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2090,7 +2251,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/master"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -2106,20 +2267,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -2131,7 +2292,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2169,7 +2330,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -2185,20 +2346,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -2207,7 +2368,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2248,7 +2409,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -2264,20 +2425,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.1",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
@@ -2286,7 +2447,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2331,7 +2492,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -2347,20 +2508,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.3.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105"
+                "reference": "95c812666f3e91db75385749fe219c5e494c7f95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/e2eaa60b558f26a4b0354e1bbb25636efaaad105",
-                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/95c812666f3e91db75385749fe219c5e494c7f95",
+                "reference": "95c812666f3e91db75385749fe219c5e494c7f95",
                 "shasum": ""
             },
             "require": {
@@ -2372,7 +2533,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2409,7 +2570,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v2.3.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -2425,20 +2586,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-28T13:05:58+00:00"
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v5.2.7",
+            "version": "v5.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "b0be0360bfbf15059308d815da7f4151bd448b37"
+                "reference": "916a7c6cf3ede36eb0e4097500e0a12dcff520a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/b0be0360bfbf15059308d815da7f4151bd448b37",
-                "reference": "b0be0360bfbf15059308d815da7f4151bd448b37",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/916a7c6cf3ede36eb0e4097500e0a12dcff520a7",
+                "reference": "916a7c6cf3ede36eb0e4097500e0a12dcff520a7",
                 "shasum": ""
             },
             "require": {
@@ -2447,7 +2608,7 @@
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "~1.0",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/translation-contracts": "^1.1|^2"
             },
             "conflict": {
@@ -2457,12 +2618,13 @@
                 "symfony/expression-language": "<5.1",
                 "symfony/http-kernel": "<4.4",
                 "symfony/intl": "<4.4",
+                "symfony/property-info": "<5.3",
                 "symfony/translation": "<4.4",
                 "symfony/yaml": "<4.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.10.4",
-                "doctrine/cache": "~1.0",
+                "doctrine/cache": "^1.0|^2.0",
                 "egulias/email-validator": "^2.1.10|^3",
                 "symfony/cache": "^4.4|^5.0",
                 "symfony/config": "^4.4|^5.0",
@@ -2476,7 +2638,7 @@
                 "symfony/intl": "^4.4|^5.0",
                 "symfony/mime": "^4.4|^5.0",
                 "symfony/property-access": "^4.4|^5.0",
-                "symfony/property-info": "^4.4|^5.0",
+                "symfony/property-info": "^5.3",
                 "symfony/translation": "^4.4|^5.0",
                 "symfony/yaml": "^4.4|^5.0"
             },
@@ -2517,6 +2679,9 @@
             ],
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v5.3.7"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2531,7 +2696,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-14T13:12:03+00:00"
+            "time": "2021-08-26T08:22:53+00:00"
         }
     ],
     "packages-dev": [
@@ -2676,16 +2841,16 @@
         },
         {
             "name": "gettext/gettext",
-            "version": "v4.8.4",
+            "version": "v4.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Gettext.git",
-                "reference": "58bc0f7f37e78efb0f9758f93d4a0f669f0f84a1"
+                "reference": "ef2e312dff383fc0e4cd62dd39042e1157f137d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/58bc0f7f37e78efb0f9758f93d4a0f669f0f84a1",
-                "reference": "58bc0f7f37e78efb0f9758f93d4a0f669f0f84a1",
+                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/ef2e312dff383fc0e4cd62dd39042e1157f137d4",
+                "reference": "ef2e312dff383fc0e4cd62dd39042e1157f137d4",
                 "shasum": ""
             },
             "require": {
@@ -2693,7 +2858,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "illuminate/view": "*",
+                "illuminate/view": "^5.0.x-dev",
                 "phpunit/phpunit": "^4.8|^5.7|^6.5",
                 "squizlabs/php_codesniffer": "^3.0",
                 "symfony/yaml": "~2",
@@ -2737,7 +2902,7 @@
             "support": {
                 "email": "oom@oscarotero.com",
                 "issues": "https://github.com/oscarotero/Gettext/issues",
-                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.4"
+                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.5"
             },
             "funding": [
                 {
@@ -2753,27 +2918,26 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-03-10T19:35:49+00:00"
+            "time": "2021-07-13T16:45:53+00:00"
         },
         {
             "name": "gettext/languages",
-            "version": "2.6.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Languages.git",
-                "reference": "38ea0482f649e0802e475f0ed19fa993bcb7a618"
+                "reference": "4ad818b6341e177b7c508ec4c37e18932a7b788a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/38ea0482f649e0802e475f0ed19fa993bcb7a618",
-                "reference": "38ea0482f649e0802e475f0ed19fa993bcb7a618",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/4ad818b6341e177b7c508ec4c37e18932a7b788a",
+                "reference": "4ad818b6341e177b7c508ec4c37e18932a7b788a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.16.0",
                 "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4"
             },
             "bin": [
@@ -2816,22 +2980,32 @@
             ],
             "support": {
                 "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.6.0"
+                "source": "https://github.com/php-gettext/Languages/tree/2.8.1"
             },
-            "time": "2019-11-13T10:30:21+00:00"
+            "funding": [
+                {
+                    "url": "https://paypal.me/mlocati",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/mlocati",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-14T15:03:58+00:00"
         },
         {
             "name": "mck89/peast",
-            "version": "v1.13.0",
+            "version": "v1.13.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "db38b1524f5bda921cbda2385e440c2bb71d18b4"
+                "reference": "4f0423441ec557f3935b056d10987f2e1c7a3e76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/db38b1524f5bda921cbda2385e440c2bb71d18b4",
-                "reference": "db38b1524f5bda921cbda2385e440c2bb71d18b4",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/4f0423441ec557f3935b056d10987f2e1c7a3e76",
+                "reference": "4f0423441ec557f3935b056d10987f2e1c7a3e76",
                 "shasum": ""
             },
             "require": {
@@ -2843,7 +3017,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13.0-dev"
+                    "dev-master": "1.13.8-dev"
                 }
             },
             "autoload": {
@@ -2865,9 +3039,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.13.0"
+                "source": "https://github.com/mck89/peast/tree/v1.13.8"
             },
-            "time": "2021-05-22T16:06:09+00:00"
+            "time": "2021-09-11T10:28:18+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -3247,33 +3421,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.13.0",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -3308,9 +3482,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2021-03-17T13:42:18+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3381,16 +3555,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/28af674ff175d0768a5a978e6de83f697d4a7f05",
+                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05",
                 "shasum": ""
             },
             "require": {
@@ -3429,7 +3603,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.4"
             },
             "funding": [
                 {
@@ -3437,7 +3611,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:25:21+00:00"
+            "time": "2021-07-19T06:46:01+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -3545,16 +3719,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
                 "shasum": ""
             },
             "require": {
@@ -3592,7 +3766,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
             },
             "funding": [
                 {
@@ -3601,7 +3775,7 @@
                 }
             ],
             "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2021-07-26T12:15:06+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -4417,16 +4591,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -4469,24 +4643,25 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.3.0",
+            "version": "v5.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6"
+                "reference": "a10000ada1e600d109a6c7632e9ac42e8bf2fb93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
-                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a10000ada1e600d109a6c7632e9ac42e8bf2fb93",
+                "reference": "a10000ada1e600d109a6c7632e9ac42e8bf2fb93",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -4514,7 +4689,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.3.0"
+                "source": "https://github.com/symfony/finder/tree/v5.3.7"
             },
             "funding": [
                 {
@@ -4530,20 +4705,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T12:52:38+00:00"
+            "time": "2021-08-04T21:20:46+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -4572,7 +4747,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -4580,7 +4755,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4642,26 +4817,29 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.2.8",
+            "version": "v2.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "8bc234617edc533590ac0f41080164a8d85ec9ce"
+                "reference": "26e171c5708060b6d7cede9af934b946f5ec3a59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/8bc234617edc533590ac0f41080164a8d85ec9ce",
-                "reference": "8bc234617edc533590ac0f41080164a8d85ec9ce",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/26e171c5708060b6d7cede9af934b946f5ec3a59",
+                "reference": "26e171c5708060b6d7cede9af934b946f5ec3a59",
                 "shasum": ""
             },
             "require": {
                 "gettext/gettext": "^4.8",
-                "mck89/peast": "^1.8",
+                "mck89/peast": "^1.13",
                 "wp-cli/wp-cli": "^2.5"
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1.2 || ^2",
                 "wp-cli/wp-cli-tests": "^3.0.11"
+            },
+            "suggest": {
+                "ext-mbstring": "Used for calculating include/exclude matches in code extraction"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -4697,9 +4875,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.2.8"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.2.9"
             },
-            "time": "2021-05-10T10:24:16+00:00"
+            "time": "2021-07-20T21:25:54+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -4754,16 +4932,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.12",
+            "version": "v0.11.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "e472e08489f7504d9e8c5c5a057e1419cd1b2b3e"
+                "reference": "a2866855ac1abc53005c102e901553ad5772dc04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/e472e08489f7504d9e8c5c5a057e1419cd1b2b3e",
-                "reference": "e472e08489f7504d9e8c5c5a057e1419cd1b2b3e",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a2866855ac1abc53005c102e901553ad5772dc04",
+                "reference": "a2866855ac1abc53005c102e901553ad5772dc04",
                 "shasum": ""
             },
             "require": {
@@ -4802,9 +4980,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.12"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.13"
             },
-            "time": "2021-03-03T12:43:49+00:00"
+            "time": "2021-07-01T15:08:16+00:00"
         },
         {
             "name": "wp-cli/wp-cli",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5017,16 +5017,6 @@
 			"integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
 			"dev": true
 		},
-		"@types/yauzl": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@typescript-eslint/experimental-utils": {
 			"version": "4.28.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.0.tgz",
@@ -8745,6 +8735,18 @@
 						"debug": "^4.1.1",
 						"get-stream": "^5.1.0",
 						"yauzl": "^2.10.0"
+					},
+					"dependencies": {
+						"@types/yauzl": {
+							"version": "2.9.2",
+							"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+							"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"@types/node": "*"
+							}
+						}
 					}
 				},
 				"file-entry-cache": {
@@ -9031,6 +9033,30 @@
 						"tar-fs": "^2.0.0",
 						"unbzip2-stream": "^1.3.3",
 						"ws": "^7.2.3"
+					},
+					"dependencies": {
+						"tar-fs": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+							"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+							"dev": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"mkdirp-classic": "^0.5.2",
+								"pump": "^3.0.0",
+								"tar-stream": "^2.1.4"
+							}
+						},
+						"unbzip2-stream": {
+							"version": "1.4.3",
+							"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+							"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.2.1",
+								"through": "^2.3.8"
+							}
+						}
 					}
 				},
 				"read-pkg": {
@@ -9234,9 +9260,9 @@
 					}
 				},
 				"ws": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-					"integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+					"integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
 					"dev": true
 				},
 				"yallist": {
@@ -27169,18 +27195,6 @@
 				}
 			}
 		},
-		"tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
 		"tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -27726,16 +27740,6 @@
 				"has-bigints": "^1.0.1",
 				"has-symbols": "^1.0.2",
 				"which-boxed-primitive": "^1.0.2"
-			}
-		},
-		"unbzip2-stream": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
 			}
 		},
 		"unherit": {

--- a/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use WC_Coupon;
 use WP_Post;
@@ -32,15 +33,22 @@ class CouponChannelVisibilityMetaBox extends SubmittableMetaBox {
 	protected $coupon_helper;
 
 	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+	
+	/**
 	 * CouponChannelVisibilityMetaBox constructor.
 	 *
 	 * @param Admin              $admin
 	 * @param CouponMetaHandler $meta_handler
 	 * @param CouponHelper      $coupon_helper
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( Admin $admin, CouponMetaHandler $meta_handler, CouponHelper $coupon_helper ) {
+	public function __construct( Admin $admin, CouponMetaHandler $meta_handler, CouponHelper $coupon_helper, MerchantCenterService $merchant_center ) {
 		$this->meta_handler   = $meta_handler;
 		$this->coupon_helper = $coupon_helper;
+		$this->merchant_center = $merchant_center;
 		parent::__construct( $admin );
 	}
 
@@ -128,6 +136,8 @@ class CouponChannelVisibilityMetaBox extends SubmittableMetaBox {
 			'channel_visibility' => $this->coupon_helper->get_channel_visibility( $coupon ),
 			'sync_status'        => $this->meta_handler->get_sync_status( $coupon ),
 			'issues'             => $this->coupon_helper->get_validation_errors( $coupon ),
+		    'is_setup_complete'  => $this->merchant_center->is_setup_complete(),
+		    'get_started_url'    => $this->get_start_url(),
 		];
 	}
 

--- a/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php
@@ -1,0 +1,189 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use WC_Coupon;
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CouponChannelVisibilityMetaBox
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox
+ */
+class CouponChannelVisibilityMetaBox extends SubmittableMetaBox {
+
+	/**
+	 * @var CouponMetaHandler
+	 */
+	protected $meta_handler;
+
+	/**
+	 * @var CouponHelper
+	 */
+	protected $coupon_helper;
+
+	/**
+	 * CouponChannelVisibilityMetaBox constructor.
+	 *
+	 * @param Admin              $admin
+	 * @param CouponMetaHandler $meta_handler
+	 * @param CouponHelper      $coupon_helper
+	 */
+	public function __construct( Admin $admin, CouponMetaHandler $meta_handler, CouponHelper $coupon_helper ) {
+		$this->meta_handler   = $meta_handler;
+		$this->coupon_helper = $coupon_helper;
+		parent::__construct( $admin );
+	}
+
+	/**
+	 * Meta box ID (used in the 'id' attribute for the meta box).
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'coupon_channel_visibility';
+	}
+
+	/**
+	 * Title of the meta box.
+	 *
+	 * @return string
+	 */
+	public function get_title(): string {
+		return __( 'Channel visibility', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * The screen on which to show the box (such as a post type, 'link', or 'comment').
+	 *
+	 * Default is the current screen.
+	 *
+	 * @return string
+	 */
+	public function get_screen(): string {
+	    return self::SCREEN_COUPON;
+	}
+
+	/**
+	 * The context within the screen where the box should display. Available contexts vary from screen to
+	 * screen. Post edit screen contexts include 'normal', 'side', and 'advanced'. Comments screen contexts
+	 * include 'normal' and 'side'. Menus meta boxes (accordion sections) all use the 'side' context.
+	 *
+	 * Global default is 'advanced'.
+	 *
+	 * @return string
+	 */
+	public function get_context(): string {
+		return self::CONTEXT_SIDE;
+	}
+
+	/**
+	 * Returns an array of CSS classes to apply to the box.
+	 *
+	 * @return array
+	 */
+	public function get_classes(): array {
+		$shown_types = array_map(
+			function ( string $coupon_type ) {
+				return "show_if_${coupon_type}";
+			},
+			CouponSyncer::get_supported_coupon_types()
+		);
+
+		$hidden_types = array_map(
+			function ( string $coupon_type ) {
+				return "hide_if_${coupon_type}";
+			},
+			CouponSyncer::get_hidden_coupon_types()
+		);
+
+		return array_merge( $shown_types, $hidden_types );
+	}
+
+	/**
+	 * Returns an array of variables to be used in the view.
+	 *
+	 * @param WP_Post $post The WordPress post object the box is loaded for.
+	 * @param array   $args Array of data passed to the callback. Defined by `get_callback_args`.
+	 *
+	 * @return array
+	 */
+	protected function get_view_context( WP_Post $post, array $args ): array {
+		$coupon_id = absint( $post->ID );
+		$coupon    = $this->coupon_helper->get_wc_coupon( $coupon_id );
+
+		return [
+			'field_id'           => $this->get_visibility_field_id(),
+			'coupon_id'         => $coupon_id,
+			'coupon'            => $coupon,
+			'channel_visibility' => $this->coupon_helper->get_channel_visibility( $coupon ),
+			'sync_status'        => $this->meta_handler->get_sync_status( $coupon ),
+			'issues'             => $this->coupon_helper->get_validation_errors( $coupon ),
+		];
+	}
+
+	/**
+	 * Register a service.
+	 */
+	public function register(): void {
+		add_action( 'woocommerce_new_coupon', [ $this, 'handle_submission' ], 10, 2 );
+		add_action( 'woocommerce_update_coupon', [ $this, 'handle_submission' ], 10, 2 );
+	}
+
+	/**
+	 * @param int        $coupon_id
+	 * @param WC_Coupon  $coupon
+	 */
+	public function handle_submission( int $coupon_id, WC_Coupon $coupon ) {
+		/**
+		 * Array of `true` values for each coupon IDs already handled by this method. Used to prevent double submission.
+		 *
+		 * @var bool[] $already_updated
+		 */
+		static $already_updated = [];
+
+		$field_id = $this->get_visibility_field_id();
+		// phpcs:disable WordPress.Security.NonceVerification
+		// nonce is verified by self::verify_nonce
+		if ( ! $this->verify_nonce() || ! isset( $_POST[ $field_id ] ) || isset( $already_updated[ $coupon_id ] ) ) {
+			return;
+		}
+
+		// Only update the value for supported coupon types
+		if (!CouponSyncer::is_coupon_supported($coupon)) {
+			return;
+		}
+
+		try {
+			$visibility = empty( $_POST[ $field_id ] ) ?
+			    ChannelVisibility::cast( ChannelVisibility::DONT_SYNC_AND_SHOW ) :
+				ChannelVisibility::cast( sanitize_key( $_POST[ $field_id ] ) );
+			// phpcs:enable WordPress.Security.NonceVerification
+
+			$this->meta_handler->update_visibility( $coupon, $visibility );
+
+			$already_updated[ $coupon_id ] = true;
+		} catch ( InvalidValue $exception ) {
+			// silently log the exception and do not set the coupon's visibility if an invalid visibility value is sent.
+			do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
+		}
+	}
+
+	/**
+	 * @return string
+	 *
+	 * @since 1.1.0
+	 */
+	protected function get_visibility_field_id(): string {
+		return $this->prefix_field_id( 'visibility' );
+	}
+}

--- a/src/Admin/MetaBox/MetaBoxInterface.php
+++ b/src/Admin/MetaBox/MetaBoxInterface.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 
 interface MetaBoxInterface extends Service, Conditional, Renderable {
 	public const SCREEN_PRODUCT = 'product';
+	public const SCREEN_COUPON = 'shop_coupon';
 
 	public const CONTEXT_NORMAL   = 'normal';
 	public const CONTEXT_SIDE     = 'side';

--- a/src/Coupon/CouponHelper.php
+++ b/src/Coupon/CouponHelper.php
@@ -1,6 +1,5 @@
 <?php
-declare( strict_types=1 );
-
+declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
@@ -11,8 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use WC_Coupon;
-
-defined( 'ABSPATH' ) || exit;
+defined('ABSPATH') || exit();
 
 /**
  * Class CouponHelper
@@ -21,260 +19,282 @@ defined( 'ABSPATH' ) || exit;
  */
 class CouponHelper implements Service {
 
-	use PluginHelper;
+    use PluginHelper;
 
-	/**
-	 * @var CouponMetaHandler
-	 */
-	protected $meta_handler;
-
-	/**
-	 * @var WC
-	 */
-	protected $wc;
-
-	/**
-	 * @var MerchantCenterService
-	 */
-	protected $merchant_center;
-
-	/**
-	 * CouponHelper constructor.
-	 *
-	 * @param CouponMetaHandler    $meta_handler
-	 * @param WC                    $wc
-	 * @param MerchantCenterService $merchant_center
-	 */
-	public function __construct( CouponMetaHandler $meta_handler, WC $wc, MerchantCenterService $merchant_center ) {
-		$this->meta_handler    = $meta_handler;
-		$this->wc              = $wc;
-		$this->merchant_center = $merchant_center;
-	}
-
-	/**
-	 * @param WC_Coupon    $coupon
-	 */
-	public function mark_as_synced( WC_Coupon $coupon, string $google_id, string $target_country) {
-		$this->meta_handler->update_synced_at( $coupon, time() );
-		$this->meta_handler->update_sync_status( $coupon, SyncStatus::SYNCED );
-		$this->update_empty_visibility( $coupon );
-		
-		// merge and update all google ids
-		$current_google_ids = $this->meta_handler->get_google_ids( $coupon );
-		$current_google_ids = ! empty( $current_google_ids ) ? $current_google_ids : [];
-		$google_ids     = array_unique( array_merge( $current_google_ids, [ $target_country => $google_id ] ) );
-		$this->meta_handler->update_google_ids( $coupon, $google_ids );
-	}
-
-	/**
-	 * @param WC_Coupon $coupon
-	 */
-	public function mark_as_unsynced( WC_Coupon $coupon ) {
-		$this->meta_handler->delete_synced_at( $coupon );
-		$this->meta_handler->update_sync_status( $coupon, SyncStatus::NOT_SYNCED );
-		$this->meta_handler->delete_google_ids( $coupon );
-		$this->meta_handler->delete_errors( $coupon );
-		$this->meta_handler->delete_failed_sync_attempts( $coupon );
-		$this->meta_handler->delete_sync_failed_at( $coupon );
-	}
-
-	/**
-	 * @param WC_Coupon  $coupon
-	 * @param string     $google_id
-	 */
-	public function remove_google_id( WC_Coupon $coupon, string $google_id ) {
-		$google_ids = $this->meta_handler->get_google_ids( $coupon );
-		if ( empty( $google_ids ) ) {
-			return;
-		}
-
-		$idx = array_search( $google_id, $google_ids, true );
-		if ( false === $idx ) {
-			return;
-		}
-
-		unset( $google_ids[ $idx ] );
-
-		if ( ! empty( $google_ids ) ) {
-			$this->meta_handler->update_google_ids( $coupon, $google_ids );
-		} else {
-			// if there are no Google IDs left then this coupon is no longer considered "synced"
-			$this->mark_as_unsynced( $coupon);
-		}
-	}
-
-	/**
-	 * Marks a WooCommerce coupon as invalid and stores the errors in a meta data key.
-	 *
-	 * @param WC_Coupon  $coupon
-	 * @param string[]   $errors
-	 */
-	public function mark_as_invalid( WC_Coupon $coupon, array $errors ) {
-		// bail if no errors exist
-		if ( empty( $errors ) ) {
-			return;
-		}
-
-		$this->meta_handler->update_errors( $coupon, $errors );
-		$this->meta_handler->update_sync_status( $coupon, SyncStatus::HAS_ERRORS );
-		$this->update_empty_visibility( $coupon );
-
-		// TODO: Update failed sync attempts count in case of internal errors
-	}
-
-	/**
-	 * Marks a WooCommerce coupon as pending synchronization.
+    /**
      *
-	 * @param WC_Coupon $coupon
-	 */
-	public function mark_as_pending( WC_Coupon $coupon ) {
-		$this->meta_handler->update_sync_status( $coupon, SyncStatus::PENDING );
-	}
+     * @var CouponMetaHandler
+     */
+    protected $meta_handler;
 
-	/**
-	 * Update empty (NOT EXIST) visibility meta values to SYNC_AND_SHOW.
-	 *
-	 * @param WC_Coupon $coupon
-	 */
-	protected function update_empty_visibility( WC_Coupon $coupon ): void {
-	    $visibility = $this->meta_handler->get_visibility( $coupon );
+    /**
+     *
+     * @var WC
+     */
+    protected $wc;
 
-		if ( empty( $visibility ) ) {
-			$this->meta_handler->update_visibility( $coupon, ChannelVisibility::SYNC_AND_SHOW );
-		}
-	}
+    /**
+     *
+     * @var MerchantCenterService
+     */
+    protected $merchant_center;
 
-	/**
-	 * @param WC_Coupon $coupon
-	 *
-	 * @return string[]|null An array of Google IDs stored for each WooCommerce coupon
-	 */
-	public function get_synced_google_ids( WC_Coupon $coupon ): ?array {
-		return $this->meta_handler->get_google_ids( $coupon );
-	}
+    /**
+     * CouponHelper constructor.
+     *
+     * @param CouponMetaHandler $meta_handler
+     * @param WC $wc
+     * @param MerchantCenterService $merchant_center
+     */
+    public function __construct(
+        CouponMetaHandler $meta_handler,
+        WC $wc,
+        MerchantCenterService $merchant_center) {
+        $this->meta_handler = $meta_handler;
+        $this->wc = $wc;
+        $this->merchant_center = $merchant_center;
+    }
 
-	/**
-	 * Get WooCommerce coupon
-	 *
-	 * @param int $coupon_id
-	 *
-	 * @return WC_Coupon
-	 *
-	 * @throws InvalidValue If the given ID doesn't reference a valid coupon.
-	 */
-	public function get_wc_coupon( int $coupon_id ): WC_Coupon {
-	    return $this->wc->get_coupon( $coupon_id );
-	}
+    /**
+     *
+     * @param WC_Coupon $coupon
+     */
+    public function mark_as_synced(
+        WC_Coupon $coupon,
+        string $google_id,
+        string $target_country) {
+        $this->meta_handler->update_synced_at($coupon, time());
+        $this->meta_handler->update_sync_status($coupon, SyncStatus::SYNCED);
+        $this->update_empty_visibility($coupon);
 
-	/**
-	 * @param WC_Coupon $coupon
-	 *
-	 * @return bool
-	 */
-	public function is_coupon_synced( WC_Coupon $coupon ): bool {
-		$synced_at  = $this->meta_handler->get_synced_at( $coupon );
-		$google_ids = $this->meta_handler->get_google_ids( $coupon );
+        // merge and update all google ids
+        $current_google_ids = $this->meta_handler->get_google_ids($coupon);
+        $current_google_ids = ! empty($current_google_ids) ? $current_google_ids : [];
+        $google_ids = array_unique(
+            array_merge($current_google_ids, [
+                $target_country => $google_id
+            ]));
+        $this->meta_handler->update_google_ids($coupon, $google_ids);
+    }
 
-		return ! empty( $synced_at ) && ! empty( $google_ids );
-	}
+    /**
+     *
+     * @param WC_Coupon $coupon
+     */
+    public function mark_as_unsynced(WC_Coupon $coupon) {
+        $this->meta_handler->delete_synced_at($coupon);
+        $this->meta_handler->update_sync_status($coupon, SyncStatus::NOT_SYNCED);
+        $this->meta_handler->delete_google_ids($coupon);
+        $this->meta_handler->delete_errors($coupon);
+        $this->meta_handler->delete_failed_sync_attempts($coupon);
+        $this->meta_handler->delete_sync_failed_at($coupon);
+    }
 
-	/**
-	 * @param WC_Coupon $coupon
-	 *
-	 * @return bool
-	 */
-	public function is_sync_ready( WC_Coupon $coupon ): bool {
-		return ( ChannelVisibility::SYNC_AND_SHOW === $this->get_channel_visibility( $coupon ) ) &&
-		       ( CouponSyncer::is_coupon_supported( $coupon ) ) &&
-		       ( ! $coupon->get_virtual() );
-	}
+    /**
+     *
+     * @param WC_Coupon $coupon
+     * @param string $google_id
+     */
+    public function remove_google_id(WC_Coupon $coupon, string $google_id) {
+        $google_ids = $this->meta_handler->get_google_ids($coupon);
+        if (empty($google_ids)) {
+            return;
+        }
 
-	/**
-	 * Whether the sync has failed repeatedly for the coupon within the given timeframe.
-	 *
-	 * @param WC_Coupon $coupon
-	 *
-	 * @return bool
-	 *
-	 * @see CouponSyncer::FAILURE_THRESHOLD        The number of failed attempts allowed per timeframe
-	 * @see CouponSyncer::FAILURE_THRESHOLD_WINDOW The specified timeframe
-	 */
-	public function is_sync_failed_recently( WC_Coupon $coupon ): bool {
-	    $failed_attempts = $this->meta_handler->get_failed_sync_attempts( $coupon );
-	    $failed_at       = $this->meta_handler->get_sync_failed_at( $coupon );
+        $idx = array_search($google_id, $google_ids, true);
+        if (false === $idx) {
+            return;
+        }
 
-		// if it has failed more times than the specified threshold AND if syncing it has failed within the specified window
-	    return $failed_attempts > CouponSyncer::FAILURE_THRESHOLD &&
-	       $failed_at > strtotime( sprintf( '-%s', CouponSyncer::FAILURE_THRESHOLD_WINDOW ) );
-	}
+        unset($google_ids[$idx]);
 
-	/**
-	 * @param WC_Coupon $coupon
-	 *
-	 * @return string|null
-	 */
-	public function get_channel_visibility( WC_Coupon $coupon ): ?string {
-		try {
-		    return $this->meta_handler->get_visibility( $coupon );
-		} catch ( InvalidValue $exception ) {
-			do_action(
-				'woocommerce_gla_debug_message',
-				sprintf( 'Channel visibility forced to "%s" for invalid coupon (ID: %s).', ChannelVisibility::DONT_SYNC_AND_SHOW, $coupon->get_id() ),
-				__METHOD__
-			);
+        if (! empty($google_ids)) {
+            $this->meta_handler->update_google_ids($coupon, $google_ids);
+        } else {
+            // if there are no Google IDs left then this coupon is no longer considered "synced"
+            $this->mark_as_unsynced($coupon);
+        }
+    }
 
-			return ChannelVisibility::DONT_SYNC_AND_SHOW;
-		}
-	}
+    /**
+     * Marks a WooCommerce coupon as invalid and stores the errors in a meta data key.
+     *
+     * @param WC_Coupon $coupon
+     * @param array of InvalidCouponEntry
+     */
+    public function mark_as_invalid(WC_Coupon $coupon, array $errors) {
+        // bail if no errors exist
+        if (empty($errors)) {
+            return;
+        }
 
-	/**
-	 * Return a string indicating sync status based on several factors.
-	 *
-	 * @param WC_Coupon $coupon
-	 *
-	 * @return string|null
-	 */
-	public function get_sync_status( WC_Coupon $coupon ): ?string {
-		return $this->meta_handler->get_sync_status( $coupon );
-	}
+        $this->meta_handler->update_errors($coupon, $errors);
+        $this->meta_handler->update_sync_status($coupon, SyncStatus::HAS_ERRORS);
+        $this->update_empty_visibility($coupon);
 
-	/**
-	 * Return the string indicating the coupon status as reported by the Merchant Center.
-	 *
-	 * @param WC_Coupon $coupon
-	 *
-	 * @return string|null
-	 */
-	public function get_mc_status( WC_Coupon $coupon ): ?string {
-		try {
-			return $this->meta_handler->get_mc_status( $coupon );
-		} catch ( InvalidValue $exception ) {
-			do_action(
-				'woocommerce_gla_debug_message',
-				sprintf( 'Coupon status returned null for invalid coupon (ID: %s).', $coupon->get_id() ),
-				__METHOD__
-			);
+        // TODO: Update failed sync attempts count in case of internal errors
+    }
 
-			return null;
-		}
-	}
+    /**
+     * Marks a WooCommerce coupon as pending synchronization.
+     *
+     * @param WC_Coupon $coupon
+     */
+    public function mark_as_pending(WC_Coupon $coupon) {
+        $this->meta_handler->update_sync_status($coupon, SyncStatus::PENDING);
+    }
 
-	/**
-	 * Get validation errors for a specific coupon.
-	 * Combines errors for variable coupons, which have a variation-indexed array of errors.
-	 *
-	 * @param WC_Coupon $coupon
-	 *
-	 * @return array
-	 */
-	public function get_validation_errors( WC_Coupon $coupon ): array {
-		$errors = $this->meta_handler->get_errors( $coupon ) ?: [];
+    /**
+     * Update empty (NOT EXIST) visibility meta values to SYNC_AND_SHOW.
+     *
+     * @param WC_Coupon $coupon
+     */
+    protected function update_empty_visibility(WC_Coupon $coupon): void {
+        $visibility = $this->meta_handler->get_visibility($coupon);
 
-		$first_key = array_key_first( $errors );
-		if ( ! empty( $errors ) && is_numeric( $first_key ) && 0 !== $first_key ) {
-			$errors = array_unique( array_merge( ...$errors ) );
-		}
+        if (empty($visibility)) {
+            $this->meta_handler->update_visibility($coupon,
+                ChannelVisibility::SYNC_AND_SHOW);
+        }
+    }
 
-		return $errors;
-	}
+    /**
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @return string[]|null An array of Google IDs stored for each WooCommerce coupon
+     */
+    public function get_synced_google_ids(WC_Coupon $coupon): ?array {
+        return $this->meta_handler->get_google_ids($coupon);
+    }
+
+    /**
+     * Get WooCommerce coupon
+     *
+     * @param int $coupon_id
+     *
+     * @return WC_Coupon
+     *
+     * @throws InvalidValue If the given ID doesn't reference a valid coupon.
+     */
+    public function get_wc_coupon(int $coupon_id): WC_Coupon {
+        return $this->wc->get_coupon($coupon_id);
+    }
+
+    /**
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @return bool
+     */
+    public function is_coupon_synced(WC_Coupon $coupon): bool {
+        $synced_at = $this->meta_handler->get_synced_at($coupon);
+        $google_ids = $this->meta_handler->get_google_ids($coupon);
+
+        return ! empty($synced_at) && ! empty($google_ids);
+    }
+
+    /**
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @return bool
+     */
+    public function is_sync_ready(WC_Coupon $coupon): bool {
+        return (ChannelVisibility::SYNC_AND_SHOW ===
+            $this->get_channel_visibility($coupon)) &&
+            (CouponSyncer::is_coupon_supported($coupon)) &&
+            (! $coupon->get_virtual());
+    }
+
+    /**
+     * Whether the sync has failed repeatedly for the coupon within the given timeframe.
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @return bool
+     *
+     * @see CouponSyncer::FAILURE_THRESHOLD The number of failed attempts allowed per timeframe
+     * @see CouponSyncer::FAILURE_THRESHOLD_WINDOW The specified timeframe
+     */
+    public function is_sync_failed_recently(WC_Coupon $coupon): bool {
+        $failed_attempts = $this->meta_handler->get_failed_sync_attempts(
+            $coupon);
+        $failed_at = $this->meta_handler->get_sync_failed_at($coupon);
+
+        // if it has failed more times than the specified threshold AND if syncing it has failed within the specified window
+        return $failed_attempts > CouponSyncer::FAILURE_THRESHOLD &&
+            $failed_at >
+            strtotime(sprintf('-%s', CouponSyncer::FAILURE_THRESHOLD_WINDOW));
+    }
+
+    /**
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @return string|null
+     */
+    public function get_channel_visibility(WC_Coupon $coupon): ?string {
+        try {
+            return $this->meta_handler->get_visibility($coupon);
+        } catch (InvalidValue $exception) {
+            do_action('woocommerce_gla_debug_message',
+                sprintf(
+                    'Channel visibility forced to "%s" for invalid coupon (ID: %s).',
+                    ChannelVisibility::DONT_SYNC_AND_SHOW, $coupon->get_id()),
+                __METHOD__);
+
+            return ChannelVisibility::DONT_SYNC_AND_SHOW;
+        }
+    }
+
+    /**
+     * Return a string indicating sync status based on several factors.
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @return string|null
+     */
+    public function get_sync_status(WC_Coupon $coupon): ?string {
+        return $this->meta_handler->get_sync_status($coupon);
+    }
+
+    /**
+     * Return the string indicating the coupon status as reported by the Merchant Center.
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @return string|null
+     */
+    public function get_mc_status(WC_Coupon $coupon): ?string {
+        try {
+            return $this->meta_handler->get_mc_status($coupon);
+        } catch (InvalidValue $exception) {
+            do_action('woocommerce_gla_debug_message',
+                sprintf(
+                    'Coupon status returned null for invalid coupon (ID: %s).',
+                    $coupon->get_id()), __METHOD__);
+
+            return null;
+        }
+    }
+
+    /**
+     * Get validation errors for a specific coupon.
+     * Combines errors for variable coupons, which have a variation-indexed array of errors.
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @return array
+     */
+    public function get_validation_errors(WC_Coupon $coupon): array {
+        $errors = $this->meta_handler->get_errors($coupon) ?: [];
+
+        $first_key = array_key_first($errors);
+        if (! empty($errors) && is_numeric($first_key) && 0 !== $first_key) {
+            $errors = array_unique(array_merge(...$errors));
+        }
+
+        return $errors;
+    }
 }

--- a/src/Coupon/CouponHelper.php
+++ b/src/Coupon/CouponHelper.php
@@ -1,0 +1,280 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use WC_Coupon;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CouponHelper
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
+ */
+class CouponHelper implements Service {
+
+	use PluginHelper;
+
+	/**
+	 * @var CouponMetaHandler
+	 */
+	protected $meta_handler;
+
+	/**
+	 * @var WC
+	 */
+	protected $wc;
+
+	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
+	 * CouponHelper constructor.
+	 *
+	 * @param CouponMetaHandler    $meta_handler
+	 * @param WC                    $wc
+	 * @param MerchantCenterService $merchant_center
+	 */
+	public function __construct( CouponMetaHandler $meta_handler, WC $wc, MerchantCenterService $merchant_center ) {
+		$this->meta_handler    = $meta_handler;
+		$this->wc              = $wc;
+		$this->merchant_center = $merchant_center;
+	}
+
+	/**
+	 * @param WC_Coupon    $coupon
+	 */
+	public function mark_as_synced( WC_Coupon $coupon, string $google_id, string $target_country) {
+		$this->meta_handler->update_synced_at( $coupon, time() );
+		$this->meta_handler->update_sync_status( $coupon, SyncStatus::SYNCED );
+		$this->update_empty_visibility( $coupon );
+		
+		// merge and update all google ids
+		$current_google_ids = $this->meta_handler->get_google_ids( $coupon );
+		$current_google_ids = ! empty( $current_google_ids ) ? $current_google_ids : [];
+		$google_ids     = array_unique( array_merge( $current_google_ids, [ $target_country => $google_id ] ) );
+		$this->meta_handler->update_google_ids( $coupon, $google_ids );
+	}
+
+	/**
+	 * @param WC_Coupon $coupon
+	 */
+	public function mark_as_unsynced( WC_Coupon $coupon ) {
+		$this->meta_handler->delete_synced_at( $coupon );
+		$this->meta_handler->update_sync_status( $coupon, SyncStatus::NOT_SYNCED );
+		$this->meta_handler->delete_google_ids( $coupon );
+		$this->meta_handler->delete_errors( $coupon );
+		$this->meta_handler->delete_failed_sync_attempts( $coupon );
+		$this->meta_handler->delete_sync_failed_at( $coupon );
+	}
+
+	/**
+	 * @param WC_Coupon  $coupon
+	 * @param string     $google_id
+	 */
+	public function remove_google_id( WC_Coupon $coupon, string $google_id ) {
+		$google_ids = $this->meta_handler->get_google_ids( $coupon );
+		if ( empty( $google_ids ) ) {
+			return;
+		}
+
+		$idx = array_search( $google_id, $google_ids, true );
+		if ( false === $idx ) {
+			return;
+		}
+
+		unset( $google_ids[ $idx ] );
+
+		if ( ! empty( $google_ids ) ) {
+			$this->meta_handler->update_google_ids( $coupon, $google_ids );
+		} else {
+			// if there are no Google IDs left then this coupon is no longer considered "synced"
+			$this->mark_as_unsynced( $coupon);
+		}
+	}
+
+	/**
+	 * Marks a WooCommerce coupon as invalid and stores the errors in a meta data key.
+	 *
+	 * @param WC_Coupon  $coupon
+	 * @param string[]   $errors
+	 */
+	public function mark_as_invalid( WC_Coupon $coupon, array $errors ) {
+		// bail if no errors exist
+		if ( empty( $errors ) ) {
+			return;
+		}
+
+		$this->meta_handler->update_errors( $coupon, $errors );
+		$this->meta_handler->update_sync_status( $coupon, SyncStatus::HAS_ERRORS );
+		$this->update_empty_visibility( $coupon );
+
+		// TODO: Update failed sync attempts count in case of internal errors
+	}
+
+	/**
+	 * Marks a WooCommerce coupon as pending synchronization.
+     *
+	 * @param WC_Coupon $coupon
+	 */
+	public function mark_as_pending( WC_Coupon $coupon ) {
+		$this->meta_handler->update_sync_status( $coupon, SyncStatus::PENDING );
+	}
+
+	/**
+	 * Update empty (NOT EXIST) visibility meta values to SYNC_AND_SHOW.
+	 *
+	 * @param WC_Coupon $coupon
+	 */
+	protected function update_empty_visibility( WC_Coupon $coupon ): void {
+	    $visibility = $this->meta_handler->get_visibility( $coupon );
+
+		if ( empty( $visibility ) ) {
+			$this->meta_handler->update_visibility( $coupon, ChannelVisibility::SYNC_AND_SHOW );
+		}
+	}
+
+	/**
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return string[]|null An array of Google IDs stored for each WooCommerce coupon
+	 */
+	public function get_synced_google_ids( WC_Coupon $coupon ): ?array {
+		return $this->meta_handler->get_google_ids( $coupon );
+	}
+
+	/**
+	 * Get WooCommerce coupon
+	 *
+	 * @param int $coupon_id
+	 *
+	 * @return WC_Coupon
+	 *
+	 * @throws InvalidValue If the given ID doesn't reference a valid coupon.
+	 */
+	public function get_wc_coupon( int $coupon_id ): WC_Coupon {
+	    return $this->wc->get_coupon( $coupon_id );
+	}
+
+	/**
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return bool
+	 */
+	public function is_coupon_synced( WC_Coupon $coupon ): bool {
+		$synced_at  = $this->meta_handler->get_synced_at( $coupon );
+		$google_ids = $this->meta_handler->get_google_ids( $coupon );
+
+		return ! empty( $synced_at ) && ! empty( $google_ids );
+	}
+
+	/**
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return bool
+	 */
+	public function is_sync_ready( WC_Coupon $coupon ): bool {
+		return ( ChannelVisibility::SYNC_AND_SHOW === $this->get_channel_visibility( $coupon ) ) &&
+		       ( CouponSyncer::is_coupon_supported( $coupon ) ) &&
+		       ( ! $coupon->get_virtual() );
+	}
+
+	/**
+	 * Whether the sync has failed repeatedly for the coupon within the given timeframe.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return bool
+	 *
+	 * @see CouponSyncer::FAILURE_THRESHOLD        The number of failed attempts allowed per timeframe
+	 * @see CouponSyncer::FAILURE_THRESHOLD_WINDOW The specified timeframe
+	 */
+	public function is_sync_failed_recently( WC_Coupon $coupon ): bool {
+	    $failed_attempts = $this->meta_handler->get_failed_sync_attempts( $coupon );
+	    $failed_at       = $this->meta_handler->get_sync_failed_at( $coupon );
+
+		// if it has failed more times than the specified threshold AND if syncing it has failed within the specified window
+	    return $failed_attempts > CouponSyncer::FAILURE_THRESHOLD &&
+	       $failed_at > strtotime( sprintf( '-%s', CouponSyncer::FAILURE_THRESHOLD_WINDOW ) );
+	}
+
+	/**
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return string|null
+	 */
+	public function get_channel_visibility( WC_Coupon $coupon ): ?string {
+		try {
+		    return $this->meta_handler->get_visibility( $coupon );
+		} catch ( InvalidValue $exception ) {
+			do_action(
+				'woocommerce_gla_debug_message',
+				sprintf( 'Channel visibility forced to "%s" for invalid coupon (ID: %s).', ChannelVisibility::DONT_SYNC_AND_SHOW, $coupon->get_id() ),
+				__METHOD__
+			);
+
+			return ChannelVisibility::DONT_SYNC_AND_SHOW;
+		}
+	}
+
+	/**
+	 * Return a string indicating sync status based on several factors.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return string|null
+	 */
+	public function get_sync_status( WC_Coupon $coupon ): ?string {
+		return $this->meta_handler->get_sync_status( $coupon );
+	}
+
+	/**
+	 * Return the string indicating the coupon status as reported by the Merchant Center.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return string|null
+	 */
+	public function get_mc_status( WC_Coupon $coupon ): ?string {
+		try {
+			return $this->meta_handler->get_mc_status( $coupon );
+		} catch ( InvalidValue $exception ) {
+			do_action(
+				'woocommerce_gla_debug_message',
+				sprintf( 'Coupon status returned null for invalid coupon (ID: %s).', $coupon->get_id() ),
+				__METHOD__
+			);
+
+			return null;
+		}
+	}
+
+	/**
+	 * Get validation errors for a specific coupon.
+	 * Combines errors for variable coupons, which have a variation-indexed array of errors.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return array
+	 */
+	public function get_validation_errors( WC_Coupon $coupon ): array {
+		$errors = $this->meta_handler->get_errors( $coupon ) ?: [];
+
+		$first_key = array_key_first( $errors );
+		if ( ! empty( $errors ) && is_numeric( $first_key ) && 0 !== $first_key ) {
+			$errors = array_unique( array_merge( ...$errors ) );
+		}
+
+		return $errors;
+	}
+}

--- a/src/Coupon/CouponMetaHandler.php
+++ b/src/Coupon/CouponMetaHandler.php
@@ -1,6 +1,5 @@
 <?php
-declare( strict_types=1 );
-
+declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidMeta;
@@ -8,14 +7,13 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use BadMethodCallException;
 use WC_Coupon;
-
-defined( 'ABSPATH' ) || exit;
+defined('ABSPATH') || exit();
 
 /**
  * Class CouponMetaHandler
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
- *
+ *         
  * @method update_synced_at( WC_Coupon c, $value )
  * @method delete_synced_at( WC_Coupon $coupon )
  * @method get_synced_at( WC_Coupon $coupon ): int|null
@@ -43,151 +41,185 @@ defined( 'ABSPATH' ) || exit;
  */
 class CouponMetaHandler implements Service {
 
-	use PluginHelper;
+    use PluginHelper;
 
-	public const KEY_SYNCED_AT            = 'synced_at';
-	public const KEY_GOOGLE_IDS           = 'google_ids';
-	public const KEY_VISIBILITY           = 'visibility';
-	public const KEY_ERRORS               = 'errors';
-	public const KEY_FAILED_SYNC_ATTEMPTS = 'failed_sync_attempts';
-	public const KEY_SYNC_FAILED_AT       = 'sync_failed_at';
-	public const KEY_SYNC_STATUS          = 'sync_status';
-	public const KEY_MC_STATUS            = 'mc_status';
+    public const KEY_SYNCED_AT = 'synced_at';
 
-	protected const TYPES = [
-		self::KEY_SYNCED_AT            => 'int',
-		self::KEY_GOOGLE_IDS           => 'array',
-		self::KEY_VISIBILITY           => 'string',
-		self::KEY_ERRORS               => 'array',
-		self::KEY_FAILED_SYNC_ATTEMPTS => 'int',
-		self::KEY_SYNC_FAILED_AT       => 'int',
-		self::KEY_SYNC_STATUS          => 'string',
-		self::KEY_MC_STATUS            => 'string',
-	];
+    public const KEY_GOOGLE_IDS = 'google_ids';
 
-	/**
-	 * @param string $name
-	 * @param mixed  $arguments
-	 *
-	 * @return mixed
-	 *
-	 * @throws BadMethodCallException If the method that's called doesn't exist.
-	 * @throws InvalidMeta            If the meta key is invalid.
-	 */
-	public function __call( string $name, $arguments ) {
-		$found_matches = preg_match( '/^([a-z]+)_([\w\d]+)$/i', $name, $matches );
+    public const KEY_VISIBILITY = 'visibility';
 
-		if ( ! $found_matches ) {
-			throw new BadMethodCallException( sprintf( 'The method %s does not exist in class CouponMetaHandler', $name ) );
-		}
+    public const KEY_ERRORS = 'errors';
 
-		[ $function_name, $method, $key ] = $matches;
+    public const KEY_FAILED_SYNC_ATTEMPTS = 'failed_sync_attempts';
 
-		// validate the method
-		if ( ! in_array( $method, [ 'update', 'delete', 'get' ], true ) ) {
-			throw new BadMethodCallException( sprintf( 'The method %s does not exist in class CouponMetaHandler', $function_name ) );
-		}
+    public const KEY_SYNC_FAILED_AT = 'sync_failed_at';
 
-		// set the value as the third argument if method is `update`
-		if ( 'update' === $method ) {
-			$arguments[2] = $arguments[1];
-		}
-		// set the key as the second argument
-		$arguments[1] = $key;
+    public const KEY_SYNC_STATUS = 'sync_status';
 
-		return call_user_func_array( [ $this, $method ], $arguments );
-	}
+    public const KEY_MC_STATUS = 'mc_status';
 
-	/**
-	 * @param WC_Coupon  $coupon
-	 * @param string     $key
-	 * @param mixed      $value
-	 *
-	 * @throws InvalidMeta If the meta key is invalid.
-	 */
-	public function update( WC_Coupon $coupon, string $key, $value ) {
-		self::validate_meta_key( $key );
+    protected const TYPES = [
+        self::KEY_SYNCED_AT => 'int',
+        self::KEY_GOOGLE_IDS => 'array',
+        self::KEY_VISIBILITY => 'string',
+        self::KEY_ERRORS => 'array',
+        self::KEY_FAILED_SYNC_ATTEMPTS => 'int',
+        self::KEY_SYNC_FAILED_AT => 'int',
+        self::KEY_SYNC_STATUS => 'string',
+        self::KEY_MC_STATUS => 'string'
+    ];
 
-		if ( isset( self::TYPES[ $key ] ) ) {
-			if ( in_array( self::TYPES[ $key ], [ 'bool', 'boolean' ], true ) ) {
-				$value = wc_bool_to_string( $value );
-			} else {
-				settype( $value, self::TYPES[ $key ] );
-			}
-		}
+    /**
+     *
+     * @param string $name
+     * @param mixed $arguments
+     *
+     * @return mixed
+     *
+     * @throws BadMethodCallException If the method that's called doesn't exist.
+     * @throws InvalidMeta If the meta key is invalid.
+     */
+    public function __call(string $name, $arguments) {
+        $found_matches = preg_match('/^([a-z]+)_([\w\d]+)$/i', $name, $matches);
 
-		$coupon->update_meta_data( $this->prefix_meta_key( $key ), $value );
-		$coupon->save_meta_data();
-	}
+        if (! $found_matches) {
+            throw new BadMethodCallException(
+                sprintf(
+                    'The method %s does not exist in class CouponMetaHandler',
+                    $name));
+        }
 
-	/**
-	 * @param WC_Coupon $coupon
-	 * @param string     $key
-	 *
-	 * @throws InvalidMeta If the meta key is invalid.
-	 */
-	public function delete( WC_Coupon $coupon, string $key ) {
-		self::validate_meta_key( $key );
+        [
+            $function_name,
+            $method,
+            $key
+        ] = $matches;
 
-		$coupon->delete_meta_data( $this->prefix_meta_key( $key ) );
-		$coupon->save_meta_data();
-	}
+        // validate the method
+        if (! in_array($method, [
+            'update',
+            'delete',
+            'get'
+        ], true)) {
+            throw new BadMethodCallException(
+                sprintf(
+                    'The method %s does not exist in class CouponMetaHandler',
+                    $function_name));
+        }
 
-	/**
-	 * @param WC_Coupn $coupon
-	 * @param string     $key
-	 *
-	 * @return mixed The value, or null if the meta key doesn't exist.
-	 *
-	 * @throws InvalidMeta If the meta key is invalid.
-	 */
-	public function get( WC_Coupon $coupon, string $key ) {
-		self::validate_meta_key( $key );
+        // set the value as the third argument if method is `update`
+        if ('update' === $method) {
+            $arguments[2] = $arguments[1];
+        }
+        // set the key as the second argument
+        $arguments[1] = $key;
 
-		$value = null;
-		if ( $coupon->meta_exists( $this->prefix_meta_key( $key ) ) ) {
-			$value = $coupon->get_meta( $this->prefix_meta_key( $key ), true );
+        return call_user_func_array([
+            $this,
+            $method
+        ], $arguments);
+    }
 
-			if ( isset( self::TYPES[ $key ] ) && in_array( self::TYPES[ $key ], [ 'bool', 'boolean' ], true ) ) {
-				$value = wc_string_to_bool( $value );
-			}
-		}
+    /**
+     *
+     * @param WC_Coupon $coupon
+     * @param string $key
+     * @param mixed $value
+     *
+     * @throws InvalidMeta If the meta key is invalid.
+     */
+    public function update(WC_Coupon $coupon, string $key, $value) {
+        self::validate_meta_key($key);
 
-		return $value;
-	}
+        if (isset(self::TYPES[$key])) {
+            if (in_array(self::TYPES[$key], [
+                'bool',
+                'boolean'
+            ], true)) {
+                $value = wc_bool_to_string($value);
+            } else {
+                settype($value, self::TYPES[$key]);
+            }
+        }
 
-	/**
-	 * @param string $key
-	 *
-	 * @throws InvalidMeta If the meta key is invalid.
-	 */
-	protected static function validate_meta_key( string $key ) {
-		if ( ! self::is_meta_key_valid( $key ) ) {
-			do_action(
-				'woocommerce_gla_error',
-				sprintf( 'Coupon meta key is invalid: %s', $key ),
-				__METHOD__
-			);
+        $coupon->update_meta_data($this->prefix_meta_key($key), $value);
+        $coupon->save_meta_data();
+    }
 
-			throw InvalidMeta::invalid_key( $key );
-		}
-	}
+    /**
+     *
+     * @param WC_Coupon $coupon
+     * @param string $key
+     *
+     * @throws InvalidMeta If the meta key is invalid.
+     */
+    public function delete(WC_Coupon $coupon, string $key) {
+        self::validate_meta_key($key);
 
-	/**
-	 * @param string $key
-	 *
-	 * @return bool Whether the meta key is valid.
-	 */
-	public static function is_meta_key_valid( string $key ): bool {
-		return isset( self::TYPES[ $key ] );
-	}
+        $coupon->delete_meta_data($this->prefix_meta_key($key));
+        $coupon->save_meta_data();
+    }
 
-	/**
-	 * Returns all available meta keys.
-	 *
-	 * @return array
-	 */
-	public static function get_all_meta_keys(): array {
-		return array_keys( self::TYPES );
-	}
+    /**
+     *
+     * @param WC_Coupn $coupon
+     * @param string $key
+     *
+     * @return mixed The value, or null if the meta key doesn't exist.
+     *        
+     * @throws InvalidMeta If the meta key is invalid.
+     */
+    public function get(WC_Coupon $coupon, string $key) {
+        self::validate_meta_key($key);
+
+        $value = null;
+        if ($coupon->meta_exists($this->prefix_meta_key($key))) {
+            $value = $coupon->get_meta($this->prefix_meta_key($key), true);
+
+            if (isset(self::TYPES[$key]) &&
+                in_array(self::TYPES[$key], [
+                    'bool',
+                    'boolean'
+                ], true)) {
+                $value = wc_string_to_bool($value);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     *
+     * @param string $key
+     *
+     * @throws InvalidMeta If the meta key is invalid.
+     */
+    protected static function validate_meta_key(string $key) {
+        if (! self::is_meta_key_valid($key)) {
+            do_action('woocommerce_gla_error',
+                sprintf('Coupon meta key is invalid: %s', $key), __METHOD__);
+
+            throw InvalidMeta::invalid_key($key);
+        }
+    }
+
+    /**
+     *
+     * @param string $key
+     *
+     * @return bool Whether the meta key is valid.
+     */
+    public static function is_meta_key_valid(string $key): bool {
+        return isset(self::TYPES[$key]);
+    }
+
+    /**
+     * Returns all available meta keys.
+     *
+     * @return array
+     */
+    public static function get_all_meta_keys(): array {
+        return array_keys(self::TYPES);
+    }
 }

--- a/src/Coupon/CouponMetaHandler.php
+++ b/src/Coupon/CouponMetaHandler.php
@@ -1,0 +1,193 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidMeta;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use BadMethodCallException;
+use WC_Coupon;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CouponMetaHandler
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
+ *
+ * @method update_synced_at( WC_Coupon c, $value )
+ * @method delete_synced_at( WC_Coupon $coupon )
+ * @method get_synced_at( WC_Coupon $coupon ): int|null
+ * @method update_google_ids( WC_Coupon $coupon, array $value )
+ * @method delete_google_ids( WC_Coupon $coupon )
+ * @method get_google_ids( WC_Coupon $coupon ): array|null
+ * @method update_visibility( WC_Coupon $coupon, $value )
+ * @method delete_visibility( WC_Coupon $coupon )
+ * @method get_visibility( WC_Coupon $coupon ): string|null
+ * @method update_errors( WC_Coupon $coupon, array $value )
+ * @method delete_errors( WC_Coupon $coupon )
+ * @method get_errors( WC_Coupon $coupon ): array|null
+ * @method update_failed_sync_attempts( WC_Coupon $coupon, int $value )
+ * @method delete_failed_sync_attempts( WC_Coupon $coupon )
+ * @method get_failed_sync_attempts( WC_Coupon $coupon ): int|null
+ * @method update_sync_failed_at( WC_Coupon $coupon, int $value )
+ * @method delete_sync_failed_at( WC_Coupon $coupon )
+ * @method get_sync_failed_at( WC_Coupon $coupon ): int|null
+ * @method update_sync_status( WC_Coupon $coupon, string $value )
+ * @method delete_sync_status( WC_Coupon $coupon )
+ * @method get_sync_status( WC_Coupon $coupon ): string|null
+ * @method update_mc_status( WC_Coupon $coupon, string $value )
+ * @method delete_mc_status( WC_Coupon $coupon )
+ * @method get_mc_status( WC_Coupon $coupon ): string|null
+ */
+class CouponMetaHandler implements Service {
+
+	use PluginHelper;
+
+	public const KEY_SYNCED_AT            = 'synced_at';
+	public const KEY_GOOGLE_IDS           = 'google_ids';
+	public const KEY_VISIBILITY           = 'visibility';
+	public const KEY_ERRORS               = 'errors';
+	public const KEY_FAILED_SYNC_ATTEMPTS = 'failed_sync_attempts';
+	public const KEY_SYNC_FAILED_AT       = 'sync_failed_at';
+	public const KEY_SYNC_STATUS          = 'sync_status';
+	public const KEY_MC_STATUS            = 'mc_status';
+
+	protected const TYPES = [
+		self::KEY_SYNCED_AT            => 'int',
+		self::KEY_GOOGLE_IDS           => 'array',
+		self::KEY_VISIBILITY           => 'string',
+		self::KEY_ERRORS               => 'array',
+		self::KEY_FAILED_SYNC_ATTEMPTS => 'int',
+		self::KEY_SYNC_FAILED_AT       => 'int',
+		self::KEY_SYNC_STATUS          => 'string',
+		self::KEY_MC_STATUS            => 'string',
+	];
+
+	/**
+	 * @param string $name
+	 * @param mixed  $arguments
+	 *
+	 * @return mixed
+	 *
+	 * @throws BadMethodCallException If the method that's called doesn't exist.
+	 * @throws InvalidMeta            If the meta key is invalid.
+	 */
+	public function __call( string $name, $arguments ) {
+		$found_matches = preg_match( '/^([a-z]+)_([\w\d]+)$/i', $name, $matches );
+
+		if ( ! $found_matches ) {
+			throw new BadMethodCallException( sprintf( 'The method %s does not exist in class CouponMetaHandler', $name ) );
+		}
+
+		[ $function_name, $method, $key ] = $matches;
+
+		// validate the method
+		if ( ! in_array( $method, [ 'update', 'delete', 'get' ], true ) ) {
+			throw new BadMethodCallException( sprintf( 'The method %s does not exist in class CouponMetaHandler', $function_name ) );
+		}
+
+		// set the value as the third argument if method is `update`
+		if ( 'update' === $method ) {
+			$arguments[2] = $arguments[1];
+		}
+		// set the key as the second argument
+		$arguments[1] = $key;
+
+		return call_user_func_array( [ $this, $method ], $arguments );
+	}
+
+	/**
+	 * @param WC_Coupon  $coupon
+	 * @param string     $key
+	 * @param mixed      $value
+	 *
+	 * @throws InvalidMeta If the meta key is invalid.
+	 */
+	public function update( WC_Coupon $coupon, string $key, $value ) {
+		self::validate_meta_key( $key );
+
+		if ( isset( self::TYPES[ $key ] ) ) {
+			if ( in_array( self::TYPES[ $key ], [ 'bool', 'boolean' ], true ) ) {
+				$value = wc_bool_to_string( $value );
+			} else {
+				settype( $value, self::TYPES[ $key ] );
+			}
+		}
+
+		$coupon->update_meta_data( $this->prefix_meta_key( $key ), $value );
+		$coupon->save_meta_data();
+	}
+
+	/**
+	 * @param WC_Coupon $coupon
+	 * @param string     $key
+	 *
+	 * @throws InvalidMeta If the meta key is invalid.
+	 */
+	public function delete( WC_Coupon $coupon, string $key ) {
+		self::validate_meta_key( $key );
+
+		$coupon->delete_meta_data( $this->prefix_meta_key( $key ) );
+		$coupon->save_meta_data();
+	}
+
+	/**
+	 * @param WC_Coupn $coupon
+	 * @param string     $key
+	 *
+	 * @return mixed The value, or null if the meta key doesn't exist.
+	 *
+	 * @throws InvalidMeta If the meta key is invalid.
+	 */
+	public function get( WC_Coupon $coupon, string $key ) {
+		self::validate_meta_key( $key );
+
+		$value = null;
+		if ( $coupon->meta_exists( $this->prefix_meta_key( $key ) ) ) {
+			$value = $coupon->get_meta( $this->prefix_meta_key( $key ), true );
+
+			if ( isset( self::TYPES[ $key ] ) && in_array( self::TYPES[ $key ], [ 'bool', 'boolean' ], true ) ) {
+				$value = wc_string_to_bool( $value );
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @param string $key
+	 *
+	 * @throws InvalidMeta If the meta key is invalid.
+	 */
+	protected static function validate_meta_key( string $key ) {
+		if ( ! self::is_meta_key_valid( $key ) ) {
+			do_action(
+				'woocommerce_gla_error',
+				sprintf( 'Coupon meta key is invalid: %s', $key ),
+				__METHOD__
+			);
+
+			throw InvalidMeta::invalid_key( $key );
+		}
+	}
+
+	/**
+	 * @param string $key
+	 *
+	 * @return bool Whether the meta key is valid.
+	 */
+	public static function is_meta_key_valid( string $key ): bool {
+		return isset( self::TYPES[ $key ] );
+	}
+
+	/**
+	 * Returns all available meta keys.
+	 *
+	 * @return array
+	 */
+	public static function get_all_meta_keys(): array {
+		return array_keys( self::TYPES );
+	}
+}

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -1,0 +1,159 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+//use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
+//use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
+//use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
+//use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Exception;
+use WC_Coupon;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CouponSyncer
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
+ */
+class CouponSyncer implements Service {
+
+	public const FAILURE_THRESHOLD        = 5;         // Number of failed attempts allowed per FAILURE_THRESHOLD_WINDOW
+	public const FAILURE_THRESHOLD_WINDOW = '3 hours'; // PHP supported Date and Time format: https://www.php.net/manual/en/datetime.formats.php
+
+	/**
+	 * @var GoogleProductService
+	 */
+	protected $google_service;
+
+	/**
+	 * @var CouponHelper
+	 */
+	protected $coupon_helper;
+
+	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
+	 * @var WC
+	 */
+	protected $wc;
+
+	/**
+	 * CouponSyncer constructor.
+	 *
+	 * @param GoogleProductService  $google_service
+	 * @param CouponHelper          $coupon_helper
+	 * @param MerchantCenterService $merchant_center
+	 * @param WC                    $wc
+	 */
+	public function __construct(
+		GoogleProductService $google_service,
+		CouponHelper $coupon_helper,
+		MerchantCenterService $merchant_center,
+		WC $wc
+	) {
+		$this->google_service  = $google_service;
+		$this->coupon_helper   = $coupon_helper;
+		$this->merchant_center = $merchant_center;
+		$this->wc              = $wc;
+	}
+
+	/**
+	 * Submit a WooCommerce coupon to Google Merchant Center.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @throws CouponSyncerException If there are any errors while syncing coupon with Google Merchant Center.
+	 */
+	public function update( WC_Coupon $coupon ): BatchProductResponse {
+		$this->validate_merchant_center_setup();
+
+		// Prepare and validate coupons
+		// TODO: Process coupon update.
+		return new BatchProductResponse([],[]);
+	}
+
+	/**
+	 * Delete a WooCommerce coupon from Google Merchant Center.
+	 *
+	 * @param int $coupon_id
+	 *
+	 * @throws CouponSyncerException If there are any errors while deleting coupon from Google Merchant Center.
+	 */
+	public function delete( int $coupon_id ): BatchProductResponse {
+		$this->validate_merchant_center_setup();
+
+		// Prepare and check to only delete synched coupon.
+		// TODO: Process coupon update.
+		return new BatchProductResponse([],[]);
+	}
+
+
+	/**
+	 * Return whether coupon is supported as visible on Google.
+	 *
+	 * @return bool
+	 */
+	public static function is_coupon_supported(WC_Coupon $coupon): bool {
+	    if ( ! empty( $coupon->get_email_restrictions() ) ) {
+	       return false;
+	    }
+	    return true;
+	}
+
+	/**
+	 * Return the list of supported coupon types.
+	 *
+	 * @return array
+	 */
+	public static function get_supported_coupon_types(): array {
+	    return (array) apply_filters( 'woocommerce_gla_supported_coupon_types', [ 'percent', 'fixed_cart', 'fixed_product' ] );
+	}
+	
+	/**
+	 * Return the list of coupon types we will hide functionality for (default none).
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return array
+	 */
+	public static function get_hidden_coupon_types(): array {
+	    return (array) apply_filters( 'woocommerce_gla_hidden_coupon_types', [] );
+	}
+
+	/**
+	 * @param BatchInvalidCouponEntry[] $invalid_coupons
+	 */
+	protected function handle_update_errors( array $invalid_coupons ) {
+	    // TODO: Handle update errors.
+	}
+
+	/**
+	 * @param BatchInvalidCouponEntry[] $invalid_coupons
+	 */
+	protected function handle_delete_errors( array $invalid_coupons ) {
+		// TODO: handle delete errors.
+	}
+
+	/**
+	 * Validates whether Merchant Center is set up and connected.
+	 *
+	 * @throws CouponSyncerException If Google Merchant Center is not set up and connected.
+	 */
+	protected function validate_merchant_center_setup(): void {
+		if ( ! $this->merchant_center->is_connected() ) {
+			do_action( 'woocommerce_gla_error', 'Cannot sync any coupons before setting up Google Merchant Center.', __METHOD__ );
+
+			throw new CouponSyncerException( __( 'Google Merchant Center has not been set up correctly. Please review your configuration.', 'google-listings-and-ads' ) );
+		}
+	}
+}

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -1,21 +1,18 @@
 <?php
-declare( strict_types=1 );
-
+declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
-//use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
-//use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
-//use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
-//use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\InvalidCouponEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Google\Exception as GoogleException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Exception;
 use WC_Coupon;
-
-defined( 'ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit();
 
 /**
  * Class CouponSyncer
@@ -24,136 +21,367 @@ defined( 'ABSPATH' ) || exit;
  */
 class CouponSyncer implements Service {
 
-	public const FAILURE_THRESHOLD        = 5;         // Number of failed attempts allowed per FAILURE_THRESHOLD_WINDOW
-	public const FAILURE_THRESHOLD_WINDOW = '3 hours'; // PHP supported Date and Time format: https://www.php.net/manual/en/datetime.formats.php
+    public const FAILURE_THRESHOLD = 5;
 
-	/**
-	 * @var GoogleProductService
-	 */
-	protected $google_service;
+    // Number of failed attempts allowed per FAILURE_THRESHOLD_WINDOW
+    public const FAILURE_THRESHOLD_WINDOW = '3 hours';
 
-	/**
-	 * @var CouponHelper
-	 */
-	protected $coupon_helper;
+    /**
+     *
+     * @var GoogleProductService
+     */
+    protected $google_service;
 
-	/**
-	 * @var MerchantCenterService
-	 */
-	protected $merchant_center;
+    /**
+     *
+     * @var CouponHelper
+     */
+    protected $coupon_helper;
 
-	/**
-	 * @var WC
-	 */
-	protected $wc;
+    /**
+     *
+     * @var ValidatorInterface
+     */
+    protected $validator;
 
-	/**
-	 * CouponSyncer constructor.
-	 *
-	 * @param GoogleProductService  $google_service
-	 * @param CouponHelper          $coupon_helper
-	 * @param MerchantCenterService $merchant_center
-	 * @param WC                    $wc
-	 */
-	public function __construct(
-		GoogleProductService $google_service,
-		CouponHelper $coupon_helper,
-		MerchantCenterService $merchant_center,
-		WC $wc
-	) {
-		$this->google_service  = $google_service;
-		$this->coupon_helper   = $coupon_helper;
-		$this->merchant_center = $merchant_center;
-		$this->wc              = $wc;
-	}
+    /**
+     *
+     * @var MerchantCenterService
+     */
+    protected $merchant_center;
 
-	/**
-	 * Submit a WooCommerce coupon to Google Merchant Center.
-	 *
-	 * @param WC_Coupon $coupon
-	 *
-	 * @throws CouponSyncerException If there are any errors while syncing coupon with Google Merchant Center.
-	 */
-	public function update( WC_Coupon $coupon ): BatchProductResponse {
-		$this->validate_merchant_center_setup();
+    /**
+     *
+     * @var WC
+     */
+    protected $wc;
 
-		// Prepare and validate coupons
-		// TODO: Process coupon update.
-		return new BatchProductResponse([],[]);
-	}
+    /**
+     * CouponSyncer constructor.
+     *
+     * @param GoogleProductService $google_service
+     * @param CouponHelper $coupon_helper
+     * @param ValidatorInterface $validator
+     * @param MerchantCenterService $merchant_center
+     * @param WC $wc
+     */
+    public function __construct( 
+        GooglePromotionService $google_service,
+        CouponHelper $coupon_helper,
+        ValidatorInterface $validator,
+        MerchantCenterService $merchant_center,
+        WC $wc ) {
+        $this->google_service = $google_service;
+        $this->coupon_helper = $coupon_helper;
+        $this->validator = $validator;
+        $this->merchant_center = $merchant_center;
+        $this->wc = $wc;
+    }
 
-	/**
-	 * Delete a WooCommerce coupon from Google Merchant Center.
-	 *
-	 * @param int $coupon_id
-	 *
-	 * @throws CouponSyncerException If there are any errors while deleting coupon from Google Merchant Center.
-	 */
-	public function delete( int $coupon_id ): BatchProductResponse {
-		$this->validate_merchant_center_setup();
+    /**
+     * Submit a WooCommerce coupon to Google Merchant Center.
+     *
+     * @param WC_Coupon $coupon
+     *
+     * @throws CouponSyncerException If there are any errors while syncing coupon with Google Merchant Center.
+     */
+    public function update( WC_Coupon $coupon ) {
+        $this->validate_merchant_center_setup();
 
-		// Prepare and check to only delete synched coupon.
-		// TODO: Process coupon update.
-		return new BatchProductResponse([],[]);
-	}
+        if ( ! $this->coupon_helper->is_sync_ready( $coupon ) ) {
+            do_action( 
+                'woocommerce_gla_debug_message',
+                sprintf( 
+                    'Skipping coupon (ID: %s) because it is not ready to be synced.',
+                    $coupon->get_id() ),
+                __METHOD__ );
+            return;
+        }
 
+        $target_country = $this->merchant_center->get_main_target_country();
+        if ( ! $this->merchant_center->is_promotion_supported_country( 
+            $target_country ) ) {
+            do_action( 
+                'woocommerce_gla_debug_message',
+                sprintf( 
+                    'Skipping coupon (ID: %s) because it is not supported in main target country %s.',
+                    $coupon->get_id(),
+                    $target_country ),
+                __METHOD__ );
+            return;
+        }
 
-	/**
-	 * Return whether coupon is supported as visible on Google.
-	 *
-	 * @return bool
-	 */
-	public static function is_coupon_supported(WC_Coupon $coupon): bool {
-	    if ( ! empty( $coupon->get_email_restrictions() ) ) {
-	       return false;
-	    }
-	    return true;
-	}
+        $adapted_coupon = new WCCouponAdapter( 
+            ['wc_coupon' => $coupon,'targetCountry' => $target_country] );
+        $validation_result = $this->validate_coupon( $adapted_coupon );
+        if ( $validation_result instanceof InvalidCouponEntry ) {
+            $this->coupon_helper->mark_as_invalid( 
+                $coupon,
+                $validation_result->get_errors() );
 
-	/**
-	 * Return the list of supported coupon types.
-	 *
-	 * @return array
-	 */
-	public static function get_supported_coupon_types(): array {
-	    return (array) apply_filters( 'woocommerce_gla_supported_coupon_types', [ 'percent', 'fixed_cart', 'fixed_product' ] );
-	}
-	
-	/**
-	 * Return the list of coupon types we will hide functionality for (default none).
-	 *
-	 * @since 1.2.0
-	 *
-	 * @return array
-	 */
-	public static function get_hidden_coupon_types(): array {
-	    return (array) apply_filters( 'woocommerce_gla_hidden_coupon_types', [] );
-	}
+            do_action( 
+                'woocommerce_gla_debug_message',
+                sprintf( 
+                    'Skipping coupon (ID: %s) because it does not pass validation: %s',
+                    $coupon->get_id(),
+                    json_encode( $validation_result ) ),
+                __METHOD__ );
 
-	/**
-	 * @param BatchInvalidCouponEntry[] $invalid_coupons
-	 */
-	protected function handle_update_errors( array $invalid_coupons ) {
-	    // TODO: Handle update errors.
-	}
+            return;
+        }
 
-	/**
-	 * @param BatchInvalidCouponEntry[] $invalid_coupons
-	 */
-	protected function handle_delete_errors( array $invalid_coupons ) {
-		// TODO: handle delete errors.
-	}
+        try {
+            $response = $this->google_service->create( $adapted_coupon );
+            $this->coupon_helper->mark_as_synced( 
+                $coupon,
+                $response->getId(),
+                $country );
+            do_action( 'woocommerce_gla_updated_coupon', $adapted_coupon );
 
-	/**
-	 * Validates whether Merchant Center is set up and connected.
-	 *
-	 * @throws CouponSyncerException If Google Merchant Center is not set up and connected.
-	 */
-	protected function validate_merchant_center_setup(): void {
-		if ( ! $this->merchant_center->is_connected() ) {
-			do_action( 'woocommerce_gla_error', 'Cannot sync any coupons before setting up Google Merchant Center.', __METHOD__ );
+            do_action( 
+                'woocommerce_gla_debug_message',
+                sprintf( 
+                    "Submitted promotion:\n%s",
+                    json_encode( $adapted_coupon ) ),
+                __METHOD__ );
+        } catch ( GoogleException $google_exception ) {
+            $invalid_promotion = new InvalidCouponEntry( 
+                $wc_coupon_id = $coupon->get_id(),
+                $target_country = $target_country,
+                $errors = [$google_exception->getMessage()] );
+            $this->coupon_helper->mark_as_invalid( 
+                $coupon,
+                [$invalid_promotion] );
 
-			throw new CouponSyncerException( __( 'Google Merchant Center has not been set up correctly. Please review your configuration.', 'google-listings-and-ads' ) );
-		}
-	}
+            $this->handle_update_errors( [$invalid_promotion] );
+
+            do_action( 
+                'woocommerce_gla_debug_message',
+                sprintf( 
+                    "Promotion failed to sync with Merchant Center:\n%s",
+                    json_encode( $invalid_promotion ) ),
+                __METHOD__ );
+        } catch ( Exception $exception ) {
+            do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
+
+            throw new CouponSyncerException( 
+                sprintf( 
+                    'Error updating Google promotion: %s',
+                    $exception->getMessage() ),
+                0,
+                $exception );
+        }
+    }
+
+    /**
+     *
+     * @param WCCouponAdapter $coupon
+     *
+     * @return InvalidCouponEntry|true
+     */
+    protected function validate_coupon( WCCouponAdapter $coupon ) {
+        $violations = $this->validator->validate( $coupon );
+
+        if ( 0 !== count( $violations ) ) {
+            $invalid_promotion = new InvalidCouponEntry( 
+                $coupon->get_wc_coupon()->get_id() );
+            $invalid_promotion->map_validation_violations( $violations );
+
+            return $invalid_promotion;
+        }
+
+        return true;
+    }
+
+    /**
+     * Filters the list of invalid coupon entries and returns an array of WooCommerce coupon IDs with internal errors
+     *
+     * @param InvalidCouponEntry[] $invalid_coupons
+     *
+     * @return int[] An array of WooCommerce coupon ids.
+     */
+    public function get_internal_error_coupons( array $invalid_coupons ): array {
+        $internal_error_ids = [];
+        foreach ( $invalid_coupons as $invalid_coupon ) {
+            if ( $invalid_coupon->has_error( 
+                GooglePromotionService::INTERNAL_ERROR_REASON ) ) {
+                $coupon_id = $invalid_coupon->get_wc_coupon_id();
+
+                $internal_error_ids[$coupon_id] = $coupon_id;
+            }
+        }
+
+        return $internal_error_ids;
+    }
+
+    /**
+     * Delete a WooCommerce coupon from Google Merchant Center.
+     *
+     * @param DeleteCouponEntry $coupon
+     *
+     * @throws CouponSyncerException If there are any errors while deleting coupon from Google Merchant Center.
+     */
+    public function delete( DeleteCouponEntry $coupon ) {
+        $this->validate_merchant_center_setup();
+
+        $deleted_promotions = [];
+        $invalid_promotions = [];
+        $synced_google_ids = $coupon->get_synced_google_ids;
+        $wc_coupon = $this->wc->maybe_get_coupon();
+        $wc_coupon_exist = $wc_product instanceof WC_Product;
+        foreach ( $synced_google_ids as $target_country => $google_id ) {
+            try {
+                $adapted_coupon = $coupon->get_coupon();
+                $adapted_coupon->setTargetCountry( $target_country );
+                $adapted_coupon->disableCoupon();
+
+                $response = $this->google_service->create( $adapted_coupon );
+                array_push( $deleted_promotions, $adapted_coupon );
+                // Remove synced google id
+                if ( $wc_coupon_exist ) {
+                    $this->coupon_helper->remove_google_id( 
+                        $wc_coupon,
+                        $google_id );
+                }
+            } catch ( GoogleException $google_exception ) {
+                array_push( 
+                    $invalid_promotions,
+                    $this->generate_update_coupon_invalid( 
+                        $coupon->get_coupon()
+                            ->getPromotionId(),
+                        $country,
+                        [$google_exception->getMessage()] ) );
+            } catch ( Exception $exception ) {
+                do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
+
+                throw new CouponSyncerException( 
+                    sprintf( 
+                        'Error deleting Google promotion: %s',
+                        $exception->getMessage() ),
+                    0,
+                    $exception );
+            }
+        }
+
+        if ( ! empty( $invalid_promotions ) ) {
+            $this->handle_delete_errors( $invalid_promotions );
+            do_action( 
+                'woocommerce_gla_debug_message',
+                sprintf( 
+                    "Failed to delete %s promotions from Merchant Center:\n%s",
+                    count( $invalid_promotions ),
+                    json_encode( $invalid_promotions ) ),
+                __METHOD__ );
+        } else if ( $wc_coupon_exist ) {
+            $this->coupon_helper->mark_as_unsynced( $wc_coupon );
+        }
+
+        do_action( 
+            'woocommerce_gla_batch_deleted_promotion',
+            $deleted_promotions,
+            $invalid_promotions );
+
+        do_action( 
+            'woocommerce_gla_debug_message',
+            sprintf( 
+                "Deleted %s promoitons:\n%s",
+                count( $deleted_promotions ),
+                json_encode( $deleted_promotions ) ),
+            __METHOD__ );
+    }
+
+    /**
+     * Return whether coupon is supported as visible on Google.
+     *
+     * @return bool
+     */
+    public static function is_coupon_supported( WC_Coupon $coupon ): bool {
+        if ( ! empty( $coupon->get_email_restrictions() ) ) {
+            return false;
+        }
+        if ( 
+            ! empty( $coupon->get_exclude_sale_items() ) &&
+            get_exclude_sale_items() ) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Return the list of supported coupon types.
+     *
+     * @return array
+     */
+    public static function get_supported_coupon_types(): array {
+        return (array) apply_filters( 
+            'woocommerce_gla_supported_coupon_types',
+            ['percent','fixed_cart','fixed_product'] );
+    }
+
+    /**
+     * Return the list of coupon types we will hide functionality for (default none).
+     *
+     * @since 1.2.0
+     *       
+     * @return array
+     */
+    public static function get_hidden_coupon_types(): array {
+        return (array) apply_filters( 'woocommerce_gla_hidden_coupon_types', [] );
+    }
+
+    /**
+     *
+     * @param InvalidCouponEntry[] $invalid_promotions
+     */
+    protected function handle_update_errors( array $invalid_promotions ) {
+        // An invalid promtoion is a wc_coupon mapping to a country.
+        // Get all related wc coupon ids that have internal errors.
+        $internal_error_coupon_ids = $this->get_internal_error_coupons( 
+            $invalid_promotions );
+
+        if ( 
+            ! empty( $internal_error_coupon_ids ) &&
+            apply_filters( 
+                'woocommerce_gla_coupons_update_retry_on_failure',
+                true,
+                $internal_error_coupon_ids ) ) {
+            do_action( 
+                'woocommerce_gla_retry_update_coupons',
+                $internal_error_coupon_ids );
+
+            do_action( 
+                'woocommerce_gla_error',
+                sprintf( 
+                    'Internal API errors while submitting the following coupons: %s',
+                    join( ', ', $internal_error_coupon_ids ) ),
+                __METHOD__ );
+        }
+    }
+
+    /**
+     *
+     * @param BatchInvalidCouponEntry[] $invalid_coupons
+     */
+    protected function handle_delete_errors( array $invalid_coupons ) {
+        // TODO: handle delete errors.
+    }
+
+    /**
+     * Validates whether Merchant Center is set up and connected.
+     *
+     * @throws CouponSyncerException If Google Merchant Center is not set up and connected.
+     */
+    protected function validate_merchant_center_setup(): void {
+        if ( ! $this->merchant_center->is_connected() ) {
+            do_action( 
+                'woocommerce_gla_error',
+                'Cannot sync any coupons before setting up Google Merchant Center.',
+                __METHOD__ );
+
+            throw new CouponSyncerException( 
+                __( 
+                    'Google Merchant Center has not been set up correctly. Please review your configuration.',
+                    'google-listings-and-ads' ) );
+        }
+    }
 }

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -151,9 +151,8 @@ class CouponSyncer implements Service {
                 $errors = [
                     $google_exception->getCode() => $google_exception->getMessage()],
                 $target_country = $target_country );
-            $this->coupon_helper->mark_as_invalid( 
-                $coupon,
-                [$invalid_promotion] );
+            $this->coupon_helper->mark_as_invalid( $coupon, [
+                $invalid_promotion] );
 
             $this->handle_update_errors( [$invalid_promotion] );
 
@@ -280,6 +279,9 @@ class CouponSyncer implements Service {
      * @return bool
      */
     public static function is_coupon_supported( WC_Coupon $coupon ): bool {
+        if ( $coupon->get_virtual() ) {
+            return false;
+        }
         if ( ! empty( $coupon->get_email_restrictions() ) ) {
             return false;
         }

--- a/src/Coupon/CouponSyncerException.php
+++ b/src/Coupon/CouponSyncerException.php
@@ -1,0 +1,17 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CouponSyncerException
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
+ */
+class CouponSyncerException extends Exception implements GoogleListingsAndAdsException {
+}

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -1,0 +1,86 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateCoupon;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SyncerHooks
+ *
+ * Hooks to various WooCommerce and WordPress actions to provide automatic coupon sync functionality.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
+ */
+class SyncerHooks implements Service, Registerable {
+    
+    use PluginHelper;
+    
+    protected const SCHEDULE_TYPE_UPDATE = 'update';
+    protected const SCHEDULE_TYPE_DELETE = 'delete';
+    
+    /**
+     * @var CouponHelper
+     */
+    //protected $coupon_helper;
+    
+    /**
+     * @var UpdateCoupon
+     */
+    protected $update_coupon_job;
+    
+    
+    /**
+     * @var MerchantCenterService
+     */
+    protected $merchant_center;
+    
+    /**
+     * @var WC
+     */
+    protected $wc;
+    
+    /**
+     * SyncerHooks constructor.
+     *
+     * @param JobRepository         $job_repository
+     * @param MerchantCenterService $merchant_center
+     * @param WC                    $wc
+     */
+    public function __construct(
+        JobRepository $job_repository,
+        MerchantCenterService $merchant_center,
+        WC $wc
+        ) {
+            $this->update_coupon_job  = $job_repository->get( UpdateCoupon::class );
+            $this->merchant_center     = $merchant_center;
+            $this->wc                  = $wc;
+    }
+    
+    /**
+     * Register a service.
+     */
+    public function register(): void {
+        // only register the hooks if Merchant Center is set up and connected.
+        if ( ! $this->merchant_center->is_connected() ) {
+            return;
+        }
+        
+        $update_by_id = function ( int $coupon_id ) {
+            $this->update_coupon_job->schedule($coupon_id);
+        };
+        
+        // when a coupon is added / updated, schedule a update job.
+        add_action( 'woocommerce_new_coupon', $update_by_id, 90, 2 );
+        add_action( 'woocommerce_update_coupon', $update_by_id, 90, 2 );
+    }
+}
+

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -1,8 +1,8 @@
 <?php
-declare( strict_types=1 );
-
+declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\DeleteCouponEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -12,8 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterSer
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use WC_Coupon;
-
-defined( 'ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit();
 
 /**
  * Class SyncerHooks
@@ -23,54 +22,78 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
  */
 class SyncerHooks implements Service, Registerable {
-    
+
     use PluginHelper;
-     
+
+    protected const SCHEDULE_TYPE_UPDATE = 'update';
+
+    protected const SCHEDULE_TYPE_DELETE = 'delete';
+
     /**
+     * Array of strings mapped to coupon IDs indicating that they have been already
+     * scheduled for update or delete during current request.
+     * Used to avoid scheduling
+     * duplicate jobs.
+     *
+     * @var string[]
+     */
+    protected $already_scheduled = [];
+
+    /**
+     *
+     * @var DeleteCouponEntry[][]
+     */
+    protected $delete_requests_map;
+
+    /**
+     *
      * @var CouponHelper
      */
     protected $coupon_helper;
-    
+
     /**
+     *
      * @var UpdateCoupon
      */
     protected $update_coupon_job;
-    
+
     /**
+     *
      * @var DeleteCoupon
      */
     protected $delete_coupon_job;
-    
+
     /**
+     *
      * @var MerchantCenterService
      */
     protected $merchant_center;
-    
+
     /**
+     *
      * @var WC
      */
     protected $wc;
-    
+
     /**
      * SyncerHooks constructor.
      *
-     * @param JobRepository         $job_repository
+     * @param JobRepository $job_repository
      * @param MerchantCenterService $merchant_center
-     * @param WC                    $wc
+     * @param WC $wc
      */
-    public function __construct(
+    public function __construct( 
         CouponHelper $coupon_helper,
         JobRepository $job_repository,
         MerchantCenterService $merchant_center,
-        WC $wc
-        ) {
-            $this->update_coupon_job  = $job_repository->get( UpdateCoupon::class );
-            $this->delete_coupon_job  = $job_repository->get( DeleteCoupon::class );
-            $this->coupon_helper      = $coupon_helper;
-            $this->merchant_center    = $merchant_center;
-            $this->wc                 = $wc;
+        WC $wc ) {
+        $this->update_coupon_job = $job_repository->get( UpdateCoupon::class );
+        $this->delete_coupon_job = $job_repository->get( DeleteCoupon::class );
+        $this->coupon_helper = $coupon_helper;
+        $this->merchant_center = $merchant_center;
+        $this->wc = $wc;
     }
-    
+
     /**
      * Register a service.
      */
@@ -79,59 +102,192 @@ class SyncerHooks implements Service, Registerable {
         if ( ! $this->merchant_center->is_connected() ) {
             return;
         }
-        
-        $update_by_object = function ( int $coupon_id, WC_Coupon $coupon) {
+
+        $update_by_object = function ( int $coupon_id, WC_Coupon $coupon ) {
             $this->handle_update_coupon( $coupon );
         };
-        
+
         $update_by_id = function ( int $coupon_id ) {
             $coupon = $this->wc->maybe_get_coupon( $coupon_id );
-            if ( $coupon instanceof WC_Coupon) {
-                $this->update_coupon_job->schedule( [ $coupon_id ] );
+            if ( $coupon instanceof WC_Coupon ) {
+                $this->update_coupon_job->schedule( [
+                    $coupon_id
+                ] );
             }
         };
-        
-        $delete_by_id = function ( int $coupon_id ) {
-            $this->delete_coupon_job->schedule( [ $coupon_id ] );
+
+        $pre_delete = function ( int $coupon_id ) {
+            $this->handle_pre_delete_coupon( $coupon_id );
         };
-        
+
+        $delete_by_id = function ( int $coupon_id ) {
+            $this->handle_delete_coupon( $coupon_id );
+        };
+
         // when a coupon is added / updated, schedule a update job.
         add_action( 'woocommerce_new_coupon', $update_by_object, 90, 2 );
         add_action( 'woocommerce_update_coupon', $update_by_object, 90, 2 );
-        // when a product is trashed or removed, schedule a delete job.
-        add_action( 'woocommerce_delete_coupon', $delete_by_id, 90, 2);
-        add_action( 'woocommerce_trash_coupon', $delete_by_id, 90, 2);
-        
+        // when a coupon is trashed or removed, schedule a delete job.
+        add_action( 'wp_trash_post', $pre_delete, 90 );
+        add_action( 'before_delete_post', $pre_delete, 90 );
+        add_action( 
+            'woocommerce_before_delete_product_variation',
+            $pre_delete,
+            90 );
+        add_action( 'trashed_post', $delete_by_id, 90 );
+        add_action( 'deleted_post', $delete_by_id, 90 );
+        add_action( 'woocommerce_delete_coupon', $delete_by_id, 90, 2 );
+        add_action( 'woocommerce_trash_coupon', $delete_by_id, 90, 2 );
+
         // when a coupon is restored from trash, schedule a update job.
         add_action( 'untrashed_post', $update_by_id, 90 );
     }
-    
+
     /**
      * Handle updating of a coupon.
      *
-     * @param WC_Coupon $coupon The coupon being saved.
-     *
+     * @param WC_Coupon $coupon
+     *            The coupon being saved.
+     *            
      * @return void
      */
     protected function handle_update_coupon( WC_Coupon $coupon ) {
         $coupon_id = $coupon->get_id();
-        
+
         // Schedule an update job if product sync is enabled.
         if ( $this->coupon_helper->is_sync_ready( $coupon ) ) {
             $this->coupon_helper->mark_as_pending( $coupon );
-            $this->update_coupon_job->schedule( [ $coupon_id ] );
+            $this->update_coupon_job->schedule( [
+                $coupon_id
+            ] );
         } elseif ( $this->coupon_helper->is_coupon_synced( $coupon ) ) {
             // Delete the coupon from Google Merchant Center if it's already synced BUT it is not sync ready after the edit.
-            $this->delete_coupon_job->schedule( [ $coupon_id ] );
-            
-            do_action(
+            $coupon_to_delete = new DeleteCouponEntry( 
+                new WCCouponAdapter( [
+                    'wc_coupon' => $coupon
+                ] ),
+                $this->coupon_helper->get_synced_google_ids( $coupon ) );
+            $this->delete_coupon_job->schedule( [
+                $coupon_to_delete
+            ] );
+
+            do_action( 
                 'woocommerce_gla_debug_message',
-                sprintf( 'Deleting coupon (ID: %s) from Google Merchant Center because it is not ready to be synced.', $coupon->get_id() ),
-                __METHOD__
-            );
+                sprintf( 
+                    'Deleting coupon (ID: %s) from Google Merchant Center because it is not ready to be synced.',
+                    $coupon->get_id() ),
+                __METHOD__ );
         } else {
             $this->coupon_helper->mark_as_unsynced( $coupon );
         }
+    }
+
+    /**
+     * Create request entries for the coupon (containing its Google ID),
+     * so we can schedule a delete job when it is actually trashed / deleted.
+     *
+     * @param int $coupon_id
+     */
+    protected function handle_pre_delete_coupon( int $coupon_id ) {
+        $coupon = $this->wc->maybe_get_coupon( $coupon_id );
+
+        if ( $coupon instanceof WC_Coupon &&
+            $this->coupon_helper->is_coupon_synced( $coupon ) ) {
+            $this->delete_requests_map[$coupon_id] = new DeleteCouponEntry( 
+                new WCCouponAdapter( [
+                    'wc_coupon' => $coupon
+                ] ),
+                $this->coupon_helper->get_synced_google_ids( $coupon ) );
+        }
+    }
+
+    /**
+     * Handle deleting of a coupon.
+     *
+     * @param int $coupon_id
+     */
+    protected function handle_delete_coupon( int $coupon_id ) {
+        if ( isset( $this->delete_requests_map[$coupon_id] ) ) {
+            $coupon_to_delete = $this->delete_requests_map[$coupon_id];
+            if ( ! empty( $coupon_to_delete->get_synced_google_ids() ) &&
+                ! $this->is_already_scheduled_to_delete( $coupon_id ) ) {
+                $this->delete_coupon_job->schedule( [
+                    $coupon_to_delete
+                ] );
+                $this->set_already_scheduled_to_delete( $coupon_id );
+            }
+        }
+    }
+
+    /**
+     *
+     * @param int $coupon_id
+     * @param string $schedule_type
+     *
+     * @return bool
+     */
+    protected function is_already_scheduled( 
+        int $coupon_id,
+        string $schedule_type ): bool {
+        return isset( $this->already_scheduled[$coupon_id] ) &&
+            $this->already_scheduled[$coupon_id] === $schedule_type;
+    }
+
+    /**
+     *
+     * @param int $coupon_id
+     *
+     * @return bool
+     */
+    protected function is_already_scheduled_to_update( int $coupon_id ): bool {
+        return $this->is_already_scheduled( 
+            $coupon_id,
+            self::SCHEDULE_TYPE_UPDATE );
+    }
+
+    /**
+     *
+     * @param int $coupon_id
+     *
+     * @return bool
+     */
+    protected function is_already_scheduled_to_delete( int $coupon_id ): bool {
+        return $this->is_already_scheduled( 
+            $coupon_id,
+            self::SCHEDULE_TYPE_DELETE );
+    }
+
+    /**
+     *
+     * @param int $coupon_id
+     * @param string $schedule_type
+     *
+     * @return void
+     */
+    protected function set_already_scheduled( 
+        int $coupon_id,
+        string $schedule_type ): void {
+        $this->already_scheduled[$coupon_id] = $schedule_type;
+    }
+
+    /**
+     *
+     * @param int $coupon_id
+     *
+     * @return void
+     */
+    protected function set_already_scheduled_to_update( int $coupon_id ): void {
+        $this->set_already_scheduled( $coupon_id, self::SCHEDULE_TYPE_UPDATE );
+    }
+
+    /**
+     *
+     * @param int $coupon_id
+     *
+     * @return void
+     */
+    protected function set_already_scheduled_to_delete( int $coupon_id ): void {
+        $this->set_already_scheduled( $coupon_id, self::SCHEDULE_TYPE_DELETE );
     }
 }
 

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -75,12 +75,17 @@ class SyncerHooks implements Service, Registerable {
         }
         
         $update_by_id = function ( int $coupon_id ) {
-            $this->update_coupon_job->schedule($coupon_id);
+            $this->update_coupon_job->schedule( [ $coupon_id ] );
+        };
+        
+        $delete_by_id = function ( int $coupon_id ) {
+            // TODO: trigger delete coupn job
         };
         
         // when a coupon is added / updated, schedule a update job.
         add_action( 'woocommerce_new_coupon', $update_by_id, 90, 2 );
         add_action( 'woocommerce_update_coupon', $update_by_id, 90, 2 );
+        add_action( 'woocommerce_delete_coupon', $delete_by_id, 90, 2);
     }
 }
 

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -27,6 +27,11 @@ class SyncerHooks implements Service, Registerable {
     use PluginHelper;
      
     /**
+     * @var CouponHelper
+     */
+    protected $coupon_helper;
+    
+    /**
      * @var UpdateCoupon
      */
     protected $update_coupon_job;
@@ -54,14 +59,16 @@ class SyncerHooks implements Service, Registerable {
      * @param WC                    $wc
      */
     public function __construct(
+        CouponHelper $coupon_helper,
         JobRepository $job_repository,
         MerchantCenterService $merchant_center,
         WC $wc
         ) {
             $this->update_coupon_job  = $job_repository->get( UpdateCoupon::class );
             $this->delete_coupon_job  = $job_repository->get( DeleteCoupon::class );
-            $this->merchant_center     = $merchant_center;
-            $this->wc                  = $wc;
+            $this->coupon_helper      = $coupon_helper;
+            $this->merchant_center    = $merchant_center;
+            $this->wc                 = $wc;
     }
     
     /**
@@ -73,10 +80,14 @@ class SyncerHooks implements Service, Registerable {
             return;
         }
         
+        $update_by_object = function ( int $coupon_id, WC_Coupon $coupon) {
+            $this->handle_update_coupon( $coupon );
+        };
+        
         $update_by_id = function ( int $coupon_id ) {
             $coupon = $this->wc->maybe_get_coupon( $coupon_id );
             if ( $coupon instanceof WC_Coupon) {
-               $this->update_coupon_job->schedule( [ $coupon_id ] );
+                $this->update_coupon_job->schedule( [ $coupon_id ] );
             }
         };
         
@@ -85,14 +96,42 @@ class SyncerHooks implements Service, Registerable {
         };
         
         // when a coupon is added / updated, schedule a update job.
-        add_action( 'woocommerce_new_coupon', $update_by_id, 90, 2 );
-        add_action( 'woocommerce_update_coupon', $update_by_id, 90, 2 );
+        add_action( 'woocommerce_new_coupon', $update_by_object, 90, 2 );
+        add_action( 'woocommerce_update_coupon', $update_by_object, 90, 2 );
         // when a product is trashed or removed, schedule a delete job.
         add_action( 'woocommerce_delete_coupon', $delete_by_id, 90, 2);
         add_action( 'woocommerce_trash_coupon', $delete_by_id, 90, 2);
         
         // when a coupon is restored from trash, schedule a update job.
         add_action( 'untrashed_post', $update_by_id, 90 );
+    }
+    
+    /**
+     * Handle updating of a coupon.
+     *
+     * @param WC_Coupon $coupon The coupon being saved.
+     *
+     * @return void
+     */
+    protected function handle_update_coupon( WC_Coupon $coupon ) {
+        $coupon_id = $coupon->get_id();
+        
+        // Schedule an update job if product sync is enabled.
+        if ( $this->coupon_helper->is_sync_ready( $coupon ) ) {
+            $this->coupon_helper->mark_as_pending( $coupon );
+            $this->update_coupon_job->schedule( [ $coupon_id ] );
+        } elseif ( $this->coupon_helper->is_coupon_synced( $coupon ) ) {
+            // Delete the coupon from Google Merchant Center if it's already synced BUT it is not sync ready after the edit.
+            $this->delete_coupon_job->schedule( [ $coupon_id ] );
+            
+            do_action(
+                'woocommerce_gla_debug_message',
+                sprintf( 'Deleting coupon (ID: %s) from Google Merchant Center because it is not ready to be synced.', $coupon->get_id() ),
+                __METHOD__
+            );
+        } else {
+            $this->coupon_helper->mark_as_unsynced( $coupon );
+        }
     }
 }
 

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateCoupon;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use WC_Coupon;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -73,7 +74,10 @@ class SyncerHooks implements Service, Registerable {
         }
         
         $update_by_id = function ( int $coupon_id ) {
-            $this->update_coupon_job->schedule( [ $coupon_id ] );
+            $coupon = $this->wc->maybe_get_coupon( $coupon_id );
+            if ( $coupon instanceof WC_Coupon) {
+               $this->update_coupon_job->schedule( [ $coupon_id ] );
+            }
         };
         
         $delete_by_id = function ( int $coupon_id ) {
@@ -87,7 +91,8 @@ class SyncerHooks implements Service, Registerable {
         add_action( 'woocommerce_delete_coupon', $delete_by_id, 90, 2);
         add_action( 'woocommerce_trash_coupon', $delete_by_id, 90, 2);
         
-        // TODO: trigger update job for coupon restore from trash
+        // when a coupon is restored from trash, schedule a update job.
+        add_action( 'untrashed_post', $update_by_id, 90 );
     }
 }
 

--- a/src/Coupon/WCCouponAdapter.php
+++ b/src/Coupon/WCCouponAdapter.php
@@ -1,0 +1,250 @@
+<?php
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Condition;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\SizeSystem;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\SizeType;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AgeGroup;
+use Automattic\WooCommerce\GoogleListingsAndAds\Validator\GooglePriceConstraint;
+use Automattic\WooCommerce\GoogleListingsAndAds\Validator\Validatable;
+use DateInterval;
+use Google\Service\ShoppingContent\PriceAmount as GooglePriceAmount;
+use Google\Service\ShoppingContent\Promotion as GooglePromotion;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use WC_DateTime;
+use WC_Coupon;
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Class WCCouponAdapter
+ *
+ * This class adapts the WooCommerce coupon class to the Google's Promotion class by mapping their attributes.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
+ */
+class WCProductAdapter extends GooglePromotion implements Validatable {
+    use PluginHelper;
+
+    public const CHANNEL_ONLINE = 'ONLINE';
+
+    public const PRODUCT_APPLICABILITY_ALL_PRODUCTS = 'ALL_PRODUCTS';
+
+    public const PRODUCT_APPLICABILITY_PRODUCT_SPECIFIC = 'PRODUCT_SPECIFIC';
+
+    public const OFFER_TYPE_GENERIC_CODE = 'GENERIC_CODE';
+
+    public const WC_DISCOUNT_TYPE_PERCENT = 'percent';
+
+    public const WC_DISCOUNT_TYPE_FIXED_CART = 'fixed_cart';
+
+    public const WC_DISCOUNT_TYPE_FIXED_PRODUCT = 'fixed_product';
+
+    public const COUPON_VALUE_TYPE_MONEY_OFF = 'MONEY_OFF';
+
+    public const COUPON_VALUE_TYPE_PERCENT_OFF = 'PERCENT_OFF';
+
+    /**
+     * Initialize this object's properties from an array.
+     *
+     * @param array $array
+     *            Used to seed this object's properties.
+     *            
+     * @return void
+     *
+     * @throws InvalidValue When a WooCommerce coupon is not provided or it is invalid.
+     */
+    public function mapTypes( $array ) {
+        if ( empty( $array['wc_coupon'] ) ||
+            ! $array['wc_coupon'] instanceof WC_Coupon ) {
+            throw InvalidValue::not_instance_of( WC_Coupon::class, 'wc_coupon' );
+        }
+
+        $wc_coupon = $array['wc_coupon'];
+        $this->map_woocommerce_coupon( $wc_coupon );
+
+        // Google doesn't expect extra fields, so it's best to remove them
+        unset( $array['wc_coupn'] );
+
+        parent::mapTypes( $array );
+    }
+
+    /**
+     * Map the WooCommerce coupon attributes to the current class.
+     *
+     * @return void
+     */
+    protected function map_woocommerce_coupon( WC_Coupon $wc_coupon ) {
+        $this->setRedemptionChannel( self::CHANNEL_ONLINE );
+
+        $content_language = empty( get_locale() ) ? 'en' : strtolower( 
+            substr( get_locale(), 0, 2 ) ); // ISO 639-1.
+        $this->setContentLanguage( $content_language );
+
+        $this->map_wc_coupon_id( $wc_coupon )
+            ->map_wc_general_attributes( $wc_coupon )
+            ->map_wc_usage_restriction( $wc_coupon );
+    }
+
+    /**
+     * Map the WooCommerce coupon ID.
+     *
+     * @return $this
+     */
+    protected function map_wc_coupon_id( WC_Coupon $wc_coupon ): WCCouponAdapter {
+        $coupon_id = "{$this->get_slug()}_{$this->wc_coupon->get_id()}";
+        $this->setPromotionId( $coupon_id );
+
+        return $this;
+    }
+
+    /**
+     * Map the general WooCommerce coupon attributes.
+     *
+     * @return $this
+     */
+    protected function map_wc_general_attributes( WC_Coupon $wc_coupon ): WCCouponAdapter {
+        $this->setOfferType( self::OFFER_TYPE_GENERIC_CODE );
+        $this->setGenericRedemptionCode( $this->wc_coupon->get_code() );
+
+        $coupon_amount = $this->wc_coupon->get_amount();
+        if ( $this->wc_coupon->is_type( self::WC_DISCOUNT_TYPE_PERCENT ) ) {
+            $this->setCouponValueType( self::COUPON_VALUE_TYPE_PERCENT_OFF );
+            $this->setPercentOff( round( $coupon_amount ) );
+        } else if ( $this->wc_coupon->is_type( 
+            [
+                self::WC_DISCOUNT_TYPE_FIXED_CART,
+                self::WC_DISCOUNT_TYPE_FIXED_PRODUCT
+            ] ) ) {
+            $this->setCouponValueType( self::COUPON_VALUE_TYPE_MONEY_OFF );
+            $this->setMoneyOffAmount( map_google_price_amount( $coupon_amount ) );
+        }
+
+        $this->setPromotionEffectiveDates( 
+            $this->get_wc_coupon_effective_dates( 
+                $wc_coupon->get_date_expires() ) );
+
+        return $this;
+    }
+
+    /**
+     * Return the effective dates for the WooCommerce couopon.
+     *
+     *
+     * @return string|null
+     */
+    protected function get_wc_coupon_effective_dates( WC_DateTime $end_date ): ?string {
+        // TODO: Get start effective date when allows to upload coupons that start in the future.
+        $now = new WC_DateTime();
+
+        if ( empty( $end_date ) ) {
+            return null;
+        }
+
+        // if we have a sale end date in the future, but no start date, set the start date to now()
+        if ( ! empty( $end_date ) && $end_date < $now ) {
+            $end_date = $now;
+        }
+        return sprintf( '%s/%s', (string) $now, (string) $end_date );
+    }
+
+    /**
+     * Map the WooCommerce coupon usage restriction.
+     *
+     * @return $this
+     */
+    protected function map_wc_usage_restriction( WC_Coupon $wc_coupon ): WCCouponAdapter {
+        $minimal_spend = $this->wc_coupon->get_minimum_amount();
+        if ( isset( $minimal_spend ) ) {
+            $this->setMinimumPurchaseAmount( 
+                map_google_price_amount( $minimal_spend ) );
+        }
+
+        $maximal_spend = $this->wc_coupon->get_maximum_amount();
+        if ( isset( $maximal_spend ) ) {
+            $this->setLimitValue( map_google_price_amount( $maximal_spend ) );
+        }
+
+        $has_product_restriction = false;
+        $wc_product_ids = $this->wc_coupon->get_product_ids();
+        if ( ! empty( $wc_product_ids ) ) {
+            $has_product_restriction = true;
+            $this->setItemId( $wc_product_ids );
+        }
+
+        $wc_exclued_product_ids = $this->wc_coupon->get_excluded_product_ids();
+        if ( ! empty( $wc_exclued_product_ids ) ) {
+            $has_product_restriction = true;
+            $this->setItemId( $wc_exclued_product_ids );
+        }
+
+        $wc_product_categories = $this->wc_coupon->get_product_categories();
+        if ( ! empty( $wc_product_categories ) ) {
+            $has_product_restriction = true;
+            // TODO: add proudct category resriction mappings.
+        }
+
+        $wc_exclued_product_categories = $this->wc_coupon->get_excluded_product_categories();
+        if ( ! empty( $wc_exclued_product_categories ) ) {
+            $has_product_restriction = true;
+            // TODO: add proudct category resriction mappings.
+        }
+
+        if ( $has_product_restriction ) {
+            $this->setProductApplicability( 
+                self::PRODUCT_APPLICABILITY_PRODUCT_SPECIFIC );
+        } else {
+            $this->setProductApplicability( 
+                self::PRODUCT_APPLICABILITY_ALL_PRODUCTS );
+        }
+    }
+
+    /**
+     * Map WooCommerce price number to Google price structure.
+     *
+     * @return GooglePriceAmount
+     */
+    protected function map_google_price_amount( $wc_amount ): GooglePriceAmount {
+        return new GooglePriceAmount( 
+            [
+                'currency' => get_woocommerce_currency(),
+                'value' => $wc_amount
+            ] );
+    }
+
+    /**
+     *
+     * @param ClassMetadata $metadata
+     */
+    public static function load_validator_metadata( ClassMetadata $metadata ) {
+        $metadata->addPropertyConstraint( 
+            'genericRedemptionCode',
+            new Assert\NotBlank() );
+    }
+
+    /**
+     * Update google promotion for a deleted or disabled WooCommerce coupon.
+     *
+     * phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+     */
+    public function disableCoupon() {
+        $end_date = new WC_DateTime();
+        $start_date = $end_date;
+        $this->setPromotionEffectiveDates( 
+            sprintf( '%s/%s', (string) $start_date, (string) $end_date ) );
+    }
+
+    /**
+     *
+     * @param string $targetCountry
+     *            phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+     */
+    public function setTargetCountry( $targetCountry ) {
+        // set the new target country
+        parent::setTargetCountry( $targetCountry );
+    }
+}

--- a/src/Exception/InvalidValue.php
+++ b/src/Exception/InvalidValue.php
@@ -85,6 +85,17 @@ class InvalidValue extends LogicException implements GoogleListingsAndAdsExcepti
 	}
 
 	/**
+	 * Create a new instance of the exception when a value isn't a valid coupon ID.
+	 *
+	 * @param mixed $value The provided coupon ID that isn't valid.
+	 *
+	 * @return static
+	 */
+	public static function not_valid_coupon_id( $value ): InvalidValue {
+	    return new static( sprintf( 'Invalid coupon ID: %s', $value ) );
+	}
+	
+	/**
 	 * Create a new instance of the exception when a value isn't a valid product ID.
 	 *
 	 * @param mixed $value The provided product ID that isn't valid.

--- a/src/Google/DeleteCouponEntry.php
+++ b/src/Google/DeleteCouponEntry.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\WCCouponAdapter;
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Class DeleteCouponEntry
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Google
+ */
+class DeleteCouponEntry {
+
+    /**
+     *
+     * @var WCCouponAdapter
+     */
+    protected $coupon;
+
+    /**
+     *
+     * @var array List of country to google promotion id mappings
+     */
+    protected $synced_google_ids;
+
+    /**
+     * BatchProductRequestEntry constructor.
+     *
+     * @param WCCouponAdapter $coupon
+     * @param array $synced_google_ids
+     */
+    public function __construct( 
+        WCCouponAdapter $coupon,
+        array $synced_google_ids ) {
+        $this->coupon = $coupon;
+        $this->synced_google_ids = $synced_google_ids;
+    }
+
+    /**
+     *
+     * @return WCCouponAdapter
+     */
+    public function get_couopn(): WCCouponAdapter {
+        return $this->coupon;
+    }
+
+    /**
+     *
+     * @return int
+     */
+    public function get_synced_google_ids(): int {
+        return $this->synced_google_ids;
+    }
+}

--- a/src/Google/DeleteCouponEntry.php
+++ b/src/Google/DeleteCouponEntry.php
@@ -41,7 +41,7 @@ class DeleteCouponEntry {
      *
      * @return WCCouponAdapter
      */
-    public function get_couopn(): WCCouponAdapter {
+    public function get_coupon(): WCCouponAdapter {
         return $this->coupon;
     }
 

--- a/src/Google/DeleteCouponEntry.php
+++ b/src/Google/DeleteCouponEntry.php
@@ -47,9 +47,9 @@ class DeleteCouponEntry {
 
     /**
      *
-     * @return int
+     * @return array
      */
-    public function get_synced_google_ids(): int {
+    public function get_synced_google_ids(): array {
         return $this->synced_google_ids;
     }
 }

--- a/src/Google/GooglePromotionService.php
+++ b/src/Google/GooglePromotionService.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Google\Exception as GoogleException;
+use Google\Service\ShoppingContent;
+use Google\Service\ShoppingContent\Promotion as GooglePromotion;
+defined('ABSPATH') || exit();
+
+/**
+ * Class GooglePromotionService
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Google
+ */
+class GooglePromotionService implements OptionsAwareInterface, Service {
+
+    use OptionsAwareTrait;
+    use ValidateInterface;
+
+    public const INTERNAL_ERROR_REASON = 'internalError';
+
+    public const NOT_FOUND_ERROR_REASON = 'notFound';
+
+    /**
+     *
+     * @var ShoppingContent
+     */
+    protected $shopping_service;
+
+    /**
+     * GooglePromotionService constructor.
+     *
+     * @param ShoppingContent $shopping_service
+     */
+    public function __construct(ShoppingContent $shopping_service) {
+        $this->shopping_service = $shopping_service;
+    }
+
+    /**
+     *
+     * @param GooglePromotion $promotion
+     *
+     * @return GooglePromotion
+     *
+     * @throws GoogleException If there are any Google API errors.
+     */
+    public function create(GooglePromotion $promotion): GooglePromotion {
+        $merchant_id = $this->options->get_merchant_id();
+
+        return $this->shopping_service->promotions->create($merchant_id,
+            $promotion);
+    }
+}

--- a/src/Google/GooglePromotionService.php
+++ b/src/Google/GooglePromotionService.php
@@ -22,9 +22,11 @@ class GooglePromotionService implements OptionsAwareInterface, Service {
     use OptionsAwareTrait;
     use ValidateInterface;
 
-    public const INTERNAL_ERROR_REASON = 'internalError';
+    public const INTERNAL_ERROR_CODE = 500;
+    
+    public const INTERNAL_ERROR_MSG = 'Internal error';
 
-    public const NOT_FOUND_ERROR_REASON = 'notFound';
+    public const NOT_FOUND_ERROR_MSG = 'notFound';
 
     /**
      *

--- a/src/Google/InvalidCouponEntry.php
+++ b/src/Google/InvalidCouponEntry.php
@@ -91,12 +91,12 @@ class InvalidCouponEntry implements JsonSerializable {
 
     /**
      *
-     * @param string $error_reason
+     * @param int $error_code
      *
      * @return bool
      */
-    public function has_error(string $error_reason): bool {
-        return ! empty($this->errors[$error_reason]);
+    public function has_error(int $error_code): bool {
+        return ! empty($this->errors[$error_code]);
     }
 
     /**

--- a/src/Google/InvalidCouponEntry.php
+++ b/src/Google/InvalidCouponEntry.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Google;
+
+use JsonSerializable;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+defined('ABSPATH') || exit();
+
+/**
+ * Class InvalidCouponEntry
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Google
+ */
+class InvalidCouponEntry implements JsonSerializable {
+
+    /**
+     *
+     * @var int WooCommerce coupon ID.
+     */
+    protected $wc_coupon_id;
+
+    /**
+     *
+     * @var string target country of the promotion.
+     */
+    protected $target_country;
+
+    /**
+     *
+     * @var string|null Google promotion ID.
+     */
+    protected $google_promotion_id;
+
+    /**
+     *
+     * @var string[]
+     */
+    protected $errors;
+
+    /**
+     * InvalidPromotionEntry constructor.
+     *
+     * @param int $wc_promotion_id
+     * @param string[] $errors
+     * @param string $target_country
+     * @param string|null $google_promotion_id
+     *
+     */
+    public function __construct(
+        int $wc_coupon_id,
+        array $errors = [],
+        string $target_country = null,
+        string $google_promotion_id = null) {
+        $this->wc_coupon_id = $wc_coupon_id;
+        $this->target_country = $target_country;
+        $this->google_promotion_id = $google_promotion_id;
+        $this->errors = $errors;
+    }
+
+    /**
+     *
+     * @return int
+     */
+    public function get_wc_coupon_id(): int {
+        return $this->wc_coupon_id;
+    }
+
+    /**
+     *
+     * @return string|null
+     */
+    public function get_google_promotion_id(): ?string {
+        return $this->google_promotion_id;
+    }
+
+    /**
+     *
+     * @return string|null
+     */
+    public function get_target_country(): ?string {
+        return $this->target_country;
+    }
+
+    /**
+     *
+     * @return string[]
+     */
+    public function get_errors(): array {
+        return $this->errors;
+    }
+
+    /**
+     *
+     * @param string $error_reason
+     *
+     * @return bool
+     */
+    public function has_error(string $error_reason): bool {
+        return ! empty($this->errors[$error_reason]);
+    }
+
+    /**
+     *
+     * @param ConstraintViolationListInterface $violations
+     *
+     * @return InvalidPromotionEntry
+     */
+    public function map_validation_violations(
+        ConstraintViolationListInterface $violations): InvalidPromotionEntry {
+        $validation_errors = [];
+        foreach ($violations as $violation) {
+            $validation_errors[] = sprintf(
+                '[%s] %s',
+                $violation->getPropertyPath(),
+                $violation->getMessage());
+        }
+
+        $this->errors = $validation_errors;
+
+        return $this;
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+        $data = [
+            'woocommerce_id' => $this->get_wc_coupon_id(),
+            'errors' => $this->get_errors()
+        ];
+
+        if (null !== $this->get_google_promotion_id()) {
+            $data['google_id'] = $this->get_google_promotion_id();
+        }
+
+        if (null !== $this->get_target_country()) {
+            $data['google_target_country'] = $this->get_target_country();
+        }
+
+        return $data;
+    }
+}

--- a/src/GoogleHelper.php
+++ b/src/GoogleHelper.php
@@ -152,8 +152,13 @@ trait GoogleHelper {
 	 * @return array
 	 */
 	protected function get_mc_promotion_supported_countries_currencies(): array {
-	    // TODO: gradually ramp up in more countries.
 	    $supported_countries = [
+	        'AU' => 'AUD', // Australia
+	        'CA' => 'CAD', // Canada
+	        'DE' => 'EUR', // Germany
+	        'FR' => 'EUR', // France
+	        'GB' => 'GBP', // United Kingdom
+	        'IN' => 'INR', // India
 	        'US' => 'USD', // United States
 	    ];
 	    

--- a/src/GoogleHelper.php
+++ b/src/GoogleHelper.php
@@ -131,7 +131,7 @@ trait GoogleHelper {
 
 		return $supported;
 	}
-
+	
 	/**
 	 * Get an array of Google Merchant Center supported countries.
 	 *
@@ -145,7 +145,30 @@ trait GoogleHelper {
 	protected function get_mc_supported_countries( bool $include_beta = true ): array {
 		return array_keys( $this->get_mc_supported_countries_currencies( $include_beta ) );
 	}
+	
+	/**
+	 * Get an array of Google Merchant Center supported countries and currencies for promotions.
+	 *
+	 * @return array
+	 */
+	protected function get_mc_promotion_supported_countries_currencies(): array {
+	    // TODO: gradually ramp up in more countries.
+	    $supported_countries = [
+	        'US' => 'USD', // United States
+	    ];
+	    
+	    return $supported_countries;
+	}
 
+	/**
+	 * Get an array of Google Merchant Center supported countries for promotions.
+     *
+	 * @return string[]
+	 */
+	protected function get_mc_promotion_supported_countries(): array {
+	    return array_keys( $this->get_mc_promotion_supported_countries_currencies() );
+	}
+	
 	/**
 	 * Get an array of Google Merchant Center supported languages (ISO 639-1).
 	 *

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -18,10 +18,14 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\RESTControllers;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\ConnectionTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer as DBInstaller;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migrator;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\TableManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Event\ClearProductStatsCache;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GlobalSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
@@ -107,6 +111,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		ContactInformationNote::class => true,
 		CompleteSetup::class          => true,
 		CompleteSetupNote::class      => true,
+	    CouponHelper::class           => true,
+	    CouponMetaHandler::class      => true,
+	    CouponSyncer::class           => true, 
 		Dashboard::class              => true,
 		DateTimeUtility::class        => true,
 		EventTracking::class          => true,
@@ -265,6 +272,22 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			ProductHelper::class,
 			MerchantCenterService::class,
 			WC::class
+		);
+		
+		// Coupon management classes
+		$this->share_with_tags( CouponMetaHandler::class );
+		$this->share_with_tags(
+		    CouponHelper::class,
+		    CouponMetaHandler::class,
+		    WC::class,
+		    MerchantCenterService::class
+		);
+		$this->share_with_tags(
+		    CouponSyncer::class,
+		    GoogleProductService::class,
+		    CouponHelper::class,
+		    MerchantCenterService::class,
+		    WC::class
 		);
 
 		// Set up inflector for tracks classes.

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\ActivationRedirect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityMetaBox;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\CouponChannelVisibilityMetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTab;
@@ -28,7 +29,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Event\ClearProductStatsCache;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GlobalSiteTag;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\ViewFactory;
@@ -299,6 +299,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Share admin meta boxes
 		$this->conditionally_share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class );
+		$this->conditionally_share_with_tags( CouponChannelVisibilityMetaBox::class, Admin::class, CouponMetaHandler::class, CouponHelper::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( MetaBoxInitializer::class, Admin::class, MetaBoxInterface::class );
 
 		$this->share_with_tags( PHPViewFactory::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -26,6 +26,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migrator;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\TableManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Event\ClearProductStatsCache;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GlobalSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
@@ -284,8 +285,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		);
 		$this->share_with_tags(
 		    CouponSyncer::class,
-		    GoogleProductService::class,
+		    GooglePromotionService::class,
 		    CouponHelper::class,
+		    ValidatorInterface::class,
 		    MerchantCenterService::class,
 		    WC::class
 		);

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -20,6 +20,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\WPError;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\WPErrorTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
@@ -74,6 +75,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		'connect_server_root'       => true,
 		Connection::class           => true,
 		GoogleProductService::class => true,
+	    GooglePromotionService::class => true,
 		SiteVerification::class     => true,
 		Settings::class             => true,
 	];
@@ -168,6 +170,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			$this->get_connect_server_url_root( 'google/google-sv' )
 		);
 		$this->share( GoogleProductService::class, ShoppingContent::class );
+		$this->share( GooglePromotionService::class, ShoppingContent::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncerJobInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ResubmitExpiringProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteCoupon;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateCoupon;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update\CleanupProductTargetCountriesJob;
@@ -94,6 +95,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		
 		// share coupon syncer jobs.
 		$this->share_coupon_syncer_job( UpdateCoupon::class );
+		$this->share_coupon_syncer_job( DeleteCoupon::class );
 
 		$this->share_with_tags(
 			JobRepository::class,

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -30,6 +30,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update\CleanupProductTargetCountriesJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update\PluginUpdate;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -118,6 +120,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		
 		$this->share_with_tags(
 		    Coupon\SyncerHooks::class,
+		    CouponHelper::class,
 		    JobRepository::class,
 		    MerchantCenterService::class,
 		    WC::class
@@ -192,6 +195,8 @@ class JobServiceProvider extends AbstractServiceProvider {
         $this->validate_interface($class, ProductSyncerJobInterface::class);
         $this->share_action_scheduler_job(
             $class,
+            CouponHelper::class,
+            CouponSyncer::class,
             WC::class,
             MerchantCenterService::class,
             ...$arguments

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -192,6 +192,7 @@ class JobServiceProvider extends AbstractServiceProvider {
         $this->validate_interface($class, ProductSyncerJobInterface::class);
         $this->share_action_scheduler_job(
             $class,
+            WC::class,
             MerchantCenterService::class,
             ...$arguments
         );

--- a/src/Jobs/AbstractCouponSyncerJob.php
+++ b/src/Jobs/AbstractCouponSyncerJob.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 
@@ -18,6 +19,16 @@ defined( 'ABSPATH' ) || exit;
  */
 abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob implements ProductSyncerJobInterface {
 
+    /**
+     * @var CouponHelper
+     */
+    protected $coupon_helper;
+    
+    /**
+     * @var CouponSyncher
+     */
+    protected $coupon_syncer;
+    
 	/**
      * @var WC
      */
@@ -33,17 +44,20 @@ abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob implem
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor
-	 * @param CouponSyncer             $coupon_syncer
-	 * @param CouponRepository         $coupon_repository
+	 * @param CouponSyncer              $coupon_syncer
+	 * @param WC                        $wc
 	 * @param MerchantCenterService     $merchant_center
 	 */
 	public function __construct(
 		ActionSchedulerInterface $action_scheduler,
 		ActionSchedulerJobMonitor $monitor,
-		//CouponSyncer $coupon_syncer,
+	    CouponHelper $coupon_helper,
+		CouponSyncer $coupon_syncer,
 	    WC $wc,
 		MerchantCenterService $merchant_center
 	) {
+	    $this->coupon_helper = $coupon_helper;
+	    $this->coupon_syncer = $coupon_syncer;
 	    $this->wc  = $wc;
 		$this->merchant_center    = $merchant_center;
 		parent::__construct( $action_scheduler, $monitor );

--- a/src/Jobs/AbstractCouponSyncerJob.php
+++ b/src/Jobs/AbstractCouponSyncerJob.php
@@ -1,0 +1,76 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AbstractCouponSyncerJob
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
+ */
+abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob implements ProductSyncerJobInterface {
+
+	/**
+	 * @var ProductSyncer
+	 */
+	//protected $coupon_syncer;
+
+	/**
+	 * @var ProductRepository
+	 */
+	//protected $coupon_repository;
+
+	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
+	 * SyncProducts constructor.
+	 *
+	 * @param ActionSchedulerInterface  $action_scheduler
+	 * @param ActionSchedulerJobMonitor $monitor
+	 * @param CouponSyncer             $coupon_syncer
+	 * @param CouponRepository         $coupon_repository
+	 * @param MerchantCenterService     $merchant_center
+	 */
+	public function __construct(
+		ActionSchedulerInterface $action_scheduler,
+		ActionSchedulerJobMonitor $monitor,
+		//CouponSyncer $coupon_syncer,
+		//CouponRepository $coupon_repository,
+		MerchantCenterService $merchant_center
+	) {
+	//	$this->coupon_syncer     = $coupon_syncer;
+	//	$this->coupon_repository = $coupon_repository;
+		$this->merchant_center    = $merchant_center;
+		parent::__construct( $action_scheduler, $monitor );
+	}
+
+	/**
+	 * Get whether Merchant Center is connected.
+	 *
+	 * @return bool
+	 */
+	public function is_mc_connected(): bool {
+		return $this->merchant_center->is_connected();
+	}
+
+	/**
+	 * Can the job be scheduled.
+	 *
+	 * @param array|null $args
+	 *
+	 * @return bool Returns true if the job can be scheduled.
+	 */
+	public function can_schedule( $args = [] ): bool {
+		return ! $this->is_running( $args ) && $this->is_mc_connected();
+	}
+}

--- a/src/Jobs/AbstractCouponSyncerJob.php
+++ b/src/Jobs/AbstractCouponSyncerJob.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -18,14 +19,9 @@ defined( 'ABSPATH' ) || exit;
 abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob implements ProductSyncerJobInterface {
 
 	/**
-	 * @var ProductSyncer
-	 */
-	//protected $coupon_syncer;
-
-	/**
-	 * @var ProductRepository
-	 */
-	//protected $coupon_repository;
+     * @var WC
+     */
+    protected $wc;
 
 	/**
 	 * @var MerchantCenterService
@@ -45,11 +41,10 @@ abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob implem
 		ActionSchedulerInterface $action_scheduler,
 		ActionSchedulerJobMonitor $monitor,
 		//CouponSyncer $coupon_syncer,
-		//CouponRepository $coupon_repository,
+	    WC $wc,
 		MerchantCenterService $merchant_center
 	) {
-	//	$this->coupon_syncer     = $coupon_syncer;
-	//	$this->coupon_repository = $coupon_repository;
+	    $this->wc  = $wc;
 		$this->merchant_center    = $merchant_center;
 		parent::__construct( $action_scheduler, $monitor );
 	}

--- a/src/Jobs/DeleteCoupon.php
+++ b/src/Jobs/DeleteCoupon.php
@@ -30,11 +30,16 @@ class DeleteCoupon extends AbstractCouponSyncerJob implements StartOnHookInterfa
 	 *
 	 * @param  int $coupon_id
 	 *
-	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
-	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
+	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
+	 * @throws JobException If invalid or non-existing coupon are provided. The exception will be logged by ActionScheduler.
 	 */
 	public function process_items( $coupon_id ) {
-		// TODO read coupon data, check if coupon is synced, and delete synchorized coupon from Google.
+	    $coupon = $this->$wc->may_get_coupon( $coupon_id );
+	    if ( $coupon instanceof WC_Coupon && $this->coupon_helper->is_sync_ready( $coupon ) ) {
+	       return;
+	    }
+	    // TODO: Pass in google id to support delete coupon.
+	    $this->$coupon_syncer->delete( $coupon_id );
 	}
 
 	/**

--- a/src/Jobs/DeleteCoupon.php
+++ b/src/Jobs/DeleteCoupon.php
@@ -1,0 +1,67 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class DeleteCoupon
+ *
+ * Delete existing WooCommerce coupon from Google Merchant Center.
+ *
+ * Note: The job will not start if it is already running.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
+ */
+class DeleteCoupon extends AbstractCouponSyncerJob implements StartOnHookInterface {
+
+	/**
+	 * Get the name of the job.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'delete_coupon';
+	}
+
+	/**
+	 * Process an item.
+	 *
+	 * @param  int $coupon_id
+	 *
+	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
+	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
+	 */
+	public function process_items( $coupon_id ) {
+		// TODO read coupon data, check if coupon is synced, and delete synchorized coupon from Google.
+	}
+
+	/**
+	 * Schedule the job.
+	 *
+	 * @param array[] $args
+	 * 
+	 * @throws JobException If no product is provided as argument. The exception will be logged by ActionScheduler.
+	 */
+	public function schedule(array $args = []) {
+	    $coupon_id = $args[0] ?? null;
+
+	    if ( !is_int( $coupon_id ) ) {
+	        throw JobException::item_not_provided( 'WooCommerce Coupon IDs' );
+	    }
+	    
+	    if ( $this->can_schedule( [ $coupon_id ] ) ) {
+	        $this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), [ $coupon_id ] );
+		}
+	}
+
+	/**
+	 * Get the name of an action hook to attach the job's start method to.
+	 *
+	 * @return StartHook
+	 */
+	public function get_start_hook(): StartHook {
+		return new StartHook( "{$this->get_hook_base_name()}start" );
+	}
+}

--- a/src/Jobs/DeleteCoupon.php
+++ b/src/Jobs/DeleteCoupon.php
@@ -1,9 +1,9 @@
 <?php
-declare( strict_types=1 );
-
+declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
-defined( 'ABSPATH' ) || exit;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\DeleteCouponEntry;
+defined( 'ABSPATH' ) || exit();
 
 /**
  * Class DeleteCoupon
@@ -14,59 +14,60 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-class DeleteCoupon extends AbstractCouponSyncerJob implements StartOnHookInterface {
+class DeleteCoupon extends AbstractCouponSyncerJob implements 
+    StartOnHookInterface {
 
-	/**
-	 * Get the name of the job.
-	 *
-	 * @return string
-	 */
-	public function get_name(): string {
-		return 'delete_coupon';
-	}
+    /**
+     * Get the name of the job.
+     *
+     * @return string
+     */
+    public function get_name(): string {
+        return 'delete_coupon';
+    }
 
-	/**
-	 * Process an item.
-	 *
-	 * @param  int $coupon_id
-	 *
-	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
-	 * @throws JobException If invalid or non-existing coupon are provided. The exception will be logged by ActionScheduler.
-	 */
-	public function process_items( $coupon_id ) {
-	    $coupon = $this->$wc->may_get_coupon( $coupon_id );
-	    if ( $coupon instanceof WC_Coupon && $this->coupon_helper->is_sync_ready( $coupon ) ) {
-	       return;
-	    }
-	    // TODO: Pass in google id to support delete coupon.
-	    $this->$coupon_syncer->delete( $coupon_id );
-	}
+    /**
+     * Process an item.
+     *
+     * @param DeleteCouponEntry[] $coupon
+     *
+     * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
+     * @throws JobException If invalid or non-existing coupon are provided. The exception will be logged by ActionScheduler.
+     */
+    public function process_items( array $coupons ) {
+        foreach ( $coupons as $coupon ) {
+            $this->$coupon_syncer->delete( $coupon );
+        }
+    }
 
-	/**
-	 * Schedule the job.
-	 *
-	 * @param array[] $args
-	 * 
-	 * @throws JobException If no product is provided as argument. The exception will be logged by ActionScheduler.
-	 */
-	public function schedule(array $args = []) {
-	    $coupon_id = $args[0] ?? null;
+    /**
+     * Schedule the job.
+     *
+     * @param array[] $args
+     *
+     * @throws JobException If no product is provided as argument. The exception will be logged by ActionScheduler.
+     */
+    public function schedule( array $args = [] ) {
+        $coupon = $args[0] ?? null;
 
-	    if ( !is_int( $coupon_id ) ) {
-	        throw JobException::item_not_provided( 'WooCommerce Coupon IDs' );
-	    }
-	    
-	    if ( $this->can_schedule( [ $coupon_id ] ) ) {
-	        $this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), [ $coupon_id ] );
-		}
-	}
+        if ( ! $coupon instanceof DeleteCouponEntry ) {
+            throw JobException::item_not_provided( 
+                'DeleteCouponEntry for the coupon to delete' );
+        }
 
-	/**
-	 * Get the name of an action hook to attach the job's start method to.
-	 *
-	 * @return StartHook
-	 */
-	public function get_start_hook(): StartHook {
-		return new StartHook( "{$this->get_hook_base_name()}start" );
-	}
+        if ( $this->can_schedule( [$coupon] ) ) {
+            $this->action_scheduler->schedule_immediate( 
+                $this->get_process_item_hook(),
+                [$coupon] );
+        }
+    }
+
+    /**
+     * Get the name of an action hook to attach the job's start method to.
+     *
+     * @return StartHook
+     */
+    public function get_start_hook(): StartHook {
+        return new StartHook( "{$this->get_hook_base_name()}start" );
+    }
 }

--- a/src/Jobs/UpdateCoupon.php
+++ b/src/Jobs/UpdateCoupon.php
@@ -3,8 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncerException;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -36,14 +34,7 @@ class UpdateCoupon extends AbstractCouponSyncerJob implements StartOnHookInterfa
 	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
 	 */
 	public function process_items( $coupon_id ) {
-		/*$args     = [ 'include' => $product_ids ];
-		$products = $this->product_repository->find_sync_ready_products( $args )->get();
-
-		if ( empty( $products ) ) {
-			throw JobException::item_not_found();
-		}
-
-		$this->product_syncer->update( $products );*/
+		// TODO read coupon data, upsert coupon to Google and mark coupon as synchronized.
 	}
 
 	/**

--- a/src/Jobs/UpdateCoupon.php
+++ b/src/Jobs/UpdateCoupon.php
@@ -34,7 +34,12 @@ class UpdateCoupon extends AbstractCouponSyncerJob implements StartOnHookInterfa
 	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
 	 */
 	public function process_items( $coupon_id ) {
-		// TODO read coupon data, upsert coupon to Google and mark coupon as synchronized.
+	    $coupon = $this->$wc->may_get_coupon( $coupon_id );
+	    if ( $coupon instanceof WC_Coupon && $this->coupon_helper->is_sync_ready( $coupon ) ) {
+	       $this->$coupon_syncer->update( $coupon );
+	       // TODO: Update sync status with google id and targeted country or log the sync errors.
+	       // $this->coupon_helper->mark_as_synced( $coupon, $google_id, $country);
+	    }
 	}
 
 	/**

--- a/src/Jobs/UpdateCoupon.php
+++ b/src/Jobs/UpdateCoupon.php
@@ -1,9 +1,8 @@
 <?php
-declare( strict_types=1 );
-
+declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
-defined( 'ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit();
 
 /**
  * Class UpdateCoupon
@@ -14,59 +13,64 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-class UpdateCoupon extends AbstractCouponSyncerJob implements StartOnHookInterface {
+class UpdateCoupon extends AbstractCouponSyncerJob implements 
+    StartOnHookInterface {
 
-	/**
-	 * Get the name of the job.
-	 *
-	 * @return string
-	 */
-	public function get_name(): string {
-		return 'update_coupon';
-	}
+    /**
+     * Get the name of the job.
+     *
+     * @return string
+     */
+    public function get_name(): string {
+        return 'update_coupon';
+    }
 
-	/**
-	 * Process an item.
-	 *
-	 * @param  int $coupon_id
-	 *
-	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
-	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
-	 */
-	public function process_items( $coupon_id ) {
-	    $coupon = $this->$wc->may_get_coupon( $coupon_id );
-	    if ( $coupon instanceof WC_Coupon && $this->coupon_helper->is_sync_ready( $coupon ) ) {
-	       $this->$coupon_syncer->update( $coupon );
-	       // TODO: Update sync status with google id and targeted country or log the sync errors.
-	       // $this->coupon_helper->mark_as_synced( $coupon, $google_id, $country);
-	    }
-	}
+    /**
+     * Process an item.
+     *
+     * @param int[] $coupon_ids
+     *
+     * @throws SyncerException If an error occurs. The exception will be logged by ActionScheduler.
+     * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
+     */
+    public function process_items( $coupon_ids ) {
+        foreach ( $coupon_ids as $coupon_id ) {
+            $coupon = $this->$wc->may_get_coupon( $coupon_id );
+            if ( 
+                $coupon instanceof WC_Coupon &&
+                $this->coupon_helper->is_sync_ready( $coupon ) ) {
+                $this->$coupon_syncer->update( $coupon );
+            }
+        }
+    }
 
-	/**
-	 * Schedule the job.
-	 *
-	 * @param array[] $args
-	 * 
-	 * @throws JobException If no product is provided as argument. The exception will be logged by ActionScheduler.
-	 */
-	public function schedule(array $args = []) {
-	    $coupon_id = $args[0] ?? null;
+    /**
+     * Schedule the job.
+     *
+     * @param array[] $args
+     *
+     * @throws JobException If no product is provided as argument. The exception will be logged by ActionScheduler.
+     */
+    public function schedule( array $args = [] ) {
+        $coupon_id = $args[0] ?? null;
 
-	    if ( !is_int( $coupon_id ) ) {
-	        throw JobException::item_not_provided( 'WooCommerce Coupon IDs' );
-	    }
-	    
-	    if ( $this->can_schedule( [ $coupon_id ] ) ) {
-	        $this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), [ $coupon_id ] );
-		}
-	}
+        if ( ! is_int( $coupon_id ) ) {
+            throw JobException::item_not_provided( 'WooCommerce Coupon IDs' );
+        }
 
-	/**
-	 * Get the name of an action hook to attach the job's start method to.
-	 *
-	 * @return StartHook
-	 */
-	public function get_start_hook(): StartHook {
-		return new StartHook( "{$this->get_hook_base_name()}start" );
-	}
+        if ( $this->can_schedule( [$coupon_id] ) ) {
+            $this->action_scheduler->schedule_immediate( 
+                $this->get_process_item_hook(),
+                [$coupon_id] );
+        }
+    }
+
+    /**
+     * Get the name of an action hook to attach the job's start method to.
+     *
+     * @return StartHook
+     */
+    public function get_start_hook(): StartHook {
+        return new StartHook( "{$this->get_hook_base_name()}start" );
+    }
 }

--- a/src/Jobs/UpdateCoupon.php
+++ b/src/Jobs/UpdateCoupon.php
@@ -1,0 +1,76 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncerException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class UpdateCoupon
+ *
+ * Submits WooCommerce coupon to Google Merchant Center and/or updates the existing one.
+ *
+ * Note: The job will not start if it is already running.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
+ */
+class UpdateCoupon extends AbstractCouponSyncerJob implements StartOnHookInterface {
+
+	/**
+	 * Get the name of the job.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'update_coupon';
+	}
+
+	/**
+	 * Process an item.
+	 *
+	 * @param  int $coupon_id
+	 *
+	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
+	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
+	 */
+	public function process_items( $coupon_id ) {
+		/*$args     = [ 'include' => $product_ids ];
+		$products = $this->product_repository->find_sync_ready_products( $args )->get();
+
+		if ( empty( $products ) ) {
+			throw JobException::item_not_found();
+		}
+
+		$this->product_syncer->update( $products );*/
+	}
+
+	/**
+	 * Schedule the job.
+	 *
+	 * @param array[] $args
+	 * 
+	 * @throws JobException If no product is provided as argument. The exception will be logged by ActionScheduler.
+	 */
+	public function schedule(array $args = []) {
+	    $coupon_id = $args[0] ?? null;
+
+	    if ( !is_int( $coupon_id ) ) {
+	        throw JobException::item_not_provided( 'WooCommerce Coupon IDs' );
+	    }
+	    
+	    if ( $this->can_schedule( [ $coupon_id ] ) ) {
+	        $this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), [ $coupon_id ] );
+		}
+	}
+
+	/**
+	 * Get the name of an action hook to attach the job's start method to.
+	 *
+	 * @return StartHook
+	 */
+	public function get_start_hook(): StartHook {
+		return new StartHook( "{$this->get_hook_base_name()}start" );
+	}
+}

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -185,6 +185,18 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 		return in_array( $shop_country, $target_countries, true ) ? $shop_country : $target_countries[0];
 	}
+	
+	/**
+	 * Return if the given country is supported to have promotions on Google.
+	 */
+	protected function is_promotion_supported_country(string $country = ''): bool {
+	    // Default to WooCommerce store country
+	    if ( empty( $country ) ) {
+	        $country = $this->container->get( WC::class )->get_base_country();
+	    }
+	    
+	    return array_key_exists( $country, $this->get_mc_promotion_supported_countries() );
+	}
 
 	/**
 	 * Get the connected merchant account.

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -189,7 +189,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	/**
 	 * Return if the given country is supported to have promotions on Google.
 	 */
-	protected function is_promotion_supported_country(string $country = ''): bool {
+	public function is_promotion_supported_country(string $country = ''): bool {
 	    // Default to WooCommerce store country
 	    if ( empty( $country ) ) {
 	        $country = $this->container->get( WC::class )->get_base_country();

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -4,8 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Proxies;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
-use WC_Product;
 use WC_Countries;
+use WC_Coupon;
+use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -102,5 +103,24 @@ class WC {
 		}
 
 		return $product;
+	}
+	
+	/**
+	 * Get a WooCommerce coupon if it exists or return null if it doesn't
+	 *
+	 * @param int $coupon_id
+	 *
+	 * @return WC_Coupon|null
+	 */
+	public function maybe_get_coupon( int $coupon_id ): ?WC_Coupon {
+	    try {
+	        $coupon = new WC_Coupon( $coupon_id );
+	        if (!$coupon->get_id()>0) {
+	           return null;
+	        }
+	        return $coupon;
+	    } catch ( Exception $e ) {
+	        return null;
+	    }
 	}
 }

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -106,6 +106,23 @@ class WC {
 	}
 	
 	/**
+	 * Get a WooCommerce coupon and confirm it exists.
+	 *
+	 * @param int $coupon_id
+	 *
+	 * @return WC_Coupon
+	 *
+	 * @throws InvalidValue When the coupon does not exist.
+	 */
+	public function get_coupon( int $coupon_id ): WC_Coupon {
+	   $coupon = new WC_Coupon( $coupon_id );
+	   if ( $coupon->get_id() === 0 ) {
+	       throw InvalidValue::not_valid_coupon_id( $coupon_id );
+	   }
+        return $coupon;
+	}
+
+	/**
 	 * Get a WooCommerce coupon if it exists or return null if it doesn't
 	 *
 	 * @param int $coupon_id
@@ -113,14 +130,10 @@ class WC {
 	 * @return WC_Coupon|null
 	 */
 	public function maybe_get_coupon( int $coupon_id ): ?WC_Coupon {
-	    try {
-	        $coupon = new WC_Coupon( $coupon_id );
-	        if (!$coupon->get_id()>0) {
-	           return null;
-	        }
-	        return $coupon;
-	    } catch ( Exception $e ) {
-	        return null;
-	    }
+	   $coupon = new WC_Coupon( $coupon_id );
+       if ( $coupon->get_id() === 0 ) {
+	       return null;
+	   }
+	   return $coupon;
 	}
 }

--- a/tests/Tools/HelperTrait/CouponTrait.php
+++ b/tests/Tools/HelperTrait/CouponTrait.php
@@ -2,6 +2,8 @@
 declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use Google\Service\ShoppingContent\Promotion as GooglePromotion;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Coupon;
 
@@ -29,13 +31,45 @@ trait CouponTrait {
     }
 
     /**
-     * Creates a simple valid WC_Coupon object
+     * Creates a valid WC_Coupon object
+     *
+     * @return WC_Coupon
+     */
+    public function create_simple_coupon() {
+        $coupon = new WC_Coupon();
+        $coupon->set_code( sprintf( 'ready_to_sync_coupon_%d', rand() ) );
+        $coupon->set_amount( 10 );
+        $coupon->set_discount_type( 'percent' );
+        $coupon->set_free_shipping( true );
+        $coupon->save();
+
+        return $coupon;
+    }
+
+    /**
+     * Creates a ready-to-sync WC_Coupon object
      *
      * @return WC_Coupon
      */
     public function create_ready_to_sync_coupon() {
-        $coupon = new WC_Coupon();
-        $coupon->set_code( 'ready_to_sync_coupon' + rand() );
+        $coupon = $this->create_simple_coupon();
+        $coupon->update_meta_data( '_wc_gla_visibility', 'sync-and-show' );
+        $coupon->save();
+
+        return $coupon;
+    }
+
+    /**
+     * Creates a ready-to-delete WC_Coupon object
+     *
+     * @return WC_Coupon
+     */
+    public function create_ready_to_delete_coupon() {
+        $coupon = $this->create_simple_coupon();
+        $coupon->update_meta_data( '_wc_gla_sync_status', SyncStatus::SYNCED );
+        $coupon->update_meta_data( '_wc_gla_synced_at', time() );
+        $coupon->update_meta_data( '_wc_gla_google_ids', ['US' => 'google_id'] );
+        $coupon->update_meta_data( '_wc_gla_visibility', 'sync-and-show' );
         $coupon->save();
 
         return $coupon;
@@ -55,15 +89,15 @@ trait CouponTrait {
         $promotion = $this->createMock( GooglePromotion::class );
 
         $target_country = $target_country ?: $this->get_sample_target_country();
-        $id = $id ?: "online:en:{$target_country}:gla_" . rand();
+        $id = $id ?: rand();
 
-        $product->expects( $this->any() )
+        $promotion->expects( $this->any() )
             ->method( 'getId' )
-            ->willReturn( $id );
-        $product->expects( $this->any() )
+            ->willReturn( sprintf( '%d', $id ) );
+        $promotion->expects( $this->any() )
             ->method( 'getTargetCountry' )
             ->willReturn( $target_country );
 
-        return $product;
+        return $promotion;
     }
 }

--- a/tests/Tools/HelperTrait/CouponTrait.php
+++ b/tests/Tools/HelperTrait/CouponTrait.php
@@ -1,6 +1,5 @@
 <?php
-declare( strict_types=1 );
-
+declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -12,20 +11,59 @@ use WC_Coupon;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait
  */
 trait CouponTrait {
-	use SettingsTrait;
+    use SettingsTrait;
 
-	/**
-	 * Generates and returns a mock of a simple WC_Coupon object
-	 *
-	 * @return MockObject|WC_Coupon
-	 */
-	public function generate_simple_coupon_mock() {
-		$coupon = $this->createMock( WC_Coupon::class );
+    /**
+     * Generates and returns a mock of a simple WC_Coupon object
+     *
+     * @return MockObject|WC_Coupon
+     */
+    public function generate_simple_coupon_mock() {
+        $coupon = $this->createMock( WC_Coupon::class );
 
-		$coupon->expects( $this->any() )
-				->method( 'get_id' )
-				->willReturn( rand() );
+        $coupon->expects( $this->any() )
+            ->method( 'get_id' )
+            ->willReturn( rand() );
 
-		return $coupon;
-	}
+        return $coupon;
+    }
+
+    /**
+     * Creates a simple valid WC_Coupon object
+     *
+     * @return WC_Coupon
+     */
+    public function create_ready_to_sync_coupon() {
+        $coupon = new WC_Coupon();
+        $coupon->set_code( 'ready_to_sync_coupon' + rand() );
+        $coupon->save();
+
+        return $coupon;
+    }
+
+    /**
+     * Generates and returns a mock of a Google promotion object
+     *
+     * @param string|null $id
+     * @param string|null $target_country
+     *
+     * @return MockObject|GooglePromotion
+     */
+    public function generate_google_promotion_mock( 
+        $id = null,
+        $target_country = null ) {
+        $promotion = $this->createMock( GooglePromotion::class );
+
+        $target_country = $target_country ?: $this->get_sample_target_country();
+        $id = $id ?: "online:en:{$target_country}:gla_" . rand();
+
+        $product->expects( $this->any() )
+            ->method( 'getId' )
+            ->willReturn( $id );
+        $product->expects( $this->any() )
+            ->method( 'getTargetCountry' )
+            ->willReturn( $target_country );
+
+        return $product;
+    }
 }

--- a/tests/Tools/HelperTrait/CouponTrait.php
+++ b/tests/Tools/HelperTrait/CouponTrait.php
@@ -1,0 +1,31 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Coupon;
+
+/**
+ * Trait Coupon
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait
+ */
+trait CouponTrait {
+	use SettingsTrait;
+
+	/**
+	 * Generates and returns a mock of a simple WC_Coupon object
+	 *
+	 * @return MockObject|WC_Coupon
+	 */
+	public function generate_simple_coupon_mock() {
+		$coupon = $this->createMock( WC_Coupon::class );
+
+		$coupon->expects( $this->any() )
+				->method( 'get_id' )
+				->willReturn( rand() );
+
+		return $coupon;
+	}
+}

--- a/tests/Unit/Coupon/CouponMetaHandlerTest.php
+++ b/tests/Unit/Coupon/CouponMetaHandlerTest.php
@@ -1,0 +1,141 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidMeta;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\CouponTrait;
+use BadMethodCallException;
+use WC_Coupon;
+use WP_UnitTestCase;
+
+/**
+ * Class ProductMetaHandlerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon
+ *
+ * @property CouponMetaHandler $coupon_meta_handler
+ */
+class CouponMetaHandlerTest extends WP_UnitTestCase {
+    use CouponTrait;
+
+	public function test_magic_call_throws_exception_invalid_method_name() {
+		$this->expectException( BadMethodCallException::class);
+		$this->coupon_meta_handler->in1va2lid_method();
+	}
+
+	public function test_magic_call_throws_exception_method_not_allowed() {
+		$this->expectException( BadMethodCallException::class);
+		$this->coupon_meta_handler->need_synced_at();
+	}
+
+	public function test_magic_update_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->coupon_meta_handler->update_invalid_meta_key_test( $this->generate_simple_coupon_mock(), 1 );
+	}
+
+	public function test_magic_delete_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->coupon_meta_handler->delete_invalid_meta_key_test( $this->generate_simple_coupon_mock() );
+	}
+
+	public function test_magic_get_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->coupon_meta_handler->get_invalid_meta_key_test( $this->generate_simple_coupon_mock() );
+	}
+
+	public function test_magic_call() {
+		$coupon = $this->generate_simple_coupon_mock();
+		$key     = 'synced_at';
+		$value   = 12345;
+
+		$coupon_meta_handler = $this->getMockBuilder( CouponMetaHandler::class )
+									 ->setMethodsExcept( [ '__call' ] )
+									 ->getMock();
+
+		$coupon_meta_handler->expects( $this->once() )
+							 ->method( 'update' )
+							 ->with( $this->equalTo( $coupon ), $this->equalTo( $key ), $this->equalTo( $value ) );
+		$coupon_meta_handler->update_synced_at( $coupon, $value );
+
+		$coupon_meta_handler->expects( $this->once() )
+							 ->method( 'get' )
+							 ->with( $this->equalTo( $coupon ), $this->equalTo( $key ) );
+		$coupon_meta_handler->get_synced_at( $coupon );
+
+		$coupon_meta_handler->expects( $this->once() )
+							 ->method( 'delete' )
+							 ->with( $this->equalTo( $coupon ), $this->equalTo( $key ) );
+		$coupon_meta_handler->delete_synced_at( $coupon );
+	}
+
+	public function test_update_type_cast() {
+		$coupon = new WC_Coupon();
+		$this->coupon_meta_handler->update( $coupon, CouponMetaHandler::KEY_SYNCED_AT, '12345' );
+		$value = $coupon->get_meta( '_wc_gla_synced_at', true );
+		$this->assertEquals( 12345, $value );
+	}
+
+	public function test_update() {
+	    $coupon = new WC_Coupon();
+	    $this->coupon_meta_handler->update( $coupon, CouponMetaHandler::KEY_SYNCED_AT, 12345 );
+		$value = $coupon->get_meta( '_wc_gla_synced_at', true );
+		$this->assertEquals( 12345, $value );
+	}
+
+	public function test_update_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->coupon_meta_handler->update( $this->generate_simple_coupon_mock(), 'invalid_meta_key_test', 1 );
+	}
+
+	public function test_delete() {
+	    $coupon = new WC_Coupon();
+		$coupon->update_meta_data( '_wc_gla_synced_at', 12345 );
+		$coupon->save_meta_data();
+
+		$this->coupon_meta_handler->delete( $coupon, CouponMetaHandler::KEY_SYNCED_AT );
+
+		$value = $coupon->get_meta( '_wc_gla_synced_at', true );
+		$this->assertEmpty( $value );
+	}
+
+	public function test_delete_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->coupon_meta_handler->delete( $this->generate_simple_coupon_mock(), 'invalid_meta_key_test' );
+	}
+
+	public function test_get_returns_null_if_no_value_exist() {
+		$coupon = new WC_Coupon();
+
+		$value = $this->coupon_meta_handler->get( $coupon, CouponMetaHandler::KEY_SYNCED_AT );
+		$this->assertNull( $value );
+	}
+
+	public function test_get() {
+		$coupon = new WC_Coupon();
+		$coupon->update_meta_data('_wc_gla_synced_at', 12345);
+		$coupon->save_meta_data();
+
+		$value = $this->coupon_meta_handler->get( $coupon, CouponMetaHandler::KEY_SYNCED_AT );
+		$this->assertEquals( 12345, $value );
+	}
+
+	public function test_get_throws_exception_invalid_meta_key() {
+		$this->expectException( InvalidMeta::class);
+		$this->coupon_meta_handler->get( $this->generate_simple_coupon_mock(), 'invalid_meta_key_test' );
+	}
+
+	public function test_is_meta_key_valid() {
+		$this->assertFalse( CouponMetaHandler::is_meta_key_valid( 'invalid_meta_key_test' ) );
+		$this->assertTrue( CouponMetaHandler::is_meta_key_valid( CouponMetaHandler::KEY_SYNCED_AT ) );
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->coupon_meta_handler = new CouponMetaHandler();
+	}
+}

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -1,0 +1,385 @@
+<?php
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\InvalidCouponEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncerException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\WCCouponAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\CouponTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\SettingsTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use Google\Service\ShoppingContent\Promotion as GooglePromotion;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Google\Exception as GoogleException;
+use WC_Coupon;
+
+/**
+ * Class CouponSyncerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon
+ *         
+ * @property MockObject|GooglePromotionService $google_service
+ * @property MockObject|MerchantCenterService $merchant_center
+ * @property MockObject|ValidatorInterface $validator
+ * @property CouponMetaHandler $coupon_meta
+ * @property CouponHelper $coupon_helper
+ * @property WC $wc
+ * @property CouponSyncer $coupon_syncer
+ */
+class CouponSyncerTest extends ContainerAwareUnitTest {
+
+    use SettingsTrait;
+    use CouponTrait;
+
+    public function test_update_succeed() {
+        $coupon = $this->create_ready_to_sync_coupon();
+        $this->mock_google_service( $coupon );
+        $coupon_syncer = new CouponSyncer( 
+            $this->google_service,
+            $this->coupon_helper,
+            $this->validator,
+            $this->merchant_center,
+            $this->wc );
+
+        $this->coupon_syncer->update( $coupon );
+       
+        $this->assert_successfull_update_results( 
+            $coupon,
+            $updated_promotions,
+            $invalid_promotions );
+    }
+
+    public function test_update_fail() {
+        $invalid_coupon = $this->create_ready_to_sync_coupon();
+        $exist_coupon = $this->create_ready_to_sync_coupon();
+        $this->mock_google_service( $exist_coupon );
+        $coupon_syncer = new CouponSyncer( 
+            $this->google_service,
+            $this->coupon_helper,
+            $this->validator,
+            $this->merchant_center,
+            $this->wc );
+
+        $this->coupon_syncer->update( $invalid_coupon );
+        
+        $this->assert_failed_update_results( 
+            $invalid_coupon = $invalid_coupon );
+    }
+ 
+    protected function assert_successfull_update_results( $updated_coupon ) {
+        $this->assertEquals( 1, did_action( 'woocommerce_gla_updated_coupon' ) );
+
+        $reloaded_coupon = new WC_Coupon( $updated_coupon->get_id() );
+        $this->assertTrue( 
+            $this->coupon_helper->is_coupon_synced( $reloaded_coupon ) );
+    }
+
+    protected function assert_failed_update_results() {
+        $this->assertEquals( 
+            1,
+            did_action( 'woocommerce_gla_retry_update_coupons' ) );
+        
+        $reloaded_coupon = new WC_Coupon( $updated_coupon->get_id() );
+        $this->assertNotEmpty( $this->meta_meta->get_errors( $reloaded_coupon ) );
+        $this->assertEquals( 
+            SyncStatus::HAS_ERRORS,
+            $this->product_meta->get_sync_status( $reloaded_coupon ) );
+    }
+
+    /*
+     * public function test_delete() {
+     * // $deleted_products: products that were successfully synced and then deleted from Merchant Center
+     * // $rejected_products: products that were synced but deleting them resulted in errors and were rejected by Google API
+     * [
+     * $deleted_products,
+     * $rejected_products
+     * ] = $this->create_multiple_simple_product_sets(2, 2);
+     *
+     * $this->mock_google_service($deleted_products, $rejected_products);
+     *
+     * $products = array_merge($deleted_products, $rejected_products);
+     *
+     * // first we mark all products as synced
+     * array_walk(
+     * $products,
+     * function (WC_Product $product) {
+     * $this->product_helper->mark_as_synced(
+     * $product,
+     * $this->generate_google_product_mock());
+     * });
+     *
+     * $results = $this->product_syncer->delete($products);
+     * $this->assert_delete_results_are_valid(
+     * $results,
+     * $deleted_products,
+     * $rejected_products);
+     * }
+     *
+     * protected function assert_delete_results_are_valid(
+     * $results,
+     * $deleted_products,
+     * $rejected_products) {
+     * $this->assertEquals(
+     * 1,
+     * did_action('woocommerce_gla_batch_deleted_products'));
+     * $this->assertEquals(
+     * 1,
+     * did_action('woocommerce_gla_batch_retry_delete_products'));
+     *
+     * $this->assertCount(count($deleted_products), $results->get_products());
+     * foreach ($results->get_products() as $product_entry) {
+     * $wc_product = wc_get_product($product_entry->get_wc_product_id());
+     * // product is no longer synced if delete succeeds
+     * $this->assertFalse(
+     * $this->product_helper->is_product_synced($wc_product));
+     * }
+     *
+     * $this->assertCount(count($rejected_products), $results->get_errors());
+     * foreach ($results->get_errors() as $error_entry) {
+     * $wc_product = wc_get_product($error_entry->get_wc_product_id());
+     * $this->assertNotEmpty($error_entry->get_errors());
+     * // product remains synced if delete failed
+     * $this->assertTrue(
+     * $this->product_helper->is_product_synced($wc_product));
+     * }
+     * }
+     *
+     * public function test_delete_removes_google_id_of_not_found_products() {
+     * // $deleted_products: products that were successfully synced and then deleted from Merchant Center
+     * // $not_found_products: products that were synced but deleting them resulted in a not-found error and were rejected by Google API
+     * [
+     * $deleted_products,
+     * $not_found_products
+     * ] = $this->create_multiple_simple_product_sets(2, 2);
+     *
+     * $this->google_service->expects($this->once())
+     * ->method('delete_batch')
+     * ->willReturnCallback(
+     * function (array $product_entries) use (
+     * $deleted_products,
+     * $not_found_products) {
+     * $errors = [];
+     * $entries = [];
+     * foreach ($product_entries as $product_entry) {
+     * if (isset(
+     * $deleted_products[$product_entry->get_wc_product_id()])) {
+     * $entries[] = new BatchProductEntry(
+     * $product_entry->get_wc_product_id(),
+     * null);
+     * } elseif (isset(
+     * $not_found_products[$product_entry->get_wc_product_id()])) {
+     * $errors[] = new BatchInvalidProductEntry(
+     * $product_entry->get_wc_product_id(),
+     * $product_entry->get_product_id(),
+     * [
+     * GoogleProductService::NOT_FOUND_ERROR_REASON => 'Not Found!'
+     * ]);
+     * }
+     * }
+     *
+     * return new BatchProductResponse($entries, $errors);
+     * });
+     *
+     * $products = array_merge($deleted_products, $not_found_products);
+     *
+     * // first we mark all products as synced
+     * array_walk(
+     * $products,
+     * function (WC_Product $product) {
+     * $this->product_helper->mark_as_synced(
+     * $product,
+     * $this->generate_google_product_mock());
+     * });
+     *
+     * $results = $this->product_syncer->delete($products);
+     *
+     * $this->assertCount(2, $results->get_products());
+     * foreach ($results->get_products() as $product_entry) {
+     * $wc_product = wc_get_product($product_entry->get_wc_product_id());
+     * // product is no longer synced if delete succeeds
+     * $this->assertFalse(
+     * $this->product_helper->is_product_synced($wc_product));
+     * }
+     *
+     * $this->assertCount(2, $results->get_errors());
+     * foreach ($results->get_errors() as $error_entry) {
+     * $wc_product = wc_get_product($error_entry->get_wc_product_id());
+     * $this->assertNotEmpty($error_entry->get_errors());
+     * // product is no longer synced if Google API returns Not Found error for it
+     * $this->assertFalse(
+     * $this->product_helper->is_product_synced($wc_product));
+     * }
+     * }
+     *
+     * public function test_update_fails_if_merchant_center_not_setup() {
+     * $product = WC_Helper_Product::create_simple_product();
+     *
+     * $merchant_center = $this->createMock(MerchantCenterService::class);
+     * $merchant_center->expects($this->any())
+     * ->method('is_connected')
+     * ->willReturn(false);
+     * $this->product_syncer = new ProductSyncer(
+     * $this->google_service,
+     * $this->batch_helper,
+     * $this->product_helper,
+     * $merchant_center,
+     * $this->wc);
+     *
+     * $this->expectException(ProductSyncerException::class);
+     * $this->product_syncer->update([
+     * $product
+     * ]);
+     * }
+     *
+     * public function test_update_by_batch_requests_fails_if_merchant_center_not_setup() {
+     * $product = WC_Helper_Product::create_simple_product();
+     *
+     * $merchant_center = $this->createMock(MerchantCenterService::class);
+     * $merchant_center->expects($this->any())
+     * ->method('is_connected')
+     * ->willReturn(false);
+     * $this->product_syncer = new ProductSyncer(
+     * $this->google_service,
+     * $this->batch_helper,
+     * $this->product_helper,
+     * $merchant_center,
+     * $this->wc);
+     *
+     * $this->expectException(ProductSyncerException::class);
+     * $this->product_syncer->update_by_batch_requests(
+     * [
+     * new BatchProductRequestEntry(
+     * $product->get_id(),
+     * $this->generate_adapted_product($product))
+     * ]);
+     * }
+     *
+     * public function test_delete_fails_if_merchant_center_not_setup() {
+     * $product = WC_Helper_Product::create_simple_product();
+     *
+     * $merchant_center = $this->createMock(MerchantCenterService::class);
+     * $merchant_center->expects($this->any())
+     * ->method('is_connected')
+     * ->willReturn(false);
+     * $this->product_syncer = new ProductSyncer(
+     * $this->google_service,
+     * $this->batch_helper,
+     * $this->product_helper,
+     * $merchant_center,
+     * $this->wc);
+     *
+     * $this->expectException(ProductSyncerException::class);
+     * $this->product_syncer->delete([
+     * $product
+     * ]);
+     * }
+     *
+     * public function test_delete_by_batch_requests_fails_if_merchant_center_not_setup() {
+     * $product = WC_Helper_Product::create_simple_product();
+     *
+     * $merchant_center = $this->createMock(MerchantCenterService::class);
+     * $merchant_center->expects($this->any())
+     * ->method('is_connected')
+     * ->willReturn(false);
+     * $this->product_syncer = new ProductSyncer(
+     * $this->google_service,
+     * $this->batch_helper,
+     * $this->product_helper,
+     * $merchant_center,
+     * $this->wc);
+     *
+     * $this->expectException(ProductSyncerException::class);
+     * $this->product_syncer->delete_by_batch_requests(
+     * [
+     * new BatchProductIDRequestEntry(
+     * $product->get_id(),
+     * $this->generate_google_id($product))
+     * ]);
+     * }
+     *
+     * public function test_update_by_batch_requests_throws_exception_if_google_api_call_fails() {
+     * $product = WC_Helper_Product::create_simple_product();
+     *
+     * $this->google_service->expects($this->any())
+     * ->method('insert_batch')
+     * ->willThrowException(new GoogleException());
+     *
+     * $this->expectException(ProductSyncerException::class);
+     * $this->product_syncer->update_by_batch_requests(
+     * [
+     * new BatchProductRequestEntry(
+     * $product->get_id(),
+     * $this->generate_adapted_product($product))
+     * ]);
+     * }
+     *
+     * public function test_delete_by_batch_requests_throws_exception_if_google_api_call_fails() {
+     * $product = WC_Helper_Product::create_simple_product();
+     *
+     * $this->google_service->expects($this->any())
+     * ->method('delete_batch')
+     * ->willThrowException(new GoogleException());
+     *
+     * $this->expectException(ProductSyncerException::class);
+     * $this->product_syncer->delete_by_batch_requests(
+     * [
+     * new BatchProductIDRequestEntry(
+     * $product->get_id(),
+     * $this->generate_google_id($product))
+     * ]);
+     * }
+     */
+    protected function mock_google_service_succeed( WC_Coupon $coupon ): void {
+        $callback = function ( $promotion ) use ($coupon ) {
+            if ( $promotion->getPromotionId() == $coupon->get_id() ) {
+                $google_promotion = $this->generate_google_promotion_mock( 
+                    $coupon->get_id() );
+                return $google_promotion;
+            } else {
+                throw new GoogleException( 
+                    GooglePromotionService::INTERNAL_ERROR_REASON );
+            }
+        };
+
+        $this->google_service->expects( $this->any() )
+            ->method( 'create' )
+            ->willReturnCallback( $callback );
+    }
+
+    /**
+     * Runs before each test is executed.
+     */
+    public function setUp() {
+        parent::setUp();
+        $this->merchant_center = $this->createMock( 
+            MerchantCenterService::class );
+        $this->merchant_center->expects( $this->any() )
+            ->method( 'is_connected' )
+            ->willReturn( true );
+        $this->merchant_center->expects( $this->any() )
+            ->method( 'get_main_target_country' )
+            ->willReturn( $this->get_sample_target_country() );
+
+        $this->google_service = $this->createMock( 
+            GooglePromotionService::class );
+        $this->validator = $this->createMock( ValidatorInterface::class );
+
+        $this->coupon_meta = $this->container->get( CouponMetaHandler::class );
+        $this->coupon_helper = $this->container->get( CouponHelper::class );
+        $this->wc = $this->container->get( WC::class );
+        $this->coupon_syncer = new CouponSyncer( 
+            $this->google_service,
+            $this->coupon_helper,
+            $this->validator,
+            $this->merchant_center,
+            $this->wc );
+    }
+}

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -50,11 +50,8 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
             $this->wc );
 
         $this->coupon_syncer->update( $coupon );
-       
-        $this->assert_successfull_update_results( 
-            $coupon,
-            $updated_promotions,
-            $invalid_promotions );
+
+        $this->assert_successfull_update_results( $coupon );
     }
 
     public function test_update_fail() {
@@ -69,283 +66,41 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
             $this->wc );
 
         $this->coupon_syncer->update( $invalid_coupon );
-        
-        $this->assert_failed_update_results( 
-            $invalid_coupon = $invalid_coupon );
+
+        $this->assert_failed_update_results( $invalid_coupon );
     }
- 
-    protected function assert_successfull_update_results( $updated_coupon ) {
+
+    protected function assert_successfull_update_results( $coupon ) {
         $this->assertEquals( 1, did_action( 'woocommerce_gla_updated_coupon' ) );
 
-        $reloaded_coupon = new WC_Coupon( $updated_coupon->get_id() );
+        $reloaded_coupon = new WC_Coupon( $coupon->get_id() );
         $this->assertTrue( 
             $this->coupon_helper->is_coupon_synced( $reloaded_coupon ) );
     }
 
-    protected function assert_failed_update_results() {
+    protected function assert_failed_update_results( $coupon ) {
         $this->assertEquals( 
             1,
             did_action( 'woocommerce_gla_retry_update_coupons' ) );
-        
-        $reloaded_coupon = new WC_Coupon( $updated_coupon->get_id() );
-        $this->assertNotEmpty( $this->meta_meta->get_errors( $reloaded_coupon ) );
+
+        $reloaded_coupon = new WC_Coupon( $coupon->get_id() );
+        $this->assertNotEmpty( 
+            $this->coupon_meta->get_errors( $reloaded_coupon ) );
         $this->assertEquals( 
             SyncStatus::HAS_ERRORS,
-            $this->product_meta->get_sync_status( $reloaded_coupon ) );
+            $this->coupon_meta->get_sync_status( $reloaded_coupon ) );
     }
 
-    /*
-     * public function test_delete() {
-     * // $deleted_products: products that were successfully synced and then deleted from Merchant Center
-     * // $rejected_products: products that were synced but deleting them resulted in errors and were rejected by Google API
-     * [
-     * $deleted_products,
-     * $rejected_products
-     * ] = $this->create_multiple_simple_product_sets(2, 2);
-     *
-     * $this->mock_google_service($deleted_products, $rejected_products);
-     *
-     * $products = array_merge($deleted_products, $rejected_products);
-     *
-     * // first we mark all products as synced
-     * array_walk(
-     * $products,
-     * function (WC_Product $product) {
-     * $this->product_helper->mark_as_synced(
-     * $product,
-     * $this->generate_google_product_mock());
-     * });
-     *
-     * $results = $this->product_syncer->delete($products);
-     * $this->assert_delete_results_are_valid(
-     * $results,
-     * $deleted_products,
-     * $rejected_products);
-     * }
-     *
-     * protected function assert_delete_results_are_valid(
-     * $results,
-     * $deleted_products,
-     * $rejected_products) {
-     * $this->assertEquals(
-     * 1,
-     * did_action('woocommerce_gla_batch_deleted_products'));
-     * $this->assertEquals(
-     * 1,
-     * did_action('woocommerce_gla_batch_retry_delete_products'));
-     *
-     * $this->assertCount(count($deleted_products), $results->get_products());
-     * foreach ($results->get_products() as $product_entry) {
-     * $wc_product = wc_get_product($product_entry->get_wc_product_id());
-     * // product is no longer synced if delete succeeds
-     * $this->assertFalse(
-     * $this->product_helper->is_product_synced($wc_product));
-     * }
-     *
-     * $this->assertCount(count($rejected_products), $results->get_errors());
-     * foreach ($results->get_errors() as $error_entry) {
-     * $wc_product = wc_get_product($error_entry->get_wc_product_id());
-     * $this->assertNotEmpty($error_entry->get_errors());
-     * // product remains synced if delete failed
-     * $this->assertTrue(
-     * $this->product_helper->is_product_synced($wc_product));
-     * }
-     * }
-     *
-     * public function test_delete_removes_google_id_of_not_found_products() {
-     * // $deleted_products: products that were successfully synced and then deleted from Merchant Center
-     * // $not_found_products: products that were synced but deleting them resulted in a not-found error and were rejected by Google API
-     * [
-     * $deleted_products,
-     * $not_found_products
-     * ] = $this->create_multiple_simple_product_sets(2, 2);
-     *
-     * $this->google_service->expects($this->once())
-     * ->method('delete_batch')
-     * ->willReturnCallback(
-     * function (array $product_entries) use (
-     * $deleted_products,
-     * $not_found_products) {
-     * $errors = [];
-     * $entries = [];
-     * foreach ($product_entries as $product_entry) {
-     * if (isset(
-     * $deleted_products[$product_entry->get_wc_product_id()])) {
-     * $entries[] = new BatchProductEntry(
-     * $product_entry->get_wc_product_id(),
-     * null);
-     * } elseif (isset(
-     * $not_found_products[$product_entry->get_wc_product_id()])) {
-     * $errors[] = new BatchInvalidProductEntry(
-     * $product_entry->get_wc_product_id(),
-     * $product_entry->get_product_id(),
-     * [
-     * GoogleProductService::NOT_FOUND_ERROR_REASON => 'Not Found!'
-     * ]);
-     * }
-     * }
-     *
-     * return new BatchProductResponse($entries, $errors);
-     * });
-     *
-     * $products = array_merge($deleted_products, $not_found_products);
-     *
-     * // first we mark all products as synced
-     * array_walk(
-     * $products,
-     * function (WC_Product $product) {
-     * $this->product_helper->mark_as_synced(
-     * $product,
-     * $this->generate_google_product_mock());
-     * });
-     *
-     * $results = $this->product_syncer->delete($products);
-     *
-     * $this->assertCount(2, $results->get_products());
-     * foreach ($results->get_products() as $product_entry) {
-     * $wc_product = wc_get_product($product_entry->get_wc_product_id());
-     * // product is no longer synced if delete succeeds
-     * $this->assertFalse(
-     * $this->product_helper->is_product_synced($wc_product));
-     * }
-     *
-     * $this->assertCount(2, $results->get_errors());
-     * foreach ($results->get_errors() as $error_entry) {
-     * $wc_product = wc_get_product($error_entry->get_wc_product_id());
-     * $this->assertNotEmpty($error_entry->get_errors());
-     * // product is no longer synced if Google API returns Not Found error for it
-     * $this->assertFalse(
-     * $this->product_helper->is_product_synced($wc_product));
-     * }
-     * }
-     *
-     * public function test_update_fails_if_merchant_center_not_setup() {
-     * $product = WC_Helper_Product::create_simple_product();
-     *
-     * $merchant_center = $this->createMock(MerchantCenterService::class);
-     * $merchant_center->expects($this->any())
-     * ->method('is_connected')
-     * ->willReturn(false);
-     * $this->product_syncer = new ProductSyncer(
-     * $this->google_service,
-     * $this->batch_helper,
-     * $this->product_helper,
-     * $merchant_center,
-     * $this->wc);
-     *
-     * $this->expectException(ProductSyncerException::class);
-     * $this->product_syncer->update([
-     * $product
-     * ]);
-     * }
-     *
-     * public function test_update_by_batch_requests_fails_if_merchant_center_not_setup() {
-     * $product = WC_Helper_Product::create_simple_product();
-     *
-     * $merchant_center = $this->createMock(MerchantCenterService::class);
-     * $merchant_center->expects($this->any())
-     * ->method('is_connected')
-     * ->willReturn(false);
-     * $this->product_syncer = new ProductSyncer(
-     * $this->google_service,
-     * $this->batch_helper,
-     * $this->product_helper,
-     * $merchant_center,
-     * $this->wc);
-     *
-     * $this->expectException(ProductSyncerException::class);
-     * $this->product_syncer->update_by_batch_requests(
-     * [
-     * new BatchProductRequestEntry(
-     * $product->get_id(),
-     * $this->generate_adapted_product($product))
-     * ]);
-     * }
-     *
-     * public function test_delete_fails_if_merchant_center_not_setup() {
-     * $product = WC_Helper_Product::create_simple_product();
-     *
-     * $merchant_center = $this->createMock(MerchantCenterService::class);
-     * $merchant_center->expects($this->any())
-     * ->method('is_connected')
-     * ->willReturn(false);
-     * $this->product_syncer = new ProductSyncer(
-     * $this->google_service,
-     * $this->batch_helper,
-     * $this->product_helper,
-     * $merchant_center,
-     * $this->wc);
-     *
-     * $this->expectException(ProductSyncerException::class);
-     * $this->product_syncer->delete([
-     * $product
-     * ]);
-     * }
-     *
-     * public function test_delete_by_batch_requests_fails_if_merchant_center_not_setup() {
-     * $product = WC_Helper_Product::create_simple_product();
-     *
-     * $merchant_center = $this->createMock(MerchantCenterService::class);
-     * $merchant_center->expects($this->any())
-     * ->method('is_connected')
-     * ->willReturn(false);
-     * $this->product_syncer = new ProductSyncer(
-     * $this->google_service,
-     * $this->batch_helper,
-     * $this->product_helper,
-     * $merchant_center,
-     * $this->wc);
-     *
-     * $this->expectException(ProductSyncerException::class);
-     * $this->product_syncer->delete_by_batch_requests(
-     * [
-     * new BatchProductIDRequestEntry(
-     * $product->get_id(),
-     * $this->generate_google_id($product))
-     * ]);
-     * }
-     *
-     * public function test_update_by_batch_requests_throws_exception_if_google_api_call_fails() {
-     * $product = WC_Helper_Product::create_simple_product();
-     *
-     * $this->google_service->expects($this->any())
-     * ->method('insert_batch')
-     * ->willThrowException(new GoogleException());
-     *
-     * $this->expectException(ProductSyncerException::class);
-     * $this->product_syncer->update_by_batch_requests(
-     * [
-     * new BatchProductRequestEntry(
-     * $product->get_id(),
-     * $this->generate_adapted_product($product))
-     * ]);
-     * }
-     *
-     * public function test_delete_by_batch_requests_throws_exception_if_google_api_call_fails() {
-     * $product = WC_Helper_Product::create_simple_product();
-     *
-     * $this->google_service->expects($this->any())
-     * ->method('delete_batch')
-     * ->willThrowException(new GoogleException());
-     *
-     * $this->expectException(ProductSyncerException::class);
-     * $this->product_syncer->delete_by_batch_requests(
-     * [
-     * new BatchProductIDRequestEntry(
-     * $product->get_id(),
-     * $this->generate_google_id($product))
-     * ]);
-     * }
-     */
-    protected function mock_google_service_succeed( WC_Coupon $coupon ): void {
+    protected function mock_google_service( WC_Coupon $coupon ): void {
         $callback = function ( $promotion ) use ($coupon ) {
-            if ( $promotion->getPromotionId() == $coupon->get_id() ) {
+            if ( $promotion->getGenericRedemptionCode() === $coupon->get_code() ) {
                 $google_promotion = $this->generate_google_promotion_mock( 
                     $coupon->get_id() );
                 return $google_promotion;
             } else {
                 throw new GoogleException( 
-                    GooglePromotionService::INTERNAL_ERROR_REASON );
+                    GooglePromotionService::INTERNAL_ERROR_MSG,
+                    GooglePromotionService::INTERNAL_ERROR_CODE );
             }
         };
 
@@ -367,6 +122,9 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
         $this->merchant_center->expects( $this->any() )
             ->method( 'get_main_target_country' )
             ->willReturn( $this->get_sample_target_country() );
+        $this->merchant_center->expects( $this->any() )
+            ->method( 'is_promotion_supported_country' )
+            ->willReturn( true );
 
         $this->google_service = $this->createMock( 
             GooglePromotionService::class );

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -1,0 +1,158 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\SyncerHooks;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteCoupon;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateCoupon;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use \WC_Coupon;
+
+/**
+ * Class SyncerHooksTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ *
+ * @property MockObject|MerchantCenterService $merchant_center
+ * @property MockObject|JobRepository         $job_repository
+ * @property MockObject|UpdateCoupon          $update_coupon_job
+ * @property WC                               $wc
+ * @property SyncerHooks                      $syncer_hooks
+ */
+class SyncerHooksTest extends ContainerAwareUnitTest {
+
+	public function test_create_new_simple_coupon_schedules_update_job() {
+		$this->update_coupon_job->expects( $this->once() )
+								->method( 'schedule' );
+	   $string_code = 'test_coupon_codes';
+       $coupon = new WC_Coupon();
+       $this->coupon_helper->mark_as_synced($coupon, 'fake_google_id', 'US');
+       $coupon->set_code( $string_code );
+	   $coupon->save();
+	}
+
+	public function test_update_simple_coupon_schedules_update_job() {
+	    $string_code = 'test_coupon_codes';
+	    $coupon = new WC_Coupon();
+	    $this->coupon_helper->mark_as_synced($coupon, 'fake_google_id', 'US');
+	    $coupon->set_code( $string_code );
+	    $coupon->save();
+
+		$this->update_coupon_job->expects( $this->once() )
+								->method( 'schedule' )
+								->with( $this->equalTo( [ $coupon->get_id() ] ) );
+		$coupon->add_meta_data('test_coupon_field', 'testing', true);
+		$coupon->save();
+	}
+	
+	public function test_update_invisible_coupon_does_not_schedule_update_job() {
+	    $string_code = 'test_coupon_codes';
+	    $coupon = new WC_Coupon();
+	    $coupon->update_meta_data('_wc_gla_visibility', 'dont-sync-and-show');
+	    $coupon->save_meta_data();
+	    $coupon->set_code( $string_code );
+	    $coupon->save();
+	    
+	    $this->update_coupon_job->expects( $this->never() )->method( 'schedule' );
+	    $coupon->add_meta_data('test_coupon_field', 'testing', true);
+	    $coupon->save();
+	}
+
+	public function test_trash_simple_coupon_schedules_delete_job() {
+	    $string_code = 'test_coupon_codes';
+	    $coupon = new WC_Coupon();
+	    $coupon->set_code( $string_code );
+	    $coupon->save();
+	    
+	    $this->delete_coupon_job->expects( $this->once() )
+	                            ->method( 'schedule' )
+	                            ->with( $this->equalTo( [ $coupon->get_id() ] ) );
+	    $coupon->delete();
+	    $coupon->save();
+	}
+
+	public function test_delete_simple_coupon_schedules_delete_job() {
+	    $string_code = 'test_coupon_codes';
+	    $coupon = new WC_Coupon();
+	    $coupon->set_code( $string_code );
+	    $coupon->save();
+	    
+	    $this->delete_coupon_job->expects( $this->once() )
+	                            ->method( 'schedule' )
+	                            ->with( $this->equalTo( [ $coupon->get_id() ] ) );
+	    $coupon->delete( array( 'force_delete' => true ) );
+	    $coupon->save();
+	}
+	
+	public function test_untrash_simple_coupon_schedules_update_job() {
+	    $string_code = 'test_coupon_codes';
+	    $coupon = new WC_Coupon();
+	    $coupon->set_code( $string_code );
+	    $coupon->save();
+	    $coupon_id = $coupon->get_id();
+	    $coupon->delete();
+	   
+	    $this->update_coupon_job->expects( $this->once() )
+	                            ->method( 'schedule' )
+	                            ->with( $this->equalTo( [ $coupon_id ] ) );   
+	    // untrash coupon
+	    wp_untrash_post( $coupon_id );
+	}
+	
+	public function test_modify_post_does_not_schedule_update_job() {  
+	    $this->update_coupon_job->expects( $this->never() )
+	                            ->method( 'schedule' );
+	    
+	    $post = $this->factory()->post->create_and_get(); 
+	    // update post
+	    $this->factory()->post->update_object( $post->ID, [ 'post_title' => 'Sample title' ] );
+	    // trash post
+	    wp_trash_post( $post->ID );
+	    // un-trash post
+	    wp_untrash_post( $post->ID );
+	}
+	
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->login_as_administrator();
+
+		$this->merchant_center = $this->createMock( MerchantCenterService::class );
+		$this->merchant_center->expects( $this->any() )
+							  ->method( 'is_connected' )
+							  ->willReturn( true );
+
+		$this->update_coupon_job   = $this->createMock( UpdateCoupon::class );
+		$this->delete_coupon_job   = $this->createMock( DeleteCoupon::class );
+		$this->job_repository      = $this->createMock( JobRepository::class );
+		$this->job_repository->expects( $this->any() )
+							 ->method( 'get' )
+							 ->willReturnMap(
+								 [
+									 [ DeleteCoupon::class, $this->delete_coupon_job ],
+								     [ UpdateCoupon::class, $this->update_coupon_job ],
+								 ]
+							 );
+
+		$this->wc             = $this->container->get( WC::class );
+		$this->coupon_helper  = $this->container->get( CouponHelper::class);
+		$this->syncer_hooks   = new SyncerHooks(
+		    $this->coupon_helper,
+		    $this->job_repository,
+		    $this->merchant_center,
+		    $this->wc
+		);
+
+		$this->syncer_hooks->register();
+	}
+}

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -1,10 +1,11 @@
 <?php
-declare( strict_types=1 );
-
+declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\SyncerHooks;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\WCCouponAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\DeleteCouponEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteCoupon;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateCoupon;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -13,146 +14,154 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
 use PHPUnit\Framework\MockObject\MockObject;
-use \WC_Coupon;
+use WC_Coupon;
 
 /**
  * Class SyncerHooksTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
+ *         
  * @property MockObject|MerchantCenterService $merchant_center
- * @property MockObject|JobRepository         $job_repository
- * @property MockObject|UpdateCoupon          $update_coupon_job
- * @property WC                               $wc
- * @property SyncerHooks                      $syncer_hooks
+ * @property MockObject|JobRepository $job_repository
+ * @property MockObject|UpdateCoupon $update_coupon_job
+ * @property WC $wc
+ * @property SyncerHooks $syncer_hooks
  */
 class SyncerHooksTest extends ContainerAwareUnitTest {
 
-	public function test_create_new_simple_coupon_schedules_update_job() {
-		$this->update_coupon_job->expects( $this->once() )
-								->method( 'schedule' );
-	   $string_code = 'test_coupon_codes';
-       $coupon = new WC_Coupon();
-       $this->coupon_helper->mark_as_synced($coupon, 'fake_google_id', 'US');
-       $coupon->set_code( $string_code );
-	   $coupon->save();
-	}
+    public function test_create_new_simple_coupon_schedules_update_job() {
+        $this->update_coupon_job->expects( $this->once() )
+            ->method( 'schedule' );
+        $string_code = 'test_coupon_codes';
+        $coupon = new WC_Coupon();
+        $this->coupon_helper->mark_as_synced( $coupon, 'fake_google_id', 'US' );
+        $coupon->set_code( $string_code );
+        $coupon->save();
+    }
 
-	public function test_update_simple_coupon_schedules_update_job() {
-	    $string_code = 'test_coupon_codes';
-	    $coupon = new WC_Coupon();
-	    $this->coupon_helper->mark_as_synced($coupon, 'fake_google_id', 'US');
-	    $coupon->set_code( $string_code );
-	    $coupon->save();
+    public function test_update_simple_coupon_schedules_update_job() {
+        $string_code = 'test_coupon_codes';
+        $coupon = new WC_Coupon();
+        $this->coupon_helper->mark_as_synced( $coupon, 'fake_google_id', 'US' );
+        $coupon->set_code( $string_code );
+        $coupon->save();
 
-		$this->update_coupon_job->expects( $this->once() )
-								->method( 'schedule' )
-								->with( $this->equalTo( [ $coupon->get_id() ] ) );
-		$coupon->add_meta_data('test_coupon_field', 'testing', true);
-		$coupon->save();
-	}
-	
-	public function test_update_invisible_coupon_does_not_schedule_update_job() {
-	    $string_code = 'test_coupon_codes';
-	    $coupon = new WC_Coupon();
-	    $coupon->update_meta_data('_wc_gla_visibility', 'dont-sync-and-show');
-	    $coupon->save_meta_data();
-	    $coupon->set_code( $string_code );
-	    $coupon->save();
-	    
-	    $this->update_coupon_job->expects( $this->never() )->method( 'schedule' );
-	    $coupon->add_meta_data('test_coupon_field', 'testing', true);
-	    $coupon->save();
-	}
+        $this->update_coupon_job->expects( $this->once() )
+            ->method( 'schedule' )
+            ->with( $this->equalTo( [$coupon->get_id()] ) );
+        $coupon->add_meta_data( 'test_coupon_field', 'testing', true );
+        $coupon->save();
+    }
 
-	public function test_trash_simple_coupon_schedules_delete_job() {
-	    $string_code = 'test_coupon_codes';
-	    $coupon = new WC_Coupon();
-	    $coupon->set_code( $string_code );
-	    $coupon->save();
-	    
-	    $this->delete_coupon_job->expects( $this->once() )
-	                            ->method( 'schedule' )
-	                            ->with( $this->equalTo( [ $coupon->get_id() ] ) );
-	    $coupon->delete();
-	    $coupon->save();
-	}
+    public function test_update_invisible_coupon_does_not_schedule_update_job() {
+        $string_code = 'test_coupon_codes';
+        $coupon = new WC_Coupon();
+        $coupon->update_meta_data( '_wc_gla_visibility', 'dont-sync-and-show' );
+        $coupon->save_meta_data();
+        $coupon->set_code( $string_code );
+        $coupon->save();
 
-	public function test_delete_simple_coupon_schedules_delete_job() {
-	    $string_code = 'test_coupon_codes';
-	    $coupon = new WC_Coupon();
-	    $coupon->set_code( $string_code );
-	    $coupon->save();
-	    
-	    $this->delete_coupon_job->expects( $this->once() )
-	                            ->method( 'schedule' )
-	                            ->with( $this->equalTo( [ $coupon->get_id() ] ) );
-	    $coupon->delete( array( 'force_delete' => true ) );
-	    $coupon->save();
-	}
-	
-	public function test_untrash_simple_coupon_schedules_update_job() {
-	    $string_code = 'test_coupon_codes';
-	    $coupon = new WC_Coupon();
-	    $coupon->set_code( $string_code );
-	    $coupon->save();
-	    $coupon_id = $coupon->get_id();
-	    $coupon->delete();
-	   
-	    $this->update_coupon_job->expects( $this->once() )
-	                            ->method( 'schedule' )
-	                            ->with( $this->equalTo( [ $coupon_id ] ) );   
-	    // untrash coupon
-	    wp_untrash_post( $coupon_id );
-	}
-	
-	public function test_modify_post_does_not_schedule_update_job() {  
-	    $this->update_coupon_job->expects( $this->never() )
-	                            ->method( 'schedule' );
-	    
-	    $post = $this->factory()->post->create_and_get(); 
-	    // update post
-	    $this->factory()->post->update_object( $post->ID, [ 'post_title' => 'Sample title' ] );
-	    // trash post
-	    wp_trash_post( $post->ID );
-	    // un-trash post
-	    wp_untrash_post( $post->ID );
-	}
-	
-	/**
-	 * Runs before each test is executed.
-	 */
-	public function setUp() {
-		parent::setUp();
+        $this->update_coupon_job->expects( $this->never() )
+            ->method( 'schedule' );
+        $coupon->add_meta_data( 'test_coupon_field', 'testing', true );
+        $coupon->save();
+    }
 
-		$this->login_as_administrator();
+    public function test_trash_simple_coupon_schedules_delete_job() {
+        $string_code = 'test_coupon_codes';
+        $coupon = new WC_Coupon();
+        $coupon->set_code( $string_code );
+        $coupon->save();
 
-		$this->merchant_center = $this->createMock( MerchantCenterService::class );
-		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
-							  ->willReturn( true );
+        $expected_coupon_entry = new DeleteCouponEntry( 
+            new WCCouponAdapter( ['wc_coupon' => $coupon] ),
+            null );
+        $this->delete_coupon_job->expects( $this->once() )
+            ->method( 'schedule' )
+            ->with( $this->equalTo( [$expected_coupon_entry] ) );
 
-		$this->update_coupon_job   = $this->createMock( UpdateCoupon::class );
-		$this->delete_coupon_job   = $this->createMock( DeleteCoupon::class );
-		$this->job_repository      = $this->createMock( JobRepository::class );
-		$this->job_repository->expects( $this->any() )
-							 ->method( 'get' )
-							 ->willReturnMap(
-								 [
-									 [ DeleteCoupon::class, $this->delete_coupon_job ],
-								     [ UpdateCoupon::class, $this->update_coupon_job ],
-								 ]
-							 );
+        wp_trash_post( $coupon->get_id() );
+    }
 
-		$this->wc             = $this->container->get( WC::class );
-		$this->coupon_helper  = $this->container->get( CouponHelper::class);
-		$this->syncer_hooks   = new SyncerHooks(
-		    $this->coupon_helper,
-		    $this->job_repository,
-		    $this->merchant_center,
-		    $this->wc
-		);
+    public function test_delete_simple_coupon_schedules_delete_job() {
+        $string_code = 'test_coupon_codes';
+        $coupon = new WC_Coupon();
+        $coupon->set_code( $string_code );
+        $coupon->save();
 
-		$this->syncer_hooks->register();
-	}
+        $expected_coupon_entry = new DeleteCouponEntry( 
+            new WCCouponAdapter( ['wc_coupon' => $coupon] ),
+            null );
+        $this->delete_coupon_job->expects( $this->once() )
+            ->method( 'schedule' )
+            ->with( $this->equalTo( [$expected_coupon_entry] ) );
+
+        // force delete post
+        wp_delete_post( $coupon->get_id(), true );
+    }
+
+    public function test_untrash_simple_coupon_schedules_update_job() {
+        $string_code = 'test_coupon_codes';
+        $coupon = new WC_Coupon();
+        $coupon->set_code( $string_code );
+        $coupon->save();
+        $coupon_id = $coupon->get_id();
+        $coupon->delete();
+
+        $this->update_coupon_job->expects( $this->once() )
+            ->method( 'schedule' )
+            ->with( $this->equalTo( [$coupon_id] ) );
+        // untrash coupon
+        wp_untrash_post( $coupon_id );
+    }
+
+    public function test_modify_post_does_not_schedule_update_job() {
+        $this->update_coupon_job->expects( $this->never() )
+            ->method( 'schedule' );
+
+        $post = $this->factory()->post->create_and_get();
+        // update post
+        $this->factory()->post->update_object( 
+            $post->ID,
+            ['post_title' => 'Sample title'] );
+        // trash post
+        wp_trash_post( $post->ID );
+        // un-trash post
+        wp_untrash_post( $post->ID );
+    }
+
+    /**
+     * Runs before each test is executed.
+     */
+    public function setUp() {
+        parent::setUp();
+
+        $this->login_as_administrator();
+
+        $this->merchant_center = $this->createMock( 
+            MerchantCenterService::class );
+        $this->merchant_center->expects( $this->any() )
+            ->method( 'is_connected' )
+            ->willReturn( true );
+
+        $this->update_coupon_job = $this->createMock( UpdateCoupon::class );
+        $this->delete_coupon_job = $this->createMock( DeleteCoupon::class );
+        $this->job_repository = $this->createMock( JobRepository::class );
+        $this->job_repository->expects( $this->any() )
+            ->method( 'get' )
+            ->willReturnMap( 
+            [
+                [DeleteCoupon::class,$this->delete_coupon_job],
+                [UpdateCoupon::class,$this->update_coupon_job]] );
+
+        $this->wc = $this->container->get( WC::class );
+        $this->coupon_helper = $this->container->get( CouponHelper::class );
+        $this->syncer_hooks = new SyncerHooks( 
+            $this->coupon_helper,
+            $this->job_repository,
+            $this->merchant_center,
+            $this->wc );
+
+        $this->syncer_hooks->register();
+    }
 }

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\CouponTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Coupon;
 
@@ -28,6 +28,7 @@ use WC_Coupon;
  * @property SyncerHooks $syncer_hooks
  */
 class SyncerHooksTest extends ContainerAwareUnitTest {
+    use CouponTrait;
 
     public function test_create_new_simple_coupon_schedules_update_job() {
         $this->update_coupon_job->expects( $this->once() )
@@ -68,14 +69,11 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
     }
 
     public function test_trash_simple_coupon_schedules_delete_job() {
-        $string_code = 'test_coupon_codes';
-        $coupon = new WC_Coupon();
-        $coupon->set_code( $string_code );
-        $coupon->save();
+        $coupon = $this->create_ready_to_delete_coupon();
 
         $expected_coupon_entry = new DeleteCouponEntry( 
             new WCCouponAdapter( ['wc_coupon' => $coupon] ),
-            null );
+            ['US' => 'google_id'] );
         $this->delete_coupon_job->expects( $this->once() )
             ->method( 'schedule' )
             ->with( $this->equalTo( [$expected_coupon_entry] ) );
@@ -84,14 +82,11 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
     }
 
     public function test_delete_simple_coupon_schedules_delete_job() {
-        $string_code = 'test_coupon_codes';
-        $coupon = new WC_Coupon();
-        $coupon->set_code( $string_code );
-        $coupon->save();
+        $coupon = $this->create_ready_to_delete_coupon();
 
         $expected_coupon_entry = new DeleteCouponEntry( 
             new WCCouponAdapter( ['wc_coupon' => $coupon] ),
-            null );
+            ['US' => 'google_id'] );
         $this->delete_coupon_job->expects( $this->once() )
             ->method( 'schedule' )
             ->with( $this->equalTo( [$expected_coupon_entry] ) );

--- a/views/meta-box/coupon_channel_visibility.php
+++ b/views/meta-box/coupon_channel_visibility.php
@@ -1,0 +1,98 @@
+<?php
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @var PHPView $this
+ */
+
+/**
+ * @var int $coupon_id
+ */
+$coupon_id = $this->coupons_id;
+/**
+ * @var WC_Coupon $product
+ */
+$coupon = $this->coupon;
+
+$channel_visibility = $this->channel_visibility;
+
+/**
+ * @var string
+ */
+$field_id = $this->field_id;
+
+/**
+ * @var string $sync_status
+ */
+if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
+    $sync_status = __( 'Issues detected', 'google-listings-and-ads' );
+} elseif ( ! is_null( $this->sync_status ) ) {
+    $sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
+}
+$show_status = $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
+
+/**
+ * @var array $issues
+ */
+$issues     = $this->issues;
+$has_issues = ! empty( $issues );
+
+$input_description = '';
+$input_disabled    = false;
+if ( $coupon->get_virtual() || ( ! CouponSyncer::is_coupon_supported( $coupon ) ) ) {
+    $channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
+    $show_status        = false;
+    $input_disabled     = true;
+    $input_description  = __(
+        $coupon->get_virtual()
+        ? 'This coupon cannot be shown on public channel because it is hidden from your store.'
+        : 'This coupon cannot be shown because the coupon restrictions are not supported to share in Google channel.',
+            'google-listings-and-ads' );
+}
+
+$custom_attributes = [];
+if ( $input_disabled ) {
+    $custom_attributes['disabled'] = 'disabled';
+}
+?>
+
+<div class="gla-channel-visibility-box">
+	<?php
+	woocommerce_wp_select(
+		[
+			'id'                => $field_id,
+			'value'             => $channel_visibility,
+			'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
+			'description'       => $input_description,
+			'desc_tip'          => false,
+			'options'           => [
+				ChannelVisibility::SYNC_AND_SHOW      => __( 'Show coupon on Google', 'google-listings-and-ads' ),
+				ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t show coupn on Google', 'google-listings-and-ads' ),
+			],
+			'custom_attributes' => $custom_attributes,
+		]
+	);
+	?>
+	<?php if ( $show_status ) : ?>
+	<div class="sync-status notice-alt notice-large notice-warning" style="border-left-style: solid">
+		<p><strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong></p>
+		<p><?php echo esc_html( $sync_status ); ?></p>
+		<?php if ( $has_issues ) : ?>
+			<div class="gla-product-issues">
+				<p><strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong></p>
+				<ul>
+					<?php foreach ( $issues as $issue ) : ?>
+					<li><?php echo esc_html( $issue ); ?></li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+		<?php endif; ?>
+	</div>
+	<?php endif; ?>
+</div>

--- a/views/meta-box/coupon_channel_visibility.php
+++ b/views/meta-box/coupon_channel_visibility.php
@@ -1,21 +1,24 @@
 <?php
-declare( strict_types=1 );
+declare(strict_types = 1);
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
 
-defined( 'ABSPATH' ) || exit;
+defined('ABSPATH') || exit();
 
 /**
+ *
  * @var PHPView $this
  */
 
 /**
+ *
  * @var int $coupon_id
  */
 $coupon_id = $this->coupons_id;
 /**
+ *
  * @var WC_Coupon $product
  */
 $coupon = $this->coupon;
@@ -23,75 +26,83 @@ $coupon = $this->coupon;
 $channel_visibility = $this->channel_visibility;
 
 /**
+ *
  * @var string
  */
 $field_id = $this->field_id;
 
 /**
+ *
  * @var string $sync_status
  */
-if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
-    $sync_status = __( 'Issues detected', 'google-listings-and-ads' );
-} elseif ( ! is_null( $this->sync_status ) ) {
-    $sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
+if (SyncStatus::HAS_ERRORS === $this->sync_status) {
+    $sync_status = __('Issues detected', 'google-listings-and-ads');
+} elseif (! is_null($this->sync_status)) {
+    $sync_status = ucfirst(str_replace('-', ' ', $this->sync_status));
 }
-$show_status = $channel_visibility === ChannelVisibility::SYNC_AND_SHOW && $this->sync_status !== SyncStatus::SYNCED;
+$show_status = $channel_visibility === ChannelVisibility::SYNC_AND_SHOW &&
+    $this->sync_status !== SyncStatus::SYNCED;
 
 /**
+ *
  * @var array $issues
  */
-$issues     = $this->issues;
-$has_issues = ! empty( $issues );
+$issues = $this->issues;
+$has_issues = ! empty($issues);
 
 $input_description = '';
-$input_disabled    = false;
-if ( $coupon->get_virtual() || ( ! CouponSyncer::is_coupon_supported( $coupon ) ) ) {
+$input_disabled = false;
+if ($coupon->get_virtual() || (! CouponSyncer::is_coupon_supported($coupon))) {
     $channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
-    $show_status        = false;
-    $input_disabled     = true;
-    $input_description  = __(
-        $coupon->get_virtual()
-        ? 'This coupon cannot be shown on public channel because it is hidden from your store.'
-        : 'This coupon cannot be shown because the coupon restrictions are not supported to share in Google channel.',
-            'google-listings-and-ads' );
+    $show_status = false;
+    $input_disabled = true;
+    $input_description = __(
+        $coupon->get_virtual() ? 'This coupon cannot be shown on public channel because it is hidden from your store.' : 'This coupon cannot be shown because the coupon restrictions are not supported to share in Google channel.',
+        'google-listings-and-ads');
 }
 
 $custom_attributes = [];
-if ( $input_disabled ) {
+if ($input_disabled) {
     $custom_attributes['disabled'] = 'disabled';
 }
 ?>
 
 <div class="gla-channel-visibility-box">
-	<?php
-	woocommerce_wp_select(
-		[
-			'id'                => $field_id,
-			'value'             => $channel_visibility,
-			'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
-			'description'       => $input_description,
-			'desc_tip'          => false,
-			'options'           => [
-				ChannelVisibility::SYNC_AND_SHOW      => __( 'Show coupon on Google', 'google-listings-and-ads' ),
-				ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t show coupn on Google', 'google-listings-and-ads' ),
-			],
-			'custom_attributes' => $custom_attributes,
-		]
-	);
-	?>
+<?php
+woocommerce_wp_select(
+    [
+        'id' => $field_id,
+        'value' => $channel_visibility,
+        'label' => __('Google Listing & Ads', 'google-listings-and-ads'),
+        'description' => $input_description,
+        'desc_tip' => false,
+        'options' => [
+            ChannelVisibility::SYNC_AND_SHOW => __('Show coupon on Google',
+                'google-listings-and-ads'),
+            ChannelVisibility::DONT_SYNC_AND_SHOW => __(
+                'Don\'t show coupn on Google', 'google-listings-and-ads')
+        ],
+        'custom_attributes' => $custom_attributes
+    ]);
+?>
 	<?php if ( $show_status ) : ?>
-	<div class="sync-status notice-alt notice-large notice-warning" style="border-left-style: solid">
-		<p><strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong></p>
+	<div class="sync-status notice-alt notice-large notice-warning"
+		style="border-left-style: solid">
+		<p>
+			<strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong>
+		</p>
 		<p><?php echo esc_html( $sync_status ); ?></p>
 		<?php if ( $has_issues ) : ?>
 			<div class="gla-product-issues">
-				<p><strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong></p>
-				<ul>
+			<p>
+				<strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong>
+			</p>
+			<ul>
 					<?php foreach ( $issues as $issue ) : ?>
 					<li><?php echo esc_html( $issue ); ?></li>
 					<?php endforeach; ?>
 				</ul>
-			</div>
+		</div>
 		<?php endif; ?>
 	</div>
 	<?php endif; ?>

--- a/views/meta-box/coupon_channel_visibility.php
+++ b/views/meta-box/coupon_channel_visibility.php
@@ -1,11 +1,12 @@
 <?php
 declare(strict_types = 1);
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPView;
 
-defined('ABSPATH') || exit();
+defined( 'ABSPATH' ) || exit();
 
 /**
  *
@@ -16,10 +17,11 @@ defined('ABSPATH') || exit();
  *
  * @var int $coupon_id
  */
-$coupon_id = $this->coupons_id;
+$coupon_id = $this->coupon_id;
+
 /**
  *
- * @var WC_Coupon $product
+ * @var WC_Coupon $coupon
  */
 $coupon = $this->coupon;
 
@@ -33,77 +35,101 @@ $field_id = $this->field_id;
 
 /**
  *
+ * @var bool
+ */
+$is_setup_complete = $this->is_setup_complete;
+
+/**
+ *
+ * @var string
+ */
+$get_started_url = $this->get_started_url;
+
+/**
+ *
  * @var string $sync_status
  */
-if (SyncStatus::HAS_ERRORS === $this->sync_status) {
-    $sync_status = __('Issues detected', 'google-listings-and-ads');
-} elseif (! is_null($this->sync_status)) {
-    $sync_status = ucfirst(str_replace('-', ' ', $this->sync_status));
+if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
+    $sync_status = __( 'Issues detected', 'google-listings-and-ads' );
+} elseif ( ! is_null( $this->sync_status ) ) {
+    $sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
 }
-$show_status = $channel_visibility === ChannelVisibility::SYNC_AND_SHOW &&
-    $this->sync_status !== SyncStatus::SYNCED;
+$show_status = 
+    $channel_visibility ===
+    ChannelVisibility::SYNC_AND_SHOW &&
+    $this->sync_status !==
+    SyncStatus::SYNCED;
 
 /**
  *
  * @var array $issues
  */
 $issues = $this->issues;
-$has_issues = ! empty($issues);
+$has_issues = ! empty( $issues );
 
 $input_description = '';
 $input_disabled = false;
-if ($coupon->get_virtual() || (! CouponSyncer::is_coupon_supported($coupon))) {
+if ( ! CouponSyncer::is_coupon_supported( $coupon ) ) {
     $channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
     $show_status = false;
     $input_disabled = true;
-    $input_description = __(
+    $input_description = __( 
         $coupon->get_virtual() ? 'This coupon cannot be shown on public channel because it is hidden from your store.' : 'This coupon cannot be shown because the coupon restrictions are not supported to share in Google channel.',
-        'google-listings-and-ads');
+        'google-listings-and-ads' );
 }
 
 $custom_attributes = [];
-if ($input_disabled) {
+if ( $input_disabled ) {
     $custom_attributes['disabled'] = 'disabled';
 }
 ?>
 
 <div class="gla-channel-visibility-box">
-<?php
-woocommerce_wp_select(
-    [
-        'id' => $field_id,
-        'value' => $channel_visibility,
-        'label' => __('Google Listing & Ads', 'google-listings-and-ads'),
-        'description' => $input_description,
-        'desc_tip' => false,
-        'options' => [
-            ChannelVisibility::SYNC_AND_SHOW => __('Show coupon on Google',
-                'google-listings-and-ads'),
-            ChannelVisibility::DONT_SYNC_AND_SHOW => __(
-                'Don\'t show coupn on Google', 'google-listings-and-ads')
-        ],
-        'custom_attributes' => $custom_attributes
-    ]);
-?>
-	<?php if ( $show_status ) : ?>
-	<div class="sync-status notice-alt notice-large notice-warning"
+	<?php if ( $is_setup_complete ) : ?>
+        <?php
+    woocommerce_wp_select( 
+        [
+            'id' => $field_id,
+            'value' => $channel_visibility,
+            'label' => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
+            'description' => $input_description,
+            'desc_tip' => false,
+            'options' => [
+                ChannelVisibility::SYNC_AND_SHOW => __( 
+                    'Show coupon on Google',
+                    'google-listings-and-ads' ),
+                ChannelVisibility::DONT_SYNC_AND_SHOW => __( 
+                    'Don\'t show coupn on Google',
+                    'google-listings-and-ads' )],
+            'custom_attributes' => $custom_attributes,
+            'wrapper_class' => 'form-row form-row-full'] );
+    ?>
+    	<?php if ( $show_status ) : ?>
+    	<div class="sync-status notice-alt notice-large notice-warning"
 		style="border-left-style: solid">
 		<p>
 			<strong><?php esc_html_e( 'Google sync status', 'google-listings-and-ads' ); ?></strong>
 		</p>
 		<p><?php echo esc_html( $sync_status ); ?></p>
-		<?php if ( $has_issues ) : ?>
-			<div class="gla-product-issues">
+    		<?php if ( $has_issues ) : ?>
+    			<div class="gla-product-issues">
 			<p>
 				<strong><?php esc_html_e( 'Issues', 'google-listings-and-ads' ); ?></strong>
 			</p>
 			<ul>
-					<?php foreach ( $issues as $issue ) : ?>
-					<li><?php echo esc_html( $issue ); ?></li>
-					<?php endforeach; ?>
-				</ul>
+    					<?php foreach ( $issues as $issue ) : ?>
+    					<li><?php echo esc_html( $issue ); ?></li>
+    					<?php endforeach; ?>
+    				</ul>
 		</div>
-		<?php endif; ?>
-	</div>
+    		<?php endif; ?>
+    	</div>
+    	<?php endif; ?>
+	<?php else : ?>
+		<p>
+		<strong><?php esc_html_e( 'Google Listings & Ads', 'google-listings-and-ads' ); ?></strong>
+	</p>
+	<p><?php esc_html_e( 'Complete setup to get your coupon listed on Google for free.', 'google-listings-and-ads' ); ?></p>
+	<a href="<?php echo esc_attr( $get_started_url ); ?>" class="button"><?php esc_html_e( 'Complete setup', 'google-listings-and-ads' ); ?></a>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
Closes #1008 
GooglePromotionService is released in https://github.com/googleapis/google-api-php-client-services (v0.211.0 and above)
Note that createPromotion API works for create or update as long as using same promotion id. In addition, we use create with set effective dates as expired to disable the promotion.

Major files that are added:
1.  Add hooks for listen coupon create/update/trash/delete
2. Add jobs to update/delete promotion on Google by calling CouponSyncer
3. Add CouponHelper and CouponMetaHelper to manage coupon sync status
4. Add CouponSyncer to manage direct call to GooglePromotionService. 
5. Add WCCouponAdapter to map WC_Coupon to Google promotion.
6. Add coupon visibility metabox to provide visibility setting option in coupon edit page


### Screenshots:

![image](https://user-images.githubusercontent.com/87394744/133841773-2ce800af-c685-42dc-96c2-12e6be680e09.png)

![image](https://user-images.githubusercontent.com/87394744/133841814-45109bb3-20e5-4888-aa3f-dbf508ed8895.png)

![image](https://user-images.githubusercontent.com/87394744/133842249-d894c357-3d4c-4424-9451-1f6f089e362d.png)

### Detailed test instructions:
1. Before mc account setup, go to coupon edit page, check setup is link displayed.
2. Create or edit a coupon with select channel visibility as show on Google
3. Sumit the change and wait for sync status shows it started to sync 
4. Trash the coupon and wait to confirm a request sent for disable promotion.



### Changelog entry
