### PR TITLE
Remove WC's `is_ajax` (deprecated in 6.1) in favor of proxied WP `wp_doing_ajax`

### DIFF
--- a/src/Admin/ActivationRedirect.php
+++ b/src/Admin/ActivationRedirect.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP as WPProxy;
 
 /**
  * Class ActivationRedirect
@@ -28,6 +29,19 @@ class ActivationRedirect implements Activateable, Service, Registerable, Options
 		'page' => 'wc-admin',
 		'path' => '/google/start',
 	];
+	/**
+	 * @var WPProxy
+	 */
+	protected $wp_proxy;
+
+	/**
+	 * Installer constructor.
+	 *
+	 * @param WPProxy $wp_proxy
+	 */
+	public function __construct( WPProxy $wp_proxy ) {
+		$this->wp_proxy = $wp_proxy;
+	}
 
 	/**
 	 * Register a service.
@@ -70,7 +84,7 @@ class ActivationRedirect implements Activateable, Service, Registerable, Options
 	 * @return bool True if the redirection should have happened
 	 */
 	protected function maybe_redirect_to_onboarding(): bool {
-		if ( wp_doing_ajax() ) {
+		if ( $this->wp_proxy->wp_doing_ajax() ) {
 			return false;
 		}
 

--- a/src/Admin/ActivationRedirect.php
+++ b/src/Admin/ActivationRedirect.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP as WPProxy;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 /**
  * Class ActivationRedirect
@@ -30,17 +30,17 @@ class ActivationRedirect implements Activateable, Service, Registerable, Options
 		'path' => '/google/start',
 	];
 	/**
-	 * @var WPProxy
+	 * @var WP
 	 */
-	protected $wp_proxy;
+	protected $wp;
 
 	/**
 	 * Installer constructor.
 	 *
-	 * @param WPProxy $wp_proxy
+	 * @param WP $wp
 	 */
-	public function __construct( WPProxy $wp_proxy ) {
-		$this->wp_proxy = $wp_proxy;
+	public function __construct( WP $wp ) {
+		$this->wp = $wp;
 	}
 
 	/**
@@ -84,7 +84,7 @@ class ActivationRedirect implements Activateable, Service, Registerable, Options
 	 * @return bool True if the redirection should have happened
 	 */
 	protected function maybe_redirect_to_onboarding(): bool {
-		if ( $this->wp_proxy->wp_doing_ajax() ) {
+		if ( $this->wp->wp_doing_ajax() ) {
 			return false;
 		}
 

--- a/src/Admin/BulkEdit/CouponBulkEdit.php
+++ b/src/Admin/BulkEdit/CouponBulkEdit.php
@@ -120,7 +120,6 @@ class CouponBulkEdit implements BulkEditInterface, Registerable {
 			$coupon     = new WC_Coupon( $post_id );
 			$visibility =
 			ChannelVisibility::cast( sanitize_key( $request_data['change_channel_visibility'] ) );
-			// phpcs:enable WordPress.Security.NonceVerification
 
 			if ( $this->meta_handler->get_visibility( $coupon ) !== $visibility ) {
 				$this->meta_handler->update_visibility( $coupon, $visibility );
@@ -138,6 +137,8 @@ class CouponBulkEdit implements BulkEditInterface, Registerable {
 	 * @return array The $_REQUEST superglobal.
 	 */
 	protected function request_data(): array {
+		// Nonce must be verified manually.
+		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return $_REQUEST;
 	}
 }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -42,11 +42,6 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	protected $wp_proxy;
 
 	/**
-	 * @var OptionsInterface
-	 */
-	protected $options;
-
-	/**
 	 * Installer constructor.
 	 *
 	 * @param InstallableInterface[]  $installables

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -69,7 +69,8 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	 * Admin init.
 	 */
 	protected function admin_init(): void {
-		if ( defined( 'IFRAME_REQUEST' ) || is_ajax() ) {
+		$is_ajax = version_compare( WC_VERSION, '6.1.0', '>=' ) ? wp_doing_ajax() : is_ajax();
+		if ( defined( 'IFRAME_REQUEST' ) || $is_ajax ) {
 			return;
 		}
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableI
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP as WPProxy;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -37,21 +37,21 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	protected $first_installers;
 
 	/**
-	 * @var WPProxy
+	 * @var WP
 	 */
-	protected $wp_proxy;
+	protected $wp;
 
 	/**
 	 * Installer constructor.
 	 *
 	 * @param InstallableInterface[]  $installables
 	 * @param FirstInstallInterface[] $first_installers
-	 * @param WPProxy                 $wp_proxy
+	 * @param WP                      $wp
 	 */
-	public function __construct( array $installables, array $first_installers, WPProxy $wp_proxy ) {
+	public function __construct( array $installables, array $first_installers, WP $wp ) {
 		$this->installables     = $installables;
 		$this->first_installers = $first_installers;
-		$this->wp_proxy         = $wp_proxy;
+		$this->wp               = $wp;
 		$this->validate_installables();
 		$this->validate_first_installers();
 	}
@@ -72,7 +72,7 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	 * Admin init.
 	 */
 	protected function admin_init(): void {
-		if ( defined( 'IFRAME_REQUEST' ) || $this->wp_proxy->wp_doing_ajax() ) {
+		if ( defined( 'IFRAME_REQUEST' ) || $this->wp->wp_doing_ajax() ) {
 			return;
 		}
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableI
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP as WPProxy;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,6 +37,11 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	protected $first_installers;
 
 	/**
+	 * @var WPProxy
+	 */
+	protected $wp_proxy;
+
+	/**
 	 * @var OptionsInterface
 	 */
 	protected $options;
@@ -45,10 +51,12 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	 *
 	 * @param InstallableInterface[]  $installables
 	 * @param FirstInstallInterface[] $first_installers
+	 * @param WPProxy                 $wp_proxy
 	 */
-	public function __construct( array $installables, array $first_installers ) {
+	public function __construct( array $installables, array $first_installers, WPProxy $wp_proxy ) {
 		$this->installables     = $installables;
 		$this->first_installers = $first_installers;
+		$this->wp_proxy         = $wp_proxy;
 		$this->validate_installables();
 		$this->validate_first_installers();
 	}
@@ -69,8 +77,7 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	 * Admin init.
 	 */
 	protected function admin_init(): void {
-		$is_ajax = version_compare( WC_VERSION, '6.1.0', '>=' ) ? wp_doing_ajax() : is_ajax();
-		if ( defined( 'IFRAME_REQUEST' ) || $is_ajax ) {
+		if ( defined( 'IFRAME_REQUEST' ) || $this->wp_proxy->wp_doing_ajax() ) {
 			return;
 		}
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -213,7 +213,12 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
 
 		// Set up the installer.
-		$installer_definition = $this->share_with_tags( Installer::class, InstallableInterface::class, FirstInstallInterface::class );
+		$installer_definition = $this->share_with_tags(
+			Installer::class,
+			InstallableInterface::class,
+			FirstInstallInterface::class,
+			WP::class
+		);
 		$installer_definition->setConcrete(
 			function ( ...$arguments ) {
 				return new Installer( ...$arguments );
@@ -233,7 +238,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			MerchantCenterService::class,
 			AdsService::class
 		);
-		$this->conditionally_share_with_tags( ActivationRedirect::class );
+		$this->conditionally_share_with_tags( ActivationRedirect::class, WP::class );
 		$this->conditionally_share_with_tags( GetStarted::class );
 		$this->conditionally_share_with_tags( SetupMerchantCenter::class );
 		$this->conditionally_share_with_tags( SetupAds::class );

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -166,4 +166,15 @@ class WP {
 	public function number_format_i18n( float $number, int $decimals = 0 ): string {
 		return number_format_i18n( $number, $decimals );
 	}
+
+	/**
+	 * Determines whether the current request is a WordPress Ajax request.
+	 *
+	 * @return bool True if it's a WordPress Ajax request, false otherwise.
+	 *
+	 * @since x.x.x
+	 */
+	public function wp_doing_ajax(): bool {
+		return wp_doing_ajax();
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce's `is_ajax()` function will be deprecated in version 6.1: https://github.com/woocommerce/woocommerce/blob/71cdcf322c972d51fa6c767a445652e74f1a6e90/plugins/woocommerce/includes/wc-deprecated-functions.php#L1129-L1139

This causes a deprecated warning in Google Listings & Ads:
![image](https://user-images.githubusercontent.com/228780/146951092-f36af1ab-bb08-4c0a-afef-90149e0381c8.png)


This PR replaces it in `Installer` with a proxied version of `wp_doing_ajax()`, which has been included in WordPress since 4.7: https://github.com/WordPress/WordPress/blob/e6b9b961305edd32fdfacc78eb6d93b22c3c8768/wp-includes/load.php#L1487-L1503

It also swaps in the proxied `wp_doing_ajax()` version in `ActivationRedirect`.


### Detailed test instructions:
**Deprecated**
1. Install WooCommerce 6.1+ (currently `trunk` of the https://github.com/woocommerce/woocommerce repo).
2. Enable debugging (`define( 'WP_DEBUG', true );`).
3. Visit any WooCommerce page and confirm that the deprecation warning is not visible.
    - Confirms using `wp_doing_ajax` instead of `is_ajax` 


**Proxied value**
1. Reset the "redirect to onboarding" and "MC setup complete" options:
```sql
UPDATE wp_options SET option_value="yes" WHERE option_name="gla_redirect_to_onboarding";
DELETE FROM wp_options WHERE option_name="gla_mc_setup_completed_at" LIMIT 1;
```
2. Visit any admin page and confirm that you're redirected to GLA onboarding.
    - Confirms the proxied `wp_doing_ajax` correctly returns false.
    - Subsequently navigating to another page should no longer redirect to onboarding.
3. Go to the add new product page (which has regular heartbeat requests).
4. Open the network inspector panel to see all requests.
1. Reset the "redirect to onboarding" and "MC setup complete" options again:
```sql
UPDATE wp_options SET option_value="yes" WHERE option_name="gla_redirect_to_onboarding";
DELETE FROM wp_options WHERE option_name="gla_mc_setup_completed_at" LIMIT 1;
```
5. Confirm that any heartbeat or other async requests return the correct data, and aren't redirected to the onboarding URL (`wp-admin/admin.php?page=wc-admin&path=/google/start`).
    - Confirms the proxied `wp_doing_ajax` correctly returns true.

(_No changelog_)
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry