### PR TITLE
Force colors in GH actions.

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -11,6 +11,8 @@ jobs:
   BundleSize:
     name: Bundle size
     runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -7,6 +7,8 @@ on:
       - develop
   pull_request:
 
+env:
+  FORCE_COLOR: 2
 jobs:
   Setup:
     name: Setup for jobs

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -11,6 +11,8 @@ jobs:
   UnitTests:
     name: JavaScript unit tests
     runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION

### Changes proposed in this Pull Request:
Force colors in GH actions.

Addresses part of https://github.com/woocommerce/google-listings-and-ads/issues/1047


### Screenshots:

![image](https://user-images.githubusercontent.com/17435/144622095-e5ee933b-81f7-4401-b7d9-ec4a7e7760d8.png)


### Detailed test instructions:

1. See GH actions' details


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
