### PR TITLE
Fix/939 postcode is not always required

### DIFF
--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -66,7 +66,7 @@ export default function useStoreAddress( source = 'wc' ) {
 
 		const [ address, address2 = '' ] = streetAddress.split( '\n' );
 		const country = countryNameDict[ storeAddress?.country ];
-		const isAddressFilled = ! contact.has_address_errors.length;
+		const isAddressFilled = ! contact.wc_address_errors.length;
 
 		data = {
 			address,

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -66,7 +66,11 @@ export default function useStoreAddress( source = 'wc' ) {
 
 		const [ address, address2 = '' ] = streetAddress.split( '\n' );
 		const country = countryNameDict[ storeAddress?.country ];
-		const isAddressFilled = !! ( address && city && country && postcode );
+		const isAddressFilled =
+			Array.isArray( contact.has_address_errors ) &&
+			contact.has_address_errors.length > 0
+				? false
+				: true;
 
 		data = {
 			address,

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -66,11 +66,7 @@ export default function useStoreAddress( source = 'wc' ) {
 
 		const [ address, address2 = '' ] = streetAddress.split( '\n' );
 		const country = countryNameDict[ storeAddress?.country ];
-		const isAddressFilled =
-			Array.isArray( contact.has_address_errors ) &&
-			contact.has_address_errors.length > 0
-				? false
-				: true;
+		const isAddressFilled = ! contact.has_address_errors.length;
 
 		data = {
 			address,

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -406,7 +406,7 @@ class Settings {
 		$countries = $wc->get_wc_countries();
 
 		$locale          = $countries->get_country_locale();
-		$locale_settings = $locale[ $country ];
+		$locale_settings = isset( $locale[ $country ] ) ? $locale[ $country ] : [];
 
 		$fields_to_validate = [
 			'address_1' => $address->getStreetAddress(),

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -394,7 +394,7 @@ class Settings {
 	 *
 	 * @return array
 	 */
-	public function has_address_errors( AccountAddress $address ): array {
+	public function wc_address_errors( AccountAddress $address ): array {
 		/** @var WC $wc */
 		$wc = $this->container->get( WC::class );
 

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -425,7 +425,7 @@ class Settings {
 		$errors = array_filter(
 			$address_fields,
 			function ( $field ) use ( $locale_settings, $address_fields ) {
-				$is_required = isset( $locale_settings[ $field ] ) && isset( $locale_settings[ $field ]['required'] ) ? $locale_settings[ $field ]['required'] : true;
+				$is_required = $locale_settings[ $field ]['required'] ?? true;
 				return $is_required && empty( $address_fields[ $field ] );
 			},
 			ARRAY_FILTER_USE_KEY

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -395,18 +395,13 @@ class Settings {
 	 * @return array
 	 */
 	public function has_address_errors( AccountAddress $address ): array {
-		if ( ! $address instanceof AccountAddress ) {
-			return [];
-		}
-
 		/** @var WC $wc */
 		$wc = $this->container->get( WC::class );
 
-		$country   = $address->getCountry();
 		$countries = $wc->get_wc_countries();
 
 		$locale          = $countries->get_country_locale();
-		$locale_settings = isset( $locale[ $country ] ) ? $locale[ $country ] : [];
+		$locale_settings = $locale[ $address->getCountry() ] ?? [];
 
 		$fields_to_validate = [
 			'address_1' => $address->getStreetAddress(),
@@ -426,12 +421,12 @@ class Settings {
 	 * @param array $locale_settings locale settings
 	 * @return array
 	 */
-	public function validate_address( array $address_fields, array $locale_settings ) {
+	public function validate_address( array $address_fields, array $locale_settings ): array {
 		$errors = array_filter(
 			$address_fields,
 			function ( $field ) use ( $locale_settings, $address_fields ) {
 				$is_required = isset( $locale_settings[ $field ] ) && isset( $locale_settings[ $field ]['required'] ) ? $locale_settings[ $field ]['required'] : true;
-				return true === $is_required && empty( $address_fields[ $field ] ) ? true : false;
+				return $is_required && empty( $address_fields[ $field ] );
 			},
 			ARRAY_FILTER_USE_KEY
 		);

--- a/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
@@ -155,9 +155,9 @@ class ContactInformationController extends BaseOptionsController {
 				'description' => __( 'Whether the Merchant Center account address is different than the WooCommerce store address.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 			],
-			'has_address_errors'      => [
+			'wc_address_errors'       => [
 				'type'        => 'array',
-				'description' => __( 'Whether the Merchant Center account address has errors', 'google-listings-and-ads' ),
+				'description' => __( 'The errors associated with the WooCommerce address', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 			],
 		];
@@ -248,7 +248,7 @@ class ContactInformationController extends BaseOptionsController {
 			}
 		}
 
-		$has_address_errors = $this->settings->has_address_errors( $wc_address );
+		$wc_address_errors = $this->settings->wc_address_errors( $wc_address );
 
 		return $this->prepare_item_for_response(
 			[
@@ -257,7 +257,7 @@ class ContactInformationController extends BaseOptionsController {
 				'mc_address'              => self::serialize_address( $mc_address ),
 				'wc_address'              => self::serialize_address( $wc_address ),
 				'is_mc_address_different' => $is_address_diff,
-				'has_address_errors'      => $has_address_errors,
+				'wc_address_errors'       => $wc_address_errors,
 			],
 			$request
 		);

--- a/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
@@ -155,6 +155,11 @@ class ContactInformationController extends BaseOptionsController {
 				'description' => __( 'Whether the Merchant Center account address is different than the WooCommerce store address.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 			],
+			'has_address_errors'      => [
+				'type'        => 'array',
+				'description' => __( 'Whether the Merchant Center account address has errors', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+			],
 		];
 	}
 
@@ -243,6 +248,8 @@ class ContactInformationController extends BaseOptionsController {
 			}
 		}
 
+		$has_address_errors = $this->settings->has_address_errors( $wc_address );
+
 		return $this->prepare_item_for_response(
 			[
 				'id'                      => $this->options->get_merchant_id(),
@@ -250,6 +257,7 @@ class ContactInformationController extends BaseOptionsController {
 				'mc_address'              => self::serialize_address( $mc_address ),
 				'wc_address'              => self::serialize_address( $wc_address ),
 				'is_mc_address_different' => $is_address_diff,
+				'has_address_errors'      => $has_address_errors,
 			],
 			$request
 		);

--- a/tests/Unit/MerchantCenter/ValidateAddressTest.php
+++ b/tests/Unit/MerchantCenter/ValidateAddressTest.php
@@ -96,6 +96,9 @@ class ValidateAddressTest extends ContainerAwareUnitTest {
 			count( $errors )
 		);
 
+		$this->assertTrue( in_array ('postcode', $errors) );
+		$this->assertTrue( in_array ('state', $errors) );
+
 	}
 	
 	public function test_address_with_multiple_no_required_empty_fields() {

--- a/tests/Unit/MerchantCenter/ValidateAddressTest.php
+++ b/tests/Unit/MerchantCenter/ValidateAddressTest.php
@@ -1,0 +1,121 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
+
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ContactInformationTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
+ *
+ * @property  MockObject|ContainerInterface $container_interface
+ * @property  Settings $google_settings
+ */
+class ValidateAddressTest extends ContainerAwareUnitTest {
+
+	use MerchantTrait;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->container_interface = $this->createMock( ContainerInterface::class );
+		$this->google_settings     = new Settings ( $this->container_interface );
+
+		$this->fields_to_validate = [
+			'address_1' => $this->get_sample_address()->getStreetAddress(),
+			'city' => $this->get_sample_address()->getLocality(),
+			'country' => $this->get_sample_address()->getCountry(),
+			'postcode' => $this->get_sample_address()->getPostalCode(),
+			'state' => $this->get_sample_address()->getRegion(),
+		];
+
+		$this->locale_settings = [];		
+	}
+
+
+	public function test_address_with_no_errors() {
+
+		$errors = $this->google_settings->validate_address( $this->fields_to_validate, $this->locale_settings );
+
+		$this->assertEquals(
+			0,
+			count( $errors )
+		);
+
+	}
+
+	public function test_address_with_empty_postcode_but_is_required() {
+
+		$this->fields_to_validate['postcode'] = '';
+
+		$errors = $this->google_settings->validate_address( $this->fields_to_validate, $this->locale_settings );
+
+		$this->assertEquals(
+			1,
+			count( $errors )
+		);
+
+	}	
+
+	public function test_address_with_empty_postcode_but_is__not_required() {
+
+		$this->fields_to_validate['postcode'] = '';
+		$this->locale_settings = [
+			"postcode" => [ "required" => false ]
+		];			
+
+		$errors = $this->google_settings->validate_address( $this->fields_to_validate, $this->locale_settings );
+
+		$this->assertEquals(
+			0,
+			count( $errors )
+		);
+
+	}
+	
+	public function test_address_with_multiple_required_empty_fields() {
+
+		$this->fields_to_validate['postcode'] = '';
+		$this->fields_to_validate['state'] = '';
+
+		$errors = $this->google_settings->validate_address( $this->fields_to_validate, $this->locale_settings );
+
+		$this->assertEquals(
+			2,
+			count( $errors )
+		);
+
+	}
+	
+	public function test_address_with_multiple_no_required_empty_fields() {
+
+		$this->fields_to_validate['postcode'] = '';
+		$this->fields_to_validate['state'] = '';
+
+		$this->locale_settings = [
+			"postcode" => [ "required" => false ],
+			"state" => [ "required" => false ],
+		];		
+
+		$errors = $this->google_settings->validate_address( $this->fields_to_validate, $this->locale_settings );
+
+		$this->assertEquals(
+			0,
+			count( $errors )
+		);
+
+	}	
+	
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #939.

### Context: 
The address validation is currently done in the frontend. It is checking if the address, city, country and postcode are filled without considering that in some countries the postcode or the state are not required. 

[`const isAddressFilled = !! ( address && city && country && postcode );`](https://github.com/woocommerce/google-listings-and-ads/blob/48df4fb68654be8c6952149aba9cfd0623ef7fba/js/src/hooks/useStoreAddress.js#L69)

If any of those values are empty it will consider that the address is incorrect. The consequences of this issue are: 

-  The user is not able to finish the onboarding process because the "complete setup" button is disabled
-  The user is not able to edit the store settings in the GLA plugin because the "save" button is disabled.

### Proposal:
In this PR I am proposing to do the validation in the backend using the method [WC_Countries::get_country_locale](https://github.com/woocommerce/woocommerce/blob/f27b4fbeba52eab06d91c3b14b2f7777f38a46f3/includes/class-wc-countries.php#L795) to get the required fields depending on the country and sending the validation to the client.

The response of `mc/contact-information` endpoint will have a  new property `has_address_errors` that will contain the required fields that are empty. If all the required fields are filled successfully, it will return an empty array.

In the future, we could expose these errors and it will help to tackle issue #634 

### Screenshots:

Example using Ireland (postcode is not required) and UK (postcode is required).

https://user-images.githubusercontent.com/2488994/147482638-ff043cc8-8a08-4b9f-8b74-caa72b3f50a9.mov


### Detailed test instructions:

### Onboarding

1. Go to Step 4 on the initial onboarding page.
2. Confirm your phone & tick all the Pre-Launch Checklists.
3. Edit your store address in WC Settings, choose one country where is not required postcode such as Ireland, Singapur, Emirates and leave blank the postcode.
3. Click save changes.
4. Go back to the "Onboarding page" and click "Refresh to sync" and the button "Complete Setup" should be enabled.

### Edit Page

1. Go to the GLA Plugin -> Settings -> In the section "Contact Information / Edit your store" click on "Edit".
2. Edit your store address in WC Settings, choose one country where is not required postcode such as Ireland, Singapur, Emirates and leave blank the postcode.
3. Click save changes.
4. Go back to the "Edit Store Address" in the GLA page and click "Refresh to sync" and the button "Save details" should be enabled.

If you repeat steps 2 and 3 but leave the postcode empty and choose one country where the postcode is required, the button "Save Details" should be disabled.

**Keep in mind that the button will also be disabled if it detects that the Google MC and WC Store addresses are the same.**

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

 > Fix - MC address validation
