### PR TITLE
Add gTag info in the Product View page

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -78,6 +78,13 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			},
 			1000000
 		);
+		add_action(
+			'wp_body_open',
+			function() {
+				$this->display_view_item_event_snippet();
+			},
+			1000002
+		);
 	}
 
 	/**
@@ -161,6 +168,37 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $order->get_total() ),
 			esc_js( $order->get_currency() ),
 			esc_js( $order->get_id() ),
+		);
+	}
+
+	/**
+	 * Display the JavaScript code to track the product view page.
+	 */
+	public function display_view_item_event_snippet(): void {
+		// Only display on the order confirmation page.
+		if ( ! is_product() ) {
+			return;
+		}
+		$product = wc_get_product( get_the_ID() );
+		printf(
+			'<script>gtag("event", "view_item", {
+				"send_to": "GLA", 
+				"developer_id.%s": "true", 
+				"ecomm_pagetype": "product", 
+				"value": "%s", 
+				items:[{
+				"id": "gla_%s", 
+				"price": %s, 
+				"google_business_vertical": "retail", 
+				"name":"%s", 
+				"category":"%s",
+			}]});</script>',
+			esc_js( self::DEVELOPER_ID ),
+			esc_js( (string) $product->get_price() ),
+			esc_js( $product->get_id() ),
+			esc_js( (string) $product->get_price() ),
+			esc_js( $product->get_name() ),
+			esc_js( join( '& ', $product->get_categories() ) ),
 		);
 	}
 

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -175,7 +175,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	 * Display the JavaScript code to track the product view page.
 	 */
 	public function display_view_item_event_snippet(): void {
-		// Only display on the order confirmation page.
+		// Only display on the product view page.
 		if ( ! is_product() ) {
 			return;
 		}
@@ -192,7 +192,8 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 				"google_business_vertical": "retail", 
 				"name":"%s", 
 				"category":"%s",
-			}]});</script>',
+				}]});
+			</script>',
 			esc_js( self::DEVELOPER_ID ),
 			esc_js( (string) $product->get_price() ),
 			esc_js( $product->get_id() ),

--- a/src/Proxies/GoogleGtagJs.php
+++ b/src/Proxies/GoogleGtagJs.php
@@ -53,7 +53,7 @@ class GoogleGtagJs {
 	 */
 	private function is_gtag_page(): bool {
 		$standard_tracking_enabled = 'yes' === $this->wcga_settings['ga_standard_tracking_enabled'];
-		$is_wc_page                = is_order_received_page() || is_woocommerce() || is_cart() || is_checkout();
+		$is_wc_page                = is_order_received_page() || is_woocommerce() || is_cart() || is_checkout() || is_product();
 
 		return $standard_tracking_enabled || $is_wc_page;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add gTag info to the product view page
Closes # .

Add the product info in the gTag in product view event. This event measure when a user visits a product page.

### Screenshots:

![Screen Shot 2022-03-01 at 9 03 08 AM](https://user-images.githubusercontent.com/97628051/156216712-848a4f4e-fe2a-4c98-84ae-7658bb6e293e.png)


### Detailed test instructions:

1. Connect Merchant Center and Ads accounts.
2. Visit the public-facing store.
3.  View the page source code and confirm:
The gTag is preceded by the new HTML comment:
gtag("event", "view_item", {...})


