### PR TITLE
Clean up outdated workarounds for WooCommerce 5.7 (L-3)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,23 +2,8 @@
 // see https://developer.wordpress.org/block-editor/packages/packages-scripts/#advanced-information-11.
 const defaultConfig = require( '@wordpress/scripts/config/jest-unit.config' );
 
-const wcPackagesNeedTransform = [
-	'components',
-	'currency',
-	'data',
-	'date',
-	'navigation',
-	'number',
-	'tracks',
-	'experimental',
-].join( '|' );
-
 module.exports = {
 	...defaultConfig,
-	// Workaround https://github.com/woocommerce/woocommerce-admin/issues/6483.
-	transformIgnorePatterns: [
-		`<rootDir>/node_modules/(?!@woocommerce/(${ wcPackagesNeedTransform })(/node_modules/@woocommerce/(${ wcPackagesNeedTransform }))?/build/)`,
-	],
 	moduleNameMapper: {
 		'\\.svg$': '<rootDir>/tests/mocks/assets/svgrMock.js',
 		'\\.scss$': '<rootDir>/tests/mocks/assets/styleMock.js',

--- a/js/src/components/free-listings/choose-audience/index.js
+++ b/js/src/components/free-listings/choose-audience/index.js
@@ -22,7 +22,7 @@ import '.~/components/free-listings/choose-audience/index.scss';
  *
  * @param {Object} props
  * @param {string} [props.initialData] Target audience data, if not given AppSinner will be rendered.
- * @param {(change: {name, value}, values: Object) => void} props.onChange Callback called with form data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
+ * @param {(change: {name, value}, values: Object) => void} props.onChange Callback called with form data once form data is changed. Forwarded from {@link Form.Props.onChange}.
  * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked.
  */
 export default function ChooseAudience( {
@@ -76,9 +76,7 @@ export default function ChooseAudience( {
 							countries: initialData.countries || [],
 						} }
 						validate={ handleValidate }
-						onSubmitCallback={ onContinue }
 						onSubmit={ onContinue }
-						onChangeCallback={ onChange }
 						onChange={ onChange }
 					>
 						{ ( formProps ) => {

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -58,7 +58,6 @@ const AddRateModal = ( { countries, onRequestClose, onSubmit } ) => {
 				rate: 0,
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmitCallback }
 			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -77,7 +77,6 @@ const EditRateModal = ( {
 				price: rate.price,
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmitCallback }
 			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -54,7 +54,6 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 				time: 0,
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmitCallback }
 			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -76,7 +76,6 @@ const EditTimeModal = ( {
 				time: time.time,
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmitCallback }
 			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -27,11 +27,11 @@ import FormContent from './form-content';
  * @param {Object} props
  * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to FormContent.
  * @param {Object} props.settings Settings data, if not given AppSpinner will be rendered.
- * @param {(change: {name, value}, values: Object) => void} props.onSettingsChange Callback called with new data once form data is changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
+ * @param {(change: {name, value}, values: Object) => void} props.onSettingsChange Callback called with new data once form data is changed. Forwarded from and {@link Form.Props.onChange}.
  * @param {Array<ShippingRateFromServerSide>} props.shippingRates Shipping rates data, if not given AppSpinner will be rendered.
- * @param {(newValue: Object) => void} props.onShippingRatesChange Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
+ * @param {(newValue: Object) => void} props.onShippingRatesChange Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChange}.
  * @param {Array<ShippingTime>} props.shippingTimes Shipping times data, if not given AppSpinner will be rendered.
- * @param {(newValue: Object) => void} props.onShippingTimesChange Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChangeCallback} and {@link Form.Props.onChange}
+ * @param {(newValue: Object) => void} props.onShippingTimesChange Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChange}.
  * @param {function(Object)} props.onContinue Callback called with form data once continue button is clicked. Could be async. While it's being resolved the form would turn into a saving state.
  * @param {string} [props.submitLabel] Submit button label, to be forwarded to `FormContent`.
  */
@@ -111,10 +111,8 @@ const SetupFreeListings = ( {
 					shipping_country_rates: shippingRates,
 					shipping_country_times: shippingTimes,
 				} }
-				onChangeCallback={ handleChange }
 				onChange={ handleChange }
 				validate={ handleValidate }
-				onSubmitCallback={ handleSubmit }
 				onSubmit={ handleSubmit }
 			>
 				{ ( formProps ) => {

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -73,7 +73,6 @@ const CreatePaidAdsCampaignForm = () => {
 				country: [],
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmit }
 			onSubmit={ handleSubmit }
 		>
 			{ ( formProps ) => {

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -67,7 +67,6 @@ const EditPaidAdsCampaignForm = ( props ) => {
 				country: [ campaign.country ],
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmit }
 			onSubmit={ handleSubmit }
 		>
 			{ ( formProps ) => {

--- a/js/src/reports/chart-section.js
+++ b/js/src/reports/chart-section.js
@@ -74,7 +74,6 @@ export default function ChartSection( { metrics, loaded, intervals } ) {
 			isRequesting={ ! loaded }
 			emptyMessage={ emptyMessage }
 			layout="time-comparison"
-			// 'hidden' is NOT a valid `legendPosition` value, but it can hack to hide the legend.
 			legendPosition="hidden"
 		/>
 	);

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -75,9 +75,7 @@ const SetupAdsForm = () => {
 		<Form
 			initialValues={ initialValues }
 			validate={ handleValidate }
-			onChangeCallback={ handleChange }
 			onChange={ handleChange }
-			onSubmitCallback={ handleSubmit }
 			onSubmit={ handleSubmit }
 		>
 			{ ( formProps ) => {

--- a/js/src/setup-mc/setup-stepper/choose-audience/index.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/index.js
@@ -75,7 +75,6 @@ const ChooseAudience = ( props ) => {
 						countries: data.countries || [],
 					} }
 					validate={ handleValidate }
-					onSubmitCallback={ handleSubmitCallback }
 					onSubmit={ handleSubmitCallback }
 				>
 					{ ( formProps ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -75,7 +75,6 @@ const SetupFreeListings = ( props ) => {
 					tax_rate: settings.tax_rate,
 				} }
 				validate={ handleValidate }
-				onSubmitCallback={ handleSubmitCallback }
 				onSubmit={ handleSubmitCallback }
 			>
 				{ ( formProps ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -62,7 +62,6 @@ const AddRateModal = ( props ) => {
 				rate: 0,
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmitCallback }
 			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -80,7 +80,6 @@ const EditRateModal = ( props ) => {
 				price: rate.price,
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmitCallback }
 			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -53,7 +53,6 @@ const AddTimeModal = ( props ) => {
 				time: 0,
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmitCallback }
 			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -73,7 +73,6 @@ const EditTimeModal = ( props ) => {
 				time: groupedTime.time,
 			} }
 			validate={ handleValidate }
-			onSubmitCallback={ handleSubmitCallback }
 			onSubmit={ handleSubmitCallback }
 		>
 			{ ( formProps ) => {

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -97,9 +97,7 @@ export default function StoreRequirements() {
 					contact_info_visible: settings.contact_info_visible,
 				} }
 				validate={ checkErrors }
-				onChangeCallback={ handleChangeCallback }
 				onChange={ handleChangeCallback }
-				onSubmitCallback={ handleSubmitCallback }
 				onSubmit={ handleSubmitCallback }
 			>
 				{ ( formProps ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up PR separated from https://github.com/woocommerce/google-listings-and-ads/pull/1179#pullrequestreview-844507060.

The minimum supported WooCommerce version 5.8 already has some new features or bug fixes. We can remove related workarounds from this repo:

1. Remove an outdated code comment about an unsupported prop of `<Chart>` component.
    - Feature PR: https://github.com/woocommerce/woocommerce-admin/pull/7378
2. Remove the workaround of transpiling @woocommerce/* packages from ECMAScript module to CommonJS module when running jest.
    - Fixing PR: https://github.com/woocommerce/woocommerce-admin/pull/7286
3. Remove all outdated compatible workarounds of `onSubmitCallback` and `onChangeCallback` from `<Form>` component.
    - Fixing PR: https://github.com/woocommerce/woocommerce-admin/pull/7356

### Detailed test instructions:

💡  Prepare the test env with WooCommerce 5.8 installed

#### Jest test after removing the transpile workaround

1. `npm install`
2. `npm run test:js`
3. It should be able to finish the jest tests
4. Or, check the **JavaScript Unit Tests** result of this PR in GitHub Actions.

#### The `onChange` and `onSubmit` callbacks of`<Form>` after removing the compatibility workarounds

1. Open the Console of browser DevTool
2. Go to the free listings edit page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Ffree-listings%2Fedit`
3. Change the audience countries. The changed countries should be applied to the displayed values on the input component.
4. It should no deprecated warning in the Console:
    > onChangeCallback is deprecated and will be removed from @woocommerce/components in version 9.0.0. Please use onChange instead.
5. Click the "Continue" button. It should bring you to step 2.
6. It should no deprecated warning in the Console:
    > onSubmitCallback is deprecated and will be removed from @woocommerce/components in version 9.0.0. Please use onSubmit instead.

💡  **About the remaining changed `<Form>` usages**

The above test steps are one of the representative ways of verification. Since there are so many changed files, I had tested all of the modified `onSubmit` and `onChange` functions of `<Form>` when developing. If the reviewers also want to verify all the changed usages, please follow the locations below to check them.

- `onSubmit`
    - Edit the free listings `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Ffree-listings%2Fedit`
        - Click the "Continue" in step 1
        - Add/edit shipping rates by the popup modal in step 2
        - Add/edit shipping times by the popup modal in step 2
        - Click the "Save changes" in step 2
    - Create paid campaign `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Fcampaigns%2Fcreate`
        - Click the "Launch paid campaign"
    - Edit paid campaign
        - Click the "Save changes"
    - Set up Google Ads `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads`
        - Click the "Launch paid campaign" in step 3
    - Set up GLA onboarding `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`
        - Click the "Continue" in step 2
        - Add/edit shipping rates by the popup modal in step 3
        - Add/edit shipping times by the popup modal in step 3
        - Click the "Continue" in step 3
        - Click the "Complete setup" in step 4
- `onChange`
    - Edit the free listings `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Ffree-listings%2Fedit&pageStep=2`
        - Change the audience countries in step 1
        - Change any settings in step 2
    - Set up Google Ads `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads`
        - Change any settings in step 2
    - Set up GLA onboarding `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`
        - Change any **Pre-Launch Checklist** options in step 4

### Changelog entry

> Tweak - Clean up outdated workarounds for WooCommerce 5.7.
