### PR TITLE
Tweak `Job` interfaces

### DIFF
--- a/src/Jobs/AbstractActionSchedulerJob.php
+++ b/src/Jobs/AbstractActionSchedulerJob.php
@@ -46,7 +46,7 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	 *
 	 * The job name is used to generate the schedule event name.
 	 */
-	public function init(): void {
+	public function register(): void {
 		add_action( $this->get_process_item_hook(), [ $this, 'handle_process_items_action' ] );
 	}
 

--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -26,9 +26,9 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 *
 	 * The job name is used to generate the schedule event name.
 	 */
-	public function init(): void {
+	public function register(): void {
 		add_action( $this->get_create_batch_hook(), [ $this, 'handle_create_batch_action' ] );
-		parent::init();
+		parent::register();
 	}
 
 	/**

--- a/src/Jobs/JobInitializer.php
+++ b/src/Jobs/JobInitializer.php
@@ -45,7 +45,7 @@ class JobInitializer implements Registerable, Conditional {
 	 */
 	public function register(): void {
 		foreach ( $this->job_repository->list() as $job ) {
-			$job->init();
+			$job->register();
 
 			if ( $job instanceof StartOnHookInterface ) {
 				add_action(

--- a/src/Jobs/JobInterface.php
+++ b/src/Jobs/JobInterface.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\JobServiceProvider;
 
@@ -17,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-interface JobInterface extends Service {
+interface JobInterface extends Service, Registerable {
 
 	/**
 	 * Get the name of the job.
@@ -25,10 +26,5 @@ interface JobInterface extends Service {
 	 * @return string
 	 */
 	public function get_name(): string;
-
-	/**
-	 * Init the job.
-	 */
-	public function init(): void;
 
 }

--- a/src/Jobs/RecurringJobInterface.php
+++ b/src/Jobs/RecurringJobInterface.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-interface RecurringJobInterface extends StartOnHookInterface {
+interface RecurringJobInterface extends ActionSchedulerJobInterface {
 
 	/**
 	 * Return the recurring job's interval in seconds.

--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implements RecurringJobInterface {
+class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implements RecurringJobInterface, StartOnHookInterface {
 
 	/**
 	 * Get the name of the job.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

@nima-karimi as prompted by our discussion here (https://github.com/woocommerce/google-listings-and-ads/pull/1021#discussion_r716465657) this PR makes two small changes to the Job interfaces:

1. Separate `StartOnHookInterface` from `RecurringJobInterface` so `RecurringJobInterface` doesn't have to start on a hook. **I just realised:** `StartOnHookInterface` interface is actually required because ActionScheduler's cron function has to be hooked to a WP action name so more refactoring would be required 😬 
2. For consistency with the rest of the plugin I thought we could rename `Job::init()` to `Job::register()` and let all jobs implement `Registerable`.

Side note: I was also thinking we could merge `JobInterface` and `ActionSchedulerJobInterface` since it seems like all our jobs will use Action Scheduler. What do you think?

### Detailed test instructions:

Nothing to test 

### Changelog entry

>
