### PR TITLE
Don't render `DifferentCurrencyNotice` when the Ads account is disconnected.

### DIFF
--- a/js/src/components/different-currency-notice.js
+++ b/js/src/components/different-currency-notice.js
@@ -24,8 +24,12 @@ export default function DifferentCurrencyNotice( { context } ) {
 	const { googleAdsAccount } = useGoogleAdsAccount();
 	const { code: storeCurrency } = useStoreCurrency();
 
-	// Do not render if data is not available, or the same currencies are used.
-	if ( ! googleAdsAccount || googleAdsAccount.currency === storeCurrency ) {
+	// Do not render if data is not available, account not connected, or the same currencies are used.
+	if (
+		! googleAdsAccount ||
+		googleAdsAccount.status !== 'connected' ||
+		googleAdsAccount.currency === storeCurrency
+	) {
 		return null;
 	}
 


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Don't render `DifferentCurrencyNotice` when the Ads account is disconnected.

Covers scenario 1. of https://github.com/woocommerce/google-listings-and-ads/issues/1028.



### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. [Set the store currency](https://gla1.test/wp-admin/admin.php?page=wc-settings) to _X_ (PLN)
2. Setup Ads account (with currency _X_)
3. Change the store currency to _Y_ (EUR)
4. On dashboard and report pages you should see the notice about different currency
2. Disconnect only Ads account in settings
3. Visit dashboard page
4. You should not see the notice 


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Don't render `DifferentCurrencyNotice` when the Ads account is disconnected.
