### PR TITLE
Unit tests for the CampaignController

### DIFF
--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -13,7 +13,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166Aware
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use DateTime;
 use Exception;
-use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
@@ -34,13 +33,14 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 	protected $ads_campaign;
 
 	/**
-	 * BaseController constructor.
+	 * CampaignController constructor.
 	 *
-	 * @param ContainerInterface $container
+	 * @param RESTServer  $server
+	 * @param AdsCampaign $ads_campaign
 	 */
-	public function __construct( ContainerInterface $container ) {
-		parent::__construct( $container->get( RESTServer::class ) );
-		$this->ads_campaign = $container->get( AdsCampaign::class );
+	public function __construct( RESTServer $server, AdsCampaign $ads_campaign ) {
+		parent::__construct( $server );
+		$this->ads_campaign = $ads_campaign;
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService as AdsAccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
@@ -82,7 +83,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( SettingsController::class );
 		$this->share( ConnectionController::class );
 		$this->share( AdsAccountController::class, AdsAccountService::class );
-		$this->share_with_container( AdsCampaignController::class );
+		$this->share( AdsCampaignController::class, AdsCampaign::class );
 		$this->share_with_container( AdsReportsController::class );
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -81,7 +81,13 @@ abstract class RESTControllerUnitTest extends UnitTest {
 	 */
 	protected function do_request( string $endpoint, string $type = 'GET', array $params = [] ): object {
 		$request = new Request( $type, $endpoint );
-		'GET' === $type ? $request->set_query_params( $params ) : $request->set_body_params( $params );
+		if ( 'GET' === $type ) {
+			$request->set_query_params( $params );
+		} else {
+			// Set the body as JSON encoded data.
+			$request->set_header( 'content-type', 'application/json' );
+			$request->set_body( wp_json_encode( $params ) );
+		}
 		return $this->server->dispatch_request( $request );
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\CampaignController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class CampaignControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ *
+ * @property AdsCampaign|MockObject         $ads_campaign
+ * @property ISO3166DataProvider|MockObject $iso_provider;
+ * @property CampaignController             $controller
+ */
+class CampaignControllerTest extends RESTControllerUnitTest {
+
+	protected const TEST_CAMPAIGN_ID = 1234567890;
+	protected const ROUTE_CAMPAIGNS  = '/wc/gla/ads/campaigns';
+	protected const ROUTE_CAMPAIGN   = '/wc/gla/ads/campaigns/' . self::TEST_CAMPAIGN_ID;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->ads_campaign = $this->createMock( AdsCampaign::class );
+		$this->iso_provider = $this->createMock( ISO3166DataProvider::class );
+
+		$this->controller = new CampaignController( $this->server, $this->ads_campaign );
+		$this->controller->register();
+		$this->controller->set_iso3166_provider( $this->iso_provider );
+	}
+
+	public function test_get_campaigns() {
+		$campaigns_data = [
+			[
+				'id'      => self::TEST_CAMPAIGN_ID,
+				'name'    => 'Campaign One',
+				'status'  => 'paused',
+				'type'    => 'shopping',
+				'amount'  => 10,
+				'country' => 'US',
+			],
+			[
+				'id'      => 5678901234,
+				'name'    => 'Campaign Two',
+				'status'  => 'enabled',
+				'type'    => 'performance_max',
+				'amount'  => 20,
+				'country' => 'UK',
+			],
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaigns' )
+			->willReturn( $campaigns_data );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'GET' );
+
+		$this->assertEquals( $campaigns_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_campaigns_with_api_exception() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaigns' )
+			->willThrowException( new Exception( 'error', 401 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'GET' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_create_campaign() {
+		$campaign_data = [
+			'name'    => 'New Campaign',
+			'amount'  => 20,
+			'country' => 'US',
+		];
+
+		$expected = [
+			'id'     => self::TEST_CAMPAIGN_ID,
+			'status' => 'enabled',
+			'type'   => 'performance_max',
+		] + $campaign_data;
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'create_campaign' )
+			->with( $campaign_data )
+			->willReturn( $expected );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_create_campaign_without_name() {
+		$campaign_data = [
+			'amount'  => 30,
+			'country' => 'GB',
+		];
+
+		$expected = [
+			'name'   => 'Campaign 2022-02-22 02:22:02',
+			'id'     => self::TEST_CAMPAIGN_ID,
+			'status' => 'enabled',
+			'type'   => 'performance_max',
+		] + $campaign_data;
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'create_campaign' )
+			->willReturnCallback(
+				function( array $data ) use ( $campaign_data, $expected ) {
+					$name = $data['name'];
+					unset( $data['name'] );
+
+					// Confirm name matches the datetime format.
+					$this->assertStringMatchesFormat( 'Campaign %d-%d-%d %d:%d:%d', $name, 'Name does not match' );
+					$this->assertEquals( $data, $campaign_data );
+
+					return $expected;
+				}
+			);
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_create_campaign_invalid_country_code() {
+		$campaign_data = [
+			'amount'  => 20,
+			'country' => 'United States',
+		];
+
+		$this->iso_provider
+			->method( 'alpha2' )
+			->willThrowException( new Exception( 'invalid_country' ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): country', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_create_campaign_with_api_exception() {
+		$campaign_data = [
+			'amount'  => 20,
+			'country' => 'US',
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'create_campaign' )
+			->willThrowException( new Exception( 'error', 401 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_create_campaign_missing_parameters() {
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', [] );
+
+		$this->assertEquals( 'Missing parameter(s): amount, country', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_get_campaign() {
+		$campaign_data = [
+			'id'      => self::TEST_CAMPAIGN_ID,
+			'name'    => 'Campaign Name',
+			'status'  => 'enabled',
+			'type'    => 'performance_max',
+			'amount'  => 10,
+			'country' => 'US',
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willReturn( $campaign_data );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'GET' );
+
+		$this->assertEquals( $campaign_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_campaign_not_found() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willReturn( [] );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'GET' );
+
+		$this->assertEquals(
+			[
+				'message' => 'Campaign is not available.',
+				'id'      => self::TEST_CAMPAIGN_ID,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	public function test_get_campaign_with_api_exception() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willThrowException( new Exception( 'error', 500 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'GET' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 500, $response->get_status() );
+	}
+
+	public function test_edit_campaign() {
+		$campaign_data = [
+			'amount'  => 44.55,
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'edit_campaign' )
+			->with( self::TEST_CAMPAIGN_ID, $campaign_data )
+			->willReturn( self::TEST_CAMPAIGN_ID );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'POST', $campaign_data );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully edited campaign.',
+				'id'      => self::TEST_CAMPAIGN_ID,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_campaign_country() {
+		$campaign_data = [
+			'country' => 'GB',
+		];
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'POST', $campaign_data );
+
+		$this->assertEquals(
+			[
+				'status'  => 'invalid_data',
+				'message' => 'Invalid edit data.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_edit_campaign_with_api_exception() {
+		$campaign_data = [
+			'amount' => 0.001,
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'edit_campaign' )
+			->with( self::TEST_CAMPAIGN_ID, $campaign_data )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'POST', $campaign_data );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_delete_campaign() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'delete_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willReturn( self::TEST_CAMPAIGN_ID );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'DELETE' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully deleted campaign.',
+				'id'      => self::TEST_CAMPAIGN_ID,
+			], $response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_delete_campaign_with_api_exception() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'delete_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'DELETE' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds unit tests for the Campaign Controller, based on the [Performance Max Campaigns branch](https://github.com/woocommerce/google-listings-and-ads/tree/feature/pmax-campaigns).

### Detailed test instructions:
Run the unit tests and confirm they all pass.

### Additional details:
The RESTControllerUnitTest class was using set_body_params for sending the data in a test request. This works fine for most controllers we test because they extract the data with `get_param` which checks if the parameter is set in any of the following:
- Query parameters ($_GET)
- Body parameters ($_POST)
- JSON parameters (parsed JSON from the body)

However in the campaign controller we extract the parameters specifically from the JSON body using `get_json_params`. That's because the regular body parameters are for post data, but we work with JSON data being sent to the API.

To fix that I modified the RESTControllerUnitTest class in this PR to set the body as JSON encoded data, and set the content-type header (which matches how we send real requests to the API).

### Changelog entry
* Add - Unit tests for the CampaignController class.
