### PR TITLE
Add type to Performance Card in order to differentiate between Paid a…

### DIFF
--- a/js/src/dashboard/summary-section/campaign-no-data.js
+++ b/js/src/dashboard/summary-section/campaign-no-data.js
@@ -36,10 +36,11 @@ const CONTENT = {
 /**
  * Show the notice and link to Google Ads when no data is available
  *
- * @param {string} campaignType The Campaign type (free|paid)
+ * @param {Object} props React props
+ * @param {string} props.campaignType The Campaign type (free|paid)
  * @return {JSX.Element} The Component to be rendered
  */
-const CampaignNoData = ( campaignType = REPORT_SOURCE_FREE ) => {
+const CampaignNoData = ( { campaignType = REPORT_SOURCE_FREE } ) => {
 	return (
 		<div className="gla-summary-card__body">
 			<p>{ CONTENT[ campaignType ].body }</p>

--- a/js/src/dashboard/summary-section/campaign-no-data.js
+++ b/js/src/dashboard/summary-section/campaign-no-data.js
@@ -10,7 +10,7 @@ import AppButton from '.~/components/app-button';
 import { REPORT_SOURCE_FREE, REPORT_SOURCE_PAID } from '.~/constants';
 
 const CONTENT = {
-	REPORT_SOURCE_FREE: {
+	[ REPORT_SOURCE_FREE ]: {
 		body: __(
 			"We're having trouble loading this data. Try again later, or track your performance in Google Merchant Center.",
 			'google-listings-and-ads'
@@ -22,7 +22,7 @@ const CONTENT = {
 			'google-listings-and-ads'
 		),
 	},
-	REPORT_SOURCE_PAID: {
+	[ REPORT_SOURCE_PAID ]: {
 		body: __(
 			"We're having trouble loading this data. Try again later, or track your performance in Google Ads.",
 			'google-listings-and-ads'
@@ -32,28 +32,29 @@ const CONTENT = {
 		buttonLabel: __( 'Open Google Ads', 'google-listings-and-ads' ),
 	},
 };
+
 /**
  * Show the notice and link to Google Ads when no data is available
  *
- * @param {string} type The Account type (free|paid)
+ * @param {string} campaignType The Campaign type (free|paid)
  * @return {JSX.Element} The Component to be rendered
  */
-const CampaignNoData = ( type ) => {
+const CampaignNoData = ( campaignType = REPORT_SOURCE_FREE ) => {
 	return (
 		<div className="gla-summary-card__body">
-			<p>{ CONTENT[ type ].body }</p>
+			<p>{ CONTENT[ campaignType ].body }</p>
 			<AppButton
-				eventName={ CONTENT[ type ].eventName }
+				eventName={ CONTENT[ campaignType ].eventName }
 				eventProps={ {
 					context: 'dashboard',
-					href: CONTENT[ type ].link,
+					href: CONTENT[ campaignType ].link,
 				} }
-				href={ CONTENT[ type ].link }
+				href={ CONTENT[ campaignType ].link }
 				target="_blank"
 				isSmall
 				isSecondary
 			>
-				{ CONTENT[ type ].buttonLabel }
+				{ CONTENT[ campaignType ].buttonLabel }
 			</AppButton>
 		</div>
 	);

--- a/js/src/dashboard/summary-section/campaign-no-data.js
+++ b/js/src/dashboard/summary-section/campaign-no-data.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
+import { REPORT_SOURCE_FREE, REPORT_SOURCE_PAID } from '.~/constants';
+
+const CONTENT = {
+	REPORT_SOURCE_FREE: {
+		body: __(
+			"We're having trouble loading this data. Try again later, or track your performance in Google Merchant Center.",
+			'google-listings-and-ads'
+		),
+		link: 'https://merchants.google.com/mc/reporting/dashboard',
+		eventName: 'gla_google_mc_link_click',
+		buttonLabel: __(
+			'Open Google Merchant Center',
+			'google-listings-and-ads'
+		),
+	},
+	REPORT_SOURCE_PAID: {
+		body: __(
+			"We're having trouble loading this data. Try again later, or track your performance in Google Ads.",
+			'google-listings-and-ads'
+		),
+		link: 'https://ads.google.com/',
+		eventName: 'gla_google_ads_link_click',
+		buttonLabel: __( 'Open Google Ads', 'google-listings-and-ads' ),
+	},
+};
+/**
+ * Show the notice and link to Google Ads when no data is available
+ *
+ * @param {string} type The Account type (free|paid)
+ * @return {JSX.Element} The Component to be rendered
+ */
+const CampaignNoData = ( type ) => {
+	return (
+		<div className="gla-summary-card__body">
+			<p>{ CONTENT[ type ].body }</p>
+			<AppButton
+				eventName={ CONTENT[ type ].eventName }
+				eventProps={ {
+					context: 'dashboard',
+					href: CONTENT[ type ].link,
+				} }
+				href={ CONTENT[ type ].link }
+				target="_blank"
+				isSmall
+				isSecondary
+			>
+				{ CONTENT[ type ].buttonLabel }
+			</AppButton>
+		</div>
+	);
+};
+
+export default CampaignNoData;

--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -33,7 +33,7 @@ const FreePerformanceCard = () => {
 			) }
 			loaded={ loaded }
 			data={ data }
-			type={ REPORT_SOURCE_FREE }
+			campaignType={ REPORT_SOURCE_FREE }
 		>
 			{ ( loadedData ) => [
 				<SummaryNumber
@@ -65,7 +65,7 @@ const PaidPerformanceCard = () => {
 			title={ paidPerformanceTitle }
 			loaded={ loaded }
 			data={ data }
-			type={ REPORT_SOURCE_PAID }
+			campaignType={ REPORT_SOURCE_PAID }
 		>
 			{ ( loadedData ) => [
 				<SummaryNumber

--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -33,6 +33,7 @@ const FreePerformanceCard = () => {
 			) }
 			loaded={ loaded }
 			data={ data }
+			type={ REPORT_SOURCE_FREE }
 		>
 			{ ( loadedData ) => [
 				<SummaryNumber
@@ -64,6 +65,7 @@ const PaidPerformanceCard = () => {
 			title={ paidPerformanceTitle }
 			loaded={ loaded }
 			data={ data }
+			type={ REPORT_SOURCE_PAID }
 		>
 			{ ( loadedData ) => [
 				<SummaryNumber

--- a/js/src/dashboard/summary-section/performance-card-no-data.js
+++ b/js/src/dashboard/summary-section/performance-card-no-data.js
@@ -41,21 +41,22 @@ const CONTENT = {
  * @return {JSX.Element} The Component to be rendered
  */
 const PerformanceCardNoData = ( { campaignType = REPORT_SOURCE_FREE } ) => {
+	const content = CONTENT[ campaignType ];
 	return (
 		<div className="gla-summary-card__body">
-			<p>{ CONTENT[ campaignType ].body }</p>
+			<p>{ content.body }</p>
 			<AppButton
-				eventName={ CONTENT[ campaignType ].eventName }
+				eventName={ content.eventName }
 				eventProps={ {
 					context: 'dashboard',
-					href: CONTENT[ campaignType ].link,
+					href: content.link,
 				} }
-				href={ CONTENT[ campaignType ].link }
+				href={ content.link }
 				target="_blank"
 				isSmall
 				isSecondary
 			>
-				{ CONTENT[ campaignType ].buttonLabel }
+				{ content.buttonLabel }
 			</AppButton>
 		</div>
 	);

--- a/js/src/dashboard/summary-section/performance-card-no-data.js
+++ b/js/src/dashboard/summary-section/performance-card-no-data.js
@@ -34,13 +34,13 @@ const CONTENT = {
 };
 
 /**
- * Show the notice and link to Google Ads when no data is available
+ * Show the notice and link to Google Ads or MC when no data is available
  *
  * @param {Object} props React props
  * @param {string} props.campaignType The Campaign type (free|paid)
  * @return {JSX.Element} The Component to be rendered
  */
-const CampaignNoData = ( { campaignType = REPORT_SOURCE_FREE } ) => {
+const PerformanceCardNoData = ( { campaignType = REPORT_SOURCE_FREE } ) => {
 	return (
 		<div className="gla-summary-card__body">
 			<p>{ CONTENT[ campaignType ].body }</p>
@@ -61,4 +61,4 @@ const CampaignNoData = ( { campaignType = REPORT_SOURCE_FREE } ) => {
 	);
 };
 
-export default CampaignNoData;
+export default PerformanceCardNoData;

--- a/js/src/dashboard/summary-section/performance-card.js
+++ b/js/src/dashboard/summary-section/performance-card.js
@@ -6,7 +6,7 @@ import { SummaryList, SummaryListPlaceholder } from '@woocommerce/components';
  * Internal dependencies
  */
 import SummaryCard from './summary-card';
-import CampaignNoData from '.~/dashboard/summary-section/campaign-no-data';
+import PerformanceCardNoData from '.~/dashboard/summary-section/performance-card-no-data';
 
 /**
  * @typedef {import('@woocommerce/components').SummaryNumber} SummaryNumber
@@ -36,7 +36,7 @@ const PerformanceCard = ( {
 	if ( ! loaded ) {
 		content = <SummaryListPlaceholder numberOfItems={ numberOfItems } />;
 	} else if ( ! data ) {
-		content = <CampaignNoData campaignType={ campaignType } />;
+		content = <PerformanceCardNoData campaignType={ campaignType } />;
 	} else {
 		content = (
 			<SummaryList>

--- a/js/src/dashboard/summary-section/performance-card.js
+++ b/js/src/dashboard/summary-section/performance-card.js
@@ -21,7 +21,7 @@ import CampaignNoData from '.~/dashboard/summary-section/campaign-no-data';
  * @param {Object | null} props.data Data to be forwarded to `children` once available.
  * @param {(availableData: Object) => Array<SummaryNumber>} props.children Data to be forwarded to `children` once available.
  * @param {number} [props.numberOfItems=2] Number of expected SummaryNumbers.
- * @param {string} props.type Type of Campaign (paid|free)
+ * @param {string} props.campaignType The Campaign type (free|paid) used to define text an links when no data
  * @return {SummaryCard} SummaryCard with Metrics data, preloader or error message.
  */
 const PerformanceCard = ( {
@@ -30,13 +30,13 @@ const PerformanceCard = ( {
 	data,
 	children,
 	numberOfItems = 2,
-	type,
+	campaignType,
 } ) => {
 	let content;
 	if ( ! loaded ) {
 		content = <SummaryListPlaceholder numberOfItems={ numberOfItems } />;
 	} else if ( ! data ) {
-		content = <CampaignNoData type={ type } />;
+		content = <CampaignNoData campaignType={ campaignType } />;
 	} else {
 		content = (
 			<SummaryList>

--- a/js/src/dashboard/summary-section/performance-card.js
+++ b/js/src/dashboard/summary-section/performance-card.js
@@ -1,20 +1,16 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { SummaryList, SummaryListPlaceholder } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
 import SummaryCard from './summary-card';
+import CampaignNoData from '.~/dashboard/summary-section/campaign-no-data';
 
 /**
  * @typedef {import('@woocommerce/components').SummaryNumber} SummaryNumber
  */
-
-const googleMCReportingDashboardURL =
-	'https://merchants.google.com/mc/reporting/dashboard';
 
 /**
  * Returns a Card with performance matrics according to the given data.
@@ -25,6 +21,7 @@ const googleMCReportingDashboardURL =
  * @param {Object | null} props.data Data to be forwarded to `children` once available.
  * @param {(availableData: Object) => Array<SummaryNumber>} props.children Data to be forwarded to `children` once available.
  * @param {number} [props.numberOfItems=2] Number of expected SummaryNumbers.
+ * @param {string} props.type Type of Campaign (paid|free)
  * @return {SummaryCard} SummaryCard with Metrics data, preloader or error message.
  */
 const PerformanceCard = ( {
@@ -33,37 +30,13 @@ const PerformanceCard = ( {
 	data,
 	children,
 	numberOfItems = 2,
+	type,
 } ) => {
 	let content;
 	if ( ! loaded ) {
 		content = <SummaryListPlaceholder numberOfItems={ numberOfItems } />;
 	} else if ( ! data ) {
-		content = (
-			<div className="gla-summary-card__body">
-				<p>
-					{ __(
-						"We're having trouble loading this data. Try again later, or track your performance in Google Merchant Center.",
-						'google-listings-and-ads'
-					) }
-				</p>
-				<AppButton
-					eventName="gla_google_mc_link_click"
-					eventProps={ {
-						context: 'dashboard',
-						href: googleMCReportingDashboardURL,
-					} }
-					href={ googleMCReportingDashboardURL }
-					target="_blank"
-					isSmall
-					isSecondary
-				>
-					{ __(
-						'Open Google Merchant Center',
-						'google-listings-and-ads'
-					) }
-				</AppButton>
-			</div>
-		);
+		content = <CampaignNoData type={ type } />;
 	} else {
 		content = (
 			<SummaryList>

--- a/js/src/dashboard/summary-section/performance-card.test.js
+++ b/js/src/dashboard/summary-section/performance-card.test.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PerformanceCard from '.~/dashboard/summary-section/performance-card';
+
+describe( 'Performance Card', () => {
+	it( 'Shows Campaign No Data for Free Campaigns', () => {
+		const { queryByText } = render(
+			<PerformanceCard
+				title="test"
+				loaded={ true }
+				data={ false }
+				campaignType="free"
+			/>
+		);
+
+		expect(
+			queryByText(
+				"We're having trouble loading this data. Try again later, or track your performance in Google Merchant Center."
+			)
+		).toBeTruthy();
+
+		const link = queryByText( 'Open Google Merchant Center' );
+
+		expect( link ).toBeTruthy();
+		expect( link.href ).toBe(
+			'https://merchants.google.com/mc/reporting/dashboard'
+		);
+	} );
+
+	it( 'Shows Campaign No Data for Paid Campaigns', () => {
+		const { queryByText } = render(
+			<PerformanceCard
+				title="test"
+				loaded={ true }
+				data={ false }
+				campaignType="paid"
+			/>
+		);
+
+		expect(
+			queryByText(
+				"We're having trouble loading this data. Try again later, or track your performance in Google Ads."
+			)
+		).toBeTruthy();
+
+		const link = queryByText( 'Open Google Ads' );
+
+		expect( link ).toBeTruthy();
+		expect( link.href ).toBe( 'https://ads.google.com/' );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1285 

We want to show different messages depending on Free or Paid Campaigns. Right now we are showing same message for both.


### Screenshots:

<img width="811" alt="Screenshot 2022-03-07 at 18 27 26" src="https://user-images.githubusercontent.com/5908855/157059097-3cd23639-420f-40d5-84f4-76cf0213eaf1.png">

<img width="814" alt="Screenshot 2022-03-07 at 18 31 08" src="https://user-images.githubusercontent.com/5908855/157059132-a520ccde-61d2-49ba-82b2-7c613a0a46d7.png">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. You should have Paid Campaign set-up done. 
2. Go to the code on this branch in `js/src/dashboard/summary-section/index.js` 
3. In lines 66-67 and lines 34-35 set `data` as `false` and `loaded` as `true` to simulate no data error.
4. Go to the dashboard and see messages like the screenshots. Paid one shows text regarding google Ads, as well as link. Free one shows text regarding Google Merchant Center as well as the Link to Google Merchant centre dashboard. 
5. Roll back your test changes and see how the Paid and free summary renders as always. 


### Additional details:

- Created a new component CampaignNoData. It renders the message and button depending on the campaign type.  

### Changelog entry

> FIx - Show right link and message in Paid Campaigns report when there is no data available
