### PR TITLE
Rename two internal functions in reducer for better readability

### DIFF
--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -40,7 +40,7 @@ const DEFAULT_STATE = {
 /**
  * @callback chainSet
  * @param {Array<string>|string} path The path of the property to set the new value.
- *   The `basePath`, which is called with `chain`, would be contacted with `path` if it exists.
+ *   The `basePath`, which is called with `chainState`, would be contacted with `path` if it exists.
  *   Array `path` is used directly as each path properties without parsing.
  *   String `path` is parsed to an array of path properties by splitting '.' and property names enclosed in square brackets. Example: 'user.settings[darkMode].schedule'.
  * @param {*} value The value to set.
@@ -69,7 +69,7 @@ const DEFAULT_STATE = {
  *
  * @return {ChainState} The chainable instance.
  */
-function chain( state, basePath = '' ) {
+function chainState( state, basePath = '' ) {
 	const nextState = Object.assign( state.constructor(), state );
 	const customizer = ( value ) => {
 		if ( value === null || value === undefined ) {
@@ -115,7 +115,7 @@ function chain( state, basePath = '' ) {
  * @return {Object|Array} The same type of passed-in `state` with placed `value` at `path` of the new state.
  */
 function setIn( state, path, value ) {
-	return chain( state ).setIn( path, value ).end();
+	return chainState( state ).setIn( path, value ).end();
 }
 
 const reducer = ( state = DEFAULT_STATE, action ) => {
@@ -304,7 +304,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				...data.issues
 			);
 
-			return chain( state, 'mc_issues' )
+			return chainState( state, 'mc_issues' )
 				.setIn( 'issues', issues )
 				.setIn( 'total', data.total )
 				.end();
@@ -313,7 +313,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		case TYPES.RECEIVE_MC_PRODUCT_FEED: {
 			const { query, data } = action;
 			const lastQuery = state.mc_product_feed || {};
-			const stateSetter = chain( state, 'mc_product_feed' );
+			const stateSetter = chainState( state, 'mc_product_feed' );
 
 			if (
 				lastQuery.per_page !== query.per_page ||

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -49,7 +49,7 @@ const DEFAULT_STATE = {
 
 /**
  * @typedef {Object} ChainState
- * @property {chainSet} set A chainable function for setting value.
+ * @property {chainSet} setIn A chainable function for setting value.
  * @property {()=>Object|Array} end Get back the updated new state after chaining calls.
  */
 
@@ -90,7 +90,7 @@ function chain( state, basePath = '' ) {
 	};
 
 	return {
-		set( path, value ) {
+		setIn( path, value ) {
 			const fullPath = combineBasePath( path );
 			setWith( nextState, fullPath, value, customizer );
 			return this;
@@ -114,14 +114,14 @@ function chain( state, basePath = '' ) {
  *
  * @return {Object|Array} The same type of passed-in `state` with placed `value` at `path` of the new state.
  */
-function set( state, path, value ) {
-	return chain( state ).set( path, value ).end();
+function setIn( state, path, value ) {
+	return chain( state ).setIn( path, value ).end();
 }
 
 const reducer = ( state = DEFAULT_STATE, action ) => {
 	switch ( action.type ) {
 		case TYPES.RECEIVE_SHIPPING_RATES: {
-			return set( state, 'mc.shipping.rates', action.shippingRates );
+			return setIn( state, 'mc.shipping.rates', action.shippingRates );
 		}
 
 		case TYPES.UPSERT_SHIPPING_RATES: {
@@ -141,7 +141,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				}
 			} );
 
-			return set( state, 'mc.shipping.rates', rates );
+			return setIn( state, 'mc.shipping.rates', rates );
 		}
 
 		case TYPES.DELETE_SHIPPING_RATES: {
@@ -150,11 +150,11 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				( el ) => ! countryCodeSet.has( el.countryCode )
 			);
 
-			return set( state, 'mc.shipping.rates', rates );
+			return setIn( state, 'mc.shipping.rates', rates );
 		}
 
 		case TYPES.RECEIVE_SHIPPING_TIMES: {
-			return set( state, 'mc.shipping.times', action.shippingTimes );
+			return setIn( state, 'mc.shipping.times', action.shippingTimes );
 		}
 
 		case TYPES.UPSERT_SHIPPING_TIMES: {
@@ -174,7 +174,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				}
 			} );
 
-			return set( state, 'mc.shipping.times', times );
+			return setIn( state, 'mc.shipping.times', times );
 		}
 
 		case TYPES.DELETE_SHIPPING_TIMES: {
@@ -183,11 +183,11 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				( el ) => ! countryCodeSet.has( el.countryCode )
 			);
 
-			return set( state, 'mc.shipping.times', times );
+			return setIn( state, 'mc.shipping.times', times );
 		}
 
 		case TYPES.RECEIVE_SETTINGS: {
-			return set( state, 'mc.settings', action.settings );
+			return setIn( state, 'mc.settings', action.settings );
 		}
 
 		case TYPES.SAVE_SETTINGS: {
@@ -195,35 +195,35 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				...state.mc.settings,
 				...action.settings,
 			};
-			return set( state, 'mc.settings', nextSettings );
+			return setIn( state, 'mc.settings', nextSettings );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_JETPACK: {
-			return set( state, 'mc.accounts.jetpack', action.account );
+			return setIn( state, 'mc.accounts.jetpack', action.account );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE: {
-			return set( state, 'mc.accounts.google', action.account );
+			return setIn( state, 'mc.accounts.google', action.account );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ACCESS: {
-			return set( state, 'mc.accounts.google_access', action.data );
+			return setIn( state, 'mc.accounts.google_access', action.data );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_MC: {
-			return set( state, 'mc.accounts.mc', action.account );
+			return setIn( state, 'mc.accounts.mc', action.account );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_MC_EXISTING: {
-			return set( state, 'mc.accounts.existing_mc', action.accounts );
+			return setIn( state, 'mc.accounts.existing_mc', action.accounts );
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS: {
-			return set( state, 'mc.accounts.ads', action.account );
+			return setIn( state, 'mc.accounts.ads', action.account );
 		}
 
 		case TYPES.DISCONNECT_ACCOUNTS_GOOGLE_ADS: {
-			return set(
+			return setIn(
 				state,
 				'mc.accounts.ads',
 				DEFAULT_STATE.mc.accounts.ads
@@ -231,7 +231,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS_BILLING_STATUS: {
-			return set(
+			return setIn(
 				state,
 				'mc.accounts.ads_billing_status',
 				action.billingStatus
@@ -239,24 +239,24 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS_EXISTING: {
-			return set( state, 'mc.accounts.existing_ads', action.accounts );
+			return setIn( state, 'mc.accounts.existing_ads', action.accounts );
 		}
 
 		case TYPES.RECEIVE_MC_CONTACT_INFORMATION: {
-			return set( state, 'mc.contact', action.data );
+			return setIn( state, 'mc.contact', action.data );
 		}
 
 		case TYPES.RECEIVE_COUNTRIES: {
-			return set( state, 'mc.countries', action.countries );
+			return setIn( state, 'mc.countries', action.countries );
 		}
 
 		case TYPES.RECEIVE_TARGET_AUDIENCE:
 		case TYPES.SAVE_TARGET_AUDIENCE: {
-			return set( state, 'mc.target_audience', action.target_audience );
+			return setIn( state, 'mc.target_audience', action.target_audience );
 		}
 
 		case TYPES.RECEIVE_ADS_CAMPAIGNS: {
-			return set( state, 'ads_campaigns', action.adsCampaigns );
+			return setIn( state, 'ads_campaigns', action.adsCampaigns );
 		}
 
 		case TYPES.UPDATE_ADS_CAMPAIGN: {
@@ -272,7 +272,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 			const newAdsCampaigns = [ ...state.ads_campaigns ];
 			newAdsCampaigns[ idx ] = updatedCampaign;
 
-			return set( state, 'ads_campaigns', newAdsCampaigns );
+			return setIn( state, 'ads_campaigns', newAdsCampaigns );
 		}
 
 		case TYPES.DELETE_ADS_CAMPAIGN: {
@@ -280,15 +280,15 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 			const adsCampaign = state.ads_campaigns.filter(
 				( el ) => el.id !== id
 			);
-			return set( state, 'ads_campaigns', adsCampaign );
+			return setIn( state, 'ads_campaigns', adsCampaign );
 		}
 
 		case TYPES.RECEIVE_MC_SETUP: {
-			return set( state, 'mc_setup', action.mcSetup );
+			return setIn( state, 'mc_setup', action.mcSetup );
 		}
 
 		case TYPES.RECEIVE_MC_PRODUCT_STATISTICS: {
-			return set(
+			return setIn(
 				state,
 				'mc_product_statistics',
 				action.mcProductStatistics
@@ -305,8 +305,8 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 			);
 
 			return chain( state, 'mc_issues' )
-				.set( 'issues', issues )
-				.set( 'total', data.total )
+				.setIn( 'issues', issues )
+				.setIn( 'total', data.total )
 				.end();
 		}
 
@@ -321,21 +321,21 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				lastQuery.orderby !== query.orderby
 			) {
 				// discard old stored data when pagination has changed.
-				stateSetter.set( 'pages', {} );
+				stateSetter.setIn( 'pages', {} );
 			}
 
 			return stateSetter
-				.set( [ 'pages', query.page ], data.products )
-				.set( 'per_page', query.per_page )
-				.set( 'order', query.order )
-				.set( 'orderby', query.orderby )
-				.set( 'total', data.total )
+				.setIn( [ 'pages', query.page ], data.products )
+				.setIn( 'per_page', query.per_page )
+				.setIn( 'order', query.order )
+				.setIn( 'orderby', query.orderby )
+				.setIn( 'total', data.total )
 				.end();
 		}
 
 		case TYPES.RECEIVE_REPORT: {
 			const { reportKey, data } = action;
-			return set( state, [ 'report', reportKey ], data );
+			return setIn( state, [ 'report', reportKey ], data );
 		}
 
 		// Page will be reloaded after all accounts have been disconnected, so no need to mutate state.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up PR separated from https://github.com/woocommerce/google-listings-and-ads/pull/1184#discussion_r781184994

To reduce the confusion of same function names with **lodash**, this PR
- renames `set` to `setIn`
- renames `chain` to `chainState`

### Detailed test instructions:

Since the two are internal functions in reducer module and have no logical change, it should be ok to verify them with test cases.

1. `npm run test:js -- reducer`
2. Check if all relevant test cases are passed with 100% coverage.

### Changelog entry
