### PR TITLE
Makes country dropdown list always below the input box

### DIFF
--- a/js/src/wcdl/select-control/index.scss
+++ b/js/src/wcdl/select-control/index.scss
@@ -36,5 +36,9 @@
 				max-height: 24px;
 			}
 		}
+
+		.woocommerce-select-control__listbox {
+			top: unset;
+		}
 	}
 }

--- a/js/src/wcdl/select-control/index.scss
+++ b/js/src/wcdl/select-control/index.scss
@@ -38,6 +38,8 @@
 		}
 
 		.woocommerce-select-control__listbox {
+			// Remove the hard coded height 57px that is causing the dropdown list
+			// not below the input box when there are multiple rows inside the input box.
 			top: unset;
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Suggested by @eason9487 in https://github.com/woocommerce/google-listings-and-ads/pull/1200#issuecomment-1015324208, the country dropdown list should always below the input box. 

### Screenshots:

#### Before the fix

<img width="1615" alt="Screenshot 2022-01-19 at 19 18 32" src="https://user-images.githubusercontent.com/914406/150120572-7c78e022-9545-4ac0-b639-cace0620a6e0.png">

#### After the fix

<img width="1613" alt="Screenshot 2022-01-19 at 19 18 54" src="https://user-images.githubusercontent.com/914406/150120626-9800e8a5-4e7a-4499-8dc3-9e79ef12b2b3.png">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to `Marketing` -> `Google Listings & Ads` -> `Dashboard` -> `Programs` -> `Free listings` -> `Edit`.
2. Choose `Selected countries only`.
3. Add some countries and you should see the country dropdown list is always below the input box.
5. Disconnect all accounts and run through the onboarding setup wizard, go to `Choose your audience` and test it from the step 2.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Makes country dropdown list always below the input box
