### PR TITLE
Separate `settings` view mode from `ContactInformation`

### DIFF
--- a/js/src/components/contact-information/contact-information-preview-card.scss
+++ b/js/src/components/contact-information/contact-information-preview-card.scss
@@ -1,15 +1,4 @@
 .gla-contact-info-preview-card {
-	&__refresh-button {
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		margin: auto;
-
-		.gridicons-refresh {
-			fill: var(--wp-admin-theme-color);
-		}
-	}
-
 	// Vertically align icon inside the title.
 	.wcdl-subsection-title {
 		display: flex;

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -76,11 +76,11 @@ export default function ContactInformation( { onPhoneNumberVerified } ) {
 	const phone = useGoogleMCPhoneNumber();
 
 	/**
-	 * Since it still lacking the phone verification state,
+	 * Since it is still lacking the phone verification state,
 	 * all onboarding accounts are considered unverified phone numbers.
 	 *
 	 * TODO: replace the code at next line back to the original logic with
-	 * `const initEditing = isSetupMC ? null : true;`
+	 * `const initEditing = null;`
 	 * after the phone verification state can be detected.
 	 */
 	const initEditing = true;

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -67,15 +67,13 @@ export function ContactInformationPreview() {
 }
 
 /**
- * Renders a contact information section with specified initial state and texts, determined by the `view` prop.
+ * Renders a contact information section with specified initial state and texts.
  *
  * @param {Object} props React props.
- * @param {'setup-mc'|'settings'} props.view Indicate where this component is used.
  * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified.
  */
-export default function ContactInformation( { view, onPhoneNumberVerified } ) {
+export default function ContactInformation( { onPhoneNumberVerified } ) {
 	const phone = useGoogleMCPhoneNumber();
-	const isSetupMC = view === 'setup-mc';
 
 	/**
 	 * Since it still lacking the phone verification state,
@@ -87,10 +85,8 @@ export default function ContactInformation( { view, onPhoneNumberVerified } ) {
 	 */
 	const initEditing = true;
 
-	const title = isSetupMC ? mcTitle : settingsTitle;
-	const trackContext = isSetupMC
-		? 'setup-mc-contact-information'
-		: 'settings-contact-information';
+	const title = mcTitle;
+	const trackContext = 'setup-mc-contact-information';
 
 	usePhoneNumberCheckTrackEventEffect( phone );
 
@@ -114,7 +110,7 @@ export default function ContactInformation( { view, onPhoneNumberVerified } ) {
 		>
 			<VerticalGapLayout size="large">
 				<PhoneNumberCard
-					view={ view }
+					view="setup-mc"
 					phoneNumber={ phone }
 					initEditing={ initEditing }
 					onPhoneNumberVerified={ onPhoneNumberVerified }

--- a/js/src/components/contact-information/store-address-card.js
+++ b/js/src/components/contact-information/store-address-card.js
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import { CardDivider } from '@wordpress/components';
 import { Spinner } from '@woocommerce/components';
-import { external as externalIcon } from '@wordpress/icons';
-import GridiconRefresh from 'gridicons/dist/refresh';
+import { update as updateIcon } from '@wordpress/icons';
 import { getPath, getQuery } from '@woocommerce/navigation';
 
 /**
@@ -17,6 +17,8 @@ import Subsection from '.~/wcdl/subsection';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import AppButton from '.~/components/app-button';
 import ContactInformationPreviewCard from './contact-information-preview-card';
+import TrackableLink from '.~/components/trackable-link';
+import './store-address-card.scss';
 
 /**
  * "Edit WC store address" Tracking event
@@ -30,7 +32,7 @@ import ContactInformationPreviewCard from './contact-information-preview-card';
 /**
  * Renders a component with a given store address.
  *
- * @fires gla_edit_wc_store_address Whenever "Edit in Settings" is clicked.
+ * @fires gla_edit_wc_store_address Whenever "Edit in WooCommerce Settings" button is clicked.
  *
  * @return {JSX.Element} Filled AccountCard component.
  */
@@ -40,23 +42,44 @@ export default function StoreAddressCard() {
 	const editButton = (
 		<AppButton
 			isSecondary
-			icon={ externalIcon }
-			iconSize={ 16 }
+			icon={ updateIcon }
+			iconSize={ 20 }
 			iconPosition="right"
-			target="_blank"
-			href="admin.php?page=wc-settings"
-			text={ __( 'Edit in Settings', 'google-listings-and-ads' ) }
-			eventName="gla_edit_wc_store_address"
-			eventProps={ { path: getPath(), subpath } }
+			text={ __( 'Refresh to sync', 'google-listings-and-ads' ) }
+			onClick={ refetch }
+			disabled={ ! loaded }
 		/>
 	);
 
 	let addressContent;
-	let description = '';
-
-	description = __(
-		'Please confirm your store address for verification.',
-		'google-listings-and-ads'
+	const description = (
+		<>
+			<p>
+				{ createInterpolateElement(
+					__(
+						'Edit your store address in your <link>WooCommerce settings</link>.',
+						'google-listings-and-ads'
+					),
+					{
+						link: (
+							<TrackableLink
+								target="_blank"
+								type="external"
+								href="admin.php?page=wc-settings"
+								eventName="gla_edit_wc_store_address"
+								eventProps={ { path: getPath(), subpath } }
+							/>
+						),
+					}
+				) }
+			</p>
+			<p>
+				{ __(
+					'Once you’ve saved your new address there, refresh to sync your new address with Google.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		</>
 	);
 
 	if ( loaded ) {
@@ -80,6 +103,7 @@ export default function StoreAddressCard() {
 
 	return (
 		<AccountCard
+			className="gla-store-address-card"
 			appearance={ APPEARANCE.ADDRESS }
 			description={ description }
 			indicator={ editButton }
@@ -88,13 +112,6 @@ export default function StoreAddressCard() {
 			<Section.Card.Body>
 				<Subsection.Title>
 					{ __( 'Store address', 'google-listings-and-ads' ) }
-					<AppButton
-						className="gla-store-address__refresh-button"
-						icon={ GridiconRefresh }
-						iconSize={ 16 }
-						onClick={ refetch }
-						disabled={ ! loaded }
-					/>
 				</Subsection.Title>
 				{ addressContent }
 			</Section.Card.Body>

--- a/js/src/components/contact-information/store-address-card.scss
+++ b/js/src/components/contact-information/store-address-card.scss
@@ -1,0 +1,22 @@
+.gla-store-address-card {
+	// We could've used `StoreAddressCard'`s selectors,
+	// but the elements are wrapped with `<FlexItem>`,
+	// which does not have accessible semantic selector.
+	// So we have to rely on `<AccountCard>`'s internal implementation details.
+	.components-flex__item {
+		align-self: start;
+	}
+
+	.components-flex__item:nth-child(3) {
+		svg {
+			margin-left: 4px;
+		}
+	}
+
+	p {
+		margin: 1em 0;
+	}
+	p:last-child {
+		margin-bottom: 0;
+	}
+}

--- a/js/src/settings/edit-phone-number.js
+++ b/js/src/settings/edit-phone-number.js
@@ -10,9 +10,26 @@ import { getSettingsUrl } from '.~/utils/urls';
 import FullContainer from '.~/components/full-container';
 import TopBar from '.~/components/stepper/top-bar';
 import HelpIconButton from '.~/components/help-icon-button';
-import ContactInformation from '.~/components/contact-information';
+import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
+import Section from '.~/wcdl/section';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import PhoneNumberCard from '.~/components/contact-information/phone-number-card';
+import usePhoneNumberCheckTrackEventEffect from '.~/components/contact-information/usePhoneNumberCheckTrackEventEffect';
 
+const learnMoreLinkId = 'contact-information-read-more';
+const learnMoreUrl =
+	'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information';
+
+/**
+ * Renders the phone number settings page.
+ *
+ * @see PhoneNumberCard
+ */
 export default function EditPhoneNumber() {
+	const phone = useGoogleMCPhoneNumber();
+
+	usePhoneNumberCheckTrackEventEffect( phone );
+
 	return (
 		<FullContainer>
 			<TopBar
@@ -23,7 +40,37 @@ export default function EditPhoneNumber() {
 				backHref={ getSettingsUrl() }
 			/>
 			<div className="gla-settings">
-				<ContactInformation view="settings" />
+				<Section
+					title={ __( 'Phone number', 'google-listings-and-ads' ) }
+					description={
+						<div>
+							<p>
+								{ __(
+									'Your phone number is required by Google for verification purposes. It will be shared with the Google Merchant Center and will not be displayed to customers.',
+									'google-listings-and-ads'
+								) }
+							</p>
+							<p>
+								<AppDocumentationLink
+									context={ 'settings-phone-number' }
+									linkId={ learnMoreLinkId }
+									href={ learnMoreUrl }
+								>
+									{ __(
+										'Learn more',
+										'google-listings-and-ads'
+									) }
+								</AppDocumentationLink>
+							</p>
+						</div>
+					}
+				>
+					<PhoneNumberCard
+						view="settings"
+						phoneNumber={ phone }
+						initEditing={ true }
+					/>
+				</Section>
 			</div>
 		</FullContainer>
 	);

--- a/js/src/settings/edit-store-address.js
+++ b/js/src/settings/edit-store-address.js
@@ -17,8 +17,19 @@ import TopBar from '.~/components/stepper/top-bar';
 import HelpIconButton from '.~/components/help-icon-button';
 import Section from '.~/wcdl/section';
 import AppButton from '.~/components/app-button';
-import ContactInformation from '.~/components/contact-information';
 
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import StoreAddressCard from '.~/components/contact-information/store-address-card';
+
+const learnMoreLinkId = 'contact-information-read-more';
+const learnMoreUrl =
+	'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information';
+
+/**
+ * Renders the store address settings page.
+ *
+ * @see StoreAddressCard
+ */
 export default function EditStoreAddress() {
 	const { updateGoogleMCContactInformation } = useAppDispatch();
 	const { data: address } = useStoreAddress();
@@ -44,7 +55,33 @@ export default function EditStoreAddress() {
 				backHref={ getSettingsUrl() }
 			/>
 			<div className="gla-settings">
-				<ContactInformation view="settings" />
+				<Section
+					title={ __( 'Store address', 'google-listings-and-ads' ) }
+					description={
+						<div>
+							<p>
+								{ __(
+									'Your store address is required by Google for verification purposes. It will be shared with the Google Merchant Center and will not be displayed to customers.',
+									'google-listings-and-ads'
+								) }
+							</p>
+							<p>
+								<AppDocumentationLink
+									context="settings-store-address"
+									linkId={ learnMoreLinkId }
+									href={ learnMoreUrl }
+								>
+									{ __(
+										'Learn more',
+										'google-listings-and-ads'
+									) }
+								</AppDocumentationLink>
+							</p>
+						</div>
+					}
+				>
+					<StoreAddressCard />
+				</Section>
 				<Section>
 					<Flex justify="flex-end">
 						<AppButton

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -113,7 +113,6 @@ export default function StoreRequirements() {
 					return (
 						<>
 							<ContactInformation
-								view="setup-mc"
 								onPhoneNumberVerified={ () =>
 									setPhoneNumberReady( true )
 								}

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -67,7 +67,7 @@ All event names are prefixed by `wcadmin_gla_`.
     -   `context`: indicate which link is clicked
     -   `href`: link's URL
 
--   `edit_wc_store_address` - Trigger when store address "Edit in settings" button is clicked.
+-   `edit_wc_store_address` - Trigger when store address "Edit in WooCommerce Settings" button is clicked.
     Before `1.5.0` it was called `edit_mc_store_address`.
 
     -   `path`: The path used in the page, e.g. `"/google/settings"`.


### PR DESCRIPTION
⚠ this PR requires https://github.com/woocommerce/google-listings-and-ads/pull/1025

### Changes proposed in this Pull Request:
- Separate `settings` view mode from `ContactInformation`
	into two "pages" components, for phone and address settings.
- Addapt StoreAddressCard's UI to the latest designs.

Implements part of https://github.com/woocommerce/google-listings-and-ads/issues/962#issuecomment-925686034.


### Screenshots:
[`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`](https://gla1-test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc)
![image](https://user-images.githubusercontent.com/17435/135356099-9970c877-760b-4ed0-8981-0588d23e7a21.png)

[`/wp-admin/admin.php?page=wc-admin&subpath=%2Fedit-phone-number&path=%2Fgoogle%2Fsettings`](https://gla1.test/wp-admin/admin.php?page=wc-admin&subpath=%2Fedit-phone-number&path=%2Fgoogle%2Fsettings)
![image](https://user-images.githubusercontent.com/17435/135356805-197ac90c-e58f-4686-b73e-f0f1641048b6.png)


[`/wp-admin/admin.php?page=wc-admin&subpath=%2Fedit-store-address&path=%2Fgoogle%2Fsettings`](https://gla1.test/wp-admin/admin.php?page=wc-admin&subpath=%2Fedit-store-address&path=%2Fgoogle%2Fsettings)
![image](https://user-images.githubusercontent.com/17435/135356276-d4788f86-85ad-40f0-9b33-135501aba51c.png)


### Detailed test instructions:

#### Onboarding
1. Go to the [last step of MC setup](https://468b-193-239-83-51.ngrok.io/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc)
2. See if the UI looks like in the latest Figma designs https://www.figma.com/file/eQ9O4m2flzrcAiDMXkOW0m/Google-Listings-%26-Ads-v1.x?node-id=1595%3A26419
3. Check if verifying a phone number, and saving the store address works as before
#### Settings
1. Go to [the GLA settings page](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings)
2. Click Phone number "Edit"
3. See if the UI looks like in the latest Figma designs 
3. Check if verifying a phone number works as before

1. Go to [the GLA settings page](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings)
2. Click Store address "Edit"
3. See if the UI looks like in the latest Figma designs 
3. Check if verifying saving the address works as before.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update phone number and store address pages flow.


### Additional notes:

- I changed the reload icon to Gutenbergs's "update" for better UI consistency, I hope that's fine.
- I changed the copy of Phone/Address section descriptions to a tiny bit less redundant:
	> Your ~contact information~**phone number** is required by Google for verification purposes. It will be shared with the Google Merchant Center and will not be displayed to customers.