### PR TITLE
Copy improvements for Inbox Notifications

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -440,6 +440,7 @@ class Proxy implements OptionsAwareInterface {
 			'status'   => $id ? 'connected' : 'disconnected',
 		];
 
+		/** @var AdsAccountState $state */
 		$state      = $this->container->get( AdsAccountState::class );
 		$incomplete = $state->last_incomplete_step();
 		if ( ! empty( $incomplete ) ) {

--- a/src/Ads/AdsService.php
+++ b/src/Ads/AdsService.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -19,8 +20,32 @@ class AdsService implements OptionsAwareInterface, Service {
 
 	use OptionsAwareTrait;
 
+	/** @var AdsAccountState */
+	protected $account_state;
+
 	/**
-	 * Get whether Ads setup is completed.
+	 * AdsService constructor.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param AdsAccountState $account_state
+	 */
+	public function __construct( AdsAccountState $account_state ) {
+		$this->account_state = $account_state;
+	}
+
+	/**
+	 * Determine whether Ads setup has been started.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	public function is_setup_started(): bool {
+		return $this->account_state->last_incomplete_step() !== '' && ! $this->is_setup_complete();
+	}
+
+	/**
+	 * Determine whether Ads setup has completed.
 	 *
 	 * @return bool
 	 */
@@ -29,7 +54,7 @@ class AdsService implements OptionsAwareInterface, Service {
 	}
 
 	/**
-	 * Get whether Ads is connected.
+	 * Determine whether Ads has connected.
 	 *
 	 * @return bool
 	 */

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -262,8 +262,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( CompleteSetupNote::class );
 		$this->share_with_tags( ReviewAfterClicksNote::class, MerchantMetrics::class, WP::class );
 		$this->share_with_tags( ReviewAfterConversionsNote::class, MerchantMetrics::class, WP::class );
-		$this->share_with_tags( SetupCampaignNote::class );
-		$this->share_with_tags( SetupCampaign2Note::class );
+		$this->share_with_tags( SetupCampaignNote::class, MerchantStatuses::class );
+		$this->share_with_tags( SetupCampaign2Note::class, MerchantStatuses::class );
 		$this->share_with_tags( SetupCouponSharingNote::class, MerchantStatuses::class );
 		$this->share_with_tags( NoteInitializer::class, ActionScheduler::class, Note::class );
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -207,7 +207,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			 ->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );
 
 		// Set up Ads service, and inflect classes that need it.
-		$this->share_with_tags( AdsService::class );
+		$this->share_with_tags( AdsAccountState::class );
+		$this->share_with_tags( AdsService::class, AdsAccountState::class );
 		$this->getLeagueContainer()
 			 ->inflector( AdsAwareInterface::class )
 			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
@@ -271,7 +272,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 
-		$this->share_with_tags( AdsAccountState::class );
 		$this->share_with_tags( MerchantAccountState::class );
 		$this->share_with_tags( MerchantStatuses::class );
 		$this->share_with_tags( PhoneVerification::class, Merchant::class, WP::class, ISOUtility::class );

--- a/src/Notes/AbstractSetupCampaign.php
+++ b/src/Notes/AbstractSetupCampaign.php
@@ -135,6 +135,8 @@ abstract class AbstractSetupCampaign extends AbstractNote implements AdsAwareInt
 	/**
 	 * Get the number of days after which to add the note.
 	 *
+	 * @since x.x.x
+	 *
 	 * @return int
 	 */
 	abstract protected function get_gla_setup_days(): int;

--- a/src/Notes/AbstractSetupCampaign.php
+++ b/src/Notes/AbstractSetupCampaign.php
@@ -63,11 +63,6 @@ abstract class AbstractSetupCampaign extends AbstractNote implements AdsAwareInt
 		$note->set_image( '' );
 		$note->set_name( $this->get_name() );
 		$note->set_source( $this->get_slug() );
-		$note->add_action(
-			'setup-campaign',
-			__( 'Get started', 'google-listings-and-ads' ),
-			$this->get_setup_ads_url()
-		);
 	}
 
 	/**

--- a/src/Notes/AbstractSetupCampaign.php
+++ b/src/Notes/AbstractSetupCampaign.php
@@ -25,6 +25,17 @@ abstract class AbstractSetupCampaign extends AbstractNote implements AdsAwareInt
 	use Utilities;
 
 	/**
+	 * Get the note entry.
+	 */
+	public function get_entry(): NoteEntry {
+		$note = new NoteEntry();
+		$this->set_title_and_content( $note );
+		$this->add_common_note_settings( $note );
+
+		return $note;
+	}
+
+	/**
 	 * @param NoteEntry $note
 	 *
 	 * @return void
@@ -74,4 +85,15 @@ abstract class AbstractSetupCampaign extends AbstractNote implements AdsAwareInt
 	 * @return int
 	 */
 	abstract protected function get_gla_setup_days(): int;
+
+	/**
+	 * Set the title and content of the Note.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param NoteEntry $note
+	 *
+	 * @return void
+	 */
+	abstract protected function set_title_and_content( NoteEntry $note ): void;
 }

--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use stdClass;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -38,7 +39,7 @@ class CompleteSetup extends AbstractNote implements MerchantCenterAwareInterface
 		$note = new NoteEntry();
 		$note->set_title( __( 'Reach more shoppers with free listings on Google', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'Finish setting up Google Listings & Ads to list your products on Google for free and promote them with paid ads.', 'google-listings-and-ads' ) );
-		$note->set_content_data( (object) [] );
+		$note->set_content_data( new stdClass() );
 		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_layout( 'plain' );
 		$note->set_image( '' );

--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -36,7 +36,7 @@ class CompleteSetup extends AbstractNote implements MerchantCenterAwareInterface
 	 */
 	public function get_entry(): NoteEntry {
 		$note = new NoteEntry();
-		$note->set_title( __( 'Complete your setup on Google', 'google-listings-and-ads' ) );
+		$note->set_title( __( 'Reach more shoppers with free listings on Google', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'Finish setting up Google Listings & Ads to list your products on Google for free and promote them with paid ads.', 'google-listings-and-ads' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -26,6 +26,8 @@ class SetupCampaign extends AbstractSetupCampaign {
 	/**
 	 * Get the number of days after which to add the note.
 	 *
+	 * @since x.x.x
+	 *
 	 * @return int
 	 */
 	protected function get_gla_setup_days(): int {

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -24,23 +24,40 @@ class SetupCampaign extends AbstractSetupCampaign {
 	}
 
 	/**
-	 * Get the note entry.
-	 */
-	public function get_entry(): NoteEntry {
-		$note = new NoteEntry();
-		$note->set_title( __( 'Create your first campaign to boost sales', 'google-listings-and-ads' ) );
-		$note->set_content( __( 'Leverage the power of paid ads to list products on Google Search, Shopping, YouTube, Gmail and the Display Network and drive sales.', 'google-listings-and-ads' ) );
-		$this->add_common_note_settings( $note );
-
-		return $note;
-	}
-
-	/**
 	 * Get the number of days after which to add the note.
 	 *
 	 * @return int
 	 */
 	protected function get_gla_setup_days(): int {
 		return 3;
+	}
+
+	/**
+	 * Set the title and content of the Note.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param NoteEntry $note
+	 *
+	 * @return void
+	 */
+	protected function set_title_and_content( NoteEntry $note ): void {
+		if ( ! $this->ads_service->is_setup_started() ) {
+			$note->set_title( __( 'Launch ads to drive traffic and grow sales', 'google-listings-and-ads' ) );
+			$note->set_content(
+				__(
+					'Your products are ready for Google Ads! Get your products shown on Google exactly when shoppers are searching for the products you offer. For new Google Ads accounts, Google will match your spend up to $150 USD over your first 30 days. T&Cs apply.',
+					'google-listings-and-ads'
+				)
+			);
+		} else {
+			$note->set_title( __( 'Finish connecting your Google Ads account', 'google-listings-and-ads' ) );
+			$note->set_content(
+				__(
+					'Your products are ready for Google Ads! Finish connecting your account, create your campaign, pick your budget, and easily measure the impact of your ads. Plus, Google will match $150 USD ad spend for new accounts. T&Cs apply.',
+					'google-listings-and-ads'
+				)
+			);
+		}
 	}
 }

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -52,6 +52,13 @@ class SetupCampaign extends AbstractSetupCampaign {
 					'google-listings-and-ads'
 				)
 			);
+			$note->add_action(
+				'setup-campaign',
+				__( 'Set up Google Ads', 'google-listings-and-ads' ),
+				$this->get_setup_ads_url(),
+				NoteEntry::E_WC_ADMIN_NOTE_ACTIONED,
+				true
+			);
 		} else {
 			$note->set_title( __( 'Finish connecting your Google Ads account', 'google-listings-and-ads' ) );
 			$note->set_content(
@@ -60,6 +67,19 @@ class SetupCampaign extends AbstractSetupCampaign {
 					'google-listings-and-ads'
 				)
 			);
+			$note->add_action(
+				'setup-campaign',
+				__( 'Complete Setup', 'google-listings-and-ads' ),
+				$this->get_setup_ads_url(),
+				NoteEntry::E_WC_ADMIN_NOTE_ACTIONED,
+				true
+			);
 		}
+
+		$note->add_action(
+			'setup-campaign-learn-more',
+			__( 'Learn more', 'google-listings-and-ads' ),
+			'https://docs.woocommerce.com/document/google-listings-and-ads/#get-500-in-free-ad-credits'
+		);
 	}
 }

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -4,10 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
 use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -16,11 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaign extends AbstractNote implements AdsAwareInterface {
-
-	use AdsAwareTrait;
-	use PluginHelper;
-	use Utilities;
+class SetupCampaign extends AbstractSetupCampaign {
 
 	/**
 	 * Get the note's unique name.
@@ -38,44 +30,17 @@ class SetupCampaign extends AbstractNote implements AdsAwareInterface {
 		$note = new NoteEntry();
 		$note->set_title( __( 'Create your first campaign to boost sales', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'Leverage the power of paid ads to list products on Google Search, Shopping, YouTube, Gmail and the Display Network and drive sales.', 'google-listings-and-ads' ) );
-		$note->set_content_data( (object) [] );
-		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_layout( 'plain' );
-		$note->set_image( '' );
-		$note->set_name( $this->get_name() );
-		$note->set_source( $this->get_slug() );
-		$note->add_action(
-			'setup-campaign',
-			__( 'Get started', 'google-listings-and-ads' ),
-			$this->get_setup_ads_url()
-		);
+		$this->add_common_note_settings( $note );
 
 		return $note;
 	}
 
 	/**
-	 * Checks if a note can and should be added.
+	 * Get the number of days after which to add the note.
 	 *
-	 * Check if ads setup IS NOT complete
-	 * Check if it is > 3 days ago from DATE OF SETUP COMPLETION
-	 * Send notification
-	 *
-	 * @return bool
+	 * @return int
 	 */
-	public function should_be_added(): bool {
-		if ( $this->has_been_added() ) {
-			return false;
-		}
-
-		if ( $this->ads_service->is_setup_complete() ) {
-			return false;
-		}
-
-		if ( ! $this->gla_setup_for( 3 * DAY_IN_SECONDS ) ) {
-			return false;
-		}
-
-		return true;
+	protected function get_gla_setup_days(): int {
+		return 3;
 	}
-
 }

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -48,7 +48,7 @@ class SetupCampaign extends AbstractSetupCampaign {
 			$note->set_title( __( 'Launch ads to drive traffic and grow sales', 'google-listings-and-ads' ) );
 			$note->set_content(
 				__(
-					'Your products are ready for Google Ads! Get your products shown on Google exactly when shoppers are searching for the products you offer. For new Google Ads accounts, Google will match your spend up to $150 USD over your first 30 days. T&Cs apply.',
+					'Your products are ready for Google Ads! Get your products shown on Google exactly when shoppers are searching for the products you offer. For new Google Ads accounts, get $500 in ad credit when you spend $500 within your first 60 days. T&Cs apply.',
 					'google-listings-and-ads'
 				)
 			);
@@ -63,7 +63,7 @@ class SetupCampaign extends AbstractSetupCampaign {
 			$note->set_title( __( 'Finish connecting your Google Ads account', 'google-listings-and-ads' ) );
 			$note->set_content(
 				__(
-					'Your products are ready for Google Ads! Finish connecting your account, create your campaign, pick your budget, and easily measure the impact of your ads. Plus, Google will match $150 USD ad spend for new accounts. T&Cs apply.',
+					'Your products are ready for Google Ads! Finish connecting your account, create your campaign, pick your budget, and easily measure the impact of your ads. Plus, Google will give you $500 USD in ad credit when you spend $500 for new accounts. T&Cs apply.',
 					'google-listings-and-ads'
 				)
 			);

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -52,6 +52,13 @@ class SetupCampaignTwoWeeks extends AbstractSetupCampaign {
 					'google-listings-and-ads'
 				)
 			);
+			$note->add_action(
+				'setup-campaign',
+				__( 'Set up Google Ads', 'google-listings-and-ads' ),
+				$this->get_setup_ads_url(),
+				NoteEntry::E_WC_ADMIN_NOTE_ACTIONED,
+				true
+			);
 		} else {
 			$note->set_title(
 				__( 'Finish setting up your ads campaign and boost your sales', 'google-listings-and-ads' )
@@ -61,6 +68,13 @@ class SetupCampaignTwoWeeks extends AbstractSetupCampaign {
 					"You're just a few steps away from reaching new shoppers across Google. Finish connecting your account, create your campaign, pick your budget, and easily measure the impact of your ads.",
 					'google-listings-and-ads'
 				)
+			);
+			$note->add_action(
+				'setup-campaign',
+				__( 'Complete Setup', 'google-listings-and-ads' ),
+				$this->get_setup_ads_url(),
+				NoteEntry::E_WC_ADMIN_NOTE_ACTIONED,
+				true
 			);
 		}
 	}

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -4,10 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
 use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -16,11 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class SetupCampaignTwoWeeks extends AbstractNote implements AdsAwareInterface {
-
-	use AdsAwareTrait;
-	use PluginHelper;
-	use Utilities;
+class SetupCampaignTwoWeeks extends AbstractSetupCampaign {
 
 	/**
 	 * Get the note's unique name.
@@ -38,43 +30,17 @@ class SetupCampaignTwoWeeks extends AbstractNote implements AdsAwareInterface {
 		$note = new NoteEntry();
 		$note->set_title( __( 'Launch your first ad in a few steps', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'You’re just a few steps away from reaching new shoppers across Google. Create your first paid ad campaign today.', 'google-listings-and-ads' ) );
-		$note->set_content_data( (object) [] );
-		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_layout( 'plain' );
-		$note->set_image( '' );
-		$note->set_name( $this->get_name() );
-		$note->set_source( $this->get_slug() );
-		$note->add_action(
-			'setup-campaign',
-			__( 'Get started', 'google-listings-and-ads' ),
-			$this->get_setup_ads_url()
-		);
+		$this->add_common_note_settings( $note );
 
 		return $note;
 	}
 
 	/**
-	 * Checks if a note can and should be added.
+	 * Get the number of days after which to add the note.
 	 *
-	 * Check if ads setup IS NOT complete
-	 * Check if it is > 14 days ago from DATE OF SETUP COMPLETION
-	 * Send notification
-	 *
-	 * @return bool
+	 * @return int
 	 */
-	public function should_be_added(): bool {
-		if ( $this->has_been_added() ) {
-			return false;
-		}
-
-		if ( $this->ads_service->is_setup_complete() ) {
-			return false;
-		}
-
-		if ( ! $this->gla_setup_for( 14 * DAY_IN_SECONDS ) ) {
-			return false;
-		}
-
-		return true;
+	protected function get_gla_setup_days(): int {
+		return 14;
 	}
 }

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -24,23 +24,42 @@ class SetupCampaignTwoWeeks extends AbstractSetupCampaign {
 	}
 
 	/**
-	 * Get the note entry.
-	 */
-	public function get_entry(): NoteEntry {
-		$note = new NoteEntry();
-		$note->set_title( __( 'Launch your first ad in a few steps', 'google-listings-and-ads' ) );
-		$note->set_content( __( 'You’re just a few steps away from reaching new shoppers across Google. Create your first paid ad campaign today.', 'google-listings-and-ads' ) );
-		$this->add_common_note_settings( $note );
-
-		return $note;
-	}
-
-	/**
 	 * Get the number of days after which to add the note.
 	 *
 	 * @return int
 	 */
 	protected function get_gla_setup_days(): int {
 		return 14;
+	}
+
+	/**
+	 * Set the title and content of the Note.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param NoteEntry $note
+	 *
+	 * @return void
+	 */
+	protected function set_title_and_content( NoteEntry $note ): void {
+		if ( ! $this->ads_service->is_setup_started() ) {
+			$note->set_title( __( 'Reach more shoppers with paid listings on Google', 'google-listings-and-ads' ) );
+			$note->set_content(
+				__(
+					'Your products are ready for Google Ads! Connect with the right shoppers at the right moment when they’re searching for products like yours. Connect your Google Ads account to create your first paid ad campaign.',
+					'google-listings-and-ads'
+				)
+			);
+		} else {
+			$note->set_title(
+				__( 'Finish setting up your ads campaign and boost your sales', 'google-listings-and-ads' )
+			);
+			$note->set_content(
+				__(
+					"You're just a few steps away from reaching new shoppers across Google. Finish connecting your account, create your campaign, pick your budget, and easily measure the impact of your ads.",
+					'google-listings-and-ads'
+				)
+			);
+		}
 	}
 }

--- a/src/Notes/SetupCampaignTwoWeeks.php
+++ b/src/Notes/SetupCampaignTwoWeeks.php
@@ -26,6 +26,8 @@ class SetupCampaignTwoWeeks extends AbstractSetupCampaign {
 	/**
 	 * Get the number of days after which to add the note.
 	 *
+	 * @since x.x.x
+	 *
 	 * @return int
 	 */
 	protected function get_gla_setup_days(): int {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1138, closes #1139, closes #1213.

This PR updates the Inbox notifications as outlined in the two issues linked above. The Inbox Notifications that we are adjusting are the ones located in the `SetupCampaign` and `SetupCampaignTwoWeeks` classes. Specifically:

**Logic Changes**

* Both classes now inherit from a new `AbstractSetupCampaign` class.
* The notes will check to ensure there aren't any account-level issues before displaying
* The notes will check to ensure there is at least one approved product before displaying
* Each note will tailor the title and message based on whether or not the user has begun Ads setup


### Detailed test instructions:

**Option 1:**

See [Mik's comment below](https://github.com/woocommerce/google-listings-and-ads/pull/1167#pullrequestreview-859449173)

**Option 2:**

1. Grab the file from [this nifty Gist](https://gist.github.com/JPry/357ee26a46e3d8e2b68d1690f5bbbf75) and drop it into your `/wp-content/mu-plugins/` directory.
2. Add some code to your own `mu-plugins` file:

    ```php
    add_action(
    	'jpry-add-notes',
    	function() {
    		$container = woogle_get_container();
    
    		/** @var SetupCampaign $setup_campaign */
    		$setup_campaign = $container->get( SetupCampaign::class );
    		$setup_campaign->should_be_added();
    		$setup_campaign->get_entry()->save();
    
    		/** @var SetupCampaignTwoWeeks $setup_campaign_two_weeks */
    		$setup_campaign_two_weeks = $container->get( SetupCampaignTwoWeeks::class );
    		$setup_campaign_two_weeks->should_be_added();
    		$setup_campaign_two_weeks->get_entry()->save();
    	}
    );
    ```

3. Use the Tools > Create Scheduled Action page to create the 'jpry-add-notes' action, or your own if desired.
4. To test the different variations, you can add the following snippet to filter the value of the Account State:

    ```php
    add_filter(
    	'pre_option_gla_ads_account_state',
    	function( $value ) {
    		return [
    			'set_id' => [
    				'status'  => 0,
    				'message' => '',
    				'data'    => [],
    			],
    		];
    	},
    );
    ```


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Inbox notifications have update promotion information from Google.
