### PR TITLE
Remove `node` and `npm` requirements during the PHP unit tests on GitHub Actions

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Prepare node
-        uses: ./.github/actions/prepare-node
-
       - name: Prepare PHP
         uses: ./.github/actions/prepare-php
         with:
@@ -39,9 +36,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Prepare node
-        uses: ./.github/actions/prepare-node
-
       - name: Prepare PHP
         uses: ./.github/actions/prepare-php
         with:
@@ -54,9 +48,6 @@ jobs:
         run: |
           sudo systemctl start mysql.service
           mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
-
-      - name: Build client bundles
-        run: npm run dev
 
       - name: Install WP tests
         shell: bash

--- a/src/TaskList/CompleteSetup.php
+++ b/src/TaskList/CompleteSetup.php
@@ -6,6 +6,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\TaskList;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\Asset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -19,8 +21,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\BuiltScriptDependencyArray
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\TaskList
  */
-class CompleteSetup implements Deactivateable, Service, Registerable, MerchantCenterAwareInterface {
+class CompleteSetup implements Deactivateable, Service, Registerable, Conditional, MerchantCenterAwareInterface {
 
+	use AdminConditional;
 	use MerchantCenterAwareTrait;
 	use PluginHelper;
 	use TaskListTrait;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1047 

- Add `Conditional` interface to `CompleteSetup` class for avoiding loading client assets during PHP unit test.
- Remove `node` and `npm` requirements during the PHP unit tests on GitHub Actions.

### Detailed test instructions:

1. Go to [PHP unit tests job of this PR](https://github.com/woocommerce/google-listings-and-ads/actions/runs/1542865725) for more details.
2. Open browser's DevTool. Go to the Home page of WC: `/wp-admin/admin.php?page=wc-admin`.
3. Check if the `/wp-content/plugins/google-listings-and-ads/js/build/task-complete-setup.js` is loaded by the Network tab of DevTool.
    - Or check if the "Set up Google Listings & Ads" item is shown on the "Things to do next" task list.
    - Before completing the onboarding setup
        ![image](https://user-images.githubusercontent.com/17420811/144781011-dac3f098-3069-4236-8c1b-37572fbb4939.png)
    - After completing the onboarding setup
        ![image](https://user-images.githubusercontent.com/17420811/144781142-7ce65052-a1c7-433e-8560-042b3915bc7a.png)

### Changelog entry
