### PR TITLE
UX improvement for Google account card on Ads setup page

### DIFF
--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -62,6 +62,7 @@ const alignStyleName = {
  * @param {APPEARANCE | {icon, title}} props.appearance Kind of account to indicate the card appearance, or a tuple with icon and title to be used.
  * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
  * @param {JSX.Element} props.description Content below the card title.
+ * @param {JSX.Element} [props.helper] Helper content below the card description.
  * @param {boolean} [props.hideIcon=false] Whether hide the leading icon.
  * @param {'center'|'top'} [props.alignIcon='center'] Specify the vertical alignment of leading icon.
  * @param {JSX.Element} [props.indicator] Indicator of actions or status on the right side of the card.
@@ -73,6 +74,7 @@ export default function AccountCard( {
 	appearance,
 	disabled = false,
 	description,
+	helper,
 	hideIcon = false,
 	alignIcon = 'center',
 	indicator,
@@ -116,6 +118,11 @@ export default function AccountCard( {
 						<div className="gla-account-card__description">
 							{ description }
 						</div>
+						{ helper && (
+							<div className="gla-account-card__helper">
+								{ helper }
+							</div>
+						) }
 					</FlexBlock>
 					{ indicator && (
 						<FlexItem className={ indicatorClassName }>

--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -112,9 +112,11 @@ export default function AccountCard( {
 						</FlexItem>
 					) }
 					<FlexBlock>
-						<Subsection.Title className="gla-account-card__title">
-							{ title }
-						</Subsection.Title>
+						{ title && (
+							<Subsection.Title className="gla-account-card__title">
+								{ title }
+							</Subsection.Title>
+						) }
 						<div className="gla-account-card__description">
 							{ description }
 						</div>

--- a/js/src/components/account-card/index.scss
+++ b/js/src/components/account-card/index.scss
@@ -9,7 +9,7 @@
 		}
 	}
 
-	&__title:not(:empty) {
+	&__title {
 		margin-bottom: 4px;
 		color: $black;
 	}

--- a/js/src/components/account-card/index.scss
+++ b/js/src/components/account-card/index.scss
@@ -19,6 +19,13 @@
 		}
 	}
 
+	&__helper {
+		margin-top: 4px;
+		font-style: italic;
+		font-size: 12px;
+		color: $gray-700;
+	}
+
 	.components-notice.is-error {
 		margin: 0;
 		background-color: #f8ebea;

--- a/js/src/components/account-card/index.scss
+++ b/js/src/components/account-card/index.scss
@@ -9,10 +9,16 @@
 		}
 	}
 
+	&__title:not(:empty) {
+		margin-bottom: 4px;
+		color: $black;
+	}
+
 	&__description {
 		display: flex;
 		flex-direction: column;
 		gap: 1em;
+		color: $gray-900;
 
 		> p {
 			margin: 0;

--- a/js/src/components/google-account-card/connected-google-account-card.js
+++ b/js/src/components/google-account-card/connected-google-account-card.js
@@ -19,10 +19,12 @@ import useSwitchGoogleAccount from './useSwitchGoogleAccount';
  * @param {Object} props React props.
  * @param {{ email: string }} props.googleAccount A data payload object contains user's Google account email.
  * @param {JSX.Element} [props.helper] Helper content below the Google account email.
+ * @param {boolean} [props.hideAccountSwitch=false] Indicate whether hide the account switch block at the card footer.
  */
 export default function ConnectedGoogleAccountCard( {
 	googleAccount,
 	helper,
+	hideAccountSwitch = false,
 } ) {
 	const [ handleSwitch, { loading } ] = useSwitchGoogleAccount();
 
@@ -33,17 +35,19 @@ export default function ConnectedGoogleAccountCard( {
 			helper={ helper }
 			indicator={ <ConnectedIconLabel /> }
 		>
-			<Section.Card.Footer>
-				<AppButton
-					isLink
-					disabled={ loading }
-					text={ __(
-						'Or, connect to a different Google account',
-						'google-listings-and-ads'
-					) }
-					onClick={ handleSwitch }
-				/>
-			</Section.Card.Footer>
+			{ ! hideAccountSwitch && (
+				<Section.Card.Footer>
+					<AppButton
+						isLink
+						disabled={ loading }
+						text={ __(
+							'Or, connect to a different Google account',
+							'google-listings-and-ads'
+						) }
+						onClick={ handleSwitch }
+					/>
+				</Section.Card.Footer>
+			) }
 		</AccountCard>
 	);
 }

--- a/js/src/components/google-account-card/connected-google-account-card.js
+++ b/js/src/components/google-account-card/connected-google-account-card.js
@@ -12,13 +12,25 @@ import ConnectedIconLabel from '.~/components/connected-icon-label';
 import Section from '.~/wcdl/section';
 import useSwitchGoogleAccount from './useSwitchGoogleAccount';
 
-export default function ConnectedGoogleAccountCard( { googleAccount } ) {
+/**
+ * Renders a Google account card UI with connected account information.
+ * It also provides a switch button that lets user connect with another Google account.
+ *
+ * @param {Object} props React props.
+ * @param {{ email: string }} props.googleAccount A data payload object contains user's Google account email.
+ * @param {JSX.Element} [props.helper] Helper content below the Google account email.
+ */
+export default function ConnectedGoogleAccountCard( {
+	googleAccount,
+	helper,
+} ) {
 	const [ handleSwitch, { loading } ] = useSwitchGoogleAccount();
 
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE }
 			description={ googleAccount.email }
+			helper={ helper }
 			indicator={ <ConnectedIconLabel /> }
 		>
 			<Section.Card.Footer>

--- a/js/src/components/google-account-card/index.js
+++ b/js/src/components/google-account-card/index.js
@@ -1,1 +1,2 @@
 export { default } from './google-account-card';
+export { default as ConnectedGoogleAccountCard } from './connected-google-account-card';

--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.js
@@ -10,13 +10,12 @@ import { __ } from '@wordpress/i18n';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
-import AccountCard from '.~/components/account-card';
+import { ConnectedGoogleAccountCard } from '.~/components/google-account-card';
 import GoogleAdsAccountSection from './google-ads-account-section';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import useGoogleAccount from '.~/hooks/useGoogleAccount';
 import AppSpinner from '.~/components/app-spinner';
 import Section from '.~/wcdl/section';
-import './index.scss';
 
 const SetupAccounts = ( props ) => {
 	const { onContinue = () => {} } = props;
@@ -48,10 +47,10 @@ const SetupAccounts = ( props ) => {
 					'google-listings-and-ads'
 				) }
 			>
-				<AccountCard
-					className="gla-setup-ads-accounts__google-card"
-					appearance={ { title: google.email } }
-					description={ __(
+				<ConnectedGoogleAccountCard
+					googleAccount={ google }
+					hideAccountSwitch
+					helper={ __(
 						'This Google account is connected to your store’s product feed.',
 						'google-listings-and-ads'
 					) }

--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
+import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import { ConnectedGoogleAccountCard } from '.~/components/google-account-card';
 import GoogleAdsAccountSection from './google-ads-account-section';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
@@ -41,20 +42,22 @@ const SetupAccounts = ( props ) => {
 				) }
 			/>
 			<Section
-				title={ __( 'Google account', 'google-listings-and-ads' ) }
+				title={ __( 'Connect accounts', 'google-listings-and-ads' ) }
 				description={ __(
-					'WooCommerce uses your Google account to sync with Google Merchant Center and Google Ads.',
+					'Any campaigns created through this app will appear in your Google Ads account. You will be billed directly through Google.',
 					'google-listings-and-ads'
 				) }
 			>
-				<ConnectedGoogleAccountCard
-					googleAccount={ google }
-					hideAccountSwitch
-					helper={ __(
-						'This Google account is connected to your store’s product feed.',
-						'google-listings-and-ads'
-					) }
-				/>
+				<VerticalGapLayout size="large">
+					<ConnectedGoogleAccountCard
+						googleAccount={ google }
+						hideAccountSwitch
+						helper={ __(
+							'This Google account is connected to your store’s product feed.',
+							'google-listings-and-ads'
+						) }
+					/>
+				</VerticalGapLayout>
 			</Section>
 			<GoogleAdsAccountSection />
 			<StepContentFooter>

--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.scss
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.scss
@@ -1,7 +1,0 @@
-.gla-setup-ads-accounts {
-	&__google-card {
-		.gla-account-card__description {
-			color: $gray-700;
-		}
-	}
-}

--- a/js/src/wcdl/subsection/title/index.scss
+++ b/js/src/wcdl/subsection/title/index.scss
@@ -6,10 +6,5 @@
 	line-height: 20px;
 	letter-spacing: 0;
 	text-align: left;
-
-	&:not(:empty) {
-		// Do not have bottom margin when the title is empty. For example:
-		// the <Subsection.Title> usage at the js/src/components/account-card/index.js
-		margin-bottom: 8px;
-	}
+	margin-bottom: 8px;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of UX improvement for Google Ads setup. It's also related to #1065.

- Adjust the section wordings and apply the `<ConnectedGoogleAccountCard>` to the ads setup page.
- Add a new prop `helper` to `<AccountCard>` and `<ConnectedGoogleAccountCard>` for showing a helper text below card description.
- Add a new prop `hideAccountSwitch` to `<ConnectedGoogleAccountCard>` for hiding the account switch within card footer.
- Tweak base styles of AccountCard to fit with the visual design of UX improvements project

### Additional notes

- This PR only adjusts the Google account card. The adjustments of Google Ads card will be a separate PR.
- After adding the `helper` prop, we could split part of glued `description` to `helper`, and it would be another PR once the main development finished
    1. [ConnectGoogleAccountCard](https://github.com/woocommerce/google-listings-and-ads/blob/5d5aca2e384a516917b1525f15e8e7ac432a6f89/js/src/components/google-account-card/connect-google-account-card.js#L23-L47)
    2. [RequestFullAccessGoogleAccountCard](https://github.com/woocommerce/google-listings-and-ads/blob/5d5aca2e384a516917b1525f15e8e7ac432a6f89/js/src/components/google-account-card/request-full-access-google-account-card.js#L33-L56)
    3. Maybe some usages within the contact information pages.

### Screenshots:

#### 🖼️ . Adjusted Google account card on Ads setup page

![image](https://user-images.githubusercontent.com/17420811/140724507-38d67c4b-bc13-4dcb-9fab-5b0c03b5bc53.png)

#### 🖼️ . Google account card on onboarding setup page is the same as the original

![image](https://user-images.githubusercontent.com/17420811/140724581-09eae709-e30c-425d-9bfe-78e961b411ae.png)

### Detailed test instructions:

1. Go to Google Ads setup page.
2. The visual of Google account card should be close to the design on Figma.
3. Go to onboarding setup page.
4. The connected Google account card should show the same UI blocks within itself as before.

### Changelog entry
