### PR TITLE
Fix the conflicts between `@woocommerce/data@1.2.0` and WC 5.8 ~ 5.9

### DIFF
--- a/js/src/tasks/complete-setup/index.js
+++ b/js/src/tasks/complete-setup/index.js
@@ -4,7 +4,12 @@
 
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { getHistory } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { getGetStartedUrl, getDashboardUrl } from '.~/utils/urls';
 
 /* global glaTaskData */
 
@@ -25,8 +30,11 @@ addFilter(
 				),
 				completed: glaTaskData.isComplete,
 				onClick: () => {
-					// Redirect to the GLA get started page.
-					getHistory().push( getNewPath( {}, '/google/start' ) );
+					// Redirect to the GLA get started or dashboard page.
+					const nextUrl = glaTaskData.isComplete
+						? getDashboardUrl()
+						: getGetStartedUrl();
+					getHistory().push( nextUrl );
 				},
 				visible: true,
 				time: __( '20 minutes', 'google-listings-and-ads' ),

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -3,6 +3,7 @@
  */
 import { getNewPath } from '@woocommerce/navigation';
 
+const getStartedUrl = '/google/start';
 const dashboardPath = '/google/dashboard';
 const settingsPath = '/google/settings';
 
@@ -28,6 +29,10 @@ export const getEditCampaignUrl = ( programId ) => {
 
 export const getCreateCampaignUrl = () => {
 	return getNewPath( { subpath: subpaths.createCampaign }, dashboardPath );
+};
+
+export const getGetStartedUrl = () => {
+	return getNewPath( null, getStartedUrl, null );
 };
 
 export const getDashboardUrl = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4921,14 +4921,6 @@
 						}
 					}
 				},
-				"@woocommerce/data": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.1.1.tgz",
-					"integrity": "sha512-grmCllxDV/0PB8Mc+w9TQFJkAzO/yjjdDmaOzNk2ICuoz2ZhUGiFXnvZmWLyZr9BDtoYK+/jBIsM2ezr34b3ww==",
-					"requires": {
-						"@babel/runtime-corejs2": "7.11.2"
-					}
-				},
 				"@woocommerce/date": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-2.0.0.tgz",
@@ -5321,13 +5313,11 @@
 			}
 		},
 		"@woocommerce/data": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.2.0.tgz",
-			"integrity": "sha512-qPvn/UaGWHsx8wGts3zFuQ0++DVDkp460GkdzveEJq8IxazsWc9+AOKdf4ts85X6S4VQV/YXcufKKQMRBXfThQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.1.1.tgz",
+			"integrity": "sha512-grmCllxDV/0PB8Mc+w9TQFJkAzO/yjjdDmaOzNk2ICuoz2ZhUGiFXnvZmWLyZr9BDtoYK+/jBIsM2ezr34b3ww==",
 			"requires": {
-				"@woocommerce/date": "2.1.0",
-				"@woocommerce/navigation": "5.2.0",
-				"rememo": "^3.0.0"
+				"@babel/runtime-corejs2": "7.11.2"
 			}
 		},
 		"@woocommerce/date": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"files": [
 			{
 				"path": "./js/build/*.js",
-				"maxSize": "1.3 kB"
+				"maxSize": "1.74 kB"
 			},
 			{
 				"path": "./js/build/index.js",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "265 kB"
+				"maxSize": "248 kB"
 			},
 			{
 				"path": "./js/build/*.css",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 	"dependencies": {
 		"@woocommerce/components": "^5.1.2",
 		"@woocommerce/currency": "^3.1.0",
-		"@woocommerce/data": "1.2.0",
+		"@woocommerce/data": ">=1.1.1 <1.2.0",
 		"@woocommerce/date": "^2.1.0",
 		"@woocommerce/navigation": "^5.2.0",
 		"@woocommerce/number": "^2.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ const requestToExternal = ( request ) => {
 	const wcDepMap = {
 		'@woocommerce/components': [ 'wc', 'components' ],
 		'@woocommerce/navigation': [ 'wc', 'navigation' ],
+		'@woocommerce/data': [ 'wc', 'data' ],
 		// Since WooCommerce 5.8, the Settings store no longer contains "countries", "currency" and "adminURL",
 		// to be able to fetch that, we use unpublished `'@woocommerce/settings': 'wc-settings` package.
 		// It's delivered with WC, so we use Dependency Extraction Webpack Plugin to import it.
@@ -40,6 +41,7 @@ const requestToHandle = ( request ) => {
 	const wcHandleMap = {
 		'@woocommerce/components': 'wc-components',
 		'@woocommerce/navigation': 'wc-navigation',
+		'@woocommerce/data': 'wc-store-data',
 		'@woocommerce/settings': 'wc-settings',
 	};
 
@@ -76,18 +78,6 @@ const webpackConfig = {
 		alias: {
 			'.~': path.resolve( process.cwd(), 'js/src/' ),
 		},
-		/**
-		 * Resolve jsx/tsx files for `@woocommerce/data@1.3.*`.
-		 *
-		 * It could be removed if one of conditions is met:
-		 *   - The L-2 support version no longer covers 1.3.* versions.
-		 *   - `@woocommerce/data` is imported from DEWP instead.
-		 *
-		 * Checking method:
-		 * Whether the module not found error of the below path is no longer occur after `npm start`.
-		 *   - `./node_modules/@woocommerce/data/build/plugins/with-plugins-hydration.js`
-		 */
-		extensions: [ '.ts', '.tsx', '.js', '.jsx', '.json' ],
 	},
 	plugins: [
 		...defaultConfig.plugins.filter(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1085 .

- Revert the commit https://github.com/woocommerce/google-listings-and-ads/commit/37c7ac83e73025fcd77355fe1fe00dbfaabe4c12 to rollback `@woocommerce/data` to 1.1.1
- Use the external injected `@woocommerce/data` via **DEWP**
- Redirect to the GLA dashboard when clicking on GLA's task item on WC dashboard if onboarding setup is completed
- Rebalance the max size config of *bundlewatch* to 1.2 times of current js files

### Tech notes

- The issue was introduced by #1073 that has never been released.
- The further cause is [this commit](https://github.com/woocommerce/woocommerce-admin/commit/fdac917d87c7a4c0b6e7f8f25968d6ea4ac8df24#diff-f6d86b7245ae2422d7027b1d4b8813225d7b105c656ed3e7ce36ffd2d3e21285L17-R23) included in `@woocommerce/data` 1.2.0 removed the double wp-store registration checking.
- Side effects when using wp-data stores provided from external libraries
    - After this time, I learned that since `@woocommerce/data` 1.1.1 (hereinafter called `wc/data`) does not overload the existed wp-stores registered from WC core `wc/data`.
    - Even if we don't use external (core) `wc/data` via **DEWP**, the registered `wc/data` stores used by GLA during the runtime, such as selectors, are still from external sources.
    - And the `wc/data` packaged into GLA index.js really be used are only three constants that are the same as the external ones.

So, the solution to above thoughts is to use `wc/data` directly from **DEWP**, and we should do this, otherwise the `wc/data` packaged by GLA will overwrite the `wc/data` stores registered by the WC core in the future.

### Detailed test instructions:

1. With WooCommerce 5.8 or 5.9
1. `npm install`
1.  Restart `npm start`, or `npm run dev`
1. Finish the GLA onboarding setup
1. Go to the WooCommerce dashboard, and the JS error found in #1085 should no longer appear
1. Click on the task item "Set up Google Listings & Ads", and it should redirect browser to GLA dashboard page instead of get started page

### Changelog entry

> Fix - Redirect to plugin dashboard when clicking on its task item on WooCommerce dashboard if plugin onboarding setup is completed.
