### PR TITLE
Refactor MCAccountController and add unit tests

### DIFF
--- a/src/API/Google/SiteVerification.php
+++ b/src/API/Google/SiteVerification.php
@@ -3,6 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Google\Service\Exception as GoogleException;
 use Exception;
@@ -20,8 +23,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
-class SiteVerification {
+class SiteVerification implements OptionsAwareInterface {
 
+	use OptionsAwareTrait;
 	use PluginHelper;
 
 	/**
@@ -122,4 +126,62 @@ class SiteVerification {
 
 		return true;
 	}
+
+	/**
+	 * Performs the three-step process of verifying the current site:
+	 * 1. Retrieves the meta tag with the verification token.
+	 * 2. Enables the meta tag in the head of the store.
+	 * 3. Instructs the Site Verification API to verify the meta tag.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $site_url Site URL to verify.
+	 *
+	 * @throws Exception If any step of the site verification process fails.
+	 */
+	public function verify_site( string $site_url ) {
+		if ( ! wc_is_valid_url( $site_url ) ) {
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'site-url' ] );
+			throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
+		}
+
+		// Retrieve the meta tag with verification token.
+		try {
+			$meta_tag = $this->get_token( $site_url );
+		} catch ( Exception $e ) {
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'token' ] );
+			throw $e;
+		}
+
+		// Store the meta tag in the options table and mark as unverified.
+		$site_verification_options = [
+			'verified' => self::VERIFICATION_STATUS_UNVERIFIED,
+			'meta_tag' => $meta_tag,
+		];
+		$this->options->update(
+			OptionsInterface::SITE_VERIFICATION,
+			$site_verification_options
+		);
+
+		// Attempt verification.
+		try {
+			if ( $this->insert( $site_url ) ) {
+				$site_verification_options['verified'] = self::VERIFICATION_STATUS_VERIFIED;
+				$this->options->update( OptionsInterface::SITE_VERIFICATION, $site_verification_options );
+				do_action( 'woocommerce_gla_site_verify_success', [] );
+
+				return;
+			}
+		} catch ( Exception $e ) {
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'meta-tag' ] );
+
+			throw $e;
+		}
+
+		// Should never reach this point.
+		do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'unknown' ] );
+
+		throw new Exception( __( 'Site verification failed.', 'google-listings-and-ads' ) );
+	}
+
 }

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -3,20 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
-use Google\Service\ShoppingContent\Account as MC_Account;
-use Exception;
-use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
@@ -27,58 +19,24 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
-class AccountController extends BaseOptionsController {
-
-	use PluginHelper;
+class AccountController extends BaseController {
 
 	/**
-	 * @var ContainerInterface
+	 * Service used to access / update Ads account data.
+	 *
+	 * @var AccountService
 	 */
-	protected $container;
-
-	/**
-	 * @var Middleware
-	 */
-	protected $middleware;
-
-	/**
-	 * @var Merchant
-	 */
-	protected $merchant;
-
-	/**
-	 * @var MerchantAccountState
-	 */
-	protected $account_state;
-
-	/**
-	 * @var MerchantCenterService
-	 */
-	protected $mc_service;
-
-	/**
-	 * @var bool Whether to perform website claim with overwrite.
-	 */
-	protected $overwrite_claim = false;
-
-
-	/**
-	 * @var bool Whether to allow changes to the existing website URL.
-	 */
-	protected $allow_switch_url = false;
+	protected $account;
 
 	/**
 	 * AccountController constructor.
 	 *
-	 * @param ContainerInterface $container
+	 * @param RESTServer     $server
+	 * @param AccountService $account
 	 */
-	public function __construct( ContainerInterface $container ) {
-		parent::__construct( $container->get( RESTServer::class ) );
-		$this->middleware    = $container->get( Middleware::class );
-		$this->merchant      = $container->get( Merchant::class );
-		$this->account_state = $container->get( MerchantAccountState::class );
-		$this->mc_service    = $container->get( MerchantCenterService::class );
-		$this->container     = $container;
+	public function __construct( RESTServer $server, AccountService $account ) {
+		parent::__construct( $server );
+		$this->account = $account;
 	}
 
 	/**
@@ -95,7 +53,7 @@ class AccountController extends BaseOptionsController {
 				],
 				[
 					'methods'             => TransportMethods::CREATABLE,
-					'callback'            => $this->set_account_id_callback(),
+					'callback'            => $this->setup_account_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_schema_properties(),
 				],
@@ -166,7 +124,7 @@ class AccountController extends BaseOptionsController {
 						$data = $this->prepare_item_for_response( $account, $request );
 						return $this->prepare_response_for_collection( $data );
 					},
-					$this->middleware->get_merchant_accounts()
+					$this->account->get_accounts()
 				);
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
@@ -180,19 +138,7 @@ class AccountController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function overwrite_claim_callback(): callable {
-		return function( Request $request ) {
-			$state               = $this->account_state->get( false );
-			$overwrite_necessary = ! empty( $state['claim']['data']['overwrite_required'] );
-			$claim_status        = $state['claim']['status'] ?? MerchantAccountState::STEP_PENDING;
-			if ( MerchantAccountState::STEP_DONE === $claim_status || ! $overwrite_necessary ) {
-				return $this->prepare_error_response(
-					[ 'message' => __( 'Attempting invalid claim overwrite.', 'google-listings-and-ads' ) ]
-				);
-			}
-
-			$this->overwrite_claim = true;
-			return $this->set_account_id( $request );
-		};
+		return $this->setup_account_callback( 'overwrite_claim' );
 	}
 
 	/**
@@ -201,29 +147,27 @@ class AccountController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function switch_url_callback(): callable {
-		return function( Request $request ) {
-			$state            = $this->account_state->get();
-			$switch_necessary = ! empty( $state['set_id']['data']['old_url'] );
-			$set_id_status    = $state['set_id']['status'] ?? MerchantAccountState::STEP_PENDING;
-			if ( empty( $request['id'] ) || MerchantAccountState::STEP_DONE === $set_id_status || ! $switch_necessary ) {
-				return $this->prepare_error_response(
-					[ 'message' => __( 'Attempting invalid URL switch.', 'google-listings-and-ads' ) ]
-				);
-			}
-
-			$this->allow_switch_url = true;
-			return $this->set_account_id( $request );
-		};
+		return $this->setup_account_callback( 'switch_url' );
 	}
 
 	/**
 	 * Get the callback function for creating or linking an account.
 	 *
+	 * @param string $action Action to call while setting up account (default is normal setup).
 	 * @return callable
 	 */
-	protected function set_account_id_callback(): callable {
-		return function( Request $request ) {
-			return $this->set_account_id( $request );
+	protected function setup_account_callback( string $action = 'setup_account' ): callable {
+		return function( Request $request ) use ( $action ) {
+			try {
+				$account_id = absint( $request['id'] );
+				$account    = $this->account->{$action}( $account_id );
+
+				return $this->prepare_item_for_response( $account, $request );
+			} catch ( MerchantTimeToWait $e ) {
+				return $this->get_time_to_wait_response( $e );
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
+			}
 		};
 	}
 
@@ -234,7 +178,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function get_connected_merchant_callback(): callable {
 		return function() {
-			return $this->mc_service->get_connected_status();
+			return $this->account->get_connected_status();
 		};
 	}
 
@@ -245,7 +189,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function get_setup_merchant_callback(): callable {
 		return function() {
-			return $this->mc_service->get_setup_status();
+			return $this->account->get_setup_status();
 		};
 	}
 
@@ -256,7 +200,7 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function disconnect_merchant_callback(): callable {
 		return function() {
-			$this->mc_service->disconnect();
+			$this->account->disconnect();
 
 			return [
 				'status'  => 'success',
@@ -312,362 +256,22 @@ class AccountController extends BaseOptionsController {
 	}
 
 	/**
-	 * Run the process for setting up a Merchant Center account (sub-account or standalone).
+	 * Return a 503 Response with Retry-After header and message.
 	 *
-	 * @param Request $request
-	 *
-	 * @return array|Response The account ID if setup has completed, or an error if not.
-	 */
-	protected function set_account_id( Request $request ) {
-		try {
-			$account_id  = absint( $request['id'] );
-			$merchant_id = $this->options->get_merchant_id();
-
-			// Reset the process if the provided ID isn't the same as the one "on file" in `options`.
-			if ( $merchant_id && $merchant_id !== $account_id ) {
-				// Can't do it if the MC connection process has been completed previously.
-				if ( $this->mc_service->is_setup_complete() ) {
-					return $this->prepare_error_response(
-						[
-							'message' => sprintf(
-								/* translators: 1: is a numeric account ID */
-								__( 'Merchant Center account already connected: %d', 'google-listings-and-ads' ),
-								$merchant_id
-							),
-						]
-					);
-				}
-
-				$this->mc_service->disconnect();
-			}
-
-			if ( $account_id ) {
-				$this->use_existing_account_id( $account_id );
-			}
-
-			$response = $this->setup_merchant_account();
-
-			return is_a( $response, Response::class ) ? $response : $this->prepare_item_for_response( $response, $request );
-		} catch ( ExceptionWithResponseData $e ) {
-			return $this->prepare_error_response( $e->get_response_data( true ), $e->getCode() );
-		} catch ( Exception $e ) {
-			return $this->prepare_error_response( [ 'message' => $e->getMessage() ], $e->getCode() );
-		}
-	}
-
-	/**
-	 * Prepare the error response:
-	 * - Ensure it has the merchant_id value
-	 * - Default to a 400 error code
-	 *
-	 * @param array    $data
-	 * @param int|null $code
+	 * @param MerchantTimeToWait $wait Exception containing the time to wait.
 	 *
 	 * @return Response
 	 */
-	protected function prepare_error_response( array $data, int $code = null ): Response {
-		$merchant_id = $this->options->get_merchant_id();
-		if ( $merchant_id ) {
-			$data['id'] = $merchant_id;
-		}
-		return new Response( $data, $code ?: 400 );
+	private function get_time_to_wait_response( MerchantTimeToWait $wait ): Response {
+		$data = $wait->get_response_data( true );
 
-	}
-
-	/**
-	 * Performs the steps necessary to initialize a Merchant Center sub-account.
-	 * Should always resume up at the last pending or unfinished step. If the Merchant Center account
-	 * has already been created, the ID is simply returned.
-	 *
-	 * @return array|Response The newly created (or pre-existing) Merchant ID or the retry delay.
-	 * @throws Exception If an error occurs during any step.
-	 */
-	protected function setup_merchant_account() {
-		$state       = $this->account_state->get();
-		$merchant_id = intval( $this->options->get( OptionsInterface::MERCHANT_ID ) );
-
-		foreach ( $state as $name => &$step ) {
-			if ( MerchantAccountState::STEP_DONE === $step['status'] ) {
-				continue;
-			}
-
-			if ( 'link' === $name ) {
-				$time_to_wait = $this->account_state->get_seconds_to_wait_after_created();
-				if ( $time_to_wait ) {
-					sleep( $time_to_wait );
-				}
-			}
-
-			try {
-				switch ( $name ) {
-					case 'set_id':
-						// Just in case, don't create another merchant ID.
-						if ( ! empty( $merchant_id ) ) {
-							break;
-						}
-						$merchant_id                       = $this->middleware->create_merchant_account();
-						$step['data']['from_mca']          = true;
-						$step['data']['created_timestamp'] = time();
-						break;
-					case 'verify':
-						$this->verify_site();
-						break;
-					case 'link':
-						$this->middleware->link_merchant_to_mca();
-						break;
-					case 'claim':
-						// At this step, the website URL is assumed to be correct.
-						// If the URL is already claimed, no claim should be attempted.
-						if ( $this->merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed() ) {
-							break;
-						}
-
-						if ( $this->overwrite_claim ) {
-							$this->middleware->claim_merchant_website( true );
-						} else {
-							$this->merchant->claimwebsite();
-						}
-						break;
-					default:
-						throw new Exception(
-							sprintf(
-								/* translators: 1: is a string representing an unknown step name */
-								__( 'Unknown merchant account creation step %1$s', 'google-listings-and-ads' ),
-								$name
-							)
-						);
-				}
-				$step['status']  = MerchantAccountState::STEP_DONE;
-				$step['message'] = '';
-				$this->account_state->update( $state );
-			} catch ( Exception $e ) {
-				$step['status']  = MerchantAccountState::STEP_ERROR;
-				$step['message'] = $e->getMessage();
-
-				// URL already claimed.
-				if ( 'claim' === $name && 403 === $e->getCode() ) {
-					$data = [
-						'id'          => $merchant_id,
-						'website_url' => $this->strip_url_protocol(
-							esc_url_raw( $this->get_site_url() )
-						),
-					];
-
-					// Sub-account: request overwrite confirmation.
-					if ( $state['set_id']['data']['from_mca'] ?? true ) {
-						do_action( 'woocommerce_gla_site_claim_overwrite_required', [] );
-
-						$step['data']['overwrite_required'] = true;
-						$e                                  = new ExceptionWithResponseData( $e->getMessage(), $e->getCode(), null, $data );
-					} else {
-						do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'independent_account' ] );
-
-						// Independent account: overwrite not possible.
-						throw new ExceptionWithResponseData(
-							__( 'Unable to claim website URL with this Merchant Center Account.', 'google-listings-and-ads' ),
-							406,
-							null,
-							$data
-						);
-					}
-				} elseif ( 'link' === $name && 401 === $e->getCode() ) {
-					// New sub-account not yet manipulable.
-					$state['set_id']['data']['created_timestamp'] = time();
-					$this->account_state->update( $state );
-					return $this->get_time_to_wait_response();
-				}
-
-				$this->account_state->update( $state );
-				throw $e;
-			}
-		}
-
-		return [ 'id' => $merchant_id ];
-	}
-
-	/**
-	 * Performs the three-step process of verifying the current site:
-	 * 1. Retrieves the meta tag with the verification token.
-	 * 2. Enables the meta tag in the head of the store.
-	 * 3. Instructs the Site Verification API to verify the meta tag.
-	 *
-	 * @throws Exception If any step of the site verification process fails.
-	 */
-	private function verify_site(): void {
-		$site_url = esc_url_raw( $this->get_site_url() );
-		if ( ! wc_is_valid_url( $site_url ) ) {
-			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'site-url' ] );
-			throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
-		}
-
-		// Inform of previous verification.
-		if ( $this->account_state->is_site_verified() ) {
-			return;
-		}
-
-		// Retrieve the meta tag with verification token.
-		/** @var SiteVerification $site_verification */
-		$site_verification = $this->container->get( SiteVerification::class );
-		try {
-			$meta_tag = $site_verification->get_token( $site_url );
-		} catch ( Exception $e ) {
-			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'token' ] );
-			throw $e;
-		}
-
-		// Store the meta tag in the options table and mark as unverified.
-		$site_verification_options = [
-			'verified' => $site_verification::VERIFICATION_STATUS_UNVERIFIED,
-			'meta_tag' => $meta_tag,
-		];
-		$this->options->update(
-			OptionsInterface::SITE_VERIFICATION,
-			$site_verification_options
-		);
-
-		// Attempt verification.
-		try {
-			if ( $site_verification->insert( $site_url ) ) {
-				$site_verification_options['verified'] = $site_verification::VERIFICATION_STATUS_VERIFIED;
-				$this->options->update( OptionsInterface::SITE_VERIFICATION, $site_verification_options );
-				do_action( 'woocommerce_gla_site_verify_success', [] );
-
-				return;
-			}
-		} catch ( Exception $e ) {
-			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'meta-tag' ] );
-
-			throw $e;
-		}
-
-		// Should never reach this point.
-		do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'unknown' ] );
-
-		throw new Exception( __( 'Site verification failed.', 'google-listings-and-ads' ) );
-	}
-
-
-
-	/**
-	 * Use an existing MC account. Mark the 'set_id' step as done, update the MC account's website URL,
-	 * and sets the Merchant ID.
-	 *
-	 * @param int $account_id The merchant ID to use.
-	 *
-	 * @throws Exception If the merchant IDs of the connected account can't be retrieved.
-	 * @throws ExceptionWithResponseData If there's a website URL conflict.
-	 */
-	private function use_existing_account_id( int $account_id ): void {
-		$state = $this->account_state->get();
-
-		// Don't do anything if this step was already finished.
-		if ( MerchantAccountState::STEP_DONE === $state['set_id']['status'] ) {
-			return;
-		}
-
-		// Make sure the existing account has the correct website URL (or fail).
-		$site_url = esc_url_raw( $this->get_site_url() );
-		$this->maybe_add_merchant_center_website_url( $account_id, $site_url );
-
-		// Maybe the existing account is sub-account!
-		$state                               = $this->account_state->get();
-		$state['set_id']['data']['from_mca'] = false;
-		foreach ( $this->middleware->get_merchant_accounts() as $existing_account ) {
-			if ( $existing_account['id'] === $account_id ) {
-				$state['set_id']['data']['from_mca'] = $existing_account['subaccount'];
-				break;
-			}
-		}
-
-		$this->middleware->link_merchant_account( $account_id );
-		$state['set_id']['status'] = MerchantAccountState::STEP_DONE;
-		$this->account_state->update( $state );
-	}
-
-	/**
-	 * Ensure the Merchant Center account's Website URL matches the site URL. Update an empty value or
-	 * a different, unclaimed URL value. Throw a 409 exception if a different, claimed URL is found.
-	 *
-	 * @param int    $merchant_id      The Merchant Center account to update
-	 * @param string $site_website_url The new website URL
-	 *
-	 * @throws Exception If the Merchant Center account can't be retrieved or the URL is invalid.
-	 * @throws ExceptionWithResponseData If the account website URL doesn't match the given URL.
-	 */
-	private function maybe_add_merchant_center_website_url( int $merchant_id, string $site_website_url ): void {
-		if ( ! wc_is_valid_url( $site_website_url ) ) {
-			throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
-		}
-
-		/** @var Account $account */
-		$account = $this->merchant->get_account( $merchant_id );
-
-		$account_website_url = $account->getWebsiteUrl();
-
-		if ( untrailingslashit( $site_website_url ) !== untrailingslashit( $account_website_url ) ) {
-
-			$is_website_claimed = $this->merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed();
-
-			if ( ! empty( $account_website_url ) && $is_website_claimed && ! $this->allow_switch_url ) {
-				$state                              = $this->account_state->get();
-				$state['set_id']['data']['old_url'] = $account_website_url;
-				$state['set_id']['status']          = MerchantAccountState::STEP_ERROR;
-				$this->account_state->update( $state );
-
-				$clean_account_website_url = $this->strip_url_protocol( $account_website_url );
-				$clean_site_website_url    = $this->strip_url_protocol( $site_website_url );
-
-				do_action( 'woocommerce_gla_url_switch_required', [] );
-
-				throw new ExceptionWithResponseData(
-					sprintf(
-					/* translators: 1: is a website URL (without the protocol) */
-						__( 'This Merchant Center account already has a verified and claimed URL, %1$s', 'google-listings-and-ads' ),
-						$clean_account_website_url
-					),
-					409,
-					null,
-					[
-						'id'          => $merchant_id,
-						'claimed_url' => $clean_account_website_url,
-						'new_url'     => $clean_site_website_url,
-					]
-				);
-			}
-
-			$account->setWebsiteUrl( $site_website_url );
-			$this->merchant->update_account( $account );
-
-			do_action( 'woocommerce_gla_url_switch_success', [] );
-		}
-	}
-
-	/**
-	 * Generate a 503 Response with Retry-After header and message.
-	 *
-	 * @return Response
-	 */
-	private function get_time_to_wait_response(): Response {
 		return new Response(
+			$data,
+			$e->getCode() ?: 503,
 			[
-				'retry_after' => MerchantAccountState::MC_DELAY_AFTER_CREATE,
-				'message'     => __( 'Please retry after the indicated number of seconds to complete the account setup process.', 'google-listings-and-ads' ),
-			],
-			503,
-			[
-				'Retry-After' => MerchantAccountState::MC_DELAY_AFTER_CREATE,
+				'Retry-After' => $data['retry_after'],
 			]
 		);
 	}
 
-	/**
-	 * Removes the protocol (http:// or https://) and trailing slash from the provided URL.
-	 *
-	 * @param string $url
-	 *
-	 * @return string
-	 */
-	private function strip_url_protocol( string $url ): string {
-		return preg_replace( '#^https?://#', '', untrailingslashit( $url ) );
-	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -161,7 +161,12 @@ class AccountController extends BaseController {
 		return function( Request $request ) use ( $action ) {
 			try {
 				$account_id = absint( $request['id'] );
-				$account    = $this->account->{$action}( $account_id );
+
+				if ( $account_id && 'setup_account' === $action ) {
+					$this->account->use_existing_account_id( $account_id );
+				}
+
+				$account = $this->account->{$action}( $account_id );
 
 				return $this->prepare_item_for_response( $account, $request );
 			} catch ( MerchantTimeToWait $e ) {

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Exception;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
@@ -267,7 +268,7 @@ class AccountController extends BaseController {
 
 		return new Response(
 			$data,
-			$e->getCode() ?: 503,
+			$wait->getCode() ?: 503,
 			[
 				'Retry-After' => $data['retry_after'],
 			]

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -5,8 +5,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ApiNotReady;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
@@ -169,7 +169,7 @@ class AccountController extends BaseController {
 				$account = $this->account->{$action}( $account_id );
 
 				return $this->prepare_item_for_response( $account, $request );
-			} catch ( MerchantTimeToWait $e ) {
+			} catch ( ApiNotReady $e ) {
 				return $this->get_time_to_wait_response( $e );
 			} catch ( ExceptionWithResponseData $e ) {
 				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
@@ -264,11 +264,11 @@ class AccountController extends BaseController {
 	/**
 	 * Return a 503 Response with Retry-After header and message.
 	 *
-	 * @param MerchantTimeToWait $wait Exception containing the time to wait.
+	 * @param ApiNotReady $wait Exception containing the time to wait.
 	 *
 	 * @return Response
 	 */
-	private function get_time_to_wait_response( MerchantTimeToWait $wait ): Response {
+	private function get_time_to_wait_response( ApiNotReady $wait ): Response {
 		$data = $wait->get_response_data( true );
 
 		return new Response(

--- a/src/Exception/ApiNotReady.php
+++ b/src/Exception/ApiNotReady.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 class ApiNotReady extends ExceptionWithResponseData {
 
 	/**
-	 * Create a new instance of the exception when a Merchant Center account connection needs to wait.
+	 * Create a new instance of the exception when an API is not ready and the request needs to be retried.
 	 *
 	 * @param int $wait Time to wait in seconds.
 	 *

--- a/src/Exception/ApiNotReady.php
+++ b/src/Exception/ApiNotReady.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class MerchantResponseException
+ * Class ApiNotReady
  *
  * Error messages generated in this class should be translated, as they are intended to be displayed
  * to end users.
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
  */
-class MerchantTimeToWait extends ExceptionWithResponseData {
+class ApiNotReady extends ExceptionWithResponseData {
 
 	/**
 	 * Create a new instance of the exception when a Merchant Center account connection needs to wait.
@@ -24,9 +24,9 @@ class MerchantTimeToWait extends ExceptionWithResponseData {
 	 *
 	 * @return static
 	 */
-	public static function retry_after( int $wait ): MerchantTimeToWait {
+	public static function retry_after( int $wait ): ApiNotReady {
 		return new static(
-			__( 'Please retry after the indicated number of seconds to complete the account setup process.', 'google-listings-and-ads' ),
+			__( 'Please retry the request after the indicated number of seconds.', 'google-listings-and-ads' ),
 			503,
 			null,
 			[

--- a/src/Exception/MerchantTimeToWait.php
+++ b/src/Exception/MerchantTimeToWait.php
@@ -27,10 +27,11 @@ class MerchantTimeToWait extends ExceptionWithResponseData {
 	public static function retry_after( int $wait ): MerchantTimeToWait {
 		return new static(
 			__( 'Please retry after the indicated number of seconds to complete the account setup process.', 'google-listings-and-ads' ),
+			503,
+			null,
 			[
 				'retry_after' => $wait,
-			],
-			503
+			]
 		);
 	}
 

--- a/src/Exception/MerchantTimeToWait.php
+++ b/src/Exception/MerchantTimeToWait.php
@@ -1,0 +1,37 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MerchantResponseException
+ *
+ * Error messages generated in this class should be translated, as they are intended to be displayed
+ * to end users.
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
+ */
+class MerchantTimeToWait extends ExceptionWithResponseData {
+
+	/**
+	 * Create a new instance of the exception when a Merchant Center account connection needs to wait.
+	 *
+	 * @param int $wait Time to wait in seconds.
+	 *
+	 * @return static
+	 */
+	public static function retry_after( int $wait ): MerchantTimeToWait {
+		return new static(
+			__( 'Please retry after the indicated number of seconds to complete the account setup process.', 'google-listings-and-ads' ),
+			[
+				'retry_after' => $wait,
+			],
+			503
+		);
+	}
+
+}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -50,6 +50,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Reports;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupAds;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupMerchantCenter;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService as MerchantAccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
@@ -176,6 +177,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		DeprecatedFilters::class      => true,
 		ShippingZone::class           => true,
 		AdsAccountService::class      => true,
+		MerchantAccountService::class => true,
 	];
 
 	/**
@@ -258,6 +260,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( MerchantSetupCompleted::class );
 		$this->conditionally_share_with_tags( AdsSetupCompleted::class );
 		$this->conditionally_share_with_tags( AdsAccountService::class, ContainerInterface::class );
+		$this->conditionally_share_with_tags( MerchantAccountService::class, ContainerInterface::class );
 
 		// Inbox Notes
 		$this->share_with_tags( ContactInformationNote::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -40,6 +40,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQue
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService as MerchantAccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
@@ -93,7 +94,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( MerchantCenterContactInformationController::class, ContactInformation::class, Settings::class, AddressUtility::class );
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class, Middleware::class );
 		$this->share( PhoneVerificationController::class, PhoneVerification::class );
-		$this->share_with_container( MerchantCenterAccountController::class );
+		$this->share( MerchantCenterAccountController::class, MerchantAccountService::class );
 		$this->share_with_container( MerchantCenterReportsController::class );
 		$this->share( ShippingRateBatchController::class, ShippingRateQuery::class, ShippingZone::class );
 		$this->share( ShippingRateController::class, ShippingRateQuery::class, ShippingZone::class );

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -292,7 +292,7 @@ class AccountService implements OptionsAwareInterface, Service {
 					case 'verify':
 						// Skip if previously verified.
 						if ( $this->state->is_site_verified() ) {
-							return;
+							break;
 						}
 
 						$site_url = esc_url_raw( $this->get_site_url() );

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -181,6 +181,7 @@ class AccountService implements OptionsAwareInterface, Service {
 		}
 
 		$this->allow_switch_url = true;
+		$this->use_existing_account_id( $account_id );
 		return $this->setup_account( $account_id );
 	}
 

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -131,6 +131,8 @@ class AccountService implements OptionsAwareInterface, Service {
 			$middleware->link_merchant_account( $account_id );
 			$state['set_id']['status'] = MerchantAccountState::STEP_DONE;
 			$this->state->update( $state );
+		} catch ( ExceptionWithResponseData $e ) {
+			throw $e;
 		} catch ( Exception $e ) {
 			throw $this->prepare_exception( $e->getMessage(), [], $e->getCode() );
 		}
@@ -153,6 +155,8 @@ class AccountService implements OptionsAwareInterface, Service {
 
 		try {
 			return $this->setup_account_steps();
+		} catch ( ExceptionWithResponseData | MerchantTimeToWait $e ) {
+			throw $e;
 		} catch ( Exception $e ) {
 			throw $this->prepare_exception( $e->getMessage(), [], $e->getCode() );
 		}
@@ -258,7 +262,8 @@ class AccountService implements OptionsAwareInterface, Service {
 	 *
 	 * @return array The newly created (or pre-existing) Merchant account data.
 	 * @throws ExceptionWithResponseData If an error occurs during any step.
-	 * @throws Exception If the step is unknown.
+	 * @throws Exception                 If the step is unknown.
+	 * @throws MerchantTimeToWait        If we should wait to complete the next step.
 	 */
 	private function setup_account_steps() {
 		$state       = $this->state->get();

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -1,0 +1,530 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Exception;
+use Psr\Container\ContainerInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountService
+ *
+ * Container used to access:
+ * - Merchant
+ * - MerchantAccountState
+ * - MerchantCenterService
+ * - MerchantIssueTable
+ * - Middleware
+ * - SiteVerification
+ * - ShippingRateTable
+ * - ShippingTimeTable
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter
+ */
+class AccountService implements OptionsAwareInterface, Service {
+
+	use OptionsAwareTrait;
+	use PluginHelper;
+
+	/**
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * @var MerchantAccountState
+	 */
+	protected $state;
+
+	/**
+	 * Perform a website claim with overwrite.
+	 *
+	 * @var bool
+	 */
+	protected $overwrite_claim = false;
+
+	/**
+	 * Allow switching the existing website URL.
+	 *
+	 * @var bool
+	 */
+	protected $allow_switch_url = false;
+
+	/**
+	 * AccountService constructor.
+	 *
+	 * @param ContainerInterface $container
+	 */
+	public function __construct( ContainerInterface $container ) {
+		$this->state     = $container->get( MerchantAccountState::class );
+		$this->container = $container;
+	}
+
+	/**
+	 * Get all Merchant Accounts associated with the connected account.
+	 *
+	 * @return array
+	 * @throws Exception When an API error occurs.
+	 */
+	public function get_accounts(): array {
+		return $this->container->get( Middleware::class )->get_merchant_accounts();
+	}
+
+	/**
+	 * Run the process for setting up a Merchant Center account (sub-account or standalone).
+	 *
+	 * @param int $account_id
+	 *
+	 * @return array The account ID if setup has completed, or an error if not.
+	 * @throws ExceptionWithResponseData When the account is already connected or a setup error occurs.
+	 */
+	public function setup_account( int $account_id ) {
+		$merchant_id = $this->options->get_merchant_id();
+
+		// Reset the process if the provided ID isn't the same as the one stored in options.
+		if ( $merchant_id && $merchant_id !== $account_id ) {
+
+			// Can't reset if the MC connection process has been completed previously.
+			if ( $this->container->get( MerchantCenterService::class )->is_setup_complete() ) {
+				throw $this->prepare_exception(
+					sprintf(
+						/* translators: 1: is a numeric account ID */
+						__( 'Merchant Center account already connected: %d', 'google-listings-and-ads' ),
+						$merchant_id
+					)
+				);
+			}
+
+			$this->disconnect();
+		}
+
+		try {
+			if ( $account_id ) {
+				$this->use_existing_account_id( $account_id );
+			}
+
+			return $this->setup_account_steps();
+
+		} catch ( Exception $e ) {
+			throw $this->prepare_exception( $e->getMessage(), [], $e->getCode() );
+		}
+	}
+
+	/**
+	 * Create or link an account, switching the URL during the set_id step.
+	 *
+	 * @param int $account_id
+	 *
+	 * @return array
+	 * @throws ExceptionWithResponseData When a setup error occurs.
+	 */
+	public function switch_url( int $account_id ): array {
+		$state            = $this->state->get();
+		$switch_necessary = ! empty( $state['set_id']['data']['old_url'] );
+		$set_id_status    = $state['set_id']['status'] ?? MerchantAccountState::STEP_PENDING;
+		if ( ! $account_id || MerchantAccountState::STEP_DONE === $set_id_status || ! $switch_necessary ) {
+			throw $this->prepare_exception(
+				__( 'Attempting invalid URL switch.', 'google-listings-and-ads' )
+			);
+		}
+
+		$this->allow_switch_url = true;
+		return $this->setup_account( $account_id );
+	}
+
+	/**
+	 * Create or link an account, overwriting the website claim during the claim step.
+	 *
+	 * @param int $account_id
+	 *
+	 * @return array
+	 * @throws ExceptionWithResponseData When a setup error occurs.
+	 */
+	public function overwrite_claim( int $account_id ): array {
+		$state               = $this->state->get( false );
+		$overwrite_necessary = ! empty( $state['claim']['data']['overwrite_required'] );
+		$claim_status        = $state['claim']['status'] ?? MerchantAccountState::STEP_PENDING;
+		if ( MerchantAccountState::STEP_DONE === $claim_status || ! $overwrite_necessary ) {
+			throw $this->prepare_exception(
+				__( 'Attempting invalid claim overwrite.', 'google-listings-and-ads' )
+			);
+		}
+
+		$this->overwrite_claim = true;
+		return $this->setup_account( $account_id );
+	}
+
+	/**
+	 * Get the connected merchant account.
+	 *
+	 * @return array
+	 */
+	public function get_connected_status(): array {
+		$id     = $this->options->get_merchant_id();
+		$status = [
+			'id'     => $id,
+			'status' => $id ? 'connected' : 'disconnected',
+		];
+
+		$incomplete = $this->state->last_incomplete_step();
+		if ( ! empty( $incomplete ) ) {
+			$status['status'] = 'incomplete';
+			$status['step']   = $incomplete;
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Return the setup status to determine what step to continue at.
+	 *
+	 * @return array
+	 */
+	public function get_setup_status(): array {
+		return $this->container->get( MerchantCenterService::class )->get_setup_status();
+	}
+
+	/**
+	 * Disconnect Merchant Center account
+	 */
+	public function disconnect() {
+		$this->options->delete( OptionsInterface::CONTACT_INFO_SETUP );
+		$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
+		$this->options->delete( OptionsInterface::MERCHANT_ACCOUNT_STATE );
+		$this->options->delete( OptionsInterface::MERCHANT_CENTER );
+		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
+		$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
+		$this->options->delete( OptionsInterface::MERCHANT_ID );
+
+		$this->container->get( MerchantStatuses::class )->delete();
+
+		$this->container->get( MerchantIssueTable::class )->truncate();
+		$this->container->get( ShippingRateTable::class )->truncate();
+		$this->container->get( ShippingTimeTable::class )->truncate();
+	}
+
+	/**
+	 * Use an existing MC account. Mark the 'set_id' step as done, update the MC account's website URL,
+	 * and sets the Merchant ID.
+	 *
+	 * @param int $account_id The merchant ID to use.
+	 *
+	 * @throws Exception If the merchant IDs of the connected account can't be retrieved.
+	 * @throws ExceptionWithResponseData If there's a website URL conflict.
+	 */
+	private function use_existing_account_id( int $account_id ): void {
+		$state = $this->state->get();
+
+		// Don't do anything if this step was already finished.
+		if ( MerchantAccountState::STEP_DONE === $state['set_id']['status'] ) {
+			return;
+		}
+
+		// Make sure the existing account has the correct website URL (or fail).
+		$this->maybe_add_merchant_center_url( $account_id );
+
+		// Re-fetch state as it might have changed.
+		$state      = $this->state->get();
+		$middleware = $this->container->get( Middleware::class );
+
+		// Maybe the existing account is a sub-account!
+		$state['set_id']['data']['from_mca'] = false;
+		foreach ( $middleware->get_merchant_accounts() as $existing_account ) {
+			if ( $existing_account['id'] === $account_id ) {
+				$state['set_id']['data']['from_mca'] = $existing_account['subaccount'];
+				break;
+			}
+		}
+
+		$middleware->link_merchant_account( $account_id );
+		$state['set_id']['status'] = MerchantAccountState::STEP_DONE;
+		$this->state->update( $state );
+	}
+
+	/**
+	 * Performs the steps necessary to initialize a Merchant Center account.
+	 * Should always resume up at the last pending or unfinished step. If the Merchant Center account
+	 * has already been created, the ID is simply returned.
+	 *
+	 * @return array The newly created (or pre-existing) Merchant account data.
+	 * @throws ExceptionWithResponseData If an error occurs during any step.
+	 * @throws Exception If the step is unknown.
+	 */
+	private function setup_account_steps() {
+		$state       = $this->state->get();
+		$merchant_id = $this->options->get_merchant_id();
+		$merchant    = $this->container->get( Merchant::class );
+		$middleware  = $this->container->get( Middleware::class );
+
+		foreach ( $state as $name => &$step ) {
+			if ( MerchantAccountState::STEP_DONE === $step['status'] ) {
+				continue;
+			}
+
+			if ( 'link' === $name ) {
+				$time_to_wait = $this->state->get_seconds_to_wait_after_created();
+				if ( $time_to_wait ) {
+					sleep( $time_to_wait );
+				}
+			}
+
+			try {
+				switch ( $name ) {
+					case 'set_id':
+						// Just in case, don't create another merchant ID.
+						if ( ! empty( $merchant_id ) ) {
+							break;
+						}
+						$merchant_id                       = $middleware->create_merchant_account();
+						$step['data']['from_mca']          = true;
+						$step['data']['created_timestamp'] = time();
+						break;
+					case 'verify':
+						$this->verify_site();
+						break;
+					case 'link':
+						$middleware->link_merchant_to_mca();
+						break;
+					case 'claim':
+						// At this step, the website URL is assumed to be correct.
+						// If the URL is already claimed, no claim should be attempted.
+						if ( $merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed() ) {
+							break;
+						}
+
+						if ( $this->overwrite_claim ) {
+							$middleware->claim_merchant_website( true );
+						} else {
+							$merchant->claimwebsite();
+						}
+						break;
+					default:
+						throw new Exception(
+							sprintf(
+								/* translators: 1: is a string representing an unknown step name */
+								__( 'Unknown merchant account creation step %1$s', 'google-listings-and-ads' ),
+								$name
+							)
+						);
+				}
+				$step['status']  = MerchantAccountState::STEP_DONE;
+				$step['message'] = '';
+				$this->state->update( $state );
+			} catch ( Exception $e ) {
+				$step['status']  = MerchantAccountState::STEP_ERROR;
+				$step['message'] = $e->getMessage();
+
+				// URL already claimed.
+				if ( 'claim' === $name && 403 === $e->getCode() ) {
+					$data = [
+						'id'          => $merchant_id,
+						'website_url' => $this->strip_url_protocol(
+							esc_url_raw( $this->get_site_url() )
+						),
+					];
+
+					// Sub-account: request overwrite confirmation.
+					if ( $state['set_id']['data']['from_mca'] ?? true ) {
+						do_action( 'woocommerce_gla_site_claim_overwrite_required', [] );
+						$step['data']['overwrite_required'] = true;
+
+						$e = $this->prepare_exception( $e->getMessage(), $data, $e->getCode() );
+					} else {
+						do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'independent_account' ] );
+
+						// Independent account: overwrite not possible.
+						$e = $this->prepare_exception(
+							__( 'Unable to claim website URL with this Merchant Center Account.', 'google-listings-and-ads' ),
+							$data,
+							406
+						);
+					}
+				} elseif ( 'link' === $name && 401 === $e->getCode() ) {
+					// New sub-account not yet manipulable.
+					$state['set_id']['data']['created_timestamp'] = time();
+
+					$e = MerchantTimeToWait::retry_after( MerchantAccountState::MC_DELAY_AFTER_CREATE );
+				}
+
+				$this->state->update( $state );
+				throw $e;
+			}
+		}
+
+		return [ 'id' => $merchant_id ];
+	}
+
+	/**
+	 * Performs the three-step process of verifying the current site:
+	 * 1. Retrieves the meta tag with the verification token.
+	 * 2. Enables the meta tag in the head of the store.
+	 * 3. Instructs the Site Verification API to verify the meta tag.
+	 *
+	 * @throws Exception If any step of the site verification process fails.
+	 */
+	private function verify_site(): void {
+		$site_url = esc_url_raw( $this->get_site_url() );
+		if ( ! wc_is_valid_url( $site_url ) ) {
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'site-url' ] );
+			throw new Exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
+		}
+
+		// Inform of previous verification.
+		if ( $this->state->is_site_verified() ) {
+			return;
+		}
+
+		// Retrieve the meta tag with verification token.
+		/** @var SiteVerification $site_verification */
+		$site_verification = $this->container->get( SiteVerification::class );
+		try {
+			$meta_tag = $site_verification->get_token( $site_url );
+		} catch ( Exception $e ) {
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'token' ] );
+			throw $e;
+		}
+
+		// Store the meta tag in the options table and mark as unverified.
+		$site_verification_options = [
+			'verified' => $site_verification::VERIFICATION_STATUS_UNVERIFIED,
+			'meta_tag' => $meta_tag,
+		];
+		$this->options->update(
+			OptionsInterface::SITE_VERIFICATION,
+			$site_verification_options
+		);
+
+		// Attempt verification.
+		try {
+			if ( $site_verification->insert( $site_url ) ) {
+				$site_verification_options['verified'] = $site_verification::VERIFICATION_STATUS_VERIFIED;
+				$this->options->update( OptionsInterface::SITE_VERIFICATION, $site_verification_options );
+				do_action( 'woocommerce_gla_site_verify_success', [] );
+
+				return;
+			}
+		} catch ( Exception $e ) {
+			do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'meta-tag' ] );
+
+			throw $e;
+		}
+
+		// Should never reach this point.
+		do_action( 'woocommerce_gla_site_verify_failure', [ 'step' => 'unknown' ] );
+
+		throw new Exception( __( 'Site verification failed.', 'google-listings-and-ads' ) );
+	}
+
+
+
+
+	/**
+	 * Ensure the Merchant Center account's Website URL matches the site URL. Update an empty value or
+	 * a different, unclaimed URL value. Throw a 409 exception if a different, claimed URL is found.
+	 *
+	 * @param int $merchant_id The Merchant Center account to update.
+	 *
+	 * @throws ExceptionWithResponseData If the account URL doesn't match the site URL or the URL is invalid.
+	 */
+	private function maybe_add_merchant_center_url( int $merchant_id ) {
+		$site_url = esc_url_raw( $this->get_site_url() );
+
+		if ( ! wc_is_valid_url( $site_url ) ) {
+			throw $this->prepare_exception( __( 'Invalid site URL.', 'google-listings-and-ads' ) );
+		}
+
+		/** @var Merchant $merchant */
+		$merchant = $this->container->get( Merchant::class );
+
+		/** @var Account $account */
+		$account     = $merchant->get_account( $merchant_id );
+		$account_url = $account->getWebsiteUrl();
+
+		if ( untrailingslashit( $site_url ) !== untrailingslashit( $account_url ) ) {
+
+			$is_website_claimed = $merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed();
+
+			if ( ! empty( $account_url ) && $is_website_claimed && ! $this->allow_switch_url ) {
+				$state                              = $this->state->get();
+				$state['set_id']['data']['old_url'] = $account_url;
+				$state['set_id']['status']          = MerchantAccountState::STEP_ERROR;
+				$this->state->update( $state );
+
+				$clean_account_url = $this->strip_url_protocol( $account_url );
+				$clean_site_url    = $this->strip_url_protocol( $site_url );
+
+				do_action( 'woocommerce_gla_url_switch_required', [] );
+
+				throw $this->prepare_exception(
+					sprintf(
+					/* translators: 1: is a website URL (without the protocol) */
+						__( 'This Merchant Center account already has a verified and claimed URL, %1$s', 'google-listings-and-ads' ),
+						$clean_account_website_url
+					),
+					[
+						'id'          => $merchant_id,
+						'claimed_url' => $clean_account_website_url,
+						'new_url'     => $clean_site_website_url,
+					],
+					409
+				);
+			}
+
+			$account->setWebsiteUrl( $site_url );
+			$merchant->update_account( $account );
+
+			do_action( 'woocommerce_gla_url_switch_success', [] );
+		}
+	}
+
+	/**
+	 * Prepares an Exception to be thrown with Merchant data:
+	 * - Ensure it has the merchant_id value
+	 * - Default to a 400 error code
+	 *
+	 * @param string   $message
+	 * @param array    $data
+	 * @param int|null $code
+	 *
+	 * @return ExceptionWithResponseData
+	 */
+	private function prepare_exception( string $message, array $data = [], int $code = null ): ExceptionWithResponseData {
+		$merchant_id = $this->options->get_merchant_id();
+
+		if ( $merchant_id && ! isset( $data['id'] ) ) {
+			$data['id'] = $merchant_id;
+		}
+
+		return new ExceptionWithResponseData( $message, $code ?: 400, null, $data );
+	}
+
+	/**
+	 * Removes the protocol (http:// or https://) and trailing slash from the provided URL.
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	private function strip_url_protocol( string $url ): string {
+		return preg_replace( '#^https?://#', '', untrailingslashit( $url ) );
+	}
+
+}

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -9,8 +9,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ApiNotReady;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
@@ -155,7 +155,7 @@ class AccountService implements OptionsAwareInterface, Service {
 
 		try {
 			return $this->setup_account_steps();
-		} catch ( ExceptionWithResponseData | MerchantTimeToWait $e ) {
+		} catch ( ExceptionWithResponseData | ApiNotReady $e ) {
 			throw $e;
 		} catch ( Exception $e ) {
 			throw $this->prepare_exception( $e->getMessage(), [], $e->getCode() );
@@ -264,7 +264,7 @@ class AccountService implements OptionsAwareInterface, Service {
 	 * @return array The newly created (or pre-existing) Merchant account data.
 	 * @throws ExceptionWithResponseData If an error occurs during any step.
 	 * @throws Exception                 If the step is unknown.
-	 * @throws MerchantTimeToWait        If we should wait to complete the next step.
+	 * @throws ApiNotReady               If we should wait to complete the next step.
 	 */
 	private function setup_account_steps() {
 		$state       = $this->state->get();
@@ -365,7 +365,7 @@ class AccountService implements OptionsAwareInterface, Service {
 					// New sub-account not yet manipulable.
 					$state['set_id']['data']['created_timestamp'] = time();
 
-					$e = MerchantTimeToWait::retry_after( MerchantAccountState::MC_DELAY_AFTER_CREATE );
+					$e = ApiNotReady::retry_after( MerchantAccountState::MC_DELAY_AFTER_CREATE );
 				}
 
 				$this->state->update( $state );

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -476,16 +476,4 @@ class AccountService implements OptionsAwareInterface, Service {
 
 		return new ExceptionWithResponseData( $message, $code ?: 400, null, $data );
 	}
-
-	/**
-	 * Removes the protocol (http:// or https://) and trailing slash from the provided URL.
-	 *
-	 * @param string $url
-	 *
-	 * @return string
-	 */
-	private function strip_url_protocol( string $url ): string {
-		return preg_replace( '#^https?://#', '', untrailingslashit( $url ) );
-	}
-
 }

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -6,9 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -37,8 +34,6 @@ defined( 'ABSPATH' ) || exit;
  * - MerchantAccountState
  * - MerchantStatuses
  * - Settings
- * - ShippingRateTable
- * - ShippingTimeTable
  * - WC
  * - WP
  *
@@ -198,27 +193,6 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	}
 
 	/**
-	 * Get the connected merchant account.
-	 *
-	 * @return array
-	 */
-	public function get_connected_status(): array {
-		$id     = $this->options->get_merchant_id();
-		$status = [
-			'id'     => $id,
-			'status' => $id ? 'connected' : 'disconnected',
-		];
-
-		$incomplete = $this->container->get( MerchantAccountState::class )->last_incomplete_step();
-		if ( ! empty( $incomplete ) ) {
-			$status['status'] = 'incomplete';
-			$status['step']   = $incomplete;
-		}
-
-		return $status;
-	}
-
-	/**
 	 * Return the setup status to determine what step to continue at.
 	 *
 	 * @return array
@@ -245,25 +219,6 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			'status' => 'incomplete',
 			'step'   => $step,
 		];
-	}
-
-	/**
-	 * Disconnect Merchant Center account
-	 */
-	public function disconnect() {
-		$this->options->delete( OptionsInterface::CONTACT_INFO_SETUP );
-		$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
-		$this->options->delete( OptionsInterface::MERCHANT_ACCOUNT_STATE );
-		$this->options->delete( OptionsInterface::MERCHANT_CENTER );
-		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
-		$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
-		$this->options->delete( OptionsInterface::MERCHANT_ID );
-
-		$this->container->get( MerchantStatuses::class )->delete();
-
-		$this->container->get( MerchantIssueTable::class )->truncate();
-		$this->container->get( ShippingRateTable::class )->truncate();
-		$this->container->get( ShippingTimeTable::class )->truncate();
 	}
 
 	/**

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -179,4 +179,16 @@ trait PluginHelper {
 	protected function get_site_url(): string {
 		return apply_filters( 'woocommerce_gla_site_url', get_home_url() );
 	}
+
+	/**
+	 * Removes the protocol (http:// or https://) and trailing slash from the provided URL.
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	protected function strip_url_protocol( string $url ): string {
+		return preg_replace( '#^https?://#', '', untrailingslashit( $url ) );
+	}
+
 }

--- a/tests/Tools/HelperTrait/MerchantTrait.php
+++ b/tests/Tools/HelperTrait/MerchantTrait.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantApiException;
 use Google\Service\ShoppingContent\Account;
 use Google\Service\ShoppingContent\AccountAddress;
 use Google\Service\ShoppingContent\AccountBusinessInformation;
+use Google\Service\ShoppingContent\AccountStatus;
 
 /**
  * Trait MerchantTrait
@@ -46,4 +47,19 @@ trait MerchantTrait {
 
 		return $account;
 	}
+
+	public function get_account_with_url( string $url ): Account {
+		$account = new Account();
+		$account->setWebsiteUrl( $url );
+
+		return $account;
+	}
+
+	public function get_status_website_claimed(): AccountStatus {
+		$status = new AccountStatus();
+		$status->setWebsiteClaimed( true );
+
+		return $status;
+	}
+
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -4,8 +4,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ApiNotReady;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Exception;
@@ -121,7 +121,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->account->expects( $this->once() )
 			->method( 'setup_account' )
 			->willThrowException(
-				new MerchantTimeToWait(
+				new ApiNotReady(
 					'error',
 					503,
 					null,

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -139,6 +139,10 @@ class AccountControllerTest extends RESTControllerUnitTest {
 
 	public function test_link_account() {
 		$this->account->expects( $this->once() )
+			->method( 'use_existing_account_id' )
+			->with( self::TEST_ACCOUNT_ID );
+
+		$this->account->expects( $this->once() )
 			->method( 'setup_account' )
 			->willReturn( self::TEST_ACCOUNT_DATA );
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class AccountControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
+ *
+ * @property RESTServer                $rest_server
+ * @property AccountService|MockObject $account
+ */
+class AccountControllerTest extends RESTControllerUnitTest {
+
+	protected const ROUTE_ACCOUNTS        = '/wc/gla/mc/accounts';
+	protected const ROUTE_CLAIM_OVERWRITE = '/wc/gla/mc/accounts/claim-overwrite';
+	protected const ROUTE_SWITCH_URL      = '/wc/gla/mc/accounts/switch-url';
+	protected const ROUTE_CONNECTION      = '/wc/gla/mc/connection';
+	protected const ROUTE_SETUP_STATUS    = '/wc/gla/mc/setup';
+	protected const TEST_ACCOUNT_ID       = 12345678;
+	protected const TEST_ACCOUNTS         = [
+		[
+			'id'         => self::TEST_ACCOUNT_ID,
+			'subaccount' => true,
+			'name'       => 'One',
+			'domain'     => 'https://account.one',
+		],
+		[
+			'id'         => 23456781,
+			'subaccount' => true,
+			'name'       => 'Two',
+			'domain'     => 'https://account.two',
+		],
+	];
+	protected const TEST_ACCOUNT_DATA     = [ 'id' => SELF::TEST_ACCOUNT_ID ];
+	protected const TEST_ACCOUNT_RESPONSE = [
+		'id'         => SELF::TEST_ACCOUNT_ID,
+		'subaccount' => null,
+		'name'       => null,
+		'domain'     => null,
+	];
+	protected const TEST_RETRY_AFTER      = 10;
+	protected const TEST_CONNECTED_DATA   = [
+		'id'       => SELF::TEST_ACCOUNT_ID,
+		'status'   => 'connected',
+	];
+	protected const TEST_STATUS_DATA      = [
+		'status' => 'complete',
+	];
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->account    = $this->createMock( AccountService::class );
+		$this->controller = new AccountController( $this->server, $this->account );
+		$this->controller->register();
+	}
+
+	public function test_get_accounts() {
+		$this->account->expects( $this->once() )
+			->method( 'get_accounts' )
+			->willReturn( self::TEST_ACCOUNTS );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
+
+		$this->assertEquals( self::TEST_ACCOUNTS, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_accounts_with_api_exception() {
+		$this->account->expects( $this->once() )
+			->method( 'get_accounts' )
+			->willThrowException( new Exception( 'error', 401 ) );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_create_account() {
+		$this->account->expects( $this->once() )
+			->method( 'setup_account' )
+			->willReturn( self::TEST_ACCOUNT_DATA );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_RESPONSE, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_create_account_with_api_exception_data() {
+		$this->account->expects( $this->once() )
+			->method( 'setup_account' )
+			->willThrowException(
+				new ExceptionWithResponseData(
+					'error',
+					406,
+					null,
+					[ 'id' => SELF::TEST_ACCOUNT_ID ]
+				)
+			);
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( SELF::TEST_ACCOUNT_ID, $response->get_data()['id'] );
+		$this->assertEquals( 406, $response->get_status() );
+	}
+
+	public function test_create_account_with_time_to_wait() {
+		$this->account->expects( $this->once() )
+			->method( 'setup_account' )
+			->willThrowException(
+				new MerchantTimeToWait(
+					'error',
+					503,
+					null,
+					[ 'retry_after' => SELF::TEST_RETRY_AFTER ]
+				)
+			);
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( SELF::TEST_RETRY_AFTER, $response->get_data()['retry_after'] );
+		$this->assertEquals( SELF::TEST_RETRY_AFTER, $response->get_headers()['Retry-After'] );
+		$this->assertEquals( 503, $response->get_status() );
+	}
+
+	public function test_link_account() {
+		$this->account->expects( $this->once() )
+			->method( 'setup_account' )
+			->willReturn( self::TEST_ACCOUNT_DATA );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST', self::TEST_ACCOUNT_DATA );
+
+		$this->assertEquals( self::TEST_ACCOUNT_RESPONSE, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_overwrite_claim() {
+		$this->account->expects( $this->once() )
+			->method( 'overwrite_claim' )
+			->willReturn( self::TEST_ACCOUNT_DATA );
+
+		$response = $this->do_request( self::ROUTE_CLAIM_OVERWRITE, 'POST', self::TEST_ACCOUNT_DATA );
+
+		$this->assertEquals( self::TEST_ACCOUNT_RESPONSE, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_switch_url() {
+		$this->account->expects( $this->once() )
+			->method( 'switch_url' )
+			->willReturn( self::TEST_ACCOUNT_DATA );
+
+		$response = $this->do_request( self::ROUTE_SWITCH_URL, 'POST', self::TEST_ACCOUNT_DATA );
+
+		$this->assertEquals( self::TEST_ACCOUNT_RESPONSE, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_connected_account() {
+		$this->account->expects( $this->once() )
+			->method( 'get_connected_status' )
+			->willReturn( self::TEST_CONNECTED_DATA );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( self::TEST_CONNECTED_DATA, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_setup_status() {
+		$this->account->expects( $this->once() )
+			->method( 'get_setup_status' )
+			->willReturn( self::TEST_STATUS_DATA );
+
+		$response = $this->do_request( self::ROUTE_SETUP_STATUS, 'GET' );
+
+		$this->assertEquals( self::TEST_STATUS_DATA, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_disconnect_account() {
+		$this->account->expects( $this->once() )
+			->method( 'disconnect' );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'DELETE' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Merchant Center account successfully disconnected.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+}

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -1,0 +1,677 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
+ *
+ * @property MockObject|Merchant              $merchant
+ * @property MockObject|MerchantCenterService $mc_service
+ * @property MockObject|MerchantIssueTable    $issue_table
+ * @property MockObject|MerchantStatuses      $merchant_statuses
+ * @property MockObject|Middleware            $middleware
+ * @property MockObject|OptionsInterface      $options
+ * @property MockObject|SiteVerification      $site_verification
+ * @property MockObject|ShippingRateTable     $rate_table
+ * @property MockObject|ShippingTimeTable     $time_table
+ * @property MockObject|MerchantAccountState  $state
+ * @property AccountService                   $account
+ * @property Container                        $container
+ */
+class AccountServiceTest extends UnitTest {
+
+	use MerchantTrait;
+
+	protected const TEST_ACCOUNT_ID     = 12345678;
+	protected const TEST_OLD_ACCOUNT_ID = 23456781;
+	protected const TEST_ACCOUNTS       = [
+		[
+			'id'         => self::TEST_ACCOUNT_ID,
+			'subaccount' => true,
+			'name'       => 'One',
+			'domain'     => 'https://account.one',
+		],
+		[
+			'id'         => 23456781,
+			'subaccount' => true,
+			'name'       => 'Two',
+			'domain'     => 'https://account.two',
+		],
+	];
+	protected const TEST_CLEANURL       = 'example.org';
+	protected const TEST_OLD_URL        = 'https://oldsite.com';
+	protected const TEST_OLD_CLEANURL   = 'oldsite.com';
+	protected const TEST_ACCOUNT_DATA   = [ 'id' => self::TEST_ACCOUNT_ID ];
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->merchant          = $this->createMock( Merchant::class );
+		$this->mc_service        = $this->createMock( MerchantCenterService::class );
+		$this->issue_table       = $this->createMock( MerchantIssueTable::class );
+		$this->merchant_statuses = $this->createMock( MerchantStatuses::class );
+		$this->middleware        = $this->createMock( Middleware::class );
+		$this->site_verification = $this->createMock( SiteVerification::class );
+		$this->rate_table        = $this->createMock( ShippingRateTable::class );
+		$this->time_table        = $this->createMock( ShippingTimeTable::class );
+		$this->state             = $this->createMock( MerchantAccountState::class );
+		$this->options           = $this->createMock( OptionsInterface::class );
+
+		$this->container = new Container();
+		$this->container->share( Merchant::class, $this->merchant );
+		$this->container->share( MerchantCenterService::class, $this->mc_service );
+		$this->container->share( MerchantIssueTable::class, $this->issue_table );
+		$this->container->share( MerchantStatuses::class, $this->merchant_statuses );
+		$this->container->share( Middleware::class, $this->middleware );
+		$this->container->share( SiteVerification::class, $this->site_verification );
+		$this->container->share( ShippingRateTable::class, $this->rate_table );
+		$this->container->share( ShippingTimeTable::class, $this->time_table );
+		$this->container->share( MerchantAccountState::class, $this->state );
+
+		$this->account = new AccountService( $this->container );
+		$this->account->set_options_object( $this->options );
+	}
+
+	public function test_get_accounts() {
+		$this->middleware->expects( $this->once() )
+			->method( 'get_merchant_accounts' )
+			->willReturn( self::TEST_ACCOUNTS );
+
+		$this->assertEquals( self::TEST_ACCOUNTS, $this->account->get_accounts() );
+	}
+
+	public function test_get_accounts_with_api_exception() {
+		$this->middleware->expects( $this->once() )
+			->method( 'get_merchant_accounts' )
+			->willThrowException( new Exception( 'error' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'error' );
+		$this->account->get_accounts();
+	}
+
+	public function test_existing_account_already_connected() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_OLD_ACCOUNT_ID );
+
+		$this->mc_service->expects( $this->once() )
+			->method( 'is_setup_complete' )
+			->willReturn( true );
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage(
+			sprintf(
+				'Merchant Center account already connected: %d',
+				self::TEST_OLD_ACCOUNT_ID
+			)
+		);
+		$this->account->use_existing_account_id( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_existing_account_already_completed() {
+		$this->options->expects( $this->once() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => MerchantAccountState::STEP_DONE ],
+				]
+			);
+
+		$this->middleware->expects( $this->never() )->method( 'link_merchant_account' );
+
+		$this->account->use_existing_account_id( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_existing_account() {
+		$this->options->expects( $this->once() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'link_merchant_account' )
+			->with( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'set_id'  => [
+						'status' => MerchantAccountState::STEP_DONE,
+						'data'   => [ 'from_mca' => false ],
+					],
+				]
+			);
+
+		$this->account->use_existing_account_id( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_existing_account_api_error() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'get_merchant_accounts' )
+			->willThrowException( new Exception( 'error' ) );
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage( 'error' );
+		$this->expectExceptionCode( 400 );
+		$this->account->use_existing_account_id( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_existing_account_invalid_url() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		add_filter(
+			'woocommerce_gla_site_url',
+			function () {
+				return 'invalid://url';
+			}
+		);
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage( 'Invalid site URL.' );
+		$this->account->use_existing_account_id( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_existing_account_update_url() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->merchant->expects( $this->any() )
+			->method( 'get_account' )
+			->willReturn( $this->get_account_with_url( self::TEST_OLD_URL ) );
+
+		$this->merchant->expects( $this->any() )
+			->method( 'get_accountstatus' )
+			->willReturn( $this->get_status_website_claimed() );
+
+		try {
+			$this->account->use_existing_account_id( self::TEST_ACCOUNT_ID );
+		} catch ( Exception $e ) {
+			$this->assertInstanceOf( ExceptionWithResponseData::class, $e );
+			$this->assertEquals( 409, $e->getCode() );
+			$this->assertEquals(
+				[
+					'id'          => self::TEST_ACCOUNT_ID,
+					'claimed_url' => self::TEST_OLD_CLEANURL,
+					'new_url'     => self::TEST_CLEANURL,
+				],
+				$e->get_response_data()
+			);
+		}
+	}
+
+	public function test_setup_account_step_set_id_already_created() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->never() )
+			->method( 'create_merchant_account' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( 0 ) );
+	}
+
+	public function test_setup_account_step_set_id() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'create_merchant_account' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( 0 ) );
+	}
+
+	public function test_setup_account_step_verify() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'verify' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->site_verification->expects( $this->once() )
+			->method( 'verify_site' )
+			->with( get_home_url() );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( self::TEST_ACCOUNT_ID ) );
+	}
+
+	public function test_setup_account_step_verify_already_verified() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'verify' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->state->expects( $this->any() )
+			->method( 'is_site_verified' )
+			->willReturn( true );
+
+		$this->site_verification->expects( $this->never() )
+			->method( 'verify_site' )
+			->with( get_home_url() );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( self::TEST_ACCOUNT_ID ) );
+	}
+
+	public function test_setup_account_step_link() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'link' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'link_merchant_to_mca' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( self::TEST_ACCOUNT_ID ) );
+	}
+
+	public function test_setup_account_step_link_retry_response() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'link' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'link_merchant_to_mca' )
+			->willThrowException( new Exception( 'error', 401 ) );
+
+		try {
+			$this->account->setup_account( self::TEST_ACCOUNT_ID );
+		} catch ( MerchantTimeToWait $e ) {
+			$this->assertInstanceOf( MerchantTimeToWait::class, $e );
+			$this->assertEquals( 503, $e->getCode() );
+			$this->assertEquals(
+				[
+					'retry_after' => MerchantAccountState::MC_DELAY_AFTER_CREATE,
+				],
+				$e->get_response_data()
+			);
+		}
+	}
+
+	public function test_setup_account_step_claim() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'claim' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->merchant->expects( $this->once() )
+			->method( 'claimwebsite' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( self::TEST_ACCOUNT_ID ) );
+	}
+
+	public function test_setup_account_step_claim_already_claimed() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'claim' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->merchant->expects( $this->any() )
+			->method( 'get_accountstatus' )
+			->willReturn( $this->get_status_website_claimed() );
+
+		$this->merchant->expects( $this->never() )
+			->method( 'claimwebsite' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( self::TEST_ACCOUNT_ID ) );
+	}
+
+	public function test_setup_account_step_claim_overwrite_required() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'claim' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->merchant->expects( $this->once() )
+			->method( 'claimwebsite' )
+			->willThrowException( new Exception( 'error', 403 ) );
+
+		$this->state->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'claim'  => [
+						'status'  => MerchantAccountState::STEP_ERROR,
+						'message' => 'error',
+						'data'    => [ 'overwrite_required' => true ],
+					],
+				]
+			);
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage( 'error' );
+		$this->expectExceptionCode( 403 );
+
+		$this->account->setup_account( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_setup_account_step_claim_overwrite_not_possible() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [
+						'status' => MerchantAccountState::STEP_DONE,
+						'data'   => [ 'from_mca' => false ],
+					],
+					'claim' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->merchant->expects( $this->once() )
+			->method( 'claimwebsite' )
+			->willThrowException( new Exception( 'error', 403 ) );
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage( 'Unable to claim website URL with this Merchant Center Account.' );
+		$this->expectExceptionCode( 406 );
+
+		$this->account->setup_account( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_setup_account_step_invalid() {
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'invalid' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unknown merchant account creation step invalid' );
+
+		$this->account->setup_account( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_switch_url() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [
+						'status' => MerchantAccountState::STEP_PENDING,
+						'data'   => [ 'old_url' => self::TEST_OLD_URL ],
+					],
+				]
+			);
+
+		$this->merchant->expects( $this->any() )
+			->method( 'get_account' )
+			->willReturn( $this->get_account_with_url( self::TEST_OLD_URL ) );
+
+		$this->merchant->expects( $this->once() )
+			->method( 'update_account' )
+			->with( $this->get_account_with_url( get_home_url() ) );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->switch_url( self::TEST_ACCOUNT_ID ) );
+	}
+
+	public function test_switch_url_invalid() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'set_id' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage( 'Attempting invalid URL switch.' );
+
+		$this->account->switch_url( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_overwrite_claim() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'claim' => [
+						'status' => MerchantAccountState::STEP_PENDING,
+						'data'   => [ 'overwrite_required' => true ],
+					],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'claim_merchant_website' )
+			->with( true );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->overwrite_claim( self::TEST_ACCOUNT_ID ) );
+	}
+
+	public function test_overwrite_claim_invalid() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'claim' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage( 'Attempting invalid claim overwrite.' );
+
+		$this->account->overwrite_claim( self::TEST_ACCOUNT_ID );
+	}
+
+	public function test_get_connected_status() {
+		$this->options->expects( $this->once() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->assertEquals(
+			[
+				'id'     => SELF::TEST_ACCOUNT_ID,
+				'status' => 'connected',
+			],
+			$this->account->get_connected_status()
+		);
+	}
+
+	public function test_get_connected_status_incomplete() {
+		$this->options->expects( $this->once() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'last_incomplete_step' )
+			->willReturn( 'verify' );
+
+		$this->assertEquals(
+			[
+				'id'     => SELF::TEST_ACCOUNT_ID,
+				'status' => 'incomplete',
+				'step'   => 'verify',
+			],
+			$this->account->get_connected_status()
+		);
+	}
+
+	public function test_get_setup_status() {
+		$this->mc_service->expects( $this->once() )
+			->method( 'get_setup_status' )
+			->willReturn( [ 'status' => 'complete' ] );
+
+		$this->assertEquals( [ 'status' => 'complete' ], $this->account->get_setup_status() );
+	}
+
+	public function test_disconnect() {
+		$this->options->expects( $this->exactly( 7 ) )
+			->method( 'delete' )
+			->withConsecutive(
+				[ OptionsInterface::CONTACT_INFO_SETUP ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT ],
+				[ OptionsInterface::MERCHANT_ACCOUNT_STATE ],
+				[ OptionsInterface::MERCHANT_CENTER ],
+				[ OptionsInterface::SITE_VERIFICATION ],
+				[ OptionsInterface::TARGET_AUDIENCE ],
+				[ OptionsInterface::MERCHANT_ID ]
+			);
+
+		$this->merchant_statuses->expects( $this->once() )->method( 'delete' );
+		$this->issue_table->expects( $this->once() )->method( 'truncate' );
+		$this->rate_table->expects( $this->once() )->method( 'truncate' );
+		$this->time_table->expects( $this->once() )->method( 'truncate' );
+
+		$this->account->disconnect();
+	}
+
+}

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -9,8 +9,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ApiNotReady;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantTimeToWait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
@@ -391,8 +391,8 @@ class AccountServiceTest extends UnitTest {
 
 		try {
 			$this->account->setup_account( self::TEST_ACCOUNT_ID );
-		} catch ( MerchantTimeToWait $e ) {
-			$this->assertInstanceOf( MerchantTimeToWait::class, $e );
+		} catch ( ApiNotReady $e ) {
+			$this->assertInstanceOf( ApiNotReady::class, $e );
 			$this->assertEquals( 503, $e->getCode() );
 			$this->assertEquals(
 				[


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a replacement for #973 and is created based on the feedback in the review of the unit tests for the Merchant AccountController, see here. The issue #388 mentions the same strategy.

In this PR I refactored the MCAccountController and moved all the account handling to a separate MCAccountService class. This simplified the unit testing as we can test each class individually.
One unit test was created for the MCAccountController (which is based on the RESTControllerUnitTest). Another unit test was created for the MCAccountService class.

The `disconnect` and `get_connected_status` function were moved from MerchantCenterService class to the MCAccountService class since they are directly related to the account (at the moment we still don't have unit tests for this class so no tests needed to be adjusted there).

The functionality for verifying a site URL was very complex to unit test as part of the account setup steps. For this reason it was moved into the SiteVerification class, it is a step in setting up the account but it's better placed within it's own class (much like the PhoneVerification class) so it can be reused by the SiteVerificationController (if those API endpoints are still used). It will need separate unit testing which can be handled in a separate PR.

Resolves part of #388

### Detailed test instructions:

The main testing is to confirm that all the added unit tests pass.

However since we also refactored the MerchantCenter account functions we need to confirm that they all continue to function the same. Following are all the affected requests and their expected outcome.

Enable the Connection Test page through a [code snippet](https://github.com/woocommerce/google-listings-and-ads/wiki/Hooks-and-Filters)

#### Merchant disconnect
- Go to Connection Test page 
- Click MC Disconnect
- Confirm that we get a success response

#### Create a new Merchant account
- Make sure we are using a public URL (ngrok or localtunnel)
- Go to Marketing > Google Listings & Ads > Set up free listings in Google (might need to refresh dashboard if we just disconnected)
- Connect WP and Google accounts (if not already connected)
- Click on "Or, create a new Merchant Center account"
- Confirm merchant account is connected
![image](https://user-images.githubusercontent.com/11388669/151973782-0cc8844a-8c6d-4dda-acd4-74df89427b84.png)

#### Link existing Merchant account
- From previous test, click on "Or, connect to a different Google Merchant Center account"
- Select a previously created account (that's also a subaccount)
- Confirm we see the message to reclaim the URL
![image](https://user-images.githubusercontent.com/11388669/151973887-b686452e-5049-4da8-ab00-28aee7871297.png)
- Reclaim URL and confirm we are once again connected
![image](https://user-images.githubusercontent.com/11388669/151973936-efc5d38e-2273-4483-897b-10c5f0715952.png)

#### Link existing standalone Merchant account
- From previous test, click on "Or, connect to a different Google Merchant Center account"
- Select a previously created account (that's a standalone account, not created through our extension)
- Confirm we see the error message that we are unable to claim the URL
![image](https://user-images.githubusercontent.com/11388669/151973966-6f6ad5a1-d5eb-4659-a0fe-e27f05292585.png)

#### Switch URL for a previously created site
- Spin up a second site (or use ngrok/localtunnel to give it a different URL)
- Go through the connection process and connect the same subaccount we used when linking existing merchant account
- Confirm that we see the switch URL messages
![image](https://user-images.githubusercontent.com/11388669/151975089-e13f2c6d-4a29-4e10-8ac7-e0faad138b3a.png)
- Switch URL and confirm that we are connected correctly
![image](https://user-images.githubusercontent.com/11388669/151974053-42593ced-c56f-4bfd-b0c1-d3c85b48009f.png)

#### Check MC connection status
- Go to the Connection Test page
- Click the MC Connection Status
- Confirm we get a connected response
```
{
    "id": 12345678,
    "status": "connected"
}
```

#### Check MC setup status
- Send GET request to "https://example-two.com/wp-json/wc/gla/mc/setup"
- Since we didn't fully complete the setup steps we expect to see a response like:
```
{
	"status": "incomplete",
	"step": "target_audience"
}
```
- Complete the next step in setting up the Merchant Center
- Repeat the request and confirm that we are on the next step:
```
{
	"status": "incomplete",
	"step": "shipping_and_taxes"
}
```
- Complete all the setup steps and confirm we get the completed response:
```
{
	"status": "complete"
}
```

### Changelog entry
* Add - Unit tests for the MerchantCenter AccountController and AccountService.
