### PR TITLE
Adjust the <AccountCard> props to make their usages clearer and tweak some wordings for GMC cards

### DIFF
--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -21,9 +21,10 @@ import './index.scss';
  * @enum {string}
  */
 export const APPEARANCE = {
+	EMPTY: 'empty',
 	GOOGLE: 'google',
 	GOOGLE_MERCHANT_CENTER: 'google_merchant_center',
-	GOOGLE_ADS: 'google-ads',
+	GOOGLE_ADS: 'google_ads',
 	PHONE: 'phone',
 	ADDRESS: 'address',
 };
@@ -38,6 +39,7 @@ const googleLogo = (
 );
 
 const appearanceDict = {
+	[ APPEARANCE.EMPTY ]: {},
 	[ APPEARANCE.GOOGLE ]: {
 		icon: googleLogo,
 		title: __( 'Google account', 'google-listings-and-ads' ),
@@ -49,7 +51,7 @@ const appearanceDict = {
 	[ APPEARANCE.GOOGLE_ADS ]: {
 		icon: googleLogo,
 		title: __( 'Google Ads', 'google-listings-and-ads' ),
-		defaultDescription: __(
+		description: __(
 			'Required to create paid campaigns with your product listings',
 			'google-listings-and-ads'
 		),
@@ -75,33 +77,33 @@ const alignStyleName = {
  *
  * @param {Object} props React props.
  * @param {string} [props.className] Additional CSS class name to be appended.
- * @param {APPEARANCE | {icon, title, defaultDescription}} props.appearance Kind of account to indicate the card appearance, or a tuple with icon, title and optional defaultDescription to be used.
  * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
- * @param {JSX.Element} [props.description] Content below the card title. It will fall back to `appearance.defaultDescription` if not specified and the default is applicable.
+ * @param {APPEARANCE} [props.appearance=APPEARANCE.EMPTY]
+ *   Kind of account to indicate the default card appearance, which could include icon, title, and description.
+ *   If didn't specify this prop, all properties of appearance will be `undefined` (nothing shown),
+ *   and it's usually used for full customization.
+ * @param {JSX.Element} [props.icon] Card icon. It will fall back to the icon of respective `appearance` config if not specified.
+ * @param {JSX.Element} [props.title] Card title. It will fall back to the title of respective `appearance` config if not specified.
+ * @param {JSX.Element} [props.description] Description content below the card title. It will fall back to the description of respective `appearance` config if not specified.
  * @param {JSX.Element} [props.helper] Helper content below the card description.
- * @param {boolean} [props.hideIcon=false] Whether hide the leading icon.
- * @param {'center'|'top'} [props.alignIcon='center'] Specify the vertical alignment of leading icon.
  * @param {JSX.Element} [props.indicator] Indicator of actions or status on the right side of the card.
+ * @param {'center'|'top'} [props.alignIcon='center'] Specify the vertical alignment of leading icon.
  * @param {'center'|'top'} [props.alignIndicator='center'] Specify the vertical alignment of `indicator`.
  * @param {Array<JSX.Element>} [props.children] Children to be rendered if needs more content within the card.
  */
 export default function AccountCard( {
 	className,
-	appearance,
 	disabled = false,
-	description,
+	appearance = 'empty',
+	icon = appearanceDict[ appearance ].icon,
+	title = appearanceDict[ appearance ].title,
+	description = appearanceDict[ appearance ].description,
 	helper,
-	hideIcon = false,
 	alignIcon = 'center',
 	indicator,
 	alignIndicator = 'center',
 	children,
 } ) {
-	const { icon, title, defaultDescription } =
-		typeof appearance === 'object'
-			? appearance
-			: appearanceDict[ appearance ];
-
 	const cardClassName = classnames(
 		'gla-account-card',
 		disabled ? 'gla-account-card--is-disabled' : false,
@@ -122,7 +124,7 @@ export default function AccountCard( {
 		<Section.Card className={ cardClassName }>
 			<Section.Card.Body>
 				<Flex gap={ 4 }>
-					{ ! hideIcon && (
+					{ icon && (
 						<FlexItem className={ iconClassName }>
 							{ icon }
 						</FlexItem>
@@ -133,9 +135,11 @@ export default function AccountCard( {
 								{ title }
 							</Subsection.Title>
 						) }
-						<div className="gla-account-card__description">
-							{ description || defaultDescription }
-						</div>
+						{ description && (
+							<div className="gla-account-card__description">
+								{ description }
+							</div>
+						) }
 						{ helper && (
 							<div className="gla-account-card__helper">
 								{ helper }

--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -98,7 +98,7 @@ const alignStyleName = {
 export default function AccountCard( {
 	className,
 	disabled = false,
-	appearance = 'empty',
+	appearance = APPEARANCE.EMPTY,
 	icon = appearanceDict[ appearance ].icon,
 	title = appearanceDict[ appearance ].title,
 	description = appearanceDict[ appearance ].description,

--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -47,6 +47,10 @@ const appearanceDict = {
 	[ APPEARANCE.GOOGLE_MERCHANT_CENTER ]: {
 		icon: googleLogo,
 		title: __( 'Google Merchant Center', 'google-listings-and-ads' ),
+		description: __(
+			'Required to sync products and list on Google Shopping',
+			'google-listings-and-ads'
+		),
 	},
 	[ APPEARANCE.GOOGLE_ADS ]: {
 		icon: googleLogo,

--- a/js/src/components/contact-information/contact-information-preview-card.js
+++ b/js/src/components/contact-information/contact-information-preview-card.js
@@ -44,6 +44,7 @@ export default function ContactInformationPreviewCard( {
 		/>
 	);
 	let description;
+	let title;
 
 	if ( loading ) {
 		description = (
@@ -54,18 +55,16 @@ export default function ContactInformationPreviewCard( {
 			></span>
 		);
 	} else if ( warning ) {
-		appearance = {
-			title: (
-				<>
-					<Icon
-						icon={ warningIcon }
-						size={ 24 }
-						className="gla-contact-info-preview-card__notice-icon"
-					/>
-					{ warning }
-				</>
-			),
-		};
+		title = (
+			<>
+				<Icon
+					icon={ warningIcon }
+					size={ 24 }
+					className="gla-contact-info-preview-card__notice-icon"
+				/>
+				{ warning }
+			</>
+		);
 		description = (
 			<span className="gla-contact-info-preview-card__notice-details">
 				{ content }
@@ -79,8 +78,9 @@ export default function ContactInformationPreviewCard( {
 		<AccountCard
 			appearance={ appearance }
 			className="gla-contact-info-preview-card"
+			icon={ null }
+			title={ title }
 			description={ description }
-			hideIcon
 			indicator={ editButton }
 		></AccountCard>
 	);

--- a/js/src/components/google-account-card/google-account-card.js
+++ b/js/src/components/google-account-card/google-account-card.js
@@ -12,7 +12,7 @@ export default function GoogleAccountCard( { disabled = false } ) {
 	const { google, scope, hasFinishedResolution } = useGoogleAccount();
 
 	if ( ! hasFinishedResolution ) {
-		return <AccountCard appearance={ {} } description={ <AppSpinner /> } />;
+		return <AccountCard description={ <AppSpinner /> } />;
 	}
 
 	const isConnected = google?.active === 'yes';

--- a/js/src/settings/account-cards-demo.js
+++ b/js/src/settings/account-cards-demo.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { Icon, warning as warningIcon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import AccountCard, { APPEARANCE } from '.~/components/account-card';
+import AppSpinner from '.~/components/app-spinner';
+import AppButton from '.~/components/app-button';
+import ConnectedIconLabel from '.~/components/connected-icon-label';
+import LoadingLabel from '.~/components/loading-label';
+import wpLogoURL from '../setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/wpcom-account-card/wp-logo.svg';
+
+const wpLogo = <img src={ wpLogoURL } width="40" height="40" alt="" />;
+const style = {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: '24px',
+	width: '680px',
+	margin: '0 auto 24px',
+};
+
+// For temporary demo.
+
+export default function AccountCardsDemo() {
+	return (
+		<div style={ style }>
+			<div>
+				Fully custom AccountCard appearance from the consumer side
+				<AccountCard
+					icon={ wpLogo }
+					title="WordPress.com"
+					description="user.somebo@example.com"
+					indicator={ <ConnectedIconLabel /> }
+				/>
+			</div>
+			<div>
+				The original usage has not changed
+				<AccountCard
+					appearance={ APPEARANCE.GOOGLE }
+					description="user.somebo@example.com"
+					helper="This Google account is connected to your store’s product feed."
+					indicator={ <LoadingLabel text="Connecting…" /> }
+				/>
+			</div>
+			<div>
+				Use default description
+				<AccountCard
+					appearance={ APPEARANCE.GOOGLE_ADS }
+					indicator={
+						<AppButton isSecondary text="Allow full access" />
+					}
+				/>
+			</div>
+			<div>
+				Specify description
+				<AccountCard
+					appearance={ APPEARANCE.GOOGLE_ADS }
+					description="Account 123456789"
+					indicator={
+						<AppButton isSecondary text="Switch account" />
+					}
+				/>
+			</div>
+			<div>
+				Warning of contact info without icon
+				<AccountCard
+					className="gla-contact-info-preview-card"
+					icon={ null }
+					title={
+						<>
+							<Icon
+								className="gla-contact-info-preview-card__notice-icon"
+								icon={ warningIcon }
+								size={ 24 }
+							/>
+							Please add your store address
+						</>
+					}
+					helper="Google requires the store address for all stores using Google Merchant Center."
+					indicator={ <AppButton isSecondary text="Edit" /> }
+				/>
+			</div>
+			<div>
+				Show loading spinner by empty appearance
+				<AccountCard description={ <AppSpinner /> } />
+			</div>
+		</div>
+	);
+}

--- a/js/src/settings/index.js
+++ b/js/src/settings/index.js
@@ -17,6 +17,7 @@ import ReconnectAccounts from './reconnect-accounts';
 import EditStoreAddress from './edit-store-address';
 import EditPhoneNumber from './edit-phone-number';
 import './index.scss';
+import AccountCardsDemo from './account-cards-demo'; // For temporary demo.
 
 const Settings = () => {
 	const { subpath } = getQuery();
@@ -43,6 +44,18 @@ const Settings = () => {
 		case subpaths.editStoreAddress:
 			return <EditStoreAddress />;
 		default:
+	}
+
+	// For temporary demo.
+	if ( true ) {
+		return (
+			<div className="gla-settings">
+				<NavigationClassic />
+				<DisconnectAccounts />
+				<ContactInformationPreview />
+				<AccountCardsDemo />
+			</div>
+		);
 	}
 
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc/index.js
@@ -76,10 +76,6 @@ const ConnectMC = () => {
 		<AccountCard
 			className="gla-connect-mc-card"
 			appearance={ APPEARANCE.GOOGLE_MERCHANT_CENTER }
-			description={ __(
-				'Required to sync products and list on Google Shopping',
-				'google-listings-and-ads'
-			) }
 		>
 			<CardDivider />
 			<Section.Card.Body>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account-card.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/create-account-card.js
@@ -15,10 +15,6 @@ const CreateAccountCard = ( props ) => {
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE_MERCHANT_CENTER }
-			description={ __(
-				'Create your Google Merchant Center account',
-				'google-listings-and-ads'
-			) }
 			indicator={
 				<CreateAccountButton
 					isSecondary

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/disabled-card.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/disabled-card.js
@@ -14,10 +14,6 @@ const DisabledCard = () => {
 		<AccountCard
 			disabled
 			appearance={ APPEARANCE.GOOGLE_MERCHANT_CENTER }
-			description={ __(
-				'Required to sync products and list on Google',
-				'google-listings-and-ads'
-			) }
 			indicator={
 				<Button isSecondary disabled>
 					{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/disabled-card.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/disabled-card.js
@@ -16,7 +16,7 @@ const DisabledCard = () => {
 			appearance={ APPEARANCE.GOOGLE_MERCHANT_CENTER }
 			indicator={
 				<Button isSecondary disabled>
-					{ __( 'Connect', 'google-listings-and-ads' ) }
+					{ __( 'Create Account', 'google-listings-and-ads' ) }
 				</Button>
 			}
 		/>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/wpcom-account-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/wordpressdotcom-account/wpcom-account-card/index.js
@@ -12,20 +12,18 @@ import wpLogoURL from './wp-logo.svg';
 const WPComAccountCard = ( props ) => {
 	return (
 		<AccountCard
-			appearance={ {
-				icon: (
-					<img
-						src={ wpLogoURL }
-						alt={ __(
-							'WordPress.com Logo',
-							'google-listings-and-ads'
-						) }
-						width="40"
-						height="40"
-					/>
-				),
-				title: 'WordPress.com',
-			} }
+			icon={
+				<img
+					src={ wpLogoURL }
+					alt={ __(
+						'WordPress.com Logo',
+						'google-listings-and-ads'
+					) }
+					width="40"
+					height="40"
+				/>
+			}
+			title="WordPress.com"
 			{ ...props }
 		/>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up PR from https://github.com/woocommerce/google-listings-and-ads/pull/1102#discussion_r753686922, and based on PR #1119.

- Adjust the `<AccountCard>` props to make their usages clearer and apply them on custom appearance cards.
    - Contact information preview card
    - Default WordPress account card
    - Loading state of Google account card
- Add default description for Google Merchant Center card appearance and apply it on relevant cards.
    - Create account card
    - Connect account card
    - Disabled card
- Tweak the button wording of the disabled Google Merchant Center card.

### Additional note


I added a demo for the sake of easy viewing of the various ways to use the `<AccountCard>`

- [x] :warning: Revert https://github.com/woocommerce/google-listings-and-ads/commit/ec10fb48841e549ebf012eeef43b482432fd2b4c before merging this PR.

### Screenshots:

#### Contact information preview card

![2021-11-29 11 39 21](https://user-images.githubusercontent.com/17420811/143810148-61bffe5a-20ad-4813-a7c2-120afe05f9f0.png)

https://user-images.githubusercontent.com/17420811/143810086-5a8d5f4e-beab-46c3-b023-905aa96a4712.mp4

#### Default WordPress account card

![image](https://user-images.githubusercontent.com/17420811/143810583-6f45931e-1ba1-4773-bedd-bdf1e624f59f.png)

#### Loading state of Google account card

![image](https://user-images.githubusercontent.com/17420811/143810620-375fb35c-5bd8-4786-9e13-c3d1a524e4d3.png)

#### Default description and adjusted wordings of Google Merchant Center cards

![2021-11-29 11 53 53](https://user-images.githubusercontent.com/17420811/143810176-77bf1a1e-69a0-40f7-98f6-edc38e9f0824.png)

![2021-11-29 11 55 23](https://user-images.githubusercontent.com/17420811/143810184-9181bdf5-1485-4f9e-9961-cc28a25bf2cb.png)

![2021-11-29 11 54 47](https://user-images.githubusercontent.com/17420811/143810183-6a309f1a-d2de-48be-8e13-9f047875a540.png)

### Detailed test instructions:

💡  Currently, we only have the Google account reconnection flow that might show [the loading Google account card](https://github.com/woocommerce/google-listings-and-ads/blob/8af03363a9b501c47c4e3b0c52896d131d0c4900/js/src/components/google-account-card/google-account-card.js#L14). But in addition to disconnecting your Google account and entering the reconnection process, and allowing only partial authorization during the process, then you would have the chance to enter this logic.

Due to the tedious process of adjusting the connection status of Google account and the API response time gap, it will take much effort and still has a very low chance of reaching that condition. Instead, in step 3 of test instructions, you could view the last demo card, which is created in the same code, on the GLA Settings page to check if it shows correctly.

1. Go to the onboarding setup to see if the WordPress account card is displayed correctly as before.
2. Go to the GLA Settings page to see if the preview of contact information is displayed correctly as before.
    - To check the warning state, you could return a mocking data before line 519 at [actions.js](https://github.com/woocommerce/google-listings-and-ads/blob/8af03363a9b501c47c4e3b0c52896d131d0c4900/js/src/data/actions.js#L518-L523) with:
    ```js
    return {
    	type: TYPES.RECEIVE_MC_CONTACT_INFORMATION,
    	data: {
    		id: 123,
    		phone_number: '',
    		is_mc_address_different: true,
    		mc_address: {},
    		wc_address: {},
    	},
    };
    ```
3. Check all demo cards on the GLA Settings page.
    ![image](https://user-images.githubusercontent.com/17420811/143816975-2d2b4bea-ce4c-403f-a850-34b5b55bd800.png)

### Changelog entry
