### PR TITLE
Add the partial auth feature of Google account to the Google Ads setup page

### DIFF
--- a/js/src/components/google-account-card/authorize-google-account-card.js
+++ b/js/src/components/google-account-card/authorize-google-account-card.js
@@ -116,6 +116,10 @@ export default function AuthorizeGoogleAccountCard( {
 					disabled={ disabled }
 					loading={ loading || data }
 					eventName="gla_google_account_connect_button_click"
+					eventProps={ {
+						context: pageName,
+						action: isAskingScope ? 'scope' : 'authorization',
+					} }
 					text={ buttonText }
 					onClick={ handleConnectClick }
 				/>

--- a/js/src/hooks/useGoogleAuthorization.js
+++ b/js/src/hooks/useGoogleAuthorization.js
@@ -13,7 +13,7 @@ import useApiFetchCallback from './useApiFetchCallback';
 /**
  * Request a Google Oauth URL.
  *
- * @param {'setup-mc'|'reconnect'} next Indicate the next page name to map the redirect URI when back from Google authorization.
+ * @param {'setup-mc'|'setup-ads'|'reconnect'} next Indicate the next page name to map the redirect URI when back from Google authorization.
  * @param {string} [loginHint] Specify the email to be requested additional scopes. Set this parameter only if wants to request a partial oauth to Google.
  * @see https://developers.google.com/identity/protocols/oauth2/openid-connect#login-hint
  * @return {Array} The same structure as `useApiFetchCallback`.

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/authorize-ads.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/authorize-ads.js
@@ -46,6 +46,7 @@ export default function AuthorizeAds( { additionalScopeEmail } ) {
 					loading={ loading || data }
 					onBeforeAskTerms={ handleBeforeAskTerms }
 					eventName="gla_google_account_connect_button_click"
+					eventProps={ { context: pageName, action: 'scope' } }
 				/>
 			}
 		/>

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/authorize-ads.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/authorize-ads.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import useGoogleAuthorization from '.~/hooks/useGoogleAuthorization';
+import CreateAccount from './create-account';
+import CreateAccountButton from './create-account-button';
+
+const pageName = 'setup-ads';
+
+export default function AuthorizeAds( { additionalScopeEmail } ) {
+	const { createNotice } = useDispatchCoreNotices();
+	const [ fetchGoogleConnect, { loading, data } ] = useGoogleAuthorization(
+		pageName,
+		additionalScopeEmail
+	);
+
+	const handleBeforeAskTerms = () => {
+		fetchGoogleConnect()
+			.then( ( { url } ) => {
+				window.location.href = url;
+			} )
+			.catch( () => {
+				createNotice(
+					'error',
+					__(
+						'Unable to get Google authorization page. Please try again later.',
+						'google-listings-and-ads'
+					)
+				);
+			} );
+
+		// Do not continue to ask for terms agreement when requesting needed permission.
+		return false;
+	};
+
+	return (
+		<CreateAccount
+			button={
+				<CreateAccountButton
+					loading={ loading || data }
+					onBeforeAskTerms={ handleBeforeAskTerms }
+					eventName="gla_google_account_connect_button_click"
+				/>
+			}
+		/>
+	);
+}

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account-button.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account-button.js
@@ -10,6 +10,8 @@ import { useState } from '@wordpress/element';
 import TermsModal from './terms-modal';
 import AppButton from '.~/components/app-button';
 
+const noop = () => {};
+
 /**
  * Renders a Google Ads account creaton button.
  * When clicking on the button, it will pop up a modal first to ask for terms agreement.
@@ -20,11 +22,11 @@ import AppButton from '.~/components/app-button';
  * @param {Function} [props.onCreateAccount] Called after the user accept the terms agreement.
  */
 const CreateAccountButton = ( props ) => {
-	const { onBeforeAskTerms, onCreateAccount, ...rest } = props;
+	const { onBeforeAskTerms = noop, onCreateAccount, ...rest } = props;
 	const [ isOpen, setOpen ] = useState( false );
 
 	const handleButtonClick = () => {
-		if ( onBeforeAskTerms && onBeforeAskTerms() === false ) {
+		if ( onBeforeAskTerms() === false ) {
 			return;
 		}
 		setOpen( true );

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account-button.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account-button.js
@@ -16,7 +16,7 @@ import AppButton from '.~/components/app-button';
  *
  * @param {Object} props React props.
  * @param {() => boolean|void} [props.onBeforeAskTerms] Called before showing the terms agreement modal.
- *     Return `true` to interrupt the ask for terms agreement and the subsequent process.
+ *     Return `false` to interrupt the ask for terms agreement and the subsequent process.
  * @param {Function} [props.onCreateAccount] Called after the user accept the terms agreement.
  */
 const CreateAccountButton = ( props ) => {

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account-button.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account-button.js
@@ -10,11 +10,23 @@ import { useState } from '@wordpress/element';
 import TermsModal from './terms-modal';
 import AppButton from '.~/components/app-button';
 
+/**
+ * Renders a Google Ads account creaton button.
+ * When clicking on the button, it will pop up a modal first to ask for terms agreement.
+ *
+ * @param {Object} props React props.
+ * @param {() => boolean|void} [props.onBeforeAskTerms] Called before showing the terms agreement modal.
+ *     Return `true` to interrupt the ask for terms agreement and the subsequent process.
+ * @param {Function} [props.onCreateAccount] Called after the user accept the terms agreement.
+ */
 const CreateAccountButton = ( props ) => {
-	const { onCreateAccount, ...rest } = props;
+	const { onBeforeAskTerms, onCreateAccount, ...rest } = props;
 	const [ isOpen, setOpen ] = useState( false );
 
 	const handleButtonClick = () => {
+		if ( onBeforeAskTerms && onBeforeAskTerms() === false ) {
+			return;
+		}
 		setOpen( true );
 	};
 
@@ -24,8 +36,8 @@ const CreateAccountButton = ( props ) => {
 
 	return (
 		<>
-			<AppButton { ...rest } onClick={ handleButtonClick }>
-				{ __( 'Create Account', 'google-listings-and-ads' ) }
+			<AppButton isSecondary { ...rest } onClick={ handleButtonClick }>
+				{ __( 'Create account', 'google-listings-and-ads' ) }
 			</AppButton>
 			{ isOpen && (
 				<TermsModal

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account.js
@@ -15,8 +15,7 @@ import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import { useAppDispatch } from '.~/data';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 
-const CreateAccount = ( props ) => {
-	const { allowShowExisting, onShowExisting } = props;
+const ClaimTermsAndCreateAccountButton = () => {
 	const { createNotice } = useDispatchCoreNotices();
 	const { fetchGoogleAdsAccount } = useAppDispatch();
 	const [ fetchAccountLoading, setFetchAccountLoading ] = useState( false );
@@ -53,6 +52,21 @@ const CreateAccount = ( props ) => {
 	};
 
 	return (
+		<CreateAccountButton
+			loading={ createLoading || fetchAccountLoading }
+			onCreateAccount={ handleCreateAccount }
+		/>
+	);
+};
+
+const CreateAccount = ( props ) => {
+	const {
+		allowShowExisting,
+		onShowExisting,
+		button = <ClaimTermsAndCreateAccountButton />,
+	} = props;
+
+	return (
 		<Section.Card>
 			<Section.Card.Body>
 				<TitleButtonLayout
@@ -60,12 +74,7 @@ const CreateAccount = ( props ) => {
 						'Create your Google Ads account',
 						'google-listings-and-ads'
 					) }
-					button={
-						<CreateAccountButton
-							loading={ createLoading || fetchAccountLoading }
-							onCreateAccount={ handleCreateAccount }
-						/>
-					}
+					button={ button }
 				/>
 			</Section.Card.Body>
 			{ allowShowExisting && (

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/create-account.js
@@ -62,7 +62,6 @@ const CreateAccount = ( props ) => {
 					) }
 					button={
 						<CreateAccountButton
-							isSecondary
 							loading={ createLoading || fetchAccountLoading }
 							onCreateAccount={ handleCreateAccount }
 						/>

--- a/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/section-content.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/google-ads-account-section/section-content.js
@@ -2,15 +2,22 @@
  * Internal dependencies
  */
 import SpinnerCard from '.~/components/spinner-card';
+import useGoogleAccount from '.~/hooks/useGoogleAccount';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import Connected from './connected';
 import NonConnected from './non-connected';
+import AuthorizeAds from './authorize-ads';
 
 const SectionContent = () => {
+	const { google, scope } = useGoogleAccount();
 	const { googleAdsAccount } = useGoogleAdsAccount();
 
-	if ( ! googleAdsAccount ) {
+	if ( ! google || ! googleAdsAccount ) {
 		return <SpinnerCard />;
+	}
+
+	if ( ! scope.adsRequired ) {
+		return <AuthorizeAds additionalScopeEmail={ google.email } />;
 	}
 
 	if ( googleAdsAccount.status === 'disconnected' ) {

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -26,6 +26,17 @@ class AccountController extends BaseController {
 	protected $connection;
 
 	/**
+	 * Mapping between the client page name and its path.
+	 *
+	 * @var string
+	 */
+	private const NEXT_PATH_MAPPING = [
+		'setup-mc'  => '/google/setup-mc',
+		'setup-ads' => '/google/setup-ads',
+		'reconnect' => '/google/settings&subpath=/reconnect-accounts',
+	];
+
+	/**
 	 * BaseController constructor.
 	 *
 	 * @param RESTServer $server
@@ -89,8 +100,7 @@ class AccountController extends BaseController {
 			try {
 				$next       = $request->get_param( 'next' );
 				$login_hint = $request->get_param( 'login_hint' ) ?: '';
-				$path       = $next === 'setup-mc' ? '/google/setup-mc' : '/google/settings&subpath=/reconnect-accounts';
-
+				$path       = self::NEXT_PATH_MAPPING[ $next ];
 				return [
 					'url' => $this->connection->connect(
 						admin_url( "admin.php?page=wc-admin&path={$path}" ),
@@ -114,8 +124,8 @@ class AccountController extends BaseController {
 			'next'       => [
 				'description'       => __( 'Indicate the next page name to map the redirect URI when back from Google authorization.', 'google-listings-and-ads' ),
 				'type'              => 'string',
-				'default'           => 'setup-mc',
-				'enum'              => [ 'setup-mc', 'reconnect' ],
+				'default'           => array_key_first( self::NEXT_PATH_MAPPING ),
+				'enum'              => array_keys( self::NEXT_PATH_MAPPING ),
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 			'login_hint' => [

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -27,8 +27,10 @@ class AccountController extends BaseController {
 
 	/**
 	 * Mapping between the client page name and its path.
+	 * The first value is also used as a default,
+	 * and changing the order of keys/values may affect things below.
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	private const NEXT_PATH_MAPPING = [
 		'setup-mc'  => '/google/setup-mc',

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -126,6 +126,11 @@ All event names are prefixed by `wcadmin_gla_`.
 
 -   `google_account_connect_button_click` - Clicking on the button to connect Google account.
 
+    -   `context`: (`setup-mc`|`setup-ads`|`reconnect`) - indicate the button is clicked from which page.
+    -   `action`: (`authorization`|`scope`)
+        -   `authorization` is used when the plugin has not been authorized yet and requests Google account access and permission scopes from users.
+        -   `scope` is used when requesting required permission scopes from users in order to proceed with more plugin functions. Added with the Partial OAuth feature (aka Incremental Authorization).
+
 -   `google_ads_account_link_click` - Clicking on a Google Ads account text link.
 
     -   `context`: indicate which page / module the link is in


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1000

- Add a new enum `'setup-ads'` for the `next` parameter of GLA's Google auth API.
- Create a new component for asking permission on Google Ads setup page.
- Check required permissions before creating/connecting Google Ads account.
- Add `eventProps` for all tracking events `google_account_connect_button_click` to tell the Google authorization is issued from which page and ask for account authorization or more permission scopes.

### Screenshots:

❗ Please note that these videos were recorded with a local change that the same temporary hack as https://github.com/woocommerce/google-listings-and-ads/pull/1064#discussion_r736426466

![Kapture 2021-10-29 at 14 44 00](https://user-images.githubusercontent.com/17420811/139389201-2b7b381d-f54d-4a79-9842-c6caa7602764.gif)

### Detailed test instructions:

💡  Please ignore the problem of entering Google account choosing page first when going to Google OAuth page. It will be resolved once the dependency PR of #1063 in WCS is merged and deployed.

1. Prepare
    - Disconnect Google and Google Ads accounts from the Connection Test page, and go to the reconnection page.
    - Or, disconnect all accounts and go to the onboarding setup page.
2. (Re)connect Google account without granting the "**Manage your AdWords campaigns**" permission.
3. Go to the Google Ads setup page.
4. It should redirect to Google auth page when clicking on the "Create account" button.
5. After accepting the required permission, should bring you back to the Google Ads setup page.
6. It should display a terms modal when clicking on the "Create account" button, or show existing accounts if your Google account has associated Ads accounts.

### Changelog entry

> Add - The partial auth feature of Google account to the Google Ads setup page.
