### PR TITLE
Update WC tested version to 6.0 after testing

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -12,7 +12,7 @@
  * Requires PHP: 7.3
  *
  * WC requires at least: 5.5
- * WC tested up to: 5.9
+ * WC tested up to: 6.0
  * Woo:
  *
  * @package WooCommerce\Admin


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Bumping WooCommerce tested up to version to 6.0  after compatibility testing.

### Smoke tests
- Onboarding completed, played randomly with the options and buttons to see it does what is expected.
- Seeing that the synchronisation started, showing me feedback in the dashboard
- Dashboard section shows and seems to work
- Reports section shows and seems to work
- Settings section shows and seems to work. Disconnected successfully my account. Change my phone etc
- No console errors/log errors so far

### Changelog entry
- Tweak - WooCommerce and WordPress compatibility testing.