### PR TITLE
Fix the partial update of MC settings state in the reducer

### DIFF
--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -129,9 +129,16 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 			return set( state, 'mc.shipping.times', times );
 		}
 
-		case TYPES.RECEIVE_SETTINGS:
-		case TYPES.SAVE_SETTINGS: {
+		case TYPES.RECEIVE_SETTINGS: {
 			return set( state, 'mc.settings', action.settings );
+		}
+
+		case TYPES.SAVE_SETTINGS: {
+			const nextSettings = {
+				...state.mc.settings,
+				...action.settings,
+			};
+			return set( state, 'mc.settings', nextSettings );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_JETPACK: {

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -267,6 +267,50 @@ describe( 'reducer', () => {
 		} );
 	} );
 
+	describe( 'Merchant Center settings', () => {
+		const path = 'mc.settings';
+
+		it( 'should return with received Merchant Center settings', () => {
+			const action = {
+				type: TYPES.SAVE_SETTINGS,
+				settings: {
+					settingA: 'A',
+					SettingB: 'B',
+				},
+			};
+			const state = reducer( prepareState(), action );
+
+			state.assertConsistentRef();
+			expect( state ).toHaveProperty( path, action.settings );
+		} );
+
+		it( 'should return with partially updated Merchant Center settings', () => {
+			const originalState = prepareState(
+				path,
+				{
+					existingSettingA: 'should be kept',
+					existingSettingB: 'should be updated from old value',
+				},
+				true
+			);
+			const action = {
+				type: TYPES.SAVE_SETTINGS,
+				settings: {
+					existingSettingB: 'should be updated to new value',
+					existingSettingC: 'should be added',
+				},
+			};
+			const state = reducer( originalState, action );
+
+			state.assertConsistentRef();
+			expect( state ).toHaveProperty( path, {
+				existingSettingA: 'should be kept',
+				existingSettingB: 'should be updated to new value',
+				existingSettingC: 'should be added',
+			} );
+		} );
+	} );
+
 	describe( 'Google Ads account connection', () => {
 		const path = 'mc.accounts.ads';
 
@@ -525,7 +569,6 @@ describe( 'reducer', () => {
 		// prettier-ignore
 		const argumentsTuples = [
 			[ TYPES.RECEIVE_SETTINGS, 'settings', 'mc.settings' ],
-			[ TYPES.SAVE_SETTINGS, 'settings', 'mc.settings' ],
 			[ TYPES.RECEIVE_ACCOUNTS_JETPACK, 'account', 'mc.accounts.jetpack' ],
 			[ TYPES.RECEIVE_ACCOUNTS_GOOGLE, 'account', 'mc.accounts.google' ],
 			[ TYPES.RECEIVE_ACCOUNTS_GOOGLE_ACCESS, 'data', 'mc.accounts.google_access' ],


### PR DESCRIPTION
### The problem

This was introduced by #1151.

The `saveSettings` action is called from several places with only partial `settings`, so the reducer of `TYPES.SAVE_SETTINGS` has to merge with `settings` in state tree before updating state tree.

https://github.com/woocommerce/google-listings-and-ads/blob/f75f58f9d98c6e929f1a420d6e557932b73a55b2/js/src/data/actions.js#L278-L289

Currently, it causes the runtime state to be incomplete on the onboarding setup. Replicate steps:
1. Go to step 3 onboarding setup `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`
2. Set up shipping rates and times.
3. Go to step 4. Check/uncheck any options in Pre-Launch Checklist.
4. Go back to step 3. The saved shipping settings were gone.
5. Go to step 4 again. The saved options in Pre-Launch Checklist were all reset to unchecked.

https://user-images.githubusercontent.com/17420811/148760260-1c44b6fe-7035-4876-90f1-e7ec2cf051f5.mp4

### Changes proposed in this Pull Request:

- Fix the partial update of MC settings state in the reducer.
- Separate `TYPES.SAVE_SETTINGS` and `TYPES.RECEIVE_SETTINGS` because they are receiving different `settings` states.
- Add relevant tests.

### Screenshots:

https://user-images.githubusercontent.com/17420811/148760806-76733e8f-d69b-45aa-8ed1-283b18a99524.mp4

### Detailed test instructions:

1. Go to step 3 onboarding setup `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc`
2. Set up shipping rates and times.
3. Go to step 4. Check/uncheck any options in Pre-Launch Checklist.
4. Go back to step 3. The saved shipping settings should still be there.
5. Go to step 4 again. The saved options in Pre-Launch Checklist should still exist and stay in the same state as this test step 3.

### Changelog entry
