### PR TITLE
Use task list API for checking if we should show tasks list.

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
  * Requires at least: 5.6
- * Tested up to: 5.8
+ * Tested up to: 5.9
  * Requires PHP: 7.3
  *
  * WC requires at least: 5.5

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, listings, ads
 Requires at least: 5.5
-Tested up to: 5.8
+Tested up to: 5.9
 Requires PHP: 7.3
 Stable tag: 1.5.1
 License: GPLv3

--- a/src/TaskList/TaskListTrait.php
+++ b/src/TaskList/TaskListTrait.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\TaskList;
 
 use Automattic\WooCommerce\Admin\Features\Onboarding;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use Automattic\WooCommerce\Admin\Loader;
 
 /**
@@ -19,6 +20,22 @@ trait TaskListTrait {
 	 * @return bool
 	 */
 	protected function should_register_tasks(): bool {
-		return class_exists( Loader::class ) && Loader::is_admin_page() && Onboarding::should_show_tasks();
+		return class_exists( Loader::class ) && Loader::is_admin_page() && $this->check_should_show_tasks();
+	}
+
+	/**
+	 * Helper function to check if UI should show tasks.
+	 *
+	 * @return bool
+	 */
+	private function check_should_show_tasks(): bool {
+		if ( version_compare( WC_VERSION, '5.9', '<' ) ) {
+			return Onboarding::should_show_tasks();
+		}
+
+		$setup_list    = TaskLists::get_list( 'setup' );
+		$extended_list = TaskLists::get_list( 'extended' );
+
+		return ( $setup_list && ! $setup_list->is_hidden() ) || ( $extended_list && ! $extended_list->is_hidden() );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use Task list API in place for the now deprecated `Onboarding::should_show_tasks()`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1080 and #1054 .

_Replace this with a good description of your changes & reasoning._



### Detailed test instructions:

1.  🤷🏻 


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Use Task List API to detect if we should register tasks.
