### PR TITLE
Cast empty arrays to objects in APIs if property type is object.

### DIFF
--- a/src/API/Site/Controllers/BaseController.php
+++ b/src/API/Site/Controllers/BaseController.php
@@ -142,7 +142,14 @@ abstract class BaseController extends WC_REST_Controller implements Registerable
 		$context  = $request['context'] ?? 'view';
 		$schema   = $this->get_schema_properties();
 		foreach ( $schema as $key => $property ) {
-			$prepared[ $key ] = $item[ $key ] ?? $property['default'] ?? null;
+			$item_value = $item[ $key ] ?? $property['default'] ?? null;
+
+			// Cast empty arrays to empty objects if property is supposed to be an object.
+			if ( is_array( $item_value ) && empty( $item_value ) && isset( $property['type'] ) && 'object' === $property['type'] ) {
+				$item_value = (object) [];
+			}
+
+			$prepared[ $key ] = $item_value;
 		}
 
 		$prepared = $this->add_additional_fields_to_object( $prepared, $request );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingRateControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingRateControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingRateController;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class ShippingRateControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
+ *
+ * @property RESTServer                   $rest_server
+ * @property ShippingRateQuery|MockObject $shipping_rate_query
+ */
+class ShippingRateControllerTest extends RESTControllerUnitTest {
+
+	protected const ROUTE_RATES = '/wc/gla/mc/shipping/rates';
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->shipping_rate_query = $this->createMock( ShippingRateQuery::class );
+		$this->controller          = new ShippingRateController( $this->server, $this->shipping_rate_query );
+		$this->controller->register();
+	}
+
+	public function test_get_all_rates() {
+		$this->shipping_rate_query->expects( $this->once() )
+								  ->method( 'set_order' )
+								  ->willReturn( $this->shipping_rate_query );
+		$this->shipping_rate_query->expects( $this->once() )
+								  ->method( 'get_results' )
+								  ->willReturn(
+									  [
+										  [
+											  'id'       => '123',
+											  'country'  => 'US',
+											  'currency' => 'USD',
+											  'rate'     => '5.00',
+											  'method'   => 'flat_rate',
+											  'options'  => [
+												  'free_shipping_threshold' => '100',
+											  ],
+										  ],
+									  ]
+								  );
+
+		$response = $this->do_request( self::ROUTE_RATES, 'GET' );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertCount( 1, $data );
+
+		$this->assertEquals( '123', $data[0]['id'] );
+		$this->assertEquals( 'US', $data[0]['country'] );
+		$this->assertEquals( 'USD', $data[0]['currency'] );
+		$this->assertEquals( '5.00', $data[0]['rate'] );
+		$this->assertEquals( 'flat_rate', $data[0]['method'] );
+		$this->assertEquals( 100, $data[0]['options']['free_shipping_threshold'] );
+	}
+
+	public function test_empty_options_array_is_returned_as_object() {
+		$this->shipping_rate_query->expects( $this->once() )
+								  ->method( 'set_order' )
+								  ->willReturn( $this->shipping_rate_query );
+		$this->shipping_rate_query->expects( $this->once() )
+								  ->method( 'get_results' )
+								  ->willReturn(
+									  [
+										  [
+											  'id'       => '123',
+											  'country'  => 'US',
+											  'currency' => 'USD',
+											  'rate'     => '5.00',
+											  'method'   => 'flat_rate',
+											  'options'  => [],
+										  ],
+									  ]
+								  );
+
+		$response = $this->do_request( self::ROUTE_RATES, 'GET' );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertCount( 1, $data );
+
+		// Confirm that the 'options' value is an object, not an array.
+		$this->assertIsObject( $data[0]['options'] );
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is to avoid including an empty `array` in the API response in case the property type is `object` but it has no properties (i.e. no array key-values).

An example of this is in the `GET mc/shipping/rates` API where the `options` property of each shipping rate could be returned as an empty array (as mentioned in https://github.com/woocommerce/google-listings-and-ads/pull/1266#discussion_r816551941) (also in p1646135001757439-slack-C01E9LB4X61).


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Since this change is applied on the `BaseController` class it will apply to any API that includes `object` properties in their schema. Meaning that they now return an empty object `{}` instead of an empty array `[]` in the JSON response if their provided value is an empty array.

The following APIs might be affected. It's worth checking if they return the expected value and if the corresponding front-end code works as expected:

|API|Potentially Affected Properties|
|---|---|
|`GET mc/shipping/rates`|`options`|
|`POST mc/shipping/rates/batch`|items in the `rates` array|
|`GET ads/reports/programs`|items in the `products`, `campaigns`, `intervals`, `totals`, and `subtotals` array|
|`GET ads/reports/products`|items in the `products`, `campaigns`, `intervals`, `totals`, and `subtotals` array|
|`GET mc/reports/programs`|items in the `products`, `free_listings`, `intervals`, `totals`, and `subtotals` array|
|`GET mc/reports/products`|items in the `products`, `free_listings`, `intervals`, `totals`, and `subtotals` array|
|`GET/POST mc/contact-information`|`mc_address` and `wc_address`|
|`GET mc/issues`|items in the `issues` property|
|`GET mc/product-feed`|items in the `products` property|
|`GET mc/product-statistics`|`statistics`|
|`GET mc/product-statistics/refresh`|`statistics`|

To test if the code actually replaces empty arrays with empty objects you can hardcode an empty array in the returned value of any of the APIs and confirm the property value in the returned response is an empty object. For example, to test the `GET mc/shipping/rates` API:

1. Set the `$rate['options']` to an empty array in the `ShippingRateController::get_read_all_rates_callback` right before the call to `prepare_item_for_response`.
2. Send a request to `GET mc/shipping/rates` API and confirm the returned `options` value is an empty object `{}`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
