### PR TITLE
Fixes fatal error in case any existing Accounts item has an invalid domain

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/getMatchingDomainAccount.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/google-mc-account/getMatchingDomainAccount.js
@@ -13,9 +13,15 @@ const getMatchingDomainAccount = ( existingAccounts = [] ) => {
 	 * before doing the comparison.
 	 */
 	const homeUrl = new URL( getSetting( 'homeUrl' ) ).toString();
-	return existingAccounts.find(
-		( el ) => new URL( el.domain ).toString() === homeUrl
-	);
+
+	return existingAccounts.find( ( el ) => {
+		try {
+			const domainUrl = new URL( el.domain );
+			return domainUrl.toString() === homeUrl;
+		} catch ( e ) {
+			return false;
+		}
+	} );
 };
 
 export default getMatchingDomainAccount;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In case some Existing Accounts have an invalid domain. (i.e A test domain) it produces a fatal error in the frontend and doesn't allow the user to finish the onboarding.


### Detailed test instructions:

1. Disconnect GLA Account 
2. Add this in `useExistingGoogleMCAccounts.js` (this is for simulating a bad domain)
```
const useExistingGoogleMCAccounts = () => {
	return {
		data: [
			{
				domain: 'https://e80d-94-43-39-97.ngrok.io',
				id: 545673514,
				name: 'wp16.test',
				subaccount: true,
			},
			{
				domain: 'bad',
				id: 545673515,
				name: 'test.test',
				subaccount: true,
			},
		],
		hasFinishedResolution: true,
		invalidateResolution: () => {},
	};

	//return useAppSelectDispatch( 'getExistingGoogleMCAccounts' );
};

```
3. Start onboarding
4. After connecting the accounts you can see the selector with the 2 domains `test.test` and `wp16.test` without fatal errors.

### Changelog entry

> Fix - Prevent a fatal error in case an existing Merchant Center account has an invalid domain.
