### PR TITLE
Separate legacy WC menu handling to a separate hook,

### DIFF
--- a/js/src/components/app-sub-nav/index.js
+++ b/js/src/components/app-sub-nav/index.js
@@ -36,7 +36,11 @@ const AppSubNav = ( props ) => {
 					<>
 						<Link
 							key={ tab.key }
-							className={ classnames( { current: isCurrent } ) }
+							className={ classnames( {
+								current: isCurrent,
+								// Workaround for https://github.com/woocommerce/woocommerce-admin/issues/7772.
+								'gla-sub-nav__item--current': isCurrent,
+							} ) }
 							tabIndex={ isCurrent ? null : -1 }
 							id={ `${ tab.key }` }
 							href={ tab.href }

--- a/js/src/components/app-sub-nav/index.scss
+++ b/js/src/components/app-sub-nav/index.scss
@@ -2,4 +2,15 @@
 	float: none;
 	text-align: left;
 	margin: calc(var(--main-gap) * -1 / 3) 0 var(--main-gap) 0;
+
+	// Duplicate WordPress's `.current` styles as `.gla-sub-nav__item--current`,
+	// to wrok around https://github.com/woocommerce/woocommerce-admin/issues/7772
+	// which removes all `current` classes.
+	.gla-sub-nav__item--current {
+		// https://github.com/WordPress/wordpress-develop/blob/5.8.1/src/wp-admin/css/common.css#L448-L451
+		font-weight: 600;
+		border: none;
+		// https://github.com/WordPress/wordpress-develop/blob/5.8.1/src/wp-admin/css/common.css#L683-L685
+		color: #000;
+	}
 }

--- a/js/src/components/navigation-classic/main-tab-nav.js
+++ b/js/src/components/navigation-classic/main-tab-nav.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getNewPath, getPath } from '@woocommerce/navigation';
 
@@ -10,6 +9,7 @@ import { getNewPath, getPath } from '@woocommerce/navigation';
  */
 import { glaData } from '.~/constants';
 import AppTabNav from '.~/components/app-tab-nav';
+import useLegacyMenuEffect from '.~/hooks/useLegacyMenuEffect';
 
 let tabs = [
 	{
@@ -46,25 +46,7 @@ const getSelectedTabKey = () => {
 };
 
 const MainTabNav = () => {
-	useEffect( () => {
-		// Highlight the wp-admin dashboard menu
-		const marketingMenu = document.querySelector(
-			'#toplevel_page_woocommerce-marketing'
-		);
-
-		if ( ! marketingMenu ) {
-			return;
-		}
-
-		const dashboardLink = marketingMenu.querySelector(
-			"a[href^='admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard']"
-		);
-
-		marketingMenu.classList.add( 'current', 'wp-has-current-submenu' );
-		if ( dashboardLink ) {
-			dashboardLink.parentElement.classList.add( 'current' );
-		}
-	}, [] );
+	useLegacyMenuEffect();
 
 	const selectedKey = getSelectedTabKey();
 

--- a/js/src/hooks/useLegacyMenuEffect.js
+++ b/js/src/hooks/useLegacyMenuEffect.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import isWCNavigationEnabled from '.~/utils/isWCNavigationEnabled';
+
+/**
+ * Mocked result of parsing a page entry from {@link /js/src/index.js} by WC-admin's <Route>.
+ *
+ * @see https://github.com/woocommerce/woocommerce-admin/blob/release/2.7.1/client/layout/controller.js#L240-L244
+ */
+const dashboardPage = {
+	match: { url: '/google/dashboard' },
+	wpOpenMenu: 'toplevel_page_woocommerce-marketing',
+};
+
+/**
+ * Effect that highlights the GLA Dashboard menu entry in the legacy WC menu.
+ *
+ * Should be called for every "root page" (`.~/pages/*`) that wants to open the GLA menu.
+ *
+ * The hook could be removed once WC Navigation will be always enabled,
+ * or if we make the plugin fully use the routing feature of WC,
+ * and let this be done by proper matching of URL matchers from {@link /js/src/index.js}
+ *
+ * @see window.wpNavMenuClassChange
+ */
+export default function useLegacyMenuEffect() {
+	const navigationEnabled = isWCNavigationEnabled();
+	return useEffect( () => {
+		// Highlight the wp-admin dashboard menu
+		if ( ! navigationEnabled ) {
+			window.wpNavMenuClassChange(
+				dashboardPage,
+				dashboardPage.match.url
+			);
+		}
+	}, [ navigationEnabled ] );
+}

--- a/js/src/settings/index.js
+++ b/js/src/settings/index.js
@@ -7,6 +7,7 @@ import { getQuery, getHistory } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import useLegacyMenuEffect from '.~/hooks/useLegacyMenuEffect';
 import useGoogleAccount from '.~/hooks/useGoogleAccount';
 import { subpaths, getReconnectAccountsUrl } from '.~/utils/urls';
 import NavigationClassic from '.~/components/navigation-classic';
@@ -19,6 +20,9 @@ import './index.scss';
 
 const Settings = () => {
 	const { subpath } = getQuery();
+	// Make the component highlight GLA entry in the WC legacy menu.
+	useLegacyMenuEffect();
+
 	const { google } = useGoogleAccount();
 	const isReconnectAccountsPage = subpath === subpaths.reconnectAccounts;
 


### PR DESCRIPTION
Tastes best with https://github.com/woocommerce/google-listings-and-ads/pull/1031 
### Changes proposed in this Pull Request:

Separate legacy WC menu handling to a separate hook, from `<MainTabNav>`.

Simplify it to use `window.wpNavMenuClassChange` instead of custom CSS selectors hacking.
Use it in `Settings` sub-pages.

Addresses part of https://github.com/woocommerce/google-listings-and-ads/issues/1037.


After this change, any page can highlight the menu, even ones without `<MainTabNav>`


### Screenshots:

#### Before 
![image](https://user-images.githubusercontent.com/17435/136079018-3b1e7fd3-4bb2-487c-bbb5-946d22fec41c.png)

#### After
![image](https://user-images.githubusercontent.com/17435/136077588-907833ac-7d25-4ffb-8e51-003a34a6cbf5.png)


### Detailed test instructions:

0. Make sure you have WC Navigation disabled
1. Go to Settings page [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings%2Fedit-phone-number)
2. and its subpages:
	1. 	[`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&subpath=%2Freconnect-accounts`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&subpath=%2Freconnect-accounts)`
	2. [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings%2Fedit-phone-number`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings%2Fedit-phone-number)/[`https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&subpath=%2Fedit-phone-number`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&subpath=%2Fedit-phone-number)

Make sure the "Google Listings & Ads" is highlighted on the left menu.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - refactored legacy WC menu highlighting effect.
> Fix - Report tabs lose active state when changing chart.


### Additional notes
1. I had a problem with naming. We have the current WC navigation and the new one. I used "Legacy" for the current one, and "WC Navigation" for the new one, but I'm still not happy with those. "New", "old", "legacy", and any time-related name are almost by definition not stable in time. Every "new" would eventually become "old" and the current "new" may at some point become "legacy" leaving no way to differentiate the two. Any ideas for something better?