### PR TITLE
Update `in_stock` and `out_of_stock` availability enums

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -37,8 +37,8 @@ defined( 'ABSPATH' ) || exit;
 class WCProductAdapter extends GoogleProduct implements Validatable {
 	use PluginHelper;
 
-	public const AVAILABILITY_IN_STOCK     = 'in stock';
-	public const AVAILABILITY_OUT_OF_STOCK = 'out of stock';
+	public const AVAILABILITY_IN_STOCK     = 'in_stock';
+	public const AVAILABILITY_OUT_OF_STOCK = 'out_of_stock';
 	public const AVAILABILITY_BACKORDER    = 'backorder';
 	public const AVAILABILITY_PREORDER     = 'preorder';
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[Google's doc for the `Availability` field](https://support.google.com/merchants/answer/6324448?hl=en) shows the supported values for availability as `in_stock` and `out_of_stock` (with an underscore instead of space). These values are hardcoded as `in stock` and `out of stock` (with space) in our codebase because that's what the Google docs previously suggested.

This PR changes the enum values for `in stock` and `out of stock` availability to `in_stock` and `out_of_stock` (with an underscore).

I am not sure if this is affecting anyone at the moment because the products seem to be syncing correctly. Probably a backward compatible change on the Google side. So this isn't a high-priority fix, but it's best to align with the Google documentation.

### Screenshots:

<img width="743" alt="image" src="https://user-images.githubusercontent.com/73110514/140501038-9083037e-e390-41e7-b43e-1baa1dde7276.png">

### Detailed test instructions:

1. Edit a product and set its availability to in stock and edit another product and set it to out of stock
2. Sync these products with Google and confirm in Merchant Center that their availability is synced correctly

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Update `in_stock` and `out_of_stock` availability enums
