### PR TITLE
Move all test files in the `js/src/data` folder to test subfolder and separate checking functions of immutable state

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,12 @@ module.exports = {
 		'^\\.~/(.*)$': '<rootDir>/js/src/$1',
 	},
 	// Exclude e2e tests from unit testing.
-	testPathIgnorePatterns: [ '/node_modules/', '/tests/e2e/' ],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'/tests/e2e/',
+		'/__helpers__/',
+	],
+	coveragePathIgnorePatterns: [ '/node_modules/', '/__helpers__/' ],
 	watchPathIgnorePatterns: [ '<rootDir>/js/build/' ],
 	globals: {
 		glaData: {

--- a/js/src/data/test/__helpers__/index.js
+++ b/js/src/data/test/__helpers__/index.js
@@ -26,6 +26,23 @@ export function deepFreeze( object ) {
 	return Object.freeze( object );
 }
 
+/**
+ * @typedef {Object} CheckingGroup
+ * @property {Object} ref The attached object for further reference checks.
+ * @property {string} refPath The access path of `ref` in the object tree.
+ */
+/**
+ * Loops through the passed-in `object` recursively and attaches (by mutating on passed-in `object`)
+ * a new object as a reference checking mark to any nodes which is an plain object type.
+ * Returns an array that contains each attached reference checking mark and its access path.
+ *
+ * @param {Object} object The object to be attached reference marks.
+ * @param {Array<string>} ignore The paths to be ignored to attach reference marks.
+ * @param {Array<CheckingGroup>} [checkingGroups=[]] The accumulator of attached reference marks passed by internal recursive call.
+ * @param {Array<string>} [paths=[]] The current looping sub-tree paths by internal recursive call.
+ *
+ * @return {Array<CheckingGroup>} An array that contains each attached reference checking mark and its access path.
+ */
 function attachRef( object, ignore, checkingGroups = [], paths = [] ) {
 	const refKey = '__refForCheck';
 

--- a/js/src/data/test/__helpers__/index.js
+++ b/js/src/data/test/__helpers__/index.js
@@ -33,7 +33,7 @@ export function deepFreeze( object ) {
  */
 /**
  * Loops through the passed-in `object` recursively and attaches (by mutating on passed-in `object`)
- * a new object as a reference checking mark to any nodes which is an plain object type.
+ * a new object as a reference checking mark to any nodes which is a plain object type.
  * Returns an array that contains each attached reference checking mark and its access path.
  *
  * @param {Object} object The object to be attached reference marks.

--- a/js/src/data/test/__helpers__/index.js
+++ b/js/src/data/test/__helpers__/index.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { cloneDeep, set, get, isPlainObject } from 'lodash';
+
+/**
+ * Use native `Object.freeze()` to make an object immutable, recursively freeze each property which is of type object.
+ *
+ * Copied from [Object.freeze() of MDN]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze}.
+ *
+ * @param {Object|Array} object The object or array to freeze.
+ * @return {Object|Array} The `object` that was passed-in this function.
+ */
+export function deepFreeze( object ) {
+	// Retrieve the property names defined on object
+	const propNames = Object.getOwnPropertyNames( object );
+
+	// Freeze properties before freezing self
+	for ( const name of propNames ) {
+		const value = object[ name ];
+		if ( value && typeof value === 'object' ) {
+			deepFreeze( value );
+		}
+	}
+
+	return Object.freeze( object );
+}
+
+function attachRef( object, ignore, checkingGroups = [], paths = [] ) {
+	const refKey = '__refForCheck';
+
+	for ( const [ name, value ] of Object.entries( object ) ) {
+		if ( isPlainObject( value ) ) {
+			const checkPaths = [ ...paths, name ];
+			attachRef( value, ignore, checkingGroups, checkPaths );
+
+			const currentPath = checkPaths.join( '.' );
+			if ( ! ignore.includes( currentPath ) ) {
+				const ref = {
+					whyFail: `If there's no mutation at \`state.${ currentPath }\`, it should be kept the same reference.`,
+				};
+				checkingGroups.push( {
+					ref,
+					refPath: `${ currentPath }.${ refKey }`,
+				} );
+				value[ refKey ] = ref;
+			}
+		}
+	}
+	return checkingGroups;
+}
+
+/**
+ * Creates a deep freeze state based on the passed-in state,
+ * and also implants a `assertConsistentRef` function for reference check.
+ * An initial value of a specific path can be set optionally to facilitate testing.
+ *
+ * Usage of `assertConsistentRef`:
+ *   After getting the new state from `reducer( preparedState, action )`,
+ *   calls `newState.assertConsistentRef()` for reference checking.
+ *
+ * @param {Object|Array} srcState The state to be attached deep freeze and reference checking.
+ * @param {string} [path] The path of state to be set.
+ * @param {*} [value] The initial value to be set.
+ * @param {true|Array<string>} [ignoreRefCheckOnMutatingPath] Indicate state paths that don't require reference check.
+ *   `true` - Set `true` to use the passed-in `path` parameter as the ignoring path.
+ *   `Array<string>` - Given an array of state paths to be ignored.
+ *
+ * @return {Object} Prepared state.
+ */
+export function prepareImmutableStateWithRefCheck(
+	srcState,
+	path,
+	value,
+	ignoreRefCheckOnMutatingPath
+) {
+	const state = cloneDeep( srcState );
+	if ( path ) {
+		set( state, path, value );
+	}
+
+	// Prepare the paths to be ignored the reference check.
+	const ignorePaths = [];
+	if ( ignoreRefCheckOnMutatingPath === true ) {
+		ignorePaths.push( path );
+	} else if ( Array.isArray( ignoreRefCheckOnMutatingPath ) ) {
+		ignorePaths.push( ...ignoreRefCheckOnMutatingPath );
+	}
+	const checkingGroups = attachRef( state, ignorePaths );
+
+	state.assertConsistentRef = function () {
+		if ( this === state ) {
+			throw new Error(
+				'Please use the state returned by `reducer` to check this assertion in the test case.'
+			);
+		}
+
+		checkingGroups.forEach( ( { refPath, ref } ) => {
+			// If you see this failed assertion, it may be because a reference has been changed unexpectedly, please check if other states have been changed. Or, the reference chage is expected but hasn't be specified ignoring. Please add that path to the `ignoreRefCheckOnMutatingPath` parameter.
+			expect( get( this, refPath ) ).toBe( ref );
+		} );
+	};
+
+	return deepFreeze( state );
+}

--- a/js/src/data/test/api-fetch-middlewares.test.js
+++ b/js/src/data/test/api-fetch-middlewares.test.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createErrorResponseCatcher } from './api-fetch-middlewares';
-import { API_NAMESPACE } from './constants';
+import { createErrorResponseCatcher } from '../api-fetch-middlewares';
+import { API_NAMESPACE } from '../constants';
 
 describe( 'createErrorResponseCatcher', () => {
 	// Ref: https://github.com/WordPress/gutenberg/blob/%40wordpress/api-fetch%405.1.1/packages/api-fetch/src/index.js#L68-L81

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -6,8 +6,8 @@ import { cloneDeep, set, get, isPlainObject } from 'lodash';
 /**
  * Internal dependencies
  */
-import reducer from './reducer';
-import TYPES from './action-types';
+import reducer from '../reducer';
+import TYPES from '../action-types';
 
 // Copied from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
 function deepFreeze( object ) {

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -1,53 +1,14 @@
 /**
  * External dependencies
  */
-import { cloneDeep, set, get, isPlainObject } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import reducer from '../reducer';
 import TYPES from '../action-types';
-
-// Copied from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
-function deepFreeze( object ) {
-	// Retrieve the property names defined on object
-	const propNames = Object.getOwnPropertyNames( object );
-
-	// Freeze properties before freezing self
-	for ( const name of propNames ) {
-		const value = object[ name ];
-		if ( value && typeof value === 'object' ) {
-			deepFreeze( value );
-		}
-	}
-
-	return Object.freeze( object );
-}
-
-function attachRef( object, ignore, checkingGroups = [], paths = [] ) {
-	const refKey = '__refForCheck';
-
-	for ( const [ name, value ] of Object.entries( object ) ) {
-		if ( isPlainObject( value ) ) {
-			const checkPaths = [ ...paths, name ];
-			attachRef( value, ignore, checkingGroups, checkPaths );
-
-			const currentPath = checkPaths.join( '.' );
-			if ( ! ignore.includes( currentPath ) ) {
-				const ref = {
-					whyFail: `If there's no mutation at \`state.${ currentPath }\`, it should be kept the same reference.`,
-				};
-				checkingGroups.push( {
-					ref,
-					refPath: `${ currentPath }.${ refKey }`,
-				} );
-				value[ refKey ] = ref;
-			}
-		}
-	}
-	return checkingGroups;
-}
+import { deepFreeze, prepareImmutableStateWithRefCheck } from './__helpers__';
 
 describe( 'reducer', () => {
 	let defaultState;
@@ -83,53 +44,10 @@ describe( 'reducer', () => {
 			report: {},
 		} );
 
-		/**
-		 * Creates a deep freeze state based on the default state,
-		 * and also implants a `assertConsistentRef` function for reference check.
-		 * An initial value of a specific path can be set optionally to facilitate testing.
-		 *
-		 * Usage of `assertConsistentRef`:
-		 *   After getting the new state from `reducer( preparedState, action )`,
-		 *   calls `newState.assertConsistentRef()` for reference checking.
-		 *
-		 * @param {string} [path] The path of state to be set.
-		 * @param {*} [value] The initial value to be set.
-		 * @param {true|Array<string>} [ignoreRefCheckOnMutatingPath] Indicate state paths that don't require reference check.
-		 *   `true` - Set `true` to use the passed-in `path` parameter as the ignoring path.
-		 *   `Array<string>` - Given an array of state paths to be ignored.
-		 *
-		 * @return {Object} Prepared state.
-		 */
-		prepareState = ( path, value, ignoreRefCheckOnMutatingPath ) => {
-			const state = cloneDeep( defaultState );
-			if ( path ) {
-				set( state, path, value );
-			}
-
-			// Prepare the paths to be ignored the reference check.
-			const ignorePaths = [];
-			if ( ignoreRefCheckOnMutatingPath === true ) {
-				ignorePaths.push( path );
-			} else if ( Array.isArray( ignoreRefCheckOnMutatingPath ) ) {
-				ignorePaths.push( ...ignoreRefCheckOnMutatingPath );
-			}
-			const checkingGroups = attachRef( state, ignorePaths );
-
-			state.assertConsistentRef = function () {
-				if ( this === state ) {
-					throw new Error(
-						'Please use the state returned by `reducer` to check this assertion in the test case.'
-					);
-				}
-
-				checkingGroups.forEach( ( { refPath, ref } ) => {
-					// If you see this failed assertion, it may be because a reference has been changed unexpectedly, please check if other states have been changed. Or, the reference chage is expected but hasn't be specified ignoring. Please add that path to the `ignoreRefCheckOnMutatingPath` parameter.
-					expect( get( this, refPath ) ).toBe( ref );
-				} );
-			};
-
-			return deepFreeze( state );
-		};
+		prepareState = prepareImmutableStateWithRefCheck.bind(
+			null,
+			defaultState
+		);
 	} );
 
 	describe( 'General reducer behaviors', () => {

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -364,7 +364,7 @@ describe( 'reducer', () => {
 	describe( 'Merchant Center issues', () => {
 		const path = 'mc_issues';
 
-		it( 'should update issues array by ascending order of paging 1, 2, ..., final, and return with received issues and total number of issues', () => {
+		it( 'should only allow receiving pagination data sequentially from the first page and return with received issues array and total number of issues', () => {
 			const pageOneState = reducer( prepareState(), {
 				type: TYPES.RECEIVE_MC_ISSUES,
 				query: { page: 1, per_page: 2 },

--- a/js/src/data/test/utils.test.js
+++ b/js/src/data/test/utils.test.js
@@ -9,7 +9,7 @@ import {
 	freeFields,
 	paidFields,
 	MISSING_FREE_LISTINGS_DATA,
-} from './utils';
+} from '../utils';
 
 /**
  * Calls given function with all combinations of possible categories and dataReferences.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up of https://github.com/woocommerce/google-listings-and-ads/pull/1150#discussion_r766756148.

In order to avoid confusion between the helper.js file that includes utils functions for testing and the plugin implementation, move all test files in the *js/src/data* folder to the *test* subfolder in it.

- Move ***.test.js** files.
- Move deep freeze and reference checking functions to a separate file.

### Detailed test instructions:

1. `npm run test:js:watch`
2. Check if all test cases are passed.
3. Make changes to state directly or other state tree node references in the *reducer.js* to see if the deep freeze and reference checking functions are able to discover unexpected mutations on state.

### Changelog entry
