### PR TITLE
Enhance `useAdsCurrency` tests and add a case for testing the fallback values of currency config

### DIFF
--- a/js/src/hooks/useAdsCurrency.js
+++ b/js/src/hooks/useAdsCurrency.js
@@ -23,8 +23,7 @@ import useGoogleAdsAccount from './useGoogleAdsAccount';
  * Usage:
  *
  * ```js
- * const { currencyConfig, hasFinishedResolution, formatAmount } = useAdsCurrency()
- * console.log( hasFinishedResolution ) // true
+ * const { currencyConfig, formatAmount } = useAdsCurrency()
  *
  * console.log( currencyConfig.config )          // { code: 'CAD', symbol: '$', decimalSeparator: '.', thousandSeparator: ',', precision: 2, priceFormat: '%1$s %2$s' }
  * console.log( formatAmount( 1234.567 ) )       // '$ 1,234.57'
@@ -37,11 +36,11 @@ import useGoogleAdsAccount from './useGoogleAdsAccount';
  *
  * @see useStoreCurrency
  *
- * @return {{adsCurrencyConfig: Object, hasFinishedResolution: boolean | undefined, formatAmount: Function}} The currency object.
+ * @return {{adsCurrencyConfig: Object, formatAmount: Function}} The currency object.
  */
 export default function useAdsCurrency() {
 	const storeCurrencySetting = useStoreCurrency();
-	const { googleAdsAccount, hasFinishedResolution } = useGoogleAdsAccount();
+	const { googleAdsAccount } = useGoogleAdsAccount();
 
 	// Apply store's foramtting config with the Ad's currency and symbol.
 	// The `currency` and `symbol` could be `null`,
@@ -62,7 +61,6 @@ export default function useAdsCurrency() {
 
 	return {
 		adsCurrencyConfig,
-		hasFinishedResolution,
 		formatAmount,
 	};
 }

--- a/js/src/hooks/useAdsCurrency.js
+++ b/js/src/hooks/useAdsCurrency.js
@@ -42,7 +42,7 @@ export default function useAdsCurrency() {
 	const storeCurrencySetting = useStoreCurrency();
 	const { googleAdsAccount } = useGoogleAdsAccount();
 
-	// Apply store's foramtting config with the Ad's currency and symbol.
+	// Apply store's formatting config with the Ad's currency and symbol.
 	// The `currency` and `symbol` could be `null`,
 	// so they cannot be assigned default values with destructuring assignment.
 	const code = googleAdsAccount?.currency || '';

--- a/js/src/hooks/useAdsCurrency.js
+++ b/js/src/hooks/useAdsCurrency.js
@@ -45,7 +45,7 @@ export default function useAdsCurrency() {
 
 	// Apply store's foramtting config with the Ad's currency and symbol.
 	// The `currency` and `symbol` could be `null`,
-	// so it cannot be assigned default values with destructuring assignment.
+	// so they cannot be assigned default values with destructuring assignment.
 	const code = googleAdsAccount?.currency || '';
 	const symbol = googleAdsAccount?.symbol || '';
 	const adsCurrencyConfig = useMemo( () => {

--- a/js/src/hooks/useAdsCurrency.test.js
+++ b/js/src/hooks/useAdsCurrency.test.js
@@ -2,44 +2,40 @@
  * External dependencies
  */
 import { renderHook } from '@testing-library/react-hooks';
-import { apiFetch } from '@wordpress/data-controls';
-import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data';
 import useAdsCurrency from './useAdsCurrency';
 import useStoreCurrency from './useStoreCurrency';
+import useGoogleAdsAccount from './useGoogleAdsAccount';
 
-// Force real timers, make sure all timers are actually ticking.
-jest.useRealTimers();
+const storeCurrencyConfig = {
+	code: 'EUR',
+	precision: 3,
+	symbol: '€',
+	symbolPosition: 'right_space',
+	decimalSeparator: ';',
+	thousandSeparator: '|',
+	priceFormat: '%2$s %1$s',
+};
 
-jest.mock( '@wordpress/data-controls', () => ( {
-	apiFetch: jest.fn().mockName( 'apiFetch mock' ),
-} ) );
-jest.mock( './useStoreCurrency', () => ( {
-	__esModule: true,
-	default: jest.fn().mockName( 'useStoreCurrency' ).mockReturnValue( {
-		code: 'EUR',
-		precision: 3,
-		symbol: '€',
-		symbolPosition: 'right_space',
-		decimalSeparator: ';',
-		thousandSeparator: '|',
-		priceFormat: '%2$s %1$s',
-	} ),
-} ) );
+jest.mock( './useStoreCurrency', () =>
+	jest
+		.fn()
+		.mockName( 'useStoreCurrency' )
+		.mockReturnValue( storeCurrencyConfig )
+);
+
+jest.mock( './useGoogleAdsAccount', () =>
+	jest.fn().mockName( 'useGoogleAdsAccount' ).mockReturnValue( {} )
+);
 
 describe( 'useAdsCurrency', () => {
-	test( 'initially should return `{ adsCurrencyConfig: Object, hasFinishedResolution: undefined, formatAmount: Function }`', () => {
+	test( 'initially should return `{ adsCurrencyConfig: Object, formatAmount: Function }`', () => {
 		const { result } = renderHook( () => useAdsCurrency() );
 
 		// assert initial state
-		expect( result.current ).toHaveProperty(
-			'hasFinishedResolution',
-			undefined
-		);
 		expect( result.current ).toHaveProperty( 'adsCurrencyConfig' );
 		expect( result.current ).toMatchObject( {
 			formatAmount: expect.any( Function ),
@@ -72,70 +68,44 @@ describe( 'useAdsCurrency', () => {
 		} );
 	} );
 
-	describe( 'eventually', () => {
-		let adsAccountData;
+	describe( 'after Google Ads Account status is fetched', () => {
+		let connectedAdsAccount;
+		let unconnectedAdsAccount;
+
 		beforeEach( () => {
-			adsAccountData = {
+			connectedAdsAccount = {
 				id: 777777,
 				currency: 'PLN',
 				symbol: 'zł',
 				status: 'connected',
 			};
-			apiFetch
-				// Mock /wp-json/wc/gla/jetpack/connected
-				.mockReturnValueOnce( {
-					active: 'yes',
-					owner: 'yes',
-					displayName: 'username',
-					email: 'tomalec.gla1.test@gmail.com',
-				} )
-				// Mock /wp-json/wc/gla/google/connected
-				.mockReturnValueOnce( {
-					active: 'yes',
-					email: 'gla1.test@example.com',
-				} )
-				// Mock /wp-json/wc/gla/ads/connection as a connected Ads account
-				.mockReturnValueOnce( adsAccountData )
-				// Mock /wp-json/wc/gla/ads/connection as a unconnected Ads account
-				.mockReturnValueOnce( {
-					id: 0,
-					currency: null,
-					symbol: null,
-					status: 'disconnected',
-				} );
-		} );
-
-		test( 'should finish resolution', async () => {
-			const { result, waitFor } = renderHook( () => useAdsCurrency() );
-
-			// assert initial state
-			expect( result.current.hasFinishedResolution ).toEqual( undefined );
-			// assert eventual state
-			await waitFor( () =>
-				expect( result.current.hasFinishedResolution ).toEqual( true )
-			);
+			unconnectedAdsAccount = {
+				id: 0,
+				currency: null,
+				symbol: null,
+				status: 'disconnected',
+			};
 		} );
 
 		test( 'should return currency config with Ads account code and symbol', async () => {
-			const { result, waitFor } = renderHook( () => useAdsCurrency() );
+			useGoogleAdsAccount.mockReturnValue( {
+				googleAdsAccount: connectedAdsAccount,
+			} );
 
-			// assert initial state
-			// expect( result.current.hasFinishedResolution ).toEqual( undefined );
-			// Unfortunately, tests are not atomic, as the state is perserved between them.
+			const { result } = renderHook( () => useAdsCurrency() );
 
-			const initialConfig = result.current.adsCurrencyConfig;
-
-			// Assert eventual value.
-			await waitFor( () =>
-				expect( result.current.adsCurrencyConfig ).toEqual( {
-					...initialConfig,
-					code: adsAccountData.currency,
-					symbol: adsAccountData.symbol,
-				} )
-			);
+			expect( result.current.adsCurrencyConfig ).toEqual( {
+				...storeCurrencyConfig,
+				code: connectedAdsAccount.currency,
+				symbol: connectedAdsAccount.symbol,
+			} );
 		} );
 
 		test( 'should be able to format value according to currency config', () => {
+			useGoogleAdsAccount.mockReturnValue( {
+				googleAdsAccount: connectedAdsAccount,
+			} );
+
 			const { result } = renderHook( () => useAdsCurrency() );
 			const { formatAmount } = result.current;
 			const value = 1234.5678;
@@ -145,25 +115,19 @@ describe( 'useAdsCurrency', () => {
 		} );
 
 		test( 'when Ads account is not connected, it should return the code/symbol of currency config with fallback value', async () => {
-			// During the test running, `@wordpress/data` will keep the store across all tests,
-			// so the tests are not atomic, as the state is perserved between them.
-			// Here we invalidate the `getGoogleAdsAccount` selector to force it to re-fetch its state.
-			dispatch( STORE_KEY ).invalidateResolution(
-				'getGoogleAdsAccount',
-				[]
-			);
-
-			const { result, waitFor } = renderHook( () => useAdsCurrency() );
-
-			await waitFor( () => {
-				const { adsCurrencyConfig, formatAmount } = result.current;
-				const value = 1234.5678;
-
-				expect( adsCurrencyConfig.code ).toBe( '' );
-				expect( adsCurrencyConfig.symbol ).toBe( '' );
-				expect( formatAmount( value ) ).toBe( '1|234;568\xA0' );
-				expect( formatAmount( value, true ) ).toBe( '1|234;568\xA0' );
+			useGoogleAdsAccount.mockReturnValue( {
+				googleAdsAccount: unconnectedAdsAccount,
 			} );
+
+			const { result } = renderHook( () => useAdsCurrency() );
+
+			const { adsCurrencyConfig, formatAmount } = result.current;
+			const value = 1234.5678;
+
+			expect( adsCurrencyConfig.code ).toBe( '' );
+			expect( adsCurrencyConfig.symbol ).toBe( '' );
+			expect( formatAmount( value ) ).toBe( '1|234;568\xA0' );
+			expect( formatAmount( value, true ) ).toBe( '1|234;568\xA0' );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I was eager to fix the bug first yesterday, so I did not add the corresponding test with #1252. This PR makes up for the test.

- Add a test case for `useAdsCurrency` hook to check the fallback values of currency config.

:warning: **UPDATE: this PR replaced the mocking from `apiFetch` to `useGoogleAdsAccount`.** Please refer to https://github.com/woocommerce/google-listings-and-ads/pull/1255#discussion_r809977404 for more context.

### Detailed test instructions:

1. `npm run test:js -- useAdsCurrency`
2. All tests should pass.
3. If assign [default values](https://github.com/woocommerce/google-listings-and-ads/blob/889d3396c79a6a102f78df0f523b5d8b4af0fe4e/js/src/hooks/useAdsCurrency.js#L49-L50) with destructuring assignment such as the following, the test should find out the problem.
    ```js
    const { currency: code = '', symbol = '' } = googleAdsAccount || {};
    ```
    (Got from the fix commit: https://github.com/woocommerce/google-listings-and-ads/pull/1252/commits/1388b515e487cafe52aecb7472b4caebc73bb8e4)

### Changelog entry
