### PR TITLE
Update budget recommendation API to support multiple countries

### DIFF
--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -113,11 +113,11 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 			if ( ! $recommendations ) {
 				return new Response(
 					[
-						'message'       => __( 'Cannot find any budget recommendations', 'google-listings-and-ads' ),
+						'message'       => __( 'Cannot find any budget recommendations.', 'google-listings-and-ads' ),
 						'currency'      => $currency,
 						'country_codes' => $country_codes,
 					],
-					400
+					404
 				);
 			}
 

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -101,27 +101,21 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 				);
 			}
 
+			$returned_recommendations = array_map(
+				function ( $recommendation ) {
+					return [
+						'country'           => $recommendation['country'],
+						'daily_budget_low'  => (float) $recommendation['daily_budget_low'],
+						'daily_budget_high' => (float) $recommendation['daily_budget_high'],
+					];
+				},
+				$recommendations
+			);
+
 			return $this->prepare_item_for_response(
 				[
-					'currency'          => $currency,
-					'country_codes'     => array_map(
-						function ( $recommendation ) {
-							return $recommendation['country'];
-						},
-						$recommendations
-					),
-					'daily_budget_low'  => array_map(
-						function ( $recommendation ) {
-							return (float) $recommendation['daily_budget_low'];
-						},
-						$recommendations
-					),
-					'daily_budget_high' => array_map(
-						function ( $recommendation ) {
-							return (float) $recommendation['daily_budget_high'];
-						},
-						$recommendations
-					),
+					'currency'        => $currency,
+					'recommendations' => $returned_recommendations,
 				],
 				$request
 			);
@@ -135,34 +129,38 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'currency'          => [
+			'currency'        => [
 				'type'              => 'string',
 				'description'       => __( 'The currency to use for the shipping rate.', 'google-listings-and-ads' ),
 				'context'           => [ 'view' ],
 				'validate_callback' => 'rest_validate_request_arg',
 				'required'          => true,
 			],
-			'country_codes'     => [
-				'type'              => [ 'string' ],
-				'description'       => __( 'An array of Country codes in ISO 3166-1 alpha-2 format.', 'google-listings-and-ads' ),
-				'context'           => [ 'view' ],
-				'sanitize_callback' => $this->get_country_code_sanitize_callback(),
-				'validate_callback' => $this->get_country_code_validate_callback(),
-				'required'          => true,
-			],
-			'daily_budget_low'  => [
-				'type'              => [ 'number' ],
-				'description'       => __( 'An array of the lower limit for the recommended budget.', 'google-listings-and-ads' ),
-				'context'           => [ 'view' ],
-				'validate_callback' => 'rest_validate_request_arg',
-				'required'          => true,
-			],
-			'daily_budget_high' => [
-				'type'              => [ 'number' ],
-				'description'       => __( 'An array of the upper limit for the recommended budget.', 'google-listings-and-ads' ),
-				'context'           => [ 'view' ],
-				'validate_callback' => 'rest_validate_request_arg',
-				'required'          => true,
+			'recommendations' => [
+				'type'  => 'array',
+				'items' => [
+					'type'       => 'object',
+					'properties' => [
+						'country'           => [
+							'type'              => 'string',
+							'description'       => __( 'Country code in ISO 3166-1 alpha-2 format.', 'google-listings-and-ads' ),
+							'context'           => [ 'view' ],
+							'sanitize_callback' => $this->get_country_code_sanitize_callback(),
+							'validate_callback' => $this->get_country_code_validate_callback(),
+							'required'          => true,
+						],
+						'daily_budget_low'  => [
+							'type'        => 'number',
+							'description' => __( 'Daily budget lower bound ', 'google-listings-and-ads' ),
+							'required'    => true,
+						],
+						'daily_budget_high' => [
+							'type'        => 'number',
+							'description' => __( 'Daily budget upper bound ', 'google-listings-and-ads' ),
+							'required'    => true,
+						],
+					],
+				],
 			],
 		];
 	}

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -154,7 +154,6 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 				'description'       => __( 'The currency to use for the shipping rate.', 'google-listings-and-ads' ),
 				'context'           => [ 'view' ],
 				'validate_callback' => 'rest_validate_request_arg',
-				'required'          => true,
 			],
 			'recommendations' => [
 				'type'  => 'array',
@@ -162,22 +161,17 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 					'type'       => 'object',
 					'properties' => [
 						'country'           => [
-							'type'              => 'string',
-							'description'       => __( 'Country code in ISO 3166-1 alpha-2 format.', 'google-listings-and-ads' ),
-							'context'           => [ 'view' ],
-							'sanitize_callback' => $this->get_country_code_sanitize_callback(),
-							'validate_callback' => $this->get_country_code_validate_callback(),
-							'required'          => true,
+							'type'        => 'string',
+							'description' => __( 'Country code in ISO 3166-1 alpha-2 format.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
 						],
 						'daily_budget_low'  => [
 							'type'        => 'number',
 							'description' => __( 'Daily budget lower bound ', 'google-listings-and-ads' ),
-							'required'    => true,
 						],
 						'daily_budget_high' => [
 							'type'        => 'number',
 							'description' => __( 'Daily budget upper bound ', 'google-listings-and-ads' ),
-							'required'    => true,
 						],
 					],
 				],

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -167,11 +167,11 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 						],
 						'daily_budget_low'  => [
 							'type'        => 'number',
-							'description' => __( 'Daily budget lower bound ', 'google-listings-and-ads' ),
+							'description' => __( 'The lower bound recommended daily budget for a country.', 'google-listings-and-ads' ),
 						],
 						'daily_budget_high' => [
 							'type'        => 'number',
-							'description' => __( 'Daily budget upper bound ', 'google-listings-and-ads' ),
+							'description' => __( 'The upper bound recommended daily budget for a country.', 'google-listings-and-ads' ),
 						],
 					],
 				],

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -96,7 +96,7 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 			if ( ! $currency ) {
 				return new Response(
 					[
-						'message'       => __( 'Invalid currency', 'google-listings-and-ads' ),
+						'message'       => __( 'No currency available for the Ads account.', 'google-listings-and-ads' ),
 						'currency'      => $currency,
 						'country_codes' => $country_codes,
 					],

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -125,8 +125,8 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 				function ( $recommendation ) {
 					return [
 						'country'           => $recommendation['country'],
-						'daily_budget_low'  => (float) $recommendation['daily_budget_low'],
-						'daily_budget_high' => (float) $recommendation['daily_budget_high'],
+						'daily_budget_low'  => (int) $recommendation['daily_budget_low'],
+						'daily_budget_high' => (int) $recommendation['daily_budget_high'],
 					];
 				},
 				$recommendations

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -80,6 +80,7 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 				'items'             => [
 					'type' => 'string',
 				],
+				'required'          => true,
 			],
 		];
 	}
@@ -89,7 +90,7 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 	 */
 	protected function get_budget_recommendation_callback(): callable {
 		return function( Request $request ) {
-			$country_codes = $request->get_params()['country_codes'];
+			$country_codes = $request->get_param( 'country_codes' );
 			$currency      = $this->middleware->get_ads_currency();
 
 			if ( ! $currency ) {

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -96,8 +96,6 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 			->method( 'get_ads_currency' )
 			->willReturn( 'TWD' );
 
-		$this->budget_recommendation_query->expects( $this->exactly(2) )->method( 'where' );
-
 		$this->budget_recommendation_query->expects( $this->once() )
 			->method( 'get_results' )
 			->willReturn( $budget_recommendation_data );

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -151,4 +151,30 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		);
 		$this->assertEquals( 400, $response->get_status() );
 	}
+
+	public function test_get_budget_recommendation_cannot_find_any_recommendations() {
+		$budget_recommendation_params = [
+			'country_codes' => ['JP', 'TW', 'GB', 'US'],
+		];
+
+		$this->middleware->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'TWD' );
+
+		$this->budget_recommendation_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn( null );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertEquals(
+			[
+				'message'       => 'Cannot find any budget recommendations',
+				'currency'      => 'TWD',
+				'country_codes' => ['JP', 'TW', 'GB', 'US'],
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 404, $response->get_status() );
+	}
 }

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -71,23 +71,23 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 			'recommendations' => [
 				[
 					'country'           => 'US',
-					'daily_budget_low'  => 330.0,
-					'daily_budget_high' => 930.0,
+					'daily_budget_low'  => 330,
+					'daily_budget_high' => 930,
 				],
 				[
 					'country'           => 'GB',
-					'daily_budget_low'  => 245.0,
-					'daily_budget_high' => 625.0,
+					'daily_budget_low'  => 245,
+					'daily_budget_high' => 625,
 				],
 				[
 					'country'           => 'TW',
-					'daily_budget_low'  => 95.0,
-					'daily_budget_high' => 255.0,
+					'daily_budget_low'  => 95,
+					'daily_budget_high' => 255,
 				],
 				[
 					'country'           => 'JP',
-					'daily_budget_low'  => 110.0,
-					'daily_budget_high' => 320.0,
+					'daily_budget_low'  => 110,
+					'daily_budget_high' => 320,
 				]
 			],
 		];

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class BudgetRecommendationControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ *
+ * @property BudgetRecommendationQuery|MockObject $budget_recommendation_query
+ * @property ISO3166DataProvider|MockObject       $iso_provider;
+ * @property BudgetRecommendationController       $controller
+ */
+class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
+
+	protected const ROUTE_BUDGET_RECOMMENDATION  = '/wc/gla/ads/campaigns/budget-recommendation';
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->budget_recommendation_query = $this->createMock( BudgetRecommendationQuery::class );
+		$this->iso_provider = $this->createMock( ISO3166DataProvider::class );
+		$this->middleware = $this->createMock( Middleware::class );
+
+		$this->controller = new BudgetRecommendationController( $this->server, $this->budget_recommendation_query, $this->middleware );
+		$this->controller->register();
+		$this->controller->set_iso3166_provider( $this->iso_provider );
+	}
+
+	public function test_get_budget_recommendation() {
+		$budget_recommendation_params = [
+			'country_codes' => 'JP,TW,GB,US',
+		];
+
+		$budget_recommendation_data = [
+			[
+				'country'           => 'US',
+				'daily_budget_low'  => '330',
+				'daily_budget_high' => '930',
+			],
+			[
+				'country'           => 'GB',
+				'daily_budget_low'  => '245',
+				'daily_budget_high' => '625',
+			],
+			[
+				'country'           => 'TW',
+				'daily_budget_low'  => '95',
+				'daily_budget_high' => '255',
+			],
+			[
+				'country'           => 'JP',
+				'daily_budget_low'  => '110',
+				'daily_budget_high' => '320',
+			]
+		];
+
+		$expected_response_data = [
+			'currency'          => 'TWD',
+			'country_codes'     => ['US', 'GB', 'TW', 'JP'],
+			'daily_budget_low'  => [330, 245, 95, 110],
+			'daily_budget_high' => [930, 625, 255, 320],
+		];
+
+		$this->middleware->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'TWD' );
+
+		$this->budget_recommendation_query->expects( $this->exactly(2) )
+			->method( 'where' )
+			->willReturn( $this->budget_recommendation_query );
+
+		$this->budget_recommendation_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn( $budget_recommendation_data );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertEquals( $expected_response_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_budget_recommendation_without_query_parameters() {
+		$budget_recommendation_params = [];
+
+		$this->middleware->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'TWD' );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertEquals(
+			[
+				'message'       => 'Invalid country_codes/currency combination',
+				'currency'      => 'TWD',
+				'country_codes' => '',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_get_budget_recommendation_with_wrong_query_parameters() {
+		$budget_recommendation_params = [
+			'country_codes' => '',
+		];
+
+		$this->middleware->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'TWD' );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertEquals(
+			[
+				'message'       => 'Invalid country_codes/currency combination',
+				'currency'      => 'TWD',
+				'country_codes' => '',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_get_budget_recommendation_with_nonexistent_country_code() {
+		$budget_recommendation_params = [
+			'country_codes' => 'AAAAA',
+		];
+
+		$this->middleware->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'TWD' );
+
+		$this->budget_recommendation_query->expects( $this->exactly(2) )
+			->method( 'where' )
+			->willReturn( $this->budget_recommendation_query );
+
+		$this->budget_recommendation_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn( null );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertEquals(
+			[
+				'message'       => 'Cannot find any budget recommendations',
+				'currency'      => 'TWD',
+				'country_codes' => 'AAAAA',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_get_budget_recommendation_without_currency() {
+		$budget_recommendation_params = [
+			'country_codes' => 'JP,TW,GB,US',
+		];
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertEquals(
+			[
+				'message'       => 'Invalid country_codes/currency combination',
+				'currency'      => '',
+				'country_codes' => 'JP,TW,GB,US',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -143,7 +143,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals(
 			[
-				'message'       => 'Invalid currency',
+				'message'       => 'No currency available for the Ads account.',
 				'currency'      => '',
 				'country_codes' => ['JP', 'TW', 'GB', 'US'],
 			],
@@ -169,7 +169,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals(
 			[
-				'message'       => 'Cannot find any budget recommendations',
+				'message'       => 'Cannot find any budget recommendations.',
 				'currency'      => 'TWD',
 				'country_codes' => ['JP', 'TW', 'GB', 'US'],
 			],

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -28,6 +28,9 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		parent::setUp();
 
 		$this->budget_recommendation_query = $this->createMock( BudgetRecommendationQuery::class );
+		$this->budget_recommendation_query->method( 'where' )
+			->willReturn( $this->budget_recommendation_query );
+
 		$this->iso_provider = $this->createMock( ISO3166DataProvider::class );
 		$this->middleware = $this->createMock( Middleware::class );
 
@@ -94,9 +97,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 			->method( 'get_ads_currency' )
 			->willReturn( 'TWD' );
 
-		$this->budget_recommendation_query->expects( $this->exactly(2) )
-			->method( 'where' )
-			->willReturn( $this->budget_recommendation_query );
+		$this->budget_recommendation_query->expects( $this->exactly(2) )->method( 'where' );
 
 		$this->budget_recommendation_query->expects( $this->once() )
 			->method( 'get_results' )

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -64,10 +64,29 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		];
 
 		$expected_response_data = [
-			'currency'          => 'TWD',
-			'country_codes'     => ['US', 'GB', 'TW', 'JP'],
-			'daily_budget_low'  => [330, 245, 95, 110],
-			'daily_budget_high' => [930, 625, 255, 320],
+			'currency'        => 'TWD',
+			'recommendations' => [
+				[
+					'country'           => 'US',
+					'daily_budget_low'  => 330.0,
+					'daily_budget_high' => 930.0,
+				],
+				[
+					'country'           => 'GB',
+					'daily_budget_low'  => 245.0,
+					'daily_budget_high' => 625.0,
+				],
+				[
+					'country'           => 'TW',
+					'daily_budget_low'  => 95.0,
+					'daily_budget_high' => 255.0,
+				],
+				[
+					'country'           => 'JP',
+					'daily_budget_low'  => 110.0,
+					'daily_budget_high' => 320.0,
+				]
+			],
 		];
 
 		$this->middleware->expects( $this->once() )
@@ -84,7 +103,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 
 		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
 
-		$this->assertEquals( $expected_response_data, $response->get_data() );
+		$this->assertSame( $expected_response_data, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -6,7 +6,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\Exception\OutOfBoundsException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -138,33 +137,12 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 
 		$this->iso_provider
 			->method( 'alpha2' )
-			->willThrowException( new OutOfBoundsException( 'Not a valid alpha2 key: AAAAA', 400 ) );
+			->willThrowException( new Exception( 'invalid_country' ) );
 
 		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
 
-		$this->assertEquals(
-			[
-				'code'    => 'rest_invalid_param',
-				'message' => 'Invalid parameter(s): country_codes',
-				'data'    => [
-					'status'  => 400,
-					'params'  => [
-						'country_codes' => 'Not a valid alpha2 key: AAAAA',
-					],
-					'details' => [
-						'country_codes' => [
-							'code'    => 'gla_invalid_country',
-							'message' => 'Not a valid alpha2 key: AAAAA',
-							'data'    => [
-								'status'  => 400,
-								'country' => 'AAAAA',
-							],
-						],
-					],
-				],
-			],
-			$response->get_data()
-		);
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): country_codes', $response->get_data()['message'] );
 		$this->assertEquals( 400, $response->get_status() );
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -109,24 +109,12 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_budget_recommendation_without_query_parameters() {
-		$budget_recommendation_params = [
-			'country_codes' => '',
-		];
-
-		$this->middleware->expects( $this->once() )
-			->method( 'get_ads_currency' )
-			->willReturn( 'TWD' );
+		$budget_recommendation_params = [];
 
 		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
 
-		$this->assertEquals(
-			[
-				'message'       => 'Cannot find any budget recommendations',
-				'currency'      => 'TWD',
-				'country_codes' => '',
-			],
-			$response->get_data()
-		);
+		$this->assertEquals( 'rest_missing_callback_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Missing parameter(s): country_codes', $response->get_data()['message'] );
 		$this->assertEquals( 400, $response->get_status() );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1248. This PR updates the API `ads/campaigns/budget-recommendation/:country-code` to `ads/campaigns/budget-recommendation?country_codes=` in order to support multiple countries' budget recommendation.

### Screenshots

<img width="820" alt="Screenshot 2022-02-18 at 17 52 53" src="https://user-images.githubusercontent.com/914406/154659436-2b1915c6-c4fc-4b0c-b82f-c9849070bb87.png">

### Detailed test instructions:

Since the frontend hasn't integrated with this new API to show the budget recommendation for multiple countries, one can test this PR through any HTTP clients like Postman.

#### Request

```
GET https://testdomain/wp-json/wc/gla/ads/campaigns/budget-recommendation?country_codes=TW,GB,US
```

#### Response

```json
{
    "currency": "EUR",
    "recommendations": [
        {
            "country": "US",
            "daily_budget_low": 10,
            "daily_budget_high": 25
        },
        {
            "country": "GB",
            "daily_budget_low": 5,
            "daily_budget_high": 20
        },
        {
            "country": "IE",
            "daily_budget_low": 5,
            "daily_budget_high": 15
        }
    ]
}
```

### Additional details

The type of the budget in `daily_budget_low` and `daily_budget_high` was of `string`, I changed the type to `number` in order to align with the type of the response data `amount` when calling `ads/campaigns` API.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Budget recommendation for multiple countries
