### PR TITLE
Fix extra margin between FAQ and Continue button in Setup MC

### DIFF
--- a/js/src/components/faqs-panel/index.js
+++ b/js/src/components/faqs-panel/index.js
@@ -34,7 +34,7 @@ const getPanelToggleHandler = ( trackName, id ) => ( isOpened ) => {
 export default function FaqsPanel( { trackName, faqItems } ) {
 	return (
 		<Panel
-			className="gla-fags-panel"
+			className="gla-faqs-panel"
 			header={ __(
 				'Frequently asked questions',
 				'google-listings-and-ads'

--- a/js/src/components/faqs-panel/index.scss
+++ b/js/src/components/faqs-panel/index.scss
@@ -1,6 +1,4 @@
 .gla-faqs-panel {
-	margin-bottom: calc(var(--main-gap) * 1.5);
-
 	.components-panel__row {
 		display: block;
 	}

--- a/js/src/components/faqs-panel/index.scss
+++ b/js/src/components/faqs-panel/index.scss
@@ -1,4 +1,4 @@
-.gla-fags-panel {
+.gla-faqs-panel {
 	margin-bottom: calc(var(--main-gap) * 1.5);
 
 	.components-panel__row {

--- a/js/src/get-started-page/index.scss
+++ b/js/src/get-started-page/index.scss
@@ -5,4 +5,8 @@
 	> * {
 		margin-bottom: calc(var(--main-gap) * 1.5);
 	}
+
+	.gla-get-started-notice {
+		margin: 0 0 $grid-unit-40;
+	}
 }

--- a/js/src/get-started-page/index.scss
+++ b/js/src/get-started-page/index.scss
@@ -2,7 +2,7 @@
 	max-width: 824px;
 	margin: 0 auto;
 
-	.components-card {
+	> * {
 		margin-bottom: calc(var(--main-gap) * 1.5);
 	}
 }

--- a/js/src/get-started-page/unsupported-notices/index.scss
+++ b/js/src/get-started-page/unsupported-notices/index.scss
@@ -1,6 +1,4 @@
 .gla-get-started-notice {
-	margin: 0 0 $grid-unit-40;
-
 	&.is-error {
 		background-color: #ffcbcb;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When I was working on #1065 , I noticed that there are extra bigger margins between the `FaqsPanel` and the "Continue" button in Setup MC Step 1 (see screenshot below). 

This PR fixes that margin issue, by removing `margin-bottom` from the `FaqsPanel`. 

`FaqsPanel`, along with `UnsupportedNotices`, is also being used in `GetStartedPage`. `UnsupportedNotices` also has its margin specified within the component. This PR contains a code refactor that lets the parent `GetStartedPage` component handle margins between its child components, i.e. `UnsupportedNotices`, `GetStartedCard`, `FeaturesCard` and `Faqs`.

Note that this PR targets the `develop` branch. It does not depend on #1065.

### Screenshots:

#### Setup MC Step 1 - Before:

![image](https://user-images.githubusercontent.com/417342/140403051-1c2c50b2-c941-4c38-aa30-f11aec801e7a.png)

#### Setup MC Step 1 - After:

![image](https://user-images.githubusercontent.com/417342/140401561-39d044a8-e460-48d2-ab19-12ec6e29b97e.png)

#### Get Started Page - Before and After should be the same:

![get started page](https://user-images.githubusercontent.com/417342/140402769-b9f8de16-30bf-45d0-bd4d-a7a8bc249ebd.png)

### Detailed test instructions:

1. Go to Get Started page: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart`. Everything should look the same as before.
2. To trigger the notices, you can change the language to "Bahasa Melayu" in WordPress settings, and country to "Aland Islands" in WooCommerce Settings. Then, go back to the Get Started page and you should see them.
3. Click on the "Set up free listings in Google" button to go to Setup MC Step 1.
4. Go to the bottom of the page. There shouldn't be extra margin between FAQs panel and the "Continue" button.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Fix extra margin between FAQs panel and button in Setup MC Step 1.
