### PR TITLE
Limit the number of addtional product images

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -296,10 +296,10 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		);
 		// Uniquify the set of additional images
 		$gallery_image_links = array_unique( $gallery_image_links, SORT_REGULAR );
-		
-		// Limit addtional image links up to 10
+
+		// Limit additional image links up to 10
 		$gallery_image_links = array_slice( $gallery_image_links, 0, 10 );
-		
+
 		$this->setAdditionalImageLinks( $gallery_image_links );
 
 		return $this;

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -296,6 +296,10 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		);
 		// Uniquify the set of additional images
 		$gallery_image_links = array_unique( $gallery_image_links, SORT_REGULAR );
+		
+		// Limit addtional image link up to 10
+		$gallery_image_links = array_slice( $gallery_image_links, 0, 10);
+		
 		$this->setAdditionalImageLinks( $gallery_image_links );
 
 		return $this;

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -298,7 +298,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$gallery_image_links = array_unique( $gallery_image_links, SORT_REGULAR );
 		
 		// Limit addtional image link up to 10
-		$gallery_image_links = array_slice( $gallery_image_links, 0, 10);
+		$gallery_image_links = array_slice( $gallery_image_links, 0, 10 );
 		
 		$this->setAdditionalImageLinks( $gallery_image_links );
 

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -297,7 +297,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		// Uniquify the set of additional images
 		$gallery_image_links = array_unique( $gallery_image_links, SORT_REGULAR );
 		
-		// Limit addtional image link up to 10
+		// Limit addtional image links up to 10
 		$gallery_image_links = array_slice( $gallery_image_links, 0, 10 );
 		
 		$this->setAdditionalImageLinks( $gallery_image_links );

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -506,11 +506,16 @@ DESCRIPTION;
 	public function test_images_are_set() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$image_1 = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ), $product->get_id() );
-		$image_2 = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-2.png' ), $product->get_id() );
+		$main_image = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ), $product->get_id() );
 
-		$product->set_image_id( $image_1 );
-		$product->set_gallery_image_ids( [ $image_2 ] );
+		$additional_images = [];
+		// Intentionally add more than 10 images to test the limiting functionality.
+		for ($i = 0; $i < 12; $i++) {
+			$additional_images[$i] = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-2.png' ), $product->get_id() );
+		}
+
+		$product->set_image_id( $main_image );
+		$product->set_gallery_image_ids( $additional_images );
 		$product->save();
 
 		$adapted_product = new WCProductAdapter(
@@ -520,11 +525,12 @@ DESCRIPTION;
 			]
 		);
 
-		$this->assertEquals( wp_get_attachment_image_url( $image_1 ), $adapted_product->getImageLink() );
-		$this->assertEquals(
-			[
-				wp_get_attachment_image_url( $image_2 ),
-			],
+		$this->assertEquals( wp_get_attachment_image_url( $main_image ), $adapted_product->getImageLink() );
+
+		// Assert that only up to 10 additional images are added.
+		$additional_images = array_slice( $additional_images, 0, 10 );
+		$this->assertEqualSets(
+			array_map( 'wp_get_attachment_image_url', $additional_images ),
 			$adapted_product->getAdditionalImageLinks()
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

According to [Google requirement](https://support.google.com/merchants/answer/6324370) in the products feed, a synced product can only have up to 10 additional images. Submitting more images will result in an error and the product will be disapproved.

This PR limits the number of additional images to 10 by slicing the array of gallery image links from the beginning.

Note: This is based on https://github.com/woocommerce/google-listings-and-ads/pull/960 and is created because the author was unresponsive. (h/t @syngoquy for noticing the issue and creating the original PR for it)

### Screenshots:

<!--- Optional --->

The issue displayed by Google when you submit more than 10 additional images for a product:

![too_many_additional_imag_link](https://user-images.githubusercontent.com/3715854/129586382-c7ecf715-6f99-4173-9b9f-3f4022006b4e.png)

### Detailed test instructions:

1. Create or edit a product and add more than 10 images to its gallery
2. Update the product and wait for it to sync (or sync manually through the Connection Test page)
3. Wait a few minutes until the Merchant Center is updated 
4. Confirm that no more than 10 image links are included in the additional images for the product


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Limit the number of synced additional product images to 10

