### PR TITLE
Adding setup & testing documentation and update deprecated attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To remove the Docker container and images (this will **delete everything** in th
 
 -   [Usage Tracking](./src/Tracking/README.md)
 
-<p style="text-align: center">
+<p align="center">
 	<br/><br/>
 	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
 	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ As per [WordPress Core Handbook](https://make.wordpress.org/core/handbook/best-p
 ## Development
 
 After cloning the repo, install dependencies:
-
+-   `nvm use` to be sure you're using the recommended node version in `.nvmrc`
 -   `npm install` to install JavaScript dependencies.
 -   `composer install` to gather PHP dependencies.
 
@@ -79,12 +79,18 @@ After running `composer install` to install PHP dependencies you can use the fol
 
 ### Prerequisites
 
-Install [`composer`](https://getcomposer.org/), `git`, `svn`, and either `wget` or `curl`.
+Install [`composer`](https://getcomposer.org/), `git`, `npm`, `svn`, and either `wget` or `curl`.
 
 Change to the plugin root directory and type:
 
 ```bash
 $ composer install
+```
+
+Change to the plugin root directory and type:
+
+```bash
+$ npm install && npm run dev
 ```
 
 ### Install Test Dependencies
@@ -146,7 +152,7 @@ To remove the Docker container and images (this will **delete everything** in th
 
 -   [Usage Tracking](./src/Tracking/README.md)
 
-<p align="center">
+<p style="text-align: center">
 	<br/><br/>
 	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
 	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

After finishing my env setup I added some more information regarding:

- `nvmrc` and `nvm use` in order to setup the correct node version
-  `npm Install && npm run dev` is a prerequisite to run the PHPUnit tests.
-  Updated from  `<p align:center>` to `<p style="text-align:center;">` at the end of Readme since this `align:center` attribute is obsolete. 

### Detailed test instructions:

1. Both section PHPUnit and Section Development make sense for you
2. You can clone the repo from scratch and run PHPUnit successfully following the guide
3. Made with 💜 section at the end of Readme is centred.

### Changelog entry

> Update - Readme - Setup and Testing information
