### PR TITLE
Removed state/region address validation

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -408,7 +408,6 @@ class Settings {
 			'city'      => $address->getLocality(),
 			'country'   => $address->getCountry(),
 			'postcode'  => $address->getPostalCode(),
-			'state'     => $address->getRegion(),
 		];
 
 		return $this->validate_address( $fields_to_validate, $locale_settings );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #939 

We found in PR #1169 that [WC core](https://github.com/woocommerce/woocommerce/blob/f27b4fbeba52eab06d91c3b14b2f7777f38a46f3/includes/class-wc-countries.php#L795) does not have the correct data related to the state/region of the countries. See the discussion: https://github.com/woocommerce/google-listings-and-ads/pull/1169#discussion_r779472185 therefore we decide to remove the state/region validation so the user will be able to complete the onboarding or the editing process.

### Detailed test instructions:

### Onboarding

1. Go to Step 4 on the initial onboarding page.
2. Confirm your phone & tick all the Pre-Launch Checklists.
3. Edit your store address in WC Settings, choose one country where is not required the **state/region** such as Taiwan or Lithuania.
4. Click save changes.
5. Go back to the "Onboarding page" and click "Refresh to sync" and the button "Complete Setup" should be enabled.

### Edit Page

1. Go to the GLA Plugin -> Settings -> In the section "Contact Information / Edit your store" click on "Edit".
2. Edit your store address in WC Settings, choose one country where is not required the **state/region** such as Taiwan or Lithuania.
3. Click save changes.
4. Go back to the "Edit Store Address" in the GLA page and click "Refresh to sync" and the button "Save details" should be enabled.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Removed state/region address validation 
