### PR TITLE
Fix the current onboarding step being returned as shipping even after saving rates

### DIFF
--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -303,8 +303,14 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		if ( isset( $merchant_center_settings['shipping_time'] ) && 'manual' === $merchant_center_settings['shipping_time'] ) {
 			$saved_shipping_time = true;
 		} else {
-			$shipping_time_rows  = $this->container->get( ShippingTimeQuery::class )->get_count();
-			$saved_shipping_time = $shipping_time_rows === count( $target_countries );
+			$shipping_time_rows = $this->container->get( ShippingTimeQuery::class )->get_results();
+
+			// Get the name of countries that have saved shipping times.
+			$saved_time_countries = array_column( $shipping_time_rows, 'country' );
+
+			// Check if all target countries have a shipping time.
+			$saved_shipping_time = count( $shipping_time_rows ) === count( $target_countries ) &&
+								   empty( array_diff( $target_countries, $saved_time_countries ) );
 		}
 
 		// Shipping rates saved if: 'manual', 'automatic', OR there are records for all countries
@@ -323,11 +329,11 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			$shipping_rate_rows = $shipping_rate_query->get_results();
 
 			// Get the name of countries that have saved shipping rates.
-			$saved_countries = array_column( $shipping_rate_rows, 'country' );
+			$saved_rates_countries = array_column( $shipping_rate_rows, 'country' );
 
 			// Check if all target countries have a shipping rate.
 			$saved_shipping_rate = count( $shipping_rate_rows ) === count( $target_countries ) &&
-								   empty( array_diff( $target_countries, $saved_countries ) );
+								   empty( array_diff( $target_countries, $saved_rates_countries ) );
 		}
 
 		return $saved_shipping_rate && $saved_shipping_time;

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -299,7 +299,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			return false;
 		}
 
-		// Shipping options saved if: 'manual' OR records for all countries
+		// Shipping time saved if: 'manual' OR records for all countries
 		if ( isset( $merchant_center_settings['shipping_time'] ) && 'manual' === $merchant_center_settings['shipping_time'] ) {
 			$saved_shipping_time = true;
 		} else {
@@ -307,16 +307,27 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			$saved_shipping_time = $shipping_time_rows === count( $target_countries );
 		}
 
-		if ( isset( $merchant_center_settings['shipping_rate'] ) && 'manual' === $merchant_center_settings['shipping_rate'] ) {
+		// Shipping rates saved if: 'manual', 'automatic', OR there are records for all countries
+		if (
+			isset( $merchant_center_settings['shipping_rate'] ) &&
+			in_array( $merchant_center_settings['shipping_rate'], [ 'manual', 'automatic' ], true )
+		) {
 			$saved_shipping_rate = true;
 		} else {
+			// Get the list of saved shipping rates grouped by country.
 			/**
 			 * @var ShippingRateQuery $shipping_rate_query
 			 */
 			$shipping_rate_query = $this->container->get( ShippingRateQuery::class );
 			$shipping_rate_query->group_by( 'country' );
-			$shipping_rate_rows  = $shipping_rate_query->get_count();
-			$saved_shipping_rate = $shipping_rate_rows === count( $target_countries );
+			$shipping_rate_rows = $shipping_rate_query->get_results();
+
+			// Get the name of countries that have saved shipping rates.
+			$saved_countries = array_column( $shipping_rate_rows, 'country' );
+
+			// Check if all target countries have a shipping rate.
+			$saved_shipping_rate = count( $shipping_rate_rows ) === count( $target_countries ) &&
+								   empty( array_diff( $target_countries, $saved_countries ) );
 		}
 
 		return $saved_shipping_rate && $saved_shipping_time;


### PR DESCRIPTION


### Changes proposed in this Pull Request:

The API to return the current onboarding step (`GET wc/gla/mc/setup`) did not recognize the newly added `automatic` mode for syncing shipping settings and also the query to count the countries that have a saved shipping rate was not working as expected. This PR fixes these issues.

### Detailed test instructions:

It's easier to test this with the UI parts in, so you can first checkout Gan's PR #1267 branch `feature/shipping-rates-ui/setup-mc` and build all the JS files to have it cached then go back to this branch and test the backend implementation. Once you have all the JS files from Gan's branch:

1. Remove all current MC settings from your DB to have a fresh onboarding
2. Go through onboarding, choose a few target audience countries, and at the shipping step, choose the "Recommended: Automatically sync my store’s shipping settings to Google." option
3. Go to the next step and then refresh the page
4. Confirm you're redirected to the store requirements page instead of the shipping
5. Go back to the shipping step and this time choose "My shipping settings are simple. I can manually estimate flat shipping rates."
6. Enter the shipping rates manually for all selected target audience countries
7. Go to the next step and then refresh the page
8. Confirm you're redirected to the store requirements page instead of the shipping

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
