### PR TITLE
Shipping rates UI changes: Better SelectControl label

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/add-rate-button/add-rate-modal/index.js
@@ -86,19 +86,15 @@ const AddRateModal = ( { countries, onRequestClose, onSubmit } ) => {
 						onRequestClose={ onRequestClose }
 					>
 						<VerticalGapLayout>
-							<div>
-								<div className="label">
-									{ __(
-										'If customer is in',
-										'google-listings-and-ads'
-									) }
-								</div>
-								<AppCountrySelect
-									options={ countries }
-									multiple
-									{ ...getInputProps( 'countries' ) }
-								/>
-							</div>
+							<AppCountrySelect
+								label={ __(
+									'If customer is in',
+									'google-listings-and-ads'
+								) }
+								options={ countries }
+								multiple
+								{ ...getInputProps( 'countries' ) }
+							/>
 							<AppInputPriceControl
 								label={ __(
 									'Then the estimated shipping rate displayed in the product listing is',

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -117,17 +117,15 @@ const EditRateModal = ( {
 						onRequestClose={ onRequestClose }
 					>
 						<VerticalGapLayout>
-							<div>
-								<AppCountrySelect
-									label={ __(
-										'If customer is in',
-										'google-listings-and-ads'
-									) }
-									options={ availableCountries }
-									multiple
-									{ ...getInputProps( 'countries' ) }
-								/>
-							</div>
+							<AppCountrySelect
+								label={ __(
+									'If customer is in',
+									'google-listings-and-ads'
+								) }
+								options={ availableCountries }
+								multiple
+								{ ...getInputProps( 'countries' ) }
+							/>
 							<AppInputPriceControl
 								label={ __(
 									'Then the estimated shipping rate displayed in the product listing is',

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.js
@@ -12,7 +12,6 @@ import AppModal from '.~/components/app-modal';
 import AppInputPriceControl from '.~/components/app-input-price-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AppCountrySelect from '.~/components/app-country-select';
-import './index.scss';
 
 /**
  * Form to edit rate for selected country(-ies).
@@ -119,13 +118,11 @@ const EditRateModal = ( {
 					>
 						<VerticalGapLayout>
 							<div>
-								<div className="label">
-									{ __(
+								<AppCountrySelect
+									label={ __(
 										'If customer is in',
 										'google-listings-and-ads'
 									) }
-								</div>
-								<AppCountrySelect
 									options={ availableCountries }
 									multiple
 									{ ...getInputProps( 'countries' ) }

--- a/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-rate/shipping-rate-setup/countries-price-input/edit-rate-button/edit-rate-modal/index.scss
@@ -1,6 +1,0 @@
-.gla-edit-rate-modal {
-	.label {
-		color: #757575;
-		padding-bottom: 4px;
-	}
-}

--- a/js/src/wcdl/select-control/index.scss
+++ b/js/src/wcdl/select-control/index.scss
@@ -1,13 +1,12 @@
 .wcdl-select-control {
-	&__label,
 	&__input,
 	&__helper-text {
 		margin-bottom: calc(var(--main-gap) / 3);
 	}
 
 	&__label {
-		font-size: 13px;
-		line-height: 16px;
+		color: $gray-700;
+		padding-bottom: 4px;
 	}
 
 	&__helper-text {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Part of a PR refactor from the huge PR https://github.com/woocommerce/google-listings-and-ads/pull/1218.

In this PR, I have simplified the way to specify label for the SelectControl. Previously, we had to manually craft a div and CSS to make the UI look nice. Now, we just need to make use of the `label` props. The impacted area in this PR is the EditRateModal in Edit Free Listings flow.

### Screenshots:

SelectControl label in EditRateModal in Edit Free Listings flow:

![image](https://user-images.githubusercontent.com/417342/155195676-2654a4c5-78b8-4de5-bd55-969c866400f5.png)

### Detailed test instructions:

1. Go to Edit Free Listings.
2. In a shipping rate row, click on the Edit button.
3. Verify that the UI looks like the above screenshot.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
