### PR TITLE
Fix the no unique key warning for the `<AppSubNav>` component

### DIFF
--- a/js/src/components/app-sub-nav/index.js
+++ b/js/src/components/app-sub-nav/index.js
@@ -36,7 +36,6 @@ const AppSubNav = ( props ) => {
 				return (
 					<Fragment key={ tab.key }>
 						<Link
-							key={ tab.key }
 							className={ classnames( {
 								current: isCurrent,
 								// Workaround for https://github.com/woocommerce/woocommerce-admin/issues/7772.

--- a/js/src/components/app-sub-nav/index.js
+++ b/js/src/components/app-sub-nav/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Fragment } from '@wordpress/element';
 import { NavigableMenu } from '@wordpress/components';
 import { Link } from '@woocommerce/components';
 import classnames from 'classnames';
@@ -33,7 +34,7 @@ const AppSubNav = ( props ) => {
 				const isCurrent = tab.key === selectedKey;
 
 				return (
-					<>
+					<Fragment key={ tab.key }>
 						<Link
 							key={ tab.key }
 							className={ classnames( {
@@ -52,7 +53,7 @@ const AppSubNav = ( props ) => {
 							{ tab.title + ' ' }
 						</Link>
 						{ index < tabs.length - 1 ? ' | ' : ' ' }
-					</>
+					</Fragment>
 				);
 			} ) }
 		</NavigableMenu>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix the no unique key warning when viewing the **Reports** page

![2021-11-05 17 05 35](https://user-images.githubusercontent.com/17420811/140486154-3df451fe-a57b-445d-bd6a-d1078983a5f6.png)

### Detailed test instructions:

1. Open browser DevTool.
2. Go to the Reports page.
3. It should no longer show `Warning: Each child in a list should have a unique "key" prop.` message in the console.

### Changelog entry
