### PR TITLE
Add packages to allow-plugins directive and update lock file (take 2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,11 @@
 		"platform": {
 			"php": "7.3.27"
 		},
-		"sort-packages": true
+		"sort-packages": true,
+		"allow-plugins": {
+			"automattic/jetpack-autoloader": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"scripts": {
 		"install-scripts": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f2547d15ebedb60326cf3053c8de1d7",
+    "content-hash": "16f2430cdfa4afda4cf867622f1e7c27",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -629,12 +629,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Google\\Service\\": "src"
-                },
                 "files": [
                     "autoload.php"
-                ]
+                ],
+                "psr-4": {
+                    "Google\\Service\\": "src"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1730,6 +1730,11 @@
                 "math",
                 "polyfill"
             ],
+            "support": {
+                "email": "terrafrost@php.net",
+                "issues": "https://github.com/phpseclib/bcmath_compat/issues",
+                "source": "https://github.com/phpseclib/bcmath_compat"
+            },
             "time": "2020-12-22T16:38:51+00:00"
         },
         {
@@ -2670,6 +2675,9 @@
             ],
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v5.2.7"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3089,9 +3097,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -3099,12 +3104,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5156,5 +5161,5 @@
     "platform-overrides": {
         "php": "7.3.27"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a redo of #1180 to limit potential dependency issues mentioned in that PR.

Composer has a new [`allow-plugins`](https://getcomposer.org/doc/06-config.md#allow-plugins) setting for the `config` property to allow for specifying trusted (or untrusted) plugins from packages. This PR specifies the trusted plugins for this project.

```
automattic/jetpack-autoloader contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "automattic/jetpack-autoloader" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y

dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "dealerdirect/phpcodesniffer-composer-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
```

### Detailed test instructions:

1. Run `composer install` from `develop` using Composer 2.2.0+, and observe the messages above
2. Run `composer install` from this branch and observe no messages, and the plugins are installed

### Changelog entry

> Dev – Update composer trusted plugins

