### PR TITLE
Cancel the previous in-progress runs of the same GitHub Actions workflow

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -7,6 +7,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   BundleSize:
     name: Bundle size

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,6 +7,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   E2ETests:
     name: E2E Tests
@@ -14,11 +18,6 @@ jobs:
     env:
       FORCE_COLOR: 2
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-            access_token: ${{ github.token }}
-
       # Needed for Ubuntu 20.04.
       - name: Kill mono to free 8084
         run: |

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -7,6 +7,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_COLOR: 2
 jobs:

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -7,6 +7,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   UnitTests:
     name: JavaScript unit tests

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -7,6 +7,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpcs:
     name: PHP coding standards

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -7,6 +7,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Setup:
     name: Setup for jobs

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![JavaScript Unit Tests](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-unit-tests.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-unit-tests.yml)
 [![PHP Coding Standards](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/php-coding-standards.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/php-coding-standards.yml)
 [![JavaScript and CSS Linting](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-css-linting.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-css-linting.yml)
+[![E2E Tests](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/e2e-tests.yml)
 [![Bundle Size](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/bundle-size.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/bundle-size.yml)
 
 A native integration with Google offering free listings and Smart Shopping ads to WooCommerce merchants.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1047 

- Add [`concurrency` syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow) to cancel the previous in-progress runs of the same GitHub Actions workflow.
- Extra change: Add the status badge of e2e test to README.

### Screenshots:

![2022-01-28 17 08 46](https://user-images.githubusercontent.com/17420811/151519080-077eeb43-3318-473b-8338-f128010a8d1a.png)


### Detailed test instructions:

1. Check the [canceled workflows](https://github.com/woocommerce/google-listings-and-ads/pull/1224/checks?sha=5e0a67248061f47dc0aa252e388a78b4a1237f98).
2. Go to the [README of this revision](https://github.com/woocommerce/google-listings-and-ads/blob/6e913d117e4ee3a3138bfe152a4eef335dc5a864/README.md) for checking the e2e status badge.

### Changelog entry
