### PR TITLE
Shipping Integration - Shipping class rates API

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -261,10 +261,10 @@ class Settings {
 		$rate_groups = [];
 		// Create a rate group for each shipping class (if any).
 		if ( is_array( $options ) && ! empty( $options['shipping_class_rates'] ) ) {
-			foreach ( $options['shipping_class_rates'] as ['class' => $class, 'rate' => $rate] ) {
+			foreach ( $options['shipping_class_rates'] as ['class' => $class, 'rate' => $class_rate] ) {
 				$rate_groups[] = $this->create_rate_group_object(
 					$currency,
-					$rate,
+					$class_rate,
 					$method,
 					[ $class ]
 				);

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
@@ -387,6 +387,17 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 				}
 			}
 
+			if ( ! empty( $method['options']['class_costs'] ) ) {
+				// If there are shipping classes, we set the cost of each class as an option.
+				$rate['options']['shipping_class_rates'] = [];
+				foreach ( $method['options']['class_costs'] as $class_id => $cost ) {
+					$rate['options']['shipping_class_rates'][] = [
+						'class' => $class_id,
+						'rate'  => $cost,
+					];
+				}
+			}
+
 			$rates[] = $rate;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Implements part of #1118.

Based on #1154 and #1171.

This PR adds the functionality to set the rates for each available shipping class using the shipping rates API. It also modifies the shipping rates suggestion API to return the list of rates for shipping classes found in WooCommerce shipping zones.


### Detailed test instructions:

1. Define a few shipping classes and a shipping zone containing a flat-rate method. Define the rates for those shipping classes in your flat rate shipping method.
2. Make a `GET` request to the `mc/shipping/rates/suggestions` API with a `country_code` parameter and confirm the rates are returned correctly according to the rates that you defined in your shipping zone settings. Note that the shipping class rates are ADDED to the flat rate.
3. Make a `POST` request to the `mc/shipping/rates` containing the following JSON data:

```JSON
{
    "country_code": "US",
    "rates": [
        {
            "method": "flat_rate",
            "currency": "USD",
            "rate": 20,
            "options": {
                "free_shipping_threshold": 4.99,
                "shipping_class_rates": [
                    {
                        "class": "heavy-weight",
                        "rate": 60
                    },
                    {
                        "class": "lightweight",
                        "rate": 15
                    }
                ]
            }
        }
    ]
}
```
4. Make two `GET` requests to the `mc/shipping/rates/US` and `mc/shipping/rates` APIs and confirm the shipping rate you set above is returned correctly by these APIs.
5. Make a `POST` request to the `mc/shipping/rates/batch` API and send the following JSON data:

```JSON
{
  "country_codes":[
    "DE",
    "US"
  ],
  "rates":[
    {
      "method":"flat_rate",
      "currency":"USD",
      "rate":50,
      "options":{
        "free_shipping_threshold":"4.99",
        "shipping_class_rates":[
          {
            "class":"heavy-weight",
            "rate":60
          },
          {
            "class":"lightweight",
            "rate":15
          }
        ]
      }
    }
  ]
}
```

6. Repeat step 4 and confirm that the rates are set for both countries (DE and US)
7. Make a `POST` request to the `wc/gla/mc/settings/sync` API
8. Confirm that the shipping rates you have just set are reflected in your Merchant Center account (https://merchants.google.com/mc/shipping/services).

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Allow configuring shipping class rates
