### PR TITLE
Refactor AdsAccountController and add unit tests

### DIFF
--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
-use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
@@ -30,11 +29,12 @@ class AccountController extends BaseController {
 	/**
 	 * AccountController constructor.
 	 *
-	 * @param ContainerInterface $container
+	 * @param RESTServer     $server
+	 * @param AccountService $account
 	 */
-	public function __construct( ContainerInterface $container ) {
-		parent::__construct( $container->get( RESTServer::class ) );
-		$this->account = $container->get( AccountService::class );
+	public function __construct( RESTServer $server, AccountService $account ) {
+		parent::__construct( $server );
+		$this->account = $account;
 	}
 
 	/**

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -3,17 +3,10 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BillingSetupStatus;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use Psr\Container\ContainerInterface;
@@ -27,32 +20,12 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
  */
-class AccountController extends BaseOptionsController {
+class AccountController extends BaseController {
 
 	/**
-	 * @var ContainerInterface
+	 * @var AccountService
 	 */
-	protected $container;
-
-	/**
-	 * @var Middleware
-	 */
-	protected $middleware;
-
-	/**
-	 * @var AdsAccountState
-	 */
-	protected $account_state;
-
-	/**
-	 * @var Ads
-	 */
-	protected $ads;
-
-	/**
-	 * @var AdsConversionAction
-	 */
-	protected $ads_conversion_action;
+	protected $account;
 
 	/**
 	 * AccountController constructor.
@@ -61,11 +34,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	public function __construct( ContainerInterface $container ) {
 		parent::__construct( $container->get( RESTServer::class ) );
-		$this->middleware            = $container->get( Middleware::class );
-		$this->ads                   = $container->get( Ads::class );
-		$this->account_state         = $container->get( AdsAccountState::class );
-		$this->ads_conversion_action = $container->get( AdsConversionAction::class );
-		$this->container             = $container;
+		$this->account = $container->get( AccountService::class );
 	}
 
 	/**
@@ -126,7 +95,7 @@ class AccountController extends BaseOptionsController {
 	protected function get_accounts_callback(): callable {
 		return function() {
 			try {
-				return new Response( $this->middleware->get_ads_account_ids() );
+				return new Response( $this->account->get_account_ids() );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
@@ -143,11 +112,11 @@ class AccountController extends BaseOptionsController {
 			try {
 				$link_id = absint( $request['id'] );
 				if ( $link_id ) {
-					$this->use_existing_account( $link_id );
+					$this->account->use_existing_account( $link_id );
 				}
 
-				$account = $this->setup_account();
-				return $this->prepare_item_for_response( $account, $request );
+				$account_data = $this->account->setup_account();
+				return $this->prepare_item_for_response( $account_data, $request );
 			} catch ( ExceptionWithResponseData $e ) {
 				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
@@ -163,7 +132,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function get_connected_ads_account_callback(): callable {
 		return function() {
-			return $this->middleware->get_connected_ads_account();
+			return $this->account->get_connected_account();
 		};
 	}
 
@@ -174,7 +143,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function disconnect_ads_account_callback(): callable {
 		return function() {
-			$this->container->get( AdsService::class )->disconnect();
+			$this->account->disconnect();
 
 			return [
 				'status'  => 'success',
@@ -191,17 +160,7 @@ class AccountController extends BaseOptionsController {
 	protected function get_billing_status_callback(): callable {
 		return function() {
 			try {
-				$status = $this->ads->get_billing_status();
-
-				if ( BillingSetupStatus::APPROVED === $status ) {
-					$this->account_state->complete_step( 'billing' );
-					return [ 'status' => $status ];
-				}
-
-				return [
-					'status'      => $status,
-					'billing_url' => $this->options->get( OptionsInterface::ADS_BILLING_URL ),
-				];
+				return $this->account->get_billing_status();
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
@@ -242,156 +201,4 @@ class AccountController extends BaseOptionsController {
 		return 'account';
 	}
 
-	/**
-	 * Use an existing Ads account. Mark the 'set_id' step as done and sets the Ads ID.
-	 *
-	 * @param int $account_id The Ads account ID to use.
-	 *
-	 * @throws Exception If there is already an Ads account ID.
-	 */
-	private function use_existing_account( int $account_id ) {
-		$ads_id = $this->options->get( OptionsInterface::ADS_ID );
-		if ( $ads_id && $ads_id !== $account_id ) {
-			throw new Exception(
-				/* translators: 1: is a numeric account ID */
-				sprintf( __( 'Ads account %1$d already connected.', 'google-listings-and-ads' ), $ads_id )
-			);
-		}
-
-		$state = $this->account_state->get();
-
-		// Don't do anything if this step was already finished.
-		if ( AdsAccountState::STEP_DONE === $state['set_id']['status'] ) {
-			return;
-		}
-
-		$this->middleware->link_ads_account( $account_id );
-
-		// Skip billing setup flow when using an existing account.
-		$state['set_id']['status']  = AdsAccountState::STEP_DONE;
-		$state['billing']['status'] = AdsAccountState::STEP_DONE;
-		$this->account_state->update( $state );
-	}
-
-	/**
-	 * Performs the steps necessary to setup an ads account.
-	 * Should always resume up at the last pending or unfinished step.
-	 * If the Ads account has already been created, the ID is simply returned.
-	 *
-	 * @return array The newly created (or pre-existing) Ads ID.
-	 * @throws Exception If an error occurs during any step.
-	 */
-	private function setup_account(): array {
-		$state   = $this->account_state->get();
-		$ads_id  = $this->options->get( OptionsInterface::ADS_ID );
-		$account = [ 'id' => $ads_id ];
-
-		foreach ( $state as $name => &$step ) {
-			if ( AdsAccountState::STEP_DONE === $step['status'] ) {
-				continue;
-			}
-
-			try {
-				switch ( $name ) {
-					case 'set_id':
-						// Just in case, don't create another Ads ID.
-						if ( ! empty( $ads_id ) ) {
-							break;
-						}
-						$account = $this->middleware->create_ads_account();
-
-						$step['data']['sub_account']       = true;
-						$step['data']['created_timestamp'] = time();
-						break;
-
-					case 'billing':
-						$this->check_billing_status( $account );
-						break;
-
-					case 'link_merchant':
-						$this->link_merchant_account();
-						break;
-
-					case 'conversion_action':
-						$this->create_conversion_action();
-						break;
-
-					default:
-						throw new Exception(
-							/* translators: 1: is a string representing an unknown step name */
-							sprintf( __( 'Unknown ads account creation step %1$s', 'google-listings-and-ads' ), $name )
-						);
-				}
-				$step['status']  = AdsAccountState::STEP_DONE;
-				$step['message'] = '';
-				$this->account_state->update( $state );
-			} catch ( Exception $e ) {
-				$step['status']  = AdsAccountState::STEP_ERROR;
-				$step['message'] = $e->getMessage();
-				$this->account_state->update( $state );
-				throw $e;
-			}
-		}
-
-		return $account;
-	}
-
-	/**
-	 * Get the callback function for linking a merchant account.
-	 *
-	 * @throws Exception When the merchant or ads account hasn't been set yet.
-	 */
-	private function link_merchant_account() {
-		/** @var Merchant $merchant */
-		$merchant = $this->container->get( Merchant::class );
-		if ( ! $this->options->get_merchant_id() ) {
-			throw new Exception( 'A Merchant Center account must be connected' );
-		}
-
-		if ( ! $this->options->get_ads_id() ) {
-			throw new Exception( 'An Ads account must be connected' );
-		}
-
-		// Create link for Merchant and accept it in Ads.
-		$merchant->link_ads_id( $this->options->get_ads_id() );
-		$this->ads->accept_merchant_link( $this->options->get_merchant_id() );
-	}
-
-	/**
-	 * Confirm the billing flow has been completed.
-	 *
-	 * @param array $account Account details.
-	 *
-	 * @throws ExceptionWithResponseData If this step hasn't been completed yet.
-	 */
-	private function check_billing_status( array $account ) {
-		$status = BillingSetupStatus::UNKNOWN;
-
-		// Only check billing status if we haven't just created the account.
-		if ( empty( $account['billing_url'] ) ) {
-			$status = $this->ads->get_billing_status();
-		}
-
-		if ( BillingSetupStatus::APPROVED !== $status ) {
-			throw new ExceptionWithResponseData(
-				__( 'Billing setup must be completed.', 'google-listings-and-ads' ),
-				428,
-				null,
-				[
-					'billing_url'    => $this->options->get( OptionsInterface::ADS_BILLING_URL ),
-					'billing_status' => $status,
-				]
-			);
-		}
-	}
-
-	/**
-	 * Create the generic GLA conversion action and store the details as an option.
-	 *
-	 * @throws Exception If the conversion action can't be created.
-	 */
-	private function create_conversion_action(): void {
-		$conversion_action = $this->ads_conversion_action->create_conversion_action();
-		$this->options->update( OptionsInterface::ADS_CONVERSION_ACTION, $conversion_action );
-	}
 }

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -159,11 +159,7 @@ class AccountController extends BaseController {
 	 */
 	protected function get_billing_status_callback(): callable {
 		return function() {
-			try {
-				return $this->account->get_billing_status();
-			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
-			}
+			return $this->account->get_billing_status();
 		};
 	}
 

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -22,6 +22,8 @@ defined( 'ABSPATH' ) || exit;
 class AccountController extends BaseController {
 
 	/**
+	 * Service used to access / update Ads account data.
+	 *
 	 * @var AccountService
 	 */
 	protected $account;

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -83,7 +83,7 @@ class AccountService implements OptionsAwareInterface, Service {
 	 * @throws Exception If there is already an Ads account ID.
 	 */
 	public function use_existing_account( int $account_id ) {
-		$ads_id = $this->options->get( OptionsInterface::ADS_ID );
+		$ads_id = $this->options->get_ads_id();
 		if ( $ads_id && $ads_id !== $account_id ) {
 			throw new Exception(
 				/* translators: 1: is a numeric account ID */
@@ -116,7 +116,7 @@ class AccountService implements OptionsAwareInterface, Service {
 	 */
 	public function setup_account(): array {
 		$state   = $this->state->get();
-		$ads_id  = $this->options->get( OptionsInterface::ADS_ID );
+		$ads_id  = $this->options->get_ads_id();
 		$account = [ 'id' => $ads_id ];
 
 		foreach ( $state as $name => &$step ) {

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -1,0 +1,260 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BillingSetupStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Exception;
+use Psr\Container\ContainerInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountService
+ *
+ * Container used to access:
+ * - Ads
+ * - AdsAccountState
+ * - AdsConversionAction
+ * - Merchant
+ * - Middleware
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Ads
+ */
+class AccountService implements OptionsAwareInterface, Service {
+
+	use OptionsAwareTrait;
+
+	/**
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * @var AdsAccountState
+	 */
+	protected $state;
+
+	/**
+	 * AccountService constructor.
+	 *
+	 * @param ContainerInterface $container
+	 */
+	public function __construct( ContainerInterface $container ) {
+		$this->state     = $container->get( AdsAccountState::class );
+		$this->container = $container;
+	}
+
+	/**
+	 * Get Ads IDs associated with the connected Google account.
+	 *
+	 * @return int[]
+	 * @throws Exception When an API error occurs.
+	 */
+	public function get_account_ids(): array {
+		return $this->container->get( Middleware::class )->get_ads_account_ids();
+	}
+
+	/**
+	 * Get the connected ads account.
+	 *
+	 * @return array
+	 */
+	public function get_connected_account(): array {
+		return $this->container->get( Middleware::class )->get_connected_ads_account();
+	}
+
+	/**
+	 * Use an existing Ads account. Mark the 'set_id' step as done and sets the Ads ID.
+	 *
+	 * @param int $account_id The Ads account ID to use.
+	 *
+	 * @throws Exception If there is already an Ads account ID.
+	 */
+	public function use_existing_account( int $account_id ) {
+		$ads_id = $this->options->get( OptionsInterface::ADS_ID );
+		if ( $ads_id && $ads_id !== $account_id ) {
+			throw new Exception(
+				/* translators: 1: is a numeric account ID */
+				sprintf( __( 'Ads account %1$d already connected.', 'google-listings-and-ads' ), $ads_id )
+			);
+		}
+
+		$state = $this->state->get();
+
+		// Don't do anything if this step was already finished.
+		if ( AdsAccountState::STEP_DONE === $state['set_id']['status'] ) {
+			return;
+		}
+
+		$this->container->get( Middleware::class )->link_ads_account( $account_id );
+
+		// Skip billing setup flow when using an existing account.
+		$state['set_id']['status']  = AdsAccountState::STEP_DONE;
+		$state['billing']['status'] = AdsAccountState::STEP_DONE;
+		$this->state->update( $state );
+	}
+
+	/**
+	 * Performs the steps necessary to setup an ads account.
+	 * Should always resume up at the last pending or unfinished step.
+	 * If the Ads account has already been created, the ID is simply returned.
+	 *
+	 * @return array The newly created (or pre-existing) Ads ID.
+	 * @throws Exception If an error occurs during any step.
+	 */
+	public function setup_account(): array {
+		$state   = $this->state->get();
+		$ads_id  = $this->options->get( OptionsInterface::ADS_ID );
+		$account = [ 'id' => $ads_id ];
+
+		foreach ( $state as $name => &$step ) {
+			if ( AdsAccountState::STEP_DONE === $step['status'] ) {
+				continue;
+			}
+
+			try {
+				switch ( $name ) {
+					case 'set_id':
+						// Just in case, don't create another Ads ID.
+						if ( ! empty( $ads_id ) ) {
+							break;
+						}
+						$account = $this->container->get( Middleware::class )->create_ads_account();
+
+						$step['data']['sub_account']       = true;
+						$step['data']['created_timestamp'] = time();
+						break;
+
+					case 'billing':
+						$this->check_billing_status( $account );
+						break;
+
+					case 'link_merchant':
+						$this->link_merchant_account();
+						break;
+
+					case 'conversion_action':
+						$this->create_conversion_action();
+						break;
+
+					default:
+						throw new Exception(
+							/* translators: 1: is a string representing an unknown step name */
+							sprintf( __( 'Unknown ads account creation step %1$s', 'google-listings-and-ads' ), $name )
+						);
+				}
+				$step['status']  = AdsAccountState::STEP_DONE;
+				$step['message'] = '';
+				$this->state->update( $state );
+			} catch ( Exception $e ) {
+				$step['status']  = AdsAccountState::STEP_ERROR;
+				$step['message'] = $e->getMessage();
+				$this->state->update( $state );
+				throw $e;
+			}
+		}
+
+		return $account;
+	}
+
+	/**
+	 * Gets the billing setup status and returns a setup URL if available.
+	 *
+	 * @return array
+	 */
+	public function get_billing_status(): array {
+		$status = $this->container->get( Ads::class )->get_billing_status();
+
+		if ( BillingSetupStatus::APPROVED === $status ) {
+			$this->state->complete_step( 'billing' );
+			return [ 'status' => $status ];
+		}
+
+		return [
+			'status'      => $status,
+			'billing_url' => $this->options->get( OptionsInterface::ADS_BILLING_URL ),
+		];
+	}
+
+	/**
+	 * Disconnect Ads account
+	 */
+	public function disconnect() {
+		$this->options->delete( OptionsInterface::ADS_ACCOUNT_CURRENCY );
+		$this->options->delete( OptionsInterface::ADS_ACCOUNT_STATE );
+		$this->options->delete( OptionsInterface::ADS_BILLING_URL );
+		$this->options->delete( OptionsInterface::ADS_CONVERSION_ACTION );
+		$this->options->delete( OptionsInterface::ADS_ID );
+		$this->options->delete( OptionsInterface::ADS_SETUP_COMPLETED_AT );
+	}
+
+	/**
+	 * Confirm the billing flow has been completed.
+	 *
+	 * @param array $account Account details.
+	 *
+	 * @throws ExceptionWithResponseData If this step hasn't been completed yet.
+	 */
+	private function check_billing_status( array $account ) {
+		$status = BillingSetupStatus::UNKNOWN;
+
+		// Only check billing status if we haven't just created the account.
+		if ( empty( $account['billing_url'] ) ) {
+			$status = $this->container->get( Ads::class )->get_billing_status();
+		}
+
+		if ( BillingSetupStatus::APPROVED !== $status ) {
+			throw new ExceptionWithResponseData(
+				__( 'Billing setup must be completed.', 'google-listings-and-ads' ),
+				428,
+				null,
+				[
+					'billing_url'    => $this->options->get( OptionsInterface::ADS_BILLING_URL ),
+					'billing_status' => $status,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Get the callback function for linking a merchant account.
+	 *
+	 * @throws Exception When the merchant or ads account hasn't been set yet.
+	 */
+	private function link_merchant_account() {
+		if ( ! $this->options->get_merchant_id() ) {
+			throw new Exception( 'A Merchant Center account must be connected' );
+		}
+
+		if ( ! $this->options->get_ads_id() ) {
+			throw new Exception( 'An Ads account must be connected' );
+		}
+
+		// Create link for Merchant and accept it in Ads.
+		$this->container->get( Merchant::class )->link_ads_id( $this->options->get_ads_id() );
+		$this->container->get( Ads::class )->accept_merchant_link( $this->options->get_merchant_id() );
+	}
+
+	/**
+	 * Create the generic GLA conversion action and store the details as an option.
+	 *
+	 * @throws Exception If the conversion action can't be created.
+	 */
+	private function create_conversion_action(): void {
+		$action = $this->container->get( AdsConversionAction::class )->create_conversion_action();
+		$this->options->update( OptionsInterface::ADS_CONVERSION_ACTION, $action );
+	}
+
+}

--- a/src/Ads/AdsService.php
+++ b/src/Ads/AdsService.php
@@ -38,15 +38,4 @@ class AdsService implements OptionsAwareInterface, Service {
 		return $google_connected && $this->is_setup_complete();
 	}
 
-	/**
-	 * Disconnect Ads account
-	 */
-	public function disconnect() {
-		$this->options->delete( OptionsInterface::ADS_ACCOUNT_CURRENCY );
-		$this->options->delete( OptionsInterface::ADS_ACCOUNT_STATE );
-		$this->options->delete( OptionsInterface::ADS_BILLING_URL );
-		$this->options->delete( OptionsInterface::ADS_CONVERSION_ACTION );
-		$this->options->delete( OptionsInterface::ADS_ID );
-		$this->options->delete( OptionsInterface::ADS_SETUP_COMPLETED_AT );
-	}
 }

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Attribu
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\VariationsAttributes;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService as AdsAccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
@@ -174,6 +175,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		VariationsAttributes::class   => true,
 		DeprecatedFilters::class      => true,
 		ShippingZone::class           => true,
+		AdsAccountService::class      => true,
 	];
 
 	/**
@@ -255,6 +257,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( SiteVerificationMeta::class, ContainerInterface::class );
 		$this->conditionally_share_with_tags( MerchantSetupCompleted::class );
 		$this->conditionally_share_with_tags( AdsSetupCompleted::class );
+		$this->conditionally_share_with_tags( AdsAccountService::class, ContainerInterface::class );
 
 		// Inbox Notes
 		$this->share_with_tags( ContactInformationNote::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService as AdsAccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
@@ -80,7 +81,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$this->share( SettingsController::class );
 		$this->share( ConnectionController::class );
-		$this->share_with_container( AdsAccountController::class );
+		$this->share( AdsAccountController::class, AdsAccountService::class );
 		$this->share_with_container( AdsCampaignController::class );
 		$this->share_with_container( AdsReportsController::class );
 		$this->share( GoogleAccountController::class, Connection::class );

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class AccountControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ *
+ * @property RESTServer                $rest_server
+ * @property AccountService|MockObject $account
+ */
+class AccountControllerTest extends RESTControllerUnitTest {
+
+	protected const ROUTE_ACCOUNTS           = '/wc/gla/ads/accounts';
+	protected const ROUTE_CONNECTION         = '/wc/gla/ads/connection';
+	protected const ROUTE_BILLING_STATUS     = '/wc/gla/ads/billing-status';
+	protected const TEST_ACCOUNT_ID          = 1234567890;
+	protected const TEST_BILLING_URL         = 'https://domain.test/billing/setup/';
+	protected const TEST_BILLING_STATUS      = 'pending';
+	protected const TEST_ACCOUNT_IDS         = [
+		self::TEST_ACCOUNT_ID,
+		2345678901,
+		3456789012,
+	];
+	protected const TEST_ACCOUNT_NO_IDS      = [];
+	protected const TEST_ACCOUNT_CREATE_DATA = [
+		'id'          => SELF::TEST_ACCOUNT_ID,
+		'billing_url' => SELF::TEST_BILLING_URL,
+	];
+	protected const TEST_ACCOUNT_LINK_ARGS   = [ 'id' => self::TEST_ACCOUNT_ID ];
+	protected const TEST_ACCOUNT_LINK_DATA   = [
+		'id'          => SELF::TEST_ACCOUNT_ID,
+		'billing_url' => null,
+	];
+	protected const TEST_CONNECTED_DATA      = [
+		'id'       => SELF::TEST_ACCOUNT_ID,
+		'currency' => 'EUR',
+		'symbol'   => '€',
+		'status'   => 'connected',
+	];
+	protected const TEST_DISCONNECTED_DATA   = [
+		'id'       => 0,
+		'currency' => null,
+		'symbol'   => '€',
+		'status'   => 'disconnected',
+	];
+	protected const TEST_BILLING_STATUS_DATA = [
+		'status'      => self::TEST_BILLING_STATUS,
+		'billing_url' => self::TEST_BILLING_URL,
+	];
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->account    = $this->createMock( AccountService::class );
+		$this->controller = new AccountController( $this->server, $this->account );
+		$this->controller->register();
+	}
+
+	public function test_get_accounts() {
+		$this->account->expects( $this->once() )
+			->method( 'get_account_ids' )
+			->willReturn( self::TEST_ACCOUNT_IDS );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_IDS, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_accounts_with_no_ids() {
+		$this->account->expects( $this->once() )
+			->method( 'get_account_ids' )
+			->willReturn( self::TEST_ACCOUNT_NO_IDS );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_NO_IDS, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_accounts_with_api_exception() {
+		$this->account->expects( $this->once() )
+			->method( 'get_account_ids' )
+			->willThrowException( new Exception( 'error' ) );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_create_account() {
+		$this->account->expects( $this->once() )
+			->method( 'setup_account' )
+			->willReturn( self::TEST_ACCOUNT_CREATE_DATA );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_CREATE_DATA, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_create_account_with_api_exception_data() {
+		$this->account->expects( $this->once() )
+			->method( 'setup_account' )
+			->willThrowException(
+				new ExceptionWithResponseData(
+					'error',
+					428,
+					null,
+					[
+						'billing_url'    => SELF::TEST_BILLING_URL,
+						'billing_status' => SELF::TEST_BILLING_STATUS,
+					]
+				)
+			);
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( SELF::TEST_BILLING_URL, $response->get_data()['billing_url'] );
+		$this->assertEquals( SELF::TEST_BILLING_STATUS, $response->get_data()['billing_status'] );
+		$this->assertEquals( 428, $response->get_status() );
+	}
+
+	public function test_create_account_with_api_exception() {
+		$this->account->expects( $this->once() )
+			->method( 'setup_account' )
+			->willThrowException( new Exception( 'error' ) );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_link_account() {
+		$this->account->expects( $this->once() )
+			->method( 'use_existing_account' )
+			->with( self::TEST_ACCOUNT_ID);
+
+		$this->account->expects( $this->once() )
+			->method( 'setup_account' )
+			->willReturn( self::TEST_ACCOUNT_LINK_DATA );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST', self::TEST_ACCOUNT_LINK_ARGS );
+
+		$this->assertEquals( self::TEST_ACCOUNT_LINK_DATA, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_connected_account() {
+		$this->account->expects( $this->once() )
+			->method( 'get_connected_account' )
+			->willReturn( self::TEST_CONNECTED_DATA );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( self::TEST_CONNECTED_DATA, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_disconnected_account() {
+		$this->account->expects( $this->once() )
+			->method( 'get_connected_account' )
+			->willReturn( self::TEST_DISCONNECTED_DATA );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( self::TEST_DISCONNECTED_DATA, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_disconnect_account() {
+		$this->account->expects( $this->once() )
+			->method( 'disconnect' );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'DELETE' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully disconnected.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_billing_status() {
+		$this->account->expects( $this->once() )
+			->method( 'get_billing_status' )
+			->willReturn( self::TEST_BILLING_STATUS_DATA );
+
+		$response = $this->do_request( self::ROUTE_BILLING_STATUS, 'GET' );
+
+		$this->assertEquals( self::TEST_BILLING_STATUS_DATA, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+}

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -91,12 +91,12 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	public function test_get_accounts_with_api_exception() {
 		$this->account->expects( $this->once() )
 			->method( 'get_account_ids' )
-			->willThrowException( new Exception( 'error' ) );
+			->willThrowException( new Exception( 'error', 401 ) );
 
 		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
 
 		$this->assertEquals( 'error', $response->get_data()['message'] );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 401, $response->get_status() );
 	}
 
 	public function test_create_account() {

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -1,0 +1,395 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BillingSetupStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads
+ *
+ * @property MockObject|Ads                 $ads
+ * @property MockObject|AdsConversionAction $conversion_action
+ * @property MockObject|Merchant            $merchant
+ * @property MockObject|Middleware          $middleware
+ * @property MockObject|AdsAccountState     $state
+ * @property AccountService                 $account
+ * @property Container                      $container
+ * @property OptionsInterface               $options
+ */
+class AccountServiceTest extends UnitTest {
+
+	protected const TEST_ACCOUNT_ID        = 1234567890;
+	protected const TEST_OLD_ACCOUNT_ID    = 2345678901;
+	protected const TEST_MERCHANT_ID       = 78123456;
+	protected const TEST_BILLING_URL       = 'https://domain.test/billing/setup/';
+	protected const TEST_ACCOUNT_IDS       = [
+		self::TEST_ACCOUNT_ID,
+		self::TEST_OLD_ACCOUNT_ID,
+		3456789012,
+	];
+	protected const TEST_ACCOUNT_NO_IDS    = [];
+	protected const TEST_CONNECTED_DATA    = [
+		'id'       => SELF::TEST_ACCOUNT_ID,
+		'currency' => 'EUR',
+		'symbol'   => '€',
+		'status'   => 'connected',
+	];
+	protected const TEST_DISCONNECTED_DATA = [
+		'id'       => 0,
+		'currency' => null,
+		'symbol'   => '€',
+		'status'   => 'disconnected',
+	];
+	protected const TEST_CONVERSION_ACTION = [
+		'id'   => 12345678,
+		'name' => 'Test Action',
+	];
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->ads               = $this->createMock( Ads::class );
+		$this->conversion_action = $this->createMock( AdsConversionAction::class );
+		$this->merchant          = $this->createMock( Merchant::class );
+		$this->middleware        = $this->createMock( Middleware::class );
+		$this->state             = $this->createMock( AdsAccountState::class );
+		$this->options           = $this->createMock( OptionsInterface::class );
+
+		$this->container = new Container();
+		$this->container->share( Ads::class, $this->ads );
+		$this->container->share( AdsConversionAction::class, $this->conversion_action );
+		$this->container->share( Merchant::class, $this->merchant );
+		$this->container->share( Middleware::class, $this->middleware );
+		$this->container->share( AdsAccountState::class, $this->state );
+
+		$this->account = new AccountService( $this->container );
+		$this->account->set_options_object( $this->options );
+	}
+
+	public function test_get_accounts_with_no_ids() {
+		$this->middleware->expects( $this->once() )
+			->method( 'get_ads_account_ids' )
+			->willReturn( self::TEST_ACCOUNT_NO_IDS );
+
+		$this->assertEquals( self::TEST_ACCOUNT_NO_IDS, $this->account->get_account_ids() );
+	}
+
+	public function test_get_accounts() {
+		$this->middleware->expects( $this->once() )
+			->method( 'get_ads_account_ids' )
+			->willReturn( self::TEST_ACCOUNT_IDS );
+
+		$this->assertEquals( self::TEST_ACCOUNT_IDS, $this->account->get_account_ids() );
+	}
+
+	public function test_get_accounts_with_api_exception() {
+		$this->middleware->expects( $this->once() )
+			->method( 'get_ads_account_ids' )
+			->willThrowException( new Exception( 'error' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'error' );
+		$this->account->get_account_ids();
+	}
+
+	public function test_get_connected_account() {
+		$this->middleware->expects( $this->once() )
+			->method( 'get_connected_ads_account' )
+			->willReturn( self::TEST_CONNECTED_DATA );
+
+		$this->assertEquals( self::TEST_CONNECTED_DATA, $this->account->get_connected_account() );
+	}
+
+	public function test_get_disconnected_account() {
+		$this->middleware->expects( $this->once() )
+			->method( 'get_connected_ads_account' )
+			->willReturn( self::TEST_DISCONNECTED_DATA );
+
+		$this->assertEquals( self::TEST_DISCONNECTED_DATA, $this->account->get_connected_account() );
+	}
+
+	public function test_use_existing_account_already_connected() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( self::TEST_OLD_ACCOUNT_ID );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage(
+			sprintf(
+				'Ads account %1$d already connected.',
+				self::TEST_OLD_ACCOUNT_ID
+			)
+		);
+		$this->account->use_existing_account( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_use_existing_account() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'link_ads_account' )
+			->with( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'set_id'  => [ 'status' => AdsAccountState::STEP_DONE ],
+					'billing' => [ 'status' => AdsAccountState::STEP_DONE ],
+				]
+			);
+
+		$this->account->use_existing_account( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_setup_account_step_set_id() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'create_ads_account' )
+			->willReturn( [ 'id' => self::TEST_ACCOUNT_ID ] );
+
+		$this->assertEquals( [ 'id' => self::TEST_ACCOUNT_ID ], $this->account->setup_account() );
+	}
+
+	public function test_setup_account_step_billing() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'billing' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->ads->expects( $this->once() )
+			->method( 'get_billing_status' )
+			->willReturn( BillingSetupStatus::APPROVED );
+
+		$this->assertEquals( [ 'id' => self::TEST_ACCOUNT_ID ], $this->account->setup_account() );
+	}
+
+	public function test_setup_account_step_billing_pending() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'billing' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->ads->expects( $this->once() )
+			->method( 'get_billing_status' )
+			->willReturn( BillingSetupStatus::PENDING );
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionCode( 428 );
+		$this->expectExceptionMessage( 'Billing setup must be completed.' );
+
+		$this->account->setup_account();
+	}
+
+	public function test_setup_account_step_link_merchant() {
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_MERCHANT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'link_merchant' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->merchant->expects( $this->once() )
+			->method( 'link_ads_id' )
+			->with( self::TEST_ACCOUNT_ID );
+
+		$this->ads->expects( $this->once() )
+			->method( 'accept_merchant_link' )
+			->with( self::TEST_MERCHANT_ID );
+
+		$this->assertEquals( [ 'id' => self::TEST_ACCOUNT_ID ], $this->account->setup_account() );
+	}
+
+	public function test_setup_account_step_link_merchant_no_ads_id() {
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->willReturn( 0 );
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_MERCHANT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'link_merchant' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'An Ads account must be connected' );
+
+		$this->account->setup_account();
+	}
+
+	public function test_setup_account_step_link_merchant_no_merchant_id() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'link_merchant' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'A Merchant Center account must be connected' );
+
+		$this->account->setup_account();
+	}
+
+	public function test_setup_account_step_conversion_action() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'conversion_action' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->conversion_action->expects( $this->once() )
+			->method( 'create_conversion_action' )
+			->willReturn( self::TEST_CONVERSION_ACTION );
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::ADS_CONVERSION_ACTION,
+				self::TEST_CONVERSION_ACTION
+			);
+
+		$this->assertEquals( [ 'id' => self::TEST_ACCOUNT_ID ], $this->account->setup_account() );
+	}
+
+	public function test_setup_account_step_invalid() {
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'invalid' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unknown ads account creation step invalid' );
+
+		$this->account->setup_account();
+	}
+
+	public function test_get_billing_status_approved() {
+		$this->ads->expects( $this->once() )
+			->method( 'get_billing_status' )
+			->willReturn( BillingSetupStatus::APPROVED );
+
+		$this->assertEquals(
+			[ 'status' => BillingSetupStatus::APPROVED ],
+			$this->account->get_billing_status()
+		);
+	}
+
+	public function test_get_billing_status_pending() {
+		$this->ads->expects( $this->once() )
+			->method( 'get_billing_status' )
+			->willReturn( BillingSetupStatus::PENDING );
+
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::ADS_BILLING_URL )
+			->willReturn( self::TEST_BILLING_URL );
+
+		$this->assertEquals(
+			[
+				'status'      => BillingSetupStatus::PENDING,
+				'billing_url' => self::TEST_BILLING_URL,
+			],
+			$this->account->get_billing_status()
+		);
+	}
+
+	public function test_disconnect() {
+		$this->options->expects( $this->exactly( 6 ) )
+			->method( 'delete' )
+			->withConsecutive(
+				[ OptionsInterface::ADS_ACCOUNT_CURRENCY ],
+				[ OptionsInterface::ADS_ACCOUNT_STATE ],
+				[ OptionsInterface::ADS_BILLING_URL ],
+				[ OptionsInterface::ADS_CONVERSION_ACTION ],
+				[ OptionsInterface::ADS_ID ],
+				[ OptionsInterface::ADS_SETUP_COMPLETED_AT ]
+			);
+
+		$this->account->disconnect();
+	}
+
+}

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -201,6 +201,9 @@ class AccountServiceTest extends UnitTest {
 			->method( 'create_ads_account' )
 			->willReturn( [ 'id' => self::TEST_ACCOUNT_ID ] );
 
+		$this->state->expects( $this->once() )
+			->method( 'update' );
+
 		$this->assertEquals( [ 'id' => self::TEST_ACCOUNT_ID ], $this->account->setup_account() );
 	}
 

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -133,6 +133,28 @@ class AccountServiceTest extends UnitTest {
 		$this->account->use_existing_account( self::TEST_ACCOUNT_ID );
 	}
 
+	public function test_use_existing_account_same_account() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => AdsAccountState::STEP_DONE ],
+				]
+			);
+
+		$this->middleware->expects( $this->never() )
+			->method( 'link_ads_account' );
+
+		$this->state->expects( $this->never() )
+			->method( 'update' );
+
+		$this->account->use_existing_account( self::TEST_ACCOUNT_ID );
+	}
+
 	public function test_use_existing_account() {
 		$this->options->expects( $this->once() )
 			->method( 'get_ads_id' )

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -44,7 +44,6 @@ class AccountServiceTest extends UnitTest {
 		self::TEST_OLD_ACCOUNT_ID,
 		3456789012,
 	];
-	protected const TEST_ACCOUNT_NO_IDS    = [];
 	protected const TEST_CONNECTED_DATA    = [
 		'id'       => SELF::TEST_ACCOUNT_ID,
 		'currency' => 'EUR',
@@ -83,14 +82,6 @@ class AccountServiceTest extends UnitTest {
 
 		$this->account = new AccountService( $this->container );
 		$this->account->set_options_object( $this->options );
-	}
-
-	public function test_get_accounts_with_no_ids() {
-		$this->middleware->expects( $this->once() )
-			->method( 'get_ads_account_ids' )
-			->willReturn( self::TEST_ACCOUNT_NO_IDS );
-
-		$this->assertEquals( self::TEST_ACCOUNT_NO_IDS, $this->account->get_account_ids() );
 	}
 
 	public function test_get_accounts() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a replacement for #977 and is created based on the feedback in the review of the unit tests for the Merchant AccountController, see [here](https://github.com/woocommerce/google-listings-and-ads/pull/973#discussion_r697233209). The issue #388 mentions the same strategy.

So in this PR I refactored the AdsAccountController and moved all the account handling to a separate AdsAccountService class. This simplified the unit testing as we can test each class individually.
One unit test was created for the AdsAccountController (which is based on the RESTControllerUnitTest). Another unit test was created for the AdsAccountService class.

The disconnect function was already in the AdsService class but I didn't want all the account functions to be mixed in with the regular functions in this class. There isn't a lot in the AdsService class, but if we copy this same pattern for the MerchantCenterService then it would be better to keep the account functions in a separate service since they are only used when connecting / disconnecting.

Resolves part of #388

### Detailed test instructions:
The main testing is to confirm that all the added unit tests pass.

However since we also refactored the Ads account functions we need to confirm that they all continue to function the same. Following are all the affected REST API requests and their expected responses. Each one can be tested with the help of Postman (or with the Connection Test page which builds the request internally).

#### Disconnect Ads account

```
DELETE https://domain.test/wp-json/wc/gla/ads/connection
Response:
{
	"status": "success",
	"message": "Successfully disconnected."
}
```

#### Create new account

```
POST https://domain.test/wp-json/wc/gla/ads/accounts
Body: <empty>
Response Code: 428
Response:
{
	"message": "Billing setup must be completed.",
	"billing_url": "https://ads.google.com/nav/startacceptinvite?ivid=123&ocid=456",
	"billing_status": "unknown"
}
```

When testing creating a new account, we need to visit the `billing_url` link and click the accept button (or view the email and click the link to accept the account). Entering the billing account info can be skipped while testing.

#### Check billing status

```
GET https://domain.test/wp-json/wc/gla/ads/billing-status
Response:
{
	"status": "pending",
	"billing_url": "https://ads.google.com/nav/startacceptinvite?ivid=123&ocid=456"
}
```

This endpoint will return status `approved`, once the billing details have been completed, or for testing we can use a [code snippet](https://github.com/woocommerce/google-listings-and-ads/wiki/Hack-for-working-locally-with-APIs#use-ads-account-without-setting-billing-data) to force it to return approved.

#### Connect an existing account

The disconnect request can be repeated before this step to ensure we aren't connected. An existing account ID is needed for this step (can use the one we created previously, check the email for the ID).

```
POST https://domain.test/wp-json/wc/gla/ads/accounts
Body:
{
	"id": 1234567890
}
Response:
{
	"id": 1234567890,
	"billing_url": null
}
```

#### Get connected account

```
GET https://domain.test/wp-json/wc/gla/ads/connection
Response:
{
	"id": 1234567890,
	"currency": "EUR",
	"symbol": "€",
	"status": "connected"
}
```

#### Get list of accounts

```
GET https://domain.test/wp-json/wc/gla/ads/accounts
Response:
[
	1234567890,
	2345678901,
	3456789012
]
```

### Changelog entry

* Add - Unit tests for the Ads AccountController and AccountService.
