### PR TITLE
Fix/484 unable to disable audience country field

### DIFF
--- a/js/src/components/paid-ads/audience-section.js
+++ b/js/src/components/paid-ads/audience-section.js
@@ -42,6 +42,7 @@ const AudienceSection = ( props ) => {
 						) }
 						helperText={ countrySelectHelperText }
 						inlineTags={ false }
+						disabled={ disabled }
 						{ ...inputProps }
 					/>
 				</Section.Card.Body>

--- a/js/src/components/paid-ads/audienceSection.test.js
+++ b/js/src/components/paid-ads/audienceSection.test.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AudienceSection from '.~/components/paid-ads/audience-section';
+
+jest.mock( '.~/hooks/useCountryKeyNameMap', () =>
+	jest.fn( () => ( {
+		GB: 'United Kingdom',
+		US: 'United States',
+		ES: 'Spain',
+	} ) )
+);
+
+jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
+	jest.fn( () => ( { data: [ 'GB', 'US', 'ES' ] } ) )
+);
+
+describe( 'audienceSection', () => {
+	const defaultProps = {
+		formProps: {
+			getInputProps: () => ( {
+				checked: true,
+				className: null,
+				help: null,
+				onBlur: ( f ) => f,
+				onChange: undefined,
+				selected: [ 'GB' ],
+				value: [ 'GB' ],
+			} ),
+		},
+		countrySelectHelperText:
+			'Once a campaign has been created, you cannot change the target country.',
+	};
+
+	test( 'If Audience section is in edit mode the country field should be disabled', async () => {
+		render( <AudienceSection { ...defaultProps } disabled={ true } /> );
+
+		const dropdown = await screen.findByRole( 'combobox' );
+
+		expect( dropdown ).toBeDisabled();
+	} );
+
+	test( 'If Audience section is in create mode the country field should be enable', async () => {
+		render( <AudienceSection { ...defaultProps } disabled={ false } /> );
+
+		const dropdown = await screen.findByRole( 'combobox' );
+
+		expect( dropdown ).not.toBeDisabled();
+	} );
+} );

--- a/js/src/components/paid-ads/audienceSection.test.js
+++ b/js/src/components/paid-ads/audienceSection.test.js
@@ -3,6 +3,7 @@
  */
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -24,15 +25,7 @@ jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
 describe( 'audienceSection', () => {
 	const defaultProps = {
 		formProps: {
-			getInputProps: () => ( {
-				checked: true,
-				className: null,
-				help: null,
-				onBlur: ( f ) => f,
-				onChange: undefined,
-				selected: [ 'GB' ],
-				value: [ 'GB' ],
-			} ),
+			getInputProps: () => ( { value: [ 'GB' ] } ),
 		},
 		countrySelectHelperText:
 			'Once a campaign has been created, you cannot change the target country.',
@@ -42,15 +35,22 @@ describe( 'audienceSection', () => {
 		render( <AudienceSection { ...defaultProps } disabled={ true } /> );
 
 		const dropdown = await screen.findByRole( 'combobox' );
-
 		expect( dropdown ).toBeDisabled();
+
+		//Test that input is not editable
+		userEvent.type( dropdown, 'Spain' );
+		expect( dropdown ).toHaveValue( 'United Kingdom' );
 	} );
 
 	test( 'If Audience section is enable the country field should be enable', async () => {
 		render( <AudienceSection { ...defaultProps } disabled={ false } /> );
 
 		const dropdown = await screen.findByRole( 'combobox' );
-
 		expect( dropdown ).not.toBeDisabled();
+
+		//Test that input is editable
+		userEvent.clear( dropdown );
+		userEvent.type( dropdown, 'S' );
+		expect( dropdown ).toHaveValue( 'S' );
 	} );
 } );

--- a/js/src/components/paid-ads/audienceSection.test.js
+++ b/js/src/components/paid-ads/audienceSection.test.js
@@ -23,12 +23,12 @@ jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
 );
 
 describe( 'audienceSection', () => {
+	const onChange = jest.fn();
+
 	const defaultProps = {
 		formProps: {
-			getInputProps: () => ( { value: [ 'GB' ] } ),
+			getInputProps: () => ( { onChange } ),
 		},
-		countrySelectHelperText:
-			'Once a campaign has been created, you cannot change the target country.',
 	};
 
 	test( 'If Audience section is disabled the country field should be disabled', async () => {
@@ -38,11 +38,15 @@ describe( 'audienceSection', () => {
 		expect( dropdown ).toBeDisabled();
 
 		//Test that input is not editable
-		userEvent.type( dropdown, 'Spain' );
-		expect( dropdown ).toHaveValue( 'United Kingdom' );
+		userEvent.clear( dropdown );
+		userEvent.type( dropdown, 'S' );
+
+		const options = screen.queryAllByRole( 'option' );
+		expect( options.length ).toBe( 0 );
+		expect( onChange ).toHaveBeenCalledTimes( 0 );
 	} );
 
-	test( 'If Audience section is enable the country field should be enable', async () => {
+	test( 'If Audience section is enable the country field should be enable & editable', async () => {
 		render( <AudienceSection { ...defaultProps } disabled={ false } /> );
 
 		const dropdown = await screen.findByRole( 'combobox' );
@@ -51,6 +55,12 @@ describe( 'audienceSection', () => {
 		//Test that input is editable
 		userEvent.clear( dropdown );
 		userEvent.type( dropdown, 'S' );
-		expect( dropdown ).toHaveValue( 'S' );
+
+		const options = await screen.findAllByRole( 'option' );
+		expect( options.length ).toBeGreaterThan( 0 );
+
+		const firstOption = options[ 0 ];
+		userEvent.click( firstOption );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/js/src/components/paid-ads/audienceSection.test.js
+++ b/js/src/components/paid-ads/audienceSection.test.js
@@ -38,7 +38,7 @@ describe( 'audienceSection', () => {
 			'Once a campaign has been created, you cannot change the target country.',
 	};
 
-	test( 'If Audience section is in edit mode the country field should be disabled', async () => {
+	test( 'If Audience section is disabled the country field should be disabled', async () => {
 		render( <AudienceSection { ...defaultProps } disabled={ true } /> );
 
 		const dropdown = await screen.findByRole( 'combobox' );
@@ -46,7 +46,7 @@ describe( 'audienceSection', () => {
 		expect( dropdown ).toBeDisabled();
 	} );
 
-	test( 'If Audience section is in create mode the country field should be enable', async () => {
+	test( 'If Audience section is enable the country field should be enable', async () => {
 		render( <AudienceSection { ...defaultProps } disabled={ false } /> );
 
 		const dropdown = await screen.findByRole( 'combobox' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes [#484](https://github.com/woocommerce/google-listings-and-ads/issues/484).

- AudienceSection Component is now passing the disabled property to AudienceCountrySelect Component that is using the [SelectComponent](https://github.com/woocommerce/woocommerce-admin/pull/6902/files). 
- If the disabled property is set to true it will disable the audience country select dropdown. Otherwise, it will be enabled.
- This is fixing the issue in the edit paid ads campaign page, the country field was enabled even when the user was not able to update the country. 
- I added unitary test in the AudienceSection Component. It is testing if the AudienceCountry Selects Component renders as expected with the disabled property.


### Screenshots:

![image](https://user-images.githubusercontent.com/2488994/145384205-b82abdf0-a1e6-4bd0-b927-6f19a5c5ab2a.png)


### Detailed test instructions:

1.  Follow the steps to run the [dev enviroment](https://github.com/woocommerce/google-listings-and-ads#development).
2. Go to Marketing -> Google Listings & Ads
3. At the bottom of the page, edit one of the paid campaigns. 
4. Audience Country dropdown should be disabled.
5. To run the unitary test run `npm run test:js -- audienceSection `

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
