### PR TITLE
Create new instance of query instead of using shared object

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
@@ -211,9 +211,10 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 	 * @return callable
 	 */
 	protected function get_create_rate_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
+			$query_object = $this->create_query();
 			$country_code = $request->get_param( 'country_code' );
-			$existing     = ! empty( $this->query->where( 'country', $country_code )->get_results() );
+			$existing     = ! empty( $query_object->where( 'country', $country_code )->get_results() );
 
 			try {
 				$data = [
@@ -223,14 +224,14 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 				];
 
 				if ( $existing ) {
-					$this->query->update(
+					$query_object->update(
 						$data,
 						[
-							'id' => $this->query->get_results()[0]['id'],
+							'id' => $query_object->get_results()[0]['id'],
 						]
 					);
 				} else {
-					$this->query->insert( $data );
+					$query_object->insert( $data );
 				}
 
 				return new Response(
@@ -264,7 +265,7 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 		return function( Request $request ) {
 			try {
 				$country_code = $request->get_param( 'country_code' );
-				$this->query->delete( 'country', $country_code );
+				$this->create_query()->delete( 'country', $country_code );
 
 				return [
 					'status'  => 'success',
@@ -291,7 +292,7 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 	 * @return array
 	 */
 	protected function get_all_shipping_rates(): array {
-		return $this->query->set_limit( 100 )->get_results();
+		return $this->create_query()->set_limit( 100 )->get_results();
 	}
 
 	/**
@@ -300,7 +301,16 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 	 * @return array
 	 */
 	protected function get_shipping_rate_for_country( string $country ): array {
-		return $this->query->where( 'country', $country )->get_results();
+		return $this->create_query()->where( 'country', $country )->get_results();
+	}
+
+	/**
+	 * Return a new instance of the shipping rate query object.
+	 *
+	 * @return ShippingRateQuery
+	 */
+	protected function create_query(): ShippingRateQuery {
+		return clone $this->query;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://github.com/woocommerce/google-listings-and-ads/issues/1158

This PR resolves the issue where saving a shipping rate for multiple countries would result in a conflicting database update. More details about the issue explained in https://github.com/woocommerce/google-listings-and-ads/issues/1158

The query object was being shared in the controller instance and when the batch controller called it multiple times, the same DB row was being updated instead of a separate row for each country. I've modified the code to use a clone instance of the query object in each method so that the logic isn't shared between them.

### Detailed test instructions:

> 1. Go to Step 3 in Setup MC. 
> 2. Select "I have a fairly simple shipping setup and I can estimate flat shipping rates and times."
> 3. In the shipping rates section, create a few rows of countries with different rates. Be sure to leave a few countries without any rates.
> 4. In one of the rows, click on the Edit button, add another country, click on the Save button. The UI should be as expected.
> 5. Reload the page. Check if the shipping rates are the same as before reloading.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
