### PR TITLE
Accept login_hint for OAuth connection

### DIFF
--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -34,18 +34,25 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 	 * Get the connection URL for performing a connection redirect.
 	 *
 	 * @param string $return_url The return URL.
+	 * @param string $login_hint Suggested Google account to use for connection.
 	 *
 	 * @return string
 	 * @throws Exception When a ClientException is caught or the response doesn't contain the oauthUrl.
 	 */
-	public function connect( string $return_url ): string {
+	public function connect( string $return_url, string $login_hint = '' ): string {
 		try {
+
+			$post_body = [ 'returnUrl' => $return_url ];
+			if ( ! empty( $login_hint ) ) {
+				$post_body['loginHint'] = $login_hint;
+			}
+
 			/** @var Client $client */
 			$client = $this->container->get( Client::class );
 			$result = $client->post(
 				$this->get_connection_url(),
 				[
-					'body' => json_encode( [ 'returnUrl' => $return_url ] ),
+					'body' => json_encode( $post_body ),
 				]
 			);
 

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -87,11 +87,15 @@ class AccountController extends BaseController {
 	protected function get_connect_callback(): callable {
 		return function( Request $request ) {
 			try {
-				$next = $request->get_param( 'next' );
-				$path = $next === 'setup-mc' ? '/google/setup-mc' : '/google/settings&subpath=/reconnect-accounts';
+				$next       = $request->get_param( 'next' );
+				$login_hint = $request->get_param( 'login_hint' ) ?: '';
+				$path       = $next === 'setup-mc' ? '/google/setup-mc' : '/google/settings&subpath=/reconnect-accounts';
 
 				return [
-					'url' => $this->connection->connect( admin_url( "admin.php?page=wc-admin&path={$path}" ) ),
+					'url' => $this->connection->connect(
+						admin_url( "admin.php?page=wc-admin&path={$path}" ),
+						$login_hint
+					),
 				];
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
@@ -106,13 +110,18 @@ class AccountController extends BaseController {
 	 */
 	protected function get_connect_params(): array {
 		return [
-			'context' => $this->get_context_param( [ 'default' => 'view' ] ),
-			'next'    => [
+			'context'    => $this->get_context_param( [ 'default' => 'view' ] ),
+			'next'       => [
 				'description'       => __( 'Indicate the next page name to map the redirect URI when back from Google authorization.', 'google-listings-and-ads' ),
 				'type'              => 'string',
 				'default'           => 'setup-mc',
 				'enum'              => [ 'setup-mc', 'reconnect' ],
 				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'login_hint' => [
+				'description'       => __( 'Indicate the Google account to suggest for authorization.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'validate_callback' => 'is_email',
 			],
 		];
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1000. 

When a merchant needs to reconnect to Google, or grant missing permissions, we should guide them to do so with the correct account. This PR adds the `login_hint` querystring parameter for the `/google/connect` REST endpoint to allow the account to preferred be specified and reduce the chance that the user choose the wrong account.


### Detailed test instructions:
1. Use the accompanying WCS PR (1835-gh-Automattic/woocommerce-connect-server)
1. Make a `GET` request to `/wp-json/wc/gla/google/connect`
2. Confirm that the `url` attribute in the response is correctly and redirects to the default Google connection prompt (with multiple accounts displayed if available, or an empty username box).
3. Make a `GET` request to `/wp-json/wc/gla/google/connect?login_hint=YOUREMAILADDRESS@GMAIL.COM` using an email address that is currently logged in.
4. Confirm that the `url` attribute in the response contains the `login_hint` parameter and that it redirects to the hinted Google connection prompt (with only the hinted account displayed, or the username box pre-filled with the email address suggested).


### Changelog entry

> Add - Accept login_hint when generating OAuth URL.