### PR TITLE
Provide granted scopes in the `google/connected` endpoint if available

### DIFF
--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -147,6 +147,7 @@ class AccountController extends BaseController {
 				return [
 					'active' => array_key_exists( 'status', $status ) && ( 'connected' === $status['status'] ) ? 'yes' : 'no',
 					'email'  => array_key_exists( 'email', $status ) ? $status['email'] : '',
+					'scope'  => array_key_exists( 'scope', $status ) ? $status['scope'] : [],
 				];
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1000. Companion to 1828-gh-Automattic/woocommerce-connect-server

This small PR adds the `scope` attribute (`string[]`) to the `/google/connected` API endpoint, if it's received from the WooCommerce Connect Server (PR incoming, pending unit tests) when querying the Google account connection status.

This attribute indicates the permissions that have been granted, so the front end can determine whether the user has granted enough permissions to continue the onboarding (MC or Ads), or if it's necessary to request that the user repeat the Google account connection process.

Example result:
```json
{
    "active": "yes",
    "email": "gla@woocommerce.com",
    "scope": [
        "openid",
        "https://www.googleapis.com/auth/userinfo.email",
        "https://www.googleapis.com/auth/adwords",
        "https://www.googleapis.com/auth/content",
        "https://www.googleapis.com/auth/siteverification.verify_only"
    ]
}
```

### Detailed test instructions:
1. Use the accompanying PR in the WooCommerce Connect Server: 1828-gh-Automattic/woocommerce-connect-serve
2. Connect a Google account, granting all requested permissions.
3. Make a `GET` request to the `wc/gla/google/connected` API endpoint and check that the correct permissions are indicated in the scope.
3. Disconnect and reconnect a Google account, granting a subset of the requested permissions.

_(No changelog necessary for this small change)._
### Changelog entry