### PR TITLE
Add the partial auth feature of Google account to the onboarding setup page

### DIFF
--- a/js/src/components/google-account-card/authorize-google-account-card.js
+++ b/js/src/components/google-account-card/authorize-google-account-card.js
@@ -43,6 +43,17 @@ export default function AuthorizeGoogleAccountCard( {
 	const handleConnectClick = async () => {
 		try {
 			const { url } = await fetchGoogleConnect();
+
+			// To demo the full process of partial auth temporarily,
+			// here is a hack to append a `login_hint` parameter to
+			// skip the account selection step after going to Google Oauth page.
+			const u = new URL( url );
+			if ( isAskingScope && ! u.searchParams.has( 'login_hint' ) ) {
+				u.searchParams.append( 'login_hint', additionalScopeEmail );
+				window.location.href = u.toString();
+				return;
+			}
+
 			window.location.href = url;
 		} catch ( error ) {
 			createNotice(

--- a/js/src/components/google-account-card/authorize-google-account-card.js
+++ b/js/src/components/google-account-card/authorize-google-account-card.js
@@ -43,17 +43,6 @@ export default function AuthorizeGoogleAccountCard( {
 	const handleConnectClick = async () => {
 		try {
 			const { url } = await fetchGoogleConnect();
-
-			// To demo the full process of partial auth temporarily,
-			// here is a hack to append a `login_hint` parameter to
-			// skip the account selection step after going to Google Oauth page.
-			const u = new URL( url );
-			if ( isAskingScope && ! u.searchParams.has( 'login_hint' ) ) {
-				u.searchParams.append( 'login_hint', additionalScopeEmail );
-				window.location.href = u.toString();
-				return;
-			}
-
 			window.location.href = url;
 		} catch ( error ) {
 			createNotice(

--- a/js/src/components/google-account-card/authorize-google-account-card.js
+++ b/js/src/components/google-account-card/authorize-google-account-card.js
@@ -78,7 +78,7 @@ export default function AuthorizeGoogleAccountCard( {
 						),
 						{
 							alert: (
-								<span className="gla-authorize-google-account-card__alter-text" />
+								<span className="gla-authorize-google-account-card__error-text" />
 							),
 							link: readMoreLink,
 						}

--- a/js/src/components/google-account-card/authorize-google-account-card.js
+++ b/js/src/components/google-account-card/authorize-google-account-card.js
@@ -11,7 +11,8 @@ import AppButton from '.~/components/app-button';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import useGoogleAuthorization from '.~/hooks/useGoogleAuthorization';
+import './authorize-google-account-card.scss';
 
 const readMoreLink = (
 	<AppDocumentationLink
@@ -21,11 +22,23 @@ const readMoreLink = (
 	/>
 );
 
-export default function AuthorizeGoogleAccountCard( { disabled = false } ) {
+/**
+ * Renders an AccountCard based on Google appearance for requesting Google authorization from user.
+ *
+ * @param {Object} props React props.
+ * @param {string} [props.additionalScopeEmail] Specify the email to be requested additional scopes. Set this prop only if wants to request a partial oauth to Google.
+ * @param {boolean} [props.disabled=false] Whether display in disabled style and disable all controllable elements within this component.
+ */
+export default function AuthorizeGoogleAccountCard( {
+	additionalScopeEmail,
+	disabled = false,
+} ) {
+	const isAskingScope = Boolean( additionalScopeEmail );
 	const { createNotice } = useDispatchCoreNotices();
-	const [ fetchGoogleConnect, { loading, data } ] = useApiFetchCallback( {
-		path: '/wc/gla/google/connect',
-	} );
+	const [ fetchGoogleConnect, { loading, data } ] = useGoogleAuthorization(
+		'setup-mc',
+		additionalScopeEmail
+	);
 
 	const handleConnectClick = async () => {
 		try {
@@ -42,7 +55,27 @@ export default function AuthorizeGoogleAccountCard( { disabled = false } ) {
 		}
 	};
 
-	const description = (
+	const description = isAskingScope ? (
+		<>
+			{ additionalScopeEmail }
+			<p>
+				<em>
+					{ createInterpolateElement(
+						__(
+							'<alert>Error:</alert> You did not allow WooCommerce sufficient access to your Google account. You must select all checkboxes in the Google account modal to proceed. <link>Read more</link>',
+							'google-listings-and-ads'
+						),
+						{
+							alert: (
+								<span className="gla-authorize-google-account-card__alter-text" />
+							),
+							link: readMoreLink,
+						}
+					) }
+				</em>
+			</p>
+		</>
+	) : (
 		<>
 			{ __(
 				'Required to sync with Google Merchant Center and Google Ads.',
@@ -62,6 +95,10 @@ export default function AuthorizeGoogleAccountCard( { disabled = false } ) {
 		</>
 	);
 
+	const buttonText = isAskingScope
+		? __( 'Allow full access', 'google-listings-and-ads' )
+		: __( 'Connect', 'google-listings-and-ads' );
+
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE }
@@ -69,13 +106,15 @@ export default function AuthorizeGoogleAccountCard( { disabled = false } ) {
 			hideIcon
 			alignIcon="top"
 			description={ description }
+			alignIndicator="top"
 			indicator={
 				<AppButton
 					isSecondary
+					isDestructive={ isAskingScope }
 					disabled={ disabled }
 					loading={ loading || data }
 					eventName="gla_google_account_connect_button_click"
-					text={ __( 'Connect', 'google-listings-and-ads' ) }
+					text={ buttonText }
 					onClick={ handleConnectClick }
 				/>
 			}

--- a/js/src/components/google-account-card/authorize-google-account-card.scss
+++ b/js/src/components/google-account-card/authorize-google-account-card.scss
@@ -1,0 +1,6 @@
+.gla-authorize-google-account-card {
+	&__alter-text {
+		font-weight: 500;
+		color: $alert-red;
+	}
+}

--- a/js/src/components/google-account-card/authorize-google-account-card.scss
+++ b/js/src/components/google-account-card/authorize-google-account-card.scss
@@ -1,5 +1,5 @@
 .gla-authorize-google-account-card {
-	&__alter-text {
+	&__error-text {
 		font-weight: 500;
 		color: $alert-red;
 	}

--- a/js/src/components/google-account-card/google-account-card.js
+++ b/js/src/components/google-account-card/google-account-card.js
@@ -18,7 +18,7 @@ export default function GoogleAccountCard( { disabled = false } ) {
 		return <ConnectedGoogleAccountCard googleAccount={ google } />;
 	}
 
-	const additionalScopeEmail = scope.gmcRequired ? undefined : google.email;
+	const additionalScopeEmail = scope.gmcRequired ? undefined : google?.email;
 
 	return (
 		<AuthorizeGoogleAccountCard

--- a/js/src/components/google-account-card/google-account-card.js
+++ b/js/src/components/google-account-card/google-account-card.js
@@ -14,11 +14,14 @@ export default function GoogleAccountCard( { disabled = false } ) {
 		return <AccountCard appearance={ {} } description={ <AppSpinner /> } />;
 	}
 
-	if ( google?.active === 'yes' && scope.gmcRequired ) {
+	const isConnected = google?.active === 'yes';
+
+	if ( isConnected && scope.gmcRequired ) {
 		return <ConnectedGoogleAccountCard googleAccount={ google } />;
 	}
 
-	const additionalScopeEmail = scope.gmcRequired ? undefined : google?.email;
+	const additionalScopeEmail =
+		isConnected && ! scope.gmcRequired ? google.email : undefined;
 
 	return (
 		<AuthorizeGoogleAccountCard

--- a/js/src/components/google-account-card/google-account-card.js
+++ b/js/src/components/google-account-card/google-account-card.js
@@ -8,15 +8,22 @@ import AuthorizeGoogleAccountCard from './authorize-google-account-card';
 import ConnectedGoogleAccountCard from './connected-google-account-card';
 
 export default function GoogleAccountCard( { disabled = false } ) {
-	const { google, hasFinishedResolution } = useGoogleAccount();
+	const { google, scope, hasFinishedResolution } = useGoogleAccount();
 
 	if ( ! hasFinishedResolution ) {
 		return <AccountCard appearance={ {} } description={ <AppSpinner /> } />;
 	}
 
-	if ( google?.active === 'yes' ) {
+	if ( google?.active === 'yes' && scope.gmcRequired ) {
 		return <ConnectedGoogleAccountCard googleAccount={ google } />;
 	}
 
-	return <AuthorizeGoogleAccountCard disabled={ disabled } />;
+	const additionalScopeEmail = scope.gmcRequired ? undefined : google.email;
+
+	return (
+		<AuthorizeGoogleAccountCard
+			additionalScopeEmail={ additionalScopeEmail }
+			disabled={ disabled }
+		/>
+	);
 }

--- a/js/src/hooks/useGoogleAuthorization.js
+++ b/js/src/hooks/useGoogleAuthorization.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { API_NAMESPACE } from '.~/data/constants';
+import useApiFetchCallback from './useApiFetchCallback';
+
+/**
+ * Request a Google Oauth URL.
+ *
+ * @param {'setup-mc'|'reconnect'} next Indicate the next page name to map the redirect URI when back from Google authorization.
+ * @param {string} [loginHint] Specify the email to be requested additional scopes. Set this parameter only if wants to request a partial oauth to Google.
+ * @see https://developers.google.com/identity/protocols/oauth2/openid-connect#login-hint
+ * @return {Array} The same structure as `useApiFetchCallback`.
+ */
+export default function useGoogleAuthorization( next, loginHint ) {
+	const fetchOption = useMemo( () => {
+		const query = { next, login_hint: loginHint };
+		const path = addQueryArgs( `${ API_NAMESPACE }/google/connect`, query );
+		return { path };
+	}, [ next, loginHint ] );
+
+	return useApiFetchCallback( fetchOption );
+}

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -24,7 +24,7 @@ import Faqs from './faqs';
 const SetupAccounts = ( props ) => {
 	const { onContinue = () => {} } = props;
 	const { jetpack } = useJetpackAccount();
-	const { google } = useGoogleAccount();
+	const { google, scope } = useGoogleAccount();
 	const { googleMCAccount } = useGoogleMCAccount();
 
 	if (
@@ -36,7 +36,10 @@ const SetupAccounts = ( props ) => {
 	}
 
 	const isGoogleAccountDisabled = jetpack?.active !== 'yes';
-	const isGoogleMCAccountDisabled = google?.active !== 'yes';
+	const isGoogleConnected = google?.active === 'yes';
+	const isGoogleMCAccountDisabled = ! (
+		isGoogleConnected && scope.gmcRequired
+	);
 	const isContinueButtonDisabled = googleMCAccount?.status !== 'connected';
 
 	return (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1000 and based on #1060

- Add a new hook `useGoogleAuthorization` for getting Google OAuth URL. It will be reused in the following development.
- Adjust the `<GoogleAccountCard>` and `<AuthorizeGoogleAccountCard>` to add partial auth UI and process.

### Additional note

- [x] Revert https://github.com/woocommerce/google-listings-and-ads/pull/1064/commits/9f465fb3af911db9f2ccf96a4955a994ee7bf329 before merging this PR. See https://github.com/woocommerce/google-listings-and-ads/pull/1064#discussion_r736426466.

### Screenshots:

#### 🎥 . Grant without optional permissions

https://user-images.githubusercontent.com/17420811/138865447-80a2134e-8746-4dc4-9d40-f876e428105e.mp4

#### 🎥 . Grant with "Manage your product listings and accounts for Google Shopping" permission only

https://user-images.githubusercontent.com/17420811/138865473-d077d17d-6335-4760-a04c-93fb53167b9c.mp4

#### 🎥 . Grant with minimal required permissions

https://user-images.githubusercontent.com/17420811/138865491-988e2d5a-2104-4bc7-92a4-653a66b49709.mp4


### Detailed test instructions:

#### Test the re-asking permission flow

1. Disconnect all accounts.
1. Go to the onboarding setup and proceed with the account connection setup.
1. When authorizing plugin with your Google account,
    1. don't tick off any optional permissions
    1. only tick off the "**Manage your product listings and accounts for Google Shopping**" permission.
1. It should display an error tip and re-ask you to provide all permission.
1. Click on the "Allow full access" button, it should bring you to the Google permissions authorization directly.
1. After accepting, it should back to GLA onboarding setup and be able to proceed with the Google Merchant Center account setup.

#### Test the minimal required permission flow
1. Disconnect all accounts.
1. Go to the onboarding setup and proceed with the account connection setup.
1. When authorizing plugin with your Google account, tick off the minimal required "**Manage your product listings and accounts for Google Shopping**" and "**Manage your new site verifications with Google**" permissions
1. Even though the "**Manage your AdWords campaigns**" was not provided, it can still able to proceed with the next setup.

### Changelog entry

> Add - The partial auth feature of Google account to the onboarding setup page.
