### PR TITLE
UX Improvement: Refetch list of Google Merchant Center accounts when users choose to connect to a different account

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connected-card.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connected-card.js
@@ -33,6 +33,17 @@ const ConnectedCard = ( props ) => {
 
 	const domain = new URL( getSetting( 'homeUrl' ) ).host;
 
+	/**
+	 * Event handler to switch GMC account. Upon click, it will:
+	 *
+	 * 1. Display a notice to indicate disconnection in progress, and advise users to wait.
+	 * 2. Call API to disconnect the current connected GMC account.
+	 * 3. Call API to refetch list of GMC accounts.
+	 * Users may have just created a new account,
+	 * and we want that new account to show up in the list.
+	 * 4. Call API to refetch GMC account connection status.
+	 * 5. If there is an error in the above API calls, display an error notice.
+	 */
 	const handleSwitch = async () => {
 		const { notice } = await createNotice(
 			'info',
@@ -44,6 +55,7 @@ const ConnectedCard = ( props ) => {
 
 		try {
 			await fetchGoogleMCDisconnect();
+			invalidateResolution( 'getExistingGoogleMCAccounts', [] );
 			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( error ) {
 			createNotice(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When I was testing https://github.com/woocommerce/google-listings-and-ads/pull/1119, I found that if I create a new Google Merchant Center account, got it connected, and then choose to click on "Or, connect to a different Google Merchant Center account" button (see screenshot below), the newly created GMC account does not show up in the dropdown SelectControl in the Connect MC card.

Connected card, with the button to connect to a different GMC account:

![image](https://user-images.githubusercontent.com/417342/143908094-9218e7ec-6ca0-4151-8982-936d5ef1e087.png)

Connect MC card - the newly created GMC account does not show up in the dropdown control:

![image](https://user-images.githubusercontent.com/417342/143908311-d9af7ab8-630a-4099-b9f9-eea72cdefbff.png)

If users refresh the page, then the account will show up in the dropdown SelectControl:

This PR fixes the issue by refetching the list of GMC account when users click on the "Or, connect to a different Google Merchant Center account" button.

### Detailed test instructions:

1. Go to Setup MC.
2. In Setup MC Step 1, complete the WordPress.com and Google account connection.
3. For the Google Merchant Center account, choose to create a new GMC account, and proceed to get it connected. You should see the Connected card as per above screenshot. Take note of your new GMC account ID.
4. Click on the "Or, connect to a different Google Merchant Center account" button. Wait for a while, and you should see the Connect MC card as per above screenshot.
5. Verify that the newly created GMC account is in the dropdown list in the Connect MC card.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Refetch list of GMC accounts when users choose to connect to a different GMC accounts.
