### PR TITLE
Select All Options in Tree Select Component

### DIFF
--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import classnames from 'classnames';
 // eslint-disable-next-line import/no-extraneous-dependencies,@woocommerce/dependency-group,@wordpress/no-unsafe-wp-apis
@@ -32,18 +33,19 @@ import './index.scss';
  * @param {Object} props Component props.
  * @param {string} props.id Component id
  * @param {string} props.label Label for the component
+ * @param {string} props.selectAllLabel Label for the Select All option
  * @param {string} props.placeholder Placeholder for the search control input
  * @param {string} props.className The class name for this component
  * @param {boolean} props.disabled Disables the component
  * @param {Option[]} props.options Options to show in the component
  * @param {{string}[]} props.value Selected values
  * @param {Function} props.onChange Callback when the selector changes
- *
  * @return {JSX.Element|null} The component
  */
 const TreeSelectControl = ( {
 	id,
 	label,
+	selectAllLabel = __( 'All', 'google-listings-and-ads' ),
 	placeholder,
 	className,
 	disabled,
@@ -54,7 +56,10 @@ const TreeSelectControl = ( {
 	let instanceId = useInstanceId( TreeSelectControl );
 	instanceId = id ?? instanceId;
 	const [ isExpanded, setIsExpanded ] = useState( false );
-	const optionsRef = useIsEqualRefValue( options );
+	const optionsRef = useIsEqualRefValue( [
+		{ value: 'all', label: selectAllLabel, children: options },
+	] );
+
 	const focusOutside = useFocusOutside( () => {
 		setIsExpanded( false );
 	} );
@@ -208,7 +213,7 @@ const TreeSelectControl = ( {
 					tabIndex="-1"
 				>
 					<Options
-						options={ options }
+						options={ optionsRef }
 						value={ value }
 						onChange={ handleOptionsChange }
 					/>

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -33,7 +33,7 @@ import './index.scss';
  * @param {Object} props Component props.
  * @param {string} props.id Component id
  * @param {string} props.label Label for the component
- * @param {string} props.selectAllLabel Label for the Select All option
+ * @param {string | false} props.selectAllLabel Label for the Select All root element. False for disable.
  * @param {string} props.placeholder Placeholder for the search control input
  * @param {string} props.className The class name for this component
  * @param {boolean} props.disabled Disables the component
@@ -56,9 +56,11 @@ const TreeSelectControl = ( {
 	let instanceId = useInstanceId( TreeSelectControl );
 	instanceId = id ?? instanceId;
 	const [ isExpanded, setIsExpanded ] = useState( false );
-	const optionsRef = useIsEqualRefValue( [
-		{ value: 'all', label: selectAllLabel, children: options },
-	] );
+	const optionsRef = useIsEqualRefValue(
+		selectAllLabel
+			? [ { label: selectAllLabel, value: '', children: options } ]
+			: options
+	);
 
 	const focusOutside = useFocusOutside( () => {
 		setIsExpanded( false );

--- a/js/src/components/tree-select-control/index.scss
+++ b/js/src/components/tree-select-control/index.scss
@@ -149,6 +149,10 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 		padding-left: calc(#{$gap} * 2);
 	}
 
+	.woocommerce-tree-select-control__main {
+		padding-left: $gap-small;
+	}
+
 	.woocommerce-tree-select-control__node {
 		padding-left: $gap;
 	}

--- a/js/src/components/tree-select-control/index.test.js
+++ b/js/src/components/tree-select-control/index.test.js
@@ -76,4 +76,50 @@ describe( 'TreeSelectControl Component', () => {
 
 		expect( queryByLabelText( 'Select' ) ).toBeTruthy();
 	} );
+
+	it( 'Renders the All Options', () => {
+		const onChange = jest.fn().mockName( 'onChange' );
+		const { queryByLabelText, queryByRole, rerender } = render(
+			<TreeSelectControl
+				options={ options }
+				label="Select"
+				onChange={ onChange }
+			/>
+		);
+
+		const control = queryByRole( 'combobox' );
+		fireEvent.click( control );
+		const allCheckbox = queryByLabelText( 'All' );
+
+		expect( allCheckbox ).toBeTruthy();
+
+		fireEvent.click( allCheckbox );
+		expect( onChange ).toHaveBeenCalledWith( [ 'ES', 'FR', 'IT', 'AS' ] );
+
+		rerender(
+			<TreeSelectControl
+				value={ [ 'ES', 'FR', 'IT', 'AS' ] }
+				options={ options }
+				label="Select"
+				onChange={ onChange }
+			/>
+		);
+		fireEvent.click( allCheckbox );
+		expect( onChange ).toHaveBeenCalledWith( [] );
+	} );
+
+	it( 'Renders the All Options custom Label', () => {
+		const { queryByLabelText, queryByRole } = render(
+			<TreeSelectControl
+				options={ options }
+				selectAllLabel="All countries"
+			/>
+		);
+
+		const control = queryByRole( 'combobox' );
+		fireEvent.click( control );
+		const allCheckbox = queryByLabelText( 'All countries' );
+
+		expect( allCheckbox ).toBeTruthy();
+	} );
 } );

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -46,11 +46,12 @@ const Options = ( {
 		);
 	};
 
-	const isRoot = ( option ) => option.value === 'all';
+	const isRoot = ( option ) => option.value === '';
 
 	return options.map( ( option ) => {
 		const isExpanded =
 			isRoot( option ) || expanded.includes( option.value );
+
 		const hasChildren = !! option.children?.length;
 
 		return (

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -46,8 +46,11 @@ const Options = ( {
 		);
 	};
 
+	const isRoot = ( option ) => option.value === 'all';
+
 	return options.map( ( option ) => {
-		const isExpanded = expanded.includes( option.value );
+		const isExpanded =
+			isRoot( option ) || expanded.includes( option.value );
 		const hasChildren = !! option.children?.length;
 
 		return (
@@ -60,16 +63,18 @@ const Options = ( {
 					className="woocommerce-tree-select-control__node"
 					justify="flex-start"
 				>
-					<Icon
-						className={ classnames(
-							'woocommerce-tree-select-control__expander-icon',
-							! hasChildren ? 'is-hidden' : false
-						) }
-						icon={ isExpanded ? chevronUp : chevronDown }
-						onClick={ () => {
-							toggleExpanded( option.value );
-						} }
-					/>
+					{ ! isRoot( option ) && (
+						<Icon
+							className={ classnames(
+								'woocommerce-tree-select-control__expander-icon',
+								! hasChildren ? 'is-hidden' : false
+							) }
+							icon={ isExpanded ? chevronUp : chevronDown }
+							onClick={ () => {
+								toggleExpanded( option.value );
+							} }
+						/>
+					) }
 
 					<CheckboxControl
 						className={ 'woocommerce-tree-select-control__option' }
@@ -86,7 +91,14 @@ const Options = ( {
 				</Flex>
 
 				{ hasChildren && isExpanded && (
-					<div className="woocommerce-tree-select-control__children">
+					<div
+						className={ classnames(
+							'woocommerce-tree-select-control__children',
+							isRoot( option )
+								? 'woocommerce-tree-select-control__main'
+								: false
+						) }
+					>
 						<Options
 							parent={ option.value }
 							options={ option.children }

--- a/js/src/pages/component-test/index.js
+++ b/js/src/pages/component-test/index.js
@@ -72,6 +72,7 @@ const ComponentTest = () => {
 				value={ selected }
 				onChange={ setSelected }
 				label="Select Country"
+				selectAllLabel="All Countries"
 				placeholder="Select"
 			/>
 			<hr />


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of the Milestone 2 for Tree Select Control Component

This PR implements the Select all feature in the component.

### Screenshots:


https://user-images.githubusercontent.com/5908855/157015336-e6f9c452-0bb4-41c3-9dc5-c5475dc9de41.mov



### Detailed test instructions:

1. Checkout the branch
2. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcomponent-test` 
3. You can see component TreeSlectControl with the label `Select Country` and the placeholder `Select`
4. Clicking on "Select" expands the TreeSlector and shows text cursor instead of the placeholder  
5. Tree Shows  the main groups collapsed  and "All Countries" at the top unselected
6. If you click on "All Countries" it selects all options
7. If you deselect some option it unchecks  "All Countries"
8. If you click again on  "All Countries" it selects all options
8. If you click again on  "All Countries" it de-selects all options

### Additional details:

We created just one extra Parent root option (all) with the Client provided options as children. Then, in the options component, we just do some checks regarding the icons, expand state and class name. The rest of the logic is exactly the same as any other Parent. The Client can provide `selectAllLabel` param to customize the "all" label. 

I would love to have thoughts about the next:

- Option A: Inject the parent option allowing to customize the label (as is in this PR)
- Option B: Same as A, but disabling the "All options" if no label is provided. 
- Option C: Same as A but adding one extra para `allOptionsDisabled` that allows the Client to disable/enable the All options feature.  
- Option D: Add one param `selectAllOption` that is an Option object (label and value) setting this will load the All Options as specified in the object.
-  Option E: Rely on the Client to load the All options option on their own in the options param. Detect programmatically if there is that root element in the data. (Not recommended)
- Option F: Other options or suggestions you want to add.

I would go for Option A or D. D increases a bit the complexity of the data but is more customizable and flexible IMH. 

