### PR TITLE
Add the UI parts of phone verification process to MC onboarding and Settings pages

### DIFF
--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -77,21 +77,26 @@ export function ContactInformationPreview() {
 }
 
 /**
- * @typedef { import("./phone-number-card").onPhoneNumberChange } onPhoneNumberChange
- */
-
-/**
  * Renders a contact information section with specified initial state and texts, determined by the `view` prop.
  *
  * @param {Object} props React props.
  * @param {'setup-mc'|'settings'} props.view Indicate where this component is used.
- * @param {onPhoneNumberChange} [props.onPhoneNumberChange] Called when phone number is changed.
+ * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified.
  */
-export default function ContactInformation( { view, onPhoneNumberChange } ) {
+export default function ContactInformation( { view, onPhoneNumberVerified } ) {
 	const phone = useGoogleMCPhoneNumber();
 	const isSetupMC = view === 'setup-mc';
 
-	const initEditing = isSetupMC ? null : true;
+	/**
+	 * Since it still lacking the phone verification state,
+	 * all onboarding accounts are considered unverified phone numbers.
+	 *
+	 * TODO: replace the code at next line back to the original logic with
+	 * `const initEditing = isSetupMC ? null : true;`
+	 * after the phone verification state can be detected.
+	 */
+	const initEditing = true;
+
 	const title = isSetupMC ? mcTitle : settingsTitle;
 	const trackContext = isSetupMC
 		? 'setup-mc-contact-information'
@@ -122,7 +127,7 @@ export default function ContactInformation( { view, onPhoneNumberChange } ) {
 					view={ view }
 					phoneNumber={ phone }
 					initEditing={ initEditing }
-					onPhoneNumberChange={ onPhoneNumberChange }
+					onPhoneNumberVerified={ onPhoneNumberVerified }
 				/>
 				<StoreAddressCard />
 			</VerticalGapLayout>

--- a/js/src/components/contact-information/phone-number-card/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card.js
@@ -12,6 +12,7 @@ import { Spinner } from '@woocommerce/components';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import AppButton from '.~/components/app-button';
 import AppSpinner from '.~/components/app-spinner';
+import VerifyPhoneNumberContent from './verify-phone-number-content';
 import EditPhoneNumberContent from './edit-phone-number-content';
 import './phone-number-card.scss';
 
@@ -24,28 +25,59 @@ const basePhoneNumberCardProps = {
 
 /**
  * @typedef { import(".~/hooks/useGoogleMCPhoneNumber").PhoneNumber } PhoneNumber
- * @typedef { import("./edit-phone-number-content").onPhoneNumberChange } onPhoneNumberChange
  */
 
-function EditPhoneNumberCard( { phoneNumber, onPhoneNumberChange } ) {
+function EditPhoneNumberCard( { phoneNumber, onPhoneNumberVerified } ) {
 	const { loaded, data } = phoneNumber;
-	const cardContent = loaded ? (
-		<EditPhoneNumberContent
-			initCountry={ data.country }
-			initNationalNumber={ data.nationalNumber }
-			onPhoneNumberChange={ onPhoneNumberChange }
-		/>
-	) : (
-		<AppSpinner />
+	const [ verifying, setVerifying ] = useState( false );
+	const [ unverifiedPhoneNumber, setUnverifiedPhoneNumber ] = useState(
+		null
 	);
+
+	let cardContent = <AppSpinner />;
+
+	if ( loaded ) {
+		cardContent = unverifiedPhoneNumber ? (
+			<VerifyPhoneNumberContent
+				{ ...unverifiedPhoneNumber }
+				onVerificationStateChange={ ( isVerifying, isVerified ) => {
+					setVerifying( isVerifying );
+
+					if ( isVerified ) {
+						onPhoneNumberVerified();
+					}
+				} }
+			/>
+		) : (
+			<EditPhoneNumberContent
+				initCountry={ data.country }
+				initNationalNumber={ data.nationalNumber }
+				onSendVerificationCodeClick={ setUnverifiedPhoneNumber }
+			/>
+		);
+	}
+
+	const description = unverifiedPhoneNumber
+		? unverifiedPhoneNumber.display
+		: __(
+				'Please enter a phone number to be used for verification.',
+				'google-listings-and-ads'
+		  );
+
+	const indicator = unverifiedPhoneNumber ? (
+		<AppButton
+			isSecondary
+			text={ __( 'Edit', 'google-listings-and-ads' ) }
+			disabled={ verifying }
+			onClick={ () => setUnverifiedPhoneNumber( null ) }
+		/>
+	) : null;
 
 	return (
 		<AccountCard
 			{ ...basePhoneNumberCardProps }
-			description={ __(
-				'Please enter a phone number to be used for verification.',
-				'google-listings-and-ads'
-			) }
+			description={ description }
+			indicator={ indicator }
 		>
 			<CardDivider />
 			{ cardContent }
@@ -66,7 +98,7 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberChange } ) {
  *     `null`: determine the initial UI state according to the `data.isValid` after the `phoneNumber` loaded.
  * @param {Function} [props.onEditClick] Called when clicking on "Edit" button.
  *     If this callback is omitted, it will enter edit mode when clicking on "Edit" button.
- * @param {onPhoneNumberChange} [props.onPhoneNumberChange] Called when inputs of phone number are changed in edit mode.
+ * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified in edit mode.
  */
 export default function PhoneNumberCard( {
 	view,
@@ -74,7 +106,7 @@ export default function PhoneNumberCard( {
 	isPreview = false,
 	initEditing = null,
 	onEditClick,
-	onPhoneNumberChange = noop,
+	onPhoneNumberVerified = noop,
 } ) {
 	const { loaded, data } = phoneNumber;
 	const [ isEditing, setEditing ] = useState(
@@ -100,10 +132,14 @@ export default function PhoneNumberCard( {
 	}
 
 	if ( isEditing ) {
+		const handlePhoneNumberVerified = () => {
+			setEditing( false );
+			onPhoneNumberVerified();
+		};
 		return (
 			<EditPhoneNumberCard
 				phoneNumber={ phoneNumber }
-				onPhoneNumberChange={ onPhoneNumberChange }
+				onPhoneNumberVerified={ handlePhoneNumberVerified }
 			/>
 		);
 	}

--- a/js/src/components/contact-information/phone-number-card/phone-number-card.scss
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card.scss
@@ -39,4 +39,9 @@
 			border-color: $gray-600;
 		}
 	}
+
+	// Verification method radio
+	.components-radio-control__option:not(:last-child) {
+		margin-bottom: 8px;
+	}
 }

--- a/js/src/components/contact-information/phone-number-card/verify-phone-number-content.js
+++ b/js/src/components/contact-information/phone-number-card/verify-phone-number-content.js
@@ -100,14 +100,14 @@ const appearanceDict = {
  * @param {string} props.country The country code. Example: 'US'.
  * @param {string} props.number The phone number string in E.164 format. Example: '+12133734253'.
  * @param {string} props.display The phone number string in international format. Example: '+1 213 373 4253'.
- * @param {Function} props.onPhoneNumberVerified Called when the phone number is verified.
+ * @param {(isVerifying: boolean, isVerified: boolean) => void} props.onVerificationStateChange Called when the verification state is changed.
  */
 export default function VerifyPhoneNumberContent( {
 	verificationMethod,
 	country,
 	number,
 	display,
-	onPhoneNumberVerified,
+	onVerificationStateChange,
 } ) {
 	const isMounted = useIsMounted();
 	const [ method, setMethod ] = useState( verificationMethod );
@@ -146,17 +146,19 @@ export default function VerifyPhoneNumberContent( {
 	const handleVerifyClick = () => {
 		setError( null );
 		setVerifying( true );
+		onVerificationStateChange( true, false );
 
 		const id = verificationIdRef.current[ method ];
 		verifyPhoneNumber( id, verification.code, method )
 			.then( () => {
-				onPhoneNumberVerified();
+				onVerificationStateChange( false, true );
 			} )
 			.catch( ( e ) => {
 				// TODO: [full-contact-info] align to the real error data structure.
 				if ( isMounted() ) {
 					setError( e );
 					setVerifying( false );
+					onVerificationStateChange( false, false );
 				}
 			} );
 	};

--- a/js/src/settings/edit-contact-information/index.js
+++ b/js/src/settings/edit-contact-information/index.js
@@ -24,33 +24,21 @@ export default function EditContactInformation() {
 	const { data: address } = useStoreAddress();
 	const [ isSaving, setSaving ] = useState( false );
 
-	// The initial `isValid: true` is to avoid blocking the submission when only the store address is changed.
-	// And the prevention of saving invalid phone number can be checked by initial `isDirty: false`.
-	const [ phoneNumber, setPhoneNumber ] = useState( {
-		isValid: true,
-		isDirty: false,
-	} );
-
 	const handleSaveClick = () => {
-		const { isDirty, countryCallingCode, nationalNumber } = phoneNumber;
-		const args = isDirty ? [ countryCallingCode, nationalNumber ] : [];
-
 		setSaving( true );
-		updateGoogleMCContactInformation( ...args )
+		updateGoogleMCContactInformation()
 			.then( () => getHistory().push( getSettingsUrl() ) )
 			.catch( () => setSaving( false ) );
 	};
 
 	const isReadyToSave =
-		phoneNumber.isValid &&
-		address.isAddressFilled &&
-		( phoneNumber.isDirty || address.isMCAddressDifferent );
+		address.isAddressFilled && address.isMCAddressDifferent;
 
 	return (
 		<FullContainer>
 			<TopBar
 				title={ __(
-					'Add contact information',
+					'Edit contact information',
 					'google-listings-and-ads'
 				) }
 				helpButton={
@@ -59,10 +47,7 @@ export default function EditContactInformation() {
 				backHref={ getSettingsUrl() }
 			/>
 			<div className="gla-settings">
-				<ContactInformation
-					view="settings"
-					onPhoneNumberChange={ setPhoneNumber }
-				/>
+				<ContactInformation view="settings" />
 				<Section>
 					<Flex justify="flex-end">
 						<AppButton

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -12,7 +12,6 @@ import { getNewPath } from '@woocommerce/navigation';
  */
 import { useAppDispatch } from '.~/data';
 import useAdminUrl from '.~/hooks/useAdminUrl';
-import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import useStoreAddress from '.~/hooks/useStoreAddress';
 import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
@@ -29,15 +28,15 @@ export default function StoreRequirements() {
 	const adminUrl = useAdminUrl();
 	const { updateGoogleMCContactInformation, saveSettings } = useAppDispatch();
 	const { createNotice } = useDispatchCoreNotices();
-	const { data: initPhoneNumber } = useGoogleMCPhoneNumber();
 	const { data: address } = useStoreAddress();
 	const { settings } = useSettings();
 
+	/**
+	 * Since it still lacking the phone verification state,
+	 * all onboarding accounts are considered unverified phone numbers.
+	 */
+	const [ isPhoneNumberReady, setPhoneNumberReady ] = useState( false );
 	const [ completing, setCompleting ] = useState( false );
-	const [ phoneNumber, setPhoneNumber ] = useState( {
-		isValid: false,
-		isDirty: false,
-	} );
 
 	const handleChangeCallback = ( _, values ) => {
 		saveSettings( values );
@@ -45,12 +44,9 @@ export default function StoreRequirements() {
 
 	const handleSubmitCallback = async () => {
 		try {
-			const { isDirty, countryCallingCode, nationalNumber } = phoneNumber;
-			const args = isDirty ? [ countryCallingCode, nationalNumber ] : [];
-
 			setCompleting( true );
 
-			await updateGoogleMCContactInformation( ...args );
+			await updateGoogleMCContactInformation();
 
 			await apiFetch( {
 				path: '/wc/gla/mc/settings/sync',
@@ -109,10 +105,6 @@ export default function StoreRequirements() {
 				{ ( formProps ) => {
 					const { handleSubmit, isValidForm } = formProps;
 
-					const isPhoneNumberReady = phoneNumber.isDirty
-						? phoneNumber.isValid
-						: initPhoneNumber.isValid;
-
 					const isReadyToComplete =
 						isValidForm &&
 						isPhoneNumberReady &&
@@ -122,7 +114,9 @@ export default function StoreRequirements() {
 						<>
 							<ContactInformation
 								view="setup-mc"
-								onPhoneNumberChange={ setPhoneNumber }
+								onPhoneNumberVerified={ () =>
+									setPhoneNumberReady( true )
+								}
 							/>
 							<PreLaunchChecklist formProps={ formProps } />
 							<StepContentFooter>

--- a/js/src/wcdl/subsection/index.scss
+++ b/js/src/wcdl/subsection/index.scss
@@ -1,5 +1,5 @@
 .wcdl-subsection {
-	&:not(:last-child) {
-		margin-bottom: var(--main-gap);
+	&:not(:first-child) {
+		margin-top: var(--main-gap);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #962.

- Add verification method selection and verification process to the `<PhoneNumberCard>`
- Add phone verification process to the MC onboarding and Settings pages.

### Screenshots:

#### 🎥 . MC onboarding

https://user-images.githubusercontent.com/17420811/134329362-3e0db490-a684-4c19-adb3-1f02b7cf0eb5.mp4

#### 🎥 . Settings

https://user-images.githubusercontent.com/17420811/134329517-1757ba0c-e838-482c-afbd-dc7926c94710.mp4

### Detailed test instructions:

💡. This PR is still communicated to mock APIs. The phone verification could be passed by entering `000000` code, and the rest will fail. And the changed phone number would not be updated to the upper/global states or server side. This part will be implemented in the next PR.

1. Go to the MC onboarding page.
    1. It should always ask you to verify a phone number no matter the number has been stored (and verified) before.
    1. Try the UI to see if the UI parts of verification process work properly.
    1. After passing the verification, the "Complete setup" should be able to click.
1. Go to the Setting pages. 
    1. Try to edit the phone number see if the UI parts of verification process work properly.

### Changelog entry
