### PR TITLE
Avoid including a nodejs library to reduce the index.js bundle size by 42%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4921,6 +4921,14 @@
 						}
 					}
 				},
+				"@woocommerce/data": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.1.1.tgz",
+					"integrity": "sha512-grmCllxDV/0PB8Mc+w9TQFJkAzO/yjjdDmaOzNk2ICuoz2ZhUGiFXnvZmWLyZr9BDtoYK+/jBIsM2ezr34b3ww==",
+					"requires": {
+						"@babel/runtime-corejs2": "7.11.2"
+					}
+				},
 				"@woocommerce/date": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-2.0.0.tgz",
@@ -5313,11 +5321,13 @@
 			}
 		},
 		"@woocommerce/data": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.1.1.tgz",
-			"integrity": "sha512-grmCllxDV/0PB8Mc+w9TQFJkAzO/yjjdDmaOzNk2ICuoz2ZhUGiFXnvZmWLyZr9BDtoYK+/jBIsM2ezr34b3ww==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.2.0.tgz",
+			"integrity": "sha512-qPvn/UaGWHsx8wGts3zFuQ0++DVDkp460GkdzveEJq8IxazsWc9+AOKdf4ts85X6S4VQV/YXcufKKQMRBXfThQ==",
 			"requires": {
-				"@babel/runtime-corejs2": "7.11.2"
+				"@woocommerce/date": "2.1.0",
+				"@woocommerce/navigation": "5.2.0",
+				"rememo": "^3.0.0"
 			}
 		},
 		"@woocommerce/date": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "457 kb"
+				"maxSize": "265 kB"
 			},
 			{
 				"path": "./js/build/*.css",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 	"dependencies": {
 		"@woocommerce/components": "^5.1.2",
 		"@woocommerce/currency": "^3.1.0",
-		"@woocommerce/data": ">=1.1.1 <1.2.0",
+		"@woocommerce/data": "1.2.0",
 		"@woocommerce/date": "^2.1.0",
 		"@woocommerce/navigation": "^5.2.0",
 		"@woocommerce/number": "^2.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,17 @@ const webpackConfig = {
 		alias: {
 			'.~': path.resolve( process.cwd(), 'js/src/' ),
 		},
-		// Resolve jsx/tsx files for `@woocommerce/data`...`/with-plugins-hydration`
+		/**
+		 * Resolve jsx/tsx files for `@woocommerce/data@1.3.*`.
+		 *
+		 * It could be removed if one of conditions is met:
+		 *   - The L-2 support version no longer covers 1.3.* versions.
+		 *   - `@woocommerce/data` is imported from DEWP instead.
+		 *
+		 * Checking method:
+		 * Whether the module not found error of the below path is no longer occur after `npm start`.
+		 *   - `./node_modules/@woocommerce/data/build/plugins/with-plugins-hydration.js`
+		 */
 		extensions: [ '.ts', '.tsx', '.js', '.jsx', '.json' ],
 	},
 	plugins: [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Found this issue when looking into https://github.com/woocommerce/google-listings-and-ads/pull/1068#discussion_r740796135.

- Specify the `@woocommerce/data` version to **1.2.0** to avoid bundling the nodejs `crypto` into index.js
- Rebalance the max size config of bundlewatch to 1.2 times 220.5 kB for index.js

### Additional details

#### Root cause

When looking into the result of bundle analysis, I notice that the obvious `bn.js` appears several times and takes up a significant file size. After some investigations, it turns out the root cause is that [`@woocommerce/data` 1.1.1 imports the nodejs built-in library `crypto`](https://github.com/woocommerce/woocommerce-admin/blob/v1.6.0/packages/data/src/export/utils.js#L4), and it doesn't set the `sideEffects` option to enable the more advanced tree shaking. Therefore, all its dependencies are included into index.js, the GLA doesn't need it though.

The overall unnecessary codes are highlighted by red background:

![2021-11-02 13 45 27](https://user-images.githubusercontent.com/17420811/139808472-eed60868-9fef-4600-b5b9-6735841b1c81.png)

#### Solution

Fortunately, the issue has been addressed by https://github.com/woocommerce/woocommerce-admin/pull/5768. And we have `@woocommerce/data` relevant changes these days:

- https://github.com/woocommerce/google-listings-and-ads/pull/1042
- https://github.com/woocommerce/google-listings-and-ads/pull/1055

So currently, we have three places using the `@woocommerce/data`:
1. A constant `NAMESPACE` for concatenating the API endpoint. [The constant was there two years ago.](https://github.com/woocommerce/woocommerce-admin/blob/v2.2.1/packages/data/src/constants.js#L2)
    https://github.com/woocommerce/google-listings-and-ads/blob/e5cf5bd8b01cc5041b3933a0a90bb10e67f908d7/js/src/reports/products/async-requests.js#L15
2. The `getItems` selector for checking where a product is a variant.
   https://github.com/woocommerce/google-listings-and-ads/blob/e5cf5bd8b01cc5041b3933a0a90bb10e67f908d7/js/src/reports/products/products-report-filters.js#L102-L104
3. The `getSetting` selector for getting store's contry.
    https://github.com/woocommerce/google-listings-and-ads/blob/e5cf5bd8b01cc5041b3933a0a90bb10e67f908d7/js/src/hooks/useStoreCountry.js#L19-L22

After specifying `@woocommerce/data` to version 1.2.0 and checking:

- [x] All relevant usages in GLA are working well
- [x] Run `npm run test-unit` and all JS unit tests are passed
- [x] Remove `package-lock.json` and `node_modules`. Run `npm install` and `npm start`. No errors occurred when reinstalling and running npm modules from scratch.
- [x] All `crypto` codes are disappeared. (See the **Screenshots** section.)

I think the problems we encountered in PR https://github.com/woocommerce/google-listings-and-ads/pull/693 are no longer present.

#### Other possible options

1. I tried 1.4.0 and 1.3.1 versions of `@woocommerce/data`, but there're many dependency tree changes in `package-lock.json`. Even though they could resolve the issue as well, I don't have much confidence to bump up `@woocommerce/data` only without related dependencies together.
2. Stay with 1.1.1 and force the importing of `crypto` to an empty object by adding the below webpack config. But I think this approach is less ideal.
    ```js
    node: {
      crypto: 'empty',
    },
    ```
#### Other details

<details>
    <summary>Diff of included module files</summary>

```diff
diff --git a/modules-before.json b/modules-after.json
index fbf71529..f39779a8 100644
--- a/modules-before.json
+++ b/modules-after.json
@@ -116,6 +116,16 @@
   "./node_modules/@woocommerce/data/build-module/items/resolvers.js",
   "./node_modules/@woocommerce/data/build-module/items/selectors.js",
   "./node_modules/@woocommerce/data/build-module/items/utils.js",
+  "./node_modules/@woocommerce/data/build-module/navigation",
+  "./node_modules/@woocommerce/data/build-module/navigation/action-types.js",
+  "./node_modules/@woocommerce/data/build-module/navigation/actions.js",
+  "./node_modules/@woocommerce/data/build-module/navigation/constants.js",
+  "./node_modules/@woocommerce/data/build-module/navigation/dispatchers.js",
+  "./node_modules/@woocommerce/data/build-module/navigation/index.js",
+  "./node_modules/@woocommerce/data/build-module/navigation/reducer.js",
+  "./node_modules/@woocommerce/data/build-module/navigation/resolvers.js",
+  "./node_modules/@woocommerce/data/build-module/navigation/selectors.js",
+  "./node_modules/@woocommerce/data/build-module/navigation/with-navigation-hydration.js",
   "./node_modules/@woocommerce/data/build-module/notes",
   "./node_modules/@woocommerce/data/build-module/notes/action-types.js",
   "./node_modules/@woocommerce/data/build-module/notes/actions.js",
@@ -179,11 +189,12 @@
   "./node_modules/@woocommerce/data/build-module/settings/selectors.js",
   "./node_modules/@woocommerce/data/build-module/settings/use-settings.js",
   "./node_modules/@woocommerce/data/build-module/settings/with-settings-hydration.js",
-  "./node_modules/@woocommerce/data/build-module/user-preferences",
-  "./node_modules/@woocommerce/data/build-module/user-preferences/constants.js",
-  "./node_modules/@woocommerce/data/build-module/user-preferences/index.js",
-  "./node_modules/@woocommerce/data/build-module/user-preferences/use-user-preferences.js",
-  "./node_modules/@woocommerce/data/build-module/user-preferences/with-current-user-hydration.js",
+  "./node_modules/@woocommerce/data/build-module/user",
+  "./node_modules/@woocommerce/data/build-module/user/constants.js",
+  "./node_modules/@woocommerce/data/build-module/user/index.js",
+  "./node_modules/@woocommerce/data/build-module/user/use-user-preferences.js",
+  "./node_modules/@woocommerce/data/build-module/user/use-user.js",
+  "./node_modules/@woocommerce/data/build-module/user/with-current-user-hydration.js",
   "./node_modules/@woocommerce/data/build-module/utils.js",
   "./node_modules/@woocommerce/date/build-module",
   "./node_modules/@woocommerce/date/build-module/index.js",
@@ -356,6 +367,8 @@
   "./node_modules/@wordpress/components/node_modules/@wordpress/compose/build-module/utils/create-higher-order-component/index.js",
   "./node_modules/@wordpress/components/node_modules/react-use-gesture/dist",
   "./node_modules/@wordpress/components/node_modules/react-use-gesture/dist/reactusegesture.esm.js",
+  "./node_modules/@wordpress/compose/build-module/utils/create-higher-order-component",
+  "./node_modules/@wordpress/compose/build-module/utils/create-higher-order-component/index.js",
   "./node_modules/@wordpress/icons/build-module",
   "./node_modules/@wordpress/icons/build-module/icon",
   "./node_modules/@wordpress/icons/build-module/icon/index.js",
@@ -482,139 +495,19 @@
   "./node_modules/@wp-g2/utils/node_modules/reakit-warning/es/index.js",
   "./node_modules/@wp-g2/utils/node_modules/reakit-warning/es/useWarning.js",
   "./node_modules/@wp-g2/utils/node_modules/reakit-warning/es/warning.js",
-  "./node_modules/asn1.js",
-  "./node_modules/asn1.js/lib",
-  "./node_modules/asn1.js/lib/asn1",
-  "./node_modules/asn1.js/lib/asn1.js",
-  "./node_modules/asn1.js/lib/asn1/api.js",
-  "./node_modules/asn1.js/lib/asn1/base",
-  "./node_modules/asn1.js/lib/asn1/base/buffer.js",
-  "./node_modules/asn1.js/lib/asn1/base/index.js",
-  "./node_modules/asn1.js/lib/asn1/base/node.js",
-  "./node_modules/asn1.js/lib/asn1/base/reporter.js",
-  "./node_modules/asn1.js/lib/asn1/constants",
-  "./node_modules/asn1.js/lib/asn1/constants/der.js",
-  "./node_modules/asn1.js/lib/asn1/constants/index.js",
-  "./node_modules/asn1.js/lib/asn1/decoders",
-  "./node_modules/asn1.js/lib/asn1/decoders/der.js",
-  "./node_modules/asn1.js/lib/asn1/decoders/index.js",
-  "./node_modules/asn1.js/lib/asn1/decoders/pem.js",
-  "./node_modules/asn1.js/lib/asn1/encoders",
-  "./node_modules/asn1.js/lib/asn1/encoders/der.js",
-  "./node_modules/asn1.js/lib/asn1/encoders/index.js",
-  "./node_modules/asn1.js/lib/asn1/encoders/pem.js",
-  "./node_modules/asn1.js/node_modules/bn.js/lib",
-  "./node_modules/asn1.js/node_modules/bn.js/lib/bn.js",
   "./node_modules/base64-js",
   "./node_modules/base64-js/index.js",
-  "./node_modules/bn.js/lib",
-  "./node_modules/bn.js/lib/bn.js",
-  "./node_modules/brorand",
-  "./node_modules/brorand/index.js",
-  "./node_modules/browserify-aes",
-  "./node_modules/browserify-aes/aes.js",
-  "./node_modules/browserify-aes/authCipher.js",
-  "./node_modules/browserify-aes/browser.js",
-  "./node_modules/browserify-aes/decrypter.js",
-  "./node_modules/browserify-aes/encrypter.js",
-  "./node_modules/browserify-aes/ghash.js",
-  "./node_modules/browserify-aes/incr32.js",
-  "./node_modules/browserify-aes/modes",
-  "./node_modules/browserify-aes/modes/cbc.js",
-  "./node_modules/browserify-aes/modes/cfb.js",
-  "./node_modules/browserify-aes/modes/cfb1.js",
-  "./node_modules/browserify-aes/modes/cfb8.js",
-  "./node_modules/browserify-aes/modes/ctr.js",
-  "./node_modules/browserify-aes/modes/ecb.js",
-  "./node_modules/browserify-aes/modes/index.js",
-  "./node_modules/browserify-aes/modes/list.json",
-  "./node_modules/browserify-aes/modes/ofb.js",
-  "./node_modules/browserify-aes/streamCipher.js",
-  "./node_modules/browserify-cipher",
-  "./node_modules/browserify-cipher/browser.js",
-  "./node_modules/browserify-des",
-  "./node_modules/browserify-des/index.js",
-  "./node_modules/browserify-des/modes.js",
-  "./node_modules/browserify-rsa",
-  "./node_modules/browserify-rsa/index.js",
-  "./node_modules/browserify-sign",
-  "./node_modules/browserify-sign/algos.js",
-  "./node_modules/browserify-sign/browser",
-  "./node_modules/browserify-sign/browser/algorithms.json",
-  "./node_modules/browserify-sign/browser/curves.json",
-  "./node_modules/browserify-sign/browser/index.js",
-  "./node_modules/browserify-sign/browser/sign.js",
-  "./node_modules/browserify-sign/browser/verify.js",
-  "./node_modules/buffer-xor",
-  "./node_modules/buffer-xor/index.js",
-  "./node_modules/cipher-base",
-  "./node_modules/cipher-base/index.js",
+  "./node_modules/charenc",
+  "./node_modules/charenc/charenc.js",
   "./node_modules/classnames",
   "./node_modules/classnames/index.js",
-  "./node_modules/core-util-is/lib",
-  "./node_modules/core-util-is/lib/util.js",
-  "./node_modules/create-ecdh",
-  "./node_modules/create-ecdh/browser.js",
-  "./node_modules/create-ecdh/node_modules/bn.js/lib",
-  "./node_modules/create-ecdh/node_modules/bn.js/lib/bn.js",
   "./node_modules/create-emotion/dist",
   "./node_modules/create-emotion/dist/create-emotion.browser.esm.js",
-  "./node_modules/create-hash",
-  "./node_modules/create-hash/browser.js",
-  "./node_modules/create-hash/md5.js",
-  "./node_modules/create-hmac",
-  "./node_modules/create-hmac/browser.js",
-  "./node_modules/create-hmac/legacy.js",
-  "./node_modules/crypto-browserify",
-  "./node_modules/crypto-browserify/index.js",
+  "./node_modules/crypt",
+  "./node_modules/crypt/crypt.js",
   "./node_modules/debug/src",
   "./node_modules/debug/src/browser.js",
   "./node_modules/debug/src/common.js",
-  "./node_modules/des.js/lib",
-  "./node_modules/des.js/lib/des",
-  "./node_modules/des.js/lib/des.js",
-  "./node_modules/des.js/lib/des/cbc.js",
-  "./node_modules/des.js/lib/des/cipher.js",
-  "./node_modules/des.js/lib/des/des.js",
-  "./node_modules/des.js/lib/des/ede.js",
-  "./node_modules/des.js/lib/des/utils.js",
-  "./node_modules/diffie-hellman",
-  "./node_modules/diffie-hellman/browser.js",
-  "./node_modules/diffie-hellman/lib",
-  "./node_modules/diffie-hellman/lib/dh.js",
-  "./node_modules/diffie-hellman/lib/generatePrime.js",
-  "./node_modules/diffie-hellman/lib/primes.json",
-  "./node_modules/diffie-hellman/node_modules/bn.js/lib",
-  "./node_modules/diffie-hellman/node_modules/bn.js/lib/bn.js",
-  "./node_modules/elliptic",
-  "./node_modules/elliptic/lib",
-  "./node_modules/elliptic/lib/elliptic",
-  "./node_modules/elliptic/lib/elliptic.js",
-  "./node_modules/elliptic/lib/elliptic/curve",
-  "./node_modules/elliptic/lib/elliptic/curve/base.js",
-  "./node_modules/elliptic/lib/elliptic/curve/edwards.js",
-  "./node_modules/elliptic/lib/elliptic/curve/index.js",
-  "./node_modules/elliptic/lib/elliptic/curve/mont.js",
-  "./node_modules/elliptic/lib/elliptic/curve/short.js",
-  "./node_modules/elliptic/lib/elliptic/curves.js",
-  "./node_modules/elliptic/lib/elliptic/ec",
-  "./node_modules/elliptic/lib/elliptic/ec/index.js",
-  "./node_modules/elliptic/lib/elliptic/ec/key.js",
-  "./node_modules/elliptic/lib/elliptic/ec/signature.js",
-  "./node_modules/elliptic/lib/elliptic/eddsa",
-  "./node_modules/elliptic/lib/elliptic/eddsa/index.js",
-  "./node_modules/elliptic/lib/elliptic/eddsa/key.js",
-  "./node_modules/elliptic/lib/elliptic/eddsa/signature.js",
-  "./node_modules/elliptic/lib/elliptic/precomputed",
-  "./node_modules/elliptic/lib/elliptic/precomputed/secp256k1.js",
-  "./node_modules/elliptic/lib/elliptic/utils.js",
-  "./node_modules/elliptic/node_modules/bn.js/lib",
-  "./node_modules/elliptic/node_modules/bn.js/lib/bn.js",
-  "./node_modules/elliptic/package.json",
-  "./node_modules/events",
-  "./node_modules/events/events.js",
-  "./node_modules/evp_bytestokey",
-  "./node_modules/evp_bytestokey/index.js",
   "./node_modules/fast-deep-equal",
   "./node_modules/fast-deep-equal/index.js",
   "./node_modules/gridicons/dist",
@@ -629,33 +522,14 @@
   "./node_modules/gridicons/dist/phone.js",
   "./node_modules/gridicons/dist/plus-small.js",
   "./node_modules/gridicons/dist/sync.js",
-  "./node_modules/hash-base",
-  "./node_modules/hash-base/index.js",
-  "./node_modules/hash.js/lib",
-  "./node_modules/hash.js/lib/hash",
-  "./node_modules/hash.js/lib/hash.js",
-  "./node_modules/hash.js/lib/hash/common.js",
-  "./node_modules/hash.js/lib/hash/hmac.js",
-  "./node_modules/hash.js/lib/hash/ripemd.js",
-  "./node_modules/hash.js/lib/hash/sha",
-  "./node_modules/hash.js/lib/hash/sha.js",
-  "./node_modules/hash.js/lib/hash/sha/1.js",
-  "./node_modules/hash.js/lib/hash/sha/224.js",
-  "./node_modules/hash.js/lib/hash/sha/256.js",
-  "./node_modules/hash.js/lib/hash/sha/384.js",
-  "./node_modules/hash.js/lib/hash/sha/512.js",
-  "./node_modules/hash.js/lib/hash/sha/common.js",
-  "./node_modules/hash.js/lib/hash/utils.js",
   "./node_modules/highlight-words-core/dist",
   "./node_modules/highlight-words-core/dist/index.js",
-  "./node_modules/hmac-drbg/lib",
-  "./node_modules/hmac-drbg/lib/hmac-drbg.js",
   "./node_modules/hoist-non-react-statics/dist",
   "./node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
   "./node_modules/ieee754",
   "./node_modules/ieee754/index.js",
-  "./node_modules/inherits",
-  "./node_modules/inherits/inherits_browser.js",
+  "./node_modules/is-buffer",
+  "./node_modules/is-buffer/index.js",
   "./node_modules/libphonenumber-js",
   "./node_modules/libphonenumber-js/es6",
   "./node_modules/libphonenumber-js/es6/ParseError.js",
@@ -793,19 +667,10 @@
   "./node_modules/lodash/keys.js",
   "./node_modules/lodash/stubArray.js",
   "./node_modules/lodash/stubFalse.js",
-  "./node_modules/md5.js",
-  "./node_modules/md5.js/index.js",
+  "./node_modules/md5",
+  "./node_modules/md5/md5.js",
   "./node_modules/memize",
   "./node_modules/memize/index.js",
-  "./node_modules/miller-rabin",
-  "./node_modules/miller-rabin/lib",
-  "./node_modules/miller-rabin/lib/mr.js",
-  "./node_modules/miller-rabin/node_modules/bn.js/lib",
-  "./node_modules/miller-rabin/node_modules/bn.js/lib/bn.js",
-  "./node_modules/minimalistic-assert",
-  "./node_modules/minimalistic-assert/index.js",
-  "./node_modules/minimalistic-crypto-utils/lib",
-  "./node_modules/minimalistic-crypto-utils/lib/utils.js",
   "./node_modules/mitt/dist",
   "./node_modules/mitt/dist/mitt.es.js",
   "./node_modules/mousetrap",
@@ -819,22 +684,8 @@
   "./node_modules/node-libs-browser/node_modules/buffer/index.js",
   "./node_modules/node-libs-browser/node_modules/isarray",
   "./node_modules/node-libs-browser/node_modules/isarray/index.js",
-  "./node_modules/parse-asn1",
-  "./node_modules/parse-asn1/aesid.json",
-  "./node_modules/parse-asn1/asn1.js",
-  "./node_modules/parse-asn1/certificate.js",
-  "./node_modules/parse-asn1/fixProc.js",
-  "./node_modules/parse-asn1/index.js",
   "./node_modules/path-browserify",
   "./node_modules/path-browserify/index.js",
-  "./node_modules/pbkdf2",
-  "./node_modules/pbkdf2/browser.js",
-  "./node_modules/pbkdf2/lib",
-  "./node_modules/pbkdf2/lib/async.js",
-  "./node_modules/pbkdf2/lib/default-encoding.js",
-  "./node_modules/pbkdf2/lib/precondition.js",
-  "./node_modules/pbkdf2/lib/sync-browser.js",
-  "./node_modules/pbkdf2/lib/to-buffer.js",
   "./node_modules/postcss",
   "./node_modules/postcss/lib",
   "./node_modules/postcss/lib/at-rule.js",
@@ -876,33 +727,18 @@
   "./node_modules/postcss/node_modules/source-map/lib/util.js",
   "./node_modules/postcss/node_modules/source-map/source-map.js",
   "./node_modules/process",
-  "./node_modules/process-nextick-args",
-  "./node_modules/process-nextick-args/index.js",
   "./node_modules/process/browser.js",
   "./node_modules/prop-types",
   "./node_modules/prop-types/factoryWithThrowingShims.js",
   "./node_modules/prop-types/index.js",
   "./node_modules/prop-types/lib",
   "./node_modules/prop-types/lib/ReactPropTypesSecret.js",
-  "./node_modules/public-encrypt",
-  "./node_modules/public-encrypt/browser.js",
-  "./node_modules/public-encrypt/mgf.js",
-  "./node_modules/public-encrypt/node_modules/bn.js/lib",
-  "./node_modules/public-encrypt/node_modules/bn.js/lib/bn.js",
-  "./node_modules/public-encrypt/privateDecrypt.js",
-  "./node_modules/public-encrypt/publicEncrypt.js",
-  "./node_modules/public-encrypt/withPublic.js",
-  "./node_modules/public-encrypt/xor.js",
   "./node_modules/qs/lib",
   "./node_modules/qs/lib/formats.js",
   "./node_modules/qs/lib/index.js",
   "./node_modules/qs/lib/parse.js",
   "./node_modules/qs/lib/stringify.js",
   "./node_modules/qs/lib/utils.js",
-  "./node_modules/randombytes",
-  "./node_modules/randombytes/browser.js",
-  "./node_modules/randomfill",
-  "./node_modules/randomfill/browser.js",
   "./node_modules/react-is",
   "./node_modules/react-is/cjs",
   "./node_modules/react-is/cjs/react-is.production.min.js",
@@ -911,28 +747,8 @@
   "./node_modules/react-merge-refs/dist/react-merge-refs.esm.js",
   "./node_modules/react-resize-aware/dist",
   "./node_modules/react-resize-aware/dist/index.js",
-  "./node_modules/readable-stream",
-  "./node_modules/readable-stream/errors-browser.js",
-  "./node_modules/readable-stream/lib",
-  "./node_modules/readable-stream/lib/_stream_duplex.js",
-  "./node_modules/readable-stream/lib/_stream_passthrough.js",
-  "./node_modules/readable-stream/lib/_stream_readable.js",
-  "./node_modules/readable-stream/lib/_stream_transform.js",
-  "./node_modules/readable-stream/lib/_stream_writable.js",
-  "./node_modules/readable-stream/lib/internal/streams",
-  "./node_modules/readable-stream/lib/internal/streams/async_iterator.js",
-  "./node_modules/readable-stream/lib/internal/streams/buffer_list.js",
-  "./node_modules/readable-stream/lib/internal/streams/destroy.js",
-  "./node_modules/readable-stream/lib/internal/streams/end-of-stream.js",
-  "./node_modules/readable-stream/lib/internal/streams/from-browser.js",
-  "./node_modules/readable-stream/lib/internal/streams/pipeline.js",
-  "./node_modules/readable-stream/lib/internal/streams/state.js",
-  "./node_modules/readable-stream/lib/internal/streams/stream-browser.js",
-  "./node_modules/readable-stream/readable-browser.js",
   "./node_modules/rememo/es",
   "./node_modules/rememo/es/rememo.js",
-  "./node_modules/ripemd160",
-  "./node_modules/ripemd160/index.js",
   "./node_modules/rtlcss/lib",
   "./node_modules/rtlcss/lib/config.js",
   "./node_modules/rtlcss/lib/directive-parser.js",
@@ -940,51 +756,9 @@
   "./node_modules/rtlcss/lib/rtlcss.js",
   "./node_modules/rtlcss/lib/state.js",
   "./node_modules/rtlcss/lib/util.js",
-  "./node_modules/safe-buffer",
-  "./node_modules/safe-buffer/index.js",
-  "./node_modules/safer-buffer",
-  "./node_modules/safer-buffer/safer.js",
-  "./node_modules/setimmediate",
-  "./node_modules/setimmediate/setImmediate.js",
-  "./node_modules/sha.js",
-  "./node_modules/sha.js/hash.js",
-  "./node_modules/sha.js/index.js",
-  "./node_modules/sha.js/sha.js",
-  "./node_modules/sha.js/sha1.js",
-  "./node_modules/sha.js/sha224.js",
-  "./node_modules/sha.js/sha256.js",
-  "./node_modules/sha.js/sha384.js",
-  "./node_modules/sha.js/sha512.js",
-  "./node_modules/stream-browserify",
-  "./node_modules/stream-browserify/index.js",
-  "./node_modules/stream-browserify/node_modules",
-  "./node_modules/stream-browserify/node_modules/isarray",
-  "./node_modules/stream-browserify/node_modules/isarray/index.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream",
-  "./node_modules/stream-browserify/node_modules/readable-stream/duplex-browser.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/_stream_duplex.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/_stream_passthrough.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/_stream_readable.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/_stream_transform.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/_stream_writable.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/internal/streams",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/internal/streams/BufferList.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/internal/streams/destroy.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/lib/internal/streams/stream-browser.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/passthrough.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/readable-browser.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/transform.js",
-  "./node_modules/stream-browserify/node_modules/readable-stream/writable-browser.js",
-  "./node_modules/stream-browserify/node_modules/safe-buffer",
-  "./node_modules/stream-browserify/node_modules/safe-buffer/index.js",
-  "./node_modules/string_decoder/lib",
-  "./node_modules/string_decoder/lib/string_decoder.js",
   "./node_modules/styled-griddie/dist",
   "./node_modules/styled-griddie/dist/index.js",
   "./node_modules/styled-griddie/dist/styled-griddie.cjs.production.min.js",
-  "./node_modules/timers-browserify",
-  "./node_modules/timers-browserify/main.js",
   "./node_modules/tinycolor2",
   "./node_modules/tinycolor2/tinycolor.js",
   "./node_modules/use-debounce/esm",
@@ -992,7 +766,5 @@
   "./node_modules/use-isomorphic-layout-effect/dist",
   "./node_modules/use-isomorphic-layout-effect/dist/use-isomorphic-layout-effect.browser.esm.js",
   "./node_modules/use-memo-one/dist",
-  "./node_modules/use-memo-one/dist/use-memo-one.esm.js",
-  "./node_modules/util-deprecate",
-  "./node_modules/util-deprecate/browser.js"
+  "./node_modules/use-memo-one/dist/use-memo-one.esm.js"
 ]
```
</details>

### Screenshots:

![2021-11-02 16 05 32](https://user-images.githubusercontent.com/17420811/139808737-875f1393-bae4-4083-84f3-eaae7b6eaa21.png)

### Detailed test instructions:

1. `npm install` to update node modules
1. Test [the store country fetching](https://github.com/woocommerce/google-listings-and-ads/blob/e5cf5bd8b01cc5041b3933a0a90bb10e67f908d7/js/src/hooks/useStoreCountry.js#L19-L22)
    - Go to the free listings edit page (`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Ffree-listings%2Fedit&pageStep=2`)
    - Makde sure `US` audience is selected in step 1
    - Check if the **Tax rate** section shows up in step 2
1. Test [the product filter](https://github.com/woocommerce/google-listings-and-ads/blob/e5cf5bd8b01cc5041b3933a0a90bb10e67f908d7/js/src/reports/products/products-report-filters.js#L102-L104)
    - Go to the the products report page
    - Filter a variant product, such as the **Hoodie** imported from the WC sample data, to see if the filter UI works well
1. Verify the bundled codes
    1. `npm run env -- NODE_ENV=production wp-scripts build --webpack-bundle-analyzer` to start the analyzer
    1. Filter files to see if there's no `crypto` relevant codes. I used a regex to check this:
    ```regex
    asn|bn|rand|(browserify|process|util)-|xor|cipher|ecdh|hmac|crypto|/des|diffie|elliptic|events|evp|miller|minimalistic|pbkdf|encrypt|stream|ripemd|safe|setimmediate|sha\b|_decoder|timers|^\./node_modules/((create-)?hash|inherits|md5\.)
    ```

### Changelog entry

> Tweak - Reduce the bundle size of the index.js file.
