### PR TITLE
Shipping Integration - Pre-fill shipping rates

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
@@ -140,7 +140,7 @@ class ShippingRateBatchController extends ShippingRateController {
 					'errors'  => $errors,
 					'success' => $responses,
 				],
-				201
+				200
 			);
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
@@ -52,7 +52,7 @@ class ShippingRateBatchController extends ShippingRateController {
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => [
 						'country_codes' => [
-							'type'              => 'string',
+							'type'              => 'array',
 							'description'       => __( 'Array of country codes in ISO 3166-1 alpha-2 format.', 'google-listings-and-ads' ),
 							'context'           => [ 'view' ],
 							'sanitize_callback' => $this->get_country_code_sanitize_callback(),

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateBatchController.php
@@ -42,6 +42,33 @@ class ShippingRateBatchController extends ShippingRateController {
 				'schema' => $this->get_api_response_schema_callback(),
 			]
 		);
+
+		$this->register_route(
+			"{$this->route_base}/suggestions/batch",
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_batch_suggestions_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => [
+						'country_codes' => [
+							'type'              => 'string',
+							'description'       => __( 'Array of country codes in ISO 3166-1 alpha-2 format.', 'google-listings-and-ads' ),
+							'context'           => [ 'view' ],
+							'sanitize_callback' => $this->get_country_code_sanitize_callback(),
+							'validate_callback' => $this->get_country_code_validate_callback(),
+							'minItems'          => 1,
+							'required'          => true,
+							'uniqueItems'       => true,
+							'items'             => [
+								'type' => 'string',
+							],
+						],
+					],
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
 	}
 
 	/**
@@ -69,6 +96,39 @@ class ShippingRateBatchController extends ShippingRateController {
 
 				$response = $this->server->dispatch_request( $new_request );
 				if ( 201 !== $response->get_status() ) {
+					$errors[] = $response->get_data();
+				} else {
+					$responses[] = $response->get_data();
+				}
+			}
+
+			return new Response(
+				[
+					'errors'  => $errors,
+					'success' => $responses,
+				],
+				201
+			);
+		};
+	}
+
+	/**
+	 * Get the callback for creating items via batch.
+	 *
+	 * @return callable
+	 */
+	protected function get_batch_suggestions_callback(): callable {
+		return function( Request $request ) {
+			$country_codes = $request->get_param( 'country_codes' );
+
+			$responses = [];
+			$errors    = [];
+			foreach ( $country_codes as $country_code ) {
+				$new_request = new Request( 'GET', "/{$this->get_namespace()}/{$this->route_base}/suggestions" );
+				$new_request->set_param( 'country_code', $country_code );
+
+				$response = $this->server->dispatch_request( $new_request );
+				if ( 200 !== $response->get_status() ) {
 					$errors[] = $response->get_data();
 				} else {
 					$responses[] = $response->get_data();

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -37,6 +37,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
@@ -93,8 +94,8 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( PhoneVerificationController::class, PhoneVerification::class );
 		$this->share_with_container( MerchantCenterAccountController::class );
 		$this->share_with_container( MerchantCenterReportsController::class );
-		$this->share_with_container( ShippingRateBatchController::class );
-		$this->share_with_container( ShippingRateController::class );
+		$this->share( ShippingRateBatchController::class, ShippingRateQuery::class, ShippingZone::class );
+		$this->share( ShippingRateController::class, ShippingRateQuery::class, ShippingZone::class );
 		$this->share_with_container( ShippingTimeBatchController::class );
 		$this->share_with_container( ShippingTimeController::class );
 		$this->share( SiteVerificationController::class, SiteVerification::class );

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -145,4 +145,15 @@ class WC {
 	public function get_shipping_zone( int $zone_id ): ?WC_Shipping_Zone {
 		return WC_Shipping_Zones::get_zone( $zone_id );
 	}
+
+	/**
+	 * Get Base Currency Code.
+	 *
+	 * @return string
+	 *
+	 * @since x.x.x
+	 */
+	public function get_woocommerce_currency(): string {
+		return get_woocommerce_currency();
+	}
 }

--- a/src/Shipping/ShippingZone.php
+++ b/src/Shipping/ShippingZone.php
@@ -6,6 +6,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use WC_Shipping_Method;
+use WC_Shipping_Zone;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -18,12 +20,21 @@ defined( 'ABSPATH' ) || exit;
  */
 class ShippingZone implements Service {
 
+	public const METHOD_FLAT_RATE = 'flat_rate';
+	public const METHOD_PICKUP    = 'local_pickup';
+	public const METHOD_FREE      = 'free_shipping';
+
 	use GoogleHelper;
 
 	/**
 	 * @var WC
 	 */
 	protected $wc;
+
+	/**
+	 * @var array|null Array of shipping methods for each country.
+	 */
+	protected $methods_countries = null;
 
 	/**
 	 * ShippingZone constructor.
@@ -37,34 +48,221 @@ class ShippingZone implements Service {
 	/**
 	 * Gets the shipping countries from the WooCommerce shipping zones.
 	 *
+	 * Note: This method only returns the countries that have at least one shipping method.
+	 *
 	 * @return string[]
 	 */
 	public function get_shipping_countries(): array {
-		$countries = [];
-		foreach ( $this->wc->get_shipping_zones() as $zone ) {
-			$zone = $this->wc->get_shipping_zone( $zone['zone_id'] );
-			foreach ( $zone->get_zone_locations() as $location ) {
-				switch ( $location->type ) {
-					case 'country':
-						$countries[ $location->code ] = $location->code;
-						break;
-					case 'continent':
-						$countries = array_merge( $countries, $this->get_countries_from_continent( $location->code ) );
-						break;
-					case 'state':
-						$country_code               = $this->get_country_of_state( $location->code );
-						$countries[ $country_code ] = $country_code;
-						break;
-					default:
-						break;
-				}
-			}
-		}
+		$this->parse_shipping_zones();
+
+		$countries = array_keys( $this->methods_countries ?: [] );
 
 		// Match the list of shipping countries with the list of Merchant Center supported countries.
 		$countries = array_intersect( $countries, $this->get_mc_supported_countries() );
 
 		return array_values( $countries );
+	}
+
+	/**
+	 * Gets the shipping methods for the given country.
+	 *
+	 * @param string $country_code
+	 *
+	 * @return array
+	 */
+	public function get_shipping_methods_for_country( string $country_code ): array {
+		$this->parse_shipping_zones();
+
+		return ! empty( $this->methods_countries[ $country_code ] ) ? array_values( $this->methods_countries[ $country_code ] ) : [];
+	}
+
+	/**
+	 * Parses the WooCommerce shipping zones and maps them into the self::$methods_countries array.
+	 */
+	protected function parse_shipping_zones(): void {
+		// Don't parse if already parsed.
+		if ( null !== $this->methods_countries ) {
+			return;
+		}
+		$this->methods_countries = [];
+
+		foreach ( $this->wc->get_shipping_zones() as $zone ) {
+			$zone = $this->wc->get_shipping_zone( $zone['zone_id'] );
+			/**
+			 * @var WC_Shipping_Method[] $methods
+			 */
+			$methods = $zone->get_shipping_methods();
+
+			// Skip if no shipping methods.
+			if ( empty( $methods ) ) {
+				continue;
+			}
+
+			foreach ( $methods as $method ) {
+				// Check if the method is supported and return its properties.
+				$method = $this->parse_method( $method );
+
+				// Skip if method is not supported.
+				if ( null === $method ) {
+					continue;
+				}
+
+				// Add the method to the list of methods for each country in the zone.
+				foreach ( $this->get_shipping_countries_from_zone( $zone ) as $country ) {
+					// Initialize the shipping methods array if it doesn't exist.
+					$this->methods_countries[ $country ] = $this->methods_countries[ $country ] ?? [];
+
+					// Add the method to the array of shipping methods for the country if it doesn't exist.
+					if ( ! isset( $this->methods_countries[ $country ][ $method['id'] ] ) ||
+						 self::should_method_be_replaced( $method, $this->methods_countries[ $country ][ $method['id'] ] )
+					) {
+						$this->methods_countries[ $country ][ $method['id'] ] = $method;
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Checks whether the shipping method should be replaced with a more suitable one.
+	 *
+	 * @param array $method
+	 * @param array $existing_method
+	 *
+	 * @return bool
+	 */
+	protected static function should_method_be_replaced( array $method, array $existing_method ): bool {
+		if ( $method['id'] !== $existing_method['id'] ) {
+			return false;
+		}
+
+		if (
+			// If a flat-rate/local-pickup method already exists, we replace it with the one with the higher cost.
+			self::does_method_have_higher_cost( $method, $existing_method ) ||
+			// If a free-shipping method already exists, we replace it with the one with the higher required minimum order amount.
+			self::does_method_have_higher_min_amount( $method, $existing_method )
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether the given method has a higher cost than the existing method.
+	 *
+	 * @param array $method          A shipping method.
+	 * @param array $existing_method Another shipping method to compare with.
+	 *
+	 * @return bool
+	 */
+	protected static function does_method_have_higher_cost( array $method, array $existing_method ): bool {
+		if ( $method['id'] !== $existing_method['id'] ) {
+			return false;
+		}
+
+		return in_array( $method['id'], [ self::METHOD_FLAT_RATE, self::METHOD_PICKUP ], true ) && $method['options']['cost'] > $existing_method['options']['cost'];
+	}
+
+	/**
+	 * Checks whether the given method has a minimum order amount higher than the existing method.
+	 *
+	 * @param array $method          A shipping method.
+	 * @param array $existing_method Another shipping method to compare with.
+	 *
+	 * @return bool
+	 */
+	protected static function does_method_have_higher_min_amount( array $method, array $existing_method ): bool {
+		if ( self::METHOD_FREE !== $method['id'] || $method['id'] !== $existing_method['id'] ) {
+			return false;
+		}
+
+		// If a free shipping method already exists but doesn't have a minimum order amount, we replace it with the one with the one that has one.
+		if ( isset( $method['options']['min_amount'] ) && ! isset( $existing_method['options']['min_amount'] ) ) {
+			return true;
+		}
+
+		return isset( $method['options']['min_amount'] ) && isset( $existing_method['options']['min_amount'] ) && $method['options']['min_amount'] > $existing_method['options']['min_amount'];
+	}
+
+	/**
+	 * Gets the list of countries defined in a shipping zone.
+	 *
+	 * @param WC_Shipping_Zone $zone
+	 *
+	 * @return string[] Array of country codes.
+	 */
+	protected function get_shipping_countries_from_zone( WC_Shipping_Zone $zone ): array {
+		$countries = [];
+		foreach ( $zone->get_zone_locations() as $location ) {
+			switch ( $location->type ) {
+				case 'country':
+					$countries[ $location->code ] = $location->code;
+					break;
+				case 'continent':
+					$countries = array_merge( $countries, $this->get_countries_from_continent( $location->code ) );
+					break;
+				case 'state':
+					$country_code               = $this->get_country_of_state( $location->code );
+					$countries[ $country_code ] = $country_code;
+					break;
+				default:
+					break;
+			}
+		}
+
+		return $countries;
+	}
+
+	/**
+	 * Parses the given shipping method and returns its properties if it's supported. Returns null otherwise.
+	 *
+	 * @param object|WC_Shipping_Method $method
+	 *
+	 * @return array|null Returns an array with the parsed shipping method or null if the shipping method is not supported. {
+	 *     Array of shipping method arguments.
+	 *
+	 *     @type string $id      The shipping method ID.
+	 *     @type string $title   The user-defined title of the shipping method.
+	 *     @type bool   $enabled A boolean indicating whether the shipping method is enabled or not.
+	 *     @type array  $options Array of options for the shipping method (varies based on the method type).
+	 * }
+	 */
+	protected function parse_method( object $method ): ?array {
+		$parsed_method = [
+			'id'       => $method->id,
+			'title'    => $method->title,
+			'enabled'  => $method->is_enabled(),
+			'currency' => $this->wc->get_woocommerce_currency(),
+			'options'  => [],
+		];
+
+		switch ( $method->id ) {
+			case self::METHOD_FLAT_RATE:
+			case self::METHOD_PICKUP:
+				$cost = $method->get_option( 'cost' );
+				// Check if the cost is a numeric value (and not null or a math expression).
+				if ( ! is_numeric( $cost ) ) {
+					return null;
+				}
+				$parsed_method['options']['cost'] = (float) $cost;
+				break;
+			case self::METHOD_FREE:
+				// Check if free shipping requires a minimum order amount.
+				$requires = $method->get_option( 'requires' );
+				if ( in_array( $requires, [ 'min_amount', 'either' ], true ) ) {
+					$parsed_method['options']['min_amount'] = (float) $method->get_option( 'min_amount' );
+				} elseif ( in_array( $requires, [ 'coupon', 'both' ], true ) ) {
+					// We can't sync this method if free shipping requires a coupon.
+					return null;
+				}
+				break;
+			default:
+				// We don't support other shipping methods.
+				return null;
+		}
+
+		return $parsed_method;
 	}
 
 	/**
@@ -97,5 +295,24 @@ class ShippingZone implements Service {
 		$location_codes = explode( ':', $state_code );
 
 		return $location_codes[0];
+	}
+
+	/**
+	 * Checks whether the given shipping method is valid.
+	 *
+	 * @param string $method
+	 *
+	 * @return bool
+	 */
+	public static function is_shipping_method_valid( string $method ): bool {
+		return in_array(
+			$method,
+			[
+				self::METHOD_FLAT_RATE,
+				self::METHOD_FREE,
+				self::METHOD_PICKUP,
+			],
+			true
+		);
 	}
 }

--- a/src/Shipping/ShippingZone.php
+++ b/src/Shipping/ShippingZone.php
@@ -68,7 +68,9 @@ class ShippingZone implements Service {
 	 *
 	 * @param string $country_code
 	 *
-	 * @return array
+	 * @return array[] Returns an array of shipping methods for the given country.
+	 *
+	 * @see ShippingZone::parse_method() for the format of the returned array.
 	 */
 	public function get_shipping_methods_for_country( string $country_code ): array {
 		$this->parse_shipping_zones();

--- a/tests/Unit/Shipping/ShippingZoneTest.php
+++ b/tests/Unit/Shipping/ShippingZoneTest.php
@@ -8,6 +8,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Countries;
+use WC_Shipping_Flat_Rate;
+use WC_Shipping_Free_Shipping;
+use WC_Shipping_Local_Pickup;
+use WC_Shipping_Method;
 use WC_Shipping_Zone;
 
 /**
@@ -20,11 +24,265 @@ use WC_Shipping_Zone;
  */
 class ShippingZoneTest extends UnitTest {
 
+	public function test_returns_supported_shipping_methods() {
+		// Return one sample shipping zone.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
+
+		// Create a sample flat-rate shipping method with a constant cost.
+		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
+		$flat_rate->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnCallback( function ( $option ) {
+					  if ( 'cost' === $option ) {
+						  return 10;
+					  }
+
+					  return null;
+				  } );
+		$pickup = $this->createMock( WC_Shipping_Local_Pickup::class );
+		$pickup->id = ShippingZone::METHOD_PICKUP;
+		$pickup->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnCallback( function ( $option ) {
+					  if ( 'cost' === $option ) {
+						  return 10;
+					  }
+
+					  return null;
+				  } );
+		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping->id = ShippingZone::METHOD_FREE;
+
+		// Adding one unsupported shipping method. This method should not be returned.
+		$unsupported_method     = $this->createMock( WC_Shipping_Method::class );
+		$unsupported_method->id = 'unsupported_method';
+
+		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate, $pickup, $free_shipping, $unsupported_method ] );
+
+		// Return the zone locations for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturn( $shipping_zone );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+
+		$this->assertCount( 3, $methods );
+
+		$methods_ids = array_map(
+			function ( $method ) {
+				return $method['id'];
+			},
+			$methods
+		);
+
+		$this->assertEqualSets(
+			[
+				ShippingZone::METHOD_FLAT_RATE,
+				ShippingZone::METHOD_PICKUP,
+				ShippingZone::METHOD_FREE,
+			],
+			$methods_ids
+		);
+	}
+
+	public function test_ignores_methods_with_null_cost() {
+		// Return one sample shipping zone.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
+
+		// Create a sample flat-rate shipping method with a constant cost.
+		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
+		$flat_rate->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnCallback( function ( $option ) {
+					  if ( 'cost' === $option ) {
+						  return null;
+					  }
+				  } );
+		$pickup = $this->createMock( WC_Shipping_Local_Pickup::class );
+		$pickup->id = ShippingZone::METHOD_PICKUP;
+		$pickup->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnCallback( function ( $option ) {
+					  if ( 'cost' === $option ) {
+						  return null;
+					  }
+				  } );
+
+		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate, $pickup ] );
+
+		// Return the zone locations for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturn( $shipping_zone );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+
+		$this->assertEmpty( $methods );
+	}
+
+	public function test_returns_shipping_method_properties() {
+		// Return one sample shipping zone.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
+
+		// Create a sample flat-rate shipping method with a constant cost.
+		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
+		$flat_rate->title = 'Flat Rate';
+		$flat_rate->expects( $this->any() )
+					->method( 'is_enabled' )
+					->willReturn( true );
+		$flat_rate->expects( $this->any() )
+					->method( 'get_option' )
+					->willReturnCallback( function ( $option ) {
+						if ( 'cost' === $option ) {
+							return 10;
+						}
+
+						return null;
+					} );
+
+		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
+
+		// Return the zone locations for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturn( $shipping_zone );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+
+		$this->assertCount( 1, $methods );
+		$this->assertEquals( ShippingZone::METHOD_FLAT_RATE, $methods[0]['id'] );
+		$this->assertEquals( 'Flat Rate', $methods[0]['title'] );
+		$this->assertEquals( true, $methods[0]['enabled'] );
+		$this->assertEquals( 'USD', $methods[0]['currency'] );
+		$this->assertNotEmpty( $methods[0]['options'] );
+		$this->assertEquals( 10, $methods[0]['options']['cost'] );
+	}
+
+	/**
+	 * @param string $requires
+	 *
+	 * @dataProvider return_free_shipping_min_amount_requirements
+	 */
+	public function test_returns_free_shipping_method_requires_min_amount( string $requires ) {
+		// Return one sample shipping zone.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
+
+		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping->id = ShippingZone::METHOD_FREE;
+		$free_shipping->expects( $this->any() )
+						->method( 'get_option' )
+						->willReturnCallback( function ( $option ) use ( $requires ) {
+							if ( 'requires' === $option ) {
+								return $requires;
+							}
+							if ( 'min_amount' === $option ) {
+								return 99.99;
+							}
+
+							return null;
+						} );
+
+		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $free_shipping ] );
+
+		// Return the zone locations for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturn( $shipping_zone );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+
+		$this->assertCount( 1, $methods );
+		$this->assertEquals( ShippingZone::METHOD_FREE, $methods[0]['id'] );
+		$this->assertNotEmpty( $methods[0]['options'] );
+		$this->assertEquals( 99.99, $methods[0]['options']['min_amount'] );
+	}
+
+	/**
+	 * @param string $requires
+	 *
+	 * @dataProvider return_free_shipping_coupon_requirements
+	 */
+	public function test_ignores_free_shipping_method_requires_coupon( string $requires ) {
+		// Return one sample shipping zone.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
+
+		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping->id = ShippingZone::METHOD_FREE;
+		$free_shipping->expects( $this->any() )
+						->method( 'get_option' )
+						->willReturnCallback( function ( $option ) use ( $requires ) {
+							if ( 'requires' === $option ) {
+								return $requires;
+							}
+
+							return null;
+						} );
+
+		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $free_shipping ] );
+
+		// Return the zone locations for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturn( $shipping_zone );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+
+		$this->assertCount( 0, $methods );
+	}
+
+	public function test_ignores_methods_with_mathematical_cost() {
+		// Return one sample shipping zone.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
+
+		// Create a sample flat-rate shipping method with a constant cost.
+		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
+		$flat_rate->title = 'Flat Rate';
+		$flat_rate->expects( $this->any() )
+					->method( 'is_enabled' )
+					->willReturn( true );
+		$flat_rate->expects( $this->any() )
+					->method( 'get_option' )
+					->willReturnCallback( function ( $option ) {
+						if ( 'cost' === $option ) {
+							return '[qty] * 5';
+						}
+
+						return null;
+					} );
+
+		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
+
+		// Return the zone locations for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturn( $shipping_zone );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+
+		$this->assertEmpty( $methods );
+	}
+
 	public function test_returns_shipping_countries() {
 		$shipping_zones = [
 			[
-				'id'             => 1,
-				'zone_id'        => 1,
+				'id'             => 0,
+				'zone_id'        => 0,
 				'zone_name'      => 'Local',
 				'zone_locations' => [
 					(object)[
@@ -38,8 +296,8 @@ class ShippingZoneTest extends UnitTest {
 				],
 			],
 			[
-				'id'             => 2,
-				'zone_id'        => 2,
+				'id'             => 1,
+				'zone_id'        => 1,
 				'zone_name'      => 'EU branches',
 				'zone_locations' =>  [
 					(object) [
@@ -53,8 +311,8 @@ class ShippingZoneTest extends UnitTest {
 				],
 			],
 			[
-				'id'             => 3,
-				'zone_id'        => 3,
+				'id'             => 2,
+				'zone_id'        => 2,
 				'zone_name'      => 'EU (Other)',
 				'zone_locations' => [
 					(object) [
@@ -70,14 +328,20 @@ class ShippingZoneTest extends UnitTest {
 				 ->method( 'get_shipping_zones' )
 				 ->willReturn( $shipping_zones );
 
-		// Mock the get_shipping_zone method to return the zone locations for the given zone id.
+		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
 		$this->wc->expects( $this->any() )
 				 ->method( 'get_shipping_zone' )
 				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
 					 $zone = $this->createMock( WC_Shipping_Zone::class );
 					 $zone->expects( $this->any() )
 						  ->method( 'get_zone_locations' )
-						  ->willReturn( $shipping_zones[ $zone_id - 1 ]['zone_locations'] );
+						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
+					 // We need at least one method for each country in order for it to show up in the list.
+					 $free_shipping     = $this->createMock( WC_Shipping_Free_Shipping::class );
+					 $free_shipping->id = ShippingZone::METHOD_FREE;
+					 $zone->expects( $this->any() )
+						  ->method( 'get_shipping_methods' )
+						  ->willReturn( [ $free_shipping ] );
 
 					 return $zone;
 				 } );
@@ -118,12 +382,382 @@ class ShippingZoneTest extends UnitTest {
 		);
 	}
 
+	public function test_ignores_shipping_countries_with_no_methods() {
+		$free_shipping     = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping->id = ShippingZone::METHOD_FREE;
+		$shipping_zones = [
+			[
+				'id'             => 0,
+				'zone_id'        => 0,
+				'zone_name'      => 'Local',
+				'zone_locations' => [
+					(object) [
+						'code' => 'GB',
+						'type' => 'country',
+					],
+				],
+				'methods' => [
+					$free_shipping
+				]
+			],
+			[
+				'id'             => 1,
+				'zone_id'        => 1,
+				'zone_name'      => 'France',
+				'zone_locations' => [
+					(object) [
+						'code' => 'FR',
+						'type' => 'country',
+					],
+				],
+				'methods' => [] // No methods for France.
+			],
+		];
+
+		// Mock the get_shipping_zones method to return the above array.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( $shipping_zones );
+
+		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
+					 $zone = $this->createMock( WC_Shipping_Zone::class );
+					 $zone->expects( $this->any() )
+						  ->method( 'get_zone_locations' )
+						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
+					 $zone->expects( $this->any() )
+						  ->method( 'get_shipping_methods' )
+						  ->willReturn( $shipping_zones[ $zone_id ]['methods'] );
+
+					 return $zone;
+				 } );
+
+		$this->assertEquals( [ 'GB' ], $this->shipping_zone->get_shipping_countries() );
+	}
+
+	public function test_returns_shipping_method_with_higher_cost() {
+		// Create a sample flat-rate shipping method with a constant cost.
+		$flat_rate_1 = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate_1->id = ShippingZone::METHOD_FLAT_RATE;
+		$flat_rate_1->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnCallback( function ( $option ) {
+					  if ( 'cost' === $option ) {
+						  return 10;
+					  }
+
+					  return null;
+				  } );
+		// Create another flat-rate shipping method with a higher cost.
+		$flat_rate_2 = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate_2->id = ShippingZone::METHOD_FLAT_RATE;
+		$flat_rate_2->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnCallback( function ( $option ) {
+					  if ( 'cost' === $option ) {
+						  return 20;
+					  }
+
+					  return null;
+				  } );
+		$shipping_zones = [
+			[
+				'id'             => 0,
+				'zone_id'        => 0,
+				'zone_name'      => 'Local',
+				'zone_locations' => [
+					(object)[
+						'code' => 'US:NV',
+						'type' => 'state',
+					],
+				],
+				'methods' => [
+					$flat_rate_1
+				]
+			],
+			[
+				'id'             => 1,
+				'zone_id'        => 1,
+				'zone_name'      => 'CA',
+				'zone_locations' => [
+					(object) [
+						'code' => 'US:CA',
+						'type' => 'state',
+					],
+				],
+				'methods' => [
+					$flat_rate_2
+				]
+			],
+		];
+
+		// Mock the get_shipping_zones method to return the above array.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( $shipping_zones );
+
+		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
+					 $zone = $this->createMock( WC_Shipping_Zone::class );
+					 $zone->expects( $this->any() )
+						  ->method( 'get_zone_locations' )
+						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
+					 $zone->expects( $this->any() )
+						  ->method( 'get_shipping_methods' )
+						  ->willReturn( $shipping_zones[ $zone_id ]['methods'] );
+
+					 return $zone;
+				 } );
+
+		$this->assertEquals( [ 'US' ], $this->shipping_zone->get_shipping_countries() );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+		$this->assertCount( 1, $methods );
+		$this->assertEquals( ShippingZone::METHOD_FLAT_RATE, $methods[0]['id'] );
+		$this->assertEquals( 20, $methods[0]['options']['cost'] );
+	}
+
+	public function test_returns_shipping_method_with_higher_min_order_amount() {
+		// Create a sample free-shipping method with a min amount option.
+		$free_shipping_1 = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping_1->id = ShippingZone::METHOD_FREE;
+		$free_shipping_1->expects( $this->any() )
+					  ->method( 'get_option' )
+					  ->willReturnCallback( function ( $option ) {
+						  if ( 'requires' === $option ) {
+							  return 'min_amount';
+						  }
+						  if ( 'min_amount' === $option ) {
+							  return 10.99;
+						  }
+
+						  return null;
+					  } );
+
+		// Create another free-shipping method with a higher min amount option.
+		$free_shipping_2 = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping_2->id = ShippingZone::METHOD_FREE;
+		$free_shipping_2->expects( $this->any() )
+					  ->method( 'get_option' )
+					  ->willReturnCallback( function ( $option ) {
+						  if ( 'requires' === $option ) {
+							  return 'min_amount';
+						  }
+						  if ( 'min_amount' === $option ) {
+							  return 50.99;
+						  }
+
+						  return null;
+					  } );
+		$shipping_zones = [
+			[
+				'id'             => 0,
+				'zone_id'        => 0,
+				'zone_name'      => 'Local',
+				'zone_locations' => [
+					(object)[
+						'code' => 'US:NV',
+						'type' => 'state',
+					],
+				],
+				'methods' => [
+					$free_shipping_1
+				]
+			],
+			[
+				'id'             => 1,
+				'zone_id'        => 1,
+				'zone_name'      => 'CA',
+				'zone_locations' => [
+					(object) [
+						'code' => 'US:CA',
+						'type' => 'state',
+					],
+				],
+				'methods' => [
+					$free_shipping_2
+				]
+			],
+		];
+
+		// Mock the get_shipping_zones method to return the above array.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( $shipping_zones );
+
+		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
+					 $zone = $this->createMock( WC_Shipping_Zone::class );
+					 $zone->expects( $this->any() )
+						  ->method( 'get_zone_locations' )
+						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
+					 $zone->expects( $this->any() )
+						  ->method( 'get_shipping_methods' )
+						  ->willReturn( $shipping_zones[ $zone_id ]['methods'] );
+
+					 return $zone;
+				 } );
+
+		$this->assertEquals( [ 'US' ], $this->shipping_zone->get_shipping_countries() );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+		$this->assertCount( 1, $methods );
+		$this->assertEquals( ShippingZone::METHOD_FREE, $methods[0]['id'] );
+		$this->assertEquals( 50.99, $methods[0]['options']['min_amount'] );
+	}
+
+	public function test_returns_shipping_method_with_existing_min_order_amount() {
+		// Create a sample free-shipping method WITHOUT min amount option.
+		$free_shipping_1 = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping_1->id = ShippingZone::METHOD_FREE;
+
+		// Create another free-shipping method with a min amount option specified.
+		$free_shipping_2 = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping_2->id = ShippingZone::METHOD_FREE;
+		$free_shipping_2->expects( $this->any() )
+					  ->method( 'get_option' )
+					  ->willReturnCallback( function ( $option ) {
+						  if ( 'requires' === $option ) {
+							  return 'min_amount';
+						  }
+						  if ( 'min_amount' === $option ) {
+							  return 10;
+						  }
+
+						  return null;
+					  } );
+		$shipping_zones = [
+			[
+				'id'             => 0,
+				'zone_id'        => 0,
+				'zone_name'      => 'Local',
+				'zone_locations' => [
+					(object)[
+						'code' => 'US:NV',
+						'type' => 'state',
+					],
+				],
+				'methods' => [
+					$free_shipping_1
+				]
+			],
+			[
+				'id'             => 1,
+				'zone_id'        => 1,
+				'zone_name'      => 'CA',
+				'zone_locations' => [
+					(object) [
+						'code' => 'US:CA',
+						'type' => 'state',
+					],
+				],
+				'methods' => [
+					$free_shipping_2
+				]
+			],
+		];
+
+		// Mock the get_shipping_zones method to return the above array.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( $shipping_zones );
+
+		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
+					 $zone = $this->createMock( WC_Shipping_Zone::class );
+					 $zone->expects( $this->any() )
+						  ->method( 'get_zone_locations' )
+						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
+					 $zone->expects( $this->any() )
+						  ->method( 'get_shipping_methods' )
+						  ->willReturn( $shipping_zones[ $zone_id ]['methods'] );
+
+					 return $zone;
+				 } );
+
+		$this->assertEquals( [ 'US' ], $this->shipping_zone->get_shipping_countries() );
+
+		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
+		$this->assertCount( 1, $methods );
+		$this->assertEquals( ShippingZone::METHOD_FREE, $methods[0]['id'] );
+		$this->assertEquals( 10, $methods[0]['options']['min_amount'] );
+	}
+
+	public function test_is_shipping_method_valid() {
+		$this->assertTrue( ShippingZone::is_shipping_method_valid( ShippingZone::METHOD_FLAT_RATE ) );
+		$this->assertFalse( ShippingZone::is_shipping_method_valid( 'some_random_method_that_should_not_be_valid' ) );
+	}
+
+	/**
+	 * Creates a mock WooCommerce shipping zone object covering the given country and including the given shipping methods.
+	 *
+	 * @param string $country
+	 * @param array $methods
+	 *
+	 * @return WC_Shipping_Zone|MockObject
+	 */
+	protected function create_mock_shipping_zone( string $country, array $methods ) {
+		$shipping_zone = $this->createMock( WC_Shipping_Zone::class );
+		$shipping_zone->expects( $this->any() )
+					  ->method( 'get_zone_locations' )
+					  ->willReturn(
+					  	[
+							(object) [
+								'code' => $country,
+								'type' => 'country',
+							],
+						]
+					  );
+		$shipping_zone->expects( $this->any() )
+					  ->method( 'get_shipping_methods' )
+					  ->willReturn( $methods );
+
+		return $shipping_zone;
+	}
+
+	/**
+	 * Returns two options for the `requires` options of a free-shipping method that require a minimum order amount.
+	 *
+	 * @return array
+	 */
+	public function return_free_shipping_min_amount_requirements(): array {
+		return [
+			[ 'min_amount' ],
+			[ 'either' ],
+		];
+	}
+
+	/**
+	 * Returns two options for the `requires` options of a free-shipping method that require a coupon.
+	 *
+	 * @return array
+	 */
+	public function return_free_shipping_coupon_requirements(): array {
+		return [
+			[ 'coupon' ],
+			[ 'both' ],
+		];
+	}
+
 	/**
 	 * Runs before each test is executed.
 	 */
 	public function setUp() {
 		parent::setUp();
-		$this->wc            = $this->createMock( WC::class );
+
+		$this->wc = $this->createMock( WC::class );
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_woocommerce_currency' )
+				 ->willReturn( 'USD' );
+
 		$this->shipping_zone = new ShippingZone( $this->wc );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Implements part of #1117.

This PR adds a new API (`mc/shipping/rates/suggestions`) that returns a list of suggested shipping rates for the given country. There is also another "batch" API under the same namespace (`mc/shipping/rates/suggestions/batch`) that accepts multiple country codes as input and returns suggested shipping rates for each of them in a batch response.

The API parses the WooCommerce shipping zones to fetch the list of shipping methods for each country and returns a rate only if there is a "Flat-rate" shipping method with a simple cost associated with the country.

The flat rate shipping method can accept a mathematical expression or formula as its "cost" parameter, which can include various variables such as item quantity and order total cost. Since Google does not support adding such formulas as shipping cost, we simply ignore those methods and only return the ones that have a simple numeric value defined as their cost. The same also applies to the "pickup" shipping method.

Even though we parse all of the supported code WooCommece shipping methods in the `ShippingZone` service (`free_shipping`, `local_pickup`, and `flat_rate`) and return them all in the `get_shipping_methods_for_country` method, the API only supports returning a `flat_rate` for a country. This means that we do not return any other shipping methods even if they exist. This is because the current shipping rate UI does not allow setting the "local pickup" or "free shipping" method separately for countries. Once we have the UI design ready, we can change the API to return the data in the desired format for the UI.

If a country has multiple instances of the same shipping method, we always return the one that has a higher cost. Cost is defined differently in the shipping methods. In the "flat rate" method, "cost" is the flat shipping fee that is defined by the user. For the "free shipping" method, however,  we always return the one that has a higher "minimum order amount" defined.

With this change, if a country has no shipping methods defined, it will no longer be returned as an option for the `mc/target_audience/suggestions` API.

Moreover, if the cost is null or undefined for a flat-rate or local-pickup shipping method, the method will not be returned as an option.

These APIs are used to pre-populate the shipping rate inputs presented to the user during onboarding.

### Detailed test instructions:

1. Define multiple shipping zones each containing various regions and shipping methods. Make sure to have at least one country that is defined in multiple zones and has a similar shipping method in each with a different cost.
2. Make a `GET` request to the `mc/shipping/rates/suggestions` API with a `country_code` parameter and confirm the rate that is returned is the same that you defined in your shipping zone settings.
3. Make a `GET` request to the `mc/shipping/rates/suggestions` API and send over the country code that is duplicated in multiple zones as the `country_code` parameter and check the rate is set to the higher one.
4. Make a `GET` request to the `mc/shipping/rates/suggestions/batch` API with multiple country codes defined as the `country_codes` parameter and confirm that the correct rate is returned for all of them.
5. Run the unit tests and confirm they pass.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Pre-fill shipping rates during free listing configuration wizard
