### PR TITLE
Adjust `toScopeState` to pass the `adsSetupComplete` parameter from callers.

### DIFF
--- a/js/src/hooks/useGoogleAccount.js
+++ b/js/src/hooks/useGoogleAccount.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { glaData } from '.~/constants';
 import { STORE_KEY } from '.~/data/constants';
 import toScopeState from '.~/utils/toScopeState';
 import useJetpackAccount from './useJetpackAccount';
@@ -22,7 +23,7 @@ const useGoogleAccount = () => {
 			if ( ! jetpack || jetpack.active === 'no' ) {
 				return {
 					google: undefined,
-					scope: toScopeState(),
+					scope: toScopeState( glaData.adsSetupComplete ),
 					isResolving: isResolvingJetpack,
 					hasFinishedResolution: hasFinishedResolutionJetpack,
 				};
@@ -37,7 +38,7 @@ const useGoogleAccount = () => {
 
 			return {
 				google,
-				scope: toScopeState( google?.scope ),
+				scope: toScopeState( glaData.adsSetupComplete, google?.scope ),
 				isResolving: isResolving( 'getGoogleAccount' ),
 				hasFinishedResolution: hasFinishedResolution(
 					'getGoogleAccount'

--- a/js/src/settings/reconnect-accounts/reconnect-accounts.js
+++ b/js/src/settings/reconnect-accounts/reconnect-accounts.js
@@ -8,6 +8,7 @@ import { getHistory } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import { glaData } from '.~/constants';
 import { getDashboardUrl } from '.~/utils/urls';
 import toScopeState from '.~/utils/toScopeState';
 import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
@@ -18,7 +19,7 @@ import DisconnectAccountCard from './disconnect-account-card';
 
 export default function ReconnectAccounts() {
 	const { data } = useAppSelectDispatch( 'getGoogleAccountAccess' );
-	const scope = toScopeState( data?.scope );
+	const scope = toScopeState( glaData.adsSetupComplete, data?.scope );
 
 	const isConnected = data?.active === 'yes';
 

--- a/js/src/utils/toScopeState.js
+++ b/js/src/utils/toScopeState.js
@@ -1,8 +1,3 @@
-/**
- * Internal dependencies
- */
-import { glaData } from '.~/constants';
-
 const SCOPE = {
 	// Manage product listings and accounts for Google Shopping
 	CONTENT: 'https://www.googleapis.com/auth/content',
@@ -25,14 +20,12 @@ const SCOPE = {
 /**
  * Convert the authorization scopes to a state that whether the minimum required scopes for each function are met.
  *
+ * @param {boolean} adsSetupComplete Whether Google Ads setup has been completed.
+ *     It should be the `glaData.adsSetupComplete` value imported from {@link .~/constants.glaData}.
  * @param {Array<string>} [scopes=[]] User authorized scopes returned from Google OAuth API.
- * @param {boolean} [adsSetupComplete=glaData.adsSetupComplete] Whether Google Ads setup has been completed.
  * @return {ScopeState} A state that whether the minimum required scopes for each function are met.
  */
-export default function toScopeState(
-	scopes = [],
-	adsSetupComplete = glaData.adsSetupComplete
-) {
+export default function toScopeState( adsSetupComplete, scopes = [] ) {
 	const state = {
 		adsRequired: scopes.includes( SCOPE.AD_WORDS ),
 	};

--- a/js/src/utils/toScopeState.test.js
+++ b/js/src/utils/toScopeState.test.js
@@ -3,14 +3,26 @@
  */
 import toScopeState from './toScopeState';
 
-const SCOPE = {
-	// Manage product listings and accounts for Google Shopping
-	CONTENT: 'https://www.googleapis.com/auth/content',
-	// Manage new site verifications with Google
-	SITE_VERIFICATION_VERIFY_ONLY:
-		'https://www.googleapis.com/auth/siteverification.verify_only',
-	// Manage AdWords campaigns
-	AD_WORDS: 'https://www.googleapis.com/auth/adwords',
+// Simulate the scopes array returned from Google API.
+const genScopes = ( ...names ) => {
+	const scopeMap = new Map( [
+		// Manage product listings and accounts for Google Shopping
+		[ 'content', 'https://www.googleapis.com/auth/content' ],
+		// Manage AdWords campaigns
+		[ 'ad_words', 'https://www.googleapis.com/auth/adwords' ],
+		// Manage new site verifications with Google
+		[
+			'site_verification_verify_only',
+			'https://www.googleapis.com/auth/siteverification.verify_only',
+		],
+	] );
+
+	return names.reduce( ( acc, name ) => {
+		if ( scopeMap.has( name ) ) {
+			acc.push( scopeMap.get( name ) );
+		}
+		return acc;
+	}, [] );
 };
 
 describe( 'toScopeState', () => {
@@ -21,15 +33,15 @@ describe( 'toScopeState', () => {
 	let allScopes;
 
 	beforeEach( () => {
-		contentScopes = [ SCOPE.CONTENT ];
-		siteVerificationScopes = [ SCOPE.SITE_VERIFICATION_VERIFY_ONLY ];
-		gmcScopes = [ SCOPE.CONTENT, SCOPE.SITE_VERIFICATION_VERIFY_ONLY ];
-		adsScopes = [ SCOPE.AD_WORDS ];
-		allScopes = [
-			SCOPE.CONTENT,
-			SCOPE.SITE_VERIFICATION_VERIFY_ONLY,
-			SCOPE.AD_WORDS,
-		];
+		contentScopes = genScopes( 'content' );
+		siteVerificationScopes = genScopes( 'site_verification_verify_only' );
+		gmcScopes = genScopes( 'content', 'site_verification_verify_only' );
+		adsScopes = genScopes( 'ad_words' );
+		allScopes = genScopes(
+			'content',
+			'site_verification_verify_only',
+			'ad_words'
+		);
 	} );
 
 	it( 'should return an object structure containing three properties', () => {

--- a/js/src/utils/toScopeState.test.js
+++ b/js/src/utils/toScopeState.test.js
@@ -1,0 +1,156 @@
+/**
+ * Internal dependencies
+ */
+import toScopeState from './toScopeState';
+
+const SCOPE = {
+	// Manage product listings and accounts for Google Shopping
+	CONTENT: 'https://www.googleapis.com/auth/content',
+	// Manage new site verifications with Google
+	SITE_VERIFICATION_VERIFY_ONLY:
+		'https://www.googleapis.com/auth/siteverification.verify_only',
+	// Manage AdWords campaigns
+	AD_WORDS: 'https://www.googleapis.com/auth/adwords',
+};
+
+describe( 'toScopeState', () => {
+	let contentScopes;
+	let siteVerificationScopes;
+	let gmcScopes;
+	let adsScopes;
+	let allScopes;
+
+	beforeEach( () => {
+		contentScopes = [ SCOPE.CONTENT ];
+		siteVerificationScopes = [ SCOPE.SITE_VERIFICATION_VERIFY_ONLY ];
+		gmcScopes = [ SCOPE.CONTENT, SCOPE.SITE_VERIFICATION_VERIFY_ONLY ];
+		adsScopes = [ SCOPE.AD_WORDS ];
+		allScopes = [
+			SCOPE.CONTENT,
+			SCOPE.SITE_VERIFICATION_VERIFY_ONLY,
+			SCOPE.AD_WORDS,
+		];
+	} );
+
+	it( 'should return an object structure containing three properties', () => {
+		const scopeState = toScopeState( false, [] );
+
+		expect( scopeState ).toHaveProperty( 'gmcRequired' );
+		expect( scopeState ).toHaveProperty( 'adsRequired' );
+		expect( scopeState ).toHaveProperty( 'glaRequired' );
+	} );
+
+	it( 'when the `scopes` parameter is not given, should get `false` for all results', () => {
+		expect( toScopeState( false ) ).toMatchObject( {
+			gmcRequired: false,
+			adsRequired: false,
+			glaRequired: false,
+		} );
+		expect( toScopeState( true ) ).toMatchObject( {
+			gmcRequired: false,
+			adsRequired: false,
+			glaRequired: false,
+		} );
+	} );
+
+	describe.each( [ [ false ], [ true ] ] )(
+		'For `gmcRequired`, if the parameter `adsSetupComplete` = %p',
+		( adsSetupComplete ) => {
+			it( 'and the `scopes` contains GMC required scopes, should be `true`', () => {
+				expect(
+					toScopeState( adsSetupComplete, gmcScopes ).gmcRequired
+				).toBe( true );
+			} );
+
+			it( "and the `scopes` doesn't contains GMC required scopes, should be `false`", () => {
+				expect( toScopeState( adsSetupComplete, [] ).gmcRequired ).toBe(
+					false
+				);
+				expect(
+					toScopeState( adsSetupComplete, contentScopes ).gmcRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, siteVerificationScopes )
+						.gmcRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, adsScopes ).gmcRequired
+				).toBe( false );
+			} );
+		}
+	);
+
+	describe.each( [ [ false ], [ true ] ] )(
+		'For `adsRequired`, if the parameter `adsSetupComplete` = %p',
+		( adsSetupComplete ) => {
+			it( 'and the `scopes` contains Google Ads required scopes, should be `true`', () => {
+				expect(
+					toScopeState( adsSetupComplete, adsScopes ).adsRequired
+				).toBe( true );
+			} );
+
+			it( "and the `scopes` doesn't contains Google Ads required scopes, should be `false`", () => {
+				expect( toScopeState( adsSetupComplete, [] ).adsRequired ).toBe(
+					false
+				);
+				expect(
+					toScopeState( adsSetupComplete, contentScopes ).adsRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, siteVerificationScopes )
+						.adsRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, gmcScopes ).adsRequired
+				).toBe( false );
+			} );
+		}
+	);
+
+	describe( 'For `glaRequired`', () => {
+		describe( 'if the parameter `adsSetupComplete` = false`', () => {
+			it( 'and the `scopes` contains GMC required scopes, should be `true`', () => {
+				expect( toScopeState( false, gmcScopes ).glaRequired ).toBe(
+					true
+				);
+			} );
+
+			it( "and the `scopes` doesn't contains GMC required scopes, should be `false`", () => {
+				expect( toScopeState( false, [] ).glaRequired ).toBe( false );
+				expect( toScopeState( false, contentScopes ).glaRequired ).toBe(
+					false
+				);
+				expect(
+					toScopeState( false, siteVerificationScopes ).glaRequired
+				).toBe( false );
+				expect( toScopeState( false, adsScopes ).glaRequired ).toBe(
+					false
+				);
+			} );
+		} );
+
+		describe( 'if the parameter `adsSetupComplete` = true`', () => {
+			it( 'and the `scopes` contains all required scopes, should be `true`', () => {
+				expect( toScopeState( true, allScopes ).glaRequired ).toBe(
+					true
+				);
+			} );
+
+			it( "and the `scopes` doesn't contains all required scopes, should be `false`", () => {
+				expect( toScopeState( true, [] ).glaRequired ).toBe( false );
+				expect( toScopeState( true, contentScopes ).glaRequired ).toBe(
+					false
+				);
+				expect(
+					toScopeState( true, siteVerificationScopes ).glaRequired
+				).toBe( false );
+				expect( toScopeState( true, adsScopes ).glaRequired ).toBe(
+					false
+				);
+				expect( toScopeState( true, gmcScopes ).glaRequired ).toBe(
+					false
+				);
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up from https://github.com/woocommerce/google-listings-and-ads/pull/1067#discussion_r739221175

- Adjust `toScopeState` to pass the `adsSetupComplete` parameter from callers.
- Add unit tests for `toScopeState` function.

### Detailed test instructions:

1. Run `npm run test-unit -- js/src/utils/toScopeState.test.js`
2. All test cases should pass.

### Changelog entry
