### PR TITLE
Fix/1205 plugin performance

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -57,7 +57,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ContactInformation as ContactInformationNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\CompleteSetup as CompleteSetupNote;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notes\Note;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\NoteInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReviewAfterClicks as ReviewAfterClicksNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReviewAfterConversions as ReviewAfterConversionsNote;
@@ -268,7 +267,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( SetupCampaignNote::class, MerchantStatuses::class );
 		$this->share_with_tags( SetupCampaign2Note::class, MerchantStatuses::class );
 		$this->share_with_tags( SetupCouponSharingNote::class, MerchantStatuses::class );
-		$this->share_with_tags( NoteInitializer::class, ActionScheduler::class, Note::class );
+		$this->share_with_tags( NoteInitializer::class, ActionScheduler::class );
 
 		// Product attributes
 		$this->conditionally_share_with_tags( AttributeManager::class );

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-interface Note extends Service {
+interface Note {
 
 	/**
 	 * Get the note's unique name.

--- a/src/Notes/NoteInitializer.php
+++ b/src/Notes/NoteInitializer.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -24,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class NoteInitializer implements Activateable, Deactivateable, InstallableInterface, Service, Registerable {
+class NoteInitializer implements Activateable, Deactivateable, InstallableInterface, Service, Registerable, ContainerAwareInterface {
 
 	use ValidateInterface;
 	use ContainerAwareTrait;

--- a/src/Notes/NoteInitializer.php
+++ b/src/Notes/NoteInitializer.php
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * NoteInitializer class.
  *
- *  * ContainerAware used to access:
+ * ContainerAware used to access:
  * - Note
  *
  * @since 1.7.0

--- a/src/Notes/NoteInitializer.php
+++ b/src/Notes/NoteInitializer.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -26,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 class NoteInitializer implements Activateable, Deactivateable, InstallableInterface, Service, Registerable {
 
 	use ValidateInterface;
-
+	use ContainerAwareTrait;
 	/**
 	 * Hook name for daily cron.
 	 */
@@ -38,25 +39,12 @@ class NoteInitializer implements Activateable, Deactivateable, InstallableInterf
 	protected $action_scheduler;
 
 	/**
-	 * Array of notes to initialize.
-	 *
-	 * @var Note[]
-	 */
-	protected $notes;
-
-	/**
 	 * Cron constructor.
 	 *
 	 * @param ActionSchedulerInterface $action_scheduler
-	 * @param Note[]                   $notes
 	 */
-	public function __construct( ActionSchedulerInterface $action_scheduler, array $notes ) {
-		foreach ( $notes as $note ) {
-			$this->validate_instanceof( $note, Note::class );
-		}
-
+	public function __construct( ActionSchedulerInterface $action_scheduler ) {
 		$this->action_scheduler = $action_scheduler;
-		$this->notes            = $notes;
 	}
 
 	/**
@@ -70,7 +58,9 @@ class NoteInitializer implements Activateable, Deactivateable, InstallableInterf
 	 * Loop through all notes to add any that should be added.
 	 */
 	public function add_notes(): void {
-		foreach ( $this->notes as $note ) {
+		$notes = $this->container->get( Note::class );
+
+		foreach ( $notes as $note ) {
 			try {
 				if ( $note->should_be_added() ) {
 					$note->get_entry()->save();

--- a/src/Notes/NoteInitializer.php
+++ b/src/Notes/NoteInitializer.php
@@ -32,6 +32,7 @@ class NoteInitializer implements Activateable, Deactivateable, InstallableInterf
 
 	use ValidateInterface;
 	use ContainerAwareTrait;
+
 	/**
 	 * Hook name for daily cron.
 	 */

--- a/src/Notes/NoteInitializer.php
+++ b/src/Notes/NoteInitializer.php
@@ -21,6 +21,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * NoteInitializer class.
  *
+ *  * ContainerAware used to access:
+ * - Note
+ *
  * @since 1.7.0
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes

--- a/src/Notes/NoteInitializer.php
+++ b/src/Notes/NoteInitializer.php
@@ -115,7 +115,8 @@ class NoteInitializer implements Activateable, Deactivateable, InstallableInterf
 		// Ensure all note names are deleted
 		if ( class_exists( Notes::class ) ) {
 			$note_names = [];
-			foreach ( $this->notes as $note ) {
+			$notes      = $this->container->get( Note::class );
+			foreach ( $notes as $note ) {
 				$note_names[] = $note->get_name();
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1205 

This PR is addressing the issue with  with the function `GoogleAdsFailures::init()` and [protobuf library](https://developers.google.com/protocol-buffers). 
See issue #1205 for more context.

![image](https://user-images.githubusercontent.com/2488994/153929242-5c1cdd34-741c-428c-9bef-8f68d7f6c0f1.png)


The issue was generated because NoteInitializer class was creating an array of `Notes`, including `ReviewAfterClicksNote` & `ReviewAfterConversionsNote` instances. Every instance of `ReviewAfterClicksNote` & `ReviewAfterConversionsNote` needs a `GoogleAdsclient` instance and `GoogleAdsclient`  is calling `GoogleAdsFailures::init()`.

The Notes are used in a scheduled job therefore is not required to load these instances on every request to the website.
To avoid this behaviour we are creating the Notes instances only when the cron job is executed.

### Screenshots:

Cachegrind report using this PR: 
![image](https://user-images.githubusercontent.com/2488994/153932991-e9b79d21-67a9-4568-b6a2-524a0695f691.png)


### Detailed test instructions:

**How to check that the bottleneck with the Google Ads library has been resolved:**
1. Set xDebug in profile mode.
2. Load the page as a visitor. 
3. Check the cachegrind reports. You should not see that the Google Ads Library is consuming excessive resources. 
It should be similar to the above image.

**How to test that Notes are working:**

1. Set up GLA account.
2. Check that in Tools->Scheduled jobs there is a wc_gla_cron_daily_notes job in the pending tab. If the cron job is not created, deactivate and activate the plugin to trigger the registration again.
3. To force to show one of the notes, add the following transient:
set_transient( 'gla_ads_metrics', [	'clicks' => 20,'conversions' => 20,'impressions' => 20], 3600 ); in plugins_loaded hook in `google-listings-and-ads.php` file. 
4. Go to Tools->Scheduled jobs and run the job manually wc_gla_cron_daily_notes.
5. Go to Woocommerce->Home in the inbox section you should see a new note: “You’ve gotten 20+ conversions through Google Ads! ”

Notes: 

If you already have the Note: “You’ve gotten X+ conversions…” you will need to delete it from the DB. In your DB run `DELETE FROM wp_wc_admin_notes WHERE `name` = 'gla-review-after-conversions';`


### Additional details:

- `GoogleAdsFailures::init()` will still be invoked in the admin page as it is required to use the GoogleAdsClient. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Performance issue related with NoteInitializer class.
