### PR TITLE
Add name to connection API

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\TosAccepted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use DateTime;
 use Exception;
 use Google\Ads\GoogleAds\Util\V8\ResourceNames;
 use Google\ApiCore\ApiException;

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -158,6 +158,7 @@ class Proxy implements OptionsAwareInterface {
 			if ( 200 === $result->getStatusCode() && isset( $response['id'] ) ) {
 				$id = absint( $response['id'] );
 				$this->update_merchant_id( $id );
+				$this->options->update( OptionsInterface::SITE_NAME, $name );
 				return $id;
 			}
 

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -159,7 +159,7 @@ class Proxy implements OptionsAwareInterface {
 			if ( 200 === $result->getStatusCode() && isset( $response['id'] ) ) {
 				$id = absint( $response['id'] );
 				$this->update_merchant_id( $id );
-				$this->options->update( OptionsInterface::SITE_NAME, $name );
+				$this->update_merchant_name( $name );
 				return $id;
 			}
 
@@ -182,14 +182,14 @@ class Proxy implements OptionsAwareInterface {
 	/**
 	 * Link an existing Merchant Center account.
 	 *
-	 * @param int $id Existing account ID.
+	 * @since x.x.x Added $name parameter.
 	 *
-	 * @return int
+	 * @param int         $id   Existing account ID.
+	 * @param string|null $name The account name.
 	 */
-	public function link_merchant_account( int $id ): int {
+	public function link_merchant_account( int $id, ?string $name ): void {
 		$this->update_merchant_id( $id );
-
-		return $id;
+		$this->update_merchant_name( $name ?? __( 'Unknown Account Name', 'google-listings-and-ads' ) );
 	}
 
 	/**
@@ -586,6 +586,19 @@ class Proxy implements OptionsAwareInterface {
 	 */
 	protected function update_merchant_id( int $id ): bool {
 		return $this->options->update( OptionsInterface::MERCHANT_ID, $id );
+	}
+
+	/**
+	 * Update the Merchant Center account name to use for requests.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $name The Merchant Center account name.
+	 *
+	 * @return bool
+	 */
+	protected function update_merchant_name( string $name ): bool {
+		return $this->options->update( OptionsInterface::SITE_NAME, $name );
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -76,7 +76,7 @@ class AccountController extends BaseOptionsController {
 		parent::__construct( $container->get( RESTServer::class ) );
 		$this->middleware    = $container->get( Middleware::class );
 		$this->merchant      = $container->get( Merchant::class );
-		$this->account_state = $container->get( AccountState::class );
+		$this->account_state = $container->get( MerchantAccountState::class );
 		$this->mc_service    = $container->get( MerchantCenterService::class );
 		$this->container     = $container;
 	}

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -568,10 +568,10 @@ class AccountController extends BaseOptionsController {
 		$this->maybe_add_merchant_center_website_url( $account_id, $site_url );
 
 		// Maybe the existing account is sub-account!
-		$state                               = $this->account_state->get();
 		$state['set_id']['data']['from_mca'] = false;
 		foreach ( $this->middleware->get_merchant_accounts() as $existing_account ) {
 			if ( $existing_account['id'] === $account_id ) {
+				$this->options->update( OptionsInterface::SITE_NAME, $existing_account['name'] );
 				$state['set_id']['data']['from_mca'] = $existing_account['subaccount'];
 				break;
 			}

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -571,13 +571,13 @@ class AccountController extends BaseOptionsController {
 		$state['set_id']['data']['from_mca'] = false;
 		foreach ( $this->middleware->get_merchant_accounts() as $existing_account ) {
 			if ( $existing_account['id'] === $account_id ) {
-				$this->options->update( OptionsInterface::SITE_NAME, $existing_account['name'] );
+				$existing_account_name               = $existing_account['name'];
 				$state['set_id']['data']['from_mca'] = $existing_account['subaccount'];
 				break;
 			}
 		}
 
-		$this->middleware->link_merchant_account( $account_id );
+		$this->middleware->link_merchant_account( $account_id, $existing_account_name ?? '' );
 		$state['set_id']['status'] = AccountState::STEP_DONE;
 		$this->account_state->update( $state );
 	}

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -264,6 +264,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
 		$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
+		$this->options->delete( OptionsInterface::SITE_NAME );
 
 		$this->container->get( MerchantStatuses::class )->delete();
 

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -213,6 +213,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			'id'     => $id,
 			'status' => $id ? 'connected' : 'disconnected',
 			'name'   => $id ? $this->options->get( OptionsInterface::SITE_NAME ) : '',
+			'domain' => $this->get_site_url(),
 		];
 
 		$incomplete = $this->container->get( MerchantAccountState::class )->last_incomplete_step();

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -212,6 +212,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		$status = [
 			'id'     => $id,
 			'status' => $id ? 'connected' : 'disconnected',
+			'name'   => $id ? $this->options->get( OptionsInterface::SITE_NAME ) : '',
 		];
 
 		$incomplete = $this->container->get( MerchantAccountState::class )->last_incomplete_step();

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -30,6 +30,7 @@ interface OptionsInterface {
 	public const REDIRECT_TO_ONBOARDING = 'redirect_to_onboarding';
 	public const SHIPPING_RATES         = 'shipping_rates';
 	public const SHIPPING_TIMES         = 'shipping_times';
+	public const SITE_NAME              = 'site_name';
 	public const SITE_VERIFICATION      = 'site_verification';
 	public const TARGET_AUDIENCE        = 'target_audience';
 	public const WP_TOS_ACCEPTED        = 'wp_tos_accepted';
@@ -50,9 +51,10 @@ interface OptionsInterface {
 		self::MERCHANT_ACCOUNT_STATE => true,
 		self::MERCHANT_CENTER        => true,
 		self::MERCHANT_ID            => true,
+		self::REDIRECT_TO_ONBOARDING => true,
 		self::SHIPPING_RATES         => true,
 		self::SHIPPING_TIMES         => true,
-		self::REDIRECT_TO_ONBOARDING => true,
+		self::SITE_NAME              => true,
 		self::SITE_VERIFICATION      => true,
 		self::TARGET_AUDIENCE        => true,
 		self::WP_TOS_ACCEPTED        => true,

--- a/uninstall.php
+++ b/uninstall.php
@@ -46,7 +46,7 @@ if ( defined( 'WC_GLA_REMOVE_ALL_DATA' ) && true === WC_GLA_REMOVE_ALL_DATA ) {
 
 	// drop custom tables
 	foreach ( TableManager::get_all_table_names() as $table ) {
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . WC_GLA_SLUG . "_{$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . WC_GLA_SLUG . "_{$table}" ); // phpcs:ignore WordPress.DB
 	}
 
 	// delete options


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This updates the `/mc/connection` API endpoint to return the name and domain as part of the response.


### Detailed test instructions:

1. Make a request to `/mc/connection` on the site.
2. Observe that the response now includes `name` and `domain` parameters.


