### PR TITLE
Use Ads currency in report pages

### DIFF
--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -56,7 +56,7 @@ const AllProgramsTableCard = ( props ) => {
 	const query = getQuery();
 	// Budget is given in the currency that is used by Google Ads, which may differ from the current store's currency.
 	// We will still use the store's currency **formatting** settings.
-	const { currencyConfig: adsCurrencyConfig } = useAdsCurrencyConfig();
+	const { adsCurrencyConfig } = useAdsCurrencyConfig();
 	const {
 		data: finalCountryCodesData,
 	} = useTargetAudienceFinalCountryCodes();

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -13,7 +13,7 @@ import EditProgramButton from './edit-program-button';
 import './index.scss';
 import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
 import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
-import useAdsCurrency from '.~/hooks/useAdsCurrency';
+import { useAdsCurrencyConfig } from '.~/hooks/useAdsCurrency';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import AppSpinner from '.~/components/app-spinner';
 import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
@@ -56,16 +56,12 @@ const AllProgramsTableCard = ( props ) => {
 	const query = getQuery();
 	// Budget is given in the currency that is used by Google Ads, which may differ from the current store's currency.
 	// We will still use the store's currency **formatting** settings.
-	const {
-		currency: { getCurrencyConfig },
-	} = useAdsCurrency();
+	const { currencyConfig: adsCurrencyConfig } = useAdsCurrencyConfig();
 	const {
 		data: finalCountryCodesData,
 	} = useTargetAudienceFinalCountryCodes();
 	const { data: adsCampaignsData } = useAdsCampaigns();
 	const map = useCountryKeyNameMap();
-
-	const adsCurrency = getCurrencyConfig();
 
 	if ( ! finalCountryCodesData || ! adsCampaignsData ) {
 		return <AppSpinner />;
@@ -93,7 +89,10 @@ const AllProgramsTableCard = ( props ) => {
 			return {
 				id: el.id,
 				title: el.name,
-				dailyBudget: formatAmountWithCode( adsCurrency, el.amount ),
+				dailyBudget: formatAmountWithCode(
+					adsCurrencyConfig,
+					el.amount
+				),
 				country: map[ el.country ],
 				active: el.status === 'enabled',
 			};

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -20,7 +20,7 @@ import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
 import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
 import ProgramToggle from './program-toggle';
 import FreeListingsDisabledToggle from './free-listings-disabled-toggle';
-import formatAmountWithCode from './format-amount-with-code';
+import formatAmountWithCode from '.~/utils/formatAmountWithCode';
 
 const headers = [
 	{

--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -8,10 +8,10 @@ import { SummaryNumber } from '@woocommerce/components';
  * Internal dependencies
  */
 import { glaData, REPORT_SOURCE_PAID, REPORT_SOURCE_FREE } from '.~/constants';
-import useAdsCurrency from '.~/hooks/useAdsCurrency';
+import { useAdsCurrencyConfig } from '.~/hooks/useAdsCurrency';
 import formatAmountWithCode from '.~/utils/formatAmountWithCode';
 import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
-import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
+import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import usePerformance from './usePerformance';
 import PerformanceCard from './performance-card';
 import PaidCampaignPromotionCard from './paid-campaign-promotion-card';
@@ -58,13 +58,9 @@ const FreePerformanceCard = () => {
 const PaidPerformanceCard = () => {
 	// Spend amount is given in the Ads' currency, but Total Sales is in store's currency.
 	// We use codes to make sure it's nonambiguous.
-	// Use just `formatAmount`s once https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
-	const { getCurrencyConfig } = useCurrencyFactory();
-	const {
-		currency: { getCurrencyConfig: getAdsCurrencyConfig },
-	} = useAdsCurrency();
-	const currency = getCurrencyConfig();
-	const adsCurrency = getAdsCurrencyConfig();
+	// Use just `useAdsCurrency`'s/`getCurrencyConfig`'s  `formatAmount`s once https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
+	const { currencyConfig: adsCurrency } = useAdsCurrencyConfig();
+	const storeCurrencyConfig = useStoreCurrency();
 	const { data, loaded } = usePerformance( REPORT_SOURCE_PAID );
 
 	return (
@@ -78,11 +74,11 @@ const PaidPerformanceCard = () => {
 					key="1"
 					label={ __( 'Total Sales', 'google-listings-and-ads' ) }
 					value={ formatAmountWithCode(
-						currency,
+						storeCurrencyConfig,
 						loadedData.sales.value
 					) }
 					prevValue={ formatAmountWithCode(
-						currency,
+						storeCurrencyConfig,
 						loadedData.sales.prevValue
 					) }
 					delta={ loadedData.sales.delta }

--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -8,6 +8,8 @@ import { SummaryNumber } from '@woocommerce/components';
  * Internal dependencies
  */
 import { glaData, REPORT_SOURCE_PAID, REPORT_SOURCE_FREE } from '.~/constants';
+import useAdsCurrency from '.~/hooks/useAdsCurrency';
+import formatAmountWithCode from '.~/utils/formatAmountWithCode';
 import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
 import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
 import usePerformance from './usePerformance';
@@ -54,7 +56,15 @@ const FreePerformanceCard = () => {
 };
 
 const PaidPerformanceCard = () => {
-	const { formatAmount } = useCurrencyFactory();
+	// Spend amount is given in the Ads' currency, but Total Sales is in store's currency.
+	// We use codes to make sure it's nonambiguous.
+	// Use just `formatAmount`s once https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
+	const { getCurrencyConfig } = useCurrencyFactory();
+	const {
+		currency: { getCurrencyConfig: getAdsCurrencyConfig },
+	} = useAdsCurrency();
+	const currency = getCurrencyConfig();
+	const adsCurrency = getAdsCurrencyConfig();
 	const { data, loaded } = usePerformance( REPORT_SOURCE_PAID );
 
 	return (
@@ -67,15 +77,27 @@ const PaidPerformanceCard = () => {
 				<SummaryNumber
 					key="1"
 					label={ __( 'Total Sales', 'google-listings-and-ads' ) }
-					value={ formatAmount( loadedData.sales.value ) }
-					prevValue={ formatAmount( loadedData.sales.prevValue ) }
+					value={ formatAmountWithCode(
+						currency,
+						loadedData.sales.value
+					) }
+					prevValue={ formatAmountWithCode(
+						currency,
+						loadedData.sales.prevValue
+					) }
 					delta={ loadedData.sales.delta }
 				/>,
 				<SummaryNumber
 					key="2"
 					label={ __( 'Total Spend', 'google-listings-and-ads' ) }
-					value={ formatAmount( loadedData.spend.value ) }
-					prevValue={ formatAmount( loadedData.spend.prevValue ) }
+					value={ formatAmountWithCode(
+						adsCurrency,
+						loadedData.spend.value
+					) }
+					prevValue={ formatAmountWithCode(
+						adsCurrency,
+						loadedData.spend.prevValue
+					) }
 					delta={ loadedData.spend.delta }
 				/>,
 			] }

--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -59,7 +59,7 @@ const PaidPerformanceCard = () => {
 	// Spend amount is given in the Ads' currency, but Total Sales is in store's currency.
 	// We use codes to make sure it's nonambiguous.
 	// Use just `useAdsCurrency`'s/`getCurrencyConfig`'s  `formatAmount`s once https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
-	const { currencyConfig: adsCurrency } = useAdsCurrencyConfig();
+	const { adsCurrencyConfig } = useAdsCurrencyConfig();
 	const storeCurrencyConfig = useStoreCurrency();
 	const { data, loaded } = usePerformance( REPORT_SOURCE_PAID );
 
@@ -87,11 +87,11 @@ const PaidPerformanceCard = () => {
 					key="2"
 					label={ __( 'Total Spend', 'google-listings-and-ads' ) }
 					value={ formatAmountWithCode(
-						adsCurrency,
+						adsCurrencyConfig,
 						loadedData.spend.value
 					) }
 					prevValue={ formatAmountWithCode(
-						adsCurrency,
+						adsCurrencyConfig,
 						loadedData.spend.prevValue
 					) }
 					delta={ loadedData.spend.delta }

--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -11,7 +11,6 @@ import { glaData, REPORT_SOURCE_PAID, REPORT_SOURCE_FREE } from '.~/constants';
 import { useAdsCurrencyConfig } from '.~/hooks/useAdsCurrency';
 import formatAmountWithCode from '.~/utils/formatAmountWithCode';
 import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
-import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import usePerformance from './usePerformance';
 import PerformanceCard from './performance-card';
 import PaidCampaignPromotionCard from './paid-campaign-promotion-card';
@@ -56,11 +55,10 @@ const FreePerformanceCard = () => {
 };
 
 const PaidPerformanceCard = () => {
-	// Spend amount is given in the Ads' currency, but Total Sales is in store's currency.
-	// We use codes to make sure it's nonambiguous.
+	// The amount of Total Sales and Total Spend are given in the Ads' currency.
+	// We use currency code to make sure it's nonambiguous.
 	// Use just `useAdsCurrency`'s/`getCurrencyConfig`'s  `formatAmount`s once https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
 	const { adsCurrencyConfig } = useAdsCurrencyConfig();
-	const storeCurrencyConfig = useStoreCurrency();
 	const { data, loaded } = usePerformance( REPORT_SOURCE_PAID );
 
 	return (
@@ -74,11 +72,11 @@ const PaidPerformanceCard = () => {
 					key="1"
 					label={ __( 'Total Sales', 'google-listings-and-ads' ) }
 					value={ formatAmountWithCode(
-						storeCurrencyConfig,
+						adsCurrencyConfig,
 						loadedData.sales.value
 					) }
 					prevValue={ formatAmountWithCode(
-						storeCurrencyConfig,
+						adsCurrencyConfig,
 						loadedData.sales.prevValue
 					) }
 					delta={ loadedData.sales.delta }

--- a/js/src/hooks/useAdsCurrency.js
+++ b/js/src/hooks/useAdsCurrency.js
@@ -2,51 +2,12 @@
  * External dependencies
  */
 import { useMemo } from '@wordpress/element';
-import CurrencyFactory from '@woocommerce/currency';
 
 /**
  * Internal dependencies
  */
 import useStoreCurrency from './useStoreCurrency';
 import useGoogleAdsAccount from './useGoogleAdsAccount';
-
-/**
- * Get the store's currency object, eventually extended with the Ads' currency and symbol.
- * This would allow using store's formatting preferences,
- * with an actual currency that's being used by Google Ads Account.
- *
- * We start with a "currency-less" config, as the store's preferences are relatively fast to obtain.
- * So, we could start serving meaningful content to the user, while they wait for Ads details to be fetched.
- *
- * Usage:
- *
- * ```js
- * const { currency, hasFinishedResolution } = useAdsCurrency()
- * console.log( currency.formatAmount( 1234.678 ) ) // Print the number in the store's currency format '1 234,68'.
- * // After some time, once Ads account details are fetched.
- * console.log( hasFinishedResolution ) // true
- * console.log( currency.formatAmount( 1234.678 ) ) // Print the number in the store's currency format with the Ad's currency '1 234,68 zł'.
- * ```
- *
- * @see CurrencyFactory
- *
- * @return {{currency: Object, currencyConfig: Object, hasFinishedResolution: boolean | undefined}} The currency object.
- */
-const useAdsCurrency = () => {
-	const { currencyConfig, hasFinishedResolution } = useAdsCurrencyConfig();
-
-	const currency = useMemo( () => CurrencyFactory( currencyConfig ), [
-		currencyConfig,
-	] );
-
-	return {
-		currency,
-		currencyConfig,
-		hasFinishedResolution,
-	};
-};
-
-export default useAdsCurrency;
 
 /**
  * Get the store's currency config, eventually extended with the Ads' currency code and symbol.
@@ -64,6 +25,9 @@ export default useAdsCurrency;
  * console.log( hasFinishedResolution ) // true
  * console.log( currencyConfig.config ) // { code: 'PLN', symbol: 'zł', … }
  * ```
+ *
+ * Once https://github.com/woocommerce/woocommerce-admin/pull/7575 will be available throught Dependency Extraction Webpack Plugin,
+ * we can consider exposing currency object given by `CurrencyFactory`, to expose `formatAmout` already customized for the currency.
  *
  * @see useStoreCurrency
  *

--- a/js/src/hooks/useAdsCurrency.js
+++ b/js/src/hooks/useAdsCurrency.js
@@ -21,41 +21,78 @@ import useGoogleAdsAccount from './useGoogleAdsAccount';
  * Usage:
  *
  * ```js
- * const { currency, isResolving } = useAdsCurrency()
+ * const { currency, hasFinishedResolution } = useAdsCurrency()
  * console.log( currency.formatAmount( 1234.678 ) ) // Print the number in the store's currency format '1 234,68'.
  * // After some time, once Ads account details are fetched.
- * console.log( currency.hasFinishedResolution ) // true
+ * console.log( hasFinishedResolution ) // true
  * console.log( currency.formatAmount( 1234.678 ) ) // Print the number in the store's currency format with the Ad's currency '1 234,68 zł'.
  * ```
  *
  * @see CurrencyFactory
  *
- * @return {{currency: Object, hasFinishedResolution: boolean | undefined}} The currency object.
+ * @return {{currency: Object, currencyConfig: Object, hasFinishedResolution: boolean | undefined}} The currency object.
  */
 const useAdsCurrency = () => {
-	const currencySetting = useStoreCurrency();
-	const { googleAdsAccount, hasFinishedResolution } = useGoogleAdsAccount();
+	const { currencyConfig, hasFinishedResolution } = useAdsCurrencyConfig();
+
+	const currency = useMemo( () => CurrencyFactory( currencyConfig ), [
+		currencyConfig,
+	] );
 
 	return {
-		currency: useMemo( () => {
-			// Apply store's foramtting data without the Ad's currency.
-			if ( googleAdsAccount && googleAdsAccount.currency ) {
-				return CurrencyFactory( {
-					...currencySetting,
-					code: googleAdsAccount.currency,
-					symbol: googleAdsAccount.symbol,
-				} );
-			}
-			// Apply store's foramtting data without a specific currency.
-			// So we could eagerly render a plain formatted number.
-			return CurrencyFactory( {
-				...currencySetting,
-				code: '',
-				symbol: '',
-			} );
-		}, [ currencySetting, googleAdsAccount ] ),
+		currency,
+		currencyConfig,
 		hasFinishedResolution,
 	};
 };
 
 export default useAdsCurrency;
+
+/**
+ * Get the store's currency config, eventually extended with the Ads' currency code and symbol.
+ * This would allow using store's formatting preferences,
+ * with an actual currency that's being used by Google Ads Account.
+ *
+ * We start with a "currency-less" config, as the store's preferences are relatively fast to obtain.
+ * So, we could start serving meaningful content to the user, while they wait for Ads details to be fetched.
+ *
+ * Usage:
+ *
+ * ```js
+ * const { currencyConfig, hasFinishedResolution } = useAdsCurrency()
+ * console.log( currencyConfig.config ) // { code: 'CAD', symbol: '$', precision: 2, symbolPosition: 'left_space', decimalSeparator: '.', thousandSeparator: ',', priceFormat }
+ * console.log( hasFinishedResolution ) // true
+ * console.log( currencyConfig.config ) // { code: 'PLN', symbol: 'zł', … }
+ * ```
+ *
+ * @see useStoreCurrency
+ *
+ * @return {{currencyConfig: Object, hasFinishedResolution: boolean | undefined}} The currency object.
+ */
+export const useAdsCurrencyConfig = () => {
+	const storeCurrencySetting = useStoreCurrency();
+	const { googleAdsAccount, hasFinishedResolution } = useGoogleAdsAccount();
+
+	const currencyConfig = useMemo( () => {
+		// Apply store's foramtting data without the Ad's currency.
+		if ( googleAdsAccount && googleAdsAccount.currency ) {
+			return {
+				...storeCurrencySetting,
+				code: googleAdsAccount.currency,
+				symbol: googleAdsAccount.symbol,
+			};
+		}
+		// Apply store's foramtting data without a specific currency.
+		// So we could eagerly render a plain formatted number.
+		return {
+			...storeCurrencySetting,
+			code: '',
+			symbol: '',
+		};
+	}, [ storeCurrencySetting, googleAdsAccount ] );
+
+	return {
+		currencyConfig,
+		hasFinishedResolution,
+	};
+};

--- a/js/src/hooks/useAdsCurrency.js
+++ b/js/src/hooks/useAdsCurrency.js
@@ -31,13 +31,13 @@ import useGoogleAdsAccount from './useGoogleAdsAccount';
  *
  * @see useStoreCurrency
  *
- * @return {{currencyConfig: Object, hasFinishedResolution: boolean | undefined}} The currency object.
+ * @return {{adsCurrencyConfig: Object, hasFinishedResolution: boolean | undefined}} The currency object.
  */
 export const useAdsCurrencyConfig = () => {
 	const storeCurrencySetting = useStoreCurrency();
 	const { googleAdsAccount, hasFinishedResolution } = useGoogleAdsAccount();
 
-	const currencyConfig = useMemo( () => {
+	const adsCurrencyConfig = useMemo( () => {
 		// Apply store's foramtting data without the Ad's currency.
 		if ( googleAdsAccount && googleAdsAccount.currency ) {
 			return {
@@ -56,7 +56,7 @@ export const useAdsCurrencyConfig = () => {
 	}, [ storeCurrencySetting, googleAdsAccount ] );
 
 	return {
-		currencyConfig,
+		adsCurrencyConfig,
 		hasFinishedResolution,
 	};
 };

--- a/js/src/hooks/useAdsCurrency.test.js
+++ b/js/src/hooks/useAdsCurrency.test.js
@@ -30,7 +30,7 @@ jest.mock( './useStoreCurrency', () => ( {
 } ) );
 
 describe( 'useAdsCurrencyConfig', () => {
-	test( 'initially should return `{ currencyConfig: Object, hasFinishedResolution: undefined }`', () => {
+	test( 'initially should return `{ adsCurrencyConfig: Object, hasFinishedResolution: undefined }`', () => {
 		const { result } = renderHook( () => useAdsCurrencyConfig() );
 
 		// assert initial state
@@ -38,8 +38,8 @@ describe( 'useAdsCurrencyConfig', () => {
 			'hasFinishedResolution',
 			undefined
 		);
-		expect( result.current ).toHaveProperty( 'currencyConfig' );
-		expect( result.current.currencyConfig ).toEqual(
+		expect( result.current ).toHaveProperty( 'adsCurrencyConfig' );
+		expect( result.current.adsCurrencyConfig ).toEqual(
 			expect.objectContaining( {
 				code: expect.any( String ),
 				precision: expect.any( Number ),
@@ -52,15 +52,15 @@ describe( 'useAdsCurrencyConfig', () => {
 		);
 	} );
 
-	test( "initially should return store's currencyConfig w/ `code` and `symbol` set to empty", () => {
+	test( "initially should return store's currency config w/ `code` and `symbol` set to empty", () => {
 		const { result } = renderHook( () => useAdsCurrencyConfig() );
 		const {
 			result: { current: storesCurrencyConfig },
 		} = renderHook( () => useStoreCurrency() );
 
 		// assert initial state
-		expect( result.current ).toHaveProperty( 'currencyConfig' );
-		expect( result.current.currencyConfig ).toEqual( {
+		expect( result.current ).toHaveProperty( 'adsCurrencyConfig' );
+		expect( result.current.adsCurrencyConfig ).toEqual( {
 			...storesCurrencyConfig,
 			code: '',
 			symbol: '',
@@ -107,7 +107,7 @@ describe( 'useAdsCurrencyConfig', () => {
 			);
 		} );
 
-		test( 'should return currencyConfig with Ads account code and symbol', async () => {
+		test( 'should return currency config with Ads account code and symbol', async () => {
 			const { result, waitFor } = renderHook( () =>
 				useAdsCurrencyConfig()
 			);
@@ -116,11 +116,11 @@ describe( 'useAdsCurrencyConfig', () => {
 			// expect( result.current.hasFinishedResolution ).toEqual( undefined );
 			// Unfortunately, tests are not atomic, as the state is perserved between them.
 
-			const initialConfig = result.current.currencyConfig;
+			const initialConfig = result.current.adsCurrencyConfig;
 
 			// Assert eventual value.
 			await waitFor( () =>
-				expect( result.current.currencyConfig ).toEqual( {
+				expect( result.current.adsCurrencyConfig ).toEqual( {
 					...initialConfig,
 					code: adsAccountData.currency,
 					symbol: adsAccountData.symbol,

--- a/js/src/hooks/useAdsCurrency.test.js
+++ b/js/src/hooks/useAdsCurrency.test.js
@@ -7,7 +7,7 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import useAdsCurrency from './useAdsCurrency';
+import { useAdsCurrencyConfig } from './useAdsCurrency';
 import useStoreCurrency from './useStoreCurrency';
 
 // Force real timers, make sure all timers are actually ticking.
@@ -29,34 +29,39 @@ jest.mock( './useStoreCurrency', () => ( {
 	} ),
 } ) );
 
-describe( 'useAdsCurrency', () => {
-	test( 'initially should return `{ currency: Object, hasFinishedResolution: undefined }`', () => {
-		const { result } = renderHook( () => useAdsCurrency() );
+describe( 'useAdsCurrencyConfig', () => {
+	test( 'initially should return `{ currencyConfig: Object, hasFinishedResolution: undefined }`', () => {
+		const { result } = renderHook( () => useAdsCurrencyConfig() );
 
 		// assert initial state
 		expect( result.current ).toHaveProperty(
 			'hasFinishedResolution',
 			undefined
 		);
-		expect( result.current ).toHaveProperty( 'currency' );
-		expect( result.current.currency ).toEqual(
+		expect( result.current ).toHaveProperty( 'currencyConfig' );
+		expect( result.current.currencyConfig ).toEqual(
 			expect.objectContaining( {
-				formatAmount: expect.any( Function ),
-				getCurrencyConfig: expect.any( Function ),
+				code: expect.any( String ),
+				precision: expect.any( Number ),
+				symbol: expect.any( String ),
+				symbolPosition: expect.any( String ),
+				decimalSeparator: expect.any( String ),
+				thousandSeparator: expect.any( String ),
+				priceFormat: expect.any( String ),
 			} )
 		);
 	} );
 
-	test( "initially should return store's currency w/ `code` and `symbol` set to empty", () => {
-		const { result } = renderHook( () => useAdsCurrency() );
+	test( "initially should return store's currencyConfig w/ `code` and `symbol` set to empty", () => {
+		const { result } = renderHook( () => useAdsCurrencyConfig() );
 		const {
-			result: { current: storesCurrency },
+			result: { current: storesCurrencyConfig },
 		} = renderHook( () => useStoreCurrency() );
 
 		// assert initial state
-		expect( result.current ).toHaveProperty( 'currency.getCurrencyConfig' );
-		expect( result.current.currency.getCurrencyConfig() ).toEqual( {
-			...storesCurrency,
+		expect( result.current ).toHaveProperty( 'currencyConfig' );
+		expect( result.current.currencyConfig ).toEqual( {
+			...storesCurrencyConfig,
 			code: '',
 			symbol: '',
 		} );
@@ -90,7 +95,9 @@ describe( 'useAdsCurrency', () => {
 				);
 		} );
 		test( 'should finish resolution', async () => {
-			const { result, waitFor } = renderHook( () => useAdsCurrency() );
+			const { result, waitFor } = renderHook( () =>
+				useAdsCurrencyConfig()
+			);
 
 			// assert initial state
 			expect( result.current.hasFinishedResolution ).toEqual( undefined );
@@ -100,18 +107,20 @@ describe( 'useAdsCurrency', () => {
 			);
 		} );
 
-		test( 'should return Ads account currency', async () => {
-			const { result, waitFor } = renderHook( () => useAdsCurrency() );
+		test( 'should return currencyConfig with Ads account code and symbol', async () => {
+			const { result, waitFor } = renderHook( () =>
+				useAdsCurrencyConfig()
+			);
 
 			// assert initial state
 			// expect( result.current.hasFinishedResolution ).toEqual( undefined );
 			// Unfortunately, tests are not atomic, as the state is perserved between them.
 
-			const initialConfig = result.current.currency.getCurrencyConfig();
+			const initialConfig = result.current.currencyConfig;
 
 			// Assert eventual value.
 			await waitFor( () =>
-				expect( result.current.currency.getCurrencyConfig() ).toEqual( {
+				expect( result.current.currencyConfig ).toEqual( {
 					...initialConfig,
 					code: adsAccountData.currency,
 					symbol: adsAccountData.symbol,

--- a/js/src/reports/chart-section.js
+++ b/js/src/reports/chart-section.js
@@ -11,7 +11,6 @@ import { getChartTypeForQuery } from '@woocommerce/date';
  */
 import useUrlQuery from '.~/hooks/useUrlQuery';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
-import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
 
 const emptyMessage = __(
 	'No data for the selected date range',
@@ -29,7 +28,6 @@ const emptyMessage = __(
 export default function ChartSection( { metrics, loaded, intervals } ) {
 	const query = useUrlQuery();
 	const currency = useStoreCurrency();
-	const { formatAmount } = useCurrencyFactory();
 
 	const { selectedMetric } = query;
 	let visibleMetric = {};
@@ -40,11 +38,11 @@ export default function ChartSection( { metrics, loaded, intervals } ) {
 			metrics[ 0 ];
 	}
 
-	const { key, label, isCurrency = false } = visibleMetric;
+	const { key, label, isCurrency = false, formatFn } = visibleMetric;
 
 	const chartType = getChartTypeForQuery( query );
 	const valueType = isCurrency ? 'currency' : 'number';
-	const tooltipValueFormat = isCurrency ? formatAmount : ',';
+	const localizedFormatFn = ( number ) => formatFn( currency, number );
 
 	const chartData = useMemo( () => {
 		if ( ! loaded ) {
@@ -70,7 +68,7 @@ export default function ChartSection( { metrics, loaded, intervals } ) {
 			currency={ currency }
 			chartType={ chartType }
 			valueType={ valueType }
-			tooltipValueFormat={ tooltipValueFormat }
+			tooltipValueFormat={ localizedFormatFn }
 			isRequesting={ ! loaded }
 			emptyMessage={ emptyMessage }
 			layout="time-comparison"

--- a/js/src/reports/chart-section.js
+++ b/js/src/reports/chart-section.js
@@ -28,7 +28,7 @@ const emptyMessage = __(
  */
 export default function ChartSection( { metrics, loaded, intervals } ) {
 	const query = useUrlQuery();
-	const { currencyConfig: adsCurrencyConfig } = useAdsCurrencyConfig();
+	const { adsCurrencyConfig } = useAdsCurrencyConfig();
 	const storeCurrencyConfig = useStoreCurrency();
 
 	const { selectedMetric } = query;

--- a/js/src/reports/compare-table-card.js
+++ b/js/src/reports/compare-table-card.js
@@ -11,6 +11,7 @@ import { onQueryChange } from '@woocommerce/navigation';
  */
 import { getIdsFromQuery } from './utils';
 import useUrlQuery from '.~/hooks/useUrlQuery';
+import { useAdsCurrencyConfig } from '.~/hooks/useAdsCurrency';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import AppTableCard from '.~/components/app-table-card';
 
@@ -43,6 +44,7 @@ const CompareTableCard = ( {
 	nameCell,
 	...restProps
 } ) => {
+	const { currencyConfig: adsCurrencyConfig } = useAdsCurrencyConfig();
 	const storeCurrencyConfig = useStoreCurrency();
 	const query = useUrlQuery();
 
@@ -113,7 +115,11 @@ const CompareTableCard = ( {
 		metrics.map( ( metric ) => {
 			const value = row.subtotals[ metric.key ];
 			return {
-				display: metric.formatFn( storeCurrencyConfig, value ),
+				display: metric.formatFn(
+					value,
+					storeCurrencyConfig,
+					adsCurrencyConfig
+				),
 			};
 		} );
 	/**

--- a/js/src/reports/compare-table-card.js
+++ b/js/src/reports/compare-table-card.js
@@ -11,11 +11,8 @@ import { onQueryChange } from '@woocommerce/navigation';
  */
 import { getIdsFromQuery } from './utils';
 import useUrlQuery from '.~/hooks/useUrlQuery';
-import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
-import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
+import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import AppTableCard from '.~/components/app-table-card';
-
-const numberFormatSetting = { precision: 0 };
 
 /**
  * All data table, with compare feature.
@@ -46,9 +43,8 @@ const CompareTableCard = ( {
 	nameCell,
 	...restProps
 } ) => {
+	const storeCurrencyConfig = useStoreCurrency();
 	const query = useUrlQuery();
-	const formatNumber = useCurrencyFormat( numberFormatSetting );
-	const { formatAmount } = useCurrencyFactory();
 
 	const [ selectedRows, setSelectedRows ] = useState( () => {
 		return new Set( getIdsFromQuery( query[ compareBy ] ) );
@@ -104,7 +100,6 @@ const CompareTableCard = ( {
 		...metricHeaders,
 	];
 
-	const unavailable = __( 'Unavailable', 'google-listings-and-ads' );
 	/**
 	 * Creates an array of metric cells for {@link getRows},
 	 * for a given row.
@@ -116,13 +111,9 @@ const CompareTableCard = ( {
 	 */
 	const renderMetricDataCells = ( row ) =>
 		metrics.map( ( metric ) => {
-			const formatFn = metric.isCurrency ? formatAmount : formatNumber;
 			const value = row.subtotals[ metric.key ];
 			return {
-				display:
-					value === null || value === undefined
-						? unavailable
-						: formatFn( value ),
+				display: metric.formatFn( storeCurrencyConfig, value ),
 			};
 		} );
 	/**

--- a/js/src/reports/compare-table-card.js
+++ b/js/src/reports/compare-table-card.js
@@ -44,7 +44,7 @@ const CompareTableCard = ( {
 	nameCell,
 	...restProps
 } ) => {
-	const { currencyConfig: adsCurrencyConfig } = useAdsCurrencyConfig();
+	const { adsCurrencyConfig } = useAdsCurrencyConfig();
 	const storeCurrencyConfig = useStoreCurrency();
 	const query = useUrlQuery();
 

--- a/js/src/reports/format-amount.js
+++ b/js/src/reports/format-amount.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { numberFormat } from '@woocommerce/number';
+
+/**
+ * Internal dependencies
+ */
+import formatAmountWithCode from '.~/utils/formatAmountWithCode';
+
+const unavailable = __( 'Unavailable', 'google-listings-and-ads' );
+
+/**
+ * Formats given number as currency
+ * according to given config, or return `"Unavailable"` if the value is undefined.
+ *
+ * Entire usage could be simplified once
+ * https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
+ *
+ * @param {Object} currencyConfig Currency config object returned by `@woocommerce/currency`.
+ * @param {number} value Value to be formatted.
+ * @return {string} Formatted currency or "Unavailable".
+ */
+export function formatCurrencyCell( currencyConfig, value ) {
+	if ( value === undefined ) {
+		return unavailable;
+	}
+	return formatAmountWithCode( currencyConfig, value );
+}
+/**
+ * Formats given number according to given config,
+ * or return `"Unavailable"` if the value is undefined.
+ *
+ * We do not use currency code or symbol, but decimal separators, etc.
+ *
+ * @param {Object} currencyConfig Currency config object returned by `@woocommerce/currency`.
+ * @param {number} value Value to be formatted.
+ * @return {string} Formatted number or "Unavailable".
+ */
+export function formatNumericCell( currencyConfig, value ) {
+	if ( value === undefined ) {
+		return unavailable;
+	}
+	return numberFormat(
+		{
+			...currencyConfig,
+			precision: 0,
+		},
+		value
+	);
+}

--- a/js/src/reports/format-amount.js
+++ b/js/src/reports/format-amount.js
@@ -18,15 +18,42 @@ const unavailable = __( 'Unavailable', 'google-listings-and-ads' );
  * Entire usage could be simplified once
  * https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
  *
- * @param {Object} currencyConfig Currency config object returned by `@woocommerce/currency`.
  * @param {number} value Value to be formatted.
+ * @param {Object} currencyConfig Currency config object returned by `@woocommerce/currency`.
  * @return {string} Formatted currency or "Unavailable".
  */
-export function formatCurrencyCell( currencyConfig, value ) {
+function formatCurrencyCell( value, currencyConfig ) {
 	if ( value === undefined ) {
 		return unavailable;
 	}
 	return formatAmountWithCode( currencyConfig, value );
+}
+/**
+ * Formats given number as Ads' currency
+ * or return `"Unavailable"` if the value is undefined.
+ *
+ * @param {number} value Value to be formatted.
+ * @param {Object} storeCurrencyConfig Store's currency config object returned by `@woocommerce/currency`.
+ * @param {Object} adsCurrencyConfig Ads' currency config object returned by `@woocommerce/currency`.
+ * @return {string} Formatted currency or "Unavailable".
+ */
+export function formatAdsCurrencyCell(
+	value,
+	storeCurrencyConfig,
+	adsCurrencyConfig
+) {
+	return formatCurrencyCell( value, adsCurrencyConfig );
+}
+/**
+ * Formats given number as store's currency
+ * or return `"Unavailable"` if the value is undefined.
+ *
+ * @param {number} value Value to be formatted.
+ * @param {Object} storeCurrencyConfig Store's currency config object returned by `@woocommerce/currency`.
+ * @return {string} Formatted currency or "Unavailable".
+ */
+export function formatStoreCurrencyCell( value, storeCurrencyConfig ) {
+	return formatCurrencyCell( value, storeCurrencyConfig );
 }
 /**
  * Formats given number according to given config,
@@ -34,11 +61,11 @@ export function formatCurrencyCell( currencyConfig, value ) {
  *
  * We do not use currency code or symbol, but decimal separators, etc.
  *
- * @param {Object} currencyConfig Currency config object returned by `@woocommerce/currency`.
  * @param {number} value Value to be formatted.
+ * @param {Object} currencyConfig Currency config object returned by `@woocommerce/currency`.
  * @return {string} Formatted number or "Unavailable".
  */
-export function formatNumericCell( currencyConfig, value ) {
+export function formatNumericCell( value, currencyConfig ) {
 	if ( value === undefined ) {
 		return unavailable;
 	}

--- a/js/src/reports/format-amount.js
+++ b/js/src/reports/format-amount.js
@@ -12,6 +12,10 @@ import formatAmountWithCode from '.~/utils/formatAmountWithCode';
 const unavailable = __( 'Unavailable', 'google-listings-and-ads' );
 
 /**
+ * @typedef {import('.~/utils/formatAmountWithCode').CurencyConfig} CurencyConfig
+ */
+
+/**
  * Formats given number as currency
  * according to given config, or return `"Unavailable"` if the value is undefined.
  *
@@ -19,7 +23,7 @@ const unavailable = __( 'Unavailable', 'google-listings-and-ads' );
  * https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
  *
  * @param {number} value Value to be formatted.
- * @param {Object} currencyConfig Currency config object returned by `@woocommerce/currency`.
+ * @param {CurencyConfig} currencyConfig Currency config used to format amount.
  * @return {string} Formatted currency or "Unavailable".
  */
 function formatCurrencyCell( value, currencyConfig ) {
@@ -33,8 +37,8 @@ function formatCurrencyCell( value, currencyConfig ) {
  * or return `"Unavailable"` if the value is undefined.
  *
  * @param {number} value Value to be formatted.
- * @param {Object} storeCurrencyConfig Store's currency config object returned by `@woocommerce/currency`.
- * @param {Object} adsCurrencyConfig Ads' currency config object returned by `@woocommerce/currency`.
+ * @param {CurencyConfig} storeCurrencyConfig Store's currency config. It's not used, it's kept to conform Metric.formatFn API.
+ * @param {CurencyConfig} adsCurrencyConfig Ads' currency config. May be fetched from {@link .~/hooks/useAdsCurrency.useAdsCurrencyConfig}.
  * @return {string} Formatted currency or "Unavailable".
  */
 export function formatAdsCurrencyCell(
@@ -49,7 +53,7 @@ export function formatAdsCurrencyCell(
  * or return `"Unavailable"` if the value is undefined.
  *
  * @param {number} value Value to be formatted.
- * @param {Object} storeCurrencyConfig Store's currency config object returned by `@woocommerce/currency`.
+ * @param {CurencyConfig} storeCurrencyConfig Store's currency config.
  * @return {string} Formatted currency or "Unavailable".
  */
 export function formatStoreCurrencyCell( value, storeCurrencyConfig ) {
@@ -62,7 +66,7 @@ export function formatStoreCurrencyCell( value, storeCurrencyConfig ) {
  * We do not use currency code or symbol, but decimal separators, etc.
  *
  * @param {number} value Value to be formatted.
- * @param {Object} currencyConfig Currency config object returned by `@woocommerce/currency`.
+ * @param {CurencyConfig} currencyConfig Currency config.
  * @return {string} Formatted number or "Unavailable".
  */
 export function formatNumericCell( value, currencyConfig ) {

--- a/js/src/reports/format-amount.js
+++ b/js/src/reports/format-amount.js
@@ -16,23 +16,6 @@ const unavailable = __( 'Unavailable', 'google-listings-and-ads' );
  */
 
 /**
- * Formats given number as currency
- * according to given config, or return `"Unavailable"` if the value is undefined.
- *
- * Entire usage could be simplified once
- * https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
- *
- * @param {number} value Value to be formatted.
- * @param {CurencyConfig} currencyConfig Currency config used to format amount.
- * @return {string} Formatted currency or "Unavailable".
- */
-function formatCurrencyCell( value, currencyConfig ) {
-	if ( value === undefined ) {
-		return unavailable;
-	}
-	return formatAmountWithCode( currencyConfig, value );
-}
-/**
  * Formats given number as Ads' currency
  * or return `"Unavailable"` if the value is undefined.
  *
@@ -46,19 +29,12 @@ export function formatAdsCurrencyCell(
 	storeCurrencyConfig,
 	adsCurrencyConfig
 ) {
-	return formatCurrencyCell( value, adsCurrencyConfig );
+	if ( value === undefined ) {
+		return unavailable;
+	}
+	return formatAmountWithCode( adsCurrencyConfig, value );
 }
-/**
- * Formats given number as store's currency
- * or return `"Unavailable"` if the value is undefined.
- *
- * @param {number} value Value to be formatted.
- * @param {CurencyConfig} storeCurrencyConfig Store's currency config.
- * @return {string} Formatted currency or "Unavailable".
- */
-export function formatStoreCurrencyCell( value, storeCurrencyConfig ) {
-	return formatCurrencyCell( value, storeCurrencyConfig );
-}
+
 /**
  * Formats given number according to given config,
  * or return `"Unavailable"` if the value is undefined.

--- a/js/src/reports/index.js
+++ b/js/src/reports/index.js
@@ -8,7 +8,7 @@ export { default as ProductsReport } from './products';
  * @typedef {Object} Metric Metric item structure for disaplying label and its currency type.
  * @property {string} key Metric key.
  * @property {string} label Metric label to display.
- * @property {(currencyConfig: Object, value: number) => string} formatFn Function to format given number to the displayed text.
+ * @property {(value: number, storeCurrencyConfig: Object, adsCurrencyConfig: Object) => string} formatFn Function to format given number to the displayed text.
  * @property {boolean} [isCurrency] Metric is a currency if true. Needed to adjust Chart's valueType => y-axis labels.
  */
 

--- a/js/src/reports/index.js
+++ b/js/src/reports/index.js
@@ -8,7 +8,8 @@ export { default as ProductsReport } from './products';
  * @typedef {Object} Metric Metric item structure for disaplying label and its currency type.
  * @property {string} key Metric key.
  * @property {string} label Metric label to display.
- * @property {boolean} [isCurrency] Metric is a currency if true.
+ * @property {(currencyConfig: Object, value: number) => string} formatFn Function to format given number to the displayed text.
+ * @property {boolean} [isCurrency] Metric is a currency if true. Needed to adjust Chart's valueType => y-axis labels.
  */
 
 /**

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -16,6 +16,7 @@ import GridiconInfoOutline from 'gridicons/dist/info-outline';
 import './metric-number.scss';
 import AppTooltip from '.~/components/app-tooltip';
 import TrackableLink from '.~/components/trackable-link';
+import { useAdsCurrencyConfig } from '.~/hooks/useAdsCurrency';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import { MISSING_FREE_LISTINGS_DATA } from '.~/data/utils';
 
@@ -46,12 +47,22 @@ const MetricNumber = ( {
 	data: { value, prevValue, delta, missingFreeListingsData },
 } ) => {
 	const storeCurrencyConfig = useStoreCurrency();
+	const { currencyConfig: adsCurrencyConfig } = useAdsCurrencyConfig();
 	const valueProps = useMemo( () => {
+		// debugger
 		return {
-			value: metric.formatFn( storeCurrencyConfig, value ),
-			prevValue: metric.formatFn( storeCurrencyConfig, prevValue ),
+			value: metric.formatFn(
+				value,
+				storeCurrencyConfig,
+				adsCurrencyConfig
+			),
+			prevValue: metric.formatFn(
+				prevValue,
+				storeCurrencyConfig,
+				adsCurrencyConfig
+			),
 		};
-	}, [ metric, storeCurrencyConfig, value, prevValue ] );
+	}, [ metric, storeCurrencyConfig, adsCurrencyConfig, value, prevValue ] );
 
 	let markedLabel = metric.label;
 	const infos = [];

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -47,7 +47,7 @@ const MetricNumber = ( {
 	data: { value, prevValue, delta, missingFreeListingsData },
 } ) => {
 	const storeCurrencyConfig = useStoreCurrency();
-	const { currencyConfig: adsCurrencyConfig } = useAdsCurrencyConfig();
+	const { adsCurrencyConfig } = useAdsCurrencyConfig();
 	const valueProps = useMemo( () => {
 		return {
 			value: metric.formatFn(

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -16,11 +16,8 @@ import GridiconInfoOutline from 'gridicons/dist/info-outline';
 import './metric-number.scss';
 import AppTooltip from '.~/components/app-tooltip';
 import TrackableLink from '.~/components/trackable-link';
-import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
-import useCurrencyFactory from '.~/hooks/useCurrencyFactory';
+import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import { MISSING_FREE_LISTINGS_DATA } from '.~/data/utils';
-
-const numberFormatSetting = { precision: 0 };
 
 const googleMCReportingDashboardURL =
 	'https://merchants.google.com/mc/reporting/dashboard';
@@ -33,39 +30,30 @@ const googleMCReportingDashboardURL =
  * informing about missing data for some metrics.
  *
  * @param {Object} props
- * @param {string} props.label Metric label.
+ * @param {import('./index').Metric} props.metric Metrics label and formatting characteristics.
  * @param {string} [props.href] An internal link to the report focused on this metric.
  * @param {boolean} [props.selected] Whether show a highlight style on this metric.
  * @param {Function} [props.onLinkClickCallback] A function to be called after a SummaryNumber, rendered as a link, is clicked.
- * @param {boolean} [props.isCurrency=false] Display `data.value` and `data.prevValue` as price format if true.
- *                                           Otherwise, display as number format.
  * @param {import('.~/data/utils').PerformanceMetrics} props.data Data as get from API.
  *
  * @return {SummaryNumber} Filled SummaryNumber.
  */
 const MetricNumber = ( {
-	label,
 	href,
 	selected,
 	onLinkClickCallback,
-	isCurrency = false,
+	metric,
 	data: { value, prevValue, delta, missingFreeListingsData },
 } ) => {
-	const formatNumber = useCurrencyFormat( numberFormatSetting );
-	const { formatAmount } = useCurrencyFactory();
+	const storeCurrencyConfig = useStoreCurrency();
 	const valueProps = useMemo( () => {
-		const formatFn = isCurrency ? formatAmount : formatNumber;
-
 		return {
-			value:
-				value === undefined
-					? __( 'Unavailable', 'google-listings-and-ads' )
-					: formatFn( value ),
-			prevValue: formatFn( prevValue ),
+			value: metric.formatFn( storeCurrencyConfig, value ),
+			prevValue: metric.formatFn( storeCurrencyConfig, prevValue ),
 		};
-	}, [ isCurrency, value, prevValue, formatNumber, formatAmount ] );
+	}, [ metric, storeCurrencyConfig, value, prevValue ] );
 
-	let markedLabel = label;
+	let markedLabel = metric.label;
 	const infos = [];
 	const ariaInfos = [];
 
@@ -136,7 +124,7 @@ const MetricNumber = ( {
 		) );
 		markedLabel = (
 			<div className="gla-reports__metric-label">
-				{ label }
+				{ metric.label }
 				<AppTooltip text={ infoElements }>
 					<GridiconInfoOutline
 						className="gla-reports__metric-infoicon"

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -49,7 +49,6 @@ const MetricNumber = ( {
 	const storeCurrencyConfig = useStoreCurrency();
 	const { currencyConfig: adsCurrencyConfig } = useAdsCurrencyConfig();
 	const valueProps = useMemo( () => {
-		// debugger
 		return {
 			value: metric.formatFn(
 				value,

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -23,6 +23,7 @@ import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProductsTableCard from './compare-products-table-card';
 import ReportsNavigation from '../reports-navigation';
+import { formatCurrencyCell, formatNumericCell } from '../format-amount';
 
 /**
  * Available metrics and their human-readable labels.
@@ -33,26 +34,31 @@ const freeMetrics = [
 	{
 		key: 'clicks',
 		label: __( 'Clicks', 'google-listings-and-ads' ),
+		formatFn: formatNumericCell,
 	},
 	{
 		key: 'impressions',
 		label: __( 'Impressions', 'google-listings-and-ads' ),
+		formatFn: formatNumericCell,
 	},
 ];
 const paidMetrics = [
 	{
 		key: 'sales',
 		label: __( 'Total Sales', 'google-listings-and-ads' ),
+		formatFn: formatCurrencyCell,
 		isCurrency: true,
 	},
 	{
 		key: 'conversions',
 		label: __( 'Conversions', 'google-listings-and-ads' ),
+		formatFn: formatNumericCell,
 	},
 	...freeMetrics,
 	{
 		key: 'spend',
 		label: __( 'Spend', 'google-listings-and-ads' ),
+		formatFn: formatCurrencyCell,
 		isCurrency: true,
 	},
 ];

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -23,7 +23,11 @@ import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProductsTableCard from './compare-products-table-card';
 import ReportsNavigation from '../reports-navigation';
-import { formatCurrencyCell, formatNumericCell } from '../format-amount';
+import {
+	formatNumericCell,
+	formatAdsCurrencyCell,
+	formatStoreCurrencyCell,
+} from '../format-amount';
 
 /**
  * Available metrics and their human-readable labels.
@@ -46,7 +50,7 @@ const paidMetrics = [
 	{
 		key: 'sales',
 		label: __( 'Total Sales', 'google-listings-and-ads' ),
-		formatFn: formatCurrencyCell,
+		formatFn: formatStoreCurrencyCell,
 		isCurrency: true,
 	},
 	{
@@ -58,7 +62,7 @@ const paidMetrics = [
 	{
 		key: 'spend',
 		label: __( 'Spend', 'google-listings-and-ads' ),
-		formatFn: formatCurrencyCell,
+		formatFn: formatAdsCurrencyCell,
 		isCurrency: true,
 	},
 ];

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -23,11 +23,7 @@ import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProductsTableCard from './compare-products-table-card';
 import ReportsNavigation from '../reports-navigation';
-import {
-	formatNumericCell,
-	formatAdsCurrencyCell,
-	formatStoreCurrencyCell,
-} from '../format-amount';
+import { formatNumericCell, formatAdsCurrencyCell } from '../format-amount';
 
 /**
  * Available metrics and their human-readable labels.
@@ -50,7 +46,7 @@ const paidMetrics = [
 	{
 		key: 'sales',
 		label: __( 'Total Sales', 'google-listings-and-ads' ),
-		formatFn: formatStoreCurrencyCell,
+		formatFn: formatAdsCurrencyCell,
 		isCurrency: true,
 	},
 	{

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -15,7 +15,11 @@ import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProgramsTableCard from './compare-programs-table-card';
 import ReportsNavigation from '../reports-navigation';
-import { formatCurrencyCell, formatNumericCell } from '../format-amount';
+import {
+	formatNumericCell,
+	formatAdsCurrencyCell,
+	formatStoreCurrencyCell,
+} from '../format-amount';
 
 /**
  * Available metrics and their human-readable labels.
@@ -26,7 +30,7 @@ const commonMetrics = [
 	{
 		key: 'sales',
 		label: __( 'Total Sales', 'google-listings-and-ads' ),
-		formatFn: formatCurrencyCell,
+		formatFn: formatStoreCurrencyCell,
 		isCurrency: true,
 	},
 	{
@@ -50,7 +54,7 @@ const performanceMetrics = [
 	{
 		key: 'spend',
 		label: __( 'Total Spend', 'google-listings-and-ads' ),
-		formatFn: formatCurrencyCell,
+		formatFn: formatAdsCurrencyCell,
 		isCurrency: true,
 	},
 ];
@@ -59,7 +63,7 @@ const tableMetrics = [
 	{
 		key: 'spend',
 		label: __( 'Spend', 'google-listings-and-ads' ),
-		formatFn: formatCurrencyCell,
+		formatFn: formatAdsCurrencyCell,
 		isCurrency: true,
 	},
 ];

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -15,6 +15,7 @@ import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProgramsTableCard from './compare-programs-table-card';
 import ReportsNavigation from '../reports-navigation';
+import { formatCurrencyCell, formatNumericCell } from '../format-amount';
 
 /**
  * Available metrics and their human-readable labels.
@@ -25,19 +26,23 @@ const commonMetrics = [
 	{
 		key: 'sales',
 		label: __( 'Total Sales', 'google-listings-and-ads' ),
+		formatFn: formatCurrencyCell,
 		isCurrency: true,
 	},
 	{
 		key: 'conversions',
 		label: __( 'Conversions', 'google-listings-and-ads' ),
+		formatFn: formatNumericCell,
 	},
 	{
 		key: 'clicks',
 		label: __( 'Clicks', 'google-listings-and-ads' ),
+		formatFn: formatNumericCell,
 	},
 	{
 		key: 'impressions',
 		label: __( 'Impressions', 'google-listings-and-ads' ),
+		formatFn: formatNumericCell,
 	},
 ];
 const performanceMetrics = [
@@ -45,6 +50,7 @@ const performanceMetrics = [
 	{
 		key: 'spend',
 		label: __( 'Total Spend', 'google-listings-and-ads' ),
+		formatFn: formatCurrencyCell,
 		isCurrency: true,
 	},
 ];
@@ -53,6 +59,7 @@ const tableMetrics = [
 	{
 		key: 'spend',
 		label: __( 'Spend', 'google-listings-and-ads' ),
+		formatFn: formatCurrencyCell,
 		isCurrency: true,
 	},
 ];

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -15,11 +15,7 @@ import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProgramsTableCard from './compare-programs-table-card';
 import ReportsNavigation from '../reports-navigation';
-import {
-	formatNumericCell,
-	formatAdsCurrencyCell,
-	formatStoreCurrencyCell,
-} from '../format-amount';
+import { formatNumericCell, formatAdsCurrencyCell } from '../format-amount';
 
 /**
  * Available metrics and their human-readable labels.
@@ -30,7 +26,7 @@ const commonMetrics = [
 	{
 		key: 'sales',
 		label: __( 'Total Sales', 'google-listings-and-ads' ),
-		formatFn: formatStoreCurrencyCell,
+		formatFn: formatAdsCurrencyCell,
 		isCurrency: true,
 	},
 	{

--- a/js/src/reports/summary-section.js
+++ b/js/src/reports/summary-section.js
@@ -51,16 +51,16 @@ export default function SummarySection( {
 	return (
 		<SummaryList>
 			{ () =>
-				metrics.map( ( { key, label, isCurrency = false } ) => {
+				metrics.map( ( metric ) => {
+					const { key } = metric;
 					const selected = selectedMetric === key;
 					const href = getNewPath( { selectedMetric: key } );
 					return (
 						<MetricNumber
 							key={ key }
-							label={ label }
+							metric={ metric }
 							href={ href }
 							selected={ selected }
-							isCurrency={ isCurrency }
 							data={ totals[ key ] || noValidData }
 							onLinkClickCallback={ () => trackClickEvent( key ) }
 						/>

--- a/js/src/utils/formatAmountWithCode.js
+++ b/js/src/utils/formatAmountWithCode.js
@@ -11,6 +11,8 @@ import { numberFormat } from '@woocommerce/number';
  * but a one that uses currency code instead of symbol to avoid ambiguity.
  * Preferably, we would do that by just setting a parameter on build in `formatAmount` without a need to recreating it.
  *
+ * To be removed once https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
+ *
  *
  * @param {Object} currency Currency config object returned by `@woocommerce/currency`.
  * @param {number} number Amount to be formatted.

--- a/js/src/utils/formatAmountWithCode.js
+++ b/js/src/utils/formatAmountWithCode.js
@@ -4,6 +4,21 @@
 import { sprintf } from '@wordpress/i18n';
 import { numberFormat } from '@woocommerce/number';
 
+// `CurencyConfig` type definition could be imported after
+// https://github.com/woocommerce/woocommerce-admin/pull/7848
+/**
+ * Currency config format from the `@woocommerce/currency`.
+ * Please note, the properties of this object are not defined in this repo.
+ *
+ * @typedef {Object} CurencyConfig
+ * @property {string} code Currency ISO code.
+ * @property {string} symbol Symbol, can be multi-character.
+ * @property {string} symbolPosition Where the symbol should be relative to the amount. One of `'left' | 'right' | 'left_space | 'right_space'`.
+ * @property {string} thousandSeparator Character used to separate thousands groups.
+ * @property {string} decimalSeparator Decimal separator.
+ * @property {number} precision Decimal precision.
+ */
+
 /**
  * Formats money value with currency code.
  *
@@ -14,7 +29,7 @@ import { numberFormat } from '@woocommerce/number';
  * To be removed once https://github.com/woocommerce/woocommerce-admin/pull/7575 is released and accessible.
  *
  *
- * @param {Object} currency Currency config object returned by `@woocommerce/currency`.
+ * @param {CurencyConfig} currency Currency config object.
  * @param {number} number Amount to be formatted.
  * @return {string} Amount foramtted according to given config, with the currency symbol.
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Move `formatAmountWithCode` to the shared `.~/utils` folder. (90ccce3)
	Addresses https://github.com/woocommerce/google-listings-and-ads/pull/920#discussion_r697353953
- Display correct Ads' currency in Dashobard's `SummarySection`. (f929745)
	Use code instead of symbol.
- Share the metric formatting logic across all report components. (789877c)
	Move the `"Unavailable"` check and precision setup to the `format-amout.js` util.
- Display Ads' currency code on report pages, (e11cb97)
	where applicable - for the "spend" values.
	
	Remove symbol from currency setting for `<Chart>` as it will not be able to change accordingly.
	Affected by https://github.com/woocommerce/woocommerce-admin/issues/7694

Implements part of https://github.com/woocommerce/google-listings-and-ads/issues/363.


### Screenshots:
#### Before: 


#### After: 
![image](https://user-images.githubusercontent.com/17435/134344308-a1699df5-c71e-4b3c-b85d-cc1a5645292e.png)


### Detailed test instructions:

1. [Set the store currency](https://gla1.test/wp-admin/admin.php?page=wc-settings) to _X_ (PLN)
2. Setup Ads account
3. Change the store currency to _Y_ (EUR)
4. Go to the Dashboard ([`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard) )
5. You should see the "Daily budget" column using store's formatting settings, but display Ads' currency symbol.
6. Go to report pages programs & products
7. You should see "Spend" sections, table & chart data in _X_ currency, and sales in _Y_.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Use Ads' account currency on report pages.


### Additional notes:

0. As it may take a while to fetch the Ads currency, I use the store's formatting setting (decimal delimiter, precision, etc. without a symbol and code) to format numbers eagerly. I believe it improves the UX by delivering the meaningful content ASAP, then loading the details later. Currently, this glitch is barely visible, as the majority of the delay in rendering anything is consumed by other APIs. @j111q  Are you ok with such an effect: 
	![lazy load currency](https://user-images.githubusercontent.com/17435/134352211-9798ebbe-3665-4b50-a705-c2c9c201c84b.gif)
1. Google API provides only the currency code, and our serverside here returns just the symbol, so we use the local store's currency formatting settings, for decimal delimiters, etc. That could be problematic when the ads account uses a currency with higher precision. For example on the local store we use `USD` and the sales are `$ 2,345.67`, while the total spend of `0.00123456 BTC`~= `$ 51.75`  will be displayed as `₿ 0.00`. I'm not sure if we should consider it an edge case, try to fetch more applicable precision from somewhere?
2. Y-axis of the Chart has hard-coded store's currency with removed symbol due to wc-admin bug: [https://github.com/woocommerce/woocommerce-admin/issues/7694](https://github.com/woocommerce/woocommerce-admin/issues/7694)
3. Preferably we would use `@woocommerce/currency`'s  `formatAmount` instead of local util, but due to dependency extraction hell, we cannot use the latest version delivered in [https://github.com/woocommerce/woocommerce-admin/pull/7575](https://github.com/woocommerce/woocommerce-admin/pull/7575). Once, that change is available, we could/should rewrite this PR with the simplified flow.
4. To make the displayed currency clearly stated and unambiguous I use currency codes instead of symbols everywhere. That may seem verbose and clutter the space. Alternatively, we could consider:
	1. Using the symbol in the chart tooltips, as the current code is stated already above.
	2. Using the symbol, only if the store's and Ads' currencies are equal.
	3. Using the symbol, only if the store's and Ads' currencies have different symbols.

	But that would be a tad more complicated to implement and could produce less consistent UI when a merchant would change their store's currency. @j111q are you fine with currency codes everywhere, or would you prefer any of the i.-iii. above?