### PR TITLE
Update get campaigns to return targeted locations

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -136,9 +136,8 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			}
 
 			if ( ! empty( $converted_campaigns ) ) {
-				$combined_results        = $this->combine_campaigns_and_campaign_criterion_results( $converted_campaigns );
-				$combined_results_values = array_values( $combined_results );
-				return reset( $combined_results_values );
+				$combined_results = $this->combine_campaigns_and_campaign_criterion_results( $converted_campaigns );
+				return reset( $combined_results );
 			}
 
 			return [];

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -96,7 +96,8 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				$converted_campaigns[ $campaign['id'] ] = $campaign;
 			}
 
-			return $this->combine_campaigns_and_campaign_criterion_results( $converted_campaigns );
+			$combined_results = $this->combine_campaigns_and_campaign_criterion_results( $converted_campaigns );
+			return array_values( $combined_results );
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
@@ -135,8 +136,9 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			}
 
 			if ( ! empty( $converted_campaigns ) ) {
-				$combined_results = $this->combine_campaigns_and_campaign_criterion_results( $converted_campaigns );
-				return reset( $combined_results );
+				$combined_results        = $this->combine_campaigns_and_campaign_criterion_results( $converted_campaigns );
+				$combined_results_values = array_values( $combined_results );
+				return reset( $combined_results_values );
 			}
 
 			return [];
@@ -436,7 +438,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			}
 		}
 
-		return array_values( $campaigns );
+		return $campaigns;
 	}
 
 	/**

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -429,8 +429,8 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			// after https://github.com/woocommerce/google-listings-and-ads/issues/1229 is done.
 			$geo_target_constant = $location ? $location->getGeoTargetConstant() : null;
 
-			if ( ! array_key_exists( 'targeted_locations', $campaigns[ $campaign_id ] ) ) {
-				$campaigns[ $campaign_id ]['targeted_locations'] = [];
+			if ( ! isset( $campaigns[ $campaign_id ] ) ) {
+				continue;
 			}
 
 			if ( ! empty( $geo_target_constant ) ) {

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -423,6 +423,10 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 
 			$campaign_key = array_search( $campaign_id, $campaign_ids, true );
 
+			if ( $campaign_key === false ) {
+				continue;
+			}
+
 			if ( ! array_key_exists( 'targeted_locations', $campaigns[ $campaign_key ] ) ) {
 				$campaigns[ $campaign_key ]['targeted_locations'] = [];
 			}

--- a/src/API/Google/Query/AdsCampaignCriterionQuery.php
+++ b/src/API/Google/Query/AdsCampaignCriterionQuery.php
@@ -1,0 +1,27 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsCampaignCriterionQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
+class AdsCampaignCriterionQuery extends AdsQuery {
+
+	/**
+	 * Query constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'campaign_criterion' );
+		$this->columns(
+			[
+				'campaign.id',
+				'campaign_criterion.location.geo_target_constant',
+			]
+		);
+	}
+}

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -299,7 +299,7 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 			],
 			'targeted_locations' => [
 				'type'        => 'array',
-				'description' => __( 'Ads campaign targeted locations retrieved from campaign criterion.', 'google-listings-and-ads' ),
+				'description' => __( 'The locations that an Ads campaign is targeting.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'items'       => [
 					'type' => 'string',

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -262,40 +262,48 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'id'      => [
+			'id'                 => [
 				'type'        => 'integer',
 				'description' => __( 'ID number.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'name'    => [
+			'name'               => [
 				'type'              => 'string',
 				'description'       => __( 'Descriptive campaign name.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',
 				'required'          => false,
 			],
-			'status'  => [
+			'status'             => [
 				'type'              => 'string',
 				'enum'              => CampaignStatus::labels(),
 				'description'       => __( 'Campaign status.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',
 			],
-			'amount'  => [
+			'amount'             => [
 				'type'              => 'number',
 				'description'       => __( 'Daily budget amount in the local currency.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',
 				'required'          => true,
 			],
-			'country' => [
+			'country'            => [
 				'type'              => 'string',
 				'description'       => __( 'Country code in ISO 3166-1 alpha-2 format.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'sanitize_callback' => $this->get_country_code_sanitize_callback(),
 				'validate_callback' => $this->get_country_code_validate_callback(),
 				'required'          => true,
+			],
+			'targeted_locations' => [
+				'type'        => 'array',
+				'description' => __( 'Ads campaign targeted locations retrieved from campaign criterion.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'items'       => [
+					'type' => 'string',
+				],
 			],
 		];
 	}

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -7,11 +7,13 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Google\Ads\GoogleAds\Util\V9\ResourceNames;
+use Google\Ads\GoogleAds\V9\Common\LocationInfo;
 use Google\Ads\GoogleAds\V9\Resources\AdGroup;
 use Google\Ads\GoogleAds\V9\Resources\AdGroupAd;
 use Google\Ads\GoogleAds\V9\Resources\AdGroupCriterion;
 use Google\Ads\GoogleAds\V9\Resources\Campaign;
 use Google\Ads\GoogleAds\V9\Resources\CampaignBudget;
+use Google\Ads\GoogleAds\V9\Resources\CampaignCriterion;
 use Google\Ads\GoogleAds\V9\Resources\Campaign\ShoppingSetting;
 use Google\Ads\GoogleAds\V9\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V9\Services\GoogleAdsServiceClient;
@@ -118,12 +120,19 @@ trait GoogleAdsClientTrait {
 	/**
 	 * Generates a mocked AdsCampaignQuery response.
 	 *
-	 * @param array $responses Set of campaign data to convert.
+	 * @param array $campaigns_responses Set of campaign data to convert.
+	 * @param array $campaign_criterion_responses Set of campaign criterion data to convert.
 	 */
-	protected function generate_ads_campaign_query_mock( array $responses ) {
-		$this->generate_ads_query_mock(
-			array_map( [ $this, 'generate_campaign_row_mock' ], $responses )
+	protected function generate_ads_campaign_query_mock( array $campaigns_responses, $campaign_criterion_responses ) {
+		$campaigns_row_mock          = array_map( [ $this, 'generate_campaign_row_mock' ], $campaigns_responses );
+		$campaign_criterion_row_mock = array_map( [ $this, 'generate_campaign_criterion_row_mock' ], $campaign_criterion_responses );
+
+		$list_response = $this->createMock( PagedListResponse::class );
+		$list_response->method( 'iterateAllElements' )->willReturnOnConsecutiveCalls(
+			$campaigns_row_mock,
+			$campaign_criterion_row_mock
 		);
+		$this->service_client->method( 'search' )->willReturn( $list_response );
 	}
 
 	/**
@@ -208,6 +217,28 @@ trait GoogleAdsClientTrait {
 		return ( new GoogleAdsRow )
 			->setCampaign( $campaign )
 			->setCampaignBudget( $budget );
+	}
+
+	/**
+	 * Converts campaign criterion data to a mocked GoogleAdsRow.
+	 *
+	 * @param array $data Campaign criterion data to convert.
+	 *
+	 * @return GoogleAdsRow
+	 */
+	protected function generate_campaign_criterion_row_mock( array $data ): GoogleAdsRow {
+		$campaign = $this->createMock( Campaign::class );
+		$campaign->method( 'getId' )->willReturn( $data['campaign_id'] );
+
+		$location_info = $this->createMock( LocationInfo::class );
+		$location_info->method( 'getGeoTargetConstant' )->willReturn( $data['geo_target_constant'] );
+
+		$campaign_criterion = $this->createMock( CampaignCriterion::class );
+		$campaign_criterion->method( 'getLocation' )->willReturn( $location_info );
+
+		return ( new GoogleAdsRow )
+			->setCampaign( $campaign )
+			->setCampaignCriterion( $campaign_criterion );
 	}
 
 	/**

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -123,33 +123,6 @@ class AdsCampaignTest extends UnitTest {
 		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
 	}
 
-	public function test_get_campaigns_with_campaign_id_of_criterion_not_found_in_campaigns() {
-		$campaign_criterion_data = [
-			[
-				'campaign_id'         => self::TEST_CAMPAIGN_ID,
-				'geo_target_constant' => 'geoTargetConstants/2158',
-			],
-			[
-				'campaign_id'         => 5678901234,
-				'geo_target_constant' => 'geoTargetConstants/2344',
-			],
-		];
-
-		$campaigns_data = [
-			[
-				'id'      => self::TEST_CAMPAIGN_ID,
-				'name'    => 'Campaign One',
-				'status'  => 'paused',
-				'amount'  => 10,
-				'country' => 'US',
-				'targeted_locations' => ['geoTargetConstants/2158'],
-			],
-		];
-
-		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
-		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
-	}
-
 	public function test_get_campaigns_exception() {
 		$this->generate_ads_query_mock_exception( new ApiException( 'unavailable', 14, 'UNAVAILABLE' ) );
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -123,6 +123,33 @@ class AdsCampaignTest extends UnitTest {
 		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
 	}
 
+	public function test_get_campaigns_with_campaign_id_of_criterion_not_found_in_campaigns() {
+		$campaign_criterion_data = [
+			[
+				'campaign_id'         => self::TEST_CAMPAIGN_ID,
+				'geo_target_constant' => 'geoTargetConstants/2158',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'geoTargetConstants/2344',
+			],
+		];
+
+		$campaigns_data = [
+			[
+				'id'      => self::TEST_CAMPAIGN_ID,
+				'name'    => 'Campaign One',
+				'status'  => 'paused',
+				'amount'  => 10,
+				'country' => 'US',
+				'targeted_locations' => ['geoTargetConstants/2158'],
+			],
+		];
+
+		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
+		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
+	}
+
 	public function test_get_campaigns_exception() {
 		$this->generate_ads_query_mock_exception( new ApiException( 'unavailable', 14, 'UNAVAILABLE' ) );
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -56,11 +56,42 @@ class AdsCampaignTest extends UnitTest {
 	}
 
 	public function test_get_campaigns_empty_list() {
-		$this->generate_ads_campaign_query_mock( [] );
+		$this->generate_ads_campaign_query_mock( [], [] );
 		$this->assertEquals( [], $this->campaign->get_campaigns() );
 	}
 
 	public function test_get_campaigns() {
+		$campaign_criterion_data = [
+			[
+				'campaign_id'         => self::TEST_CAMPAIGN_ID,
+				'geo_target_constant' => 'geoTargetConstants/2158',
+			],
+			[
+				'campaign_id'         => self::TEST_CAMPAIGN_ID,
+				'geo_target_constant' => '',
+			],
+			[
+				'campaign_id'         => self::TEST_CAMPAIGN_ID,
+				'geo_target_constant' => null,
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'geoTargetConstants/2344',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => '',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'geoTargetConstants/2826',
+			],
+			[
+				'campaign_id'         => 8888877777,
+				'geo_target_constant' => '',
+			],
+		];
+
 		$campaigns_data = [
 			[
 				'id'      => self::TEST_CAMPAIGN_ID,
@@ -68,6 +99,7 @@ class AdsCampaignTest extends UnitTest {
 				'status'  => 'paused',
 				'amount'  => 10,
 				'country' => 'US',
+				'targeted_locations' => ['geoTargetConstants/2158'],
 			],
 			[
 				'id'      => 5678901234,
@@ -75,10 +107,19 @@ class AdsCampaignTest extends UnitTest {
 				'status'  => 'enabled',
 				'amount'  => 20,
 				'country' => 'UK',
+				'targeted_locations' => ['geoTargetConstants/2344', 'geoTargetConstants/2826'],
+			],
+			[
+				'id'      => 8888877777,
+				'name'    => 'Campaign Three',
+				'status'  => 'enabled',
+				'amount'  => 30,
+				'country' => 'TW',
+				'targeted_locations' => [],
 			],
 		];
 
-		$this->generate_ads_campaign_query_mock( $campaigns_data );
+		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
 		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
 	}
 
@@ -100,15 +141,21 @@ class AdsCampaignTest extends UnitTest {
 	}
 
 	public function test_get_campaign() {
+		$campaign_criterion_data = [
+			'campaign_id'         => self::TEST_CAMPAIGN_ID,
+			'geo_target_constant' => '',
+		];
+
 		$campaign_data = [
 			'id'      => self::TEST_CAMPAIGN_ID,
 			'name'    => 'Single Campaign',
 			'status'  => 'enabled',
 			'amount'  => 10,
 			'country' => 'US',
+			'targeted_locations' => [],
 		];
 
-		$this->generate_ads_campaign_query_mock( [ $campaign_data ] );
+		$this->generate_ads_campaign_query_mock( [ $campaign_data ], [ $campaign_criterion_data ] );
 		$this->assertEquals( $campaign_data, $this->campaign->get_campaign( self::TEST_CAMPAIGN_ID ) );
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -43,6 +43,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 				'status'  => 'paused',
 				'amount'  => 10,
 				'country' => 'US',
+				'targeted_locations' => [],
 			],
 			[
 				'id'      => 5678901234,
@@ -50,6 +51,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 				'status'  => 'enabled',
 				'amount'  => 20,
 				'country' => 'UK',
+				'targeted_locations' => [],
 			],
 		];
 
@@ -79,6 +81,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 			'name'    => 'New Campaign',
 			'amount'  => 20,
 			'country' => 'US',
+			'targeted_locations' => [],
 		];
 
 		$expected = [
@@ -101,6 +104,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 		$campaign_data = [
 			'amount'  => 30,
 			'country' => 'GB',
+			'targeted_locations' => [],
 		];
 
 		$expected = [
@@ -177,6 +181,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 			'status'  => 'enabled',
 			'amount'  => 10,
 			'country' => 'US',
+			'targeted_locations' => [],
 		];
 
 		$this->ads_campaign->expects( $this->once() )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1248, this PR updates two endpoints `GET ads/campaigns` and `GET ads/campaigns/:campaign-id` to have `targeted_locations` in the response payload in order to support multi-country targeting. Multiple targeted locations can be retrieve from [CampaignCriterion](https://developers.google.com/google-ads/api/reference/rpc/v9/CampaignCriterion)'s [LocationInfo](https://developers.google.com/google-ads/api/reference/rpc/v9/LocationInfo).

In the implementation we need to send two queries to Google Ads in order to get all the data of campaigns, campaign budgets, and campaign criterion:

1. Get campaigns and its budget in the first query.
2. Get campaign criterion with its corresponding campaign ID in the second query.
3. Combine two results in a single array by campaign ID.

This is because CampaignBudget is an Attributed Resource of Campaign, while CampaignCriterion is not an Attributed Resource of Campaign. More information can be seen [here](https://developers.google.com/google-ads/api/docs/query/structure#from). 

### Screenshots:

#### GET ads/campaigns

✍️ Note: it will be an old campaign created before this feature if the targeted_locations is an empty array.

<img width="1009" alt="Screenshot 2022-03-03 at 12 57 09" src="https://user-images.githubusercontent.com/914406/156499275-4904f66b-baa8-4304-bf08-ab722bafabfd.png">

#### GET ads/campaigns/:campaign-id - Has targeted locations

<img width="1010" alt="Screenshot 2022-03-03 at 12 58 32" src="https://user-images.githubusercontent.com/914406/156499372-296d5d61-947e-48d4-b868-a3ba43dc9ff3.png">

#### GET ads/campaigns/:campaign-id - No targeted locations

<img width="1008" alt="Screenshot 2022-03-03 at 12 57 57" src="https://user-images.githubusercontent.com/914406/156499413-57724d0e-f20b-43af-aa92-d2d3340b5e58.png">

### Detailed test instructions:

1. Create some paid campaigns in GLA's dashboard: `/wp-admin/admin.php?page=wc-admin&path=/google/dashboard`.
2. Go to Google Ads Campaigns Dashboard and add targeted locations in some of the campaigns you created.
    - <img width="2555" alt="Screenshot 2022-03-03 at 13 09 34" src="https://user-images.githubusercontent.com/914406/156500476-8d9e00d5-ff0f-429b-895c-3a4ffedae06d.png">
3. Using Postman, request to `GET ads/campaigns` and `GET ads/campaigns/:campaign-id` like the screenshots in the `Screenshots` section. Remember to add your `wp-cookie` and `x-wp-nonce` in the request headers.

### Additional details:

In this PR I haven't converted the `geo_target_constant` value returned from CampaignCriterion to `ISO 3166-1 alpha-2` country code format. I will update it in another PR once #1229 is done.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Include targeted locations in get campaigns requests
