### PR TITLE
Code refactor: Change `useShippingRates` and `useShippingTimes` to use `useAppSelectDispatch`

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -116,13 +116,13 @@ export default function EditFreeCampaign() {
 	const loadedShippingRates = ! hfrShippingRates ? null : shippingRates;
 
 	const {
+		hasFinishedResolution: hfrShippingTimes,
 		data: savedShippingTimes,
-		loading: loadingShippingTimes,
 	} = useShippingTimes();
 	const [ shippingTimes, updateShippingTimes ] = useState(
 		savedShippingTimes
 	);
-	const loadedShippingTimes = loadingShippingTimes ? null : shippingTimes;
+	const loadedShippingTimes = ! hfrShippingTimes ? null : shippingTimes;
 
 	// TODO: Consider making it less repetitive.
 	useEffect( () => updateSettings( savedSettings ), [ savedSettings ] );

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -102,8 +102,8 @@ export default function EditFreeCampaign() {
 	const [ settings, updateSettings ] = useState( savedSettings );
 
 	const {
+		hasFinishedResolution: hfrShippingRates,
 		data: savedShippingRates,
-		loading: loadingShippingRates,
 	} = useShippingRates();
 	const [ shippingRates, updateShippingRates ] = useState(
 		savedShippingRates
@@ -113,7 +113,7 @@ export default function EditFreeCampaign() {
 	// - `<Form>` element ignoring changes to its `initialValues` prop
 	// - default state of shipping* data of `[]`
 	// - resolver not signaling, that data is not ready yet
-	const loadedShippingRates = loadingShippingRates ? null : shippingRates;
+	const loadedShippingRates = ! hfrShippingRates ? null : shippingRates;
 
 	const {
 		data: savedShippingTimes,

--- a/js/src/hooks/useShippingRates.js
+++ b/js/src/hooks/useShippingRates.js
@@ -1,25 +1,10 @@
 /**
- * External dependencies
- */
-import { useSelect } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data';
+import useAppSelectDispatch from './useAppSelectDispatch';
 
 const useShippingRates = () => {
-	return useSelect( ( select ) => {
-		const { getShippingRates, isResolving } = select( STORE_KEY );
-
-		const data = getShippingRates();
-		const loading = isResolving( 'getShippingRates' );
-
-		return {
-			loading,
-			data,
-		};
-	}, [] );
+	return useAppSelectDispatch( 'getShippingRates' );
 };
 
 export default useShippingRates;

--- a/js/src/hooks/useShippingTimes.js
+++ b/js/src/hooks/useShippingTimes.js
@@ -1,25 +1,10 @@
 /**
- * External dependencies
- */
-import { useSelect } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data';
+import useAppSelectDispatch from './useAppSelectDispatch';
 
 const useShippingTimes = () => {
-	return useSelect( ( select ) => {
-		const { getShippingTimes, isResolving } = select( STORE_KEY );
-
-		const data = getShippingTimes();
-		const loading = isResolving( 'getShippingTimes' );
-
-		return {
-			loading,
-			data,
-		};
-	}, [] );
+	return useAppSelectDispatch( 'getShippingTimes' );
 };
 
 export default useShippingTimes;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a code refactor to change `useShippingRates` and `useShippingTimes` hooks to use `useAppSelectDispatch` instead of repeating duplicating code.

There will be no more `loading` in the object returned by the hooks. Instead there will be `hasFinishedResolution`, which is the opposite of `loading`. This change impacts the `EditFreeCampaign` page.

In terms of behavior, everything should still work the same.

### Detailed test instructions:

Test on the impacted Edit Free Campaign page:

1. Go through and complete the Setup MC flow.
2. Go to Dashboard. In the Programs table, look for "Free listings", and click on the Edit button. Click on "Continue to edit" button.
3. Proceed through Step 1 and Step 2 in Edit Free Listings. All the values (especially shipping rates and shipping times) should load and display correctly.

Check for code refactor correctness: search in the code base for all the occurrences of `useShippingRates` and `useShippingTimes` and make sure there is no more usage of `loading`.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
