### PR TITLE
Fix the `null.toString()` exception in the `useAdsCurrency` hook

### DIFF
--- a/js/src/hooks/useAdsCurrency.js
+++ b/js/src/hooks/useAdsCurrency.js
@@ -44,7 +44,10 @@ export default function useAdsCurrency() {
 	const { googleAdsAccount, hasFinishedResolution } = useGoogleAdsAccount();
 
 	// Apply store's foramtting config with the Ad's currency and symbol.
-	const { currency: code = '', symbol = '' } = googleAdsAccount || {};
+	// The `currency` and `symbol` could be `null`,
+	// so it cannot be assigned default values with destructuring assignment.
+	const code = googleAdsAccount?.currency || '';
+	const symbol = googleAdsAccount?.symbol || '';
 	const adsCurrencyConfig = useMemo( () => {
 		return {
 			...storeCurrencySetting,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug introduced by #1240. 🤦‍♂️  And the bug is not released.

#### The problem

An exception will occur when no connected Google Ads account.

![image](https://user-images.githubusercontent.com/17420811/154454037-58dffae3-0830-40d1-8967-23a6876a68de.png)

### Screenshots:

#### 📷  Without connected Google Ads account.
![image](https://user-images.githubusercontent.com/17420811/154454362-ecac5897-8fc9-4fdb-8edd-3c4fc51e4095.png)

#### 📷  After connecting Google Ads account.
![image](https://user-images.githubusercontent.com/17420811/154455540-d6496c27-96c5-4444-9be0-6a8262e73053.png)

### Detailed test instructions:

1. Add snippets in the **google-listings-and-ads.php** file if you don't have report data to check it
    ```php
    add_filter(
    	'woocommerce_gla_prepared_response_mc-reports-programs',
    	function( $response ) {
    		return json_decode( file_get_contents( __DIR__ . '/tests/mocks/mc/reports/programs.json' ), true ) ?: [];
    	},
    );
    
    add_filter(
    	'woocommerce_gla_prepared_response_ads-reports-programs',
    	function( $response ) {
    		return json_decode( file_get_contents( __DIR__ . '/tests/mocks/ads/reports/programs.json' ), true ) ?: [];
    	},
    );
    
    add_filter(
    	'woocommerce_gla_prepared_response_mc-reports-products',
    	function( $response ) {
    		return json_decode( file_get_contents( __DIR__ . '/tests/mocks/mc/reports/products.json' ), true ) ?: [];
    	},
    );
    
    add_filter(
    	'woocommerce_gla_prepared_response_ads-reports-products',
    	function( $response ) {
    		return json_decode( file_get_contents( __DIR__ . '/tests/mocks/ads/reports/products.json' ), true ) ?: [];
    	},
    );
    ```
2. Disconnect Google Ads account or simulate the `null` properties by adding the following codes
    ```js
    response.currency = null;
    response.symbol = null;
    ```
    at the line **397** of *js/src/data/actions.js*
    https://github.com/woocommerce/google-listings-and-ads/blob/1388b515e487cafe52aecb7472b4caebc73bb8e4/js/src/data/actions.js#L392-L401
3. Go to dashboard page or report pages.
4. It should have no exception that calls `toString()` on `null`.
5. Complete Google Ads setup or remove the simulation codes added by step 2.
6. All the "Total Sales", "Total Spend" and "Spend" metrics should be displayed in your ads account's currency.

### Changelog entry
