### PR TITLE
Use lodash via DEWP instead of packing it to bundle files

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -6,7 +6,7 @@ import { Stepper } from '@woocommerce/components';
 import { getQuery, getNewPath, getHistory } from '@woocommerce/navigation';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies

--- a/js/src/hooks/useIsEqualRefValue.js
+++ b/js/src/hooks/useIsEqualRefValue.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 import { useRef } from '@wordpress/element';
 
 /**

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { Form } from '@woocommerce/components';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While reviewing PR https://github.com/woocommerce/google-listings-and-ads/pull/1196#discussion_r785638630, I noticed we import `isEqual` from `'lodash/isEqual'` in three places. So there's a part of lodash that is packed into bundle files.

Since lodash is also injected by `@wordpress/dependency-extraction-webpack-plugin`(aka DEWP), its version changes are relatively few and much more stable. This PR attempts to use all lodash functions via DEWP, and therefore, we could reduce the bundle size by about 4 KB.

- Replace all `import isEqual from 'lodash/isEqual';` to `import { isEqual } from 'lodash';`

### Screenshots:

#### Before

![image](https://user-images.githubusercontent.com/17420811/149723383-f681f55a-5df0-416d-b5c9-8150d3a806f3.png)

#### After

![image](https://user-images.githubusercontent.com/17420811/149723445-4fc74250-2e20-4cfb-bb45-ba4da306d27e.png)

[![image](https://user-images.githubusercontent.com/17420811/149726706-3cb306e0-7162-4bdb-b35e-433dee7fb59f.png)](https://ja2r7.app.goo.gl/oXzBfXkQfmuq4ihs8)

### Detailed test instructions:

#### Check the bundle results

1. `npm run env -- NODE_ENV=production wp-scripts build --webpack-bundle-analyzer`
2. Check if lodash codes are not packed into index.js

#### Check for functional equivalence

💡  Considering the changes are all `isEqual` and for the same purpose, we can verify the equivalence in one of the changed places.

1. Go to the edit free listings page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Ffree-listings%2Fedit`
2. Change any settings and leave edit free listings page without saving.
3. It should pop up a prompt to confirm if you want to leave without saving data.
    ![image](https://user-images.githubusercontent.com/17420811/149725809-96e41ad2-2ff9-4cec-8344-91169d89b101.png)
4. Change unsaved changes back to the same settings when entering this edit page.
5. It should be no prompts when leaving this edit page.

### Changelog entry

> Tweak - Change the importing way of lodash package to reduce the bundle size by 4 KB.
