### PR TITLE
Explanation tip for Google Merchant Center

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.js
@@ -2,32 +2,51 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Tip } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Section from '.~/wcdl/section';
+import AppTooltip from '.~/components/app-tooltip';
 import DisabledDiv from '.~/components/disabled-div';
 import SectionContent from './section-content';
+import './index.scss';
 
 const GoogleMCAccount = ( props ) => {
 	const { disabled = false } = props;
 
 	return (
-		<Section
-			title={ __(
-				'Google Merchant Center account',
-				'google-listings-and-ads'
-			) }
-			description={ __(
-				'WooCommerce products synced to your Merchant Center product feed will allow you to list your products on Google.',
-				'google-listings-and-ads'
-			) }
-		>
-			<DisabledDiv disabled={ disabled }>
-				<SectionContent disabled={ disabled } />
-			</DisabledDiv>
-		</Section>
+		<div className="gla-google-mc-account">
+			<Section
+				description={
+					<Tip>
+						{ createInterpolateElement(
+							__(
+								'Google’s Shopping tab has an average of <strong>over 50% increase in clicks and over 100% increase in impressions</strong> across free listings and ads. <tooltip>Source</tooltip>',
+								'google-listings-and-ads'
+							),
+							{
+								strong: <strong></strong>,
+								tooltip: (
+									<AppTooltip
+										text={ __(
+											'Google Internal Data, July 2020, based on an A/B test comparing performance for users seeing the updated layout on the Shopping property vs a control group not seeing the new experience',
+											'google-listings-and-ads'
+										) }
+									></AppTooltip>
+								),
+							}
+						) }
+					</Tip>
+				}
+			>
+				<DisabledDiv disabled={ disabled }>
+					<SectionContent disabled={ disabled } />
+				</DisabledDiv>
+			</Section>
+		</div>
 	);
 };
 

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.js
@@ -32,7 +32,7 @@ const GoogleMCAccount = ( props ) => {
 								tooltip: (
 									<AppTooltip
 										text={ __(
-											'Google Internal Data, July 2020, based on an A/B test comparing performance for users seeing the updated layout on the Shopping property vs a control group not seeing the new experience',
+											'Google Internal Data, July 2020, based on an A/B test comparing performance for users seeing the updated layout on the Shopping property vs a control group not seeing the new experience.',
 											'google-listings-and-ads'
 										) }
 									></AppTooltip>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.scss
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.scss
@@ -6,7 +6,40 @@
 
 			.components-tip {
 				svg {
+					/*
+					* Original values below are:
+					* 	align-self: center;
+					* 	fill: $alert-yellow;
+					*
+					* See: https://github.com/WordPress/gutenberg/blob/ba5f6d061934625027beab9d2bf600ae42a63be9/packages/components/src/tip/style.scss.
+					*
+					* We change the fill color to $gray-700 so that it is same as Tip component text color:
+					* See: https://github.com/WordPress/gutenberg/blob/ba5f6d061934625027beab9d2bf600ae42a63be9/packages/components/src/tip/style.scss#L3
+					*/
 					align-self: flex-start;
+					fill: $gray-700;
+				}
+
+				.app-tooltip__children-container {
+					/*
+					* Make the "Source" text color blue.
+					*/
+					color: #007CBA;
+
+					.components-popover {
+						&__content {
+							/*
+							* Specify these so that the text wraps around within a box with 250px width.
+							* Without these, the popover text will show up in one long horizontal line.
+							* Original values below are:
+							* 	width: (not specified);
+							* 	white-space: nowrap;
+							*/
+							width: 250px;
+							white-space: normal;
+							text-align: left;
+						}
+					}
 				}
 			}
 		}

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.scss
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.scss
@@ -1,0 +1,14 @@
+.gla-google-mc-account {
+	.wcdl-section {
+		header {
+			box-shadow: inset 0px 1px 0px #DDDDDD;
+			padding-top: var(--main-gap);
+
+			.components-tip {
+				svg {
+					align-self: flex-start;
+				}
+			}
+		}
+	}
+}

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.scss
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.scss
@@ -12,12 +12,9 @@
 					* 	fill: $alert-yellow;
 					*
 					* See: https://github.com/WordPress/gutenberg/blob/ba5f6d061934625027beab9d2bf600ae42a63be9/packages/components/src/tip/style.scss.
-					*
-					* We change the fill color to $gray-700 so that it is same as Tip component text color:
-					* See: https://github.com/WordPress/gutenberg/blob/ba5f6d061934625027beab9d2bf600ae42a63be9/packages/components/src/tip/style.scss#L3
 					*/
 					align-self: flex-start;
-					fill: $gray-700;
+					fill: currentColor;
 				}
 
 				.app-tooltip__children-container {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.scss
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/index.scss
@@ -1,7 +1,7 @@
 .gla-google-mc-account {
 	.wcdl-section {
 		header {
-			box-shadow: inset 0px 1px 0px #DDDDDD;
+			box-shadow: inset 0 1px 0 #ddd;
 			padding-top: var(--main-gap);
 
 			.components-tip {
@@ -24,7 +24,7 @@
 					/*
 					* Make the "Source" text color blue.
 					*/
-					color: #007CBA;
+					color: #007cba;
 
 					.components-popover {
 						&__content {

--- a/js/src/wcdl/section/index.js
+++ b/js/src/wcdl/section/index.js
@@ -10,7 +10,7 @@ const Section = ( props ) => {
 	return (
 		<section className="wcdl-section">
 			<header>
-				<h1>{ title }</h1>
+				{ title && <h1>{ title }</h1> }
 				{ description }
 			</header>
 			<div className="wcdl-section__body">{ children }</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1065 .

This PR changes the Google Merchant Center section in Setup MC Step 1 to display an explanation tip. Hovering your mouse over the "Source" text would display a popover with more info.

### Screenshots:

#### Before

![image](https://user-images.githubusercontent.com/417342/140382529-2856b5c1-9831-4840-9a9c-a00629d87415.png)

#### After

Demo video, no voice: (https://d.pr/v/woSC9M)

https://user-images.githubusercontent.com/417342/140382298-b0da8bcf-d915-4ee7-8805-c7f5015bed18.mp4

### Detailed test instructions:

1. Go to Setup MC Step 1: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`
2. The Google Merchant Center section should look like the above video.
3. Hover your mouse to the "Source" text and there should be a popover with more explanation.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Display better explanation tip for Google Merchant Center in Setup MC Step 1.
