### PR TITLE
Shipping rates UI changes: Better card title layout

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
@@ -13,7 +13,6 @@ import RadioHelperText from '.~/wcdl/radio-helper-text';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import ShippingTimeSetup from './shipping-time/shipping-time-setup';
-import Subsection from '.~/wcdl/subsection';
 
 const ShippingTimeSection = ( {
 	formProps,
@@ -91,12 +90,12 @@ const ShippingTimeSection = ( {
 				{ values.shipping_time === 'flat' && (
 					<Section.Card>
 						<Section.Card.Body>
-							<Subsection.Title>
+							<Section.Card.Title>
 								{ __(
 									'Estimated shipping times',
 									'google-listings-and-ads'
 								) }
-							</Subsection.Title>
+							</Section.Card.Title>
 							<ShippingTimeSetup
 								selectedCountryCodes={ selectedCountryCodes }
 								formProps={ formProps }

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time-section.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time-section.js
@@ -13,7 +13,6 @@ import RadioHelperText from '.~/wcdl/radio-helper-text';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import ShippingTimeSetup from './shipping-time/shipping-time-setup';
-import Subsection from '.~/wcdl/subsection';
 
 const ShippingTimeSection = ( { formProps } ) => {
 	const { getInputProps, values } = formProps;
@@ -88,12 +87,12 @@ const ShippingTimeSection = ( { formProps } ) => {
 				{ values.shipping_time === 'flat' && (
 					<Section.Card>
 						<Section.Card.Body>
-							<Subsection.Title>
+							<Section.Card.Title>
 								{ __(
 									'Estimated shipping times',
 									'google-listings-and-ads'
 								) }
-							</Subsection.Title>
+							</Section.Card.Title>
 							<ShippingTimeSetup formProps={ formProps } />
 						</Section.Card.Body>
 					</Section.Card>

--- a/js/src/wcdl/section/card/index.js
+++ b/js/src/wcdl/section/card/index.js
@@ -8,6 +8,7 @@ import { Card as WPCard } from '@wordpress/components';
  */
 import Body from './body';
 import Footer from './footer';
+import Title from './title';
 
 const Card = ( props ) => {
 	return <WPCard { ...props } size="none" />;
@@ -15,5 +16,6 @@ const Card = ( props ) => {
 
 Card.Body = Body;
 Card.Footer = Footer;
+Card.Title = Title;
 
 export default Card;

--- a/js/src/wcdl/section/card/title/index.js
+++ b/js/src/wcdl/section/card/title/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Subsection from '.~/wcdl/subsection';
+import './index.scss';
+
+const Title = ( props ) => {
+	const { className, ...rest } = props;
+
+	return (
+		<Subsection.Title
+			className={ classnames( 'wcdl-section-card-title', className ) }
+			{ ...rest }
+		/>
+	);
+};
+
+export default Title;

--- a/js/src/wcdl/section/card/title/index.scss
+++ b/js/src/wcdl/section/card/title/index.scss
@@ -1,0 +1,3 @@
+.wcdl-section-card-title {
+	margin-bottom: calc(var(--large-gap) / 2);
+}

--- a/js/src/wcdl/section/card/title/index.scss
+++ b/js/src/wcdl/section/card/title/index.scss
@@ -1,3 +1,3 @@
 .wcdl-section-card-title {
-	margin-bottom: calc(var(--large-gap) / 2);
+	margin-bottom: calc(var(--main-gap) / 3 * 2);
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Part of a PR refactor from the huge PR https://github.com/woocommerce/google-listings-and-ads/pull/1218.

Figma: 2bb94-pb

In this PR, I created a new `Section.Card.Title` component to better manage the title layout in the card. The component will be used in shipping rates component in subsequent PRs. The only impacted area in this PR is the shipping time card in Edit Free Listings and in Setup MC.

### Screenshots:

`Section.Card.Title` in shipping time card in Edit Free Listings:

<img width="702" alt="image" src="https://user-images.githubusercontent.com/417342/156426892-e60e3826-a521-4cab-b832-ec8fb91b7e94.png">

### Detailed test instructions:

1. Go to Edit Free Listings. 
2. The shipping time card should look like the screenshot above.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
