### PR TITLE
Adjust the `install_wc` function to fix the PHP unit tests on GitHub Actions

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -60,30 +60,30 @@ set -ex
 
 install_wp() {
 
-  if [ -d $WP_CORE_DIR ]; then
+  if [ -d "$WP_CORE_DIR" ]; then
     return
   fi
 
-  mkdir -p $WP_CORE_DIR
+  mkdir -p "$WP_CORE_DIR"
 
   if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-    mkdir -p $TMPDIR/wordpress-trunk
-    rm -rf $TMPDIR/wordpress-trunk/*
-    svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
-    mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
+    mkdir -p "$TMPDIR"/wordpress-trunk
+    rm -rf "$TMPDIR"/wordpress-trunk/*
+    svn export --quiet https://core.svn.wordpress.org/trunk "$TMPDIR"/wordpress-trunk/wordpress
+    mv "$TMPDIR"/wordpress-trunk/wordpress/* "$WP_CORE_DIR"
   else
     if [ $WP_VERSION == 'latest' ]; then
       local ARCHIVE_NAME='latest'
     elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
       # https serves multiple offers, whereas http serves single.
-      download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+      download https://api.wordpress.org/core/version-check/1.7/ "$TMPDIR"/wp-latest.json
       if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
         # version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
         LATEST_VERSION=${WP_VERSION%??}
       else
         # otherwise, scan the releases and get the most up to date minor version of the major release
         local VERSION_ESCAPED=$(echo $WP_VERSION | sed 's/\./\\\\./g')
-        LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+        LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' "$TMPDIR"/wp-latest.json | sed 's/"version":"//' | head -1)
       fi
       if [[ -z "$LATEST_VERSION" ]]; then
         local ARCHIVE_NAME="wordpress-$WP_VERSION"
@@ -93,11 +93,11 @@ install_wp() {
     else
       local ARCHIVE_NAME="wordpress-$WP_VERSION"
     fi
-    download https://wordpress.org/${ARCHIVE_NAME}.tar.gz $TMPDIR/wordpress.tar.gz
-    tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+    download https://wordpress.org/${ARCHIVE_NAME}.tar.gz "$TMPDIR"/wordpress.tar.gz
+    tar --strip-components=1 -zxmf "$TMPDIR"/wordpress.tar.gz -C "$WP_CORE_DIR"
   fi
 
-  download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+  download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR"/wp-content/db.php
 }
 
 install_test_suite() {
@@ -109,12 +109,12 @@ install_test_suite() {
   fi
 
   # set up testing suite if it doesn't yet exist
-  if [ ! -d $WP_TESTS_DIR ]; then
+  if [ ! -d "$WP_TESTS_DIR" ]; then
     # set up testing suite
-    mkdir -p $WP_TESTS_DIR
-    rm -rf $WP_TESTS_DIR/{includes,data}
-    svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-    svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+    mkdir -p "$WP_TESTS_DIR"
+    rm -rf "$WP_TESTS_DIR"/{includes,data}
+    svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ "$WP_TESTS_DIR"/includes
+    svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ "$WP_TESTS_DIR"/data
   fi
 
   if [ ! -f wp-tests-config.php ]; then
@@ -180,15 +180,15 @@ install_db() {
 }
 
 install_wc() {
-  if [ ! -d $WC_DIR ]; then
+  if [ ! -d "$WC_DIR" ]; then
     # set up testing suite
-    mkdir -p $WC_DIR
+    mkdir -p "$WC_DIR"
     echo "Installing WooCommerce ($WC_VERSION)."
     # Grab the necessary plugins.
     if [ $WC_VERSION == 'trunk' ]; then
-      rm -rf $TMPDIR/woocommerce-trunk
+      rm -rf "$TMPDIR"/woocommerce-trunk
       git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${TMPDIR}/woocommerce-trunk"
-      mv $TMPDIR/woocommerce-trunk/plugins/woocommerce/* $WC_DIR
+      mv "$TMPDIR"/woocommerce-trunk/plugins/woocommerce/* "$WC_DIR"
     else
       echo "Test with specified WooCommerce version ${WC_VERSION} is not yet supported."
       exit 1

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -185,7 +185,14 @@ install_wc() {
     mkdir -p $WC_DIR
     echo "Installing WooCommerce ($WC_VERSION)."
     # Grab the necessary plugins.
-    git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${WC_DIR}"
+    if [ $WC_VERSION == 'trunk' ]; then
+      rm -rf $TMPDIR/woocommerce-trunk
+      git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${TMPDIR}/woocommerce-trunk"
+      mv $TMPDIR/woocommerce-trunk/plugins/woocommerce/* $WC_DIR
+    else
+      echo "Test with specified WooCommerce version ${WC_VERSION} is not yet supported."
+      exit 1
+    fi
 
     # Install composer for WooCommerce
     cd "${WC_DIR}"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[WooCommerce repo is starting the move to be a monorepo](https://github.com/woocommerce/woocommerce/pull/30945). With the change, the [PHP unit tests on GitHub Actions](https://github.com/woocommerce/google-listings-and-ads/pull/1056/checks?check_run_id=3935120358) also broke down along with it.

![image](https://user-images.githubusercontent.com/17420811/137875990-ab899a89-7e5e-4191-930c-1b054eeb9499.png)

This PR aims to give a quick fix by adjusting the `install_wc` function in the **bin/install-wp-tests.sh** to fit with the new file structure of WooCommerce repo.

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/137876748-0c848e69-49a3-4130-a58b-ea7e8b5197bf.png)

### Detailed test instructions:

1. Go to [the Checks tab](https://github.com/woocommerce/google-listings-and-ads/runs/3936771130#step:7:37) for more details

### Changelog entry
