### PR TITLE
Avoid the false positive of PHP test failures

### DIFF
--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -82,7 +82,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
             ->with( $this->callback( function ( $entries ) use ( $expected_coupon_entry ) {
                 return $entries[0]->get_wc_coupon_id() === $expected_coupon_entry->get_wc_coupon_id();
             } ) );
-        sleep(1);
+
         wp_trash_post( $coupon->get_id() );
     }
 
@@ -100,7 +100,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
             ->with( $this->callback( function ( $entries ) use ( $expected_coupon_entry ) {
                 return $entries[0]->get_wc_coupon_id() === $expected_coupon_entry->get_wc_coupon_id();
             } ) );
-        sleep(1);
+
         // force delete post
         wp_delete_post( $coupon->get_id(), true );
     }

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -80,7 +80,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
         $this->delete_coupon_job->expects( $this->once() )
             ->method( 'schedule' )
             ->with( $this->equalTo( [$expected_coupon_entry] ) );
-
+        sleep(1);
         wp_trash_post( $coupon->get_id() );
     }
 
@@ -96,7 +96,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
         $this->delete_coupon_job->expects( $this->once() )
             ->method( 'schedule' )
             ->with( $this->equalTo( [$expected_coupon_entry] ) );
-
+        sleep(1);
         // force delete post
         wp_delete_post( $coupon->get_id(), true );
     }

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -79,7 +79,9 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
             ['US' => 'google_id'] );
         $this->delete_coupon_job->expects( $this->once() )
             ->method( 'schedule' )
-            ->with( $this->equalTo( [$expected_coupon_entry] ) );
+            ->with( $this->callback( function ( $entries ) use ( $expected_coupon_entry ) {
+                return $entries[0]->get_wc_coupon_id() === $expected_coupon_entry->get_wc_coupon_id();
+            } ) );
         sleep(1);
         wp_trash_post( $coupon->get_id() );
     }
@@ -95,7 +97,9 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
             ['US' => 'google_id'] );
         $this->delete_coupon_job->expects( $this->once() )
             ->method( 'schedule' )
-            ->with( $this->equalTo( [$expected_coupon_entry] ) );
+            ->with( $this->callback( function ( $entries ) use ( $expected_coupon_entry ) {
+                return $entries[0]->get_wc_coupon_id() === $expected_coupon_entry->get_wc_coupon_id();
+            } ) );
         sleep(1);
         // force delete post
         wp_delete_post( $coupon->get_id(), true );

--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -145,7 +145,7 @@ class WCCouponAdapterTest extends UnitTest {
 	        'post_date_gmt' => $postdate,
 	    );
 	    wp_update_post( $post_args);
-	    sleep(1);
+
 	    $adapted_coupon = new WCCouponAdapter(
 	        [
 	            'wc_coupon'     => $coupon,

--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -154,9 +154,12 @@ class WCCouponAdapterTest extends UnitTest {
 	        );
 	    $adapted_coupon->disable_promotion( $coupon );
 
-	    $this->assertEquals(
-	        "$postdate/$postdate",
-	        $adapted_coupon->getPromotionEffectiveDates() );
+	    $dates = explode( '/', $adapted_coupon->getPromotionEffectiveDates() );
+	    $now = date(DATE_ATOM);
+
+	    $this->assertEquals( $postdate, $dates[0] );
+	    $this->assertGreaterThanOrEqual( $postdate, $dates[1] );
+	    $this->assertLessThanOrEqual( $now, $dates[1] );
 	}
 
 	public function test_product_id_restrictions() {

--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -145,7 +145,7 @@ class WCCouponAdapterTest extends UnitTest {
 	        'post_date_gmt' => $postdate,
 	    );
 	    wp_update_post( $post_args);
-
+	    sleep(1);
 	    $adapted_coupon = new WCCouponAdapter(
 	        [
 	            'wc_coupon'     => $coupon,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I've encountered several false positive of PHP test failures, and although I can pass after re-run GH Action jobs, it's still a bit distracting. Such as these jobs:
- https://github.com/woocommerce/google-listings-and-ads/runs/5194436368?check_suite_focus=true#step:6:36
- https://github.com/woocommerce/google-listings-and-ads/runs/5094880222?check_suite_focus=true#step:6:41
- https://github.com/woocommerce/google-listings-and-ads/runs/4949201564?check_suite_focus=true#step:6:41

This PR tries to avoid the above problems by:
- Match a range for the end date of disabling a coupon.
- Assert coupon ID instead of an entire instance when scheduling jobs of trashing and deleting a coupon.

### Screenshots:

#### 📷  Added `sleep(1)` to force these time factor PHP test to fail
![2022-02-15 18 51 37](https://user-images.githubusercontent.com/17420811/154047603-26a5ef7f-70e2-4bea-b677-c75bed4afd6b.png)

#### 📷  After the fixes, those tests are passed without removing the above forcing `sleep(1)` codes
![image](https://user-images.githubusercontent.com/17420811/154049376-0cebd3d6-feab-4a86-a08a-06fcc5557c4b.png)

### Detailed test instructions:

#### Check on GitHub

1. Go to [this Actions page](https://github.com/woocommerce/google-listings-and-ads/runs/5198695049?check_suite_focus=true#step:6:28) to see the failed tests, which were seeded by https://github.com/woocommerce/google-listings-and-ads/pull/1245/commits/12d1593242ad73240bec5d3a01b94e9ef2655c1a.
2. Go to [this Actions page](https://github.com/woocommerce/google-listings-and-ads/runs/5198738262?check_suite_focus=true#step:6:28) to see those tests are passed after the fixes by https://github.com/woocommerce/google-listings-and-ads/pull/1245/commits/6ea98444cd2f99138a40cc77badbaaf882598b32.

#### Test on local env

1. Check out `12d1593242ad73240bec5d3a01b94e9ef2655c1a`
2. Run `vendor/bin/phpunit --filter '/test_disable_promotion|test_(trash|delete)_simple_coupon_schedules_delete_job/'` to see the failed tests.
3. Check out `6ea98444cd2f99138a40cc77badbaaf882598b32`
4. Run `vendor/bin/phpunit --filter '/test_disable_promotion|test_(trash|delete)_simple_coupon_schedules_delete_job/'` to check if the above failed tests are passed.

### Changelog entry
