### PR TITLE
Changing Google Listings icon for Google Listings And Ads Attributes

### DIFF
--- a/js/src/product-attributes/index.scss
+++ b/js/src/product-attributes/index.scss
@@ -36,6 +36,12 @@
 	}
 }
 
+#woocommerce-product-data ul.wc-tabs li.gla_attributes_tab {
+	a::before {
+		content: "\f18b";
+	}
+}
+
 .gla-channel-visibility-box .form-row > select {
 	display: block;
 	margin: $grid-unit-10 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Replacing the default wrench icon to Google icon.

Closes #1232 .

When editing a product you will see product data tabs. Each tab has a corresponding icon. When installing and activating Goole Listings And Ads extension, each product will receive an another tab called Google Listings And Ads, but with the wrench icon which is also the icon for General product attributes tab and a default one. Assign Google Listings And Ads with its own Google icon from the icon set.

### Screenshots:

![Edit_product_“Beanie_with_Logo”_‹_Woo_s_👾_Commerce_—_WordPress](https://user-images.githubusercontent.com/9010963/154247844-4ec26e12-2377-4e79-856d-d8e587410fff.png)

### Detailed test instructions:

1. Install and Activate Google Listings And Ads extension
2. Go Edit a product
3. Look for Google Listings And Ads attributes tab

Was:
![Edit_product_“Beanie_with_Logo”_‹_Woo_s_👾_Commerce_—_WordPress](https://user-images.githubusercontent.com/9010963/154248327-94dc711a-c971-4bb8-8d95-eab4685765e4.png)

Should be:
![Edit_product_“Beanie_with_Logo”_‹_Woo_s_👾_Commerce_—_WordPress](https://user-images.githubusercontent.com/9010963/154247844-4ec26e12-2377-4e79-856d-d8e587410fff.png)

### Changelog entry

> Add - Google Listings And Ads product attributes icon
