### PR TITLE
Fix/1078 shipping values flash during onboarding setup

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/countriesPriceInput.test.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/countriesPriceInput.test.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import CountriesPriceInputForm from './';
+import { useAppDispatch } from '.~/data';
+
+jest.mock( '.~/hooks/useStoreCurrency', () =>
+	jest.fn( () => ( {
+		code: 'GBP',
+	} ) )
+);
+
+jest.mock( '.~/hooks/useCountryKeyNameMap', () =>
+	jest.fn( () => ( {
+		GB: 'United Kingdom',
+		US: 'United States',
+		ES: 'Spain',
+	} ) )
+);
+
+jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
+	jest.fn( () => ( {
+		data: {
+			selectedCountryCodes: [ 'GB', 'US', 'ES' ],
+		},
+	} ) )
+);
+
+jest.mock( '.~/data', () => ( {
+	useAppDispatch: jest.fn( () => {
+		return {
+			upsertShippingRates: jest.fn(),
+		};
+	} ),
+} ) );
+
+describe( 'CountriesPriceInput', () => {
+	const defaultProps = {
+		savedValue: {
+			countries: [ 'ES' ],
+			price: '1',
+		},
+	};
+
+	test( 'Check if the saved price value is set in the input', () => {
+		render( <CountriesPriceInputForm { ...defaultProps } /> );
+
+		const input = screen.getByRole( 'textbox' );
+		fireEvent.blur( input );
+		expect( input ).toHaveValue( defaultProps.savedValue.price );
+	} );
+
+	test( 'Check if the new value is updated', () => {
+		render( <CountriesPriceInputForm { ...defaultProps } /> );
+
+		const input = screen.getByRole( 'textbox' );
+		expect( input ).toHaveValue( defaultProps.savedValue.price );
+
+		userEvent.clear( input );
+		userEvent.type( input, '2' );
+
+		fireEvent.blur( input );
+
+		expect( input ).toHaveValue( '2' );
+	} );
+
+	test( 'Check when the saved price value is null and it has not been edited', () => {
+		render(
+			<CountriesPriceInputForm
+				savedValue={ { ...defaultProps.savedValue, price: null } }
+			/>
+		);
+
+		const input = screen.getByRole( 'textbox' );
+		fireEvent.blur( input );
+		expect( input ).toHaveValue( '0' );
+	} );
+} );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
@@ -8,15 +8,16 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import { useAppDispatch } from '.~/data';
 import CountriesPriceInput from '../countries-price-input';
+import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
 
 const CountriesPriceInputForm = ( props ) => {
-	const { savedValue } = props;
+	const savedValue = useIsEqualRefValue( props.savedValue );
 	const [ value, setValue ] = useState( savedValue );
 	const { upsertShippingRates } = useAppDispatch();
 
 	useEffect( () => {
-		setValue( ( state ) => ( { ...state, price: savedValue.price } ) );
-	}, [ savedValue.price ] );
+		setValue( savedValue );
+	}, [ savedValue ] );
 
 	const handleBlur = ( event, numberValue ) => {
 		const { countries, currency, price } = value;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
@@ -18,7 +18,7 @@ const CountriesPriceInputForm = ( props ) => {
 		if ( value.price === null ) {
 			setValue( savedValue );
 		}
-	}, [ savedValue ] );
+	}, [ savedValue, value ] );
 
 	const handleBlur = ( event, numberValue ) => {
 		const { countries, currency, price } = value;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
@@ -15,7 +15,9 @@ const CountriesPriceInputForm = ( props ) => {
 	const { upsertShippingRates } = useAppDispatch();
 
 	useEffect( () => {
-		setValue( savedValue );
+		if ( value.price === null ) {
+			setValue( savedValue );
+		}
 	}, [ savedValue ] );
 
 	const handleBlur = ( event, numberValue ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
@@ -15,7 +15,7 @@ const CountriesPriceInputForm = ( props ) => {
 	const { upsertShippingRates } = useAppDispatch();
 
 	useEffect( () => {
-		setValue( savedValue );
+		setValue( ( state ) => ( { ...state, price: savedValue.price } ) );
 	}, [ savedValue.price ] );
 
 	const handleBlur = ( event, numberValue ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input-form/index.js
@@ -15,10 +15,8 @@ const CountriesPriceInputForm = ( props ) => {
 	const { upsertShippingRates } = useAppDispatch();
 
 	useEffect( () => {
-		if ( value.price === null ) {
-			setValue( savedValue );
-		}
-	}, [ savedValue, value ] );
+		setValue( savedValue );
+	}, [ savedValue.price ] );
 
 	const handleBlur = ( event, numberValue ) => {
 		const { countries, currency, price } = value;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/countriesTimeInput.test.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/countriesTimeInput.test.js
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import CountriesPriceInputForm from './';
+import CountriesTimeInputForm from './';
 
 jest.mock( '.~/hooks/useStoreCurrency', () =>
 	jest.fn( () => ( {
@@ -28,19 +28,19 @@ jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () => () => ( {
 	data: { selectedCountryCodes: [ 'ES' ] },
 } ) );
 
-const mockupsertShippingRates = jest.fn();
+const mockupsertShippingTimes = jest.fn();
 
 jest.mock( '.~/data', () => ( {
 	useAppDispatch: () => ( {
-		upsertShippingRates: mockupsertShippingRates,
+		upsertShippingTimes: mockupsertShippingTimes,
 	} ),
 } ) );
 
-describe( 'CountriesPriceInput', () => {
+describe( 'CountriesTimeInput', () => {
 	const defaultProps = {
 		savedValue: {
 			countries: [ 'ES' ],
-			price: '1',
+			time: '1',
 		},
 	};
 
@@ -48,18 +48,18 @@ describe( 'CountriesPriceInput', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'Check if the saved price value is set in the input', () => {
-		render( <CountriesPriceInputForm { ...defaultProps } /> );
+	test( 'Check if the saved time value is set in the input', () => {
+		render( <CountriesTimeInputForm { ...defaultProps } /> );
 
 		const input = screen.getByRole( 'textbox' );
-		expect( input ).toHaveValue( defaultProps.savedValue.price );
+		expect( input ).toHaveValue( defaultProps.savedValue.time );
 	} );
 
-	test( 'Check if the new value is updated without using the saved value & upsertShippingRates is called', () => {
-		render( <CountriesPriceInputForm { ...defaultProps } /> );
+	test( 'Check if the new value is updated without using the saved value & upsertShippingTimes is called', () => {
+		render( <CountriesTimeInputForm { ...defaultProps } /> );
 
 		const input = screen.getByRole( 'textbox' );
-		expect( input ).toHaveValue( defaultProps.savedValue.price );
+		expect( input ).toHaveValue( defaultProps.savedValue.time );
 
 		userEvent.clear( input );
 		userEvent.type( input, '2' );
@@ -67,19 +67,19 @@ describe( 'CountriesPriceInput', () => {
 		fireEvent.blur( input );
 
 		expect( input ).toHaveValue( '2' );
-		expect( mockupsertShippingRates ).toHaveBeenCalledTimes( 1 );
+		expect( mockupsertShippingTimes ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	test( 'Check when the saved price value is null and it has not been edited & upsertShippingRates is called', () => {
+	test( 'Check when the saved time value is null and it has not been edited & upsertShippingTimes is called', () => {
 		render(
-			<CountriesPriceInputForm
-				savedValue={ { ...defaultProps.savedValue, price: null } }
+			<CountriesTimeInputForm
+				savedValue={ { ...defaultProps.savedValue, time: null } }
 			/>
 		);
 
 		const input = screen.getByRole( 'textbox' );
 		fireEvent.blur( input );
 		expect( input ).toHaveValue( '0' );
-		expect( mockupsertShippingRates ).toHaveBeenCalledTimes( 1 );
+		expect( mockupsertShippingTimes ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
@@ -15,10 +15,8 @@ const CountriesTimeInputForm = ( props ) => {
 	const { upsertShippingTimes } = useAppDispatch();
 
 	useEffect( () => {
-		if ( ! value.time === null ) {
-			setValue( savedValue );
-		}
-	}, [ savedValue, value ] );
+		setValue( savedValue );
+	}, [ savedValue.time ] );
 
 	const handleBlur = ( event, numberValue ) => {
 		const { countries, time } = value;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
@@ -15,10 +15,10 @@ const CountriesTimeInputForm = ( props ) => {
 	const { upsertShippingTimes } = useAppDispatch();
 
 	useEffect( () => {
-		if ( ! value.price === null ) {
+		if ( ! value.time === null ) {
 			setValue( savedValue );
 		}
-	}, [ savedValue ] );
+	}, [ savedValue, value ] );
 
 	const handleBlur = ( event, numberValue ) => {
 		const { countries, time } = value;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
@@ -15,7 +15,7 @@ const CountriesTimeInputForm = ( props ) => {
 	const { upsertShippingTimes } = useAppDispatch();
 
 	useEffect( () => {
-		setValue( savedValue );
+		setValue( ( state ) => ( { ...state, time: savedValue.time } ) );
 	}, [ savedValue.time ] );
 
 	const handleBlur = ( event, numberValue ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
@@ -15,7 +15,9 @@ const CountriesTimeInputForm = ( props ) => {
 	const { upsertShippingTimes } = useAppDispatch();
 
 	useEffect( () => {
-		setValue( savedValue );
+		if ( ! value.price === null ) {
+			setValue( savedValue );
+		}
 	}, [ savedValue ] );
 
 	const handleBlur = ( event, numberValue ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input-form/index.js
@@ -8,15 +8,16 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import { useAppDispatch } from '.~/data';
 import CountriesTimeInput from '../countries-time-input';
+import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
 
 const CountriesTimeInputForm = ( props ) => {
-	const { savedValue } = props;
+	const savedValue = useIsEqualRefValue( props.savedValue );
 	const [ value, setValue ] = useState( savedValue );
 	const { upsertShippingTimes } = useAppDispatch();
 
 	useEffect( () => {
-		setValue( ( state ) => ( { ...state, time: savedValue.time } ) );
-	}, [ savedValue.time ] );
+		setValue( savedValue );
+	}, [ savedValue ] );
 
 	const handleBlur = ( event, numberValue ) => {
 		const { countries, time } = value;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1078

### What was causing the issue?

The issue was caused because: 

1. When the Shipping Rate/Shipping Times field is updated, it triggers the API to save the values in the server.  
2. Once the values are saved and the request is finished, the store is updated. 
3. Each input (Shipping Rates & Time Rates) has a useEffect with the following format:

```
const [ value, setValue ] = useState( savedValue );

useEffect( () => {
	setValue( savedValue );
	}, [ savedValue ] );

//Sample of savedValue = { countries:["UK"..] , price: 1 }
```


It should only update the state if the savedValue is updated. I did some debugging and I see that React detects that savedValue is different every time therefore is creating extras re-renderings in both components. This causes that the input gets re-render always with the savedValue instead of the value from the state, consequently showing old data. 

### Proposed solution

This has been resolved updating the useEffect function with the following format: 

	useEffect( () => {
		setValue( savedValue );
	}, [ savedValue.price ] );

	useEffect( () => {
		setValue( savedValue );
	}, [ savedValue.time ] );

In this way we make sure that it should only update the state with the savedValues if the price or time has been updated.

I think we should check other components that can have the same issue and could impact the performance.

With quicker connections, the same issue was happening but it was not visible for the user. 

### Screenshots:

![Screen Capture on 2021-12-15 at 17-38-20](https://user-images.githubusercontent.com/2488994/146227666-4c7afd6a-7bd3-4c9a-8616-d56094f4b213.gif)



### Detailed test instructions:

Visual Testing

1. Go to step 2 of onboarding setup page.
2. Select "All countries" for audience location.
3. Move to step 3
4. Open browser DevTool and throttle network with "Slow 3G"

Unit Tests:

1.  npm run test:js -- countriesTimeInput
2. npm run test:js -- countriesPriceInput

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->

>
