### PR TITLE
Remove type hint on ActionScheduler::cancel().

### DIFF
--- a/src/ActionScheduler/ActionScheduler.php
+++ b/src/ActionScheduler/ActionScheduler.php
@@ -157,11 +157,11 @@ class ActionScheduler implements ActionSchedulerInterface, Service {
 	 * @param string     $hook The hook that the job will trigger.
 	 * @param array|null $args Args that would have been passed to the job.
 	 *
-	 * @return string The scheduled action ID if a scheduled action was found.
+	 * @return int The scheduled action ID if a scheduled action was found.
 	 *
 	 * @throws ActionSchedulerException If no matching action found.
 	 */
-	public function cancel( string $hook, $args = [] ): string {
+	public function cancel( string $hook, $args = [] ) {
 		$action_id = as_unschedule_action( $hook, $args, $this->get_slug() );
 
 		if ( null === $action_id ) {

--- a/src/ActionScheduler/ActionSchedulerInterface.php
+++ b/src/ActionScheduler/ActionSchedulerInterface.php
@@ -127,11 +127,11 @@ interface ActionSchedulerInterface {
 	 * @param string     $hook The hook that the job will trigger.
 	 * @param array|null $args Args that would have been passed to the job.
 	 *
-	 * @return string The scheduled action ID if a scheduled action was found.
+	 * @return int The scheduled action ID if a scheduled action was found.
 	 *
 	 * @throws ActionSchedulerException If no matching action found.
 	 */
-	public function cancel( string $hook, $args = [] ): string;
+	public function cancel( string $hook, $args = [] );
 
 	/**
 	 * Retrieve an action.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removing the type hint on `ActionScheduler::cancel()`. We are not really dealing with the return type `string` but `int`. This looks like an error in AS. An issue was created for this in the AS repo:

https://github.com/woocommerce/action-scheduler/issues/792

We could just change the type hint to `int` but it is not clear yet if AS will be fixed by changing the documentation and leaving `int` or changing the returned value type and keeping the documentation. So for now this is the safest approach.

### Detailed test instructions:

Check #1141 for reproduction instructions.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

Fix -  Fatal error on plugin deactivation.
>
