### PR TITLE
Specify `lts/fermium` in `.nvmrc` to use Node.js version 14 and not 16 

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/fermium


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1089 .

This PR changes `.nvmrc` from `lts/*` to `lts/fermium`. [Fermium](https://nodejs.org/en/about/releases/) refers to Node.js version 14. 

Currently our code does not work with Node.js version 16. By having this change, it should help prevent accidentally using Node.js version 16.

### Detailed test instructions:

1. Checkout this branch. 
2. Run `nvm use` in your command line. It should be using Node.js 14.18.1.
3. Run `npm ci` or `npm install`. It should complete successfully.
4. Run `npm start`. It should start successfully.
