### PR TITLE
Update campaign classes to support PMax

### DIFF
--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -1,0 +1,200 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAssetGroupQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsListingGroupFilterQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Google\Ads\GoogleAds\Util\V9\ResourceNames;
+use Google\Ads\GoogleAds\V9\Enums\ListingGroupFilterTypeEnum\ListingGroupFilterType;
+use Google\Ads\GoogleAds\V9\Enums\ListingGroupFilterVerticalEnum\ListingGroupFilterVertical;
+use Google\Ads\GoogleAds\V9\Enums\AssetGroupStatusEnum\AssetGroupStatus;
+use Google\Ads\GoogleAds\V9\Resources\AssetGroup;
+use Google\Ads\GoogleAds\V9\Resources\AssetGroupListingGroupFilter;
+use Google\Ads\GoogleAds\V9\Services\AssetGroupListingGroupFilterOperation;
+use Google\Ads\GoogleAds\V9\Services\AssetGroupOperation;
+use Google\Ads\GoogleAds\V9\Services\GoogleAdsRow;
+use Google\Ads\GoogleAds\V9\Services\MutateOperation;
+
+/**
+ * Class AdsAssetGroup
+ *
+ * Used for the Performance Max Campaigns
+ * https://developers.google.com/google-ads/api/docs/performance-max/asset-groups
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class AdsAssetGroup implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/**
+	 * Temporary ID to use within a batch job.
+	 * A negative number which is unique for all the created resources.
+	 *
+	 * @var int
+	 */
+	protected const TEMPORARY_ID = -3;
+
+	/**
+	 * The Google Ads Client.
+	 *
+	 * @var GoogleAdsClient
+	 */
+	protected $client;
+
+	/**
+	 * List of asset group resource names.
+	 *
+	 * @var string[]
+	 */
+	protected $asset_groups;
+
+	/**
+	 * AdsGroup constructor.
+	 *
+	 * @param GoogleAdsClient $client
+	 */
+	public function __construct( GoogleAdsClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Returns a set of operations to create an asset group.
+	 *
+	 * @param string $campaign_resource_name
+	 * @param string $campaign_name
+	 * @return array
+	 */
+	public function create_operations( string $campaign_resource_name, string $campaign_name ): array {
+		// Asset must be created before listing group.
+		return [
+			$this->asset_group_create_operation( $campaign_resource_name, $campaign_name ),
+			$this->listing_group_create_operation(),
+		];
+	}
+
+	/**
+	 * Returns a set of operations to delete an asset group.
+	 *
+	 * @param string $campaign_resource_name
+	 * @return array
+	 */
+	public function delete_operations( string $campaign_resource_name ): array {
+		$asset_group_operations   = $this->asset_group_delete_operations( $campaign_resource_name );
+		$listing_group_operations = $this->listing_group_delete_operations();
+
+		// All assets must be deleted from the group before deleting the asset group.
+		return array_merge(
+			$listing_group_operations,
+			$asset_group_operations
+		);
+	}
+
+	/**
+	 * Returns an asset group create operation.
+	 *
+	 * @param string $campaign_resource_name
+	 * @param string $campaign_name
+	 *
+	 * @return MutateOperation
+	 */
+	protected function asset_group_create_operation( string $campaign_resource_name, string $campaign_name ): MutateOperation {
+		$asset_group = new AssetGroup(
+			[
+				'resource_name' => $this->temporary_resource_name(),
+				'name'          => $campaign_name . ' Asset Group',
+				'campaign'      => $campaign_resource_name,
+				'status'        => AssetGroupStatus::ENABLED,
+			]
+		);
+
+		$operation = ( new AssetGroupOperation() )->setCreate( $asset_group );
+		return ( new MutateOperation() )->setAssetGroupOperation( $operation );
+	}
+
+	/**
+	 * Returns an asset group listing group filter create operation.
+	 *
+	 * @return MutateOperation
+	 */
+	protected function listing_group_create_operation(): MutateOperation {
+		$listing_group = new AssetGroupListingGroupFilter(
+			[
+				'asset_group' => $this->temporary_resource_name(),
+				'type'        => ListingGroupFilterType::UNIT_INCLUDED,
+				'vertical'    => ListingGroupFilterVertical::SHOPPING,
+			]
+		);
+
+		$operation = ( new AssetGroupListingGroupFilterOperation() )->setCreate( $listing_group );
+		return ( new MutateOperation() )->setAssetGroupListingGroupFilterOperation( $operation );
+	}
+
+	/**
+	 * Returns an asset group delete operation.
+	 *
+	 * @param string $campaign_resource_name
+	 *
+	 * @return MutateOperation[]
+	 */
+	protected function asset_group_delete_operations( string $campaign_resource_name ): array {
+		$operations         = [];
+		$this->asset_groups = [];
+
+		$results = ( new AdsAssetGroupQuery() )
+			->set_client( $this->client, $this->options->get_ads_id() )
+			->where( 'asset_group.campaign', $campaign_resource_name )
+			->get_results();
+
+		/** @var GoogleAdsRow $row */
+		foreach ( $results->iterateAllElements() as $row ) {
+			$resource_name        = $row->getAssetGroup()->getResourceName();
+			$this->asset_groups[] = $resource_name;
+			$operation            = ( new AssetGroupOperation() )->setRemove( $resource_name );
+			$operations[]         = ( new MutateOperation() )->setAssetGroupOperation( $operation );
+		}
+
+		return $operations;
+	}
+
+	/**
+	 * Returns an asset group listing group filter delete operation.
+	 *
+	 * @return MutateOperation[]
+	 */
+	protected function listing_group_delete_operations(): array {
+		if ( empty( $this->asset_groups ) ) {
+			return [];
+		}
+
+		$operations = [];
+		$results    = ( new AdsListingGroupFilterQuery() )
+			->set_client( $this->client, $this->options->get_ads_id() )
+			->where( 'asset_group_listing_group_filter.asset_group', $this->asset_groups, 'IN' )
+			->get_results();
+
+		/** @var GoogleAdsRow $row */
+		foreach ( $results->iterateAllElements() as $row ) {
+			$resource_name = $row->getAssetGroupListingGroupFilter()->getResourceName();
+			$operation     = ( new AssetGroupListingGroupFilterOperation() )->setRemove( $resource_name );
+			$operations[]  = ( new MutateOperation() )->setAssetGroupListingGroupFilterOperation( $operation );
+		}
+
+		return $operations;
+	}
+
+	/**
+	 * Return a temporary resource name for the campaign.
+	 *
+	 * @return string
+	 */
+	protected function temporary_resource_name() {
+		return ResourceNames::forAssetGroup( $this->options->get_ads_id(), self::TEMPORARY_ID );
+	}
+}

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -253,7 +253,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				[ $this->budget->delete_operation( $campaign_id ) ]
 			);
 
-			return $this->mutate( $operations ) ?: $campaign_id;
+			return $this->mutate( $operations );
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -5,34 +5,51 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCampaignQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Google\Ads\GoogleAds\Util\FieldMasks;
 use Google\Ads\GoogleAds\Util\V9\ResourceNames;
 use Google\Ads\GoogleAds\V9\Common\MaximizeConversionValue;
-use Google\Ads\GoogleAds\V9\Enums\AdvertisingChannelSubTypeEnum\AdvertisingChannelSubType;
 use Google\Ads\GoogleAds\V9\Enums\AdvertisingChannelTypeEnum\AdvertisingChannelType;
 use Google\Ads\GoogleAds\V9\Resources\Campaign;
 use Google\Ads\GoogleAds\V9\Resources\Campaign\ShoppingSetting;
-use Google\Ads\GoogleAds\V9\Services\CampaignOperation;
 use Google\Ads\GoogleAds\V9\Services\CampaignServiceClient;
+use Google\Ads\GoogleAds\V9\Services\CampaignOperation;
 use Google\Ads\GoogleAds\V9\Services\GoogleAdsRow;
-use Google\Ads\GoogleAds\V9\Services\MutateCampaignResult;
+use Google\Ads\GoogleAds\V9\Services\MutateOperation;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;
 use Exception;
 
 /**
- * Class AdsCampaign
+ * Class AdsCampaign (Performance Max Campaign)
+ * https://developers.google.com/google-ads/api/docs/performance-max/overview
+ *
+ * ContainerAware used for:
+ * - AdsAssetGroup
+ * - AdsGroup
+ *
+ * @since x.x.x Refactored to support PMax and (legacy) SSC.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
-class AdsCampaign implements OptionsAwareInterface {
+class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 
 	use ApiExceptionTrait;
+	use ContainerAwareTrait;
 	use OptionsAwareTrait;
 	use MicroTrait;
+
+	/**
+	 * Temporary ID to use within a batch job.
+	 * A negative number which is unique for all the created resources.
+	 *
+	 * @var int
+	 */
+	protected const TEMPORARY_ID = -1;
 
 	/**
 	 * The Google Ads Client.
@@ -42,30 +59,24 @@ class AdsCampaign implements OptionsAwareInterface {
 	protected $client;
 
 	/**
-	 * @var AdsCampaignBudget $ads_campaign_budget
+	 * @var AdsCampaignBudget $budget
 	 */
-	protected $ads_campaign_budget;
-
-	/**
-	 * @var AdsGroup $ads_group
-	 */
-	protected $ads_group;
-
+	protected $budget;
 
 	/**
 	 * AdsCampaign constructor.
 	 *
 	 * @param GoogleAdsClient   $client
-	 * @param AdsCampaignBudget $ads_campaign_budget
-	 * @param AdsGroup          $ads_group
+	 * @param AdsCampaignBudget $budget
 	 */
-	public function __construct( GoogleAdsClient $client, AdsCampaignBudget $ads_campaign_budget, AdsGroup $ads_group ) {
-		$this->client              = $client;
-		$this->ads_campaign_budget = $ads_campaign_budget;
-		$this->ads_group           = $ads_group;
+	public function __construct( GoogleAdsClient $client, AdsCampaignBudget $budget ) {
+		$this->client = $client;
+		$this->budget = $budget;
 	}
 
 	/**
+	 * Returns a list of campaigns
+	 *
 	 * @return array
 	 * @throws Exception When an ApiException is caught.
 	 */
@@ -88,65 +99,6 @@ class AdsCampaign implements OptionsAwareInterface {
 			throw new Exception(
 				/* translators: %s Error message */
 				sprintf( __( 'Error retrieving campaigns: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
-				$e->getCode()
-			);
-		}
-	}
-
-
-	/**
-	 * Create a new campaign.
-	 *
-	 * @param array $params Request parameters.
-	 *
-	 * @return array
-	 * @throws Exception When an ApiException is caught or the created ID is invalid.
-	 */
-	public function create_campaign( array $params ): array {
-		try {
-			$budget = $this->ads_campaign_budget->create_campaign_budget( $params['amount'] );
-
-			$campaign = new Campaign(
-				[
-					'name'                         => $params['name'],
-					'advertising_channel_type'     => AdvertisingChannelType::SHOPPING,
-					'advertising_channel_sub_type' => AdvertisingChannelSubType::SHOPPING_SMART_ADS,
-					'status'                       => CampaignStatus::number( 'enabled' ),
-					'campaign_budget'              => $budget,
-					'maximize_conversion_value'    => new MaximizeConversionValue(),
-					'shopping_setting'             => new ShoppingSetting(
-						[
-							'merchant_id'   => $this->options->get_merchant_id(),
-							'sales_country' => $params['country'],
-						]
-					),
-				]
-			);
-
-			$operation = new CampaignOperation();
-			$operation->setCreate( $campaign );
-			$created_campaign = $this->mutate_campaign( $operation );
-			$campaign_id      = $this->parse_campaign_id( $created_campaign->getResourceName() );
-
-			$this->ads_group->set_up_for_campaign( $created_campaign->getResourceName(), $params['name'] );
-
-			return [
-				'id'     => $campaign_id,
-				'status' => CampaignStatus::ENABLED,
-			] + $params;
-		} catch ( ApiException $e ) {
-			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
-
-			if ( $this->has_api_exception_error( $e, 'DUPLICATE_CAMPAIGN_NAME' ) ) {
-				throw new Exception(
-					__( 'A campaign with this name already exists', 'google-listings-and-ads' ),
-					$e->getCode()
-				);
-			}
-
-			throw new Exception(
-				/* translators: %s Error message */
-				sprintf( __( 'Error creating campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
 				$e->getCode()
 			);
 		}
@@ -184,6 +136,53 @@ class AdsCampaign implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Create a new campaign.
+	 *
+	 * @param array $params Request parameters.
+	 *
+	 * @return array
+	 * @throws Exception When an ApiException is caught.
+	 */
+	public function create_campaign( array $params ): array {
+		try {
+			/** @var AdsAssetGroup $asset_group */
+			$asset_group = $this->container->get( AdsAssetGroup::class );
+
+			// Operations must be in a specific order to match the temporary ID's.
+			$operations = array_merge(
+				[ $this->budget->create_operation( $params['name'], $params['amount'] ) ],
+				[ $this->create_operation( $params['name'], $params['country'] ) ],
+				$this->container->get( AdsAssetGroup::class )->create_operations(
+					$this->temporary_resource_name(),
+					$params['name']
+				)
+			);
+
+			$campaign_id = $this->mutate( $operations );
+
+			return [
+				'id'     => $campaign_id,
+				'status' => CampaignStatus::ENABLED,
+			] + $params;
+		} catch ( ApiException $e ) {
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
+
+			if ( $this->has_api_exception_error( $e, 'DUPLICATE_CAMPAIGN_NAME' ) ) {
+				throw new Exception(
+					__( 'A campaign with this name already exists', 'google-listings-and-ads' ),
+					$e->getCode()
+				);
+			}
+
+			throw new Exception(
+				/* translators: %s Error message */
+				sprintf( __( 'Error creating campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
+				$e->getCode()
+			);
+		}
+	}
+
+	/**
 	 * Edit a campaign.
 	 *
 	 * @param int   $campaign_id Campaign ID.
@@ -194,26 +193,27 @@ class AdsCampaign implements OptionsAwareInterface {
 	 */
 	public function edit_campaign( int $campaign_id, array $params ): int {
 		try {
-			$campaign_fields = [
-				'resource_name' => ResourceNames::forCampaign( $this->options->get_ads_id(), $campaign_id ),
-			];
+			$operations      = [];
+			$campaign_fields = [];
+
 			if ( ! empty( $params['name'] ) ) {
 				$campaign_fields['name'] = $params['name'];
 			}
+
 			if ( ! empty( $params['status'] ) ) {
 				$campaign_fields['status'] = CampaignStatus::number( $params['status'] );
 			}
+
 			if ( ! empty( $params['amount'] ) ) {
-				$this->ads_campaign_budget->edit_campaign_budget( $campaign_id, $params['amount'] );
+				$operations[] = $this->budget->edit_operation( $campaign_id, $params['amount'] );
 			}
 
-			if ( count( $campaign_fields ) > 1 ) {
-				$campaign  = new Campaign( $campaign_fields );
-				$operation = new CampaignOperation();
-				$operation->setUpdate( $campaign );
-				$operation->setUpdateMask( FieldMasks::allSetFieldsOf( $campaign ) );
-				$edited_campaign = $this->mutate_campaign( $operation );
-				$campaign_id     = $this->parse_campaign_id( $edited_campaign->getResourceName() );
+			if ( ! empty( $campaign_fields ) ) {
+				$operations[] = $this->edit_operation( $campaign_id, $campaign_fields );
+			}
+
+			if ( ! empty( $operations ) ) {
+				return $this->mutate( $operations ) ?: $campaign_id;
 			}
 
 			return $campaign_id;
@@ -238,17 +238,24 @@ class AdsCampaign implements OptionsAwareInterface {
 	 */
 	public function delete_campaign( int $campaign_id ): int {
 		try {
-			$resource_name = ResourceNames::forCampaign( $this->options->get_ads_id(), $campaign_id );
+			$campaign_resource_name = ResourceNames::forCampaign( $this->options->get_ads_id(), $campaign_id );
 
-			$this->ads_group->delete_for_campaign( $resource_name );
+			$asset_group_operations = $this->container->get( AdsAssetGroup::class )->delete_operations( $campaign_resource_name );
 
-			$operation = new CampaignOperation();
-			$operation->setRemove( $resource_name );
-			$deleted_campaign = $this->mutate_campaign( $operation );
+			// Retrieve legacy SSC ad group if we haven't gotten any asset group.
+			$ad_group_operations = empty( $asset_group_operations ) ?
+				$this->container->get( AdsGroup::class )->delete_operations( $campaign_resource_name ) :
+				[];
 
-			$this->ads_campaign_budget->delete_campaign_budget( $campaign_id );
+			// Include operations for AdsGroup (legacy SSC)
+			$operations = array_merge(
+				$asset_group_operations,
+				$ad_group_operations,
+				[ $this->delete_operation( $campaign_resource_name ) ],
+				[ $this->budget->delete_operation( $campaign_id ) ]
+			);
 
-			return $this->parse_campaign_id( $deleted_campaign->getResourceName() );
+			return $this->mutate( $operations ) ?: $campaign_id;
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
@@ -265,6 +272,76 @@ class AdsCampaign implements OptionsAwareInterface {
 				$e->getCode()
 			);
 		}
+	}
+
+	/**
+	 * Return a temporary resource name for the campaign.
+	 *
+	 * @return string
+	 */
+	public function temporary_resource_name() {
+		return ResourceNames::forCampaign( $this->options->get_ads_id(), self::TEMPORARY_ID );
+	}
+
+	/**
+	 * Returns a campaign create operation.
+	 *
+	 * @param string $campaign_name
+	 * @param string $country
+	 *
+	 * @return MutateOperation
+	 */
+	protected function create_operation( string $campaign_name, string $country ): MutateOperation {
+		$campaign = new Campaign(
+			[
+				'resource_name'             => $this->temporary_resource_name(),
+				'name'                      => $campaign_name,
+				'advertising_channel_type'  => AdvertisingChannelType::PERFORMANCE_MAX,
+				'status'                    => CampaignStatus::number( 'enabled' ),
+				'campaign_budget'           => $this->budget->temporary_resource_name(),
+				'maximize_conversion_value' => new MaximizeConversionValue(),
+				'url_expansion_opt_out'     => true,
+				'shopping_setting'          => new ShoppingSetting(
+					[
+						'merchant_id'   => $this->options->get_merchant_id(),
+						'sales_country' => $country,
+					]
+				),
+			]
+		);
+
+		$operation = ( new CampaignOperation() )->setCreate( $campaign );
+		return ( new MutateOperation() )->setCampaignOperation( $operation );
+	}
+
+	/**
+	 * Returns a campaign edit operation.
+	 *
+	 * @param integer $campaign_id
+	 * @param array   $fields
+	 *
+	 * @return MutateOperation
+	 */
+	protected function edit_operation( int $campaign_id, array $fields ): MutateOperation {
+		$fields['resource_name'] = ResourceNames::forCampaign( $this->options->get_ads_id(), $campaign_id );
+
+		$campaign  = new Campaign( $fields );
+		$operation = new CampaignOperation();
+		$operation->setUpdate( $campaign );
+		$operation->setUpdateMask( FieldMasks::allSetFieldsOf( $campaign ) );
+		return ( new MutateOperation() )->setCampaignOperation( $operation );
+	}
+
+	/**
+	 * Returns a campaign delete operation.
+	 *
+	 * @param string $campaign_resource_name
+	 *
+	 * @return MutateOperation
+	 */
+	protected function delete_operation( string $campaign_resource_name ): MutateOperation {
+		$operation = ( new CampaignOperation() )->setRemove( $campaign_resource_name );
+		return ( new MutateOperation() )->setCampaignOperation( $operation );
 	}
 
 	/**
@@ -300,20 +377,28 @@ class AdsCampaign implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Run a single mutate campaign operation.
+	 * Send a batch of operations to mutate a campaign.
 	 *
-	 * @param CampaignOperation $operation Operation we would like to run.
+	 * @param MutateOperation[] $operations
 	 *
-	 * @return MutateCampaignResult
-	 * @throws ApiException If the campaign mutate fails.
+	 * @return int Campaign ID from the MutateOperationResponse.
+	 * @throws ApiException If any of the operations fail.
 	 */
-	protected function mutate_campaign( CampaignOperation $operation ): MutateCampaignResult {
-		$response = $this->client->getCampaignServiceClient()->mutateCampaigns(
+	protected function mutate( array $operations ): int {
+		$responses = $this->client->getGoogleAdsServiceClient()->mutate(
 			$this->options->get_ads_id(),
-			[ $operation ]
+			$operations
 		);
 
-		return $response->getResults()[0];
+		foreach ( $responses->getMutateOperationResponses() as $response ) {
+			if ( 'campaign_result' === $response->getResponse() ) {
+				$campaign_result = $response->getCampaignResult();
+				return $this->parse_campaign_id( $campaign_result->getResourceName() );
+			}
+		}
+
+		// When editing only the budget there is no campaign mutate result.
+		return 0;
 	}
 
 	/**

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -163,6 +163,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			return [
 				'id'     => $campaign_id,
 				'status' => CampaignStatus::ENABLED,
+				'type'   => CampaignType::PERFORMANCE_MAX,
 			] + $params;
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -145,9 +145,6 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	public function create_campaign( array $params ): array {
 		try {
-			/** @var AdsAssetGroup $asset_group */
-			$asset_group = $this->container->get( AdsAssetGroup::class );
-
 			// Operations must be in a specific order to match the temporary ID's.
 			$operations = array_merge(
 				[ $this->budget->create_operation( $params['name'], $params['amount'] ) ],

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -358,6 +358,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			'id'     => $campaign->getId(),
 			'name'   => $campaign->getName(),
 			'status' => CampaignStatus::label( $campaign->getStatus() ),
+			'type'   => CampaignType::label( $campaign->getAdvertisingChannelType() ),
 		];
 
 		$budget = $row->getCampaignBudget();

--- a/src/API/Google/AdsCampaignBudget.php
+++ b/src/API/Google/AdsCampaignBudget.php
@@ -13,7 +13,7 @@ use Google\Ads\GoogleAds\Util\V9\ResourceNames;
 use Google\Ads\GoogleAds\V9\Resources\CampaignBudget;
 use Google\Ads\GoogleAds\V9\Services\CampaignBudgetOperation;
 use Google\Ads\GoogleAds\V9\Services\CampaignBudgetServiceClient;
-use Google\Ads\GoogleAds\V9\Services\MutateCampaignBudgetResult;
+use Google\Ads\GoogleAds\V9\Services\MutateOperation;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;
 use Exception;
@@ -21,12 +21,22 @@ use Exception;
 /**
  * Class AdsCampaignBudget
  *
+ * @since x.x.x Refactored to support PMax and (legacy) SSC.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
 class AdsCampaignBudget implements OptionsAwareInterface {
 
 	use MicroTrait;
 	use OptionsAwareTrait;
+
+	/**
+	 * Temporary ID to use within a batch job.
+	 * A negative number which is unique for all the created resources.
+	 *
+	 * @var int
+	 */
+	protected const TEMPORARY_ID = -2;
 
 	/**
 	 * The Google Ads Client.
@@ -45,26 +55,25 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Creates a new campaign budget.
+	 * Returns a new campaign budget create operation.
 	 *
-	 * @param float $amount Budget amount in the local currency.
+	 * @param string $campaign_name New campaign name.
+	 * @param float  $amount        Budget amount in the local currency.
 	 *
-	 * @return string Resource name of the newly created budget.
-	 * @throws ApiException If the campaign budget can't be created.
+	 * @return MutateOperation
 	 */
-	public function create_campaign_budget( float $amount ): string {
+	public function create_operation( string $campaign_name, float $amount ): MutateOperation {
 		$budget = new CampaignBudget(
 			[
+				'resource_name'     => $this->temporary_resource_name(),
+				'name'              => $campaign_name . ' Budget',
 				'amount_micros'     => $this->to_micro( $amount ),
 				'explicitly_shared' => false,
 			]
 		);
 
-		$operation = new CampaignBudgetOperation();
-		$operation->setCreate( $budget );
-		$created_budget = $this->mutate_budget( $operation );
-
-		return $created_budget->getResourceName();
+		$operation = ( new CampaignBudgetOperation() )->setCreate( $budget );
+		return ( new MutateOperation() )->setCampaignBudgetOperation( $operation );
 	}
 
 	/**
@@ -77,7 +86,7 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 	 * @throws ApiException If the campaign budget can't be mutated.
 	 * @throws Exception If no linked budget has been found.
 	 */
-	public function edit_campaign_budget( int $campaign_id, float $amount ): string {
+	public function edit_operation( int $campaign_id, float $amount ): MutateOperation {
 		$budget_id = $this->get_budget_from_campaign( $campaign_id );
 		$budget    = new CampaignBudget(
 			[
@@ -89,26 +98,31 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 		$operation = new CampaignBudgetOperation();
 		$operation->setUpdate( $budget );
 		$operation->setUpdateMask( FieldMasks::allSetFieldsOf( $budget ) );
-		$edited_budget = $this->mutate_budget( $operation );
-
-		return $edited_budget->getResourceName();
+		return ( new MutateOperation() )->setCampaignBudgetOperation( $operation );
 	}
 
 	/**
+	 * Returns a campaign delete operation.
+	 *
 	 * @param int $campaign_id
 	 *
-	 * @return array resource names of deleted budgets.
-	 * @throws ApiException If the budget isn't deleted.
-	 * @throws Exception If no linked budget has been found.
+	 * @return MutateOperation
 	 */
-	public function delete_campaign_budget( int $campaign_id ): array {
+	public function delete_operation( int $campaign_id ): MutateOperation {
 		$budget_id            = $this->get_budget_from_campaign( $campaign_id );
 		$budget_resource_name = ResourceNames::forCampaignBudget( $this->options->get_ads_id(), $budget_id );
 
-		$operation = new CampaignBudgetOperation();
-		$operation->setRemove( $budget_resource_name );
-		$deleted_budget = $this->mutate_budget( $operation );
-		return [ $deleted_budget->getResourceName() ];
+		$operation = ( new CampaignBudgetOperation() )->setRemove( $budget_resource_name );
+		return ( new MutateOperation() )->setCampaignBudgetOperation( $operation );
+	}
+
+	/**
+	 * Return a temporary resource name for the campaign budget.
+	 *
+	 * @return string
+	 */
+	public function temporary_resource_name() {
+		return ResourceNames::forCampaignBudget( $this->options->get_ads_id(), self::TEMPORARY_ID );
 	}
 
 	/**
@@ -132,23 +146,6 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 
 		/* translators: %d Campaign ID */
 		throw new Exception( sprintf( __( 'No budget found for campaign %d', 'google-listings-and-ads' ), $campaign_id ) );
-	}
-
-	/**
-	 * Run a single mutate campaign budget operation.
-	 *
-	 * @param CampaignBudgetOperation $operation Operation we would like to run.
-	 *
-	 * @return MutateCampaignBudgetResult
-	 * @throws ApiException If the remote call to mutate the campaign budget fails.
-	 */
-	protected function mutate_budget( CampaignBudgetOperation $operation ): MutateCampaignBudgetResult {
-		$response = $this->client->getCampaignBudgetServiceClient()->mutateCampaignBudgets(
-			$this->options->get_ads_id(),
-			[ $operation ]
-		);
-
-		return $response->getResults()[0];
 	}
 
 	/**

--- a/src/API/Google/AdsGroup.php
+++ b/src/API/Google/AdsGroup.php
@@ -9,30 +9,19 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsListingGroup
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
-use Google\Ads\GoogleAds\V9\Common\ListingGroupInfo;
-use Google\Ads\GoogleAds\V9\Common\ShoppingSmartAdInfo;
-use Google\Ads\GoogleAds\V9\Enums\AdGroupAdStatusEnum\AdGroupAdStatus;
-use Google\Ads\GoogleAds\V9\Enums\AdGroupStatusEnum\AdGroupStatus;
-use Google\Ads\GoogleAds\V9\Enums\AdGroupTypeEnum\AdGroupType;
-use Google\Ads\GoogleAds\V9\Enums\ListingGroupTypeEnum\ListingGroupType;
 use Google\Ads\GoogleAds\V9\Resources\Ad;
-use Google\Ads\GoogleAds\V9\Resources\AdGroup;
-use Google\Ads\GoogleAds\V9\Resources\AdGroupAd;
-use Google\Ads\GoogleAds\V9\Resources\AdGroupCriterion;
 use Google\Ads\GoogleAds\V9\Services\AdGroupAdOperation;
 use Google\Ads\GoogleAds\V9\Services\AdGroupCriterionOperation;
 use Google\Ads\GoogleAds\V9\Services\AdGroupOperation;
 use Google\Ads\GoogleAds\V9\Services\GoogleAdsRow;
-use Google\Ads\GoogleAds\V9\Services\MutateAdGroupAdResult;
-use Google\Ads\GoogleAds\V9\Services\MutateAdGroupCriterionResult;
-use Google\Ads\GoogleAds\V9\Services\MutateAdGroupResult;
-use Google\ApiCore\ApiException;
-use Google\ApiCore\ValidationException;
+use Google\Ads\GoogleAds\V9\Services\MutateOperation;
 
 /**
  * Class AdsGroup
  *
- * Straight up copying is the sincerest form of flattery.
+ * @since x.x.x Refactored to support deleting of a legacy SSC Ad Group.
+ *
+ * Used for legacy Smart Shopping Campaigns (SSC)
  * https://developers.google.com/google-ads/api/docs/samples/add-shopping-smart-ad
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
@@ -49,6 +38,13 @@ class AdsGroup implements OptionsAwareInterface {
 	protected $client;
 
 	/**
+	 * List of ad group resource names.
+	 *
+	 * @var string[]
+	 */
+	protected $ad_groups;
+
+	/**
 	 * AdsGroup constructor.
 	 *
 	 * @param GoogleAdsClient $client
@@ -58,79 +54,35 @@ class AdsGroup implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Set up the additional objects for the specified campaign:
-	 * Ad group
-	 * Ad group ad
-	 * Listing group
+	 * Returns a set of operations to delete an ad group.
 	 *
 	 * @param string $campaign_resource_name
-	 * @param string $campaign_name
-	 *
-	 * @throws ApiException If any object isn't created.
+	 * @return array
 	 */
-	public function set_up_for_campaign( string $campaign_resource_name, string $campaign_name = '' ) {
-		// Create Smart Shopping ad group.
-		$created_ad_group_resource_name = $this->create_ad_group( $campaign_resource_name, $campaign_name );
+	public function delete_operations( string $campaign_resource_name ): array {
+		$ad_group_operations      = $this->ad_group_delete_operations( $campaign_resource_name );
+		$ad_group_ad_operations   = $this->ad_group_ad_delete_operations( $campaign_resource_name );
+		$listing_group_operations = $this->listing_group_delete_operations();
 
-		// Create Smart Shopping ad group ad.
-		$this->create_ad_group_ad( $created_ad_group_resource_name );
-
-		// Create ad group criterion containing listing group.
-		$this->create_shopping_listing_group( $created_ad_group_resource_name );
-	}
-
-	/**
-	 * Delete the additional objects for the specified campaign:
-	 * Ad group
-	 * Ad group ad
-	 * Listing group
-	 *
-	 * Should only be called before removing the campaign.
-	 *
-	 * @param string $campaign_resource_name
-	 *
-	 * @throws ApiException|ValidationException If any object isn't deleted.
-	 */
-	public function delete_for_campaign( string $campaign_resource_name ) {
-		$this->delete_shopping_listing_group( $campaign_resource_name );
-		$this->delete_ad_group_ad( $campaign_resource_name );
-		$this->delete_ad_group( $campaign_resource_name );
-	}
-
-	/**
-	 * @param string $campaign_resource_name
-	 * @param string $campaign_name
-	 *
-	 * @return string
-	 * @throws ApiException If the ad group isn't created.
-	 */
-	protected function create_ad_group( string $campaign_resource_name, string $campaign_name = '' ): string {
-		$ad_group = new AdGroup(
-			[
-				'name'     => $campaign_name . ' Ad Group',
-				'campaign' => $campaign_resource_name,
-				'type'     => AdGroupType::SHOPPING_SMART_ADS,
-				'status'   => AdGroupStatus::ENABLED,
-			]
+		// All assets must be deleted from the group before deleting the ad group.
+		return array_merge(
+			$listing_group_operations,
+			$ad_group_ad_operations,
+			$ad_group_operations
 		);
-
-		// Creates an ad group operation.
-		$operation = new AdGroupOperation();
-		$operation->setCreate( $ad_group );
-		$created_ad_group = $this->mutate_ad_group( $operation );
-
-		return $created_ad_group->getResourceName();
 	}
 
 	/**
+	 * Returns an ad group delete operation.
+	 *
 	 * @param string $campaign_resource_name
 	 *
-	 * @return array resource names of deleted ad groups
-	 * @throws ApiException If the ad group isn't deleted.
-	 * @throws ValidationException If the ad group query has no results.
+	 * @return MutateOperation[]
 	 */
-	public function delete_ad_group( string $campaign_resource_name ): array {
-		$return  = [];
+	protected function ad_group_delete_operations( string $campaign_resource_name ): array {
+		$operations      = [];
+		$this->ad_groups = [];
+
 		$results = ( new AdsGroupQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
 			->where( 'ad_group.campaign', $campaign_resource_name )
@@ -138,154 +90,64 @@ class AdsGroup implements OptionsAwareInterface {
 
 		/** @var GoogleAdsRow $row */
 		foreach ( $results->iterateAllElements() as $row ) {
-			$resource_name = $row->getAdGroup()->getResourceName();
-			$operation     = new AdGroupOperation();
-			$operation->setRemove( $resource_name );
-			$deleted_ad_group = $this->mutate_ad_group( $operation );
-			$return[]         = $deleted_ad_group->getResourceName();
+			$resource_name     = $row->getAdGroup()->getResourceName();
+			$this->ad_groups[] = $resource_name;
+			$operation         = ( new AdGroupOperation() )->setRemove( $resource_name );
+			$operations[]      = ( new MutateOperation() )->setAdGroupOperation( $operation );
 		}
-		return $return;
+
+		return $operations;
 	}
 
 	/**
-	 * @param AdGroupOperation $operation
+	 * Returns an ad group ad delete operation.
 	 *
-	 * @return MutateAdGroupResult
-	 * @throws ApiException If the mutate call fails.
+	 * @return MutateOperation[]
 	 */
-	protected function mutate_ad_group( AdGroupOperation $operation ): MutateAdGroupResult {
-		$response = $this->client->getAdGroupServiceClient()->mutateAdGroups(
-			$this->options->get_ads_id(),
-			[ $operation ]
-		);
+	protected function ad_group_ad_delete_operations(): array {
+		if ( empty( $this->ad_groups ) ) {
+			return [];
+		}
 
-		return $response->getResults()[0];
-	}
-
-	/**
-	 * @param string $ad_group_resource_name
-	 *
-	 * @return string
-	 * @throws ApiException If the ad group ad isn't created.
-	 */
-	protected function create_ad_group_ad( string $ad_group_resource_name ): string {
-		$ad_group_ad = new AdGroupAd(
-			[
-				'ad'       => new Ad( [ 'shopping_smart_ad' => new ShoppingSmartAdInfo() ] ),
-				'ad_group' => $ad_group_resource_name,
-			]
-		);
-
-		// Creates an ad group ad operation.
-		$operation = new AdGroupAdOperation();
-		$operation->setCreate( $ad_group_ad );
-
-		$created_ad_group_ad = $this->mutate_ad_group_ad( $operation );
-
-		return $created_ad_group_ad->getResourceName();
-	}
-
-	/**
-	 * @param string $campaign_resource_name
-	 *
-	 * @return array resource names of deleted ad group ads
-	 * @throws ApiException If the ad group ad isn't deleted.
-	 * @throws ValidationException If the ad group ad query has no results.
-	 */
-	public function delete_ad_group_ad( string $campaign_resource_name ): array {
-		$return  = [];
-		$results = ( new AdsGroupAdQuery() )
+		$operations = [];
+		$results    = ( new AdsGroupAdQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
-			->where( 'ad_group.campaign', $campaign_resource_name )
+			->where( 'ad_group_ad.ad_group', $this->ad_groups, 'IN' )
 			->get_results();
 
 		/** @var GoogleAdsRow $row */
 		foreach ( $results->iterateAllElements() as $row ) {
 			$resource_name = $row->getAdGroupAd()->getResourceName();
-			$operation     = new AdGroupAdOperation();
-			$operation->setRemove( $resource_name );
-			$deleted_ad_group_ad = $this->mutate_ad_group_ad( $operation );
-			$return[]            = $deleted_ad_group_ad->getResourceName();
+			$operation     = ( new AdGroupAdOperation() )->setRemove( $resource_name );
+			$operations[]  = ( new MutateOperation() )->setAdGroupAdOperation( $operation );
 		}
-		return $return;
+
+		return $operations;
 	}
 
 	/**
-	 * @param AdGroupAdOperation $operation
+	 * Returns an ad group listing group delete operation.
 	 *
-	 * @return MutateAdGroupAdResult
-	 * @throws ApiException If the mutate call fails.
+	 * @return MutateOperation[]
 	 */
-	protected function mutate_ad_group_ad( AdGroupAdOperation $operation ): MutateAdGroupAdResult {
-		$response = $this->client->getAdGroupAdServiceClient()->mutateAdGroupAds(
-			$this->options->get_ads_id(),
-			[ $operation ]
-		);
+	protected function listing_group_delete_operations(): array {
+		if ( empty( $this->ad_groups ) ) {
+			return [];
+		}
 
-		return $response->getResults()[0];
-	}
-
-	/**
-	 * @param string $ad_group_resource_name
-	 *
-	 * @return string
-	 * @throws ApiException If the ad group criterion isn't created.
-	 */
-	protected function create_shopping_listing_group( string $ad_group_resource_name ): string {
-		$ad_group_criterion = new AdGroupCriterion(
-			[
-				'ad_group'      => $ad_group_resource_name,
-				'status'        => AdGroupAdStatus::ENABLED,
-				'listing_group' => new ListingGroupInfo( [ 'type' => ListingGroupType::UNIT ] ),
-			]
-		);
-
-		// Creates an ad group criterion operation.
-		$operation = new AdGroupCriterionOperation();
-		$operation->setCreate( $ad_group_criterion );
-		$created_ad_group_criterion = $this->mutate_shopping_listing_group( $operation );
-
-		return $created_ad_group_criterion->getResourceName();
-	}
-
-	/**
-	 * @param string $campaign_resource_name
-	 *
-	 * @return array resource names of deleted shopping list groups
-	 * @throws ApiException If the ad group criterion isn't deleted.
-	 * @throws ValidationException If the ad group criterion query has no results.
-	 */
-	protected function delete_shopping_listing_group( string $campaign_resource_name ): array {
-		$return  = [];
-		$results = ( new AdsListingGroupQuery() )
+		$operations = [];
+		$results    = ( new AdsListingGroupQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
-			->where( 'ad_group.campaign', $campaign_resource_name )
+			->where( 'ad_group_criterion.ad_group', $this->ad_groups, 'IN' )
 			->get_results();
 
 		/** @var GoogleAdsRow $row */
 		foreach ( $results->iterateAllElements() as $row ) {
 			$resource_name = $row->getAdGroupCriterion()->getResourceName();
-			$operation     = new AdGroupCriterionOperation();
-			$operation->setRemove( $resource_name );
-			$deleted_ad_group_criterion = $this->mutate_shopping_listing_group( $operation );
-			$return[]                   = $deleted_ad_group_criterion->getResourceName();
+			$operation     = ( new AdGroupCriterionOperation() )->setRemove( $resource_name );
+			$operations[]  = ( new MutateOperation() )->setAdGroupCriterionOperation( $operation );
 		}
 
-		return $return;
-	}
-
-	/**
-	 * @param AdGroupCriterionOperation $operation
-	 *
-	 * @return MutateAdGroupCriterionResult
-	 * @throws ApiException If the mutate call fails.
-	 */
-	protected function mutate_shopping_listing_group( AdGroupCriterionOperation $operation ): MutateAdGroupCriterionResult {
-		$response = $this->client->getAdGroupCriterionServiceClient()->mutateAdGroupCriteria(
-			$this->options->get_ads_id(),
-			[ $operation ]
-		);
-
-		return $response->getResults()[0];
+		return $operations;
 	}
 }

--- a/src/API/Google/CampaignType.php
+++ b/src/API/Google/CampaignType.php
@@ -1,0 +1,114 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Google\Ads\GoogleAds\V9\Enums\AdvertisingChannelTypeEnum\AdvertisingChannelType as AdsCampaignType;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\StatusMapping;
+
+/**
+ * Mapping between Google and internal CampaignTypes
+ * https://developers.google.com/google-ads/api/reference/rpc/v9/AdvertisingChannelTypeEnum.AdvertisingChannelType
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class CampaignType extends StatusMapping {
+
+	/**
+	 * Not specified.
+	 *
+	 * @var string
+	 */
+	public const UNSPECIFIED = 'unspecified';
+
+	/**
+	 * Used for return value only. Represents value unknown in this version.
+	 *
+	 * @var string
+	 */
+	public const UNKNOWN = 'unknown';
+
+	/**
+	 * Search Network. Includes display bundled, and Search+ campaigns.
+	 *
+	 * @var string
+	 */
+	public const SEARCH = 'search';
+
+	/**
+	 * Google Display Network only.
+	 *
+	 * @var string
+	 */
+	public const DISPLAY = 'display';
+
+	/**
+	 * Shopping campaigns serve on the shopping property and on google.com search results.
+	 *
+	 * @var string
+	 */
+	public const SHOPPING = 'shopping';
+
+	/**
+	 * Hotel Ads campaigns.
+	 *
+	 * @var string
+	 */
+	public const HOTEL = 'hotel';
+
+	/**
+	 * Video campaigns.
+	 *
+	 * @var string
+	 */
+	public const VIDEO = 'video';
+
+	/**
+	 * App Campaigns, and App Campaigns for Engagement, that run across multiple channels.
+	 *
+	 * @var string
+	 */
+	public const MULTI_CHANNEL = 'multi_channel';
+
+	/**
+	 * Local ads campaigns.
+	 *
+	 * @var string
+	 */
+	public const LOCAL = 'local';
+
+	/**
+	 * Smart campaigns.
+	 *
+	 * @var string
+	 */
+	public const SMART = 'smart';
+
+	/**
+	 * Performance Max campaigns.
+	 *
+	 * @var string
+	 */
+	public const PERFORMANCE_MAX = 'performance_max';
+
+	/**
+	 * Mapping between status number and it's label.
+	 *
+	 * @var string
+	 */
+	protected const MAPPING = [
+		AdsCampaignType::UNSPECIFIED     => self::UNSPECIFIED,
+		AdsCampaignType::UNKNOWN         => self::UNKNOWN,
+		AdsCampaignType::SEARCH          => self::SEARCH,
+		AdsCampaignType::DISPLAY         => self::DISPLAY,
+		AdsCampaignType::SHOPPING        => self::SHOPPING,
+		AdsCampaignType::HOTEL           => self::HOTEL,
+		AdsCampaignType::VIDEO           => self::VIDEO,
+		AdsCampaignType::MULTI_CHANNEL   => self::MULTI_CHANNEL,
+		AdsCampaignType::LOCAL           => self::LOCAL,
+		AdsCampaignType::SMART           => self::SMART,
+		AdsCampaignType::PERFORMANCE_MAX => self::PERFORMANCE_MAX,
+	];
+}

--- a/src/API/Google/Query/AdsAssetGroupQuery.php
+++ b/src/API/Google/Query/AdsAssetGroupQuery.php
@@ -1,0 +1,24 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsAssetGroupQuery
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
+class AdsAssetGroupQuery extends AdsQuery {
+
+	/**
+	 * Query constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'asset_group' );
+		$this->columns( [ 'asset_group.resource_name' ] );
+	}
+}

--- a/src/API/Google/Query/AdsCampaignQuery.php
+++ b/src/API/Google/Query/AdsCampaignQuery.php
@@ -22,6 +22,7 @@ class AdsCampaignQuery extends AdsQuery {
 				'campaign.id',
 				'campaign.name',
 				'campaign.status',
+				'campaign.advertising_channel_type',
 				'campaign.shopping_setting.sales_country',
 				'campaign_budget.amount_micros',
 			]

--- a/src/API/Google/Query/AdsListingGroupFilterQuery.php
+++ b/src/API/Google/Query/AdsListingGroupFilterQuery.php
@@ -1,0 +1,22 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsListingGroupFilterQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
+class AdsListingGroupFilterQuery extends AdsQuery {
+
+	/**
+	 * Query constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'asset_group_listing_group_filter' );
+		$this->columns( [ 'asset_group_listing_group_filter.asset_group' ] );
+	}
+}

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
@@ -268,6 +269,13 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 				'type'              => 'string',
 				'enum'              => CampaignStatus::labels(),
 				'description'       => __( 'Campaign status.', 'google-listings-and-ads' ),
+				'context'           => [ 'view', 'edit' ],
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'type'    => [
+				'type'              => 'string',
+				'enum'              => CampaignType::labels(),
+				'description'       => __( 'Campaign type.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',
 			],

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -100,16 +100,11 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->add( Settings::class, ContainerInterface::class );
 
 		$this->share( Ads::class, GoogleAdsClient::class );
+		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class );
 		$this->share( AdsCampaignBudget::class, GoogleAdsClient::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsGroup::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );
-		$this->share(
-			AdsCampaign::class,
-			GoogleAdsClient::class,
-			AdsCampaignBudget::class,
-			AdsGroup::class
-		);
 
 		$this->share( Merchant::class, ShoppingContent::class );
 		$this->share( MerchantMetrics::class, ShoppingContent::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignBudget;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
@@ -71,6 +72,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		Merchant::class               => true,
 		MerchantMetrics::class        => true,
 		Ads::class                    => true,
+		AdsAssetGroup::class          => true,
 		AdsCampaign::class            => true,
 		AdsCampaignBudget::class      => true,
 		AdsConversionAction::class    => true,
@@ -100,6 +102,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->add( Settings::class, ContainerInterface::class );
 
 		$this->share( Ads::class, GoogleAdsClient::class );
+		$this->share( AdsAssetGroup::class, GoogleAdsClient::class );
 		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class );
 		$this->share( AdsCampaignBudget::class, GoogleAdsClient::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To support the new Performance Max campaign types we need to update the classes to create different assets for the campaign. Following is a summary of all the changes which were implemented in this PR:

- Refactor AdsCampaign to support the creation of PMax campaigns.
- Batched operations to create the campaign, it's budget and all it's assets in one request.
- Refactor AdsCampaignBudget for batched operations.
- Add AssetGroup for PMax campaigns.
- Add queries to retrieve Campaign assets. Only used for deletion since we don't show them in Get / List requests, nor do we allow them to be edited.
- Refactor AdGroup to support delete of SSC campaigns. Edit / List / Get campaign don't show any details from this group. We no longer support creation of SSC campaigns since they are being phased out, so this class only contains the delete functionality which has been refactored to support batched operations.
- Add the campaign type when we List / Get a campaign. These are added to the internal API requests, but they are not shown in the UI. At the moment the type isn't used for anything, as it automatically detects which assets to handle regardless of type. However the type can be useful when we will need to convert campaigns from SSC > PMax.


### Detailed test instructions:

One way to test this PR is to connect an Ads account (one which has been authorized for Performance Max Campaigns). Go to Marketing > Google Listings & Ads > Dashboard where the following actions can be tested:

- Add paid campaign
- List existing campaigns
- Pause / Enable a campaign
- Edit a campaign
- Delete a campaign

It will not be visible in the UI whether we are working with a SSC or a PMax campaigns, they will both show as identical.

Another alternative for testing is through Postman requests.

#### Create campaign
`POST https://domain.test/wp-json/wc/gla/ads/campaigns`

Body:
```json
{
	"name": "Campaign 2022-02-11",
	"amount": 12.00,
	"country": "US"
}
```
Response:
```json
{
	"id": 1234567890,
	"name": "Campaign 2022-02-11",
	"status": "enabled",
	"type": "performance_max",
	"amount": 12,
	"country": "US"
}
```

#### List campaigns
`GET https://domain.test/wp-json/wc/gla/ads/campaigns`

Response:
```json
[
	{
		"id": 5678901234,
		"name": "Campaign 2022-01-01",
		"status": "enabled",
		"type": "shopping",
		"amount": 18.50,
		"country": "US"
	},
	{
		"id": 1234567890
		"name": "Campaign 2022-02-11",
		"status": "enabled",
		"type": "performance_max",
		"amount": 12,
		"country": "US"
	}
]
```

#### Edit a campaign
`PATCH https://domain.test/wp-json/wc/gla/ads/campaigns/1234567890`

Body:
```json
{
	"status": "paused",
	"name": "Performance Max Campaign",
	"amount": 25
}
```

Response:
```json
{
	"status": "success",
	"message": "Successfully edited campaign.",
	"id": 1234567890
}
```

#### Delete a campaign
`DELETE https://domain.test/wp-json/wc/gla/ads/campaigns/1234567890`

Response:
```json
{
	"status": "success",
	"message": "Successfully deleted campaign.",
	"id": 1234567890
}
```

### Additional details:

Followup tasks to perform:

1. The previous classes didn't have any unit tests for campaigns. Since this is all going to be merged in a feature branch I'm planning to create an additional followup PR with some unit testing.
2. Another followup PR will need to address the reporting data to ensure this is compatible with both types of campaigns.
3. Any text where it refers to Smart Shopping Campaigns in the UI will need to be adjusted (like in the create campaign modal).

### Changelog entry
* Add - Support for Performance Max Campaigns.
>
