### PR TITLE
Fixing coupon test issue

### DIFF
--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -80,7 +80,7 @@ class WCCouponAdapterTest extends UnitTest {
 
 		$this->assertEquals( 'fr', $adapted_coupon->getContentLanguage() );
 	}
-	
+
 	public function test_destination_ids_are_set() {
 	    $coupon = $this->create_ready_to_sync_coupon();
 	    $adapted_coupon = new WCCouponAdapter(
@@ -126,7 +126,7 @@ class WCCouponAdapterTest extends UnitTest {
 	        'post_date_gmt' => $postdate,
 	    );
 	    wp_update_post( $post_args);
-	    
+
 	    $adapted_coupon = new WCCouponAdapter(
 	        [
 	            'wc_coupon'     => $coupon,
@@ -135,17 +135,17 @@ class WCCouponAdapterTest extends UnitTest {
 	        );
 	    $this->assertEquals( '2021-01-01T02:03:45+00:00/2021-07-03T02:03:45+00:00', $adapted_coupon->getPromotionEffectiveDates() );
 	}
-	
+
 	public function test_disable_promotion() {
 	    $coupon = $this->create_ready_to_sync_coupon();
-	    $postdate = '2022-01-01T02:03:45';
+	    $postdate = date(DATE_ATOM);
 	    $post_args = array(
 	        'ID' => $coupon->get_id(),
 	        'post_date' => $postdate,
 	        'post_date_gmt' => $postdate,
 	    );
 	    wp_update_post( $post_args);
-	    
+
 	    $adapted_coupon = new WCCouponAdapter(
 	        [
 	            'wc_coupon'     => $coupon,
@@ -153,12 +153,12 @@ class WCCouponAdapterTest extends UnitTest {
 	        ]
 	        );
 	    $adapted_coupon->disable_promotion( $coupon );
-	    
+
 	    $this->assertEquals(
-	        '2022-01-01T02:03:45+00:00/2022-01-01T02:03:46+00:00',
+	        "$postdate/$postdate",
 	        $adapted_coupon->getPromotionEffectiveDates() );
 	}
-	
+
 	public function test_product_id_restrictions() {
 	    $product_id_1 = rand();
 	    $product_id_2 = rand();
@@ -166,18 +166,18 @@ class WCCouponAdapterTest extends UnitTest {
 	    $coupon->set_product_ids([$product_id_1]);
 	    $coupon->set_excluded_product_ids([$product_id_2]);
 	    $coupon->save();
-	    
+
 	    $adapted_coupon = new WCCouponAdapter(
 	        [
 	            'wc_coupon'     => $coupon,
 	            'targetCountry' => 'US',
 	        ]
 	        );
-	    
+
 	    $this->assertEquals( ["gla_{$product_id_1}"], $adapted_coupon->getItemId() );
 	    $this->assertEquals( ["gla_{$product_id_2}"], $adapted_coupon->getItemIdExclusion() );
 	}
-	
+
 	public function test_product_type_restrictions() {
 	    $category_1 = wp_insert_term( 'Zulu Category', 'product_cat' );
 	    $category_2 = wp_insert_term( 'Alpha Category', 'product_cat' );
@@ -187,18 +187,18 @@ class WCCouponAdapterTest extends UnitTest {
 	    $coupon->set_product_categories( [$category_1['term_id'], $category_2['term_id']] );
 	    $coupon->set_excluded_product_categories( [$category_3['term_id']] );
 	    $coupon->save();
-	    
+
 	    $adapted_coupon = new WCCouponAdapter(
 	        [
 	            'wc_coupon'     => $coupon,
 	            'targetCountry' => 'US',
 	        ]
 	        );
-	    
+
 	    $this->assertEquals( ["Zulu Category","Alpha Category"], $adapted_coupon->getProductType() );
 	    $this->assertEquals( ['Alpha Category > Beta Category'], $adapted_coupon->getProductTypeExclusion() );
 	}
-	
+
 	public function test_load_validator_metadata() {
 		$metadata = new ClassMetadata( WCCouponAdapter::class );
 		WCCouponAdapter::load_validator_metadata( $metadata );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since we reach 2022. There are a test relying on a coupon post date in the past 01-01-2022. Which makes the test to fail. 

### Detailed test instructions:

1. Test pass now. 
2. Check that the new logic makes sense for you. For preventing this in the future. 

