### PR TITLE
:nail_care: :building_construction: Decrease bundlewatch `maxSize`s,

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,11 +104,11 @@
 		"files": [
 			{
 				"path": "./js/build/*.js",
-				"maxSize": "3 kB"
+				"maxSize": "2.3 kB"
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "3 mB"
+				"maxSize": "743 kb"
 			},
 			{
 				"path": "./js/build/*.css",

--- a/package.json
+++ b/package.json
@@ -104,23 +104,23 @@
 		"files": [
 			{
 				"path": "./js/build/*.js",
-				"maxSize": "2.3 kB"
+				"maxSize": "1.3 kB"
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "743 kb"
+				"maxSize": "457 kb"
 			},
 			{
 				"path": "./js/build/*.css",
-				"maxSize": "1 kB"
+				"maxSize": "364 B"
 			},
 			{
 				"path": "./js/build/index.css",
-				"maxSize": "10 kB"
+				"maxSize": "8 kB"
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "12 mB",
+				"maxSize": "11.8 mB",
 				"compression": "none"
 			}
 		],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Set `index.js` bundle size to 150% of median JS file size from
https://httparchive.org/reports/page-weight#bytesJs.
Set other `*.js` size, to twice the size of the biggest one.

So we could set more ambitious goals, and get warned/blocked at more proportional change.

IMHO, it's still very forgiving, as we would have to make the biggest JS bundles twice a size to get blocked.
So I'm open to discussion to make those limits even smaller.
- Maybe 120% of current file sizes?



### Screenshots:

#### before
![image](https://user-images.githubusercontent.com/17435/136974367-2fb59e61-f381-4c20-850a-b06f3e83a8c9.png)
#### after
![image](https://user-images.githubusercontent.com/17435/137115397-11343fa1-bf53-4fdc-aaab-0c9fb11e15a6.png)


### Detailed test instructions:

1. See the bundlewatch details


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
