### PR TITLE
Make the campaign creation and edit APIs respond correct HTTP status codes

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -784,19 +784,6 @@ export function* createAdsCampaign( amount, country ) {
 			},
 		} );
 
-		{
-			/**
-			 * If the campaign creation fails, the API still responds a HTTP status code 200 response
-			 * with `message` property only. So here check the fails by data structure.
-			 *
-			 * TODO: Remove this code block after the API responds the fails in a more specific way.
-			 */
-			const keys = Object.keys( createdCampaign );
-			if ( keys.length === 1 && keys.pop() === 'message' ) {
-				throw createdCampaign;
-			}
-		}
-
 		return {
 			type: TYPES.CREATE_ADS_CAMPAIGN,
 			createdCampaign,
@@ -825,24 +812,11 @@ export function* createAdsCampaign( amount, country ) {
  */
 export function* updateAdsCampaign( id, data ) {
 	try {
-		const updatedCampaign = yield apiFetch( {
+		yield apiFetch( {
 			path: `${ API_NAMESPACE }/ads/campaigns/${ id }`,
 			method: 'PATCH',
 			data,
 		} );
-
-		{
-			/**
-			 * If the campaign update fails, the API still responds a HTTP status code 200 response
-			 * with `message` property only. So here check the fails by data structure.
-			 *
-			 * TODO: Remove this code block after the API responds the fails in a more specific way.
-			 */
-			const keys = Object.keys( updatedCampaign );
-			if ( keys.length === 1 && keys.pop() === 'message' ) {
-				throw updatedCampaign;
-			}
-		}
 
 		return {
 			type: TYPES.UPDATE_ADS_CAMPAIGN,

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -147,7 +147,7 @@ class AdsCampaign implements OptionsAwareInterface {
 			throw new Exception(
 				/* translators: %s Error message */
 				sprintf( __( 'Error creating campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
-				$this->map_grpc_code_to_http_status_code( $e ),
+				$this->map_grpc_code_to_http_status_code( $e )
 			);
 		}
 	}
@@ -223,7 +223,7 @@ class AdsCampaign implements OptionsAwareInterface {
 			throw new Exception(
 				/* translators: %s Error message */
 				sprintf( __( 'Error editing campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
-				$this->map_grpc_code_to_http_status_code( $e ),
+				$this->map_grpc_code_to_http_status_code( $e )
 			);
 		}
 	}

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -147,7 +147,7 @@ class AdsCampaign implements OptionsAwareInterface {
 			throw new Exception(
 				/* translators: %s Error message */
 				sprintf( __( 'Error creating campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
-				$e->getCode()
+				$this->map_grpc_code_to_http_status_code( $e ),
 			);
 		}
 	}
@@ -223,7 +223,7 @@ class AdsCampaign implements OptionsAwareInterface {
 			throw new Exception(
 				/* translators: %s Error message */
 				sprintf( __( 'Error editing campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
-				$e->getCode()
+				$this->map_grpc_code_to_http_status_code( $e ),
 			);
 		}
 	}

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -88,7 +88,7 @@ class AdsCampaign implements OptionsAwareInterface {
 			throw new Exception(
 				/* translators: %s Error message */
 				sprintf( __( 'Error retrieving campaigns: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
-				$e->getCode()
+				$this->map_grpc_code_to_http_status_code( $e )
 			);
 		}
 	}
@@ -140,7 +140,7 @@ class AdsCampaign implements OptionsAwareInterface {
 			if ( $this->has_api_exception_error( $e, 'DUPLICATE_CAMPAIGN_NAME' ) ) {
 				throw new Exception(
 					__( 'A campaign with this name already exists', 'google-listings-and-ads' ),
-					$e->getCode()
+					$this->map_grpc_code_to_http_status_code( $e )
 				);
 			}
 
@@ -178,7 +178,7 @@ class AdsCampaign implements OptionsAwareInterface {
 			throw new Exception(
 				/* translators: %s Error message */
 				sprintf( __( 'Error retrieving campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
-				$e->getCode()
+				$this->map_grpc_code_to_http_status_code( $e )
 			);
 		}
 	}
@@ -255,14 +255,14 @@ class AdsCampaign implements OptionsAwareInterface {
 			if ( $this->has_api_exception_error( $e, 'OPERATION_NOT_PERMITTED_FOR_REMOVED_RESOURCE' ) ) {
 				throw new Exception(
 					__( 'This campaign has already been deleted', 'google-listings-and-ads' ),
-					$e->getCode()
+					$this->map_grpc_code_to_http_status_code( $e )
 				);
 			}
 
 			throw new Exception(
 				/* translators: %s Error message */
 				sprintf( __( 'Error deleting campaign: %s', 'google-listings-and-ads' ), $e->getBasicMessage() ),
-				$e->getCode()
+				$this->map_grpc_code_to_http_status_code( $e )
 			);
 		}
 	}

--- a/src/API/Google/ApiExceptionTrait.php
+++ b/src/API/Google/ApiExceptionTrait.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\BadResponseException;
 use Google\ApiCore\ApiException;
+use Google\Rpc\Code;
 use Psr\Http\Client\ClientExceptionInterface;
 
 /**
@@ -58,5 +59,72 @@ trait ApiExceptionTrait {
 			return $message ? $default . ': ' . $message : $default;
 		}
 		return $default;
+	}
+
+	/**
+	 * Map a gRPC code to HTTP status code.
+	 *
+	 * @param ApiException $exception Exception to check.
+	 *
+	 * @return int The HTTP status code.
+	 *
+	 * @see Google\Rpc\Code for the list of gRPC codes.
+	 */
+	protected function map_grpc_code_to_http_status_code( ApiException $exception ) {
+		switch ( $exception->getCode() ) {
+			case Code::OK:
+				return 200;
+
+			case Code::CANCELLED:
+				return 499;
+
+			case Code::UNKNOWN:
+				return 500;
+
+			case Code::INVALID_ARGUMENT:
+				return 400;
+
+			case Code::DEADLINE_EXCEEDED:
+				return 504;
+
+			case Code::NOT_FOUND:
+				return 404;
+
+			case Code::ALREADY_EXISTS:
+				return 409;
+
+			case Code::PERMISSION_DENIED:
+				return 403;
+
+			case Code::UNAUTHENTICATED:
+				return 401;
+
+			case Code::RESOURCE_EXHAUSTED:
+				return 429;
+
+			case Code::FAILED_PRECONDITION:
+				return 400;
+
+			case Code::ABORTED:
+				return 409;
+
+			case Code::OUT_OF_RANGE:
+				return 400;
+
+			case Code::UNIMPLEMENTED:
+				return 501;
+
+			case Code::INTERNAL:
+				return 500;
+
+			case Code::UNAVAILABLE:
+				return 503;
+
+			case Code::DATA_LOSS:
+				return 500;
+
+			default:
+				return 500;
+		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1210 

- Add a new helper function to **ApiExceptionTrait.php** for mapping gRPC code to HTTP status code. And apply it to campaign APIs:
    - POST `ads/campaigns`
    - PATCH `ads/campaigns/:id`
- Remove the relevant client-side workarounds from **actions.js**.

### Screenshots:

https://user-images.githubusercontent.com/17420811/153840533-d95e64ff-ddd8-4fae-9587-be08b3c708cd.mp4

### Detailed test instructions:

1. Change the **Number of decimals** to 3 in WC Settings: `/wp-admin/admin.php?page=wc-settings`.
1. Open browser DevTool.
1. Go to GLA admin page and add a paid campaign.
1. Enter 0.001 in the daily average cost field.
1. Click on "Launch paid campaign" button. The `ads/campaigns` API should respond with 400 error and it should show a failure notification at bottom of page.
1. Go to edit a paid campaign.
1. Enter 0.001 in the daily average cost field.
1. Click on "Save changes" button. The `ads/campaigns/:id` API should respond with 400 error and it should show a failure notification at bottom of page.

### Additional details:

The reference of the gPRC codes in `googleads/google-ads-php` package:
- https://github.com/googleapis/common-protos-php/blob/1.4.0/src/Rpc/Code.php

### Changelog entry

> Fix - Fix incorrect HTTP status code when campaign creation and edit APIs call fails.
