### PR TITLE
Fix `woocommerceTranslation` used in title breadcrumb

### DIFF
--- a/js/src/hooks/useAdminUrl.js
+++ b/js/src/hooks/useAdminUrl.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
 

--- a/js/src/hooks/useCountryKeyNameMap.js
+++ b/js/src/hooks/useCountryKeyNameMap.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { decodeEntities } from '@wordpress/html-entities';
-import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
 

--- a/js/src/hooks/useStoreCountry.js
+++ b/js/src/hooks/useStoreCountry.js
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { SETTINGS_STORE_NAME } from '@woocommerce/data';
-import { getSetting as getWCSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+import { getSetting as getWCSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
 

--- a/js/src/hooks/useStoreCurrency.js
+++ b/js/src/hooks/useStoreCurrency.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
-import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -22,7 +22,11 @@ import Settings from './settings';
 import './data';
 import isWCNavigationEnabled from './utils/isWCNavigationEnabled';
 
-const woocommerceTranslation = getSetting( 'woocommerceTranslation' );
+const woocommerceTranslation =
+	// Pre WC 5.8
+	getSetting( 'woocommerceTranslation' ) ||
+	// WC 5.8+
+	getSetting( 'admin' )?.woocommerceTranslation;
 
 addFilter(
 	'woocommerce_admin_pages_list',

--- a/js/src/reports/products/async-requests.js
+++ b/js/src/reports/products/async-requests.js
@@ -13,7 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { identity } from 'lodash';
 import { getIdsFromQuery } from '@woocommerce/navigation';
 import { NAMESPACE } from '@woocommerce/data';
-import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
 

--- a/js/src/reports/products/products-report-filters.js
+++ b/js/src/reports/products/products-report-filters.js
@@ -11,7 +11,7 @@ import {
 } from '@woocommerce/date';
 import { ITEMS_STORE_NAME } from '@woocommerce/data';
 
-import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
 

--- a/js/src/reports/programs/programs-report-filters.js
+++ b/js/src/reports/programs/programs-report-filters.js
@@ -11,7 +11,7 @@ import {
 // https://github.com/woocommerce/woocommerce-admin/issues/6890
 // https://github.com/woocommerce/woocommerce-admin/issues/6062
 // import { ReportFilters } from '@woocommerce/components';
-import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved, @woocommerce/dependency-group
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved, @woocommerce/dependency-group
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ const requestToHandle = ( request ) => {
 	const wcHandleMap = {
 		'@woocommerce/components': 'wc-components',
 		'@woocommerce/navigation': 'wc-navigation',
-		'@woocommerce/wc-settings': 'wc-settings',
+		'@woocommerce/settings': 'wc-settings',
 	};
 
 	return wcHandleMap[ request ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extrac
 const path = require( 'path' );
 
 const requestToExternal = ( request ) => {
+	// Opt-out WordPress packages.
 	// The following default externals are bundled for compatibility with older versions of WP
 	// Note CSS for specific components is bundled via admin/assets/src/index.scss
 	// WP 5.4 is the min version for <Card* />, <TabPanel />
@@ -15,14 +16,21 @@ const requestToExternal = ( request ) => {
 		return false;
 	}
 
+	// Opt-in WooCommerce packages.
+	// To switch to opt-out, we would have to use '@woocommerce/dependency-extraction-webpack-plugin'.
 	const wcDepMap = {
 		'@woocommerce/components': [ 'wc', 'components' ],
 		'@woocommerce/navigation': [ 'wc', 'navigation' ],
 		// Since WooCommerce 5.8, the Settings store no longer contains "countries", "currency" and "adminURL",
-		// to be able to fetch that, we use unpublished `@woocommerce/wc-admin-settings` package.
-		// It's delivered with WC, so we use DEWP to import it.
-		// See https://github.com/woocommerce/woocommerce-admin/issues/7781
-		'@woocommerce/wc-admin-settings': [ 'wc', 'wcSettings' ],
+		// to be able to fetch that, we use unpublished `'@woocommerce/settings': 'wc-settings` package.
+		// It's delivered with WC, so we use Dependency Extraction Webpack Plugin to import it.
+		// See https://github.com/woocommerce/woocommerce-admin/issues/7781,
+		// https://github.com/woocommerce/woocommerce-admin/issues/7810
+		// Please note, that this is NOT https://www.npmjs.com/package/@woocommerce/settings,
+		// or https://github.com/woocommerce/woocommerce-admin/tree/main/packages/wc-admin-settings
+		// but https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/settings/shared/index.ts
+		// (at an unknown version).
+		'@woocommerce/settings': [ 'wc', 'wcSettings' ],
 	};
 
 	return wcDepMap[ request ];
@@ -32,7 +40,7 @@ const requestToHandle = ( request ) => {
 	const wcHandleMap = {
 		'@woocommerce/components': 'wc-components',
 		'@woocommerce/navigation': 'wc-navigation',
-		'@woocommerce/wc-admin-settings': 'wc-settings',
+		'@woocommerce/wc-settings': 'wc-settings',
 	};
 
 	return wcHandleMap[ request ];
@@ -77,9 +85,12 @@ const webpackConfig = {
 				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 		),
 		new DependencyExtractionWebpackPlugin( {
+			combineAssets: false,
+			outputFormat: 'json',
 			injectPolyfill: true,
 			requestToExternal,
 			requestToHandle,
+			externalizedReportFile: 'externalized.json',
 		} ),
 	],
 	entry: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,12 +85,9 @@ const webpackConfig = {
 				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 		),
 		new DependencyExtractionWebpackPlugin( {
-			combineAssets: false,
-			outputFormat: 'json',
 			injectPolyfill: true,
 			requestToExternal,
 			requestToHandle,
-			externalizedReportFile: 'externalized.json',
 		} ),
 	],
 	entry: {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Rename `wc-admin-settings` to `settings` to match Woo/DEWP mapping. (86c2a76)
  Mention findings from https://github.com/woocommerce/woocommerce-admin/issues/7810- the unobvious source of unpublished `@woocommerce/settings` -> https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/settings/shared/index.ts
- Fix `woocommerceTranslation` used in title breadcrumb (947aa89)
  Fixes #1050


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Checkout the branch
2. `npm install`
3. `npm run build`
4. Open any GLA page, like[`/wp-admin/admin.php?page=wc-admin&subpath=%2Freconnect-accounts&path=%2Fgoogle%2Fsettings`](https://gla1.test/wp-admin/admin.php?page=wc-admin&subpath=%2Freconnect-accounts&path=%2Fgoogle%2Fsettings)
5. Check the page title, `document.title` in the console


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - `woocommerceTranslation` used in title breadcrumb
