### PR TITLE
Drop support for WC 5.7 (L-3).

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 We aim to support the latest two minor versions of WordPress, WooCommerce, and PHP. (L-2 policy)
 
 -   WordPress 5.6+
--   WooCommerce 5.7+
+-   WooCommerce 5.8+
 -   PHP 7.3+
 
 ## Browsers supported

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -11,7 +11,7 @@
  * Tested up to: 5.9
  * Requires PHP: 7.3
  *
- * WC requires at least: 5.7
+ * WC requires at least: 5.8
  * WC tested up to: 6.0
  * Woo:
  *
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '1.9.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.3' );
-define( 'WC_GLA_MIN_WC_VER', '5.7' );
+define( 'WC_GLA_MIN_WC_VER', '5.8' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5237,15 +5237,16 @@
 			}
 		},
 		"@woocommerce/components": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-7.1.0.tgz",
-			"integrity": "sha512-Ha8Y+GWLvsk4CLEoBMdBakpuEyhWt5BX/33oi6LVtguAOwokDR7F4+13Epx1gsmE5yRfrbx165GKfQGMhyX0Iw==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-8.1.0.tgz",
+			"integrity": "sha512-MfDJN/1mGl+oqoIyFIzNgct+Rn7pAwIVPEkBWn515kCZA2WcIMGL3xMpBIEarEb0JY29c/sT7z73zck77vj2uQ==",
 			"requires": {
-				"@woocommerce/csv-export": "^1.3.2",
-				"@woocommerce/currency": "^3.1.0",
-				"@woocommerce/data": "^1.3.2",
-				"@woocommerce/date": "^3.0.0",
-				"@woocommerce/navigation": "^6.0.1",
+				"@storybook/addon-knobs": "^6.3.0",
+				"@woocommerce/csv-export": "^1.4.0",
+				"@woocommerce/currency": "^3.2.0",
+				"@woocommerce/data": "^1.4.0",
+				"@woocommerce/date": "^3.1.0",
+				"@woocommerce/navigation": "^6.1.0",
 				"@wordpress/api-fetch": "^3.21.5",
 				"@wordpress/components": "10.2.0",
 				"@wordpress/compose": "3.23.1",
@@ -5257,6 +5258,7 @@
 				"@wordpress/i18n": "3.17.0",
 				"@wordpress/icons": "^2.10.3",
 				"@wordpress/keycodes": "2.18.0",
+				"@wordpress/url": "2.21.0",
 				"@wordpress/viewport": "2.24.0",
 				"classnames": "^2.3.1",
 				"core-js": "3.9.1",
@@ -5271,11 +5273,9 @@
 				"emoji-flags": "1.3.0",
 				"gridicons": "3.3.1",
 				"interpolate-components": "1.1.1",
-				"md5": "2.3.0",
 				"memoize-one": "5.1.1",
 				"moment": "2.29.1",
 				"prop-types": "15.7.2",
-				"qs": "6.9.6",
 				"react-dates": "^17.2.0",
 				"react-router-dom": "5.2.0",
 				"react-transition-group": "4.4.1"
@@ -5303,6 +5303,16 @@
 								"memize": "^1.1.0",
 								"sprintf-js": "^1.1.1",
 								"tannin": "^1.2.0"
+							}
+						},
+						"@wordpress/url": {
+							"version": "2.22.2",
+							"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.22.2.tgz",
+							"integrity": "sha512-aqpYKQXzyzkCOm+GzZRYlLb+wh58g0cwR1PaKAl0UXaBS4mdS+X6biMriylb4P8CVC/RR7CSw5XI20JC24KDwQ==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"lodash": "^4.17.19",
+								"react-native-url-polyfill": "^1.1.2"
 							}
 						}
 					}
@@ -5421,6 +5431,16 @@
 						"memize": "^1.1.0",
 						"sprintf-js": "^1.1.1",
 						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.21.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.21.0.tgz",
+					"integrity": "sha512-asTEPDkKirHyoGeoSv3tKHtqNStVUa0E/7ecd667rU7rnXQRB4AJU76fPdmi7aC9rpAz+en4FPtKrcloA2Sjgg==",
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"lodash": "^4.17.19",
+						"react-native-url-polyfill": "^1.1.2"
 					}
 				},
 				"gridicons": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"prettier": "npm:wp-prettier@^2.0.5"
 	},
 	"dependencies": {
-		"@woocommerce/components": "7.1.0",
+		"@woocommerce/components": "8.1.0",
 		"@woocommerce/currency": "^3.1.0",
 		"@woocommerce/customer-effort-score": "^1.1.0",
 		"@woocommerce/data": "1.4.0",

--- a/readme.txt
+++ b/readme.txt
@@ -63,7 +63,7 @@ Get up to  $150\* in ad credit to help you get started on Smart Shopping Campaig
 = Minimum Requirements =
 
 * WordPress 5.6 or greater
-* WooCommerce 5.7 or greater
+* WooCommerce 5.8 or greater
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater
 


### PR DESCRIPTION
:warning: This PR is based on changes from https://github.com/woocommerce/google-listings-and-ads/tree/update/npm not to create too many conflicts in `package-lock.json`

### Changes proposed in this Pull Request:

Follow L-2 policy:
- Bump minimum supported WC version to 5.8 in readmes and plugin header,
- Bump `@woocommerce/components@8.1.0`, as [WC 5.8.0 uses WC-a 2.7.2](https://github.com/woocommerce/woocommerce/blob/5.8.0/composer.json#L24), which [uses `/components` 8.1.0](https://github.com/woocommerce/woocommerce-admin/blob/v2.7.2/packages/components/package.json#L3)


### Screenshots:

#### Before

![image](https://user-images.githubusercontent.com/17435/147943114-c9457dae-33f1-40c5-9b34-eb8010ecb0ac.png)

#### After

![image](https://user-images.githubusercontent.com/17435/147943171-655c0812-9bb3-4d6d-a18b-f6fa8d289fa7.png)



### Detailed test instructions:

1. This change should not affect the package build and runtime, as `@woocommerce/components` is externalized with DEWP
2. `npm run test:js`


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Drop WC 5.7 support.
