### PR TITLE
Multi-country targeting campaign - Integrate UI with `ads/campaigns` related endpoints

### DIFF
--- a/js/src/components/paid-ads/audience-section.js
+++ b/js/src/components/paid-ads/audience-section.js
@@ -36,7 +36,7 @@ const AudienceSection = ( props ) => {
 	} = props;
 
 	const countryNameMap = useCountryKeyNameMap();
-	const inputProps = getInputProps( 'country' );
+	const inputProps = getInputProps( 'countryCodes' );
 
 	/**
 	 * Hack to prevent tags being removed even when disabled.

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -33,7 +33,7 @@ const BudgetSection = ( props ) => {
 		disabled = false,
 	} = props;
 	const {
-		country: [ selectedCountryCode ],
+		countryCodes: [ selectedCountryCode ],
 		amount,
 	} = values;
 	const { googleAdsAccount } = useGoogleAdsAccount();

--- a/js/src/components/paid-ads/create-campaign-form-content.js
+++ b/js/src/components/paid-ads/create-campaign-form-content.js
@@ -8,7 +8,7 @@ import './campaign-form-content.scss';
 
 const CreateCampaignFormContent = ( props ) => {
 	const { formProps } = props;
-	const disabledBudgetSection = ! formProps.values.country.length;
+	const disabledBudgetSection = ! formProps.values.countryCodes.length;
 
 	return (
 		<div className="gla-campaign-form-content">

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -44,6 +44,21 @@ const headers = [
 	{ key: 'actions', label: '', required: true },
 ];
 
+function CountryColumn( { countryCodes, countryNameMap } ) {
+	const [ first ] = countryCodes;
+	return (
+		<span>
+			{ countryNameMap[ first ] }
+			{ countryCodes.length >= 2 &&
+				sprintf(
+					// translators: %s: number of countries, with minimum value of 1.
+					__( ' + %s more', 'google-listings-and-ads' ),
+					countryCodes.length - 1
+				) }
+		</span>
+	);
+}
+
 /**
  * All programs table.
  *
@@ -72,24 +87,27 @@ const AllProgramsTableCard = ( props ) => {
 			title: __( 'Free listings', 'google-listings-and-ads' ),
 			dailyBudget: __( 'Free', 'google-listings-and-ads' ),
 			country: (
-				<span>
-					{ map[ finalCountryCodesData[ 0 ] ] }
-					{ finalCountryCodesData.length >= 2 &&
-						sprintf(
-							// translators: %s: number of campaigns, with minimum value of 1.
-							__( ' + %s more', 'google-listings-and-ads' ),
-							finalCountryCodesData.length - 1
-						) }
-				</span>
+				<CountryColumn
+					countryCodes={ finalCountryCodesData }
+					countryNameMap={ map }
+				/>
 			),
 			active: true,
 		},
 		...adsCampaignsData.map( ( el ) => {
+			const countryCodes = el.allowMultiple
+				? el.targeted_locations
+				: [ el.country ];
 			return {
 				id: el.id,
 				title: el.name,
 				dailyBudget: formatAmount( el.amount, true ),
-				country: map[ el.country ],
+				country: (
+					<CountryColumn
+						countryCodes={ countryCodes }
+						countryNameMap={ map }
+					/>
+				),
 				active: el.status === 'enabled',
 			};
 		} ),

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -51,8 +51,8 @@ function CountryColumn( { countryCodes, countryNameMap } ) {
 			{ countryNameMap[ first ] }
 			{ countryCodes.length >= 2 &&
 				sprintf(
-					// translators: %s: number of countries, with minimum value of 1.
-					__( ' + %s more', 'google-listings-and-ads' ),
+					// translators: %d: number of countries, with minimum value of 1.
+					__( ' + %d more', 'google-listings-and-ads' ),
 					countryCodes.length - 1
 				) }
 		</span>

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -95,16 +95,13 @@ const AllProgramsTableCard = ( props ) => {
 			active: true,
 		},
 		...adsCampaignsData.map( ( el ) => {
-			const countryCodes = el.allowMultiple
-				? el.targeted_locations
-				: [ el.country ];
 			return {
 				id: el.id,
 				title: el.name,
 				dailyBudget: formatAmount( el.amount, true ),
 				country: (
 					<CountryColumn
-						countryCodes={ countryCodes }
+						countryCodes={ el.displayCountries }
 						countryNameMap={ map }
 					/>
 				),

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import TYPES from './action-types';
 import { API_NAMESPACE } from './constants';
+import { adaptAdsCampaign } from './adapters';
 
 export function handleFetchError( error, message ) {
 	const { createNotice } = dispatch( 'core/notices' );
@@ -760,24 +761,6 @@ export function* saveTargetAudience( targetAudience ) {
 	}
 }
 
-/**
- * Adaptes the campaign entity received from API.
- *
- * @param {Object} campaign The campaign entity to be adapted.
- * @return {Campaign} Campaign data.
- */
-function adapteAdsCampaign( campaign ) {
-	const allowMultiple = campaign.targeted_locations.length > 0;
-	const displayCountries = allowMultiple
-		? campaign.targeted_locations
-		: [ campaign.country ];
-	return {
-		...campaign,
-		allowMultiple,
-		displayCountries,
-	};
-}
-
 export function* fetchAdsCampaigns() {
 	try {
 		const campaigns = yield apiFetch( {
@@ -786,7 +769,7 @@ export function* fetchAdsCampaigns() {
 
 		return {
 			type: TYPES.RECEIVE_ADS_CAMPAIGNS,
-			adsCampaigns: campaigns.map( adapteAdsCampaign ),
+			adsCampaigns: campaigns.map( adaptAdsCampaign ),
 		};
 	} catch ( error ) {
 		yield handleFetchError(
@@ -820,7 +803,7 @@ export function* createAdsCampaign( amount, countryCodes ) {
 
 		return {
 			type: TYPES.CREATE_ADS_CAMPAIGN,
-			createdCampaign: adapteAdsCampaign( createdCampaign ),
+			createdCampaign: adaptAdsCampaign( createdCampaign ),
 		};
 	} catch ( error ) {
 		yield handleFetchError(

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -796,18 +796,18 @@ export function* fetchAdsCampaigns() {
  * Create a new ads campaign.
  *
  * @param {number} amount Daily average cost of the paid ads campaign.
- * @param {string} country Country code of the paid ads campaign audience country. Example: 'US'.
+ * @param {Array<CountryCode>} countryCodes Country code of the paid ads campaign audience country. Example: 'US'.
  *
  * @throws { { message: string } } Will throw an error if the campaign creation fails.
  */
-export function* createAdsCampaign( amount, country ) {
+export function* createAdsCampaign( amount, countryCodes ) {
 	try {
 		const createdCampaign = yield apiFetch( {
 			path: `${ API_NAMESPACE }/ads/campaigns`,
 			method: 'POST',
 			data: {
 				amount,
-				country,
+				targeted_locations: countryCodes,
 			},
 		} );
 

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -54,6 +54,8 @@ export function handleFetchError( error, message ) {
  *   For single-country campaigns, it will an empty array.
  * @property {boolean} allowMultiple Indicate whether this campaign allows multi-country targeting.
  *   This can be used to distinguish this campaign is multi-country or single-country targeting.
+ * @property {Array<CountryCode>} displayCountries Campaign's targeting countries used to present on the UI without making merchants feel ambiguous.
+ *   Please refer to the descriptions of `country`, `targeted_locations` and `allowMultiple` for more context about this property.
  */
 
 /**
@@ -765,9 +767,14 @@ export function* saveTargetAudience( targetAudience ) {
  * @return {Campaign} Campaign data.
  */
 function adapteAdsCampaign( campaign ) {
+	const allowMultiple = campaign.targeted_locations.length > 0;
+	const displayCountries = allowMultiple
+		? campaign.targeted_locations
+		: [ campaign.country ];
 	return {
 		...campaign,
-		allowMultiple: campaign.targeted_locations.length > 0,
+		allowMultiple,
+		displayCountries,
 	};
 }
 

--- a/js/src/data/adapters.js
+++ b/js/src/data/adapters.js
@@ -1,0 +1,21 @@
+/**
+ * @typedef {import('.~/data/actions').Campaign} Campaign
+ */
+
+/**
+ * Adapts the campaign entity received from API.
+ *
+ * @param {Object} campaign The campaign entity to be adapted.
+ * @return {Campaign} Campaign data.
+ */
+export function adaptAdsCampaign( campaign ) {
+	const allowMultiple = campaign.targeted_locations.length > 0;
+	const displayCountries = allowMultiple
+		? campaign.targeted_locations
+		: [ campaign.country ];
+	return {
+		...campaign,
+		allowMultiple,
+		displayCountries,
+	};
+}

--- a/js/src/hooks/useAdsCampaigns.js
+++ b/js/src/hooks/useAdsCampaigns.js
@@ -11,6 +11,21 @@ import { glaData } from '.~/constants';
 
 const selectorName = 'getAdsCampaigns';
 
+/**
+ * @typedef {import('.~/data/actions').Campaign} Campaign
+ *
+ * @typedef {Object} AdsCampaignsPayload
+ * @property {Array<Campaign>|null} data Current campaigns obtained from merchant's Google Ads account if connected. It will be `null` before load finished.
+ * @property {boolean} loading Whether the `data` is loading. It's equal to `isResolving` state of wp-data selector.
+ * @property {boolean} loaded Whether the `data` is finished loading. It's equal to `hasFinishedResolution` state of wp-data selector.
+ */
+
+/**
+ * A hook that calls `getAdsCampaigns` selector to load current campaigns
+ * from merchant's Google Ads account if connected.
+ *
+ * @return {AdsCampaignsPayload} The data and its state.
+ */
 const useAdsCampaigns = () => {
 	return useSelect( ( select ) => {
 		// TODO: ideally adsSetupComplete should be retrieved from API endpoint

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -34,8 +34,8 @@ const CreatePaidAdsCampaignForm = () => {
 		setLoading( true );
 
 		try {
-			const { amount, country: countryArr } = values;
-			const country = countryArr && countryArr[ 0 ];
+			const { amount, countryCodes } = values;
+			const country = countryCodes[ 0 ];
 
 			recordLaunchPaidCampaignClickEvent( amount, country );
 
@@ -60,7 +60,7 @@ const CreatePaidAdsCampaignForm = () => {
 		<Form
 			initialValues={ {
 				amount: 0,
-				country: [],
+				countryCodes: [],
 			} }
 			validate={ handleValidate }
 			onSubmit={ handleSubmit }

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -35,11 +35,10 @@ const CreatePaidAdsCampaignForm = () => {
 
 		try {
 			const { amount, countryCodes } = values;
-			const country = countryCodes[ 0 ];
 
-			recordLaunchPaidCampaignClickEvent( amount, country );
+			recordLaunchPaidCampaignClickEvent( amount, countryCodes );
 
-			await createAdsCampaign( amount, country );
+			await createAdsCampaign( amount, countryCodes );
 
 			createNotice(
 				'success',

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -21,8 +21,13 @@ import validateForm from '.~/utils/paid-ads/validateForm';
 
 const EditPaidAdsCampaignForm = ( props ) => {
 	const { campaign } = props;
+	const { amount, allowMultiple } = campaign;
 	const [ loading, setLoading ] = useState( false );
 	const { updateAdsCampaign } = useAppDispatch();
+
+	const countryCodes = allowMultiple
+		? campaign.targeted_locations
+		: [ campaign.country ];
 
 	const handleValidate = ( values ) => {
 		return validateForm( values );
@@ -43,11 +48,7 @@ const EditPaidAdsCampaignForm = ( props ) => {
 
 	return (
 		<Form
-			initialValues={ {
-				id: campaign.id,
-				amount: campaign.amount,
-				country: [ campaign.country ],
-			} }
+			initialValues={ { amount, countryCodes } }
 			validate={ handleValidate }
 			onSubmit={ handleSubmit }
 		>
@@ -82,7 +83,7 @@ const EditPaidAdsCampaignForm = ( props ) => {
 						/>
 						<EditPaidAdsCampaignFormContent
 							formProps={ formProps }
-							allowMultiple={ campaign.allowMultiple }
+							allowMultiple={ allowMultiple }
 						/>
 						<StepContentFooter>
 							<AppButton

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -21,13 +21,9 @@ import validateForm from '.~/utils/paid-ads/validateForm';
 
 const EditPaidAdsCampaignForm = ( props ) => {
 	const { campaign } = props;
-	const { amount, allowMultiple } = campaign;
+	const { amount, allowMultiple, displayCountries: countryCodes } = campaign;
 	const [ loading, setLoading ] = useState( false );
 	const { updateAdsCampaign } = useAppDispatch();
-
-	const countryCodes = allowMultiple
-		? campaign.targeted_locations
-		: [ campaign.country ];
 
 	const handleValidate = ( values ) => {
 		return validateForm( values );

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -58,11 +58,10 @@ const SetupAdsForm = () => {
 
 	const handleSubmit = ( values ) => {
 		const { amount, countryCodes } = values;
-		const country = countryCodes[ 0 ];
 
-		recordLaunchPaidCampaignClickEvent( amount, country );
+		recordLaunchPaidCampaignClickEvent( amount, countryCodes );
 
-		handleSetupComplete( amount, country, () => {
+		handleSetupComplete( amount, countryCodes, () => {
 			setSubmitted( true );
 		} );
 	};

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -21,7 +21,7 @@ import { recordLaunchPaidCampaignClickEvent } from '.~/utils/recordEvent';
 // it will cause runtime error with the Form component.
 const initialValues = {
 	amount: 0,
-	country: [],
+	countryCodes: [],
 };
 
 const SetupAdsForm = () => {
@@ -57,8 +57,8 @@ const SetupAdsForm = () => {
 	);
 
 	const handleSubmit = ( values ) => {
-		const { amount, country: countryArr } = values;
-		const country = countryArr && countryArr[ 0 ];
+		const { amount, countryCodes } = values;
+		const country = countryCodes[ 0 ];
 
 		recordLaunchPaidCampaignClickEvent( amount, country );
 

--- a/js/src/setup-ads/useSetupCompleteCallback.js
+++ b/js/src/setup-ads/useSetupCompleteCallback.js
@@ -34,9 +34,9 @@ export default function useSetupCompleteCallback() {
 	}, [ createNotice ] );
 
 	const handleFinishSetup = useCallback(
-		( amount, country, onCompleted ) => {
+		( amount, countryCodes, onCompleted ) => {
 			setLoading( true );
-			createAdsCampaign( amount, country )
+			createAdsCampaign( amount, countryCodes )
 				.then( completeAdsSetup )
 				.then( onCompleted )
 				.catch( () => setLoading( false ) );

--- a/js/src/utils/paid-ads/validateForm.js
+++ b/js/src/utils/paid-ads/validateForm.js
@@ -4,19 +4,23 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ */
+
+/**
  * Validate paid ads form. Accepts the form values object and returns errors object.
  *
  * @param {Object} values Form values.
- * @param {Array<string>} values.country Selected country for the paid ads campaign.
+ * @param {Array<CountryCode>} values.countryCodes Selected country codes for the paid ads campaign.
  * @param {number} values.amount The daily average cost amount.
  * @return {Object} errors.
  */
 const validateForm = ( values ) => {
 	const errors = {};
 
-	if ( values.country.length === 0 ) {
-		errors.country = __(
-			'Please select a country for your ads campaign.',
+	if ( values.countryCodes.length === 0 ) {
+		errors.countryCodes = __(
+			'Please select at least one country for your ads campaign.',
 			'google-listings-and-ads'
 		);
 	}

--- a/js/src/utils/recordEvent.js
+++ b/js/src/utils/recordEvent.js
@@ -102,11 +102,11 @@ export const recordSetupAdsEvent = ( target, trigger = 'click' ) => {
  * Records `gla_launch_paid_campaign_button_click` tracking event.
  *
  * @param {number} budget Daily average cost of the paid campaign.
- * @param {CountryCode} audience Country code of the paid campaign audience country.
+ * @param {Array<CountryCode>} audiences Country code array of the paid campaign audience country.
  */
-export const recordLaunchPaidCampaignClickEvent = ( budget, audience ) => {
+export const recordLaunchPaidCampaignClickEvent = ( budget, audiences ) => {
 	recordEvent( 'gla_launch_paid_campaign_button_click', {
-		audience,
+		audiences: audiences.join( ',' ),
 		budget,
 	} );
 };

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -149,8 +149,8 @@ All event names are prefixed by `wcadmin_gla_`.
 
 -   `launch_paid_campaign_button_click` - Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign
 
-    -   `audience`: country code of the paid campaign audience country. This is inapplicable when a campaign is created with the multi-country targeting feature.
-    -   `audiences`: country codes of the paid campaign audience countries, e.g. `'US,JP,AU'`
+    -   `audience`: country code of the paid campaign audience country. e.g. `'US`. This means the campaign is created with the "sales country" targeting only, and it is inapplicable when created with the multi-country targeting feature.
+    -   `audiences`: country codes of the paid campaign audience countries, e.g. `'US,JP,AU'`. This means the campaign is created with the multi-country targeting feature. Before this feature support, it was implemented as 'audience'.
     -   `budget`: daily average cost of the paid campaign
 
 -   `mc_account_connect_button_click` - Clicking on the button to connect an existing Google Merchant Center account.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -149,7 +149,8 @@ All event names are prefixed by `wcadmin_gla_`.
 
 -   `launch_paid_campaign_button_click` - Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign
 
-    -   `audience`: country code of the paid campaign audience country
+    -   `audience`: country code of the paid campaign audience country. This is inapplicable when a campaign is created with the multi-country targeting feature.
+    -   `audiences`: country codes of the paid campaign audience countries, e.g. `'US,JP,AU'`
     -   `budget`: daily average cost of the paid campaign
 
 -   `mc_account_connect_button_click` - Clicking on the button to connect an existing Google Merchant Center account.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implemented the "**Integrate `ads/campaigns` related endpoints with mocking API**" part of #1248, and it's based on #1271.

- Adapt each received campaign entity in *actions.js*.
- Change the `country` initial value to `countryCodes` for all campaign \<Form\> and update related uses.
- Change campaign creation to multiple countries.
- Show multiple countries on `<AllProgramsTableCard>`.

💡  Please note that the UI integration of budget section will be done in another subsequence PR.

### Screenshots:

#### 📹  Create campaign
https://user-images.githubusercontent.com/17420811/155689353-73ced7d1-4cf7-4412-ab39-5629b68fbe00.mp4

#### 📷  Edit multi-country targeting campaign
![image](https://user-images.githubusercontent.com/17420811/155688647-f6f16ff5-2480-4890-8925-8818ff70d31a.png)

#### 📷  Programs table
![image](https://user-images.githubusercontent.com/17420811/155689591-017ffb25-2e05-4a68-9078-a5b54fb59e2c.png)

#### Event tracking of `gla_launch_paid_campaign_button_click`
![image](https://user-images.githubusercontent.com/17420811/155689338-744a5ac6-2a48-4d0d-9987-2ad0f7f14a1d.png)

### Detailed test instructions:

💡  Please note that this PR is currently using mocked API. And the country list used in `<AudienceCountrySelect>` is the selected targeting audience when setting free listings (or onboarding). So that the mocking countries in the `targeted_locations` of campaign would not appear on the selector UI if they are not in your targeting audience.
https://github.com/woocommerce/google-listings-and-ads/blob/f3f4e1e5c82789bed7b4c8692a76c77031c49303/js/src/components/audience-country-select.js#L8-L15
1. Open browser DevTool and run `localStorage.setItem( 'debug', 'wc-admin:*' )` in the Console tab for checking the event tracking.
2. Go to create campaign and check if the country selector UI works correctly.
3. Finish the creation. Check if the `audiences` property is shown in the format of concatenating country codes with `','`. For example `'US,JP,AU'`.
4. With at least two campaigns, go to dashboard to check if the multiple countries are shown in "United States (US) + 2 more" format in the **Country** column of Programes table.
5. Edit a multiple countries campaign and check if the country selector UI is displayed correctly.
6. Edit a single countries campaign and check if the country selector UI is displayed correctly.

### Changelog entry
