### PR TITLE
Add missing DateTime import

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\TosAccepted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use DateTime;
 use Exception;
 use Google\Ads\GoogleAds\Util\V8\ResourceNames;
 use Google\ApiCore\ApiException;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After a merge conflict one of the import lines for the DateTime class got removed. This PR brings it back to prevent a fatal error. The error is only reproducible when the Site Title uses a blank value (so there is not a lot of sites that would run into this issue).

Note: Ideally we would have a unit test to cover this scenario, but we haven't implemented any unit testing for the proxy class yet, so I've left it as is now.

Closes #1170 

### Detailed test instructions:

1. Go to Settings > General and save the Site Title as a blank value
2. On the connection test page disconnect the current ads account (can be skipped if testing on a new site)
3. On the connection test page create a new ads account (leaving the ID field blank)
4. Confirm we do not get a fatal error and the new account is created (pending the billing setup step)

The same flow can also be tested with the regular onboarding screens and creating a new ads account.

### Changelog entry
* Fix - Fatal error when creating Ads account without Site Title.
