### PR TITLE
Add name and domain to account API to facilitate UX improvements

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -50,26 +50,28 @@ class Proxy implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Get merchant IDs associated with the connected Merchant Center account.
+	 * Get all Merchant Accounts associated with the connected account.
 	 *
-	 * @return int[]
+	 * @since x.x.x
+	 *
+	 * @return array
 	 * @throws Exception When an Exception is caught.
 	 */
-	public function get_merchant_ids(): array {
+	public function get_merchant_accounts(): array {
 		try {
 			/** @var Client $client */
 			$client   = $this->container->get( Client::class );
 			$result   = $client->get( $this->get_manager_url( 'merchant-accounts' ) );
 			$response = json_decode( $result->getBody()->getContents(), true );
-			$ids      = [];
+			$accounts = [];
 
 			if ( 200 === $result->getStatusCode() && is_array( $response ) ) {
-				foreach ( $response as $id ) {
-					$ids[] = $id;
+				foreach ( $response as $account ) {
+					$accounts[] = $account;
 				}
 			}
 
-			return $ids;
+			return $accounts;
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
@@ -78,6 +80,15 @@ class Proxy implements OptionsAwareInterface {
 				$e->getCode()
 			);
 		}
+	}
+
+	/**
+	 * Get merchant IDs associated with the connected Merchant Center account.
+	 *
+	 * @return int[]
+	 */
+	public function get_merchant_ids(): array {
+		return array_column( $this->get_merchant_accounts(), 'id' );
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -166,7 +166,7 @@ class AccountController extends BaseOptionsController {
 						$data = $this->prepare_item_for_response( $account, $request );
 						return $this->prepare_response_for_collection( $data );
 					},
-					$this->middleware->get_merchant_ids()
+					$this->middleware->get_merchant_accounts()
 				);
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
@@ -572,7 +572,7 @@ class AccountController extends BaseOptionsController {
 		// Maybe the existing account is sub-account!
 		$state                               = $this->account_state->get();
 		$state['set_id']['data']['from_mca'] = false;
-		foreach ( $this->middleware->get_merchant_ids() as $existing_account ) {
+		foreach ( $this->middleware->get_merchant_accounts() as $existing_account ) {
 			if ( $existing_account['id'] === $account_id ) {
 				$state['set_id']['data']['from_mca'] = $existing_account['subaccount'];
 				break;

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -285,6 +285,18 @@ class AccountController extends BaseOptionsController {
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
+			'name'       => [
+				'type'        => 'string',
+				'description' => __( 'The Merchant Center Account name.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'required'    => false,
+			],
+			'domain'     => [
+				'type'        => 'string',
+				'description' => __( 'The domain registered with the Merchant Center Account.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
 		];
 	}
 

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -898,7 +898,7 @@ class ConnectionTest implements Service, Registerable {
 
 				/** @var Proxy $proxy */
 				$proxy = $this->container->get( Proxy::class );
-				foreach ( $proxy->get_merchant_ids() as $account ) {
+				foreach ( $proxy->get_merchant_accounts() as $account ) {
 					$this->response     .= sprintf(
 						"Merchant ID: %s%s\n",
 						$account['id'],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This sets up the plugin to handle the updated API responses from the connect server. The connect server will start including `name` and `domain` information for each linked Merchant Center account.

The main changes here are to our REST API schema, and also to the Google API class. The API class renames `Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy::get_merchant_ids()` to `Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy::get_merchant_accounts()`. I've also created a new version of the `get_merchant_ids()` method, in case it is being used by any 3rd parties.


### Changelog entry

> Update – Add support for retrieving the name and domain from the Google API
