### PR TITLE
Update WC tested version to 6.0 after testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 We aim to support the latest two minor versions of WordPress, WooCommerce, and PHP. (L-2 policy)
 
 -   WordPress 5.6+
--   WooCommerce 5.7+
+-   WooCommerce 5.8+
 -   PHP 7.3+
 
 ## Browsers supported

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 
 We aim to support the latest two minor versions of WordPress, WooCommerce, and PHP. (L-2 policy)
 
--   WordPress 5.6+
+-   WordPress 5.7+
 -   WooCommerce 5.8+
 -   PHP 7.3+
 

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,11 +7,11 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 5.6
+ * Requires at least: 5.7
  * Tested up to: 5.9
  * Requires PHP: 7.3
  *
- * WC requires at least: 5.7
+ * WC requires at least: 5.8
  * WC tested up to: 6.0
  * Woo:
  *

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,11 +7,11 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 5.7
+ * Requires at least: 5.6
  * Tested up to: 5.9
  * Requires PHP: 7.3
  *
- * WC requires at least: 5.8
+ * WC requires at least: 5.7
  * WC tested up to: 6.0
  * Woo:
  *
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '1.8.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.3' );
-define( 'WC_GLA_MIN_WC_VER', '5.8' );
+define( 'WC_GLA_MIN_WC_VER', '5.7' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -12,7 +12,7 @@
  * Requires PHP: 7.3
  *
  * WC requires at least: 5.7
- * WC tested up to: 5.9
+ * WC tested up to: 6.0
  * Woo:
  *
  * @package WooCommerce\Admin

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '1.8.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.3' );
-define( 'WC_GLA_MIN_WC_VER', '5.7' );
+define( 'WC_GLA_MIN_WC_VER', '5.8' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,10 @@
 === Google Listings & Ads ===
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, listings, ads
-Requires at least: 5.5
+Requires at least: 5.7
 Tested up to: 5.9
+WC requires at least: 5.8
+WC Tested up to: 6.0
 Requires PHP: 7.3
 Stable tag: 1.8.0
 License: GPLv3
@@ -62,8 +64,8 @@ Get up to  $150\* in ad credit to help you get started on Smart Shopping Campaig
 
 = Minimum Requirements =
 
-* WordPress 5.6 or greater
-* WooCommerce 5.7 or greater
+* WordPress 5.7 or greater
+* WooCommerce 5.8 or greater
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, google, listings, ads
 Requires at least: 5.7
 Tested up to: 5.9
 WC requires at least: 5.8
-WC Tested up to: 6.0
+WC tested up to: 6.0
 Requires PHP: 7.3
 Stable tag: 1.8.0
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Google Listings & Ads ===
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, listings, ads
-Requires at least: 5.7
+Requires at least: 5.6
 Tested up to: 5.9
-WC requires at least: 5.8
+WC requires at least: 5.7
 WC tested up to: 6.0
 Requires PHP: 7.3
 Stable tag: 1.8.0
@@ -64,8 +64,8 @@ Get up to  $150\* in ad credit to help you get started on Smart Shopping Campaig
 
 = Minimum Requirements =
 
-* WordPress 5.7 or greater
-* WooCommerce 5.8 or greater
+* WordPress 5.6 or greater
+* WooCommerce 5.7 or greater
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Bumping WooCommerce tested up to version to 6.0  after compatibility testing.

### Smoke tests
- Onboarding completed, played randomly with the options and buttons to see it does what is expected.
- Seeing that the synchronisation started, showing me feedback in the dashboard
- Dashboard section shows and seems to work
- Reports section shows and seems to work
- Settings section shows and seems to work. Disconnected successfully my account. Change my phone etc
- No console errors/log errors so far

### Changelog entry
> Tweak - WooCommerce and WordPress compatibility testing.