### PR TITLE
Shipping rates UI changes: Remove `offers_free_shipping` and `free_shipping_threshold` settings 

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
+++ b/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
@@ -6,12 +6,6 @@ exports[`checkErrors For tax rate, if selected country codes include 'US' When t
 
 exports[`checkErrors For tax rate, if selected country codes include 'US' When the tax rate option is an invalid value or missing, should not pass 3`] = `"Please specify tax rate option."`;
 
-exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value or missing, should not pass 1`] = `"Please specify a valid minimum order price for free shipping"`;
-
-exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value or missing, should not pass 2`] = `"Please specify a valid minimum order price for free shipping"`;
-
-exports[`checkErrors Shipping rates For flat type When the free shipping threshold is an invalid value or missing, should not pass 3`] = `"Please specify a valid minimum order price for free shipping"`;
-
 exports[`checkErrors Shipping rates For flat type When there are any selected countries with shipping rates not set, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;
 
 exports[`checkErrors Shipping rates For flat type When there are any shipping rates is < 0, should not pass 1`] = `"Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0."`;

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -36,19 +36,6 @@ const checkErrors = (
 		);
 	}
 
-	// When set up from scratch, the initial value of `free_shipping_threshold` is null.
-	const threshold = values.free_shipping_threshold;
-	if (
-		values.shipping_rate === 'flat' &&
-		values.offers_free_shipping &&
-		( ! Number.isFinite( threshold ) || threshold < 0 )
-	) {
-		errors.free_shipping_threshold = __(
-			'Please specify a valid minimum order price for free shipping',
-			'google-listings-and-ads'
-		);
-	}
-
 	/**
 	 * Check shipping times.
 	 */

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -30,8 +30,6 @@ describe( 'checkErrors', () => {
 		const values = {
 			shipping_rate: 'flat',
 			shipping_time: 'flat',
-			offers_free_shipping: true,
-			free_shipping_threshold: 100,
 			tax_rate: 'manual',
 		};
 		const rates = toRates( [ 'US', 10 ], [ 'JP', 30 ] );
@@ -99,14 +97,6 @@ describe( 'checkErrors', () => {
 		} );
 
 		describe( 'For flat type', () => {
-			function createFreeShipping( threshold ) {
-				return {
-					...flatShipping,
-					offers_free_shipping: true,
-					free_shipping_threshold: threshold,
-				};
-			}
-
 			it( `When there are any selected countries with shipping rates not set, should not pass`, () => {
 				const rates = toRates( [ 'US', 10.5 ], [ 'FR', 12.8 ] );
 				const codes = [ 'US', 'JP', 'FR' ];
@@ -143,57 +133,6 @@ describe( 'checkErrors', () => {
 				const errors = checkErrors( flatShipping, rates, [], codes );
 
 				expect( errors ).not.toHaveProperty( 'shipping_rate' );
-			} );
-
-			it( 'When the free shipping threshold is an invalid value or missing, should not pass', () => {
-				// Not set yet
-				// When set up from scratch, the initial value of `free_shipping_threshold` is null.
-				let freeShipping = createFreeShipping( null );
-				const rates = toRates( [ 'JP', 2 ] );
-				const codes = [ 'JP' ];
-
-				let errors = checkErrors( freeShipping, rates, [], codes );
-
-				expect( errors ).toHaveProperty( 'free_shipping_threshold' );
-				expect( errors.free_shipping_threshold ).toMatchSnapshot();
-
-				// Invalid value
-				freeShipping = createFreeShipping( true );
-
-				errors = checkErrors( freeShipping, rates, [], codes );
-
-				expect( errors ).toHaveProperty( 'free_shipping_threshold' );
-				expect( errors.free_shipping_threshold ).toMatchSnapshot();
-
-				// Invalid range
-				freeShipping = createFreeShipping( -0.01 );
-
-				errors = checkErrors( freeShipping, rates, [], codes );
-
-				expect( errors ).toHaveProperty( 'free_shipping_threshold' );
-				expect( errors.free_shipping_threshold ).toMatchSnapshot();
-			} );
-
-			it( 'When the free shipping threshold ≥ 0, should pass', () => {
-				// Free threshold is 0
-				let freeShipping = createFreeShipping( 0 );
-				const rates = toRates( [ 'JP', 2 ] );
-				const codes = [ 'JP' ];
-
-				let errors = checkErrors( freeShipping, rates, [], codes );
-
-				expect( errors ).not.toHaveProperty(
-					'free_shipping_threshold'
-				);
-
-				// Free threshold is a positive number
-				freeShipping = createFreeShipping( 0.01 );
-
-				errors = checkErrors( freeShipping, rates, [], codes );
-
-				expect( errors ).not.toHaveProperty(
-					'free_shipping_threshold'
-				);
 			} );
 		} );
 	} );

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/index.js
@@ -1,13 +1,6 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
-import AppInputPriceControl from '.~/components/app-input-price-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import AppSpinner from '.~/components/app-spinner';
@@ -22,11 +15,11 @@ import './index.scss';
  * Form control to edit shipping rate settings.
  *
  * @param {Object} props React props.
- * @param {Object} props.formProps Form props forwarded from `Form` component, containing `offers_free_shipping` and `free_shipping_threshold` properties.
+ * @param {Object} props.formProps Form props forwarded from `Form` component.
  * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
  */
 const ShippingRateSetup = ( { formProps, selectedCountryCodes } ) => {
-	const { getInputProps, values } = formProps;
+	const { getInputProps } = formProps;
 	const { code: currencyCode } = useStoreCurrency();
 
 	if ( ! selectedCountryCodes ) {
@@ -41,24 +34,6 @@ const ShippingRateSetup = ( { formProps, selectedCountryCodes } ) => {
 					currencyCode={ currencyCode }
 					audienceCountries={ selectedCountryCodes }
 				/>
-				<CheckboxControl
-					label={ __(
-						'I also offer free shipping for all countries for products over a certain price.',
-						'google-listings-and-ads'
-					) }
-					{ ...getInputProps( 'offers_free_shipping' ) }
-				/>
-				{ values.offers_free_shipping && (
-					<div className="price-over-input">
-						<AppInputPriceControl
-							label={ __(
-								'I offer free shipping for products priced over',
-								'google-listings-and-ads'
-							) }
-							{ ...getInputProps( 'free_shipping_threshold' ) }
-						/>
-					</div>
-				) }
 			</VerticalGapLayout>
 		</div>
 	);

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
@@ -14,7 +14,7 @@ import './index.scss';
  * Form control to edit shipping rate settings.
  *
  * @param {Object} props React props.
- * @param {Object} props.formProps Form props forwarded from `Form` component, containing `offers_free_shipping` property.
+ * @param {Object} props.formProps Form props forwarded from `Form` component.
  * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
  */
 const ShippingTimeSetup = ( { formProps, selectedCountryCodes } ) => {

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -98,8 +98,6 @@ const SetupFreeListings = ( {
 			<Form
 				initialValues={ {
 					shipping_rate: settings.shipping_rate,
-					offers_free_shipping: settings.offers_free_shipping,
-					free_shipping_threshold: settings.free_shipping_threshold,
 					shipping_time: settings.shipping_time,
 					tax_rate: settings.tax_rate,
 					website_live: settings.website_live,

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -69,8 +69,6 @@ const SetupFreeListings = ( props ) => {
 			<Form
 				initialValues={ {
 					shipping_rate: settings.shipping_rate || 'automatic',
-					offers_free_shipping: settings.offers_free_shipping,
-					free_shipping_threshold: settings.free_shipping_threshold,
 					shipping_time: settings.shipping_time,
 					tax_rate: settings.tax_rate,
 				} }

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate-section.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate-section.js
@@ -115,7 +115,7 @@ const ShippingRateSection = ( { formProps } ) => {
 									'google-listings-and-ads'
 								) }
 							</Subsection.Title>
-							<ShippingRateSetup formProps={ formProps } />
+							<ShippingRateSetup />
 						</Section.Card.Body>
 					</Section.Card>
 				) }

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-rate/shipping-rate-setup/index.js
@@ -1,13 +1,6 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
-import AppInputPriceControl from '.~/components/app-input-price-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AddRateButton from './add-rate-button';
 import CountriesPriceInputForm from './countries-price-input-form';
@@ -18,10 +11,7 @@ import AppSpinner from '.~/components/app-spinner';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import './index.scss';
 
-const ShippingRateSetup = ( props ) => {
-	const {
-		formProps: { getInputProps, values },
-	} = props;
+const ShippingRateSetup = () => {
 	const {
 		loading: loadingShippingRates,
 		data: dataShippingRates,
@@ -74,24 +64,6 @@ const ShippingRateSetup = ( props ) => {
 						) }
 					</VerticalGapLayout>
 				</div>
-				<CheckboxControl
-					label={ __(
-						'I also offer free shipping for all countries for products over a certain price.',
-						'google-listings-and-ads'
-					) }
-					{ ...getInputProps( 'offers_free_shipping' ) }
-				/>
-				{ values.offers_free_shipping && (
-					<div className="price-over-input">
-						<AppInputPriceControl
-							label={ __(
-								'I offer free shipping for products priced over',
-								'google-listings-and-ads'
-							) }
-							{ ...getInputProps( 'free_shipping_threshold' ) }
-						/>
-					</div>
-				) }
 			</VerticalGapLayout>
 		</div>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Part of a PR refactor from the huge PR https://github.com/woocommerce/google-listings-and-ads/pull/1218.
- Related to following PRs: 
  - https://github.com/woocommerce/google-listings-and-ads/pull/1171
  - https://github.com/woocommerce/google-listings-and-ads/pull/1215

Figma: 2bb94-pb

In PR #1171 and #1215, `offers_free_shipping` and `free_shipping_threshold` options have been removed from Merchant Center settings. These options are managed in the shipping settings for each country separately, and they are not set globally anymore.

In this PR, we removed `offers_free_shipping` and `free_shipping_threshold` from the UI code base.

### Screenshots:

Prior to this PR, we would have the checkbox and free shipping amount input like below:

![image](https://user-images.githubusercontent.com/417342/155191120-49d43306-4c05-4dbd-9f4c-acb8f6b90a07.png)

In this PR, the checkbox and the input will be gone.

![image](https://user-images.githubusercontent.com/417342/155191234-d822e3ce-1b97-4d30-b2d1-882cfb249164.png)

### Detailed test instructions:

Look into the code base and do a global search on `offers_free_shipping` and `offers_free_shipping`, there should be 0 search result.

To test the UI, you could try check out the branch and go through Setup MC or Edit Free Listings flow, and verify if you see the UI as per above screenshot. Alternatively, you can check out PR #1218 which contains the same changes, and test the Setup MC or Edit Free Listings flows, and you should not see the checkbox and free shipping amount input.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
