### PR TITLE
Setup MC Step 1: Refetch list of GMC accounts when users choose to switch account

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/connect-mc/index.js
@@ -22,7 +22,8 @@ import useCreateMCAccount from '../useCreateMCAccount';
 import CreatingCard from '../creating-card';
 import './index.scss';
 
-const ConnectMC = () => {
+const ConnectMC = ( props ) => {
+	const { onSwitchAccount } = props;
 	const [ value, setValue ] = useState();
 	const [ handleConnectMC, resultConnectMC ] = useConnectMCAccount( value );
 	const [ handleCreateAccount, resultCreateAccount ] = useCreateMCAccount();
@@ -34,7 +35,7 @@ const ConnectMC = () => {
 				message={ resultConnectMC.error.message }
 				claimedUrl={ resultConnectMC.error.claimed_url }
 				newUrl={ resultConnectMC.error.new_url }
-				onSelectAnotherAccount={ resultConnectMC.reset }
+				onSwitchAccount={ onSwitchAccount }
 			/>
 		);
 	}
@@ -52,10 +53,7 @@ const ConnectMC = () => {
 					resultConnectMC.error?.website_url ||
 					resultCreateAccount.error?.website_url
 				}
-				onSwitchAccount={ () => {
-					resultConnectMC.reset();
-					resultCreateAccount.reset();
-				} }
+				onSwitchAccount={ onSwitchAccount }
 			/>
 		);
 	}

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/non-connected.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/non-connected.js
@@ -18,7 +18,7 @@ const NonConnected = () => {
 	}
 
 	if ( existingAccounts.length > 0 ) {
-		return <ConnectMC />;
+		return <ConnectMC onSwitchAccount={ invalidateResolution } />;
 	}
 
 	return <CreateAccount onSwitchAccount={ invalidateResolution } />;

--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/switch-url-card/index.js
@@ -23,7 +23,7 @@ import AppInputLinkControl from '.~/components/app-input-link-control';
 import './index.scss';
 
 const SwitchUrlCard = ( props ) => {
-	const { id, claimedUrl, newUrl, onSelectAnotherAccount = () => {} } = props;
+	const { id, claimedUrl, newUrl, onSwitchAccount } = props;
 	const { createNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
 	const [
@@ -54,16 +54,12 @@ const SwitchUrlCard = ( props ) => {
 		}
 	};
 
-	const handleUseDifferentMCClick = () => {
-		onSelectAnotherAccount();
-	};
-
 	if ( response && response.status === 403 ) {
 		return (
 			<ReclaimUrlCard
 				id={ error.id }
 				websiteUrl={ error.website_url }
-				onSwitchAccount={ handleUseDifferentMCClick }
+				onSwitchAccount={ onSwitchAccount }
 			/>
 		);
 	}
@@ -86,7 +82,7 @@ const SwitchUrlCard = ( props ) => {
 					eventProps={ {
 						context: 'switch-url',
 					} }
-					onClick={ handleUseDifferentMCClick }
+					onClick={ onSwitchAccount }
 				>
 					{ __( 'Switch account', 'google-listings-and-ads' ) }
 				</AppButton>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the Switch URL card and Reclaim URL card, when users choose to "Switch account", they will go back to the Connect MC card. The Google Merchant Center accounts in the dropdown list is retrieved from the wp-data store, and they may be stale / not up-to-date data. This can present a problem when users create a new GMC account, then go into Switch URL card or Reclaim URL, click on the "Switch account" button, and the newly created account does not appear in the dropdown list.

This PR attempts to fix this the issue by always refetching the list of GMC accounts when users click on the "Switch account" button. The refetched list of GMC accounts may not immediately contain the newly created GMC account (shown in the demo video below), possibly due to some caching on the server side, which may be fixed in a separate PR.

https://user-images.githubusercontent.com/417342/144558088-e2981fac-3fae-42af-9917-f734ba0db14f.mp4

### Screenshots:

Connect MC card, where users can choose to connect an existing GMC account, or create a new one:

![image](https://user-images.githubusercontent.com/417342/144034670-a82407c4-eb4d-453b-96dc-2295f819bf3e.png)

Reclaim URL card, with "Switch account" button:

![image](https://user-images.githubusercontent.com/417342/144034611-6756fd72-2f27-41c6-9371-71de958133da.png)


### Detailed test instructions:

Pre-condition: you should already have an existing GMC account connected to your site, so that you are able to see Switch URL card or Reclaim URL card below.

1. Go to Connection Test page and disconnect all accounts.
1. Open your browser dev tools: network panel.
1. Go to Setup MC.
2. Proceed with WordPress.com and Google account connection.
3. In Google Merchant Center section, choose to create a new GMC account. Proceed through warning modal and terms agreement modal. You should see the Switch URL card or Reclaim URL card. Note down the GMC account ID.
4. Click on the "Switch account" button in the card. There should be a `GET /mc/accounts` request in the network panel. The response would be an array, and it should contain an `id` that matches the newly created GMC account ID. If it does not, refresh the page and look into the same request again. After a few minutes, the ID should show up in the response.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Refetch list of GMC accounts when users choose to "Switch account" in Setup MC Step 1.
