### PR TITLE
Change id and name in favour of value and label

### DIFF
--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -21,8 +21,8 @@ import './index.scss';
  * The Option type Object. This is how we send the options to the selector.
  *
  * @typedef { Object } Option
- * @property {string} id The unique ID for the option
- * @property {string} name The name for the option
+ * @property {string} value The unique value for the option
+ * @property {string} label The label for the option
  * @property {Option[]} [children] The children Option objects
  */
 
@@ -69,7 +69,7 @@ const TreeSelectControl = ( {
 
 		function loadOption( option ) {
 			if ( ! option.children ) {
-				repository[ option.id ] = { ...option };
+				repository[ option.value ] = { ...option };
 			} else {
 				option.children.forEach( ( child ) => {
 					loadOption( child );
@@ -85,7 +85,7 @@ const TreeSelectControl = ( {
 	/**
 	 * Get formatted Tags from the selected values.
 	 *
-	 * @return {{name: {string}, id: {string}}[]} An array of Tags
+	 * @return {{label: {string}, id: {string}}[]} An array of Tags
 	 */
 	const getTags = () => {
 		if ( ! options.length ) {
@@ -94,7 +94,7 @@ const TreeSelectControl = ( {
 
 		return value.map( ( key ) => {
 			const option = optionsRepository[ key ];
-			return { id: key, name: option.name };
+			return { id: key, label: option.label };
 		} );
 	};
 
@@ -121,8 +121,8 @@ const TreeSelectControl = ( {
 	 */
 	const handleSingleChange = ( checked, option ) => {
 		const newValue = checked
-			? [ ...value, option.id ]
-			: value.filter( ( el ) => el !== option.id );
+			? [ ...value, option.value ]
+			: value.filter( ( el ) => el !== option.value );
 
 		onChange( newValue );
 	};
@@ -147,14 +147,14 @@ const TreeSelectControl = ( {
 					return;
 				}
 
-				const childIdPosition = newValue.indexOf( child.id );
+				const childIdPosition = newValue.indexOf( child.value );
 
 				if ( ! checked && childIdPosition >= 0 ) {
 					newValue.splice( childIdPosition, 1 );
 				}
 
 				if ( checked && childIdPosition < 0 ) {
-					newValue.push( child.id );
+					newValue.push( child.value );
 				}
 			} );
 		}

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -147,13 +147,13 @@ const TreeSelectControl = ( {
 					return;
 				}
 
-				const childIdPosition = newValue.indexOf( child.value );
+				const childPosition = newValue.indexOf( child.value );
 
-				if ( ! checked && childIdPosition >= 0 ) {
-					newValue.splice( childIdPosition, 1 );
+				if ( ! checked && childPosition >= 0 ) {
+					newValue.splice( childPosition, 1 );
 				}
 
-				if ( checked && childIdPosition < 0 ) {
+				if ( checked && childPosition < 0 ) {
 					newValue.push( child.value );
 				}
 			} );

--- a/js/src/components/tree-select-control/index.test.js
+++ b/js/src/components/tree-select-control/index.test.js
@@ -9,20 +9,20 @@ import TreeSelectControl from '.~/components/tree-select-control/index';
 
 const options = [
 	{
-		id: 'EU',
-		name: 'Europe',
+		value: 'EU',
+		label: 'Europe',
 		children: [
-			{ id: 'ES', name: 'Spain' },
-			{ id: 'FR', name: 'France' },
-			{ id: 'IT', name: 'Italy' },
+			{ value: 'ES', label: 'Spain' },
+			{ value: 'FR', label: 'France' },
+			{ value: 'IT', label: 'Italy' },
 		],
 	},
 	{
-		id: 'AS',
-		name: 'Asia',
+		value: 'AS',
+		label: 'Asia',
 		children: [
-			{ id: 'JP', name: 'Japan' },
-			{ id: 'CH', name: 'China' },
+			{ value: 'JP', label: 'Japan' },
+			{ value: 'CH', label: 'China' },
 		],
 	},
 ];
@@ -39,7 +39,7 @@ describe( 'TreeSelectControl Component', () => {
 		expect( queryByRole( 'listbox' ) ).toBeFalsy();
 		options.forEach( ( { children } ) => {
 			children.forEach( ( item ) => {
-				expect( queryByLabelText( item.name ) ).toBeFalsy();
+				expect( queryByLabelText( item.label ) ).toBeFalsy();
 			} );
 		} );
 
@@ -48,10 +48,10 @@ describe( 'TreeSelectControl Component', () => {
 
 		options.forEach( ( { children } ) => {
 			children.forEach( ( item ) => {
-				const checkbox = queryByLabelText( item.name );
+				const checkbox = queryByLabelText( item.label );
 				expect( checkbox ).toBeTruthy();
 				expect( checkbox.checked ).toEqual(
-					selectedValues.includes( item.id )
+					selectedValues.includes( item.value )
 				);
 			} );
 		} );

--- a/js/src/components/tree-select-control/list.js
+++ b/js/src/components/tree-select-control/list.js
@@ -40,7 +40,8 @@ const Options = ( { options = [], value, parent = '', onChange } ) => {
 		}
 
 		return option.children.every(
-			( child ) => value.includes( child.id ) || isParentSelected( child )
+			( child ) =>
+				value.includes( child.value ) || isParentSelected( child )
 		);
 	};
 
@@ -49,15 +50,15 @@ const Options = ( { options = [], value, parent = '', onChange } ) => {
 	return options.map( ( option ) => {
 		return (
 			<div
-				key={ `${ parent }-${ option.id }` }
+				key={ `${ parent }-${ option.value }` }
 				className="woocommerce-tree-select-control__group"
 			>
 				<CheckboxControl
-					value={ option.id }
+					value={ option.value }
 					className={ 'woocommerce-tree-select-control__option' }
-					label={ option.name }
+					label={ option.label }
 					checked={
-						value.includes( option.id ) ||
+						value.includes( option.value ) ||
 						isParentSelected( option )
 					}
 					onChange={ ( checked ) => {
@@ -68,7 +69,7 @@ const Options = ( { options = [], value, parent = '', onChange } ) => {
 				{ hasChildren( option ) && (
 					<div className="woocommerce-tree-select-control__children">
 						<Options
-							parent={ option.id }
+							parent={ option.value }
 							options={ option.children }
 							onChange={ onChange }
 							value={ value }

--- a/js/src/components/tree-select-control/tags.js
+++ b/js/src/components/tree-select-control/tags.js
@@ -37,13 +37,13 @@ const Tags = ( { tags, disabled, onChange = () => {} } ) => {
 	return (
 		<div className="woocommerce-tree-select-control__tags">
 			{ tags.map( ( item, i ) => {
-				if ( ! item.name ) {
+				if ( ! item.label || ! item.id ) {
 					return null;
 				}
 				const screenReaderLabel = sprintf(
-					// translators: 1: Tag Name, 2: Current Tag index, 3: Total amount of tags.
-					__( '%1$s (%2$s of %3$s)', 'woocommerce-admin' ),
-					item.name,
+					// translators: 1: Tag Label, 2: Current Tag index, 3: Total amount of tags.
+					__( '%1$s (%2$d of %3$d)', 'woocommerce-admin' ),
+					item.label,
 					i + 1,
 					tags.length
 				);
@@ -51,7 +51,7 @@ const Tags = ( { tags, disabled, onChange = () => {} } ) => {
 					<Tag
 						key={ item.id }
 						id={ item.id }
-						label={ item.name }
+						label={ item.label }
 						screenReaderLabel={ screenReaderLabel }
 						remove={ remove }
 					/>

--- a/js/src/pages/component-test/index.js
+++ b/js/src/pages/component-test/index.js
@@ -22,36 +22,36 @@ const ComponentTest = () => {
 
 	const treeSelectControlOptions = [
 		{
-			id: 'EU',
-			name: 'Europe',
+			value: 'EU',
+			label: 'Europe',
 			children: [
-				{ id: 'ES', name: 'Spain' },
-				{ id: 'FR', name: 'France' },
-				{ id: 'IT', name: 'Italy' },
+				{ value: 'ES', label: 'Spain' },
+				{ value: 'FR', label: 'France' },
+				{ value: 'IT', label: 'Italy' },
 			],
 		},
 		{
-			id: 'AS',
-			name: 'Asia',
+			value: 'AS',
+			label: 'Asia',
 			children: [
-				{ id: 'JP', name: 'Japan' },
-				{ id: 'CH', name: 'China' },
-				{ id: 'MY', name: 'Malaysia' },
+				{ value: 'JP', label: 'Japan' },
+				{ value: 'CH', label: 'China' },
+				{ value: 'MY', label: 'Malaysia' },
 			],
 		},
 		{
-			id: 'NA',
-			name: 'North America',
+			value: 'NA',
+			label: 'North America',
 			children: [
 				{
-					id: 'US',
-					name: 'United States',
+					value: 'US',
+					label: 'United States',
 					children: [
-						{ id: 'NY', name: 'New York' },
-						{ id: 'TX', name: 'Texas' },
+						{ value: 'NY', label: 'New York' },
+						{ value: 'TX', label: 'Texas' },
 					],
 				},
-				{ id: 'CA', name: 'Canada' },
+				{ value: 'CA', label: 'Canada' },
 			],
 		},
 	];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of Milestone 2 in TreeSelectComponent

Replacing `id` field in the options data structure in favour of `value`
Replacing `name` field in the options data structure in favour of `label`

More info: https://github.com/woocommerce/google-listings-and-ads/pull/1243#discussion_r816914726

### Detailed test instructions:

1. Checkout the branch
2. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcomponent-test` 
3. You can see component TreeSlectControl with the label `Select Country` and the placeholder `Select`
4. Clicking on "Select" expands the TreeSlector and shows text cursor instead of the placeholder  
5. Tree Shows Europe (It, Es, Fr) and Asia (Ch, Jp)
6. Clicking on the country checks it and shows the tag
7. Clicking again unchecks it and removes the tag
8. Clicking on the "x" button in a tag, removes the tag
9. If you click on all the countries, it automatically selects the Continent and adds all of the countries on it
10. If you click the Continent it deselects/select all the countries
11. If some country is not checked, the continent is not checked
12. Clicking out the selector close the tree
13. Clicking again in the selector expands the tree and preserves the selections