### PR TITLE
Improve Ads error messages returned by the API

### DIFF
--- a/src/API/Google/AdsCampaignBudget.php
+++ b/src/API/Google/AdsCampaignBudget.php
@@ -14,7 +14,6 @@ use Google\Ads\GoogleAds\V9\Resources\CampaignBudget;
 use Google\Ads\GoogleAds\V9\Services\CampaignBudgetOperation;
 use Google\Ads\GoogleAds\V9\Services\CampaignBudgetServiceClient;
 use Google\Ads\GoogleAds\V9\Services\MutateOperation;
-use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;
 use Exception;
 
@@ -83,7 +82,6 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 	 * @param float $amount Budget amount in the local currency.
 	 *
 	 * @return string Resource name of the updated budget.
-	 * @throws ApiException If the campaign budget can't be mutated.
 	 * @throws Exception If no linked budget has been found.
 	 */
 	public function edit_operation( int $campaign_id, float $amount ): MutateOperation {

--- a/src/API/Google/AdsReport.php
+++ b/src/API/Google/AdsReport.php
@@ -96,9 +96,9 @@ class AdsReport implements OptionsAwareInterface {
 				$this->map_grpc_code_to_http_status_code( $e ),
 				null,
 				[
-					'errors' => $errors,
-					'type'   => $type,
-					'args'   => $args,
+					'errors'            => $errors,
+					'report_type'       => $type,
+					'report_query_args' => $args,
 				]
 			);
 		}

--- a/src/API/Google/ApiExceptionTrait.php
+++ b/src/API/Google/ApiExceptionTrait.php
@@ -58,15 +58,22 @@ trait ApiExceptionTrait {
 
 		if ( is_array( $meta ) ) {
 			foreach ( $meta as $data ) {
-				if ( ! is_array( $data['errors'] ) ) {
+				if ( empty( $data['errors'] ) || ! is_array( $data['errors'] ) ) {
 					continue;
 				}
 
 				foreach ( $data['errors'] as $error ) {
-					if ( ! empty( $error['message'] ) ) {
-						$error_code            = reset( $error['errorCode'] ) ?: 'ERROR';
-						$errors[ $error_code ] = $error['message'];
+					if ( empty( $error['message'] ) ) {
+						continue;
 					}
+
+					if ( ! empty( $error['errorCode'] ) && is_array( $error['errorCode'] ) ) {
+						$error_code = reset( $error['errorCode'] );
+					} else {
+						$error_code = 'ERROR';
+					}
+
+					$errors[ $error_code ] = $error['message'];
 				}
 			}
 		}

--- a/src/API/Google/ApiExceptionTrait.php
+++ b/src/API/Google/ApiExceptionTrait.php
@@ -30,7 +30,7 @@ trait ApiExceptionTrait {
 		}
 
 		foreach ( $meta as $data ) {
-			if ( empty( $data['errors'] || ! is_array( $data['errors'] ) ) ) {
+			if ( empty( $data['errors'] ) || ! is_array( $data['errors'] ) ) {
 				continue;
 			}
 

--- a/src/API/Google/ApiExceptionTrait.php
+++ b/src/API/Google/ApiExceptionTrait.php
@@ -45,6 +45,37 @@ trait ApiExceptionTrait {
 	}
 
 	/**
+	 * Returns a list of detailed errors from an ApiException.
+	 * If no errors are found the default Exception message is returned.
+	 *
+	 * @param ApiException $exception Exception to check.
+	 *
+	 * @return array
+	 */
+	protected function get_api_exception_errors( ApiException $exception ): array {
+		$errors = [];
+		$meta   = $exception->getMetadata();
+
+		if ( is_array( $meta ) ) {
+			foreach ( $meta as $data ) {
+				if ( ! is_array( $data['errors'] ) ) {
+					continue;
+				}
+
+				foreach ( $data['errors'] as $error ) {
+					if ( ! empty( $error['message'] ) ) {
+						$error_code            = reset( $error['errorCode'] ) ?: 'ERROR';
+						$errors[ $error_code ] = $error['message'];
+					}
+				}
+			}
+		}
+
+		$errors[ $exception->getStatus() ] = $exception->getBasicMessage();
+		return $errors;
+	}
+
+	/**
 	 * Get an error message from a ClientException.
 	 *
 	 * @param ClientExceptionInterface $exception Exception to check.

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -98,6 +98,8 @@ class AccountController extends BaseController {
 		return function() {
 			try {
 				return new Response( $this->account->get_account_ids() );
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166AwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use DateTime;
@@ -103,6 +104,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					},
 					$this->ads_campaign->get_campaigns()
 				);
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
@@ -132,6 +135,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 				$campaign = $this->ads_campaign->create_campaign( $fields );
 
 				return $this->prepare_item_for_response( $campaign, $request );
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
@@ -160,6 +165,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 				}
 
 				return $this->prepare_item_for_response( $campaign, $request );
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
@@ -192,6 +199,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					'message' => __( 'Successfully edited campaign.', 'google-listings-and-ads' ),
 					'id'      => $campaign_id,
 				];
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
@@ -213,6 +222,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					'message' => __( 'Successfully deleted campaign.', 'google-listings-and-ads' ),
 					'id'      => $deleted_id,
 				];
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}

--- a/src/API/Site/Controllers/Ads/ReportsController.php
+++ b/src/API/Site/Controllers/Ads/ReportsController.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseReportsController;
@@ -63,6 +64,8 @@ class ReportsController extends BaseReportsController {
 				$ads  = $this->container->get( AdsReport::class );
 				$data = $ads->get_report_data( 'campaigns', $this->prepare_query_arguments( $request ) );
 				return $this->prepare_item_for_response( $data, $request );
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}
@@ -81,6 +84,8 @@ class ReportsController extends BaseReportsController {
 				$ads  = $this->container->get( AdsReport::class );
 				$data = $ads->get_report_data( 'products', $this->prepare_query_arguments( $request ) );
 				return $this->prepare_item_for_response( $data, $request );
+			} catch ( ExceptionWithResponseData $e ) {
+				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
 			}

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -6,12 +6,12 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignBudget;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsGroup;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Google\ApiCore\ApiException;
-use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
 defined( 'ABSPATH' ) || exit;
@@ -85,11 +85,18 @@ class AdsCampaignTest extends UnitTest {
 	public function test_get_campaigns_exception() {
 		$this->generate_ads_query_mock_exception( new ApiException( 'unavailable', 14, 'UNAVAILABLE' ) );
 
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Error retrieving campaigns: unavailable' );
-		$this->expectExceptionCode( 503 );
-
-		$this->campaign->get_campaigns();
+		try {
+			$this->campaign->get_campaigns();
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertEquals(
+				[
+					'message' => 'Error retrieving campaigns: unavailable',
+					'errors'  => [ 'UNAVAILABLE' => 'unavailable' ],
+				],
+				$e->get_response_data( true )
+			);
+			$this->assertEquals( 503, $e->getCode() );
+		}
 	}
 
 	public function test_get_campaign() {
@@ -108,11 +115,19 @@ class AdsCampaignTest extends UnitTest {
 	public function test_get_campaign_exception() {
 		$this->generate_ads_query_mock_exception( new ApiException( 'not found', 5, 'NOT_FOUND' ) );
 
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Error retrieving campaign: not found' );
-		$this->expectExceptionCode( 404 );
-
-		$this->campaign->get_campaign( self::TEST_CAMPAIGN_ID );
+		try {
+			$this->campaign->get_campaign( self::TEST_CAMPAIGN_ID );
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertEquals(
+				[
+					'message' => 'Error retrieving campaign: not found',
+					'errors'  => [ 'NOT_FOUND' => 'not found' ],
+					'id'      => self::TEST_CAMPAIGN_ID,
+				],
+				$e->get_response_data( true )
+			);
+			$this->assertEquals( 404, $e->getCode() );
+		}
 	}
 
 	public function test_create_campaign() {
@@ -148,6 +163,7 @@ class AdsCampaignTest extends UnitTest {
 					'errorCode' => [
 						'campaignError' => 'DUPLICATE_CAMPAIGN_NAME',
 					],
+					'message'   => 'Duplicate campaign name',
 				],
 			],
 		];
@@ -156,11 +172,21 @@ class AdsCampaignTest extends UnitTest {
 			new ApiException( 'invalid', 3, 'INVALID_ARGUMENT', [ 'metadata' => [ $errors ] ] )
 		);
 
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'A campaign with this name already exists' );
-		$this->expectExceptionCode( 400 );
-
-		$this->campaign->create_campaign( $campaign_data );
+		try {
+			$this->campaign->create_campaign( $campaign_data );
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertEquals(
+				[
+					'message' => 'A campaign with this name already exists',
+					'errors'  => [
+						'DUPLICATE_CAMPAIGN_NAME' => 'Duplicate campaign name',
+						'INVALID_ARGUMENT'        => 'invalid',
+					],
+				],
+				$e->get_response_data( true )
+			);
+			$this->assertEquals( 400, $e->getCode() );
+		}
 	}
 
 	public function test_edit_campaign() {
@@ -184,11 +210,19 @@ class AdsCampaignTest extends UnitTest {
 
 		$this->generate_campaign_mutate_mock_exception( new ApiException( 'invalid', 3, 'INVALID_ARGUMENT' ) );
 
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Error editing campaign: invalid' );
-		$this->expectExceptionCode( 400 );
-
-		$this->campaign->edit_campaign( self::TEST_CAMPAIGN_ID, $campaign_data );
+		try {
+			$this->campaign->edit_campaign( self::TEST_CAMPAIGN_ID, $campaign_data );
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertEquals(
+				[
+					'message' => 'Error editing campaign: invalid',
+					'errors'  => [ 'INVALID_ARGUMENT' => 'invalid' ],
+					'id'      => self::TEST_CAMPAIGN_ID,
+				],
+				$e->get_response_data( true )
+			);
+			$this->assertEquals( 400, $e->getCode() );
+		}
 	}
 
 	public function test_delete_campaign() {
@@ -207,6 +241,7 @@ class AdsCampaignTest extends UnitTest {
 					'errorCode' => [
 						'campaignError' => 'OPERATION_NOT_PERMITTED_FOR_REMOVED_RESOURCE',
 					],
+					'message'   => 'Campaign already deleted',
 				],
 			],
 		];
@@ -215,10 +250,21 @@ class AdsCampaignTest extends UnitTest {
 			new ApiException( 'invalid', 3, 'INVALID_ARGUMENT', [ 'metadata' => [ $errors ] ] )
 		);
 
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'This campaign has already been deleted' );
-		$this->expectExceptionCode( 400 );
-
-		$this->campaign->delete_campaign( self::TEST_CAMPAIGN_ID );
+		try {
+			$this->campaign->delete_campaign( self::TEST_CAMPAIGN_ID );
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertEquals(
+				[
+					'message' => 'This campaign has already been deleted',
+					'errors'  => [
+						'OPERATION_NOT_PERMITTED_FOR_REMOVED_RESOURCE' => 'Campaign already deleted',
+						'INVALID_ARGUMENT'                             => 'invalid',
+					],
+					'id'      => self::TEST_CAMPAIGN_ID,
+				],
+				$e->get_response_data( true )
+			);
+			$this->assertEquals( 400, $e->getCode() );
+		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolves the backend part of #1246 

This PR handles the backend error messages when we catch an ApiException from the Ads API.

The following changes have been added to this PR:

- Add a helper function for extracting the errors from an ApiException object
- Return detailed error messages containing a list of errors as well as relevant data such as the campaign ID
- Pass on the detailed messages in the CampaignController
- Add a detailed error for report requests
- Add a detailed error when requesting a list of Ad accounts

Before this PR if the request for retrieving account ID's failed we wouldn't map the error code (causing a 200 response to be returned). This scenario seems to have gone untested as it causes a failure when trying to add an Ad account

![image](https://user-images.githubusercontent.com/11388669/154706263-8b985ed0-59d2-4b81-b47f-c9cdb33b057b.png)

This PR fixes the behaviour so it correctly maps the error code, which results in the error being handled correctly. However the user is unable to continue since it stays in the loading state.

![image](https://user-images.githubusercontent.com/11388669/154706566-5fbfcc12-c3ee-40c3-ae46-05af0e72d63c.png)

### Unit tests
Explicit testing for detailed error messages was added in the AdsCampaignTest. However there are no unit tests for Proxy or AdsReport, so I didn't add anything there. That's something which can be done in a followup PR although it would cover a lot more code.

### Detailed test instructions:

#### Campaign errors
1. Go to WooCommerce > Settings > General and set the number of decimals to 3
2. Confirm we have an Ads account connected with some existing campaigns
3. Edit a campaign and try to set the budget amount to 0.001
4. Confirm that the UI responds the same as previously with a default error message
![image](https://user-images.githubusercontent.com/11388669/154707355-d8d89a13-65e6-491d-8200-ec9c968b82bd.png)
5. Open the network tab in the browser and confirm the request status remains the same and the response has additional details about the error:

```json
{
	"message": "Error editing campaign: A money amount was less than the minimum CPC for currency.",
	"errors": {
		"MONEY_AMOUNT_LESS_THAN_CURRENCY_MINIMUM_CPC": "A money amount was less than the minimum CPC for currency.",
		"INVALID_ARGUMENT": "Request contains an invalid argument."
	},
	"id": 1234567890
}
```

The error used to contain just the message:
```json
{
	"message": "Error editing campaign: Request contains an invalid argument."
}
```

#### Get accounts error
1. Disconnect any connected Ads account
2. Simulate an error by adding the following line in the file `src/API/Google/Proxy.php` within the `try` block of the function `get_ads_account_ids`
```php
throw new ApiException( 'invalid', 3, 'INVALID_ARGUMENT' );
```
3. Go Marketing > Google Listings & Ads > Dashboard and add a campaign to connect our Ad account
4. Confirm the error appears for the existing ad accounts
![image](https://user-images.githubusercontent.com/11388669/154706566-5fbfcc12-c3ee-40c3-ae46-05af0e72d63c.png)

#### Report errors 
1. Simulate an error by adding the following line in the file `src/API/Google/AdsReport.php` within the `try` block of the function `get_report_data`
```php
throw new ApiException( 'invalid', 3, 'INVALID_ARGUMENT' );
```
2. Go to the Reports page and inspect the network request to see them fail with a detailed error message:
```json
{
	"message": "Unable to retrieve report data: invalid",
	"errors": {
		"INVALID_ARGUMENT": "invalid"
	},
	"report_type": "products",
	"report_query_args": {
		"context": "view",
		"after": {
			"date": "2022-02-01 00:00:00.000000",
			"timezone_type": 3,
			"timezone": "Europe\/Dublin"
		},
		"before": {
			"date": "2022-02-18 00:00:00.000000",
			"timezone_type": 3,
			"timezone": "Europe\/Dublin"
		},
		"order": "desc",
		"per_page": 200,
		"fields": [
			"sales",
			"conversions",
			"spend",
			"clicks",
			"impressions"
		],
		"interval": "day",
		"orderby": "sales"
	}
}
```

### Changelog entry
* Tweak - Improve Ads error messages returned by the API.
