### PR TITLE
Remove the caching setup step for the workflow of "JavaScript and CSS Linting" from GitHub Actions

### DIFF
--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -9,20 +9,10 @@ on:
 
 env:
   FORCE_COLOR: 2
+
 jobs:
-  Setup:
-    name: Setup for jobs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Prepare node
-        uses: ./.github/actions/prepare-node
-
   JSLintingCheck:
     name: Lint JavaScript
-    needs: Setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -50,7 +40,6 @@ jobs:
 
   CSSLintingCheck:
     name: Lint CSS
-    needs: Setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1047 

As the discussion in https://github.com/woocommerce/google-listings-and-ads/pull/1133#discussion_r761753593, and currently, almost all of the "JavaScript and CSS Linting" workflows take at least 2.5 minutes, and most of them take about 3 minutes.

This PR removed the possibly ineffective caching setup to evaluate if more time could be saved in this workflow.

### Screenshots:

![2022-01-27 11 54 32](https://user-images.githubusercontent.com/17420811/151289320-6bb693c7-1b0b-4c65-96f4-a324093da075.png)

### Detailed test instructions:

1. Go to the [Checks tab](https://github.com/woocommerce/google-listings-and-ads/pull/1220/checks) of this PR.
2. Check if the "JavaScript and CSS Linting" workflow is run correctly and saves more time.

### Changelog entry
