### PR TITLE
Support paste verification

### DIFF
--- a/js/src/components/contact-information/phone-number-card/verification-code-control.js
+++ b/js/src/components/contact-information/phone-number-card/verification-code-control.js
@@ -154,11 +154,6 @@ export default function VerificationCodeControl( {
 		};
 	};
 
-	// Reset the inputs' refs and state when resetNeedle changes.
-	useEffect( () => {
-		updateState( initDigits );
-	}, [ resetNeedle, updateState ] );
-
 	/**
 	 * Set the focus to the first input if the control's value is (back) at the initial state.
 	 *
@@ -182,10 +177,9 @@ export default function VerificationCodeControl( {
 	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/input-control/input-field.js#L73-L90
 	 */
 	useEffect( () => {
-		if ( digits === initDigits ) {
-			maybeMoveFocus( 0 );
-		}
-	}, [ digits, resetNeedle ] );
+		updateState( initDigits );
+		setFocus( 0 );
+	}, [ resetNeedle, updateState ] );
 
 	useEffect( () => {
 		maybeMoveFocus( focus );

--- a/js/src/components/contact-information/phone-number-card/verification-code-control.js
+++ b/js/src/components/contact-information/phone-number-card/verification-code-control.js
@@ -43,10 +43,7 @@ export default function VerificationCodeControl( {
 } ) {
 	const inputsRef = useRef( [] );
 	const cursorRef = useRef( 0 );
-	const onCodeChangeRef = useRef();
 	const [ digits, setDigits ] = useState( initDigits );
-
-	onCodeChangeRef.current = onCodeChange;
 
 	/**
 	 * Moves focus to the input at given input
@@ -79,7 +76,7 @@ export default function VerificationCodeControl( {
 
 	const updateState = ( nextDigits ) => {
 		setDigits( nextDigits );
-		onCodeChangeRef.current( toCallbackData( digits ) );
+		onCodeChange( toCallbackData( nextDigits ) );
 	};
 
 	const handleKeyDown = ( e ) => {
@@ -185,7 +182,6 @@ export default function VerificationCodeControl( {
 		if ( digits === initDigits ) {
 			maybeMoveFocus( 0 );
 		} else {
-			// Update internal AppInputControl values
 			updateInputRefs( digits );
 		}
 	}, [ digits ] );

--- a/js/src/components/contact-information/phone-number-card/verification-code-control.js
+++ b/js/src/components/contact-information/phone-number-card/verification-code-control.js
@@ -154,7 +154,10 @@ export default function VerificationCodeControl( {
 		);
 
 		// set next focus index to the last inserted digit
-		return { nextDigits, nextFocusIdx: newDigits.length + idx - 1 };
+		return {
+			nextDigits,
+			nextFocusIdx: Math.min( newDigits.length + idx, DIGIT_LENGTH - 1 ),
+		};
 	};
 
 	// Reset the inputs' refs and state when resetNeedle changes.

--- a/js/src/components/contact-information/phone-number-card/verification-code-control.js
+++ b/js/src/components/contact-information/phone-number-card/verification-code-control.js
@@ -177,7 +177,7 @@ export default function VerificationCodeControl( {
 	 * So here we await the `digits` is reset back to `initDigits` by above useEffect and sync to internal value,
 	 * then move the focus calling after the synchronization tick finished.
 	 *
-	 * Note the above also impacts in the stat updates for the focused element...
+	 * Note the above also impacts in the state updates for the focused element...
 	 *
 	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/input-control/input-field.js#L73-L90
 	 */

--- a/js/src/components/contact-information/phone-number-card/verification-code-control.js
+++ b/js/src/components/contact-information/phone-number-card/verification-code-control.js
@@ -44,6 +44,7 @@ export default function VerificationCodeControl( {
 	const inputsRef = useRef( [] );
 	const cursorRef = useRef( 0 );
 	const [ digits, setDigits ] = useState( initDigits );
+	const [ focus, setFocus ] = useState( 0 );
 
 	/**
 	 * Moves focus to the input at given input
@@ -66,12 +67,6 @@ export default function VerificationCodeControl( {
 			idx,
 			value: e.clipboardData?.getData( 'text/plain' ) ?? value,
 		};
-	};
-
-	const updateInputRefs = ( nextDigits ) => {
-		inputsRef.current.forEach(
-			( el, idx ) => ( el.value = nextDigits[ idx ] )
-		);
 	};
 
 	const handleKeyDown = ( e ) => {
@@ -114,7 +109,7 @@ export default function VerificationCodeControl( {
 			? handlePaste( e )
 			: handleInput( e );
 
-		maybeMoveFocus( nextFocusIdx );
+		setFocus( nextFocusIdx );
 
 		if ( nextDigits !== digits ) {
 			updateState( nextDigits );
@@ -148,7 +143,6 @@ export default function VerificationCodeControl( {
 		];
 
 		const nextDigits = [ ...digits ];
-
 		newDigits.forEach(
 			( digit, i ) => ( nextDigits[ i + idx ] = newDigits[ i ] )
 		);
@@ -162,7 +156,6 @@ export default function VerificationCodeControl( {
 
 	// Reset the inputs' refs and state when resetNeedle changes.
 	useEffect( () => {
-		updateInputRefs( initDigits );
 		updateState( initDigits );
 	}, [ resetNeedle, updateState ] );
 
@@ -184,6 +177,7 @@ export default function VerificationCodeControl( {
 	 * then move the focus calling after the synchronization tick finished.
 	 *
 	 * Note the above also impacts in the state updates for the focused element...
+	 * That's why we need setFocus state in order to sync these internal values.
 	 *
 	 * @see https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/input-control/input-field.js#L73-L90
 	 */
@@ -193,10 +187,9 @@ export default function VerificationCodeControl( {
 		}
 	}, [ digits, resetNeedle ] );
 
-	// update internal state values on InputControl
 	useEffect( () => {
-		updateInputRefs( digits );
-	}, [ digits ] );
+		maybeMoveFocus( focus );
+	}, [ focus ] );
 
 	return (
 		<Flex

--- a/js/src/components/contact-information/phone-number-card/verification-code-control.test.js
+++ b/js/src/components/contact-information/phone-number-card/verification-code-control.test.js
@@ -175,4 +175,68 @@ describe( 'VerificationCodeControl component', () => {
 			expect( el.value ).toBe( expectedValue );
 		} );
 	} );
+
+	test( 'updates validation code prop on paste', async () => {
+		const onCodeChange = jest
+			.fn( ( data ) => data )
+			.mockName( 'onCodeChange' );
+
+		render( <VerificationCodeControl onCodeChange={ onCodeChange } /> );
+		const inputs = screen.getAllByRole( 'textbox' );
+
+		expect( onCodeChange.mock.results[ 0 ].value ).toStrictEqual( {
+			code: '',
+			isFilled: false,
+		} );
+
+		let paste = createEvent.paste( inputs[ 0 ], {
+			clipboardData: {
+				getData: () => '222',
+			},
+		} );
+
+		fireEvent( inputs[ 0 ], paste );
+
+		expect( onCodeChange.mock.results[ 1 ].value ).toStrictEqual( {
+			code: '222',
+			isFilled: false,
+		} );
+
+		paste = createEvent.paste( inputs[ 0 ], {
+			clipboardData: {
+				getData: () => '333333',
+			},
+		} );
+
+		fireEvent( inputs[ 0 ], paste );
+
+		expect( onCodeChange.mock.results[ 2 ].value ).toStrictEqual( {
+			code: '333333',
+			isFilled: true,
+		} );
+	} );
+	test( 'updates validation code prop on input', async () => {
+		const onCodeChange = jest
+			.fn( ( data ) => data )
+			.mockName( 'onCodeChange' );
+
+		render( <VerificationCodeControl onCodeChange={ onCodeChange } /> );
+		const inputs = screen.getAllByRole( 'textbox' );
+
+		expect( onCodeChange.mock.results[ 0 ].value ).toStrictEqual( {
+			code: '',
+			isFilled: false,
+		} );
+
+		let currentCode = '';
+		for ( const input of inputs ) {
+			const i = inputs.indexOf( input ) + 1;
+			await userEvent.type( input, '1' );
+			currentCode += '1';
+			expect( onCodeChange.mock.results[ i ].value ).toStrictEqual( {
+				code: currentCode,
+				isFilled: i === 6,
+			} );
+		}
+	} );
 } );

--- a/js/src/components/contact-information/phone-number-card/verification-code-control.test.js
+++ b/js/src/components/contact-information/phone-number-card/verification-code-control.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -126,5 +126,53 @@ describe( 'VerificationCodeControl component', () => {
 		);
 
 		expect( onSubmit ).toHaveBeenCalled();
+	} );
+
+	test( 'it is possible to paste multiple digits', async () => {
+		render( <VerificationCodeControl onCodeChange={ () => {} } /> );
+		const inputs = screen.getAllByRole( 'textbox' );
+
+		const paste = createEvent.paste( inputs[ 0 ], {
+			clipboardData: {
+				getData: () => '222222',
+			},
+		} );
+
+		fireEvent( inputs[ 0 ], paste );
+
+		inputs.forEach( ( el ) => expect( el.value ).toBe( '2' ) );
+	} );
+
+	test( 'it pastes a maximum of {DIGIT_LENGTH} digits', async () => {
+		render( <VerificationCodeControl onCodeChange={ () => {} } /> );
+		const inputs = screen.getAllByRole( 'textbox' );
+
+		const paste = createEvent.paste( inputs[ 0 ], {
+			clipboardData: {
+				getData: () => '22222233333333',
+			},
+		} );
+
+		fireEvent( inputs[ 0 ], paste );
+
+		inputs.forEach( ( el ) => expect( el.value ).toBe( '2' ) );
+	} );
+
+	test( 'it pastes with other indexes and number of digits', async () => {
+		render( <VerificationCodeControl onCodeChange={ () => {} } /> );
+		const inputs = screen.getAllByRole( 'textbox' );
+
+		const paste = createEvent.paste( inputs[ 1 ], {
+			clipboardData: {
+				getData: () => '22',
+			},
+		} );
+
+		fireEvent( inputs[ 1 ], paste );
+
+		inputs.forEach( ( el, idx ) => {
+			const expectedValue = idx > 0 && idx < 3 ? '2' : '';
+			expect( el.value ).toBe( expectedValue );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1001 .

Added functionality in order to allow the user to paste the code inside the verification code control inputs.

### Screenshots:

<!--- Optional --->

https://user-images.githubusercontent.com/5908855/143000769-1969f4b8-b0ba-4a24-9f63-f14544e8c1dd.mov



### Changes

* Mainly a refactor in verification Code Control
* Added a new `handlePaste` function to handle the input in the case is a paste event
* Added some tests  

### Detailed test instructions:

1. Go to Onboarding Setup Dashboard or to Settings -> Edit Phone
2. Edit the phone and click on Verify Phone Number
3. Check you can paste digits on the inputs 
4. Check you can insert the input as normal
5. You cannot insert letters or symbols, only digits. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Improve accessibility in Verification Code Control
