### PR TITLE
Return the updated or inserted rate in the response

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
@@ -186,14 +186,11 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 				$existing       = ! empty( $existing_query->get_results() );
 
 				if ( $existing ) {
-					$update_query->update(
-						$data,
-						[
-							'id' => $existing_query->get_results()[0]['id'],
-						]
-					);
+					$rate_id = $existing_query->get_results()[0]['id'];
+					$update_query->update( $data, [ 'id' => $rate_id ] );
 				} else {
 					$update_query->insert( $data );
+					$rate_id = $update_query->last_insert_id();
 				}
 			} catch ( InvalidQuery $e ) {
 				return $this->error_from_exception(
@@ -206,14 +203,21 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 				);
 			}
 
+			// Fetch updated/inserted rate to return in response.
+			$rate_response = $this->prepare_item_for_response(
+				$this->get_shipping_rate_by_id( (string) $rate_id ),
+				$request
+			);
+
 			return new Response(
 				[
 					'status'  => 'success',
 					'message' => sprintf(
-					/* translators: %s is the country code in ISO 3166-1 alpha-2 format. */
-						__( 'Successfully added rates for country: "%s".', 'google-listings-and-ads' ),
+						/* translators: %s is the country code in ISO 3166-1 alpha-2 format. */
+						__( 'Successfully added rate for country: "%s".', 'google-listings-and-ads' ),
 						$country
 					),
+					'rate'    => $rate_response->get_data(),
 				],
 				201
 			);

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
@@ -175,7 +175,7 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 	 */
 	protected function get_create_rate_callback(): callable {
 		return function ( Request $request ) {
-			$update_query = $this->create_query();
+			$shipping_rate_query = $this->create_query();
 
 			try {
 				$data    = $this->prepare_item_for_database( $request );
@@ -187,10 +187,10 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 
 				if ( $existing ) {
 					$rate_id = $existing_query->get_results()[0]['id'];
-					$update_query->update( $data, [ 'id' => $rate_id ] );
+					$shipping_rate_query->update( $data, [ 'id' => $rate_id ] );
 				} else {
-					$update_query->insert( $data );
-					$rate_id = $update_query->last_insert_id();
+					$shipping_rate_query->insert( $data );
+					$rate_id = $shipping_rate_query->last_insert_id();
 				}
 			} catch ( InvalidQuery $e ) {
 				return $this->error_from_exception(

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -397,6 +397,17 @@ abstract class Query implements QueryInterface {
 	}
 
 	/**
+	 * Returns the last inserted ID. Must be called after insert.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return int
+	 */
+	public function last_insert_id(): int {
+		return $this->wpdb->insert_id;
+	}
+
+	/**
 	 * Delete rows from the database.
 	 *
 	 * @param string $where_column Column to use when looking for values to delete.

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -42,6 +42,13 @@ abstract class Query implements QueryInterface {
 	 */
 	protected $count = null;
 
+	/**
+	 * The last inserted ID (updated after a call to insert).
+	 *
+	 * @var int
+	 */
+	protected $last_insert_id = null;
+
 	/** @var TableInterface */
 	protected $table;
 
@@ -393,6 +400,9 @@ abstract class Query implements QueryInterface {
 			throw InvalidQuery::from_insert( $this->wpdb->last_error ?: 'Error inserting data.' );
 		}
 
+		// Save a local copy of the last inserted ID.
+		$this->last_insert_id = $this->wpdb->insert_id;
+
 		return $result;
 	}
 
@@ -401,10 +411,10 @@ abstract class Query implements QueryInterface {
 	 *
 	 * @since x.x.x
 	 *
-	 * @return int
+	 * @return int|null
 	 */
-	public function last_insert_id(): int {
-		return $this->wpdb->insert_id;
+	public function last_insert_id(): ?int {
+		return $this->last_insert_id;
 	}
 
 	/**

--- a/src/DB/QueryInterface.php
+++ b/src/DB/QueryInterface.php
@@ -92,6 +92,15 @@ interface QueryInterface {
 	public function insert( array $data ): int;
 
 	/**
+	 * Returns the last inserted ID. Must be called after insert.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return int
+	 */
+	public function last_insert_id(): int;
+
+	/**
 	 * Delete rows from the database.
 	 *
 	 * @param string $where_column Column to use when looking for values to delete.
@@ -112,6 +121,7 @@ interface QueryInterface {
 	 * @throws InvalidQuery When there is an error updating data, or when an empty where array is provided.
 	 */
 	public function update( array $data, array $where ): int;
+
 	/**
 	 * Batch update or insert a set of records.
 	 *

--- a/src/DB/QueryInterface.php
+++ b/src/DB/QueryInterface.php
@@ -96,9 +96,9 @@ interface QueryInterface {
 	 *
 	 * @since x.x.x
 	 *
-	 * @return int
+	 * @return int|null
 	 */
-	public function last_insert_id(): int;
+	public function last_insert_id(): ?int;
 
 	/**
 	 * Delete rows from the database.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The delete batch endpoint for shipping rates requires a list of ID's. However if we have just inserted new shipping rates (which are auto-saved) we won't know their ID's until we refetch the whole list of shipping rates again.

This PR prevents the refetch from being required by returning the inserted/updated rates within the response.

Note: We do refetch the full shipping rate again from the database, however since this is from the local DB I think this is still acceptable and shouldn't create any additional delays.

### Detailed test instructions:

Send a batch request to update/insert several rates.

`POST https://domain.test/wp-json/wc/gla/mc/shipping/rates/batch`

```json
{
  "rates": [
    {
      "country": "PT",
      "method": "flat_rate",
      "currency": "USD",
      "rate": 80,
      "options": {
        "free_shipping_threshold": "2000"
      }
    },
    {
      "country": "DE",
      "method": "flat_rate",
      "currency": "USD",
      "rate": 50,
      "options": {
        "free_shipping_threshold": "1200"
      }
    },
    {
      "country": "US",
      "method": "flat_rate",
      "currency": "USD",
      "rate": 10
    }
  ]
}
```

Expected response with rates:

```json
{
	"errors": [],
	"success": [
		{
			"status": "success",
			"message": "Successfully added rate for country: \"PT\".",
			"rate": {
				"id": "2",
				"country": "PT",
				"method": "flat_rate",
				"currency": "USD",
				"rate": "80",
				"options": {
					"free_shipping_threshold": 2000
				}
			}
		},
		{
			"status": "success",
			"message": "Successfully added rate for country: \"DE\".",
			"rate": {
				"id": "3",
				"country": "DE",
				"method": "flat_rate",
				"currency": "USD",
				"rate": "50",
				"options": {
					"free_shipping_threshold": 1200
				}
			}
		},
		{
			"status": "success",
			"message": "Successfully added rate for country: \"US\".",
			"rate": {
				"id": "4",
				"country": "US",
				"method": "flat_rate",
				"currency": "USD",
				"rate": "10",
				"options": []
			}
		}
	]
}
```

### Changelog entry

* Tweak - Return the updated or inserted rate in the API response.
