### PR TITLE
Migrate Travis CI tasks to GitHub Actions

### DIFF
--- a/.github/actions/prepare-node/action.yml
+++ b/.github/actions/prepare-node/action.yml
@@ -4,10 +4,12 @@ description: Load npm cache, install Node dependencies
 inputs:
   install-deps:
     description: Whether to run `npm ci`. Set "maybe" to install deps if cache is missing. "yes" by default.
+    required: false
     default: "yes"
 
   ignore-scripts:
     description: Whether to run `npm ci` with --ignore-scripts. "yes" by default.
+    required: false
     default: "yes"
 
 runs:

--- a/.github/actions/prepare-node/action.yml
+++ b/.github/actions/prepare-node/action.yml
@@ -1,0 +1,39 @@
+name: Prepare Node
+description: Load npm cache, install Node dependencies
+
+inputs:
+  install-deps:
+    description: Whether to run `npm ci`. Set "maybe" to install deps if cache is missing. "yes" by default.
+    default: "yes"
+
+  ignore-scripts:
+    description: Whether to run `npm ci` with --ignore-scripts. "yes" by default.
+    default: "yes"
+
+runs:
+  using: composite
+  steps:
+    # Log debug information
+    - shell: sh -e {0}
+      run: |
+        node --version
+        npm --version
+
+    # Get npm cache directory
+    - uses: actions/cache@v2
+      id: npm-cache
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    # Install node dependencies
+    - shell: sh -e {0}
+      # Update npm cache directory if package-lock has changed
+      run: |
+        if [ "${{ inputs.install-deps }}" = "yes" ] || [ "${{ steps.npm-cache.outputs.cache-hit }}" != "true" ]; then
+          npm ci `if [ "${{ inputs.ignore-scripts }}" = "yes" ]; then printf %s "--ignore-scripts"; fi`
+        else
+          echo "Skip npm ci"
+        fi

--- a/.github/actions/prepare-php/action.yml
+++ b/.github/actions/prepare-php/action.yml
@@ -4,14 +4,17 @@ description: Set up PHP, load Composer cache, install Composer dependencies
 inputs:
   php-version:
     description: Specify PHP version. "7.4" by default.
+    required: false
     default: "7.4"
 
   tools:
     description: Specify the tools parameter of shivammathur/setup-php@v2. null by default.
+    required: false
     default: null
 
   install-deps:
     description: Whether to run `composer install`. Set "maybe" to install deps if cache is missing. "yes" by default.
+    required: false
     default: "yes"
 
 runs:

--- a/.github/actions/prepare-php/action.yml
+++ b/.github/actions/prepare-php/action.yml
@@ -1,0 +1,57 @@
+name: Prepare PHP
+description: Set up PHP, load Composer cache, install Composer dependencies
+
+inputs:
+  php-version:
+    description: Specify PHP version. "7.4" by default.
+    default: "7.4"
+
+  tools:
+    description: Specify the tools parameter of shivammathur/setup-php@v2. null by default.
+    default: null
+
+  install-deps:
+    description: Whether to run `composer install`. Set "maybe" to install deps if cache is missing. "yes" by default.
+    default: "yes"
+
+runs:
+  using: composite
+  steps:
+    # Set up PHP
+    - name: 
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        coverage: none
+        tools: ${{ inputs.tools }}
+
+    # Log debug information
+    - shell: sh -e {0}
+      run: |
+        php --version
+        composer --version
+
+    # Get Composer cache directory
+    - shell: sh -e {0}
+      id: composer-cache-config
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    # Set up Composer caching
+    - uses: actions/cache@v2
+      id: composer-cache
+      with:
+        path: ${{ steps.composer-cache-config.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    # Install Composer dependencies
+    - shell: sh -e {0}
+      # Update Composer cache directory if composer.lock has changed
+      run: |
+        if [ "${{ inputs.install-deps }}" = "yes" ] || [ "${{ steps.composer-cache.outputs.cache-hit }}" != "true" ]; then
+          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+        else
+          echo "Skip composer install"
+        fi

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -15,39 +15,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      - name: Prepare PHP
+        uses: ./.github/actions/prepare-php
         with:
-          php-version: "7.4"
-          coverage: none
+          install-deps: "maybe"
 
-      - name: Set up Node
-        uses: actions/setup-node@v2
+      - name: Prepare node
+        uses: ./.github/actions/prepare-node
         with:
-          node-version: "12.21.0"
-          cache: "npm"
-
-      - name: Log debug information
-        run: |
-          php --version
-          composer --version
-          node --version
-          npm --version
-
-      - name: Get Composer cache directory
-        id: composer-cache-config
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache-config.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install Node dependencies
-        run: npm ci
+          ignore-scripts: "no"
 
       - name: Build production bundle
         run: |

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,61 @@
+name: Bundle Size
+
+on:
+  pull_request:
+
+jobs:
+  BundleSize:
+    name: Bundle size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+          coverage: none
+
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12.21.0"
+          cache: "npm"
+
+      - name: Log debug information
+        run: |
+          php --version
+          composer --version
+          node --version
+          npm --version
+
+      - name: Get Composer cache directory
+        id: composer-cache-config
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Set up Composer caching
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache-config.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build production bundle
+        run: |
+          echo "::group::Build log"
+          npm run build
+          echo "::endgroup::"
+
+      - name: Run BundleWatch
+        env:
+          BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+          # Workaround of https://github.com/bundlewatch/bundlewatch/issues/423
+          CI_BRANCH_BASE: ${{ github.base_ref }}
+          # Workaround of https://github.com/bundlewatch/bundlewatch/issues/220
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node ./node_modules/bundlewatch/lib/bin/index.js

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -43,15 +43,16 @@ jobs:
           BRANCH=$(echo '${{ github.event.ref }}' | sed 's/^refs\/heads\///')
           echo "CI_BRANCH=$BRANCH" >> $GITHUB_ENV
           echo "CI_BRANCH_BASE=$BRANCH" >> $GITHUB_ENV
+          echo "CI_COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Prepare BundleWatch env values - pull request
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo "CI_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
           echo "CI_BRANCH_BASE=${{ github.base_ref }}" >> $GITHUB_ENV
+          echo "CI_COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
       - name: Run BundleWatch
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
-          CI_COMMIT_SHA: ${{ github.sha }}
         run: node ./node_modules/bundlewatch/lib/bin/index.js

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,6 +1,10 @@
 name: Bundle Size
 
 on:
+  push:
+    branches:
+      - trunk
+      - develop
   pull_request:
 
 jobs:
@@ -51,11 +55,27 @@ jobs:
           npm run build
           echo "::endgroup::"
 
+      # Since BundleWatch is having issues when getting some environment variables from GitHub Actions,
+      # it needs some workarounds to specify `CI_COMMIT_SHA`, `CI_BRANCH`, and `CI_BRANCH_BASE` here.
+      # References:
+      # - https://github.com/bundlewatch/bundlewatch/blob/v0.3.2/src/app/config/getCIVars.js#L8-L10
+      # - https://github.com/bundlewatch/bundlewatch/issues/423
+      # - https://github.com/bundlewatch/bundlewatch/issues/220
+      - name: Prepare BundleWatch env values - push
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          BRANCH=$(echo '${{ github.event.ref }}' | sed 's/^refs\/heads\///')
+          echo "CI_BRANCH=$BRANCH" >> $GITHUB_ENV
+          echo "CI_BRANCH_BASE=$BRANCH" >> $GITHUB_ENV
+
+      - name: Prepare BundleWatch env values - pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "CI_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+          echo "CI_BRANCH_BASE=${{ github.base_ref }}" >> $GITHUB_ENV
+
       - name: Run BundleWatch
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
-          # Workaround of https://github.com/bundlewatch/bundlewatch/issues/423
-          CI_BRANCH_BASE: ${{ github.base_ref }}
-          # Workaround of https://github.com/bundlewatch/bundlewatch/issues/220
-          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_COMMIT_SHA: ${{ github.sha }}
         run: node ./node_modules/bundlewatch/lib/bin/index.js

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -15,23 +15,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Log debug information
-        run: |
-          node --version
-          npm --version
-
-      - name: Get npm cache directory
-        id: npm-cache
-        uses: actions/cache@v2
+      - name: Prepare node
+        uses: ./.github/actions/prepare-node
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Update npm cache directory # if package-lock has changed
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci --ignore-scripts
+          install-deps: "maybe"
 
   JSLintingCheck:
     name: Lint JavaScript
@@ -41,16 +28,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get npm cache directory
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install Node dependencies
-        run: npm ci --ignore-scripts
+      - name: Prepare node
+        uses: ./.github/actions/prepare-node
 
       - name: Save code linting report JSON
         run: npm run lint:js -- --quiet --output-file eslint_report.json --format json
@@ -77,16 +56,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get npm cache directory
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install Node dependencies
-        run: npm ci --ignore-scripts
+      - name: Prepare node
+        uses: ./.github/actions/prepare-node
 
       - name: Lint CSS
         run: npm run lint:css

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -1,0 +1,92 @@
+name: JavaScript and CSS Linting
+
+on:
+  push:
+    branches:
+      - trunk
+      - develop
+  pull_request:
+
+jobs:
+  Setup:
+    name: Setup for jobs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log debug information
+        run: |
+          node --version
+          npm --version
+
+      - name: Get npm cache directory
+        id: npm-cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Update npm cache directory # if package-lock has changed
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
+
+  JSLintingCheck:
+    name: Lint JavaScript
+    needs: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get npm cache directory
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Node dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Save code linting report JSON
+        run: npm run lint:js -- --quiet --output-file eslint_report.json --format json
+        # Continue to the next step even if this fails
+        continue-on-error: true
+
+      - name: Annotate code linting results
+        uses: ataylorme/eslint-annotate-action@1.2.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          report-json: "eslint_report.json"
+
+      - name: Upload ESLint report
+        uses: actions/upload-artifact@v2
+        with:
+          name: eslint_report.json
+          path: eslint_report.json
+
+  CSSLintingCheck:
+    name: Lint CSS
+    needs: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get npm cache directory
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Node dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint CSS
+        run: npm run lint:css

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -1,0 +1,35 @@
+name: JavaScript Unit Tests
+
+on:
+  push:
+    branches:
+      - trunk
+      - develop
+  pull_request:
+
+jobs:
+  UnitTests:
+    name: JavaScript unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log debug information
+        run: |
+          node --version
+          npm --version
+
+      - name: Get npm cache directory
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Node dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run JavaScript unit tests
+        run: npm run test-unit

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -15,21 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Log debug information
-        run: |
-          node --version
-          npm --version
-
-      - name: Get npm cache directory
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install Node dependencies
-        run: npm ci --ignore-scripts
+      - name: Prepare node
+        uses: ./.github/actions/prepare-node
 
       - name: Run JavaScript unit tests
         run: npm run test-unit

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -15,34 +15,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      - name: Prepare PHP
+        uses: ./.github/actions/prepare-php
         with:
-          php-version: "7.4"
-          coverage: none
           tools: cs2pr
-
-      - name: Log debug information
-        run: |
-          php --version
-          composer --version
-
-      - name: Get Composer cache directory
-        id: composer-cache-config
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache-config.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install Composer dependencies
-        run: |
-          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
-          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
 
       - name: Log PHPCS debug information
         run: vendor/bin/phpcs -i

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -1,0 +1,51 @@
+name: PHP Coding Standards
+
+on:
+  push:
+    branches:
+      - trunk
+      - develop
+  pull_request:
+
+jobs:
+  phpcs:
+    name: PHP coding standards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+          coverage: none
+          tools: cs2pr
+
+      - name: Log debug information
+        run: |
+          php --version
+          composer --version
+
+      - name: Get Composer cache directory
+        id: composer-cache-config
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Set up Composer caching
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache-config.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+
+      - name: Log PHPCS debug information
+        run: vendor/bin/phpcs -i
+
+      - name: Run PHPCS on all files
+        run: vendor/bin/phpcs ./src -q -n --report=checkstyle | cs2pr

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -15,24 +15,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Prepare node
+        uses: ./.github/actions/prepare-node
+        with:
+          install-deps: "maybe"
+
       - name: Log debug information
         run: |
-          node --version
-          npm --version
           composer --version
-
-      - name: Get npm cache directory
-        id: npm-cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Update npm cache directory # if package-lock has changed
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci --ignore-scripts
 
       - name: Get Composer cache directory
         id: composer-cache-config
@@ -67,13 +57,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get npm cache directory
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+      - name: Prepare node
+        uses: ./.github/actions/prepare-node
 
       - name: Get Composer cache directory
         id: composer-cache-config
@@ -104,10 +89,8 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
 
-      - name: Install Node dependencies and build
-        run: |
-          npm ci
-          npm run dev
+      - name: Build client bundles
+        run: npm run dev
 
       - name: Install WP tests
         shell: bash

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -20,26 +20,10 @@ jobs:
         with:
           install-deps: "maybe"
 
-      - name: Log debug information
-        run: |
-          composer --version
-
-      - name: Get Composer cache directory
-        id: composer-cache-config
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        id: composer-cache
-        uses: actions/cache@v2
+      - name: Prepare PHP
+        uses: ./.github/actions/prepare-php
         with:
-          path: ${{ steps.composer-cache-config.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Update Composer cache directory # if composer-lock has changed
-        if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+          install-deps: "maybe"
 
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}
@@ -60,17 +44,10 @@ jobs:
       - name: Prepare node
         uses: ./.github/actions/prepare-node
 
-      - name: Get Composer cache directory
-        id: composer-cache-config
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v2
+      - name: Prepare PHP
+        uses: ./.github/actions/prepare-php
         with:
-          path: ${{ steps.composer-cache-config.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
+          php-version: "${{ matrix.php }}"
 
       - name: Set up MySQL
         # MySQL 8.0 uses the `caching_sha2_password` authentication method by default.
@@ -79,15 +56,6 @@ jobs:
         run: |
           sudo systemctl start mysql.service
           mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: none
-
-      - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
 
       - name: Build client bundles
         run: npm run dev

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -1,0 +1,117 @@
+name: PHP Unit Tests
+
+on:
+  push:
+    branches:
+      - trunk
+      - develop
+  pull_request:
+
+jobs:
+  Setup:
+    name: Setup for jobs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log debug information
+        run: |
+          node --version
+          npm --version
+          composer --version
+
+      - name: Get npm cache directory
+        id: npm-cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Update npm cache directory # if package-lock has changed
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
+
+      - name: Get Composer cache directory
+        id: composer-cache-config
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Set up Composer caching
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache-config.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Update Composer cache directory # if composer-lock has changed
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+
+  UnitTests:
+    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}
+    needs: Setup
+    runs-on: ubuntu-latest
+    env:
+      WP_CORE_DIR: "/tmp/wordpress/src"
+      WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
+    strategy:
+      matrix:
+        php: [7.3, 7.4]
+        wp-version: [5.6, 5.7, 5.8]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get npm cache directory
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Get Composer cache directory
+        id: composer-cache-config
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Set up Composer caching
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache-config.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Set up MySQL
+        # MySQL 8.0 uses the `caching_sha2_password` authentication method by default.
+        # So here alter password with `mysql_native_password` authentication method
+        # to make older PHP (7.3.x) mysql client be able to create database connections.
+        run: |
+          sudo systemctl start mysql.service
+          mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+
+      - name: Install Node dependencies and build
+        run: |
+          npm ci
+          npm run dev
+
+      - name: Install WP tests
+        shell: bash
+        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }}
+
+      - name: Run PHP unit tests
+        run: composer test-unit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Google Listings & Ads [![Build Status](https://travis-ci.com/woocommerce/google-listings-and-ads.svg?branch=trunk)](https://travis-ci.com/woocommerce/google-listings-and-ads)
+# Google Listings & Ads
+
+[![PHP Unit Tests](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/php-unit-tests.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/php-unit-tests.yml)
+[![JavaScript Unit Tests](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-unit-tests.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-unit-tests.yml)
+[![PHP Coding Standards](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/php-coding-standards.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/php-coding-standards.yml)
+[![JavaScript and CSS Linting](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-css-linting.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-css-linting.yml)
+[![Bundle Size](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/bundle-size.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/bundle-size.yml)
 
 A native integration with Google offering free listings and Smart Shopping ads to WooCommerce merchants.
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^v0.7",
 		"phpunit/phpunit": "^7.5",
 		"wp-cli/i18n-command": "^2.2",
-		"wp-coding-standards/wpcs": "^2.3"
+		"wp-coding-standards/wpcs": "^2.3",
+		"yoast/phpunit-polyfills": "^1.0"
 	},
 	"replace": {
 		"symfony/polyfill-mbstring": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20773c0eb40754596a49e0af2f484e21",
+    "content-hash": "651f3c4636b67e442557e021bec6ea80",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -4927,6 +4927,67 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-10-03T08:40:26+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Somehow seems all repos under Woo were stopped CI tasks on Travis CI. This PR migrates CI tasks to GitHub Actions:

- Run PHP unit tests
- Run JavaScript unit tests
- Check PHP coding standards
- Lint JavaScript and CSS
- Check bundle size
- Add status badges to README

### Additional notes

Since the `WC_VERSION` in **install-wp-tests.sh** doesn't take from a command param, the `WC_VERSION` of matrix values in **.travis.yml** have never been used when running PHP unit tests on Travis CI. Therefore, I didn't migrate the matrix of specified `WC_VERSION` such as `WC_VERSION=5.2`.

https://github.com/woocommerce/google-listings-and-ads/blob/56ee88b5f3a1acb3dd869f9a4c0072447498a141/bin/install-wp-tests.sh#L23

https://github.com/woocommerce/google-listings-and-ads/blob/56ee88b5f3a1acb3dd869f9a4c0072447498a141/.travis.yml#L32-L37

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/136178477-d22af6f9-57c5-44e4-8abe-cf49d35b8cab.png)


### Detailed test instructions:

Go to [the Checks tab](https://github.com/woocommerce/google-listings-and-ads/pull/1040/checks) for details

### Changelog entry
