### PR TITLE
Fix the issue that all data on the report pages are not shown

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -34,7 +34,10 @@ module.exports = {
 		'/__helpers__/',
 	],
 	coveragePathIgnorePatterns: [ '/node_modules/', '/__helpers__/' ],
-	watchPathIgnorePatterns: [ '<rootDir>/js/build/' ],
+	watchPathIgnorePatterns: [
+		'<rootDir>/.externalized.json',
+		'<rootDir>/js/build/',
+	],
 	globals: {
 		glaData: {
 			mcSetupComplete: true,

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -37,7 +37,38 @@ const DEFAULT_STATE = {
 	report: {},
 };
 
-// Referenced and modified from https://github.com/lodash/lodash/issues/1696#issuecomment-328335502
+/**
+ * @callback chainSet
+ * @param {Array<string>|string} path The path of the property to set the new value.
+ *   The `basePath`, which is called with `chain`, would be contacted with `path` if it exists.
+ *   Array `path` is used directly as each path properties without parsing.
+ *   String `path` is parsed to an array of path properties by splitting '.' and property names enclosed in square brackets. Example: 'user.settings[darkMode].schedule'.
+ * @param {*} value The value to set.
+ * @return {ChainState} The instance.
+ */
+
+/**
+ * @typedef {Object} ChainState
+ * @property {chainSet} set A chainable function for setting value.
+ * @property {()=>Object|Array} end Get back the updated new state after chaining calls.
+ */
+
+/**
+ * A helper to chain multiple values setting into the same new state.
+ *
+ * Recursively creates a shallow copied new state from `state`,
+ * and returns a chainable instance for setting values.
+ * Objects are created for missing or `null` paths.
+ *
+ * Referenced and modified from https://github.com/lodash/lodash/issues/1696#issuecomment-328335502
+ *
+ * @param {Object|Array} state The state to create and set the new value.
+ * @param {Array<string>|string} [basePath='']
+ *   The base path to be contacted to the passed-in `path` when chaining calls.
+ *   Use this when setting multiple values and don't want to repeat the base path multiple times.
+ *
+ * @return {ChainState} The chainable instance.
+ */
 function chain( state, basePath = '' ) {
 	const nextState = Object.assign( state.constructor(), state );
 	const customizer = ( value ) => {
@@ -46,6 +77,8 @@ function chain( state, basePath = '' ) {
 		}
 		return clone( value );
 	};
+	// The `path` of lodash `setWith` can be either a string or an array.
+	// Here combines `basePath` and `path` to the final path to be called with lodash `setWith`.
 	const combineBasePath = ( path ) => {
 		if ( basePath ) {
 			if ( Array.isArray( basePath ) || Array.isArray( path ) ) {
@@ -66,6 +99,21 @@ function chain( state, basePath = '' ) {
 	};
 }
 
+/**
+ * An immutable version of lodash `set` function with the same arguments.
+ *
+ * Recursively creates a shallow copied new state from `state`,
+ * and sets the `value` at `path` of the new state.
+ * Objects are created for missing or `null` paths.
+ *
+ * @param {Object|Array} state The state to create and set the new value.
+ * @param {Array<string>|string} path The path of the property to set the new value.
+ *   Array `path` is used directly as each path properties without parsing.
+ *   String `path` is parsed to an array of path properties by splitting '.' and property names enclosed in square brackets. Example: 'user.settings[darkMode].schedule'.
+ * @param {*} value The value to set.
+ *
+ * @return {Object|Array} The same type of passed-in `state` with placed `value` at `path` of the new state.
+ */
 function set( state, path, value ) {
 	return chain( state ).set( path, value ).end();
 }

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -270,7 +270,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 			}
 
 			return stateSetter
-				.set( `pages.[${ query.page }]`, data.products )
+				.set( [ 'pages', query.page ], data.products )
 				.set( 'per_page', query.per_page )
 				.set( 'order', query.order )
 				.set( 'orderby', query.orderby )

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -46,10 +46,19 @@ function chain( state, basePath = '' ) {
 		}
 		return clone( value );
 	};
+	const combinBasePath = ( path ) => {
+		if ( basePath ) {
+			if ( Array.isArray( basePath ) || Array.isArray( path ) ) {
+				return [].concat( basePath, path );
+			}
+			return `${ basePath }.${ path }`;
+		}
+		return path;
+	};
 
 	return {
 		set( path, value ) {
-			const fullPath = basePath ? `${ basePath }.${ path }` : path;
+			const fullPath = combinBasePath( path );
 			setWith( nextState, fullPath, value, customizer );
 			return this;
 		},
@@ -271,7 +280,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 
 		case TYPES.RECEIVE_REPORT: {
 			const { reportKey, data } = action;
-			return set( state, `report.${ reportKey }`, data );
+			return set( state, [ 'report', reportKey ], data );
 		}
 
 		// Page will be reloaded after all accounts have been disconnected, so no need to mutate state.

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -46,7 +46,7 @@ function chain( state, basePath = '' ) {
 		}
 		return clone( value );
 	};
-	const combinBasePath = ( path ) => {
+	const combineBasePath = ( path ) => {
 		if ( basePath ) {
 			if ( Array.isArray( basePath ) || Array.isArray( path ) ) {
 				return [].concat( basePath, path );
@@ -58,7 +58,7 @@ function chain( state, basePath = '' ) {
 
 	return {
 		set( path, value ) {
-			const fullPath = combinBasePath( path );
+			const fullPath = combineBasePath( path );
 			setWith( nextState, fullPath, value, customizer );
 			return this;
 		},

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -498,6 +498,19 @@ describe( 'reducer', () => {
 	describe( 'Reports of programs and products', () => {
 		const path = 'report';
 
+		it( 'should store paginated data by the stringified `reportKey`, which contains JSON syntax', () => {
+			const reportKey =
+				'programs:free:{"after":"2021-01-01","before":"2021-01-07","fields":["sales","conversions","spend","clicks","impressions"],"interval":"day","order":"desc","orderby":"sales"}';
+			const state = reducer( prepareState(), {
+				type: TYPES.RECEIVE_REPORT,
+				reportKey,
+				data: '#1',
+			} );
+
+			state.assertConsistentRef();
+			expect( state ).toHaveProperty( [ path, reportKey ], '#1' );
+		} );
+
 		it( 'should store paginated data by `reportKey` and return with received report data', () => {
 			const pageOneState = reducer( prepareState(), {
 				type: TYPES.RECEIVE_REPORT,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1183

- Make `path` argument of `chain` and `set` functions accept array type to fix the incorrect path parsing issue of report data in the reducer.
- Extra change: Change the dynamic storing paths of MC product feed to use array `path` to make it look clearer in the reducer.
- Extra change: Add the **.externalized.json** file to the ignored watching patterns of jest to avoid repeatedly running the same test after modifying js file.

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/148714572-aacfc137-2c58-4c62-80b1-9a686e63c539.png)

### Detailed test instructions:

#### The report page

1. Add snippets in the **google-listings-and-ads.php** file if you don't have report data to check it.
    ```php
    add_filter(
    	'woocommerce_gla_prepared_response_mc-reports-programs',
    	function( $response ) {
    		return json_decode( file_get_contents( __DIR__ . '/tests/mocks/mc/reports/programs.json' ), true ) ?: [];
    	},
    );
    
    add_filter(
    	'woocommerce_gla_prepared_response_ads-reports-programs',
    	function( $response ) {
    		return json_decode( file_get_contents( __DIR__ . '/tests/mocks/ads/reports/programs.json' ), true ) ?: [];
    	},
    );
    ``` 
2. Go to the programs report page `/wp-admin/admin.php?page=wc-admin&reportKey=programs&path=%2Fgoogle%2Freports`.
3. Data in the chart and **Program** table should be displayed.

#### The product feed page

1. Go to the programs report page `/wp-admin/admin.php?page=wc-admin&reportKey=programs&path=%2Fgoogle%2Fproduct-feed`.
2. Data in the **Issues to resolve** table should be displayed as before.

### Changelog entry
