### PR TITLE
Update Google Ads credit incentive in WordPress.org plugin landing page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -45,18 +45,9 @@ Connect your Google Ads account, choose a budget, and launch your campaign strai
 
 *Learn more about supported countries and currencies for Smart Shopping campaigns [here](https://support.google.com/merchants/answer/160637#countrytable).*
 
-= Get started with up to $150 in ad credit when you create a Google Ads account =
+= Get $500 in Google Ads credit when you spend your first $500! =
 
-Get up to  $150\* in ad credit to help you get started on Smart Shopping Campaigns. The promotional code will be applied when you start spending and serve your first ad impression, and whatever you spend over the next 30 days, up to $150, will be added back to your account.
-
-*\*Ad credit amounts vary by country and region.*
-
-= The eligibility criteria: =
-- The account has no other promotions applied.
-- The account is billed to a country where Google Partners promotions are offered.
-- The account served its first ad impression within the last 14 days.
-
-*Review the static terms [here](http://www.google.com/ads/coupons/terms.html).*
+Create a new Google Ads account through Google Listings & Ads and a promotional code will be automatically applied to your account. You’ll have 60 days to spend $500 to qualify for the $500 ads credit. See full terms and conditions [here](https://www.google.com/ads/coupons/terms/).
 
 == Installation ==
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1212 .

This PR updates the Google Ads credit incentive information in the WordPress.org plugin landing page: https://wordpress.org/plugins/google-listings-and-ads/

The change is from Spend Match $150 to Spend Get $500. Visit the internal link below and look for "Messaging Update Tracker" for more info.

Internal link: pcTzPl-eI-p2

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Visit the internal link above and open the "Messaging Update Tracker" document.
2. Make sure the changes in this PR matches the changes stated in the document.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Update Google Ads credit incentive in WordPress.org plugin landing page.
