### PR TITLE
Refactor Campaign to use batch operations

### DIFF
--- a/src/API/Google/AdsCampaignBudget.php
+++ b/src/API/Google/AdsCampaignBudget.php
@@ -13,7 +13,7 @@ use Google\Ads\GoogleAds\Util\V9\ResourceNames;
 use Google\Ads\GoogleAds\V9\Resources\CampaignBudget;
 use Google\Ads\GoogleAds\V9\Services\CampaignBudgetOperation;
 use Google\Ads\GoogleAds\V9\Services\CampaignBudgetServiceClient;
-use Google\Ads\GoogleAds\V9\Services\MutateCampaignBudgetResult;
+use Google\Ads\GoogleAds\V9\Services\MutateOperation;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;
 use Exception;
@@ -21,12 +21,22 @@ use Exception;
 /**
  * Class AdsCampaignBudget
  *
+ * @since x.x.x Refactored to use batch requests when operating on campaigns.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
 class AdsCampaignBudget implements OptionsAwareInterface {
 
 	use MicroTrait;
 	use OptionsAwareTrait;
+
+	/**
+	 * Temporary ID to use within a batch job.
+	 * A negative number which is unique for all the created resources.
+	 *
+	 * @var int
+	 */
+	protected const TEMPORARY_ID = -2;
 
 	/**
 	 * The Google Ads Client.
@@ -45,26 +55,25 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Creates a new campaign budget.
+	 * Returns a new campaign budget create operation.
 	 *
-	 * @param float $amount Budget amount in the local currency.
+	 * @param string $campaign_name New campaign name.
+	 * @param float  $amount        Budget amount in the local currency.
 	 *
-	 * @return string Resource name of the newly created budget.
-	 * @throws ApiException If the campaign budget can't be created.
+	 * @return MutateOperation
 	 */
-	public function create_campaign_budget( float $amount ): string {
+	public function create_operation( string $campaign_name, float $amount ): MutateOperation {
 		$budget = new CampaignBudget(
 			[
+				'resource_name'     => $this->temporary_resource_name(),
+				'name'              => $campaign_name . ' Budget',
 				'amount_micros'     => $this->to_micro( $amount ),
 				'explicitly_shared' => false,
 			]
 		);
 
-		$operation = new CampaignBudgetOperation();
-		$operation->setCreate( $budget );
-		$created_budget = $this->mutate_budget( $operation );
-
-		return $created_budget->getResourceName();
+		$operation = ( new CampaignBudgetOperation() )->setCreate( $budget );
+		return ( new MutateOperation() )->setCampaignBudgetOperation( $operation );
 	}
 
 	/**
@@ -77,7 +86,7 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 	 * @throws ApiException If the campaign budget can't be mutated.
 	 * @throws Exception If no linked budget has been found.
 	 */
-	public function edit_campaign_budget( int $campaign_id, float $amount ): string {
+	public function edit_operation( int $campaign_id, float $amount ): MutateOperation {
 		$budget_id = $this->get_budget_from_campaign( $campaign_id );
 		$budget    = new CampaignBudget(
 			[
@@ -89,26 +98,31 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 		$operation = new CampaignBudgetOperation();
 		$operation->setUpdate( $budget );
 		$operation->setUpdateMask( FieldMasks::allSetFieldsOf( $budget ) );
-		$edited_budget = $this->mutate_budget( $operation );
-
-		return $edited_budget->getResourceName();
+		return ( new MutateOperation() )->setCampaignBudgetOperation( $operation );
 	}
 
 	/**
+	 * Returns a campaign delete operation.
+	 *
 	 * @param int $campaign_id
 	 *
-	 * @return array resource names of deleted budgets.
-	 * @throws ApiException If the budget isn't deleted.
-	 * @throws Exception If no linked budget has been found.
+	 * @return MutateOperation
 	 */
-	public function delete_campaign_budget( int $campaign_id ): array {
+	public function delete_operation( int $campaign_id ): MutateOperation {
 		$budget_id            = $this->get_budget_from_campaign( $campaign_id );
 		$budget_resource_name = ResourceNames::forCampaignBudget( $this->options->get_ads_id(), $budget_id );
 
-		$operation = new CampaignBudgetOperation();
-		$operation->setRemove( $budget_resource_name );
-		$deleted_budget = $this->mutate_budget( $operation );
-		return [ $deleted_budget->getResourceName() ];
+		$operation = ( new CampaignBudgetOperation() )->setRemove( $budget_resource_name );
+		return ( new MutateOperation() )->setCampaignBudgetOperation( $operation );
+	}
+
+	/**
+	 * Return a temporary resource name for the campaign budget.
+	 *
+	 * @return string
+	 */
+	public function temporary_resource_name() {
+		return ResourceNames::forCampaignBudget( $this->options->get_ads_id(), self::TEMPORARY_ID );
 	}
 
 	/**
@@ -132,23 +146,6 @@ class AdsCampaignBudget implements OptionsAwareInterface {
 
 		/* translators: %d Campaign ID */
 		throw new Exception( sprintf( __( 'No budget found for campaign %d', 'google-listings-and-ads' ), $campaign_id ) );
-	}
-
-	/**
-	 * Run a single mutate campaign budget operation.
-	 *
-	 * @param CampaignBudgetOperation $operation Operation we would like to run.
-	 *
-	 * @return MutateCampaignBudgetResult
-	 * @throws ApiException If the remote call to mutate the campaign budget fails.
-	 */
-	protected function mutate_budget( CampaignBudgetOperation $operation ): MutateCampaignBudgetResult {
-		$response = $this->client->getCampaignBudgetServiceClient()->mutateCampaignBudgets(
-			$this->options->get_ads_id(),
-			[ $operation ]
-		);
-
-		return $response->getResults()[0];
 	}
 
 	/**

--- a/src/API/Google/AdsGroup.php
+++ b/src/API/Google/AdsGroup.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsListingGroup
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Google\Ads\GoogleAds\Util\V9\ResourceNames;
 use Google\Ads\GoogleAds\V9\Common\ListingGroupInfo;
 use Google\Ads\GoogleAds\V9\Common\ShoppingSmartAdInfo;
 use Google\Ads\GoogleAds\V9\Enums\AdGroupAdStatusEnum\AdGroupAdStatus;
@@ -23,16 +24,14 @@ use Google\Ads\GoogleAds\V9\Services\AdGroupAdOperation;
 use Google\Ads\GoogleAds\V9\Services\AdGroupCriterionOperation;
 use Google\Ads\GoogleAds\V9\Services\AdGroupOperation;
 use Google\Ads\GoogleAds\V9\Services\GoogleAdsRow;
-use Google\Ads\GoogleAds\V9\Services\MutateAdGroupAdResult;
-use Google\Ads\GoogleAds\V9\Services\MutateAdGroupCriterionResult;
-use Google\Ads\GoogleAds\V9\Services\MutateAdGroupResult;
-use Google\ApiCore\ApiException;
-use Google\ApiCore\ValidationException;
+use Google\Ads\GoogleAds\V9\Services\MutateOperation;
 
 /**
  * Class AdsGroup
  *
- * Straight up copying is the sincerest form of flattery.
+ * @since x.x.x Refactored to use batch requests when operating on campaigns.
+ *
+ * Used for Smart Shopping Campaigns (SSC)
  * https://developers.google.com/google-ads/api/docs/samples/add-shopping-smart-ad
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
@@ -42,11 +41,26 @@ class AdsGroup implements OptionsAwareInterface {
 	use OptionsAwareTrait;
 
 	/**
+	 * Temporary ID to use within a batch job.
+	 * A negative number which is unique for all the created resources.
+	 *
+	 * @var int
+	 */
+	protected const TEMPORARY_ID = -3;
+
+	/**
 	 * The Google Ads Client.
 	 *
 	 * @var GoogleAdsClient
 	 */
 	protected $client;
+
+	/**
+	 * List of ad group resource names.
+	 *
+	 * @var string[]
+	 */
+	protected $ad_groups;
 
 	/**
 	 * AdsGroup constructor.
@@ -58,79 +72,109 @@ class AdsGroup implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Set up the additional objects for the specified campaign:
-	 * Ad group
-	 * Ad group ad
-	 * Listing group
+	 * Returns a set of operations to create an ad group.
+	 *
+	 * @param string $campaign_resource_name
+	 * @param string $campaign_name
+	 * @return array
+	 */
+	public function create_operations( string $campaign_resource_name, string $campaign_name ): array {
+		// Ad group must be created before listing group.
+		return [
+			$this->ad_group_create_operation( $campaign_resource_name, $campaign_name ),
+			$this->ad_group_ad_create_operation(),
+			$this->listing_group_create_operation(),
+		];
+	}
+
+	/**
+	 * Returns a set of operations to delete an ad group.
+	 *
+	 * @param string $campaign_resource_name
+	 * @return array
+	 */
+	public function delete_operations( string $campaign_resource_name ): array {
+		$ad_group_operations      = $this->ad_group_delete_operations( $campaign_resource_name );
+		$ad_group_ad_operations   = $this->ad_group_ad_delete_operations( $campaign_resource_name );
+		$listing_group_operations = $this->listing_group_delete_operations();
+
+		// All assets must be deleted from the group before deleting the ad group.
+		return array_merge(
+			$listing_group_operations,
+			$ad_group_ad_operations,
+			$ad_group_operations
+		);
+	}
+
+	/**
+	 * Returns an ad group create operation.
 	 *
 	 * @param string $campaign_resource_name
 	 * @param string $campaign_name
 	 *
-	 * @throws ApiException If any object isn't created.
+	 * @return MutateOperation
 	 */
-	public function set_up_for_campaign( string $campaign_resource_name, string $campaign_name = '' ) {
-		// Create Smart Shopping ad group.
-		$created_ad_group_resource_name = $this->create_ad_group( $campaign_resource_name, $campaign_name );
-
-		// Create Smart Shopping ad group ad.
-		$this->create_ad_group_ad( $created_ad_group_resource_name );
-
-		// Create ad group criterion containing listing group.
-		$this->create_shopping_listing_group( $created_ad_group_resource_name );
-	}
-
-	/**
-	 * Delete the additional objects for the specified campaign:
-	 * Ad group
-	 * Ad group ad
-	 * Listing group
-	 *
-	 * Should only be called before removing the campaign.
-	 *
-	 * @param string $campaign_resource_name
-	 *
-	 * @throws ApiException|ValidationException If any object isn't deleted.
-	 */
-	public function delete_for_campaign( string $campaign_resource_name ) {
-		$this->delete_shopping_listing_group( $campaign_resource_name );
-		$this->delete_ad_group_ad( $campaign_resource_name );
-		$this->delete_ad_group( $campaign_resource_name );
-	}
-
-	/**
-	 * @param string $campaign_resource_name
-	 * @param string $campaign_name
-	 *
-	 * @return string
-	 * @throws ApiException If the ad group isn't created.
-	 */
-	protected function create_ad_group( string $campaign_resource_name, string $campaign_name = '' ): string {
+	protected function ad_group_create_operation( string $campaign_resource_name, string $campaign_name ): MutateOperation {
 		$ad_group = new AdGroup(
 			[
-				'name'     => $campaign_name . ' Ad Group',
-				'campaign' => $campaign_resource_name,
-				'type'     => AdGroupType::SHOPPING_SMART_ADS,
-				'status'   => AdGroupStatus::ENABLED,
+				'resource_name' => $this->temporary_resource_name(),
+				'name'          => $campaign_name . ' Ad Group',
+				'campaign'      => $campaign_resource_name,
+				'type'          => AdGroupType::SHOPPING_SMART_ADS,
+				'status'        => AdGroupStatus::ENABLED,
 			]
 		);
 
-		// Creates an ad group operation.
-		$operation = new AdGroupOperation();
-		$operation->setCreate( $ad_group );
-		$created_ad_group = $this->mutate_ad_group( $operation );
-
-		return $created_ad_group->getResourceName();
+		$operation = ( new AdGroupOperation() )->setCreate( $ad_group );
+		return ( new MutateOperation() )->setAdGroupOperation( $operation );
 	}
 
 	/**
+	 * Returns an ad group ad create operation.
+	 *
+	 * @return MutateOperation
+	 */
+	protected function ad_group_ad_create_operation(): MutateOperation {
+		$ad_group_ad = new AdGroupAd(
+			[
+				'ad'       => new Ad( [ 'shopping_smart_ad' => new ShoppingSmartAdInfo() ] ),
+				'ad_group' => $this->temporary_resource_name(),
+			]
+		);
+
+		$operation = ( new AdGroupAdOperation() )->setCreate( $ad_group_ad );
+		return ( new MutateOperation() )->setAdGroupAdOperation( $operation );
+	}
+
+	/**
+	 * Returns an ad group criterion create operation.
+	 *
+	 * @return MutateOperation
+	 */
+	protected function listing_group_create_operation(): MutateOperation {
+		$ad_group_criterion = new AdGroupCriterion(
+			[
+				'ad_group'      => $this->temporary_resource_name(),
+				'status'        => AdGroupAdStatus::ENABLED,
+				'listing_group' => new ListingGroupInfo( [ 'type' => ListingGroupType::UNIT ] ),
+			]
+		);
+
+		$operation = ( new AdGroupCriterionOperation() )->setCreate( $ad_group_criterion );
+		return ( new MutateOperation() )->setAdGroupCriterionOperation( $operation );
+	}
+
+	/**
+	 * Returns an ad group delete operation.
+	 *
 	 * @param string $campaign_resource_name
 	 *
-	 * @return array resource names of deleted ad groups
-	 * @throws ApiException If the ad group isn't deleted.
-	 * @throws ValidationException If the ad group query has no results.
+	 * @return MutateOperation[]
 	 */
-	public function delete_ad_group( string $campaign_resource_name ): array {
-		$return  = [];
+	protected function ad_group_delete_operations( string $campaign_resource_name ): array {
+		$operations      = [];
+		$this->ad_groups = [];
+
 		$results = ( new AdsGroupQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
 			->where( 'ad_group.campaign', $campaign_resource_name )
@@ -138,154 +182,73 @@ class AdsGroup implements OptionsAwareInterface {
 
 		/** @var GoogleAdsRow $row */
 		foreach ( $results->iterateAllElements() as $row ) {
-			$resource_name = $row->getAdGroup()->getResourceName();
-			$operation     = new AdGroupOperation();
-			$operation->setRemove( $resource_name );
-			$deleted_ad_group = $this->mutate_ad_group( $operation );
-			$return[]         = $deleted_ad_group->getResourceName();
+			$resource_name     = $row->getAdGroup()->getResourceName();
+			$this->ad_groups[] = $resource_name;
+			$operation         = ( new AdGroupOperation() )->setRemove( $resource_name );
+			$operations[]      = ( new MutateOperation() )->setAdGroupOperation( $operation );
 		}
-		return $return;
+
+		return $operations;
 	}
 
 	/**
-	 * @param AdGroupOperation $operation
+	 * Returns an ad group ad delete operation.
 	 *
-	 * @return MutateAdGroupResult
-	 * @throws ApiException If the mutate call fails.
+	 * @return MutateOperation[]
 	 */
-	protected function mutate_ad_group( AdGroupOperation $operation ): MutateAdGroupResult {
-		$response = $this->client->getAdGroupServiceClient()->mutateAdGroups(
-			$this->options->get_ads_id(),
-			[ $operation ]
-		);
+	protected function ad_group_ad_delete_operations(): array {
+		if ( empty( $this->ad_groups ) ) {
+			return [];
+		}
 
-		return $response->getResults()[0];
-	}
-
-	/**
-	 * @param string $ad_group_resource_name
-	 *
-	 * @return string
-	 * @throws ApiException If the ad group ad isn't created.
-	 */
-	protected function create_ad_group_ad( string $ad_group_resource_name ): string {
-		$ad_group_ad = new AdGroupAd(
-			[
-				'ad'       => new Ad( [ 'shopping_smart_ad' => new ShoppingSmartAdInfo() ] ),
-				'ad_group' => $ad_group_resource_name,
-			]
-		);
-
-		// Creates an ad group ad operation.
-		$operation = new AdGroupAdOperation();
-		$operation->setCreate( $ad_group_ad );
-
-		$created_ad_group_ad = $this->mutate_ad_group_ad( $operation );
-
-		return $created_ad_group_ad->getResourceName();
-	}
-
-	/**
-	 * @param string $campaign_resource_name
-	 *
-	 * @return array resource names of deleted ad group ads
-	 * @throws ApiException If the ad group ad isn't deleted.
-	 * @throws ValidationException If the ad group ad query has no results.
-	 */
-	public function delete_ad_group_ad( string $campaign_resource_name ): array {
-		$return  = [];
-		$results = ( new AdsGroupAdQuery() )
+		$operations = [];
+		$results    = ( new AdsGroupAdQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
-			->where( 'ad_group.campaign', $campaign_resource_name )
+			->where( 'ad_group_ad.ad_group', $this->ad_groups, 'IN' )
 			->get_results();
 
 		/** @var GoogleAdsRow $row */
 		foreach ( $results->iterateAllElements() as $row ) {
 			$resource_name = $row->getAdGroupAd()->getResourceName();
-			$operation     = new AdGroupAdOperation();
-			$operation->setRemove( $resource_name );
-			$deleted_ad_group_ad = $this->mutate_ad_group_ad( $operation );
-			$return[]            = $deleted_ad_group_ad->getResourceName();
+			$operation     = ( new AdGroupAdOperation() )->setRemove( $resource_name );
+			$operations[]  = ( new MutateOperation() )->setAdGroupAdOperation( $operation );
 		}
-		return $return;
+
+		return $operations;
 	}
 
 	/**
-	 * @param AdGroupAdOperation $operation
+	 * Returns an ad group listing group delete operation.
 	 *
-	 * @return MutateAdGroupAdResult
-	 * @throws ApiException If the mutate call fails.
+	 * @return MutateOperation[]
 	 */
-	protected function mutate_ad_group_ad( AdGroupAdOperation $operation ): MutateAdGroupAdResult {
-		$response = $this->client->getAdGroupAdServiceClient()->mutateAdGroupAds(
-			$this->options->get_ads_id(),
-			[ $operation ]
-		);
+	protected function listing_group_delete_operations(): array {
+		if ( empty( $this->ad_groups ) ) {
+			return [];
+		}
 
-		return $response->getResults()[0];
-	}
-
-	/**
-	 * @param string $ad_group_resource_name
-	 *
-	 * @return string
-	 * @throws ApiException If the ad group criterion isn't created.
-	 */
-	protected function create_shopping_listing_group( string $ad_group_resource_name ): string {
-		$ad_group_criterion = new AdGroupCriterion(
-			[
-				'ad_group'      => $ad_group_resource_name,
-				'status'        => AdGroupAdStatus::ENABLED,
-				'listing_group' => new ListingGroupInfo( [ 'type' => ListingGroupType::UNIT ] ),
-			]
-		);
-
-		// Creates an ad group criterion operation.
-		$operation = new AdGroupCriterionOperation();
-		$operation->setCreate( $ad_group_criterion );
-		$created_ad_group_criterion = $this->mutate_shopping_listing_group( $operation );
-
-		return $created_ad_group_criterion->getResourceName();
-	}
-
-	/**
-	 * @param string $campaign_resource_name
-	 *
-	 * @return array resource names of deleted shopping list groups
-	 * @throws ApiException If the ad group criterion isn't deleted.
-	 * @throws ValidationException If the ad group criterion query has no results.
-	 */
-	protected function delete_shopping_listing_group( string $campaign_resource_name ): array {
-		$return  = [];
-		$results = ( new AdsListingGroupQuery() )
+		$operations = [];
+		$results    = ( new AdsListingGroupQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
-			->where( 'ad_group.campaign', $campaign_resource_name )
+			->where( 'ad_group_criterion.ad_group', $this->ad_groups, 'IN' )
 			->get_results();
 
 		/** @var GoogleAdsRow $row */
 		foreach ( $results->iterateAllElements() as $row ) {
 			$resource_name = $row->getAdGroupCriterion()->getResourceName();
-			$operation     = new AdGroupCriterionOperation();
-			$operation->setRemove( $resource_name );
-			$deleted_ad_group_criterion = $this->mutate_shopping_listing_group( $operation );
-			$return[]                   = $deleted_ad_group_criterion->getResourceName();
+			$operation     = ( new AdGroupCriterionOperation() )->setRemove( $resource_name );
+			$operations[]  = ( new MutateOperation() )->setAdGroupCriterionOperation( $operation );
 		}
 
-		return $return;
+		return $operations;
 	}
 
 	/**
-	 * @param AdGroupCriterionOperation $operation
+	 * Return a temporary resource name for the ad group.
 	 *
-	 * @return MutateAdGroupCriterionResult
-	 * @throws ApiException If the mutate call fails.
+	 * @return string
 	 */
-	protected function mutate_shopping_listing_group( AdGroupCriterionOperation $operation ): MutateAdGroupCriterionResult {
-		$response = $this->client->getAdGroupCriterionServiceClient()->mutateAdGroupCriteria(
-			$this->options->get_ads_id(),
-			[ $operation ]
-		);
-
-		return $response->getResults()[0];
+	protected function temporary_resource_name() {
+		return ResourceNames::forAdGroup( $this->options->get_ads_id(), self::TEMPORARY_ID );
 	}
 }

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -12,7 +12,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166Aware
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use DateTime;
 use Exception;
-use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
@@ -33,13 +32,14 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 	protected $ads_campaign;
 
 	/**
-	 * BaseController constructor.
+	 * CampaignController constructor.
 	 *
-	 * @param ContainerInterface $container
+	 * @param RESTServer  $server
+	 * @param AdsCampaign $ads_campaign
 	 */
-	public function __construct( ContainerInterface $container ) {
-		parent::__construct( $container->get( RESTServer::class ) );
-		$this->ads_campaign = $container->get( AdsCampaign::class );
+	public function __construct( RESTServer $server, AdsCampaign $ads_campaign ) {
+		parent::__construct( $server );
+		$this->ads_campaign = $ads_campaign;
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -100,16 +100,11 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->add( Settings::class, ContainerInterface::class );
 
 		$this->share( Ads::class, GoogleAdsClient::class );
+		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class );
 		$this->share( AdsCampaignBudget::class, GoogleAdsClient::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsGroup::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );
-		$this->share(
-			AdsCampaign::class,
-			GoogleAdsClient::class,
-			AdsCampaignBudget::class,
-			AdsGroup::class
-		);
 
 		$this->share( Merchant::class, ShoppingContent::class );
 		$this->share( MerchantMetrics::class, ShoppingContent::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService as AdsAccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
@@ -83,7 +84,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( SettingsController::class );
 		$this->share( ConnectionController::class );
 		$this->share( AdsAccountController::class, AdsAccountService::class );
-		$this->share_with_container( AdsCampaignController::class );
+		$this->share( AdsCampaignController::class, AdsCampaign::class );
 		$this->share_with_container( AdsReportsController::class );
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -81,7 +81,15 @@ abstract class RESTControllerUnitTest extends UnitTest {
 	 */
 	protected function do_request( string $endpoint, string $type = 'GET', array $params = [] ): object {
 		$request = new Request( $type, $endpoint );
-		'GET' === $type ? $request->set_query_params( $params ) : $request->set_body_params( $params );
+
+		if ( 'GET' === $type ) {
+			$request->set_query_params( $params );
+		} else {
+			// Set the body as JSON encoded data.
+			$request->set_header( 'content-type', 'application/json' );
+			$request->set_body( wp_json_encode( $params ) );
+		}
+
 		return $this->server->dispatch_request( $request );
 	}
 

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -1,0 +1,258 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Google\Ads\GoogleAds\Util\V9\ResourceNames;
+use Google\Ads\GoogleAds\V9\Resources\AdGroup;
+use Google\Ads\GoogleAds\V9\Resources\AdGroupAd;
+use Google\Ads\GoogleAds\V9\Resources\AdGroupCriterion;
+use Google\Ads\GoogleAds\V9\Resources\Campaign;
+use Google\Ads\GoogleAds\V9\Resources\CampaignBudget;
+use Google\Ads\GoogleAds\V9\Resources\Campaign\ShoppingSetting;
+use Google\Ads\GoogleAds\V9\Services\GoogleAdsRow;
+use Google\Ads\GoogleAds\V9\Services\GoogleAdsServiceClient;
+use Google\Ads\GoogleAds\V9\Services\MutateGoogleAdsResponse;
+use Google\Ads\GoogleAds\V9\Services\MutateCampaignResult;
+use Google\Ads\GoogleAds\V9\Services\MutateOperationResponse;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\PagedListResponse;
+
+/**
+ * Trait GoogleAdsClient
+ *
+ * @property int                               $ads_id
+ * @property MockObject|GoogleAdsClient        $client
+ * @property MockObject|GoogleAdsServiceClient $service_client
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait
+ */
+trait GoogleAdsClientTrait {
+
+	use MicroTrait;
+
+	protected $client;
+	protected $service_client;
+
+	/**
+	 * Generate a mocked GoogleAdsClient.
+	 */
+	protected function ads_client_setup() {
+		$this->ads_id = 12345;
+
+		$this->service_client = $this->createMock( GoogleAdsServiceClient::class );
+		$this->client         = $this->createMock( GoogleAdsClient::class );
+		$this->client->method( 'getGoogleAdsServiceClient' )->willReturn( $this->service_client );
+	}
+
+	/**
+	 * Generates a mocked exception when an campaign is mutated.
+	 *
+	 * @param ApiException $exception
+	 */
+	protected function generate_campaign_mutate_mock_exception( ApiException $exception ) {
+		$this->service_client->method( 'mutate' )->willThrowException( $exception );
+	}
+
+	/**
+	 * Generate a mocked mutate campaign response.
+	 * Asserts that set of operations contains an operation with the expected type.
+	 *
+	 * @param string $type         Mutation type we are expecting (create/update/remove).
+	 * @param int    $campaign_id  Campaign ID we expect to see in the mutate result.
+	 */
+	protected function generate_campaign_mutate_mock( string $type, int $campaign_id ) {
+		$campaign_result = $this->createMock( MutateCampaignResult::class );
+		$campaign_result->method( 'getResourceName' )->willReturn(
+			ResourceNames::forCampaign( $this->ads_id, $campaign_id )
+		);
+
+		$response = ( new MutateGoogleAdsResponse() )->setMutateOperationResponses(
+			[
+				( new MutateOperationResponse() )->setCampaignResult( $campaign_result ),
+			]
+		);
+
+		$this->service_client->expects( $this->once() )
+			->method( 'mutate' )
+			->willReturnCallback(
+				function( int $ads_id, array $operations ) use ( $type, $response ) {
+
+					// Assert that the campaign operation is the right type.
+					foreach( $operations as $operation ) {
+						if ( 'campaign_operation' === $operation->getOperation() ) {
+							$operation = $operation->getCampaignOperation();
+							$this->assertEquals( $type, $operation->getOperation() );
+						}
+					}
+
+					return $response;
+				}
+			);
+	}
+
+	/**
+	 * Generates a mocked exception when an AdsQuery run.
+	 *
+	 * @param ApiException $exception
+	 */
+	protected function generate_ads_query_mock_exception( ApiException $exception ) {
+		$this->service_client->method( 'search' )->willThrowException( $exception );
+	}
+
+	/**
+	 * Generates a mocked AdsQuery response with a list of mocked rows.
+	 *
+	 * @param GoogleAdsRow[] $rows
+	 */
+	protected function generate_ads_query_mock( array $rows ) {
+		$list_response = $this->createMock( PagedListResponse::class );
+		$list_response->method( 'iterateAllElements' )->willReturn( $rows );
+
+		$this->service_client->method( 'search' )->willReturn( $list_response );
+	}
+
+	/**
+	 * Generates a mocked AdsCampaignQuery response.
+	 *
+	 * @param array $responses Set of campaign data to convert.
+	 */
+	protected function generate_ads_campaign_query_mock( array $responses ) {
+		$this->generate_ads_query_mock(
+			array_map( [ $this, 'generate_campaign_row_mock' ], $responses )
+		);
+	}
+
+	/**
+	 * Generates a mocked AdsCampaignBudgetQuery response.
+	 *
+	 * @param int $budget_id
+	 */
+	protected function generate_ads_campaign_budget_query_mock( int $budget_id ) {
+		$campaign = $this->createMock( Campaign::class );
+		$campaign->method( 'getCampaignBudget' )->willReturn(
+			$this->generate_campaign_budget_resource_name( $budget_id )
+		);
+
+		$this->generate_ads_query_mock(
+			[
+				( new GoogleAdsRow )->setCampaign( $campaign ),
+			]
+		);
+	}
+
+	/**
+	 * Generates a mocked AdsGroupQuery response.
+	 *
+	 * @param string $ad_group_resource_name
+	 * @param string $ad_group_ad_resource_name
+	 * @param string $listing_group_resource_name
+	 */
+	protected function generate_ads_group_query_mock(
+		string $ad_group_resource_name,
+		string $ad_group_ad_resource_name,
+		string $listing_group_resource_name
+	) {
+		$ad_group = $this->createMock( AdGroup::class );
+		$ad_group->method( 'getResourceName' )->willReturn( $ad_group_resource_name );
+
+		$ad_group_ad = $this->createMock( AdGroupAd::class );
+		$ad_group_ad->method( 'getResourceName' )->willReturn( $ad_group_ad_resource_name );
+
+		$listing_group = $this->createMock( AdGroupCriterion::class );
+		$listing_group->method( 'getResourceName' )->willReturn( $listing_group_resource_name );
+
+		$list_response = $this->createMock( PagedListResponse::class );
+		$list_response->expects( $this->exactly( 3 ) )
+			->method( 'iterateAllElements' )
+			->will(
+				$this->onConsecutiveCalls(
+					[
+						( new GoogleAdsRow )->setAdGroup( $ad_group ),
+					],
+					[
+						( new GoogleAdsRow )->setAdGroupAd( $ad_group_ad ),
+					],
+					[
+						( new GoogleAdsRow )->setAdGroupCriterion( $listing_group ),
+					]
+				)
+			);
+
+		$this->service_client->method( 'search' )->willReturn( $list_response );
+	}
+
+	/**
+	 * Converts campaign data to a mocked GoogleAdsRow.
+	 *
+	 * @param array $data Campaign data to convert.
+	 *
+	 * @return GoogleAdsRow
+	 */
+	protected function generate_campaign_row_mock( array $data ): GoogleAdsRow {
+		$setting = $this->createMock( ShoppingSetting::class );
+		$setting->method( 'getSalesCountry' )->willReturn( $data['country'] );
+
+		$campaign = $this->createMock( Campaign::class );
+		$campaign->method( 'getId' )->willReturn( $data['id'] );
+		$campaign->method( 'getName' )->willReturn( $data['name'] );
+		$campaign->method( 'getStatus' )->willReturn( CampaignStatus::number( $data['status'] ) );
+		$campaign->method( 'getShoppingSetting' )->willReturn( $setting );
+
+		$budget = $this->createMock( CampaignBudget::class );
+		$budget->method( 'getAmountMicros' )->willReturn( $this->to_micro( $data['amount'] ) );
+
+		return ( new GoogleAdsRow )
+			->setCampaign( $campaign )
+			->setCampaignBudget( $budget );
+	}
+
+	/**
+	 * Generates a campaign resource name.
+	 *
+	 * @param int $campaign_id
+	 */
+	protected function generate_campaign_resource_name( int $campaign_id ) {
+		return ResourceNames::forCampaign( $this->ads_id, $campaign_id );
+	}
+
+	/**
+	 * Generates a campaign budget resource name.
+	 *
+	 * @param int $budget_id
+	 */
+	protected function generate_campaign_budget_resource_name( int $budget_id ) {
+		return ResourceNames::forCampaignBudget( $this->ads_id, $budget_id );
+	}
+
+	/**
+	 * Generates an ad group resource name.
+	 *
+	 * @param int $ad_group_id
+	 */
+	protected function generate_ad_group_resource_name( int $ad_group_id ) {
+		return ResourceNames::forAdGroup( $this->ads_id, $ad_group_id );
+	}
+
+	/**
+	 * Generates an ad group ad resource name.
+	 *
+	 * @param int $ad_group_ad_id
+	 */
+	protected function generate_ad_group_ad_resource_name( int $ad_group_id, int $ad_group_ad_id ) {
+		return ResourceNames::forAdGroupAd( $this->ads_id, $ad_group_id, $ad_group_ad_id );
+	}
+
+	/**
+	 * Generates an ad group criterion resource name.
+	 *
+	 * @param int $ad_group_id
+	 * @param int $listing_group_id
+	 */
+	protected function generate_listing_group_resource_name( int $ad_group_id, int $listing_group_id ) {
+		return ResourceNames::forAdGroupCriterion( $this->ads_id, $ad_group_id, $listing_group_id );
+	}
+}

--- a/tests/Unit/API/Google/AdsCampaignBudgetTest.php
+++ b/tests/Unit/API/Google/AdsCampaignBudgetTest.php
@@ -1,0 +1,87 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignBudget;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsCampaignBudgetTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ *
+ * @property MockObject|OptionsInterface $options
+ * @property AdsCampaignBudget           $budget
+ */
+class AdsCampaignBudgetTest extends UnitTest {
+
+	use GoogleAdsClientTrait;
+
+	protected const TEST_CAMPAIGN_ID = 1234567890;
+	protected const TEST_BUDGET_ID   = 4455667788;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->ads_client_setup();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+
+		$this->budget = new AdsCampaignBudget( $this->client );
+		$this->budget->set_options_object( $this->options );
+	}
+
+	public function test_create_operation() {
+		$operation = $this->budget->create_operation(
+			'New Campaign',
+			12
+		)->getCampaignBudgetOperation();
+		$this->assertTrue( $operation->hasCreate() );
+
+		$budget = $operation->getCreate();
+		$this->assertEquals( 'New Campaign Budget', $budget->getName() );
+		$this->assertEquals( 12 * 1000000, $budget->getAmountMicros() );
+		$this->assertEquals( $this->budget->temporary_resource_name(), $budget->getResourceName() );
+	}
+
+	public function test_edit_operation() {
+		$this->generate_ads_campaign_budget_query_mock( self::TEST_BUDGET_ID );
+
+		$operation = $this->budget->edit_operation(
+			self::TEST_CAMPAIGN_ID,
+			10.50
+		)->getCampaignBudgetOperation();
+		$this->assertTrue( $operation->hasUpdate() );
+
+		$budget = $operation->getUpdate();
+		$this->assertEquals( 10.50 * 1000000, $budget->getAmountMicros() );
+		$this->assertEquals(
+			$this->generate_campaign_budget_resource_name( self::TEST_BUDGET_ID ),
+			$budget->getResourceName()
+		);
+	}
+
+	public function test_delete_operation() {
+		$this->generate_ads_campaign_budget_query_mock( self::TEST_BUDGET_ID );
+
+		$operation = $this->budget->delete_operation(
+			self::TEST_CAMPAIGN_ID
+		)->getCampaignBudgetOperation();
+		$this->assertTrue( $operation->hasRemove() );
+
+		$this->assertEquals(
+			$this->generate_campaign_budget_resource_name( self::TEST_BUDGET_ID ),
+			$operation->getRemove()
+		);
+	}
+}

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -1,0 +1,224 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignBudget;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsGroup;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Google\ApiCore\ApiException;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsCampaignTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ *
+ * @property MockObject|AdsGroup          $ad_group
+ * @property MockObject|AdsCampaignBudget $budget
+ * @property MockObject|OptionsInterface  $options
+ * @property AdsCampaign                  $campaign
+ * @property Container                    $container
+ */
+class AdsCampaignTest extends UnitTest {
+
+	use GoogleAdsClientTrait;
+
+	protected const TEST_CAMPAIGN_ID = 1234567890;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->ads_client_setup();
+
+		$this->ad_group    = $this->createMock( AdsGroup::class );
+		$this->budget      = $this->createMock( AdsCampaignBudget::class );
+		$this->options     = $this->createMock( OptionsInterface::class );
+
+		$this->container = new Container();
+		$this->container->share( AdsGroup::class, $this->ad_group );
+
+		$this->campaign = new AdsCampaign( $this->client, $this->budget );
+		$this->campaign->set_options_object( $this->options );
+		$this->campaign->set_container( $this->container );
+
+		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+	}
+
+	public function test_get_campaigns_empty_list() {
+		$this->generate_ads_campaign_query_mock( [] );
+		$this->assertEquals( [], $this->campaign->get_campaigns() );
+	}
+
+	public function test_get_campaigns() {
+		$campaigns_data = [
+			[
+				'id'      => self::TEST_CAMPAIGN_ID,
+				'name'    => 'Campaign One',
+				'status'  => 'paused',
+				'amount'  => 10,
+				'country' => 'US',
+			],
+			[
+				'id'      => 5678901234,
+				'name'    => 'Campaign Two',
+				'status'  => 'enabled',
+				'amount'  => 20,
+				'country' => 'UK',
+			],
+		];
+
+		$this->generate_ads_campaign_query_mock( $campaigns_data );
+		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
+	}
+
+	public function test_get_campaigns_exception() {
+		$this->generate_ads_query_mock_exception( new ApiException( 'unavailable', 14, 'UNAVAILABLE' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Error retrieving campaigns: unavailable' );
+		$this->expectExceptionCode( 503 );
+
+		$this->campaign->get_campaigns();
+	}
+
+	public function test_get_campaign() {
+		$campaign_data = [
+			'id'      => self::TEST_CAMPAIGN_ID,
+			'name'    => 'Single Campaign',
+			'status'  => 'enabled',
+			'amount'  => 10,
+			'country' => 'US',
+		];
+
+		$this->generate_ads_campaign_query_mock( [ $campaign_data ] );
+		$this->assertEquals( $campaign_data, $this->campaign->get_campaign( self::TEST_CAMPAIGN_ID ) );
+	}
+
+	public function test_get_campaign_exception() {
+		$this->generate_ads_query_mock_exception( new ApiException( 'not found', 5, 'NOT_FOUND' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Error retrieving campaign: not found' );
+		$this->expectExceptionCode( 404 );
+
+		$this->campaign->get_campaign( self::TEST_CAMPAIGN_ID );
+	}
+
+	public function test_create_campaign() {
+		$campaign_data = [
+			'name'    => 'New Campaign',
+			'amount'  => 20,
+			'country' => 'US',
+		];
+
+		$this->generate_campaign_mutate_mock( 'create', self::TEST_CAMPAIGN_ID );
+
+		$expected = [
+			'id'     => self::TEST_CAMPAIGN_ID,
+			'status' => 'enabled',
+		] + $campaign_data;
+
+		$this->assertEquals(
+			$expected,
+			$this->campaign->create_campaign( $campaign_data )
+		);
+	}
+
+	public function test_create_campaign_exception() {
+		$campaign_data = [
+			'name'    => 'Invalid Campaign',
+			'amount'  => 20,
+			'country' => 'US',
+		];
+
+		$errors = [
+			'errors' => [
+				[
+					'errorCode' => [
+						'campaignError' => 'DUPLICATE_CAMPAIGN_NAME',
+					],
+				],
+			],
+		];
+
+		$this->generate_campaign_mutate_mock_exception(
+			new ApiException( 'invalid', 3, 'INVALID_ARGUMENT', [ 'metadata' => [ $errors ] ] )
+		);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'A campaign with this name already exists' );
+		$this->expectExceptionCode( 400 );
+
+		$this->campaign->create_campaign( $campaign_data );
+	}
+
+	public function test_edit_campaign() {
+		$campaign_data = [
+			'amount'  => 40,
+			'status' => 'paused',
+		];
+
+		$this->generate_campaign_mutate_mock( 'update', self::TEST_CAMPAIGN_ID );
+
+		$this->assertEquals(
+			self::TEST_CAMPAIGN_ID,
+			$this->campaign->edit_campaign( self::TEST_CAMPAIGN_ID, $campaign_data )
+		);
+	}
+
+	public function test_edit_campaign_exception() {
+		$campaign_data = [
+			'amount' => 0.001,
+		];
+
+		$this->generate_campaign_mutate_mock_exception( new ApiException( 'invalid', 3, 'INVALID_ARGUMENT' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Error editing campaign: invalid' );
+		$this->expectExceptionCode( 400 );
+
+		$this->campaign->edit_campaign( self::TEST_CAMPAIGN_ID, $campaign_data );
+	}
+
+	public function test_delete_campaign() {
+		$this->generate_campaign_mutate_mock( 'remove', self::TEST_CAMPAIGN_ID );
+
+		$this->assertEquals(
+			self::TEST_CAMPAIGN_ID,
+			$this->campaign->delete_campaign( self::TEST_CAMPAIGN_ID )
+		);
+	}
+
+	public function test_delete_campaign_exception() {
+		$errors = [
+			'errors' => [
+				[
+					'errorCode' => [
+						'campaignError' => 'OPERATION_NOT_PERMITTED_FOR_REMOVED_RESOURCE',
+					],
+				],
+			],
+		];
+
+		$this->generate_campaign_mutate_mock_exception(
+			new ApiException( 'invalid', 3, 'INVALID_ARGUMENT', [ 'metadata' => [ $errors ] ] )
+		);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'This campaign has already been deleted' );
+		$this->expectExceptionCode( 400 );
+
+		$this->campaign->delete_campaign( self::TEST_CAMPAIGN_ID );
+	}
+}

--- a/tests/Unit/API/Google/AdsGroupTest.php
+++ b/tests/Unit/API/Google/AdsGroupTest.php
@@ -1,0 +1,126 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsGroup;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use Google\Ads\GoogleAds\V9\Common\ShoppingSmartAdInfo;
+use Google\Ads\GoogleAds\V9\Enums\AdGroupAdStatusEnum\AdGroupAdStatus;
+use Google\Ads\GoogleAds\V9\Enums\AdGroupStatusEnum\AdGroupStatus;
+use Google\Ads\GoogleAds\V9\Enums\AdGroupTypeEnum\AdGroupType;
+use Google\Ads\GoogleAds\V9\Enums\ListingGroupTypeEnum\ListingGroupType;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsGroupTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ *
+ * @property MockObject|OptionsInterface $options
+ * @property AdsGroup                    $ad_group
+ */
+class AdsGroupTest extends UnitTest {
+
+	use GoogleAdsClientTrait;
+
+	protected const TEST_CAMPAIGN_ID      = 1234567890;
+	protected const TEST_AD_GROUP_ID      = 5566778899;
+	protected const TEST_AD_GROUP_AD_ID   = 6677889911;
+	protected const TEST_LISTING_GROUP_ID = 7788991122;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->ads_client_setup();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+
+		$this->ad_group = new AdsGroup( $this->client );
+		$this->ad_group->set_options_object( $this->options );
+	}
+
+	public function test_create_operations() {
+		$campaign_resource_name = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
+		$ad_group_resource_name = $this->generate_ad_group_resource_name( -3 );
+
+		$operations = $this->ad_group->create_operations(
+			$campaign_resource_name,
+			'New Campaign'
+		);
+
+		$operation_ad_group = $operations[0]->getAdGroupOperation();
+		$this->assertTrue( $operation_ad_group->hasCreate() );
+
+		$ad_group = $operation_ad_group->getCreate();
+		$this->assertEquals( 'New Campaign Ad Group', $ad_group->getName() );
+		$this->assertEquals( $campaign_resource_name, $ad_group->getCampaign() );
+		$this->assertEquals( $ad_group_resource_name, $ad_group->getResourceName() );
+		$this->assertEquals( AdGroupStatus::ENABLED, $ad_group->getStatus() );
+		$this->assertEquals( AdGroupType::SHOPPING_SMART_ADS, $ad_group->getType() );
+
+		$operation_ad_group_ad = $operations[1]->getAdGroupAdOperation();
+		$this->assertTrue( $operation_ad_group_ad->hasCreate() );
+
+		$ad_group_ad = $operation_ad_group_ad->getCreate();
+		$this->assertEquals( $ad_group_resource_name, $ad_group_ad->getAdGroup() );
+		$this->assertEquals( new ShoppingSmartAdInfo(), $ad_group_ad->getAd()->getShoppingSmartAd() );
+
+		$operation_listing_group = $operations[2]->getAdGroupCriterionOperation();
+		$this->assertTrue( $operation_listing_group->hasCreate() );
+
+		$listing_group = $operation_listing_group->getCreate();
+		$this->assertEquals( $ad_group_resource_name, $listing_group->getAdGroup() );
+		$this->assertEquals( AdGroupAdStatus::ENABLED, $listing_group->getStatus() );
+		$this->assertEquals(
+			ListingGroupType::UNIT,
+			$listing_group->getListingGroup()->getType()
+		);
+	}
+
+	public function test_delete_operations() {
+		$campaign_resource_name      = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
+		$ad_group_resource_name      = $this->generate_ad_group_resource_name( self::TEST_AD_GROUP_ID );
+		$ad_group_ad_resource_name   = $this->generate_ad_group_ad_resource_name( self::TEST_AD_GROUP_ID, self::TEST_AD_GROUP_AD_ID );
+		$listing_group_resource_name = $this->generate_listing_group_resource_name( self::TEST_AD_GROUP_ID, self::TEST_LISTING_GROUP_ID );
+
+		$this->generate_ads_group_query_mock(
+			$ad_group_resource_name,
+			$ad_group_ad_resource_name,
+			$listing_group_resource_name
+		);
+
+		$operations = $this->ad_group->delete_operations(
+			$campaign_resource_name
+		);
+
+		$operation_listing_group = $operations[0]->getAdGroupCriterionOperation();
+		$this->assertTrue( $operation_listing_group->hasRemove() );
+		$this->assertEquals(
+			$listing_group_resource_name,
+			$operation_listing_group->getRemove()
+		);
+
+		$operation_ad_group_ad = $operations[1]->getAdGroupAdOperation();
+		$this->assertTrue( $operation_ad_group_ad->hasRemove() );
+		$this->assertEquals(
+			$ad_group_ad_resource_name,
+			$operation_ad_group_ad->getRemove()
+		);
+
+		$operation_ad_group = $operations[2]->getAdGroupOperation();
+		$this->assertTrue( $operation_ad_group->hasRemove() );
+		$this->assertEquals(
+			$ad_group_resource_name,
+			$operation_ad_group->getRemove()
+		);
+	}
+}

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\CampaignController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class CampaignControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ *
+ * @property AdsCampaign|MockObject         $ads_campaign
+ * @property ISO3166DataProvider|MockObject $iso_provider;
+ * @property CampaignController             $controller
+ */
+class CampaignControllerTest extends RESTControllerUnitTest {
+
+	protected const TEST_CAMPAIGN_ID = 1234567890;
+	protected const ROUTE_CAMPAIGNS  = '/wc/gla/ads/campaigns';
+	protected const ROUTE_CAMPAIGN   = '/wc/gla/ads/campaigns/' . self::TEST_CAMPAIGN_ID;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->ads_campaign = $this->createMock( AdsCampaign::class );
+		$this->iso_provider = $this->createMock( ISO3166DataProvider::class );
+
+		$this->controller = new CampaignController( $this->server, $this->ads_campaign );
+		$this->controller->register();
+		$this->controller->set_iso3166_provider( $this->iso_provider );
+	}
+
+	public function test_get_campaigns() {
+		$campaigns_data = [
+			[
+				'id'      => self::TEST_CAMPAIGN_ID,
+				'name'    => 'Campaign One',
+				'status'  => 'paused',
+				'amount'  => 10,
+				'country' => 'US',
+			],
+			[
+				'id'      => 5678901234,
+				'name'    => 'Campaign Two',
+				'status'  => 'enabled',
+				'amount'  => 20,
+				'country' => 'UK',
+			],
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaigns' )
+			->willReturn( $campaigns_data );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'GET' );
+
+		$this->assertEquals( $campaigns_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_campaigns_with_api_exception() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaigns' )
+			->willThrowException( new Exception( 'error', 401 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'GET' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_create_campaign() {
+		$campaign_data = [
+			'name'    => 'New Campaign',
+			'amount'  => 20,
+			'country' => 'US',
+		];
+
+		$expected = [
+			'id'     => self::TEST_CAMPAIGN_ID,
+			'status' => 'enabled',
+		] + $campaign_data;
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'create_campaign' )
+			->with( $campaign_data )
+			->willReturn( $expected );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_create_campaign_without_name() {
+		$campaign_data = [
+			'amount'  => 30,
+			'country' => 'GB',
+		];
+
+		$expected = [
+			'name'   => 'Campaign 2022-02-22 02:22:02',
+			'id'     => self::TEST_CAMPAIGN_ID,
+			'status' => 'enabled',
+		] + $campaign_data;
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'create_campaign' )
+			->willReturnCallback(
+				function( array $data ) use ( $campaign_data, $expected ) {
+					$name = $data['name'];
+					unset( $data['name'] );
+
+					// Confirm name matches the datetime format.
+					$this->assertStringMatchesFormat( 'Campaign %d-%d-%d %d:%d:%d', $name, 'Name does not match' );
+					$this->assertEquals( $data, $campaign_data );
+
+					return $expected;
+				}
+			);
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_create_campaign_invalid_country_code() {
+		$campaign_data = [
+			'amount'  => 20,
+			'country' => 'United States',
+		];
+
+		$this->iso_provider
+			->method( 'alpha2' )
+			->willThrowException( new Exception( 'invalid_country' ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): country', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_create_campaign_with_api_exception() {
+		$campaign_data = [
+			'amount'  => 20,
+			'country' => 'US',
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'create_campaign' )
+			->willThrowException( new Exception( 'error', 401 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_create_campaign_missing_parameters() {
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', [] );
+
+		$this->assertEquals( 'Missing parameter(s): amount, country', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_get_campaign() {
+		$campaign_data = [
+			'id'      => self::TEST_CAMPAIGN_ID,
+			'name'    => 'Campaign Name',
+			'status'  => 'enabled',
+			'amount'  => 10,
+			'country' => 'US',
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willReturn( $campaign_data );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'GET' );
+
+		$this->assertEquals( $campaign_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_campaign_not_found() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willReturn( [] );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'GET' );
+
+		$this->assertEquals(
+			[
+				'message' => 'Campaign is not available.',
+				'id'      => self::TEST_CAMPAIGN_ID,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	public function test_get_campaign_with_api_exception() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willThrowException( new Exception( 'error', 500 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'GET' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 500, $response->get_status() );
+	}
+
+	public function test_edit_campaign() {
+		$campaign_data = [
+			'amount'  => 44.55,
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'edit_campaign' )
+			->with( self::TEST_CAMPAIGN_ID, $campaign_data )
+			->willReturn( self::TEST_CAMPAIGN_ID );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'POST', $campaign_data );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully edited campaign.',
+				'id'      => self::TEST_CAMPAIGN_ID,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_campaign_country() {
+		$campaign_data = [
+			'country' => 'GB',
+		];
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'POST', $campaign_data );
+
+		$this->assertEquals(
+			[
+				'status'  => 'invalid_data',
+				'message' => 'Invalid edit data.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_edit_campaign_with_api_exception() {
+		$campaign_data = [
+			'amount' => 0.001,
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'edit_campaign' )
+			->with( self::TEST_CAMPAIGN_ID, $campaign_data )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'POST', $campaign_data );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_delete_campaign() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'delete_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willReturn( self::TEST_CAMPAIGN_ID );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'DELETE' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully deleted campaign.',
+				'id'      => self::TEST_CAMPAIGN_ID,
+			], $response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_delete_campaign_with_api_exception() {
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'delete_campaign' )
+			->with( self::TEST_CAMPAIGN_ID )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'DELETE' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In PR #1241 it was a requirement to switch to batch operations to handle PMax campaigns. For the multi country support we would like to make use of the same changes (without the support for PMax campaigns). So this PR encapsulates only the batch operations as well as the matching unit tests taken from PR #1251 and #1254.
All the PR's this code was copied from have already been reviewed and tested, but since it takes away the support for PMax campaigns there is some new code introduced for testing the creation of SSC campaigns with batch operations.

### Detailed test instructions:

One way to test this PR is to connect an Ads account. Go to Marketing > Google Listings & Ads > Dashboard where the following actions can be tested:

- Add paid campaign
- List existing campaigns
- Pause / Enable a campaign
- Edit a campaign
- Delete a campaign

Another alternative for testing is through Postman requests.

#### Create campaign
`POST https://domain.test/wp-json/wc/gla/ads/campaigns`

Body:
```json
{
	"name": "Campaign 2022-02-22",
	"amount": 12.00,
	"country": "US"
}
```
Response:
```json
{
	"id": 1234567890,
	"name": "Campaign 2022-02-22",
	"status": "enabled",
	"amount": 12,
	"country": "US"
}
```

#### List campaigns
`GET https://domain.test/wp-json/wc/gla/ads/campaigns`

Response:
```json
[
	{
		"id": 5678901234,
		"name": "Campaign 2022-01-01",
		"status": "enabled",
		"amount": 18.50,
		"country": "US"
	},
	{
		"id": 1234567890
		"name": "Campaign 2022-02-22",
		"status": "enabled",
		"amount": 12,
		"country": "US"
	}
]
```

#### Edit a campaign
`PATCH https://domain.test/wp-json/wc/gla/ads/campaigns/1234567890`

Body:
```json
{
	"status": "paused",
	"name": "Updated Campaign Name",
	"amount": 25
}
```

Response:
```json
{
	"status": "success",
	"message": "Successfully edited campaign.",
	"id": 1234567890
}
```

#### Delete a campaign
`DELETE https://domain.test/wp-json/wc/gla/ads/campaigns/1234567890`

Response:
```json
{
	"status": "success",
	"message": "Successfully deleted campaign.",
	"id": 1234567890
}
```

### Changelog entry
* Update - Change Campaign operations to batch requests.
