### PR TITLE
Hot fix lack of countries in WC 5.8 settings store

### DIFF
--- a/js/src/hooks/useAdminUrl.js
+++ b/js/src/hooks/useAdminUrl.js
@@ -1,21 +1,15 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
-import { useSelect } from '@wordpress/data';
+import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Get the base URL of WP admin. For example: 'https://example.com/wp-admin/'
  *
  * @return {string} The base URL of WP admin.
  */
-const useAdminUrl = () => {
-	return useSelect( ( select ) => {
-		return select( SETTINGS_STORE_NAME ).getSetting(
-			'wc_admin',
-			'adminUrl'
-		);
-	}, [] );
-};
+const useAdminUrl = () => getSetting( 'adminUrl' );
 
 export default useAdminUrl;

--- a/js/src/hooks/useCountryKeyNameMap.js
+++ b/js/src/hooks/useCountryKeyNameMap.js
@@ -21,7 +21,14 @@ const useCountryKeyNameMap = () => {
 	return useSelect( ( select ) => {
 		const { getSetting } = select( SETTINGS_STORE_NAME );
 		const countries = {
-			...getSetting( 'wc_admin', 'countries' ),
+			...getSetting(
+				'wc_admin',
+				'countries',
+				// Use global settings as a fallback value,
+				// to hotfix lack of countries in Settings Store in WC 5.8
+				// See https://github.com/woocommerce/woocommerce-admin/issues/7781
+				window.wcSettings.countries
+			),
 		};
 
 		/*

--- a/js/src/hooks/useCountryKeyNameMap.js
+++ b/js/src/hooks/useCountryKeyNameMap.js
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
-import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Get a country key-name map object. Used for getting complete country name based on country code.
@@ -18,32 +19,22 @@ import { decodeEntities } from '@wordpress/html-entities';
  * @return {Object} A map object where the key is the country code and the value is the country name.
  */
 const useCountryKeyNameMap = () => {
-	return useSelect( ( select ) => {
-		const { getSetting } = select( SETTINGS_STORE_NAME );
-		const countries = {
-			...getSetting(
-				'wc_admin',
-				'countries',
-				// Use global settings as a fallback value,
-				// to hotfix lack of countries in Settings Store in WC 5.8
-				// See https://github.com/woocommerce/woocommerce-admin/issues/7781
-				window.wcSettings.countries
-			),
-		};
+	const countries = {
+		...getSetting( 'countries' ),
+	};
 
-		/*
-		 * There are HTML entities in some country names.
-		 * Examples:
-		 * - Cura&ccedil;ao                             -> Curaçao
-		 * - Saint Barth&eacute;lemy                    -> Saint Barthélemy
-		 * - S&atilde;o Tom&eacute; and Pr&iacute;ncipe -> São Tomé and Príncipe
-		 */
-		Object.keys( countries ).forEach( ( key ) => {
-			countries[ key ] = decodeEntities( countries[ key ] );
-		} );
+	/*
+	 * There are HTML entities in some country names.
+	 * Examples:
+	 * - Cura&ccedil;ao                             -> Curaçao
+	 * - Saint Barth&eacute;lemy                    -> Saint Barthélemy
+	 * - S&atilde;o Tom&eacute; and Pr&iacute;ncipe -> São Tomé and Príncipe
+	 */
+	Object.keys( countries ).forEach( ( key ) => {
+		countries[ key ] = decodeEntities( countries[ key ] );
+	} );
 
-		return countries;
-	}, [] );
+	return countries;
 };
 
 export default useCountryKeyNameMap;

--- a/js/src/hooks/useStoreCountry.js
+++ b/js/src/hooks/useStoreCountry.js
@@ -3,6 +3,9 @@
  */
 import { useSelect } from '@wordpress/data';
 import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { getSetting as getWCSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Gets the store's country.
@@ -12,7 +15,7 @@ import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 export default function useStoreCountry() {
 	return useSelect( ( select ) => {
 		const { getSetting } = select( SETTINGS_STORE_NAME );
-		const countryNames = getSetting( 'wc_admin', 'countries' );
+		const countryNames = getWCSetting( 'countries' );
 		const general = getSetting( 'general', 'general' );
 		const [ code ] = general.woocommerce_default_country.split( ':' );
 

--- a/js/src/hooks/useStoreCurrency.js
+++ b/js/src/hooks/useStoreCurrency.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
-import { useSelect } from '@wordpress/data';
+import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Get the store's currency object.
@@ -16,13 +17,6 @@ import { useSelect } from '@wordpress/data';
  *
  * @return {Object} The store's currency object.
  */
-const useStoreCurrency = () => {
-	return useSelect( ( select ) => {
-		return select( SETTINGS_STORE_NAME ).getSetting(
-			'wc_admin',
-			'currency'
-		);
-	}, [] );
-};
+const useStoreCurrency = () => getSetting( 'currency' );
 
 export default useStoreCurrency;

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -3,6 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Internal dependencies
@@ -19,14 +22,14 @@ import Settings from './settings';
 import './data';
 import isWCNavigationEnabled from './utils/isWCNavigationEnabled';
 
+const woocommerceTranslation = getSetting( 'woocommerceTranslation' );
+
 addFilter(
 	'woocommerce_admin_pages_list',
 	'woocommerce-marketing',
 	( pages ) => {
 		const navigationEnabled = isWCNavigationEnabled();
-		const initialBreadcrumbs = [
-			[ '', wcSettings.woocommerceTranslation ],
-		];
+		const initialBreadcrumbs = [ [ '', woocommerceTranslation ] ];
 
 		/**
 		 * If the WooCommerce Navigation feature is not enabled,

--- a/js/src/reports/products/async-requests.js
+++ b/js/src/reports/products/async-requests.js
@@ -13,9 +13,9 @@ import apiFetch from '@wordpress/api-fetch';
 import { identity } from 'lodash';
 import { getIdsFromQuery } from '@woocommerce/navigation';
 import { NAMESPACE } from '@woocommerce/data';
-
-const variationTitleAttributesSeparator =
-	wcSettings.variationTitleAttributesSeparator;
+import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Get a function that accepts ids as they are found in url parameter and
@@ -62,7 +62,7 @@ export const getProductLabels = getRequestByIdString(
  * @return {string} - formatted variation name
  */
 export function getVariationName( { attributes, name } ) {
-	const separator = variationTitleAttributesSeparator;
+	const separator = getSetting( 'variationTitleAttributesSeparator', ' - ' );
 
 	if ( name.indexOf( separator ) > -1 ) {
 		return name;

--- a/js/src/reports/products/products-report-filters.js
+++ b/js/src/reports/products/products-report-filters.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-
 import { omitBy, isUndefined } from 'lodash';
 import { ReportFilters } from '@woocommerce/components';
 import {
@@ -11,6 +10,10 @@ import {
 	isoDateFormat,
 } from '@woocommerce/date';
 import { ITEMS_STORE_NAME } from '@woocommerce/data';
+
+import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Internal dependencies
@@ -21,9 +24,8 @@ import {
 } from '.~/utils/recordEvent';
 import { productsFilter, advancedFilters } from './filter-config';
 
-// TODO: Consider importing it from something like '@woocommerce/wc-admin-settings'.
-const currency = wcSettings.currency;
-const siteLocale = wcSettings.locale.siteLocale;
+const currency = getSetting( 'currency' );
+const siteLocale = getSetting( 'locale' ).siteLocale;
 
 /**
  * Set of filters to be used in Products Report page.

--- a/js/src/reports/programs/programs-report-filters.js
+++ b/js/src/reports/programs/programs-report-filters.js
@@ -11,6 +11,9 @@ import {
 // https://github.com/woocommerce/woocommerce-admin/issues/6890
 // https://github.com/woocommerce/woocommerce-admin/issues/6062
 // import { ReportFilters } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved, @woocommerce/dependency-group
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Internal dependencies
@@ -24,8 +27,7 @@ import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import ReportFilters from '.~/external-components/woocommerce/filters';
 
-// TODO: Consider importing it from something like '@woocommerce/wc-admin-settings'.
-const siteLocale = wcSettings.locale.siteLocale;
+const siteLocale = getSetting( 'locale' ).siteLocale;
 const getProgramsFilter = createProgramsFilterConfig();
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,11 @@ const requestToExternal = ( request ) => {
 	const wcDepMap = {
 		'@woocommerce/components': [ 'wc', 'components' ],
 		'@woocommerce/navigation': [ 'wc', 'navigation' ],
+		// Since WooCommerce 5.8, the Settings store no longer contains "countries", "currency" and "adminURL",
+		// to be able to fetch that, we use unpublished `@woocommerce/wc-admin-settings` package.
+		// It's delivered with WC, so we use DEWP to import it.
+		// See https://github.com/woocommerce/woocommerce-admin/issues/7781
+		'@woocommerce/wc-admin-settings': [ 'wc', 'wcSettings' ],
 	};
 
 	return wcDepMap[ request ];
@@ -27,6 +32,7 @@ const requestToHandle = ( request ) => {
 	const wcHandleMap = {
 		'@woocommerce/components': 'wc-components',
 		'@woocommerce/navigation': 'wc-navigation',
+		'@woocommerce/wc-admin-settings': 'wc-settings',
 	};
 
 	return wcHandleMap[ request ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use `window.wcSettings.countries` as a fallback for Settings Store `getSetting( 'wc_admin', 'countries' )`, as the WC 5.8 does not have that field.

Hotfixes: https://github.com/woocommerce/google-listings-and-ads/issues/1041


This is by no means a complete fix, as we need more investigation results from https://github.com/woocommerce/woocommerce-admin/issues/7781 to know whether the backward-incompatible WC 5.8 change was desired or not. It would be nice to have tests for this hook, and the test that uses actual WC (see running tests with DEWP on multiple versions). Also, probably using globals is not recommended way to fetch settings for React components.

The idea is to fix it quickly.

### Screenshots:

![image](https://user-images.githubusercontent.com/17435/136825881-f266f625-af80-40fb-89bf-5bb469642b31.png)


### Detailed test instructions:

0. Install WC [5.8.0-rc.1](https://github.com/woocommerce/woocommerce/releases/tag/5.8.0-rc.1), or activate `main` branch of WC-admin.
1. If your MC is connected 
	1. got to Ads campaign setup [`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads).
	2. Go to the second step
2. If you MC is not set up, go to the audience selection step
3. See if countries are suggested for the Audience field
4. Do 1-3 with WC 5.7



<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Fetch countries for dropdowns in WC 5.8
