### PR TITLE
Fix the archive compatibility of composer v2.2+

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,9 @@ js/src export-ignore
 README.md export-ignore
 package.json export-ignore
 package-lock.json export-ignore
+coverage export-ignore
 node_modules export-ignore
+npm-debug.log export-ignore
 composer.json export-ignore
 composer.lock export-ignore
 phpcs.xml.dist export-ignore
@@ -17,10 +19,11 @@ webpack.config.js export-ignore
 jest.config.js export-ignore
 wordpress_org_assets export-ignore
 .editorconfig export-ignore
-.travis.yml export-ignore
-.stylelintrc export-ignore
-.prettierrc export-ignore
+.externalized.json export-ignore
+.prettierrc.js export-ignore
+.prettierignore export-ignore
 .eslintignore export-ignore
+.eslintrc.js export-ignore
 .stylelintignore export-ignore
-.eslintrc export-ignore
+.stylelintrc.json export-ignore
 .nvmrc export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@ js/src export-ignore
 README.md export-ignore
 package.json export-ignore
 package-lock.json export-ignore
+node_modules export-ignore
 composer.json export-ignore
 composer.lock export-ignore
 phpcs.xml.dist export-ignore


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since [composer version 2.2.0](https://github.com/composer/composer/releases/tag/2.2.0), the `.gitignore` file is no longer to be taken into account as ignore patterns when running `composer archive`, this PR adds the missing folders and files to *.gitattributes* to fix the compatibility of composer v2.2+.

- Add `node_modules` as an ignore folder to *.gitattributes* for fixing the bloated bundle size of archive file.
- Add other unneeded files to *.gitattributes* to be ignored when running `composer archive`.

### Detailed test instructions:

1. Run `npm run build` locally with composer version below 2.2.0 and see if the file size and contents of the archive zip file are correct.
2. Check the fixed result of [bundle size workflow](https://github.com/woocommerce/google-listings-and-ads/runs/4639035015?check_suite_focus=true#step:3:23) on GitHub Actions currently using composer 2.2.1.

### Changelog entry
