### PR TITLE
Pre-fill shipping rates in Setup MC

### DIFF
--- a/js/src/hooks/useCallbackOnceEffect.js
+++ b/js/src/hooks/useCallbackOnceEffect.js
@@ -8,6 +8,13 @@ import { useEffect, useRef } from '@wordpress/element';
  */
 import useIsEqualRefValue from './useIsEqualRefValue';
 
+/**
+ * A hook to call a callback function once when a condition is set to true.
+ *
+ * @param {boolean} condition Condition to call the callback.
+ * @param {Function} callback Callback to be executed once when condition is true.
+ * @param  {...any} args Arguments to be passed to the callback.
+ */
 const useCallbackOnceEffect = ( condition, callback, ...args ) => {
 	const calledRef = useRef( false );
 	const argsRefValue = useIsEqualRefValue( args );

--- a/js/src/hooks/useCallbackOnceEffect.js
+++ b/js/src/hooks/useCallbackOnceEffect.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useIsEqualRefValue from './useIsEqualRefValue';
+
+const useCallbackOnceEffect = ( condition, callback, ...args ) => {
+	const calledRef = useRef( false );
+	const argsRefValue = useIsEqualRefValue( args );
+
+	useEffect( () => {
+		if ( calledRef.current === true ) {
+			return;
+		}
+
+		if ( condition ) {
+			calledRef.current = true;
+			callback( ...argsRefValue );
+		}
+	}, [ argsRefValue, callback, condition ] );
+};
+
+export default useCallbackOnceEffect;

--- a/js/src/hooks/useCallbackOnceEffect.test.js
+++ b/js/src/hooks/useCallbackOnceEffect.test.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+
+import useCallbackOnceEffect from './useCallbackOnceEffect';
+
+describe( 'useCallbackOnceEffect', () => {
+	it( 'should only call the callback once when the condition is true', () => {
+		const callbackMock = jest.fn();
+
+		const { rerender } = renderHook(
+			( { condition, callback, arg1 } ) =>
+				useCallbackOnceEffect( condition, callback, arg1 ),
+			{
+				initialProps: {
+					condition: false,
+					callback: callbackMock,
+					arg1: 1,
+				},
+			}
+		);
+
+		/**
+		 * callback is not called because condition was false.
+		 */
+		expect( callbackMock ).toHaveBeenCalledTimes( 0 );
+
+		/**
+		 * set condition to true, callback should be called with arg1.
+		 */
+		rerender( {
+			condition: true,
+			callback: callbackMock,
+			arg1: 2,
+		} );
+		expect( callbackMock ).toHaveBeenCalledTimes( 1 );
+		expect( callbackMock ).toHaveBeenLastCalledWith( 2 );
+
+		/**
+		 * set condition to false, callback should not be called.
+		 */
+		rerender( {
+			condition: false,
+			callback: callbackMock,
+			arg1: 3,
+		} );
+		expect( callbackMock ).toHaveBeenCalledTimes( 1 );
+
+		/**
+		 * set condition to true again, callback should not be called.
+		 */
+		rerender( {
+			condition: true,
+			callback: callbackMock,
+			arg1: 4,
+		} );
+		expect( callbackMock ).toHaveBeenCalledTimes( 1 );
+		expect( callbackMock ).toHaveBeenLastCalledWith( 2 );
+	} );
+} );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
@@ -12,7 +12,7 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AddRateButton from './add-rate-button';
 import CountriesPriceInputForm from './countries-price-input-form';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
-import useShippingRatesWithSuggestions from './useShippingRatesWithSuggestions';
+import useShippingRatesWithSavedSuggestions from './useShippingRatesWithSavedSuggestions';
 import getCountriesPriceArray from './getCountriesPriceArray';
 import AppSpinner from '.~/components/app-spinner';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
@@ -25,7 +25,7 @@ const ShippingRateSetup = ( props ) => {
 	const {
 		loading: loadingShippingRates,
 		data: dataShippingRates,
-	} = useShippingRatesWithSuggestions();
+	} = useShippingRatesWithSavedSuggestions();
 	const { code: currencyCode } = useStoreCurrency();
 	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
@@ -12,7 +12,7 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AddRateButton from './add-rate-button';
 import CountriesPriceInputForm from './countries-price-input-form';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
-import useShippingRates from '.~/hooks/useShippingRates';
+import useShippingRatesWithSuggestions from './useShippingRatesWithSuggestions';
 import getCountriesPriceArray from './getCountriesPriceArray';
 import AppSpinner from '.~/components/app-spinner';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
@@ -22,19 +22,22 @@ const ShippingRateSetup = ( props ) => {
 	const {
 		formProps: { getInputProps, values },
 	} = props;
-	const { data: shippingRates } = useShippingRates();
+	const {
+		loading: loadingShippingRates,
+		data: dataShippingRates,
+	} = useShippingRatesWithSuggestions();
 	const { code: currencyCode } = useStoreCurrency();
 	const { data: selectedCountryCodes } = useTargetAudienceFinalCountryCodes();
 
-	if ( ! selectedCountryCodes ) {
+	if ( loadingShippingRates || ! selectedCountryCodes ) {
 		return <AppSpinner />;
 	}
 
 	const expectedCountryCount = selectedCountryCodes.length;
-	const actualCountryCount = shippingRates.length;
+	const actualCountryCount = dataShippingRates.length;
 	const remainingCount = expectedCountryCount - actualCountryCount;
 
-	const countriesPriceArray = getCountriesPriceArray( shippingRates );
+	const countriesPriceArray = getCountriesPriceArray( dataShippingRates );
 
 	// Prefill to-be-added price.
 	if ( countriesPriceArray.length === 0 ) {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useSaveSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useSaveSuggestions.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import getCountriesPriceArray from './getCountriesPriceArray';
+import { useAppDispatch } from '.~/data';
+
+/**
+ * Convert shipping rates suggestions to aggregated shipping rates
+ * that are ready to be saved.
+ *
+ * @param {Array<import('.~/data/actions').ShippingRate>} suggestions Shipping rate suggestions.
+ * @return {Array<import('.~/data/actions').AggregatedShippingRate>} Aggregated shipping rates.
+ */
+const convertSuggestionsToAggregatedShippingRates = ( suggestions ) => {
+	const countriesPriceArray = getCountriesPriceArray( suggestions );
+	const values = countriesPriceArray.map( ( el ) => ( {
+		countryCodes: el.countries,
+		currency: el.currency,
+		rate: el.price,
+	} ) );
+
+	return values;
+};
+
+/**
+ * A hook that returns a `saveSuggestions` callback.
+ *
+ * If there is an error during saving suggestions,
+ * it will display an error notice in the UI.
+ *
+ * @return {Function} `saveSuggestions` function to save suggestions as shipping rates.
+ */
+const useSaveSuggestions = () => {
+	const { createNotice } = useDispatchCoreNotices();
+	const { upsertShippingRates } = useAppDispatch();
+
+	const saveSuggestions = useCallback(
+		async ( suggestions ) => {
+			try {
+				const shippingRates = convertSuggestionsToAggregatedShippingRates(
+					suggestions
+				);
+				const promises = shippingRates.map( ( el ) => {
+					return upsertShippingRates( el );
+				} );
+				await Promise.all( promises );
+			} catch ( error ) {
+				createNotice(
+					'error',
+					__(
+						`Unable to use your WooCommerce shipping settings as shipping rates in Google. You may have to enter shipping rates manually.`,
+						'google-listings-and-ads'
+					)
+				);
+			}
+		},
+		[ createNotice, upsertShippingRates ]
+	);
+
+	return saveSuggestions;
+};
+
+export default useSaveSuggestions;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.js
@@ -10,6 +10,20 @@ import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalC
 import useApiFetchEffect from '.~/hooks/useApiFetchEffect';
 import { API_NAMESPACE } from '.~/data/constants';
 
+/**
+ * @typedef {Object} ShippingRatesSuggestionsResult
+ * @property {boolean} loading Whether loading is in progress.
+ * @property {import('.~/data/actions').ShippingRate?} data Shipping rates suggestions.
+ */
+
+/**
+ * Get the shipping rates suggestions.
+ *
+ * This depends on the `useTargetAudienceFinalCountryCodes` hook,
+ * i.e. the target audience countres specified in Setup MC Step 2.
+ *
+ * @return {ShippingRatesSuggestionsResult} Result object with `loading` and `data`.
+ */
 const useShippingRatesSuggestions = () => {
 	const {
 		loading: loadingFinalCountryCodes,
@@ -32,15 +46,17 @@ const useShippingRatesSuggestions = () => {
 	);
 
 	/**
-	 * Returned `data` is consistent with shipping rates structure in wp-data.
+	 * Make returned `data` consistent with shipping rates structure in wp-data.
 	 */
+	const data = dataSuggestions?.success.map( ( el ) => ( {
+		countryCode: el.country_code,
+		currency: el.currency,
+		rate: el.rate,
+	} ) );
+
 	return {
 		loading: loadingFinalCountryCodes || loadingSuggestions,
-		data: dataSuggestions?.success.map( ( el ) => ( {
-			countryCode: el.country_code,
-			currency: el.currency,
-			rate: el.rate,
-		} ) ),
+		data,
 	};
 };
 

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
+import useApiFetchEffect from '.~/hooks/useApiFetchEffect';
+import { API_NAMESPACE } from '.~/data/constants';
+
+const useShippingRatesSuggestions = () => {
+	const {
+		loading: loadingFinalCountryCodes,
+		data: dataFinalCountryCodes,
+	} = useTargetAudienceFinalCountryCodes();
+
+	/**
+	 * The API will only be called when `dataFinalCountryCodes` is truthy.
+	 */
+	const {
+		loading: loadingSuggestions,
+		data: dataSuggestions,
+	} = useApiFetchEffect(
+		dataFinalCountryCodes && {
+			path: addQueryArgs(
+				`${ API_NAMESPACE }/mc/shipping/rates/suggestions/batch`,
+				{ country_codes: dataFinalCountryCodes }
+			),
+		}
+	);
+
+	/**
+	 * Returned `data` is consistent with shipping rates structure in wp-data.
+	 */
+	return {
+		loading: loadingFinalCountryCodes || loadingSuggestions,
+		data: dataSuggestions?.success.map( ( el ) => ( {
+			countryCode: el.country_code,
+			currency: el.currency,
+			rate: el.rate,
+		} ) ),
+	};
+};
+
+export default useShippingRatesSuggestions;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.js
@@ -13,7 +13,7 @@ import { API_NAMESPACE } from '.~/data/constants';
 /**
  * @typedef {Object} ShippingRatesSuggestionsResult
  * @property {boolean} loading Whether loading is in progress.
- * @property {import('.~/data/actions').ShippingRate?} data Shipping rates suggestions.
+ * @property {Array<import('.~/data/actions').ShippingRate>?} data Shipping rates suggestions.
  */
 
 /**

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.test.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.test.js
@@ -10,95 +10,75 @@ import useShippingRatesSuggestions from './useShippingRatesSuggestions';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import useApiFetchEffect from '.~/hooks/useApiFetchEffect';
 
-jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
-	jest.fn( () => ( { loading: true, data: undefined } ) )
-);
-
-jest.mock( '.~/hooks/useApiFetchEffect', () =>
-	jest.fn( () => ( { loading: true, data: undefined } ) )
-);
+jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () => jest.fn() );
+jest.mock( '.~/hooks/useApiFetchEffect', () => jest.fn() );
 
 describe( 'useShippingRatesSuggestions', () => {
-	it( 'should contain loading and data properties', () => {
+	it( 'should return loading true when it is still loading target audience final country codes', () => {
+		useTargetAudienceFinalCountryCodes.mockReturnValue( {
+			loading: true,
+		} );
+		useApiFetchEffect.mockReturnValue( {
+			loading: true,
+		} );
+
 		const { result } = renderHook( () => useShippingRatesSuggestions() );
 
-		expect( result.current ).toHaveProperty( 'loading' );
-		expect( result.current ).toHaveProperty( 'data' );
+		expect( result.current.loading ).toBe( true );
+		expect( result.current.data ).toBe( undefined );
 	} );
 
-	describe( 'loading property', () => {
-		it( 'should be true when it is still loading target audience final country codes', () => {
-			useTargetAudienceFinalCountryCodes.mockReturnValue( {
-				loading: true,
-			} );
-			useApiFetchEffect.mockReturnValue( {
-				loading: true,
-			} );
-
-			const { result } = renderHook( () =>
-				useShippingRatesSuggestions()
-			);
-
-			expect( result.current.loading ).toBe( true );
-			expect( result.current.data ).toBe( undefined );
+	it( 'should return loading true when it is still loading shipping rates suggestions', () => {
+		useTargetAudienceFinalCountryCodes.mockReturnValue( {
+			loading: false,
+		} );
+		useApiFetchEffect.mockReturnValue( {
+			loading: true,
 		} );
 
-		it( 'should be true when it is still loading shipping rates suggestions', () => {
-			useTargetAudienceFinalCountryCodes.mockReturnValue( {
-				loading: false,
-			} );
-			useApiFetchEffect.mockReturnValue( {
-				loading: true,
-			} );
+		const { result } = renderHook( () => useShippingRatesSuggestions() );
 
-			const { result } = renderHook( () =>
-				useShippingRatesSuggestions()
-			);
+		expect( result.current.loading ).toBe( true );
+		expect( result.current.data ).toBe( undefined );
+	} );
 
-			expect( result.current.loading ).toBe( true );
-			expect( result.current.data ).toBe( undefined );
+	it( 'should return loading false with data when target audience final country codes and shipping rates suggestions are both loaded', () => {
+		useTargetAudienceFinalCountryCodes.mockReturnValue( {
+			loading: false,
+			data: [ 'GB', 'US', 'ES' ],
+		} );
+		useApiFetchEffect.mockReturnValue( {
+			loading: false,
+			data: {
+				success: [
+					{
+						country_code: 'GB',
+						currency: 'US',
+						rate: 12,
+					},
+					{
+						country_code: 'US',
+						currency: 'US',
+						rate: 10,
+					},
+				],
+			},
 		} );
 
-		it( 'should be false when target audience final country codes and shipping rates suggestions are both loaded', () => {
-			useTargetAudienceFinalCountryCodes.mockReturnValue( {
-				loading: false,
-				data: [ 'GB', 'US', 'ES' ],
-			} );
-			useApiFetchEffect.mockReturnValue( {
-				loading: false,
-				data: {
-					success: [
-						{
-							country_code: 'GB',
-							currency: 'US',
-							rate: 12,
-						},
-						{
-							country_code: 'US',
-							currency: 'US',
-							rate: 10,
-						},
-					],
-				},
-			} );
+		const { result } = renderHook( () => useShippingRatesSuggestions() );
 
-			const { result } = renderHook( () =>
-				useShippingRatesSuggestions()
-			);
-
-			expect( result.current.loading ).toBe( false );
-			expect( result.current.data ).toStrictEqual( [
-				{
-					countryCode: 'GB',
-					currency: 'US',
-					rate: 12,
-				},
-				{
-					countryCode: 'US',
-					currency: 'US',
-					rate: 10,
-				},
-			] );
-		} );
+		expect( result.current.loading ).toBe( false );
+		expect( result.current.data ).toStrictEqual( [
+			{
+				countryCode: 'GB',
+				currency: 'US',
+				rate: 12,
+			},
+			{
+				countryCode: 'US',
+				currency: 'US',
+				rate: 10,
+			},
+		] );
 	} );
 } );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.test.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesSuggestions.test.js
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useShippingRatesSuggestions from './useShippingRatesSuggestions';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
+import useApiFetchEffect from '.~/hooks/useApiFetchEffect';
+
+jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
+	jest.fn( () => ( { loading: true, data: undefined } ) )
+);
+
+jest.mock( '.~/hooks/useApiFetchEffect', () =>
+	jest.fn( () => ( { loading: true, data: undefined } ) )
+);
+
+describe( 'useShippingRatesSuggestions', () => {
+	it( 'should contain loading and data properties', () => {
+		const { result } = renderHook( () => useShippingRatesSuggestions() );
+
+		expect( result.current ).toHaveProperty( 'loading' );
+		expect( result.current ).toHaveProperty( 'data' );
+	} );
+
+	describe( 'loading property', () => {
+		it( 'should be true when it is still loading target audience final country codes', () => {
+			useTargetAudienceFinalCountryCodes.mockReturnValue( {
+				loading: true,
+			} );
+			useApiFetchEffect.mockReturnValue( {
+				loading: true,
+			} );
+
+			const { result } = renderHook( () =>
+				useShippingRatesSuggestions()
+			);
+
+			expect( result.current.loading ).toBe( true );
+			expect( result.current.data ).toBe( undefined );
+		} );
+
+		it( 'should be true when it is still loading shipping rates suggestions', () => {
+			useTargetAudienceFinalCountryCodes.mockReturnValue( {
+				loading: false,
+			} );
+			useApiFetchEffect.mockReturnValue( {
+				loading: true,
+			} );
+
+			const { result } = renderHook( () =>
+				useShippingRatesSuggestions()
+			);
+
+			expect( result.current.loading ).toBe( true );
+			expect( result.current.data ).toBe( undefined );
+		} );
+
+		it( 'should be false when target audience final country codes and shipping rates suggestions are both loaded', () => {
+			useTargetAudienceFinalCountryCodes.mockReturnValue( {
+				loading: false,
+				data: [ 'GB', 'US', 'ES' ],
+			} );
+			useApiFetchEffect.mockReturnValue( {
+				loading: false,
+				data: {
+					success: [
+						{
+							country_code: 'GB',
+							currency: 'US',
+							rate: 12,
+						},
+						{
+							country_code: 'US',
+							currency: 'US',
+							rate: 10,
+						},
+					],
+				},
+			} );
+
+			const { result } = renderHook( () =>
+				useShippingRatesSuggestions()
+			);
+
+			expect( result.current.loading ).toBe( false );
+			expect( result.current.data ).toStrictEqual( [
+				{
+					countryCode: 'GB',
+					currency: 'US',
+					rate: 12,
+				},
+				{
+					countryCode: 'US',
+					currency: 'US',
+					rate: 10,
+				},
+			] );
+		} );
+	} );
+} );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { useState, useRef, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -9,6 +9,7 @@ import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import useShippingRates from '.~/hooks/useShippingRates';
 import useShippingRatesSuggestions from './useShippingRatesSuggestions';
 import useSaveSuggestions from './useSaveSuggestions';
+import useCallbackOnceEffect from '.~/hooks/useCallbackOnceEffect';
 
 /**
  * @typedef {Object} ShippingRatesWithSavedSuggestionsResult
@@ -73,28 +74,16 @@ const useShippingRatesWithSavedSuggestions = () => {
 	);
 
 	/**
-	 * Used to track whether `saveSuggestions` has been called in the `useEffect`.
-	 * We want to call the function one time only.
-	 */
-	const hasCalledSaveSuggestions = useRef( false );
-
-	/**
-	 * Call `saveSuggestions` when:
+	 * `callSaveSuggestions` when:
 	 *
 	 * - there is no pre-saved initial shipping rates value.
 	 * - we have suggestions data.
-	 * - we have not saved the suggestions data as shipping rates.
 	 */
-	useEffect( () => {
-		if (
-			isInitialShippingRatesEmpty.current &&
-			dataSuggestions &&
-			hasCalledSaveSuggestions.current === false
-		) {
-			hasCalledSaveSuggestions.current = true;
-			callSaveSuggestions( dataSuggestions );
-		}
-	}, [ dataSuggestions, callSaveSuggestions ] );
+	useCallbackOnceEffect(
+		isInitialShippingRatesEmpty.current && dataSuggestions,
+		callSaveSuggestions,
+		dataSuggestions
+	);
 
 	return {
 		loading:

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
@@ -30,7 +30,7 @@ const convertSuggestionsToAggregatedShippingRates = ( suggestions ) => {
 };
 
 /**
- * @typedef {Object} ShippingRatesWithSuggestionsResult
+ * @typedef {Object} ShippingRatesWithSavedSuggestionsResult
  * @property {boolean} loading Whether loading is in progress.
  * @property {Array<import('.~/data/actions').ShippingRate>?} data Shipping rates.
  */
@@ -39,9 +39,9 @@ const convertSuggestionsToAggregatedShippingRates = ( suggestions ) => {
  * Check existing shipping rates, and if it is empty, get shipping rates suggestions
  * and save the suggestions as shipping rates.
  *
- * @return {ShippingRatesWithSuggestionsResult} Result object with `loading` and `data`.
+ * @return {ShippingRatesWithSavedSuggestionsResult} Result object with `loading` and `data`.
  */
-const useShippingRatesWithSuggestions = () => {
+const useShippingRatesWithSavedSuggestions = () => {
 	const {
 		hasFinishedResolution: hfrShippingRates,
 		data: dataShippingRates,
@@ -131,4 +131,4 @@ const useShippingRatesWithSuggestions = () => {
 	};
 };
 
-export default useShippingRatesWithSuggestions;
+export default useShippingRatesWithSavedSuggestions;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
@@ -34,7 +34,7 @@ const useShippingRatesWithSavedSuggestions = () => {
 	} = useShippingRatesSuggestions();
 
 	/**
-	 * `isInitialShippingRatesEmpty` is used to indicate
+	 * `isInitialShippingRatesEmptyRef` is used to indicate
 	 * whether the initial loaded shipping rates
 	 * has a pre-saved value or not.
 	 *
@@ -49,13 +49,21 @@ const useShippingRatesWithSavedSuggestions = () => {
 	 * and then reload the page,
 	 * then the suggestions would be saved as shipping rates as per above logic.
 	 */
-	const isInitialShippingRatesEmpty = useRef( undefined );
+	const isInitialShippingRatesEmptyRef = useRef( undefined );
 	if (
 		hfrShippingRates &&
-		isInitialShippingRatesEmpty.current === undefined
+		isInitialShippingRatesEmptyRef.current === undefined
 	) {
-		isInitialShippingRatesEmpty.current = dataShippingRates.length === 0;
+		isInitialShippingRatesEmptyRef.current = dataShippingRates.length === 0;
 	}
+
+	/**
+	 * Boolean to indicate we should save suggestions,
+	 * when the initial shipping rates is empty
+	 * and we have suggestions data.
+	 */
+	const shouldSaveSuggestions =
+		isInitialShippingRatesEmptyRef.current && dataSuggestions;
 
 	/**
 	 * `saveSuggestionsFinished` is used to indicate whether saving has finished.
@@ -76,13 +84,11 @@ const useShippingRatesWithSavedSuggestions = () => {
 	);
 
 	/**
-	 * `callSaveSuggestions` when:
-	 *
-	 * - there is no pre-saved initial shipping rates value.
-	 * - we have suggestions data.
+	 * Call save suggestions with dataSuggestions for one time only
+	 * when shouldSaveSuggestions is true.
 	 */
 	useCallbackOnceEffect(
-		isInitialShippingRatesEmpty.current && dataSuggestions,
+		shouldSaveSuggestions,
 		callSaveSuggestions,
 		dataSuggestions
 	);
@@ -91,8 +97,7 @@ const useShippingRatesWithSavedSuggestions = () => {
 		loading:
 			loadingSuggestions ||
 			! hfrShippingRates ||
-			( isInitialShippingRatesEmpty.current &&
-				! saveSuggestionsFinished ),
+			( shouldSaveSuggestions && ! saveSuggestionsFinished ),
 		data: dataShippingRates,
 	};
 };

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
@@ -58,17 +58,19 @@ const useShippingRatesWithSavedSuggestions = () => {
 	}
 
 	/**
-	 * `done` is used to indicate whether saving has finished.
+	 * `saveSuggestionsFinished` is used to indicate whether saving has finished.
 	 * This is only used when we have no pre-saved initial shipping rates value
 	 * and we call `saveSuggestions`. It is initially set to `false`,
 	 * and will be set to `true` after the suggestions are saved.
 	 */
-	const [ done, setDone ] = useState( false );
+	const [ saveSuggestionsFinished, setSaveSuggestionsFinished ] = useState(
+		false
+	);
 	const saveSuggestions = useSaveSuggestions();
 	const callSaveSuggestions = useCallback(
 		async ( suggestions ) => {
 			await saveSuggestions( suggestions );
-			setDone( true );
+			setSaveSuggestionsFinished( true );
 		},
 		[ saveSuggestions ]
 	);
@@ -89,7 +91,8 @@ const useShippingRatesWithSavedSuggestions = () => {
 		loading:
 			loadingSuggestions ||
 			! hfrShippingRates ||
-			( isInitialShippingRatesEmpty.current && ! done ),
+			( isInitialShippingRatesEmpty.current &&
+				! saveSuggestionsFinished ),
 		data: dataShippingRates,
 	};
 };

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.js
@@ -89,7 +89,7 @@ const useShippingRatesWithSavedSuggestions = () => {
 		loading:
 			loadingSuggestions ||
 			! hfrShippingRates ||
-			( isInitialShippingRatesEmpty.current ? ! done : false ),
+			( isInitialShippingRatesEmpty.current && ! done ),
 		data: dataShippingRates,
 	};
 };

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.test.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.test.js
@@ -1,0 +1,148 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useShippingRatesWithSavedSuggestions from './useShippingRatesWithSavedSuggestions';
+import useShippingRates from '.~/hooks/useShippingRates';
+import useShippingRatesSuggestions from './useShippingRatesSuggestions';
+import useSaveSuggestions from './useSaveSuggestions';
+
+jest.mock( '.~/hooks/useShippingRates', () => jest.fn() );
+jest.mock( './useShippingRatesSuggestions', () => jest.fn() );
+jest.mock( './useSaveSuggestions', () => jest.fn() );
+
+const shippingRatesData = [
+	{
+		country: 'Malaysia',
+		country_code: 'MY',
+		currency: 'USD',
+		rate: '20',
+	},
+];
+
+const shippingRatesSuggestionsData = [
+	{
+		country: 'Malaysia',
+		country_code: 'MY',
+		currency: 'USD',
+		rate: 20,
+	},
+];
+
+describe( 'useShippingRatesWithSavedSuggestions', () => {
+	it( 'should save suggestions as shipping rates when initial shipping rates is empty', async () => {
+		useShippingRates
+			.mockReturnValueOnce( {
+				hasFinishedResolution: false,
+				data: undefined,
+			} )
+			.mockReturnValue( {
+				hasFinishedResolution: true,
+				data: [],
+			} );
+		useShippingRatesSuggestions
+			.mockReturnValueOnce( {
+				loading: true,
+				data: undefined,
+			} )
+			.mockReturnValueOnce( {
+				loading: true,
+				data: undefined,
+			} )
+			.mockReturnValue( {
+				loading: false,
+				data: shippingRatesSuggestionsData,
+			} );
+		const mockSaveSuggestions = jest.fn();
+		useSaveSuggestions.mockReturnValue( mockSaveSuggestions );
+
+		const { result, rerender, waitForNextUpdate } = renderHook( () =>
+			useShippingRatesWithSavedSuggestions()
+		);
+
+		/**
+		 * Shipping rates and suggestions are loading.
+		 */
+		expect( result.current.loading ).toBe( true );
+		expect( result.current.data ).toBe( undefined );
+		expect( mockSaveSuggestions ).toHaveBeenCalledTimes( 0 );
+
+		/**
+		 * Shipping rates are loaded; suggestions are loading.
+		 */
+		rerender();
+		expect( result.current.loading ).toBe( true );
+		expect( result.current.data ).toStrictEqual( [] );
+		expect( mockSaveSuggestions ).toHaveBeenCalledTimes( 0 );
+
+		/**
+		 * Shipping rates and suggestions are loaded,
+		 * and saveSuggestions is called.
+		 */
+		rerender();
+		await waitForNextUpdate();
+		expect( result.current.loading ).toBe( false );
+		expect( result.current.data ).toStrictEqual( [] );
+		expect( mockSaveSuggestions ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not save suggestions as shipping rates when there is an initial shipping rates', async () => {
+		useShippingRates
+			.mockReturnValueOnce( {
+				hasFinishedResolution: false,
+				data: undefined,
+			} )
+			.mockReturnValue( {
+				hasFinishedResolution: true,
+				data: shippingRatesData,
+			} );
+		useShippingRatesSuggestions
+			.mockReturnValueOnce( {
+				loading: true,
+				data: undefined,
+			} )
+			.mockReturnValueOnce( {
+				loading: true,
+				data: undefined,
+			} )
+			.mockReturnValue( {
+				loading: false,
+				data: shippingRatesSuggestionsData,
+			} );
+		const mockSaveSuggestions = jest.fn();
+		useSaveSuggestions.mockReturnValue( mockSaveSuggestions );
+
+		const { result, rerender } = renderHook( () =>
+			useShippingRatesWithSavedSuggestions()
+		);
+
+		/**
+		 * Shipping rates and suggestions are loading.
+		 */
+		expect( result.current.loading ).toBe( true );
+		expect( result.current.data ).toBe( undefined );
+		expect( mockSaveSuggestions ).toHaveBeenCalledTimes( 0 );
+
+		// rerender();
+		/**
+		 * Shipping rates are loaded; suggestions are loading.
+		 */
+		rerender();
+		expect( result.current.loading ).toBe( true );
+		expect( result.current.data ).toStrictEqual( shippingRatesData );
+		expect( mockSaveSuggestions ).toHaveBeenCalledTimes( 0 );
+
+		/**
+		 * Shipping rates and suggestions are loaded,
+		 * and saveSuggestions is not called.
+		 */
+		rerender();
+		expect( result.current.loading ).toBe( false );
+		expect( result.current.data ).toStrictEqual( shippingRatesData );
+		expect( mockSaveSuggestions ).toHaveBeenCalledTimes( 0 );
+	} );
+} );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.test.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSavedSuggestions.test.js
@@ -127,7 +127,6 @@ describe( 'useShippingRatesWithSavedSuggestions', () => {
 		expect( result.current.data ).toBe( undefined );
 		expect( mockSaveSuggestions ).toHaveBeenCalledTimes( 0 );
 
-		// rerender();
 		/**
 		 * Shipping rates are loaded; suggestions are loading.
 		 */

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSuggestions.js
@@ -24,7 +24,7 @@ const useShippingRatesWithSuggestions = () => {
 	} = useShippingRatesSuggestions();
 
 	/**
-	 * `hasInitialShippingRates` is used to indicate
+	 * `isInitialShippingRatesEmpty` is used to indicate
 	 * whether the initial loaded shipping rates
 	 * has a pre-saved value or not.
 	 *
@@ -39,9 +39,12 @@ const useShippingRatesWithSuggestions = () => {
 	 * and then reload the page,
 	 * then the suggestions would be saved as shipping rates as per above logic.
 	 */
-	const hasInitialShippingRates = useRef( undefined );
-	if ( hfrShippingRates && hasInitialShippingRates.current === undefined ) {
-		hasInitialShippingRates.current = dataShippingRates.length > 0;
+	const isInitialShippingRatesEmpty = useRef( undefined );
+	if (
+		hfrShippingRates &&
+		isInitialShippingRatesEmpty.current === undefined
+	) {
+		isInitialShippingRatesEmpty.current = dataShippingRates.length === 0;
 	}
 
 	const saveSuggestions = useCallback(
@@ -76,7 +79,7 @@ const useShippingRatesWithSuggestions = () => {
 	 */
 	useEffect( () => {
 		if (
-			hasInitialShippingRates.current === false &&
+			isInitialShippingRatesEmpty.current &&
 			dataSuggestions &&
 			hasSavedSuggestions.current === false
 		) {
@@ -89,7 +92,7 @@ const useShippingRatesWithSuggestions = () => {
 		loading:
 			loadingSuggestions ||
 			! hfrShippingRates ||
-			( hasInitialShippingRates.current === false ? saving : false ),
+			( isInitialShippingRatesEmpty.current ? saving : false ),
 		data: dataShippingRates,
 	};
 };

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/useShippingRatesWithSuggestions.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useShippingRates from '.~/hooks/useShippingRates';
+import getCountriesPriceArray from './getCountriesPriceArray';
+import { useAppDispatch } from '.~/data';
+import useShippingRatesSuggestions from './useShippingRatesSuggestions';
+
+const useShippingRatesWithSuggestions = () => {
+	const [ saving, setSaving ] = useState( true );
+	const { upsertShippingRates } = useAppDispatch();
+	const {
+		hasFinishedResolution: hfrShippingRates,
+		data: dataShippingRates,
+	} = useShippingRates();
+	const {
+		loading: loadingSuggestions,
+		data: dataSuggestions,
+	} = useShippingRatesSuggestions();
+
+	/**
+	 * `hasInitialShippingRates` is used to indicate
+	 * whether the initial loaded shipping rates
+	 * has a pre-saved value or not.
+	 *
+	 * If it does not have a pre-saved value,
+	 * shipping rates should be an empty array,
+	 * and we should save the suggestions as shipping rates.
+	 *
+	 * If it does have a pre-saved value,
+	 * then we should not save the suggestions,
+	 * even when users manually deleted all the pre-saved shipping rates value.
+	 * The exception is when users deleted all the pre-saved value
+	 * and then reload the page,
+	 * then the suggestions would be saved as shipping rates as per above logic.
+	 */
+	const hasInitialShippingRates = useRef( undefined );
+	if ( hfrShippingRates && hasInitialShippingRates.current === undefined ) {
+		hasInitialShippingRates.current = dataShippingRates.length > 0;
+	}
+
+	const saveSuggestions = useCallback(
+		async ( suggestions ) => {
+			const countriesPriceArray = getCountriesPriceArray( suggestions );
+			const values = countriesPriceArray.map( ( el ) => ( {
+				countryCodes: el.countries,
+				currency: el.currency,
+				rate: el.price,
+			} ) );
+			const promises = values.map( ( el ) => {
+				return upsertShippingRates( el );
+			} );
+			await Promise.all( promises );
+			setSaving( false );
+		},
+		[ upsertShippingRates ]
+	);
+
+	/**
+	 * Used to track whether `saveSuggestions` has been called.
+	 * We want to call the function one time only.
+	 */
+	const hasSavedSuggestions = useRef( false );
+
+	/**
+	 * Call `saveSuggestions` when:
+	 *
+	 * - there is no pre-saved initial shipping rates value.
+	 * - we have suggestions data.
+	 * - we have not saved the suggestions data as shipping rates.
+	 */
+	useEffect( () => {
+		if (
+			hasInitialShippingRates.current === false &&
+			dataSuggestions &&
+			hasSavedSuggestions.current === false
+		) {
+			hasSavedSuggestions.current = true;
+			saveSuggestions( dataSuggestions );
+		}
+	}, [ dataSuggestions, saveSuggestions ] );
+
+	return {
+		loading:
+			loadingSuggestions ||
+			! hfrShippingRates ||
+			( hasInitialShippingRates.current === false ? saving : false ),
+		data: dataShippingRates,
+	};
+};
+
+export default useShippingRatesWithSuggestions;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Based on #1160, depends on shipping rates suggestions developed by @nima-karimi in PR #1144. 

Prior to this PR, when users go through the Setup MC flow and arrive at Step 3 page, they would have to manually key in shipping rates settings, even though they already have something similar setup in WooCommerce settings.

In this PR, we use the shipping rates suggestions API and pre-fill it into the Setup MC Step 3 form. The logic goes like this: 

1. We call shipping rates API to check if there is existing shipping rates already setup, and also shipping rates suggestions API to get the suggestions.
2. Check shipping rates: 
    - If there are existing shipping rates, we will use the existing shipping rates, and ignore the shipping rates suggestions. It would behave like existing production behavior.
    - If there are no existing shipping rates, we will save the suggestions as shipping rates. When the saving is done, we display the UI with the values filled in.

**Technical notes:**

- I added a new hook called `useCallbackOnceEffect`. It allows us to call a callback function only once, when a condition is set to `true`.

### Screenshots:

📹 Demo video with voice:

https://user-images.githubusercontent.com/417342/146678326-4431bf2a-6dc8-4c8d-a880-c6005ff8d4e5.mov

### Detailed test instructions:

1. Make sure you have some shipping zones and shipping methods already setup in WooCommerce settings: `/wp-admin/admin.php?page=wc-settings&tab=shipping`. Make sure you have different rates, so that you will see multiple shipping rates rows in the following steps.
2. Go through Setup MC flow until you arrive at Step 3. Open browser dev tools network panel to inspect the API calls.
3. Click on the "I have a fairly simple shipping setup and I can estimate flat shipping rates and times." radio button. The estimated shipping rates section should show up with a loading indicator. 
4. While the loading indicator is displayed, there should be a number of API calls in the network panel. 
    1. `GET /mc/shipping/rates` and `GET /mc/shipping/rates/suggestions/batch` with country codes in the query string. 
    2. Because you do not have any existing shipping rates, the suggestions will be used and saved as your shipping rates. You should see multiple calls of `POST /mc/shipping/rates/batch` to save the suggestions as shipping rates.
5. The shipping rates countries and values should show up.
6. Delete or modify one of the shipping rates, and then reload the page. The shipping rates setup should be the same as prior to the reload. (Note: if you modify the shipping rates and then reload the page, you might encounter issue https://github.com/woocommerce/google-listings-and-ads/issues/1158.)
7. Remove all the shipping rates, and then reload the page. You should see the shipping rates being filled with the shipping rates suggestions again.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Pre-fill shipping rates in Setup Merchant Center flow based on store's shipping settings.
