### PR TITLE
Multi-country targeting campaign - Integrate UI with `ads/campaigns/budget-recommendation` endpoint

### DIFF
--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
@@ -12,9 +12,25 @@ import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
 import useFetchBudgetRecommendationEffect from './useFetchBudgetRecommendationEffect';
 import './index.scss';
 
+/*
+ * If a merchant selects more than one country, the budget recommendation
+ * takes the highest country out from the selected countries.
+ * When looking for the highest one, it should only consider the `daily_budget_high` value.
+ *
+ * For example, a merchant selected Brunei (5-20 USD) and Croatia (10-15 USD),
+ * then the budget recommendation should be (5-20 USD).
+ */
+function getHighestBudget( recommendations ) {
+	return recommendations.reduce( ( defender, challenger ) => {
+		if ( challenger.daily_budget_high > defender.daily_budget_high ) {
+			return challenger;
+		}
+		return defender;
+	} );
+}
+
 const BudgetRecommendation = ( props ) => {
 	const { countryCodes, dailyAverageCost } = props;
-	const [ countryCode ] = countryCodes;
 	const { data } = useFetchBudgetRecommendationEffect( countryCodes );
 	const map = useCountryKeyNameMap();
 
@@ -23,12 +39,13 @@ const BudgetRecommendation = ( props ) => {
 	}
 
 	const { currency, recommendations } = data;
-	const [ recommendation ] = recommendations;
 	const {
 		daily_budget_low: dailyBudgetLow,
 		daily_budget_high: dailyBudgetHigh,
-	} = recommendation;
-	const countryName = map[ countryCode ];
+		country,
+	} = getHighestBudget( recommendations );
+	const [ recommendation ] = recommendations;
+	const countryName = map[ country ];
 
 	const showLowerBudgetNotice =
 		dailyAverageCost !== '' &&

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import GridiconInfoOutline from 'gridicons/dist/info-outline';
 
@@ -29,8 +29,28 @@ function getHighestBudget( recommendations ) {
 	} );
 }
 
+function toRecommendationRange( isMultiple, ...values ) {
+	const conversionMap = { strong: <strong /> };
+	const template = isMultiple
+		? // translators: it's a range of recommended budget amount. 1: the low value of the range, 2: the high value of the range, 3: the currency of amount.
+		  __(
+				'Most merchants targeting similar countries set a daily budget of <strong>%1$f to %2$f %3$s</strong> for approximately 10 conversions a week.',
+				'google-listings-and-ads'
+		  )
+		: // translators: it's a range of recommended budget amount. 1: the low value of the range, 2: the high value of the range, 3: the currency of amount, 4: a country name selected by the merchant.
+		  __(
+				'Most merchants targeting <strong>%4$s</strong> set a daily budget of <strong>%1$f to %2$f %3$s</strong> for approximately 10 conversions a week.',
+				'google-listings-and-ads'
+		  );
+
+	return createInterpolateElement(
+		sprintf( template, ...values ),
+		conversionMap
+	);
+}
+
 const BudgetRecommendation = ( props ) => {
-	const { countryCodes, dailyAverageCost } = props;
+	const { countryCodes, dailyAverageCost = Infinity } = props;
 	const { data } = useFetchBudgetRecommendationEffect( countryCodes );
 	const map = useCountryKeyNameMap();
 
@@ -44,43 +64,23 @@ const BudgetRecommendation = ( props ) => {
 		daily_budget_high: dailyBudgetHigh,
 		country,
 	} = getHighestBudget( recommendations );
-	const [ recommendation ] = recommendations;
-	const countryName = map[ country ];
 
-	const showLowerBudgetNotice =
-		dailyAverageCost !== '' &&
-		Number( dailyAverageCost ) < Number( recommendation.daily_budget_low );
+	const countryName = map[ country ];
+	const recommendationRange = toRecommendationRange(
+		recommendations.length > 1,
+		dailyBudgetLow,
+		dailyBudgetHigh,
+		currency,
+		countryName
+	);
+
+	const showLowerBudgetNotice = dailyAverageCost < dailyBudgetLow;
 
 	return (
 		<div className="gla-budget-recommendation">
 			<div className="gla-budget-recommendation__recommendation">
 				<GridiconInfoOutline />
-				<div>
-					{ createInterpolateElement(
-						__(
-							'Most merchants targeting <countryname /> set a daily budget of <budgetrange /> for approximately 10 conversions a week.',
-							'google-listings-and-ads'
-						),
-						{
-							countryname: <strong>{ countryName }</strong>,
-							budgetrange: (
-								<strong>
-									{ createInterpolateElement(
-										__(
-											'<low /> to <high /> <currency />',
-											'google-listings-and-ads'
-										),
-										{
-											low: <>{ dailyBudgetLow }</>,
-											high: <>{ dailyBudgetHigh }</>,
-											currency: <>{ currency }</>,
-										}
-									) }
-								</strong>
-							),
-						}
-					) }
-				</div>
+				<div>{ recommendationRange }</div>
 			</div>
 			{ showLowerBudgetNotice && (
 				<div className="gla-budget-recommendation__low-budget">

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
@@ -13,20 +13,20 @@ import useFetchBudgetRecommendationEffect from './useFetchBudgetRecommendationEf
 import './index.scss';
 
 const BudgetRecommendation = ( props ) => {
-	const { countryCode, dailyAverageCost } = props;
-	const { data: recommendation } = useFetchBudgetRecommendationEffect(
-		countryCode
-	);
+	const { countryCodes, dailyAverageCost } = props;
+	const [ countryCode ] = countryCodes;
+	const { data } = useFetchBudgetRecommendationEffect( countryCodes );
 	const map = useCountryKeyNameMap();
 
-	if ( ! recommendation ) {
+	if ( ! data ) {
 		return null;
 	}
 
+	const { currency, recommendations } = data;
+	const [ recommendation ] = recommendations;
 	const {
 		daily_budget_low: dailyBudgetLow,
 		daily_budget_high: dailyBudgetHigh,
-		currency,
 	} = recommendation;
 	const countryName = map[ countryCode ];
 

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/useFetchBudgetRecommendationEffect.js
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/useFetchBudgetRecommendationEffect.js
@@ -1,18 +1,29 @@
 /**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
  * Internal dependencies
  */
+import { API_NAMESPACE } from '.~/data/constants';
 import useApiFetchEffect from '.~/hooks/useApiFetchEffect';
+
+/**
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ */
 
 /**
  * Fetch the budget recommendation for a country in a side effect.
  *
- * @param {string} countryCode Country code string, e.g. 'US'.
+ * @param {Array<CountryCode>} countryCodes Country code array.
  * @return {Object} Budget recommendation.
  */
-const useFetchBudgetRecommendationEffect = ( countryCode ) => {
-	return useApiFetchEffect( {
-		path: `/wc/gla/ads/campaigns/budget-recommendation/${ countryCode }`,
-	} );
+const useFetchBudgetRecommendationEffect = ( countryCodes ) => {
+	const url = `${ API_NAMESPACE }/ads/campaigns/budget-recommendation`;
+	const query = { country_codes: countryCodes };
+	const path = addQueryArgs( url, query );
+	return useApiFetchEffect( { path } );
 };
 
 export default useFetchBudgetRecommendationEffect;

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -32,10 +32,7 @@ const BudgetSection = ( props ) => {
 		formProps: { getInputProps, setValue, values },
 		disabled = false,
 	} = props;
-	const {
-		countryCodes: [ selectedCountryCode ],
-		amount,
-	} = values;
+	const { countryCodes, amount } = values;
 	const { googleAdsAccount } = useGoogleAdsAccount();
 	const monthlyMaxEstimated = getMonthlyMaxEstimated( amount );
 	// Display the currency code that will be used by Google Ads, but still use the store's currency formatting settings.
@@ -102,9 +99,9 @@ const BudgetSection = ( props ) => {
 								value={ monthlyMaxEstimated }
 							/>
 						</div>
-						{ selectedCountryCode && (
+						{ countryCodes.length > 0 && (
 							<BudgetRecommendation
-								countryCode={ selectedCountryCode }
+								countryCodes={ countryCodes }
 								dailyAverageCost={ amount }
 							/>
 						) }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implemented the "**Integrate `ads/campaigns/budget-recommendation` related endpoints with mocking API**" part of #1248, and it's based on #1273.

- Integrate with new budget recommendation API that supports querying multiple countries.
- Display different budget recommendation sentences with the highest recommended budget when selecting more than one country.

### Screenshots:

https://user-images.githubusercontent.com/17420811/155709295-3a94d249-83aa-4a06-9073-60e614e1be1f.mp4

### Detailed test instructions:

💡  Please note that this PR is currently using mocked API. The fetched budget recommendation data may be weird.

1. Open the Console tab of browser DevTool.
1. Go to create campaign.
1. Select one county.
   - The sentence under the input field should be "Most merchants targeting **United States (US)** set a daily budget of **1225 to 3455 JPY** for approximately 10 conversions a week." with the select county, its range, and your Google ads account currency.
   - Enter budget. If the input budget is greater than or equal to the recommended low value, the sentence "With a budget lower than your competitor range, your campaign may not get noticeable results." should disappear.
1. Select more than one country.
   - The sentence under the input field should be "Most merchants targeting similar countries set a daily budget of **5 to 3655 JPY** for approximately 10 conversions a week." with the select county, its range, and your Google ads account currency. The country name shown in step 2 should be replaced with *similar countries*.
   - Check the mocked API response printed in Console and find out the highest one. The range in the above sentence should be the highest one. The details of this logic can be found in #1248 by searching "If the merchant selects more than one country" on the webpage.
   - Enter budget. If the input budget is greater than or equal to the recommended low value, the sentence "With a budget lower than your competitor range, your campaign may not get noticeable results." should disappear.

### Changelog entry
