### PR TITLE
Fix incorrect font color for disabled primary destructive button

### DIFF
--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -1,15 +1,12 @@
 // Import Gutenberg components that aren't already imported in the lowest WC Admin version we support
-@import "node_modules/@wordpress/components/src/button/style"; // required for tab-panel
+// @import "node_modules/@wordpress/components/src/button/style"; // required for tab-panel
 @import "node_modules/@wordpress/components/src/panel/style";
 
 .components-button {
-	// hack to make primary destructive button.
-	&.is-primary.is-destructive {
-		background-color: $alert-red;
-
-		&:hover {
-			background-color: darken($color: $alert-red, $amount: 10%);
-		}
+	// Hack to show correct font color for disabled primary destructive button.
+	// The color style is copied from https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L67-L72
+	&.is-primary.is-destructive:disabled {
+		color: rgba($white, 0.4);
 	}
 
 	// hack to fix tertiary destructive button.

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -1,5 +1,5 @@
 // Import Gutenberg components that aren't already imported in the lowest WC Admin version we support
-// @import "node_modules/@wordpress/components/src/button/style"; // required for tab-panel
+@import "node_modules/@wordpress/components/src/button/style"; // required for tab-panel
 @import "node_modules/@wordpress/components/src/panel/style";
 
 .components-button {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1005 

- Fix incorrect font color for disabled primary destructive button.
- Remove the hack of background color for primary destructive button. It has been fixed by https://github.com/WordPress/gutenberg/pull/27774 and released with WordPress 5.9 which is using `@wordpress/components` 12.0.2.

### Screenshots:

![Kapture 2022-01-26 at 16 37 08](https://user-images.githubusercontent.com/17420811/151131268-d0f73fc3-df9a-4bb2-875f-7f05a65da758.gif)

### Detailed test instructions:

1. Go to the Setting page.
2. Click on "Disconnect Google Ads account only" or "Disconnect all accounts".
3. In the pop-up modal, hover on the primary destructive button. The button style should look more like disabled state and have no hover style effects.
4. Check the "Yes, I want to disconnect ..." box on the side. When hovering on the primary destructive button, the primary destructive button should look like a clickable state and have hover style effects.

### Changelog entry

> Fix - Fix the incorrect text color of the disabled "Disconnect account" buttons on the Settings page.
