### PR TITLE
Multi-country targeting campaign - Temporarily mock some ads API on the frontend side

### DIFF
--- a/js/src/data/index.js
+++ b/js/src/data/index.js
@@ -14,7 +14,10 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 import * as resolvers from './resolvers';
 import reducer from './reducer';
-import { createErrorResponseCatcher } from './api-fetch-middlewares';
+import {
+	createErrorResponseCatcher,
+	mockCampaignForMultiCountryTargeting,
+} from './api-fetch-middlewares';
 import { getReconnectAccountsUrl } from '.~/utils/urls';
 
 registerStore( STORE_KEY, {
@@ -51,6 +54,8 @@ apiFetch.use(
 		throw response;
 	} )
 );
+
+apiFetch.use( mockCampaignForMultiCountryTargeting );
 
 export { STORE_KEY };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To develop frontend parts easier before API implementation merged to shared branch, this PR implemented the "**Mock new API design with mocking data**" part of #1248, and it's based on #1268.

- The proposed API designs are listed in the **Backend** section of #1248. Here mocks API will be changed on request or/and response:
   - `GET ads/campaigns`
   - `POST ads/campaigns`
   - `GET ads/campaigns/budget-recommendation`

:warning: Please note that all commits in this PR will be reverted once API development is ready. Please ignore the code quality and readability, etc when reviewing. 🙈 

### Screenshots:

![2022-02-24 17 59 12](https://user-images.githubusercontent.com/17420811/155503531-9220fc07-43e6-44a6-8ecc-970ba3a325a7.png)

![2022-02-24 17 57 47](https://user-images.githubusercontent.com/17420811/155503524-4d767976-e575-4a80-ab8b-1b66bb07e20f.png)

![Kapture 2022-02-24 at 17 59 59](https://user-images.githubusercontent.com/17420811/155503540-0d671b9d-4e6f-4757-b9ab-caff23786c3a.gif)

### Detailed test instructions:

💡  The mocked API will be printed in the Console tab browser's DevTool 

1. Open browser's DevTool and navigate to Console tab.
1. Go to dashboard page.
1. Create a new campaign.
1. It should show the mocked results of `GET ads/campaigns` and `POST ads/campaigns` in Console.
1. Check if the responses are the same as the proposed API design.

💡  Since the endpoint of budget recommendation is different, it couldn't trigger via UI. I added an entry point to test it.

1. Run `wc.gla.queryBudget( 'GB', 'US', 'JP' )` in Console.
1. Call the function with other country codes.
1. It should show the mocked results of `GET ads/campaigns/budget-recommendation`.
1. Check if the responses are the same as the proposed API design.

### Changelog entry
