### PR TITLE
Add infrastructure for easily adding daily tasks and apply to existing notes

### DIFF
--- a/src/Infrastructure/RunDaily.php
+++ b/src/Infrastructure/RunDaily.php
@@ -1,0 +1,13 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure;
+
+/**
+ * Something that will be run daily.
+ *
+ * Classes that implement this will be automatically "run" each day via the Action Scheduler cron task.
+ *
+ * @since x.x.x
+ */
+interface RunDaily extends Runnable {}

--- a/src/Infrastructure/Runnable.php
+++ b/src/Infrastructure/Runnable.php
@@ -1,0 +1,20 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure;
+
+/**
+ * Something that can be run e.g. on a specific schedule.
+ *
+ * @since x.x.x
+ */
+interface Runnable {
+
+	/**
+	 * Run a task.
+	 *
+	 * @return void
+	 */
+	public function run(): void;
+
+}

--- a/src/Internal/Cron.php
+++ b/src/Internal/Cron.php
@@ -1,0 +1,74 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\RunDaily;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Cron
+ *
+ * Responsible for managing the plugin's cron jobs and for running services that implement cron interfaces e.g. RunDaily.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Internal
+ *
+ * @since x.x.x
+ */
+class Cron implements ContainerAwareInterface, InstallableInterface, Registerable, Service {
+
+	use ContainerAwareTrait;
+
+	/**
+	 * Hook name for daily cron.
+	 */
+	protected const DAILY = 'wc_gla_cron_daily';
+
+	/**
+	 * @var ActionSchedulerInterface
+	 */
+	protected $action_scheduler;
+
+	/**
+	 * Cron constructor.
+	 *
+	 * @param ActionSchedulerInterface $action_scheduler
+	 */
+	public function __construct( ActionSchedulerInterface $action_scheduler ) {
+		$this->action_scheduler = $action_scheduler;
+	}
+
+	/**
+	 * Register cron services.
+	 */
+	public function register(): void {
+		add_action(
+			self::DAILY,
+			function() {
+				$services = $this->container->get( RunDaily::class );
+				foreach ( $services as $service ) {
+					$service->run();
+				}
+			}
+		);
+	}
+
+	/**
+	 * Ensure cron jobs are created when plugin is first installed or is updated.
+	 *
+	 * @param string $old_version Previous version before updating.
+	 * @param string $new_version Current version after updating.
+	 */
+	public function install( string $old_version, string $new_version ): void {
+		if ( ! $this->action_scheduler->has_scheduled_action( self::DAILY ) ) {
+			$this->action_scheduler->schedule_recurring( time(), DAY_IN_SECONDS, self::DAILY );
+		}
+	}
+
+}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\ActivationRedirect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityMetaBox;
@@ -28,6 +29,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\ViewFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Cron;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DeprecatedFilters;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\InstallTimestamp;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\FirstInstallInterface;
@@ -201,6 +203,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Share utility classes
 		$this->share_with_tags( AddressUtility::class );
 		$this->share_with_tags( DateTimeUtility::class );
+		$this->share_with_tags( Cron::class, ActionScheduler::class );
 		$this->share_with_tags( ISOUtility::class, ISO3166DataProvider::class );
 
 		// Share our regular service classes.

--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
 use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\RunDaily;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -18,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class CompleteSetup extends Note implements MerchantCenterAwareInterface {
+class CompleteSetup extends Note implements MerchantCenterAwareInterface, RunDaily {
 
 	use MerchantCenterAwareTrait;
 	use PluginHelper;
@@ -34,9 +35,9 @@ class CompleteSetup extends Note implements MerchantCenterAwareInterface {
 	}
 
 	/**
-	 * Possibly add the note
+	 * Check if the note should be added each day.
 	 */
-	public function possibly_add_note(): void {
+	public function run(): void {
 		if ( ! $this->can_add_note() ) {
 			return;
 		}

--- a/src/Notes/ContactInformation.php
+++ b/src/Notes/ContactInformation.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
 use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\RunDaily;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
@@ -18,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.4.0
  */
-class ContactInformation extends Note implements MerchantCenterAwareInterface {
+class ContactInformation extends Note implements MerchantCenterAwareInterface, RunDaily {
 
 	use MerchantCenterAwareTrait;
 	use PluginHelper;
@@ -34,9 +35,9 @@ class ContactInformation extends Note implements MerchantCenterAwareInterface {
 	}
 
 	/**
-	 * Possibly add the note
+	 * Check if the note should be added each day.
 	 */
-	public function possibly_add_note(): void {
+	public function run(): void {
 		if ( ! $this->can_add_note() ) {
 			return;
 		}

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
 use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use WC_Data_Store;
@@ -19,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-abstract class Note implements Service, Registerable, Deactivateable, OptionsAwareInterface {
+abstract class Note implements Service, Deactivateable, OptionsAwareInterface {
 
 	/**
 	 * Get the note's unique name.
@@ -27,23 +26,6 @@ abstract class Note implements Service, Registerable, Deactivateable, OptionsAwa
 	 * @return string
 	 */
 	abstract protected function get_note_name(): string;
-
-	/**
-	 * Possibly add the note
-	 */
-	abstract public function possibly_add_note(): void;
-
-	/**
-	 * Register a service.
-	 */
-	public function register(): void {
-		add_action(
-			'admin_init',
-			function() {
-				$this->possibly_add_note();
-			}
-		);
-	}
 
 	/**
 	 * Deactivate the service.

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\RunDaily;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
@@ -16,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaign extends Note implements AdsAwareInterface {
+class SetupCampaign extends Note implements AdsAwareInterface, RunDaily {
 
 	use AdsAwareTrait;
 	use PluginHelper;
@@ -32,9 +33,9 @@ class SetupCampaign extends Note implements AdsAwareInterface {
 	}
 
 	/**
-	 * Possibly add the note
+	 * Check if the note should be added each day.
 	 */
-	public function possibly_add_note(): void {
+	public function run(): void {
 		if ( ! $this->can_add_note() ) {
 			return;
 		}

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\RunDaily;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
@@ -16,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaignTwoWeeks extends Note implements AdsAwareInterface {
+class SetupCampaignTwoWeeks extends Note implements AdsAwareInterface, RunDaily {
 
 	use AdsAwareTrait;
 	use PluginHelper;
@@ -32,9 +33,9 @@ class SetupCampaignTwoWeeks extends Note implements AdsAwareInterface {
 	}
 
 	/**
-	 * Possibly add the note
+	 * Check if the note should be added each day.
 	 */
-	public function possibly_add_note(): void {
+	public function run(): void {
 		if ( ! $this->can_add_note() ) {
 			return;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is related to #1012 where I'm wanting to add a note that relies on calculating the number of free listing clicks a store has. I want to avoid doing this on every `admin_init` hook. It's also related to our 4 existing notes because they are currently doing work on every `admin_init` hook which could be done less frequently e.g. once per day.

The solution I'm proposing with this PR sets up a new `Cron` service that uses the `InstallableInterface` to ensure cron tasks are registered after installation or plugin update (rather than on every request).

I've added interfaces: `Runnable` and `RunDaily`, when a service implements `RunDaily` it will automatically hooked to the daily cron job.

### Detailed test instructions:

1. Check out this PR
1. Deleting your existing notes `DELETE FROM wp_wc_admin_notes WHERE name LIKE 'gla-%'`
1. Manually change the `WC_GLA_VERSION` value to something else (this makes the cron job get added)
1. Any valid inbox notification should be re-added now 

### Changelog entry

> Tweak - Improve performance of loading of inbox notifications
