### PR TITLE
Fix retries when deleting products

### DIFF
--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -37,6 +37,11 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
 	public function process_items( array $product_id_map ) {
+		$ready_ids = $this->product_repository->find_delete_product_ids( $product_id_map );
+
+		// Exclude any ID's which are not ready to delete.
+		$product_id_map = array_intersect( $product_id_map, $ready_ids );
+
 		$product_entries = BatchProductIDRequestEntry::create_from_id_map( new ProductIDMap( $product_id_map ) );
 		$this->product_syncer->delete_by_batch_requests( $product_entries );
 	}

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -61,7 +61,10 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 			throw JobException::item_not_provided( 'Array of WooCommerce product IDs' );
 		}
 
-		if ( $this->can_schedule( [ $id_map ] ) ) {
+		if ( did_action( 'woocommerce_gla_batch_retry_delete_products' ) ) {
+			// Retry after one minute.
+			$this->action_scheduler->schedule_single( gmdate( 'U' ) + 60, $this->get_process_item_hook(), [ $id_map ] );
+		} elseif ( $this->can_schedule( [ $id_map ] ) ) {
 			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), [ $id_map ] );
 		}
 	}

--- a/src/Product/ProductFilter.php
+++ b/src/Product/ProductFilter.php
@@ -67,4 +67,28 @@ class ProductFilter implements Service {
 
 		return new FilteredProductList( $results, $unfiltered_count );
 	}
+
+	/**
+	 * Filter and return a list of products that can be deleted.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param WC_Product[] $products
+	 * @param boolean      $return_ids
+	 *
+	 * @return array
+	 */
+	public function filter_products_for_delete( array $products, bool $return_ids = false ): array {
+		$results = [];
+		foreach ( $products as $product ) {
+			// Skip if the failed threshold has been reached.
+			if ( $this->product_helper->is_delete_failed_threshold_reached( $product ) ) {
+				continue;
+			}
+
+			$results[] = $return_ids ? $product->get_id() : $product;
+		}
+
+		return $results;
+	}
 }

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -59,6 +59,7 @@ class ProductHelper implements Service {
 	 * @param GoogleProduct $google_product
 	 */
 	public function mark_as_synced( WC_Product $product, GoogleProduct $google_product ) {
+		$this->meta_handler->delete_failed_delete_attempts( $product );
 		$this->meta_handler->update_synced_at( $product, time() );
 		$this->meta_handler->update_sync_status( $product, SyncStatus::SYNCED );
 		$this->update_empty_visibility( $product );
@@ -352,6 +353,32 @@ class ProductHelper implements Service {
 		// if it has failed more times than the specified threshold AND if syncing it has failed within the specified window
 		return $failed_attempts > ProductSyncer::FAILURE_THRESHOLD &&
 			   $failed_at > strtotime( sprintf( '-%s', ProductSyncer::FAILURE_THRESHOLD_WINDOW ) );
+	}
+
+	/**
+	 * Increment failed delete attempts.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param WC_Product $product
+	 */
+	public function increment_failed_delete_attempt( WC_Product $product ) {
+		$failed_attempts = $this->meta_handler->get_failed_delete_attempts( $product ) ?? 0;
+		$this->meta_handler->update_failed_delete_attempts( $product, $failed_attempts + 1 );
+	}
+
+	/**
+	 * Whether deleting has failed more times than the specified threshold.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param WC_Product $product
+	 *
+	 * @return boolean
+	 */
+	public function is_delete_failed_threshold_reached( WC_Product $product ): bool {
+		$failed_attempts = $this->meta_handler->get_failed_delete_attempts( $product ) ?? 0;
+		return $failed_attempts >= ProductSyncer::FAILURE_THRESHOLD;
 	}
 
 	/**

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -57,7 +57,7 @@ class ProductHelper implements Service {
 	/**
 	 * Mark a product as synced in the local database.
 	 * This function also handles the following cleanup tasks:
-	 * - Remove any failed delete attemps
+	 * - Remove any failed delete attempts
 	 * - Update the visibility (if it was previously empty)
 	 * - Remove any previous product errors (if it was synced for all target countries)
 	 *

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -55,6 +55,12 @@ class ProductHelper implements Service {
 	}
 
 	/**
+	 * Mark a product as synced in the local database.
+	 * This function also handles the following cleanup tasks:
+	 * - Remove any failed delete attemps
+	 * - Update the visibility (if it was previously empty)
+	 * - Remove any previous product errors (if it was synced for all target countries)
+	 *
 	 * @param WC_Product    $product
 	 * @param GoogleProduct $google_product
 	 */

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -29,6 +29,9 @@ defined( 'ABSPATH' ) || exit;
  * @method update_errors( WC_Product $product, array $value )
  * @method delete_errors( WC_Product $product )
  * @method get_errors( WC_Product $product ): array|null
+ * @method update_failed_delete_attempts( WC_Product $product, int $value )
+ * @method delete_failed_delete_attempts( WC_Product $product )
+ * @method get_failed_delete_attempts( WC_Product $product ): int|null
  * @method update_failed_sync_attempts( WC_Product $product, int $value )
  * @method delete_failed_sync_attempts( WC_Product $product )
  * @method get_failed_sync_attempts( WC_Product $product ): int|null
@@ -46,24 +49,26 @@ class ProductMetaHandler implements Service, Registerable {
 
 	use PluginHelper;
 
-	public const KEY_SYNCED_AT            = 'synced_at';
-	public const KEY_GOOGLE_IDS           = 'google_ids';
-	public const KEY_VISIBILITY           = 'visibility';
-	public const KEY_ERRORS               = 'errors';
-	public const KEY_FAILED_SYNC_ATTEMPTS = 'failed_sync_attempts';
-	public const KEY_SYNC_FAILED_AT       = 'sync_failed_at';
-	public const KEY_SYNC_STATUS          = 'sync_status';
-	public const KEY_MC_STATUS            = 'mc_status';
+	public const KEY_SYNCED_AT              = 'synced_at';
+	public const KEY_GOOGLE_IDS             = 'google_ids';
+	public const KEY_VISIBILITY             = 'visibility';
+	public const KEY_ERRORS                 = 'errors';
+	public const KEY_FAILED_DELETE_ATTEMPTS = 'failed_delete_attempts';
+	public const KEY_FAILED_SYNC_ATTEMPTS   = 'failed_sync_attempts';
+	public const KEY_SYNC_FAILED_AT         = 'sync_failed_at';
+	public const KEY_SYNC_STATUS            = 'sync_status';
+	public const KEY_MC_STATUS              = 'mc_status';
 
 	protected const TYPES = [
-		self::KEY_SYNCED_AT            => 'int',
-		self::KEY_GOOGLE_IDS           => 'array',
-		self::KEY_VISIBILITY           => 'string',
-		self::KEY_ERRORS               => 'array',
-		self::KEY_FAILED_SYNC_ATTEMPTS => 'int',
-		self::KEY_SYNC_FAILED_AT       => 'int',
-		self::KEY_SYNC_STATUS          => 'string',
-		self::KEY_MC_STATUS            => 'string',
+		self::KEY_SYNCED_AT              => 'int',
+		self::KEY_GOOGLE_IDS             => 'array',
+		self::KEY_VISIBILITY             => 'string',
+		self::KEY_ERRORS                 => 'array',
+		self::KEY_FAILED_DELETE_ATTEMPTS => 'int',
+		self::KEY_FAILED_SYNC_ATTEMPTS   => 'int',
+		self::KEY_SYNC_FAILED_AT         => 'int',
+		self::KEY_SYNC_STATUS            => 'string',
+		self::KEY_MC_STATUS              => 'string',
 	];
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -152,6 +152,22 @@ class ProductRepository implements Service {
 	}
 
 	/**
+	 * Find and return an array of WooCommerce product ID's ready to be deleted from the Google Merchant Center.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int[] $ids    Array of WooCommerce product IDs
+	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
+	 * @param int   $offset Amount to offset product results.
+	 *
+	 * @return array
+	 */
+	public function find_delete_product_ids( array $ids, int $limit = - 1, int $offset = 0 ): array {
+		$results = $this->find_by_ids( $ids, $limit, $offset );
+		return $this->product_filter->filter_products_for_delete( $results, true );
+	}
+
+	/**
 	 * Find and return an array of WooCommerce product IDs ready to be submitted to Google Merchant Center.
 	 *
 	 * @param array $args   Array of WooCommerce args (except 'return'), and product metadata.

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -314,6 +314,7 @@ class ProductSyncer implements Service {
 			// internal error
 			if ( $invalid_product->has_error( GoogleProductService::INTERNAL_ERROR_REASON ) ) {
 				$internal_error_ids[ $google_product_id ] = $wc_product_id;
+				$this->product_helper->increment_failed_delete_attempt( $wc_product );
 			}
 		}
 

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -313,8 +313,12 @@ class ProductSyncer implements Service {
 
 			// internal error
 			if ( $invalid_product->has_error( GoogleProductService::INTERNAL_ERROR_REASON ) ) {
-				$internal_error_ids[ $google_product_id ] = $wc_product_id;
 				$this->product_helper->increment_failed_delete_attempt( $wc_product );
+
+				// Only schedule for retry if the failure threshold has not been reached.
+				if ( ! $this->product_helper->is_delete_failed_threshold_reached( $wc_product ) ) {
+					$internal_error_ids[ $google_product_id ] = $wc_product_id;
+				}
 			}
 		}
 

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -910,6 +910,31 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_test_products
+	 */
+	public function test_increment_failed_delete_attempt( WC_Product $product ) {
+		$this->product_meta->update_failed_delete_attempts( $product, 1 );
+		$this->product_helper->increment_failed_delete_attempt( $product );
+
+		$this->assertEquals( 2, $this->product_meta->get_failed_delete_attempts( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_test_products
+	 */
+	public function test_is_delete_failed_threshold_reached( WC_Product $product ) {
+		$this->product_meta->update_failed_delete_attempts( $product, 4 );
+		$this->assertFalse( $this->product_helper->is_delete_failed_threshold_reached( $product ) );
+
+		$this->product_helper->increment_failed_delete_attempt( $product );
+		$this->assertTrue( $this->product_helper->is_delete_failed_threshold_reached( $product ) );
+	}
+
+	/**
 	 * @return array
 	 */
 	public function return_test_products(): array {

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -300,6 +300,22 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 			$this->product_repository->find_all_synced_google_ids()
 		);
 	}
+	public function test_find_delete_product_ids() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+
+		// A synced product with 5 failed delete attempts.
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
+		$this->product_meta->update_failed_delete_attempts( $product_2, 5 );
+
+		$ids = [ $product_1->get_id(), $product_2->get_id() ];
+
+		$this->assertEquals(
+			[ $product_1->get_id() ],
+			$this->product_repository->find_delete_product_ids( $ids )
+		);
+	}
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -189,6 +189,8 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 			$this->assertNotEmpty( $error_entry->get_errors() );
 			// product remains synced if delete failed
 			$this->assertTrue( $this->product_helper->is_product_synced( $wc_product ) );
+			// first failed delete attempt
+			$this->assertEquals( 1, $this->product_meta->get_failed_delete_attempts( $wc_product ) );
 		}
 	}
 

--- a/tests/proxy/config.js
+++ b/tests/proxy/config.js
@@ -5,5 +5,6 @@ module.exports = {
 	connectServer:
 		process.env.WOOCOMMERCE_CONNECT_SERVER ||
 		'https://api-vipgo.woocommerce.com',
+	proxyMode: process.env.PROXY_MODE || 'default',
 	logResponses: process.env.PROXY_LOG_RESPONSES || false,
 };

--- a/tests/proxy/config.js
+++ b/tests/proxy/config.js
@@ -5,4 +5,5 @@ module.exports = {
 	connectServer:
 		process.env.WOOCOMMERCE_CONNECT_SERVER ||
 		'https://api-vipgo.woocommerce.com',
+	logResponses: process.env.PROXY_LOG_RESPONSES || false,
 };

--- a/tests/proxy/handler.js
+++ b/tests/proxy/handler.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const config = require( './config' );
+
 module.exports.checkRequest = ( request ) => {
 	if ( request.params.path.includes( 'googleAds:search' ) ) {
 		const body = JSON.parse( request.payload );
@@ -20,6 +22,14 @@ module.exports.checkRequest = ( request ) => {
 		const page = body.pageToken ? '-' + body.pageToken : '';
 
 		return require( `./mocks/mc/reports/${ file }${ page }.json` );
+	}
+
+	if ( 'delete_error' === config.proxyMode && request.params.path.includes( 'products/batch' ) ) {
+		const body = JSON.parse( request.payload );
+		if ( 'delete' === body.entries[0].method ) {
+			const response = require( './mocks/mc/delete_errors' );
+			return response.deleteErrors( body );
+		}
 	}
 
 	return false;

--- a/tests/proxy/handler.js
+++ b/tests/proxy/handler.js
@@ -24,9 +24,12 @@ module.exports.checkRequest = ( request ) => {
 		return require( `./mocks/mc/reports/${ file }${ page }.json` );
 	}
 
-	if ( 'delete_error' === config.proxyMode && request.params.path.includes( 'products/batch' ) ) {
+	if (
+		config.proxyMode === 'delete_error' &&
+		request.params.path.includes( 'products/batch' )
+	) {
 		const body = JSON.parse( request.payload );
-		if ( 'delete' === body.entries[0].method ) {
+		if ( body.entries[ 0 ].method === 'delete' ) {
 			const response = require( './mocks/mc/delete_errors' );
 			return response.deleteErrors( body );
 		}

--- a/tests/proxy/index.js
+++ b/tests/proxy/index.js
@@ -22,12 +22,30 @@ const init = async () => {
 					return response;
 				}
 
-				return h.proxy( {
+				let proxy = {
 					uri: `${ config.connectServer }/${ request.params.path }${
 						request.url.search || ''
 					}`,
 					passThrough: true,
-				} );
+				};
+
+				if ( config.logResponses ) {
+					proxy.onResponse = ( err, res, request, reply, settings, ttl ) => {
+						let body = '';
+
+						res.on( 'data', ( chunk ) => {
+							body += chunk;
+						} );
+
+						res.on( 'end', () => {
+							console.log( body );
+						} );
+
+						return res;
+					};
+				}
+
+				return h.proxy( proxy );
 			},
 			payload: {
 				parse: false,

--- a/tests/proxy/index.js
+++ b/tests/proxy/index.js
@@ -20,12 +20,13 @@ const init = async () => {
 				const response = handler.checkRequest( request );
 				if ( response ) {
 					if ( config.logResponses ) {
+						// eslint-disable-next-line no-console
 						console.log( 'Mocked response: ', response );
 					}
 					return response;
 				}
 
-				let proxy = {
+				const proxy = {
 					uri: `${ config.connectServer }/${ request.params.path }${
 						request.url.search || ''
 					}`,
@@ -33,7 +34,7 @@ const init = async () => {
 				};
 
 				if ( config.logResponses ) {
-					proxy.onResponse = ( err, res, request, reply, settings, ttl ) => {
+					proxy.onResponse = ( err, res ) => {
 						let body = '';
 
 						res.on( 'data', ( chunk ) => {
@@ -41,6 +42,7 @@ const init = async () => {
 						} );
 
 						res.on( 'end', () => {
+							// eslint-disable-next-line no-console
 							console.log( 'API response: ', body );
 						} );
 

--- a/tests/proxy/index.js
+++ b/tests/proxy/index.js
@@ -57,9 +57,10 @@ const init = async () => {
 
 	// eslint-disable-next-line no-console
 	console.log(
-		'Proxy server running on %s > %s',
+		'Proxy server running on %s > %s in %s mode',
 		server.info.uri,
-		config.connectServer
+		config.connectServer,
+		config.proxyMode
 	);
 };
 

--- a/tests/proxy/index.js
+++ b/tests/proxy/index.js
@@ -19,6 +19,9 @@ const init = async () => {
 			handler: ( request, h ) => {
 				const response = handler.checkRequest( request );
 				if ( response ) {
+					if ( config.logResponses ) {
+						console.log( 'Mocked response: ', response );
+					}
 					return response;
 				}
 
@@ -38,7 +41,7 @@ const init = async () => {
 						} );
 
 						res.on( 'end', () => {
-							console.log( body );
+							console.log( 'API response: ', body );
 						} );
 
 						return res;

--- a/tests/proxy/mocks/mc/delete_errors.js
+++ b/tests/proxy/mocks/mc/delete_errors.js
@@ -11,16 +11,16 @@ module.exports.deleteErrors = ( requests ) => {
 						domain: 'global',
 						reason: 'internalError',
 						message: 'internal error',
-					}
+					},
 				],
 				code: 500,
 				message: 'internal error',
-			}
-		}
+			},
+		};
 	} );
 
 	return {
 		kind: 'content#productsCustomBatchResponse',
-		entries
+		entries,
 	};
 };

--- a/tests/proxy/mocks/mc/delete_errors.js
+++ b/tests/proxy/mocks/mc/delete_errors.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports.deleteErrors = ( requests ) => {
+	const entries = requests.entries.map( ( entry ) => {
+		return {
+			kind: 'content#productsCustomBatchResponseEntry',
+			batchId: entry.batchId,
+			errors: {
+				errors: [
+					{
+						domain: 'global',
+						reason: 'internalError',
+						message: 'internal error',
+					}
+				],
+				code: 500,
+				message: 'internal error',
+			}
+		}
+	} );
+
+	return {
+		kind: 'content#productsCustomBatchResponse',
+		entries
+	};
+};

--- a/tests/proxy/proxy.md
+++ b/tests/proxy/proxy.md
@@ -17,6 +17,12 @@ Or, if you want to use a local connect server:
 WOOCOMMERCE_CONNECT_SERVER=http://localhost:5000 npm run test-proxy
 ```
 
+### Run the proxy in a specific mode
+The mode will determine what kind of responses will be returned, this is used to mock specific responses which can't be reproduced through regular requests.
+
+Modes:
+- `delete_error` will return an internal error when deleting products
+
 ### Log responses when running the proxy
 This option will allow us to view the responses which are returned from the API, this is useful for generating mocked responses to return.
 

--- a/tests/proxy/proxy.md
+++ b/tests/proxy/proxy.md
@@ -17,6 +17,13 @@ Or, if you want to use a local connect server:
 WOOCOMMERCE_CONNECT_SERVER=http://localhost:5000 npm run test-proxy
 ```
 
+### Log responses when running the proxy
+This option will allow us to view the responses which are returned from the API, this is useful for generating mocked responses to return.
+
+```
+PROXY_LOG_RESPONSES=true npm run test-proxy
+```
+
 ## Connect test site to proxy
 
 On your test site you will need to run a PHP snippet to use the proxy to handle any requests:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The task in the initial issue was to limit the amount of retries so if we would receive internal errors it wouldn't endlessly retry. However after additional testing it appears the `can_schedule` will check if there is a scheduled task running with the same hook name and the same list of arguments. When we call the action `woocommerce_gla_batch_retry_delete_products` we are still running the scheduled task with the same hook name. So if all the products in the delete batch fail we will have the same list of arguments and the retry will not be scheduled. This can occur easier if we are only deleting one product at a time (for example when we set a single product to not sync or show, or it goes out of stock).

So this PR changes the following things:
- Always reschedule when we called the action `woocommerce_gla_batch_retry_delete_products`
- Reschedule a retry after 1 minute (no use to retry an internal error right away)
- Limit retries to the product syncer threshold (5 tries)
- Filter the delete ready products when processing the DeleteProducts job, this removes any products that aren't ready (like the ones that reached the failure threshold)
- Add unit tests for the added products

Closes #1193

### Detailed test instructions:

Since we can't simulate internal errors in the Google API's we will need to test this PR with our test proxy in the `delete_error` mode so it can return mocked error responses. If you are using docker see instructions [here](https://github.com/woocommerce/google-listings-and-ads/blob/develop/tests/proxy/proxy.md#connect-test-site-to-proxy) on how to get it running.

1. Run the proxy with a command like: `PROXY_MODE=delete_error cd tests/proxy && npm run test-proxy`
2. Use a code snippet to get our site to connect to the proxy:
```php
define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://localhost:5500' );
```
3. Connect your Merchant account and sync all or some products (ensure we waited for the syncing to complete)
4. Edit one of the synced products and mark it as "Don't Sync and show" and save it
5. This will trigger a product delete, since we mocked the errors it will trigger a retry until it reaches the threshold of 5
6. Wait for at least 6 minutes till it completes all the retries
7. View the GLA log file in WooCommerce > Status > Logs
8. Confirm that you see 4 failures in the log with a message like (the 5th time it won't be retried so it will only show debug messages that it failed):
```
2022-02-10T08:12:24+00:00 ERROR Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer::handle_delete_errors Internal API errors while deleting the following products: Array
(
    [online:en:US:gla_1234] => 1234
)
``` 
9. Check in WooCommerce > Status > Scheduled Actions and confirm that we have no more pending actions with the hook `gla/jobs/delete_products/process_item`
10. If we check the completed actions we will see 5 with the hook `gla/jobs/delete_products/process_item`

### Changelog entry
* Fix - Limit failed delete retries to 5 and schedule again after one minute.
