### PR TITLE
Replace `cloneDeep` for `.~/data/reducer.js` and apply new state mutation function to whole reducer

### DIFF
--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -159,13 +159,19 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.DISCONNECT_ACCOUNTS_GOOGLE_ADS: {
-			const value = DEFAULT_STATE.mc.accounts.ads;
-			return set( state, 'mc.accounts.ads', value );
+			return set(
+				state,
+				'mc.accounts.ads',
+				DEFAULT_STATE.mc.accounts.ads
+			);
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS_BILLING_STATUS: {
-			const path = 'mc.accounts.ads_billing_status';
-			return set( state, path, action.billingStatus );
+			return set(
+				state,
+				'mc.accounts.ads_billing_status',
+				action.billingStatus
+			);
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS_EXISTING: {
@@ -218,8 +224,11 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.RECEIVE_MC_PRODUCT_STATISTICS: {
-			const value = action.mcProductStatistics;
-			return set( state, 'mc_product_statistics', value );
+			return set(
+				state,
+				'mc_product_statistics',
+				action.mcProductStatistics
+			);
 		}
 
 		case TYPES.RECEIVE_MC_ISSUES: {

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -39,7 +39,7 @@ const DEFAULT_STATE = {
 
 // Referenced and modified from https://github.com/lodash/lodash/issues/1696#issuecomment-328335502
 function chain( state, basePath = '' ) {
-	const nextState = clone( state );
+	const nextState = Object.assign( state.constructor(), state );
 	const customizer = ( value ) => {
 		if ( value === null || value === undefined ) {
 			return {};

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cloneDeep } from 'lodash';
+import { setWith, clone } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,6 +36,30 @@ const DEFAULT_STATE = {
 	mc_product_feed: null,
 	report: {},
 };
+
+// Referenced and modified from https://github.com/lodash/lodash/issues/1696#issuecomment-328335502
+function chain( state, basePath = '' ) {
+	const nextState = clone( state );
+	const customizer = ( value ) => {
+		if ( value === null || value === undefined ) {
+			return {};
+		}
+		return clone( value );
+	};
+
+	return {
+		set( path, value ) {
+			const fullPath = basePath ? `${ basePath }.${ path }` : path;
+			setWith( nextState, fullPath, value, customizer );
+			return this;
+		},
+		end: () => nextState,
+	};
+}
+
+function set( state, path, value ) {
+	return chain( state ).set( path, value ).end();
+}
 
 const getNextStateForShipping = ( state ) => {
 	return {
@@ -146,17 +170,11 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_JETPACK: {
-			const { account } = action;
-			const newState = cloneDeep( state );
-			newState.mc.accounts.jetpack = account;
-			return newState;
+			return set( state, 'mc.accounts.jetpack', action.account );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE: {
-			const { account } = action;
-			const newState = cloneDeep( state );
-			newState.mc.accounts.google = account;
-			return newState;
+			return set( state, 'mc.accounts.google', action.account );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ACCESS: {
@@ -173,24 +191,15 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_MC: {
-			const { account } = action;
-			const newState = cloneDeep( state );
-			newState.mc.accounts.mc = account;
-			return newState;
+			return set( state, 'mc.accounts.mc', action.account );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_MC_EXISTING: {
-			const { accounts } = action;
-			const newState = cloneDeep( state );
-			newState.mc.accounts.existing_mc = accounts;
-			return newState;
+			return set( state, 'mc.accounts.existing_mc', action.accounts );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS: {
-			const { account } = action;
-			const newState = cloneDeep( state );
-			newState.mc.accounts.ads = account;
-			return newState;
+			return set( state, 'mc.accounts.ads', action.account );
 		}
 
 		case TYPES.DISCONNECT_ACCOUNTS_GOOGLE_ADS: {
@@ -207,17 +216,12 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS_BILLING_STATUS: {
-			const { billingStatus } = action;
-			const newState = cloneDeep( state );
-			newState.mc.accounts.ads_billing_status = billingStatus;
-			return newState;
+			const path = 'mc.accounts.ads_billing_status';
+			return set( state, path, action.billingStatus );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS_EXISTING: {
-			const { accounts } = action;
-			const newState = cloneDeep( state );
-			newState.mc.accounts.existing_ads = accounts;
-			return newState;
+			return set( state, 'mc.accounts.existing_ads', action.accounts );
 		}
 
 		case TYPES.RECEIVE_MC_CONTACT_INFORMATION: {
@@ -232,17 +236,12 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.RECEIVE_COUNTRIES: {
-			const { countries } = action;
-			const newState = cloneDeep( state );
-			newState.mc.countries = countries;
-			return newState;
+			return set( state, 'mc.countries', action.countries );
 		}
 
 		case TYPES.RECEIVE_TARGET_AUDIENCE:
 		case TYPES.SAVE_TARGET_AUDIENCE: {
-			const newState = cloneDeep( state );
-			newState.mc.target_audience = action.target_audience;
-			return newState;
+			return set( state, 'mc.target_audience', action.target_audience );
 		}
 
 		case TYPES.RECEIVE_ADS_CAMPAIGNS: {

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -61,29 +61,13 @@ function set( state, path, value ) {
 	return chain( state ).set( path, value ).end();
 }
 
-const getNextStateForShipping = ( state ) => {
-	return {
-		...state,
-		mc: {
-			...state.mc,
-			shipping: {
-				...state.mc.shipping,
-			},
-		},
-	};
-};
-
 const reducer = ( state = DEFAULT_STATE, action ) => {
 	switch ( action.type ) {
 		case TYPES.RECEIVE_SHIPPING_RATES: {
-			const { shippingRates } = action;
-			const newState = getNextStateForShipping( state );
-			newState.mc.shipping.rates = shippingRates;
-			return newState;
+			return set( state, 'mc.shipping.rates', action.shippingRates );
 		}
 
 		case TYPES.UPSERT_SHIPPING_RATES: {
-			const nextState = getNextStateForShipping( state );
 			const { countryCodes, currency, rate } = action.shippingRate;
 			const rates = [ ...state.mc.shipping.rates ];
 
@@ -100,30 +84,23 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				}
 			} );
 
-			nextState.mc.shipping.rates = rates;
-			return nextState;
+			return set( state, 'mc.shipping.rates', rates );
 		}
 
 		case TYPES.DELETE_SHIPPING_RATES: {
-			const nextState = getNextStateForShipping( state );
 			const countryCodeSet = new Set( action.countryCodes );
 			const rates = state.mc.shipping.rates.filter(
 				( el ) => ! countryCodeSet.has( el.countryCode )
 			);
 
-			nextState.mc.shipping.rates = rates;
-			return nextState;
+			return set( state, 'mc.shipping.rates', rates );
 		}
 
 		case TYPES.RECEIVE_SHIPPING_TIMES: {
-			const { shippingTimes } = action;
-			const newState = getNextStateForShipping( state );
-			newState.mc.shipping.times = shippingTimes;
-			return newState;
+			return set( state, 'mc.shipping.times', action.shippingTimes );
 		}
 
 		case TYPES.UPSERT_SHIPPING_TIMES: {
-			const nextState = getNextStateForShipping( state );
 			const { countryCodes, time } = action.shippingTime;
 			const times = [ ...state.mc.shipping.times ];
 
@@ -140,19 +117,16 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				}
 			} );
 
-			nextState.mc.shipping.times = times;
-			return nextState;
+			return set( state, 'mc.shipping.times', times );
 		}
 
 		case TYPES.DELETE_SHIPPING_TIMES: {
-			const nextState = getNextStateForShipping( state );
 			const countryCodeSet = new Set( action.countryCodes );
 			const times = state.mc.shipping.times.filter(
 				( el ) => ! countryCodeSet.has( el.countryCode )
 			);
 
-			nextState.mc.shipping.times = times;
-			return nextState;
+			return set( state, 'mc.shipping.times', times );
 		}
 
 		case TYPES.RECEIVE_SETTINGS:

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -233,7 +233,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 
 		case TYPES.RECEIVE_MC_ISSUES: {
 			const { query, data } = action;
-			const issues = state.mc_issues?.issues?.slice() || [];
+			const issues = state.mc_issues?.issues.slice() || [];
 			issues.splice(
 				( query.page - 1 ) * query.per_page,
 				query.per_page,

--- a/js/src/data/reducer.test.js
+++ b/js/src/data/reducer.test.js
@@ -359,8 +359,7 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			// TODO: Uncomment the next line after replacing the `cloneDeep` in reducer.
-			// state.assertConsistentRef();
+			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, action.account );
 		} );
 
@@ -632,8 +631,7 @@ describe( 'reducer', () => {
 				const action = { type, [ key ]: payload };
 				const state = reducer( prepareState(), action );
 
-				// TODO: Uncomment the next line after replacing the `cloneDeep` in reducer.
-				// state.assertConsistentRef();
+				state.assertConsistentRef();
 				expect( state ).toHaveProperty( path, payload );
 			}
 		);

--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoClearShippingEffect.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoClearShippingEffect.js
@@ -13,9 +13,6 @@ import useShippingRates from '.~/hooks/useShippingRates';
 
 const wait = 500;
 
-// TODO: review the following effect (specifically the useShippingRates and useShippingTimes)
-// after reducer deepClone issue (https://github.com/woocommerce/google-listings-and-ads/issues/270)
-// has been addressed.
 const useAutoClearShippingEffect = ( location, countries ) => {
 	const { data: shippingRates } = useShippingRates();
 	const { data: shippingTimes } = useShippingTimes();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #270

- Add `chain` and `set` functions to update state without mutating other references of state tree.
- Replace all `cloneDeep` and `getNextStateForShipping`.
- Replace the remaining reducer with the `chain` and `set` functions.
- Revert the temporary commit https://github.com/woocommerce/google-listings-and-ads/commit/ece1da7bb7fe7ae9a1e69db673874b0ad7a028c3 to check references of state tree for all test cases.

:warning: It depends on #1150.

### Detailed test instructions:

1. `npm run test:js:watch -- reducer`
2. Check if all test cases are passed.
3. Browse GLA pages to see if there are any unusual results or errors

### Changelog entry

> Fix - Replace `cloneDeep` within `.~/data/reducer.js` with functions that would not mutate other references of the state tree.
