### PR TITLE
Remove deprecated is_ajax and change it to wp_doing_ajax

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -69,7 +69,7 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	 * Admin init.
 	 */
 	protected function admin_init(): void {
-		if ( defined( 'IFRAME_REQUEST' ) || is_ajax() ) {
+		if ( defined( 'IFRAME_REQUEST' ) || wp_doing_ajax() ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[In WC 6.1.0 is_ajax will be deprecated](https://developer.woocommerce.com/2021/12/21/woocommerce-6-1-0-beta-1/#:~:text=The%20is_ajax%20function%20has%20been%20deprecated.%20The%20WordPress%20function%20wp_doing_ajax%20should%20be%20used%20instead.). So it's recommended to change it to `wp_doing_ajax`

### Screenshots:

<img width="894" alt="Screenshot 2021-12-28 at 17 16 44" src="https://user-images.githubusercontent.com/5908855/147585971-b0940728-6433-485f-866d-1570d5f80505.png">

The change can still detect when the system is doing ajax. (Actually is_ajax is a wrapper for wp_doing_ajax)

### Changelog entry

> Tweak - Remove deprecated is_ajax
