### PR TITLE
#611: Throw an exception when invalid top level domain is returned.

### DIFF
--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidTerm;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidDomainName;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -137,6 +138,7 @@ class Proxy implements OptionsAwareInterface {
 	 *
 	 * @throws Exception   When an Exception is caught or we receive an invalid response.
 	 * @throws InvalidTerm When the account name contains invalid terms.
+	 * @throws InvalidDomainName When an Exception related to an invalid top level domain is received.
 	 */
 	protected function create_merchant_account_request( string $name, string $site_url ): int {
 		try {
@@ -171,6 +173,10 @@ class Proxy implements OptionsAwareInterface {
 
 			if ( preg_match( '/terms?.* are|is not allowed/', $message ) ) {
 				throw InvalidTerm::contains_invalid_terms( $name );
+			}
+
+			if ( preg_match( '/URL?.* invalid top-level domain name/', $message ) ) {
+				throw InvalidDomainName::invalid_top_level_domain_name( $this->get_site_url() );
 			}
 
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );

--- a/src/API/Google/Proxy.php
+++ b/src/API/Google/Proxy.php
@@ -138,7 +138,7 @@ class Proxy implements OptionsAwareInterface {
 	 *
 	 * @throws Exception   When an Exception is caught or we receive an invalid response.
 	 * @throws InvalidTerm When the account name contains invalid terms.
-	 * @throws InvalidDomainName When an Exception related to an invalid top level domain is received.
+	 * @throws InvalidDomainName When the site URL ends with an invalid top-level domain.
 	 */
 	protected function create_merchant_account_request( string $name, string $site_url ): int {
 		try {
@@ -175,8 +175,12 @@ class Proxy implements OptionsAwareInterface {
 				throw InvalidTerm::contains_invalid_terms( $name );
 			}
 
-			if ( preg_match( '/URL?.* invalid top-level domain name/', $message ) ) {
-				throw InvalidDomainName::invalid_top_level_domain_name( $this->get_site_url() );
+			if ( strpos( $message, 'URL ends with an invalid top-level domain name' ) !== false ) {
+				throw InvalidDomainName::create_account_failed_invalid_top_level_domain_name(
+					$this->strip_url_protocol(
+						esc_url_raw( $this->get_site_url() )
+					)
+				);
 			}
 
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );

--- a/src/Exception/InvalidDomainName.php
+++ b/src/Exception/InvalidDomainName.php
@@ -22,10 +22,10 @@ class InvalidDomainName extends InvalidArgumentException implements GoogleListin
 	 *
 	 * @return static
 	 */
-	public static function invalid_top_level_domain_name( string $domain_name ): InvalidDomainName {
+	public static function create_account_failed_invalid_top_level_domain_name( string $domain_name ): InvalidDomainName {
 		return new static(
 		/* translators: 1 top level domain name. */
-			sprintf( __( 'Error creating account: "%1$s" URL ends with an invalid top-level domain name.', 'google-listings-and-ads' ), $domain_name )
+			sprintf( __( 'Unable to create an account, the domain name "%s" must end with a valid top-level domain name.', 'google-listings-and-ads' ), $domain_name )
 		);
 	}
 }

--- a/src/Exception/InvalidDomainName.php
+++ b/src/Exception/InvalidDomainName.php
@@ -1,0 +1,31 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
+
+use InvalidArgumentException;
+
+defined( 'ABSPATH' ) || exit;
+
+
+/**
+ * Class InvalidDomainName
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
+ */
+class InvalidDomainName extends InvalidArgumentException implements GoogleListingsAndAdsException {
+	/**
+	 * Create a new instance of the exception when a Merchant Center account can't be created
+	 * because of an invalid top-level domain name.
+	 *
+	 * @param string $domain_name The top level domain name.
+	 *
+	 * @return static
+	 */
+	public static function invalid_top_level_domain_name( string $domain_name ): InvalidDomainName {
+		return new static(
+		/* translators: 1 top level domain name. */
+			sprintf( __( 'Error creating account: "%1$s" URL ends with an invalid top-level domain name.', 'google-listings-and-ads' ), $domain_name )
+		);
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

An exception error was returned when creating a new merchant account from a site with a URL ending with an invalid top-level domain name. However, this error returned the placeholder "[websiteUrl]" instead of the invalid site URL. This PR corrects this by: 

* Catching errors related to invalid top-level domains specifically, and throwing an error that includes the site's URL.


Closes #611.


### Screenshots:
![Screenshot](https://user-images.githubusercontent.com/4209011/155365739-66d8e235-cddb-445b-ae47-a1cc14c1edb5.jpg)


### Detailed test instructions:


1. [Disconnect](https://wpsandbox.localhost/wp-admin/admin.php?page=connection-test-admin-page) your MC account
2. Go to Setup MC page on you local domain [https://wpsandbox.localhost/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc](https://wpsandbox.localhost/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc)
3. Click "Create Account"
4. The error message should include the website URL. eg Error creating an account: "https://wpsandbox.localhost" URL ends with an invalid top-level domain name


### Additional details:

> Add -A new exception class -- InvalidDomainName -- that is thrown when a Merchant Center account can't be created because of an invalid top-level domain name.
> Fix -Return an InvalidDomainName when an error related to an invalid top-level domain name is caught

### Changelog entry

> Tweak - Catch errors related to invalid top-level domains specifically, and throw an error when the site's URL ends with an invalid top-level domain.
