### PR TITLE
RFC: Remove `subpath` URLQueryParam from settings pages.

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -113,7 +113,7 @@ addFilter(
 					__( 'Settings', 'google-listings-and-ads' ),
 				],
 				container: Settings,
-				path: '/google/settings',
+				path: '/google/settings/:subpath?',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 				navArgs: {
 					id: 'google-settings',

--- a/js/src/settings/index.js
+++ b/js/src/settings/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { getQuery, getHistory } from '@woocommerce/navigation';
+import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -17,8 +17,15 @@ import EditStoreAddress from './edit-store-address';
 import EditPhoneNumber from './edit-phone-number';
 import './index.scss';
 
-const Settings = () => {
-	const { subpath } = getQuery();
+/**
+ * Settings page component.
+ *
+ * @param {Object} [props] React props
+ * @param {Object} [props.params = {}] `path` params extracted by React `<Router>`.
+ * @param {string} [props.params.subpath] Sub path of a nested settings page.
+ * @return {JSX.Element} Settings page component.
+ */
+const Settings = ( { params: { subpath } = {} } ) => {
 	const { google } = useGoogleAccount();
 	const isReconnectAccountsPage = subpath === subpaths.reconnectAccounts;
 
@@ -31,7 +38,7 @@ const Settings = () => {
 	}, [ isReconnectAccountsPage, google ] );
 
 	// Navigate to subpath is any.
-	switch ( subpath ) {
+	switch ( '/' + subpath ) {
 		case subpaths.reconnectAccounts:
 			return <ReconnectAccounts />;
 		case subpaths.editPhoneNumber:

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -39,24 +39,12 @@ export const getSettingsUrl = () => {
 };
 
 export const getEditPhoneNumberUrl = () => {
-	return getNewPath(
-		{ subpath: subpaths.editPhoneNumber },
-		settingsPath,
-		null
-	);
+	return getNewPath( null, settingsPath + subpaths.editPhoneNumber, null );
 };
 export const getEditStoreAddressUrl = () => {
-	return getNewPath(
-		{ subpath: subpaths.editStoreAddress },
-		settingsPath,
-		null
-	);
+	return getNewPath( null, settingsPath + subpaths.editStoreAddress, null );
 };
 
 export const getReconnectAccountsUrl = () => {
-	return getNewPath(
-		{ subpath: subpaths.reconnectAccounts },
-		settingsPath,
-		null
-	);
+	return getNewPath( null, settingsPath + subpaths.reconnectAccounts, null );
 };

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -88,7 +88,7 @@ class AccountController extends BaseController {
 		return function( Request $request ) {
 			try {
 				$next = $request->get_param( 'next' );
-				$path = $next === 'setup-mc' ? '/google/setup-mc' : '/google/settings&subpath=/reconnect-accounts';
+				$path = $next === 'setup-mc' ? '/google/setup-mc' : '/google/settings/reconnect-accounts';
 
 				return [
 					'url' => $this->connection->connect( admin_url( "admin.php?page=wc-admin&path={$path}" ) ),

--- a/src/Menu/Settings.php
+++ b/src/Menu/Settings.php
@@ -32,6 +32,33 @@ class Settings implements Service, Registerable {
 						],
 					]
 				);
+				// TODO:  Check if we can make it a bit DRYier, and reduce the below, to smth like `'path' => '/google/settings/:subpage?'`
+				// So far it's hard to guess the type of register_page options,
+				// which is documented to be the type of "Options for PageController::register_page()." ➰
+				wc_admin_register_page(
+					[
+						'title'  => __( 'Settings', 'google-listings-and-ads' ),
+						'parent' => 'google-listings-and-ads-category',
+						'path'   => '/google/settings/edit-phone-number',
+						'id'     => 'google-settings-phone-number',
+					]
+				);
+				wc_admin_register_page(
+					[
+						'title'  => __( 'Settings', 'google-listings-and-ads' ),
+						'parent' => 'google-listings-and-ads-category',
+						'path'   => '/google/settings/edit-store-address',
+						'id'     => 'google-settings-store-address',
+					]
+				);
+				wc_admin_register_page(
+					[
+						'title'  => __( 'Settings', 'google-listings-and-ads' ),
+						'parent' => 'google-listings-and-ads-category',
+						'path'   => '/google/settings/reconnect-accounts',
+						'id'     => 'google-settings-reconnect-accounts',
+					]
+				);
 			}
 		);
 	}

--- a/src/Menu/Settings.php
+++ b/src/Menu/Settings.php
@@ -29,6 +29,8 @@ class Settings implements Service, Registerable {
 						'nav_args' => [
 							'order'  => 40,
 							'parent' => 'google-listings-and-ads-category',
+							// Highlight this menu item for other subpages.
+							'matchExpression' => '/google/settings(/[^/]+)?',
 						],
 					]
 				);


### PR DESCRIPTION
_(This is a follow-up from https://github.com/woocommerce/google-listings-and-ads/pull/1025#discussion_r717420234)_

### Changes proposed in this Pull Request:

Remove `subpath` URLQueryParam from settings pages.
Use WC navigation features instead.

This way we have 
- routing unified with the WC stack
- less noise in URLs & track events
- more intuitive URL & track event props, as the entire path is in a single param, not divided into a number of chunks
- could get closer to [simplify `.~/utils/url.js`](https://github.com/woocommerce/google-listings-and-ads/issues/1024), as we no longer need to construct a query object, but just use `path` param.
- remove the source of problems like the one discussed at https://github.com/woocommerce/google-listings-and-ads/pull/1025#discussion_r717420234, TL;DR: "what if `subpath` is empty?"


What's left/missing/to be done later:
- [ ] Update track event README
- [ ] Try to simplify `wc_admin_register_page` calls in `src/Menu/Settings.php`
- [ ] :scroll: extrapolate for all other pages using `subpath` or similar param.
- (edit) ~[ ] 📜(not sure if possible in WC-plaform) DRY/reduce duplication, of pages configs in `src/Menu/*.php`s, `js/src/index.js` and `js/src/utils/url.js`~ -> https://github.com/woocommerce/google-listings-and-ads/issues/1037


### Screenshots:

![path](https://user-images.githubusercontent.com/17435/135463973-1ab3084a-9067-4e4d-8514-682ec47cbafc.gif)

### Detailed test instructions:

1. Go to Settings page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings)
2. Navigate into phone & address pages - "Edit" buttons
3. Navigate away and around observing how URL changes, and what track events are fired.
(full page reloads instead of SPA-morph, is an unrelated issue https://github.com/woocommerce/google-listings-and-ads/issues/1027)


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Make all settings pages use only `path` for navigation.

-----

//cc @eason9487 @ecgan 

