### PR TITLE
Bump min version of WC and WP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ env:
     - WC_LATEST=trunk
   matrix:
     - WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}"
-    - WP_VERSION="${WP_LATEST}" WC_VERSION=5.2
-    - WP_VERSION=5.7 WC_VERSION=5.2
-    - WP_VERSION=5.6 WC_VERSION=5.2
+    - WP_VERSION="${WP_LATEST}" WC_VERSION=5.4
+    - WP_VERSION=5.7 WC_VERSION=5.4
+    - WP_VERSION=5.6 WC_VERSION=5.4
 
 # Additional tests
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ env:
     - WC_LATEST=trunk
   matrix:
     - WP_VERSION="${WP_LATEST}" WC_VERSION="${WC_LATEST}"
-    - WP_VERSION="${WP_LATEST}" WC_VERSION=5.4
-    - WP_VERSION=5.7 WC_VERSION=5.4
-    - WP_VERSION=5.6 WC_VERSION=5.4
+    - WP_VERSION="${WP_LATEST}" WC_VERSION=5.5
+    - WP_VERSION=5.7 WC_VERSION=5.5
+    - WP_VERSION=5.6 WC_VERSION=5.5
 
 # Additional tests
 matrix:

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 
 ## Prerequisites
 
+We aim to support the latest two minor versions of WordPress, WooCommerce, and PHP. (L-2 policy)
+
 -   WordPress 5.6+
--   WooCommerce 5.4+
+-   WooCommerce 5.5+
 -   PHP 7.3+
 
 ## Browsers supported

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 
 ## Prerequisites
 
--   WordPress 5.5+
--   WooCommerce 5.2+
+-   WordPress 5.6+
+-   WooCommerce 5.4+
 -   PHP 7.3+
 
 ## Browsers supported
@@ -96,7 +96,7 @@ $ ./bin/install-wp-tests.sh wordpress_tests root root localhost
 ```
 
 This script installs the test dependencies into your system's temporary directory and also creates a test database.
-  
+
 You can also specify the path to their directories by setting the following environment variables:
 
 -   `WP_TESTS_DIR`: WordPress Unit Test lib directory

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,11 +7,11 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 5.5
+ * Requires at least: 5.6
  * Tested up to: 5.8
  * Requires PHP: 7.3
  *
- * WC requires at least: 5.2
+ * WC requires at least: 5.4
  * WC tested up to: 5.7
  * Woo:
  *
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '1.5.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.3' );
-define( 'WC_GLA_MIN_WC_VER', '5.2' );
+define( 'WC_GLA_MIN_WC_VER', '5.4' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -11,7 +11,7 @@
  * Tested up to: 5.8
  * Requires PHP: 7.3
  *
- * WC requires at least: 5.4
+ * WC requires at least: 5.5
  * WC tested up to: 5.7
  * Woo:
  *
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '1.5.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.3' );
-define( 'WC_GLA_MIN_WC_VER', '5.4' );
+define( 'WC_GLA_MIN_WC_VER', '5.5' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/readme.txt
+++ b/readme.txt
@@ -62,8 +62,8 @@ Get up to  $150\* in ad credit to help you get started on Smart Shopping Campaig
 
 = Minimum Requirements =
 
-* WordPress 5.5 or greater
-* WooCommerce 5.2 or greater
+* WordPress 5.6 or greater
+* WooCommerce 5.4 or greater
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater
 

--- a/readme.txt
+++ b/readme.txt
@@ -63,7 +63,7 @@ Get up to  $150\* in ad credit to help you get started on Smart Shopping Campaig
 = Minimum Requirements =
 
 * WordPress 5.6 or greater
-* WooCommerce 5.4 or greater
+* WooCommerce 5.5 or greater
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Bump min version of WC and WP, to the ~lowest versions used by our team during development~ L-2.

As per our internal Environment-Developer Distribution table (Pb0Spc-1Nl-p2)
The lowest version used by us are: WordPress 5.6.5, WooCommerce 5.4.2 (used by @ecgan)
And the L-2 police resolves to WordPress 5.6.5, WooCommerce 5.5.2

As we don't have sufficient E2E test coverage, it's hard to say we support any lower version if nobody is actively running it.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Changed minimum version of WordPress to 5.6 and WooCommerce to 5.5

### Additional notes

- I wondered we should update our Dependency Extraction Webpack Plugin config, as there is a note https://github.com/woocommerce/google-listings-and-ads/blob/develop/webpack.config.js#L8
 	> `// WP 5.4 is the min version for <Card* />, <TabPanel />`