### PR TITLE
Handle a disconnected Jetpack account in the backend

### DIFF
--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -140,7 +140,7 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	public function get_reconnect_status(): array {
 		$status = $this->get_status();
-		$email  = $status['email'] ?: '';
+		$email  = $status['email'] ?? '';
 
 		if ( ! isset( $status['status'] ) || 'connected' !== $status['status'] ) {
 			return $status;

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use WP_REST_Request as Request;
@@ -98,10 +97,8 @@ class AccountController extends BaseController {
 		return function() {
 			try {
 				return new Response( $this->account->get_account_ids() );
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -121,10 +118,8 @@ class AccountController extends BaseController {
 
 				$account_data = $this->account->setup_account();
 				return $this->prepare_item_for_response( $account_data, $request );
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -8,7 +8,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166AwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use DateTime;
@@ -104,10 +103,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					},
 					$this->ads_campaign->get_campaigns()
 				);
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -135,10 +132,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 				$campaign = $this->ads_campaign->create_campaign( $fields );
 
 				return $this->prepare_item_for_response( $campaign, $request );
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -165,10 +160,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 				}
 
 				return $this->prepare_item_for_response( $campaign, $request );
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -199,10 +192,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					'message' => __( 'Successfully edited campaign.', 'google-listings-and-ads' ),
 					'id'      => $campaign_id,
 				];
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -222,10 +213,8 @@ class CampaignController extends BaseController implements ISO3166AwareInterface
 					'message' => __( 'Successfully deleted campaign.', 'google-listings-and-ads' ),
 					'id'      => $deleted_id,
 				];
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/Ads/ReportsController.php
+++ b/src/API/Site/Controllers/Ads/ReportsController.php
@@ -3,14 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseReportsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Exception;
 use WP_REST_Request as Request;
-use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -64,10 +62,8 @@ class ReportsController extends BaseReportsController {
 				$ads  = $this->container->get( AdsReport::class );
 				$data = $ads->get_report_data( 'campaigns', $this->prepare_query_arguments( $request ) );
 				return $this->prepare_item_for_response( $data, $request );
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -84,10 +80,8 @@ class ReportsController extends BaseReportsController {
 				$ads  = $this->container->get( AdsReport::class );
 				$data = $ads->get_report_data( 'products', $this->prepare_query_arguments( $request ) );
 				return $this->prepare_item_for_response( $data, $request );
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/BaseController.php
+++ b/src/API/Site/Controllers/BaseController.php
@@ -18,7 +18,7 @@ use WP_REST_Response as Response;
  */
 abstract class BaseController extends WC_REST_Controller implements Registerable {
 
-	use PluginHelper, PermissionsTrait;
+	use PluginHelper, PermissionsTrait, ResponseFromExceptionTrait;
 
 	/**
 	 * @var RESTServer

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use WP_REST_Request as Request;
-use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -110,7 +109,7 @@ class AccountController extends BaseController {
 					),
 				];
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -171,7 +170,7 @@ class AccountController extends BaseController {
 					'scope'  => array_key_exists( 'scope', $status ) ? $status['scope'] : [],
 				];
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -190,7 +189,7 @@ class AccountController extends BaseController {
 
 				return $status;
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ApiNotReady;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
@@ -128,7 +127,7 @@ class AccountController extends BaseController {
 					$this->account->get_accounts()
 				);
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}
@@ -171,8 +170,8 @@ class AccountController extends BaseController {
 				return $this->prepare_item_for_response( $account, $request );
 			} catch ( ApiNotReady $e ) {
 				return $this->get_time_to_wait_response( $e );
-			} catch ( ExceptionWithResponseData $e ) {
-				return new Response( $e->get_response_data( true ), $e->getCode() ?: 400 );
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
@@ -5,14 +5,13 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ResponseFromExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\AddressUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\PhoneNumber;
+use Exception;
 use Google\Service\ShoppingContent\AccountAddress;
 use Google\Service\ShoppingContent\AccountBusinessInformation;
 use WP_REST_Request as Request;
@@ -28,8 +27,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
 class ContactInformationController extends BaseOptionsController {
-
-	use ResponseFromExceptionTrait;
 
 	/**
 	 * @var ContactInformation $contact_information
@@ -96,7 +93,7 @@ class ContactInformationController extends BaseOptionsController {
 					$this->contact_information->get_contact_information(),
 					$request
 				);
-			} catch ( MerchantApiException $e ) {
+			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}
 		};
@@ -114,7 +111,7 @@ class ContactInformationController extends BaseOptionsController {
 					$this->contact_information->update_address_based_on_store_settings(),
 					$request
 				);
-			} catch ( MerchantApiException $e ) {
+			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}
 		};

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -85,7 +85,7 @@ class IssuesController extends BaseOptionsController {
 				$results         = $this->merchant_statuses->get_issues( $type_filter, $per_page, $page );
 				$results['page'] = $page;
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 
 			// Replace variation IDs with parent ID (for Edit links).

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ResponseFromExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
@@ -26,7 +25,6 @@ defined( 'ABSPATH' ) || exit;
 class PhoneVerificationController extends BaseOptionsController {
 
 	use EmptySchemaPropertiesTrait;
-	use ResponseFromExceptionTrait;
 
 	/**
 	 * @var PhoneVerification

--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -67,7 +67,7 @@ class ProductFeedController extends BaseController {
 					'page'     => $request['per_page'] > 0 && $request['page'] > 0 ? $request['page'] : 1,
 				];
 			} catch ( Exception $e ) {
-				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
@@ -114,7 +114,7 @@ class ProductStatisticsController extends BaseOptionsController {
 
 			return $this->prepare_item_for_response( $response, $request );
 		} catch ( Exception $e ) {
-			return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+			return $this->response_from_exception( $e );
 		}
 	}
 

--- a/src/API/Site/Controllers/MerchantCenter/ReportsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ReportsController.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseReportsController;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ResponseFromExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Exception;
 use WP_REST_Request as Request;
@@ -18,8 +17,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
 class ReportsController extends BaseReportsController {
-
-	use ResponseFromExceptionTrait;
 
 	/**
 	 * Register rest routes with WordPress.

--- a/src/Exception/AccountReconnect.php
+++ b/src/Exception/AccountReconnect.php
@@ -1,0 +1,54 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountReconnect
+ *
+ * Error messages generated in this class should be translated, as they are intended to be displayed
+ * to end users.
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
+ */
+class AccountReconnect extends ExceptionWithResponseData {
+
+	/**
+	 * Create a new instance of the exception when the Jetpack account is not connected.
+	 *
+	 * @return static
+	 */
+	public static function jetpack_disconnected(): AccountReconnect {
+		return new static(
+			__( 'Please reconnect your Jetpack account.', 'google-listings-and-ads' ),
+			401,
+			null,
+			[
+				'status' => 401,
+				'code'   => 'JETPACK_DISCONNECTED',
+			]
+		);
+	}
+
+	/**
+	 * Create a new instance of the exception when the Google account is not connected.
+	 *
+	 * @return static
+	 */
+	public static function google_disconnected(): AccountReconnect {
+		return new static(
+			__( 'Please reconnect your Google account.', 'google-listings-and-ads' ),
+			401,
+			null,
+			[
+				'status' => 401,
+				'code'   => 'GOOGLE_DISCONNECTED',
+			]
+		);
+	}
+
+}

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -23,6 +23,7 @@ interface OptionsInterface {
 	public const FILE_VERSION           = 'file_version';
 	public const GOOGLE_CONNECTED       = 'google_connected';
 	public const INSTALL_TIMESTAMP      = 'install_timestamp';
+	public const JETPACK_CONNECTED      = 'jetpack_connected';
 	public const MC_SETUP_COMPLETED_AT  = 'mc_setup_completed_at';
 	public const MERCHANT_ACCOUNT_STATE = 'merchant_account_state';
 	public const MERCHANT_CENTER        = 'merchant_center';
@@ -46,6 +47,7 @@ interface OptionsInterface {
 		self::FILE_VERSION           => true,
 		self::GOOGLE_CONNECTED       => true,
 		self::INSTALL_TIMESTAMP      => true,
+		self::JETPACK_CONNECTED      => true,
 		self::MC_SETUP_COMPLETED_AT  => true,
 		self::MERCHANT_ACCOUNT_STATE => true,
 		self::MERCHANT_CENTER        => true,

--- a/tests/Unit/API/Site/Controllers/Google/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Google/AccountControllerTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Google\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+
+/**
+ * Class AccountControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Google
+ *
+ * @property Connection|MockObject $connection
+ * @property AccountController     $controller
+ */
+class AccountControllerTest extends RESTControllerUnitTest {
+
+	protected const ROUTE_CONNECT     = '/wc/gla/google/connect';
+	protected const ROUTE_CONNECTED   = '/wc/gla/google/connected';
+	protected const ROUTE_RECONNECTED = '/wc/gla/google/reconnected';
+	protected const TEST_EMAIL        = 'john@doe.email';
+	protected const TEST_SCOPE        = [ 'https://www.googleapis.com/auth/content' ];
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->connection = $this->createMock( Connection::class );
+		$this->controller = new AccountController( $this->server, $this->connection );
+		$this->controller->register();
+	}
+
+	public function test_connect() {
+		$auth_url          = 'https://domain.test?auth=1';
+		$expected_auth_url = $auth_url . '&from=google-listings-and-ads';
+
+		$this->connection->expects( $this->once() )
+			->method( 'connect' )
+			->willReturn( $auth_url );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals(
+			[
+				'url' => $auth_url,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connect_invalid_parameter() {
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET', [ 'next' => 'invalid' ] );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_connect_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'connect' )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_disconnect() {
+		$this->connection->expects( $this->once() )
+			->method( 'disconnect' );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'DELETE' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully disconnected.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connected() {
+		$status = [
+			'status' => 'connected',
+			'email'  => self::TEST_EMAIL,
+			'scope'  => self::TEST_SCOPE,
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( $status );
+
+		$response = $this->do_request( self::ROUTE_CONNECTED, 'GET' );
+
+		$this->assertEquals(
+			[
+				'active' => 'yes',
+				'email'  => self::TEST_EMAIL,
+				'scope'  => self::TEST_SCOPE,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_disconnected() {
+
+		$response = $this->do_request( self::ROUTE_CONNECTED, 'GET' );
+
+		$this->assertEquals(
+			[
+				'active' => 'no',
+				'email'  => '',
+				'scope'  => [],
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_reconnected() {
+		$status = [
+			'status'           => 'connected',
+			'email'            => self::TEST_EMAIL,
+			'scope'            => self::TEST_SCOPE,
+			'merchant_account' => 12345678,
+			'merchant_access'  => 'yes',
+			'ads_account'      => 23456789,
+			'ads_access'       => 'yes',
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'get_reconnect_status' )
+			->willReturn( $status );
+
+		$response = $this->do_request( self::ROUTE_RECONNECTED, 'GET' );
+
+		$this->assertEquals(
+			[
+				'active'           => 'yes',
+				'email'            => self::TEST_EMAIL,
+				'scope'            => self::TEST_SCOPE,
+				'merchant_account' => 12345678,
+				'merchant_access'  => 'yes',
+				'ads_account'      => 23456789,
+				'ads_access'       => 'yes',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_reconnected_with_disconnected_status() {
+		$response = $this->do_request( self::ROUTE_RECONNECTED, 'GET' );
+
+		$this->assertEquals(
+			[
+				'active' => 'no',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test a Jetpack disconnected error since it's a dependency for a connected Google account.
+	 */
+	public function test_connected_with_jetpack_disconnected() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willThrowException( AccountReconnect::jetpack_disconnected() );
+
+		$response = $this->do_request( self::ROUTE_CONNECTED, 'GET' );
+		$this->assertEquals( 'JETPACK_DISCONNECTED', $response->get_data()['code'] );
+		$this->assertEquals( 401, $response->get_data()['status'] );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Jetpack;
+
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Jetpack\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_Error;
+
+/**
+ * Class AccountControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Jetpack
+ *
+ * @property Manager|MockObject    $manager
+ * @property Middleware|MockObject $middleware
+ * @property Options|MockObject    $options
+ * @property AccountController     $controller
+ */
+class AccountControllerTest extends RESTControllerUnitTest {
+
+	protected const ROUTE_CONNECT   = '/wc/gla/jetpack/connect';
+	protected const ROUTE_CONNECTED = '/wc/gla/jetpack/connected';
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->manager    = $this->createMock( Manager::class );
+		$this->middleware = $this->createMock( Middleware::class );
+		$this->options    = $this->createMock( OptionsInterface::class );
+
+		$this->controller = new AccountController( $this->server, $this->manager, $this->middleware );
+		$this->controller->register();
+		$this->controller->set_options_object( $this->options );
+	}
+
+	public function test_connect() {
+		$auth_url          = 'https://domain.test?auth=1';
+		$expected_auth_url = $auth_url . '&from=google-listings-and-ads';
+
+		$this->manager->expects( $this->once() )
+			->method( 'get_authorization_url' )
+			->willReturn( $auth_url );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals(
+			[
+				'url' => $expected_auth_url,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connect_with_error() {
+		$this->manager->expects( $this->once() )
+			->method( 'register' )
+			->willReturn( new WP_Error( 'error', 'Error message' ) );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'error',
+				'message' => 'Error message',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_disconnect() {
+		$this->manager->expects( $this->once() )
+			->method( 'remove_connection' );
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::WP_TOS_ACCEPTED );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'DELETE' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully disconnected.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connected() {
+		$name      = 'John Doe';
+		$email     = 'john@doe.email';
+		$user_data = [
+			'display_name' => $name,
+			'email'        => $email,
+		];
+
+		$this->manager->method( 'is_active' )->willReturn( true );
+		$this->manager->method( 'is_connection_owner' )->willReturn( true );
+
+		// Confirm the WP TOS is marked as accepted for the current user.
+		$this->middleware->expects( $this->once() )
+			->method( 'mark_tos_accepted' )
+			->with( 'wp-com', wp_get_current_user()->user_email );
+
+		$this->manager->expects( $this->once() )
+			->method( 'get_connected_user_data' )
+			->willReturn( $user_data );
+
+		$response = $this->do_request( self::ROUTE_CONNECTED, 'GET' );
+
+		$this->assertEquals(
+			[
+				'active'      => 'yes',
+				'owner'       => 'yes',
+				'displayName' => $name,
+				'email'       => $email,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_disconnected() {
+		$this->manager->method( 'is_active' )->willReturn( false );
+		$this->manager->method( 'is_connection_owner' )->willReturn( false );
+
+		$response = $this->do_request( self::ROUTE_CONNECTED, 'GET' );
+
+		$this->assertEquals(
+			[
+				'active'      => 'no',
+				'owner'       => 'no',
+				'displayName' => '',
+				'email'       => '',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a handler to check why a request to the WCS failed when receiving a 401 error. If it's related to the Jetpack header then we return a standard error response, which will prompt the UI to reconnect. The response that's returned is:

```json
{
	"message": "Please reconnect your Jetpack account.",
	"status": 401,
	"code": "JETPACK_DISCONNECTED"
}
```

We previously implemented a 401 response will prompt the UI to reconnect the Google account, this still works the same but the error response was standardized to clearly indicate which account should be reconnected:

```json
{
	"message": "Please reconnect your Google account.",
	"status": 401,
	"code": "GOOGLE_DISCONNECTED"
}
```

The next step would be for the UI to differentiate between the returned `code` and redirect to the right reconnect page.

Additionally the following changes were made in this PR:
- Standardize all the controllers (that send a request to WCS), to use the helper function `response_from_exception`, which will create a Response containing all the details within the exception
- Add an option to keep track of the Jetpack connected status
- Unit test for the Jetpack AccountController
- Unit test for the Google AccountController

Resolves the backend part of #775 

### Detailed test instructions:

#### Simulate Jetpack disconnect
- In the wp_options table modify the option with the name `jetpack_private_options`, change `blog_token` > `fail_token`
- Send a request to check the Google account status:
`GET https://domain.test/wp-json/wc/gla/google/connected`

Expected response:
```json
{
	"message": "Please reconnect your Jetpack account.",
	"status": 401,
	"code": "JETPACK_DISCONNECTED"
}
```

- Change the option `jetpack_private_options` back to it's original value.
- Resend the previous request:
`GET https://domain.test/wp-json/wc/gla/google/connected`

Expected response:
```json
{
	"active": "yes",
	"email": "john@doe.email",
	"scope": [
		"https://www.googleapis.com/auth/content"
	]
}
```

#### Simulate Google disconnect
- In the connection test page disconnect your Google account
- Send a proxied request to the Merchant Account (like getting the contact info):
`GET https://domain.test/wp-json/wc/gla/mc/contact-information`

Expected response:
```json
{
	"message": "Please reconnect your Google account.",
	"status": 401,
	"code": "GOOGLE_DISCONNECTED"
}
```

- Reconnect the Google account in the Connection Test page
- Resend the previous request to retrieve the contact information
- Confirm that this time we receive the contact information stored in WC and MC

### Changelog entry
* Add - Handler for detecting a Jetpack disconnect.
