### PR TITLE
Multi-country targeting campaign - Integrate with budget recommendation API

### DIFF
--- a/js/src/data/api-fetch-middlewares.js
+++ b/js/src/data/api-fetch-middlewares.js
@@ -85,71 +85,19 @@ function adapteCampaignEntity( campaign, i = 0 ) {
 	};
 }
 
-function adapteBudgetResponse( response ) {
-	const codes = this;
-
-	return response
-		.json()
-		.then( ( data ) => {
-			const {
-				currency,
-				country_code: country,
-				daily_budget_low: low,
-				daily_budget_high: high,
-			} = data;
-
-			const baseHigh = Number( high );
-			return {
-				currency,
-				recommendations: [
-					{
-						country,
-						daily_budget_low: Number( low ),
-						daily_budget_high: baseHigh,
-					},
-					...codes.map( ( code, i ) => ( {
-						country: code,
-						daily_budget_low: 5,
-						daily_budget_high:
-							i % 2 ? baseHigh * 1.2 : baseHigh + 200,
-					} ) ),
-				],
-			};
-		} )
-		.then( ( resolvedBody ) => {
-			const json = () => resolvedBody;
-			return {
-				clone: () => ( { json } ),
-				resolvedBody,
-			};
-		} );
-}
-
 export function mockCampaignForMultiCountryTargeting( options, next ) {
 	const { path, method = 'GET' } = options;
 	const route = path.replace( '/wc/gla/', `${ method } ` );
 
 	function logMocks( body ) {
-		const patterns = [
-			/^GET ads\/campaigns$/,
-			/^POST ads\/campaigns$/,
-			/^GET ads\/campaigns\/budget-recommendation\?/,
-		];
+		const patterns = [ /^GET ads\/campaigns$/, /^POST ads\/campaigns$/ ];
 
 		if ( patterns.some( route.match.bind( route ) ) ) {
-			const json = JSON.stringify( body.resolvedBody ?? body, null, 2 );
+			const json = JSON.stringify( body, null, 2 );
 			console.log( `%cMocked: ${ route }`, 'color:#005caf' ); // eslint-disable-line no-console
 			console.log( `%c${ json }`, 'color:#0b346e' ); // eslint-disable-line no-console
 		}
 		return body;
-	}
-
-	if ( route.startsWith( 'GET ads/campaigns/budget-recommendation?' ) ) {
-		const [ code, ...codes ] = wp.url.getQueryArgs( path ).country_codes;
-		options.path = `/wc/gla/ads/campaigns/budget-recommendation/${ code }`;
-		return next( options )
-			.then( adapteBudgetResponse.bind( codes ) )
-			.then( logMocks );
 	}
 
 	if ( route === 'POST ads/campaigns' && options.data.targeted_locations ) {
@@ -170,15 +118,4 @@ export function mockCampaignForMultiCountryTargeting( options, next ) {
 			return body;
 		} )
 		.then( logMocks );
-}
-
-if ( window.wc ) {
-	window.wc.gla = {
-		queryBudget( ...countryCodes ) {
-			const url = `${ API_NAMESPACE }/ads/campaigns/budget-recommendation`;
-			const query = { country_codes: countryCodes };
-			const path = wp.url.addQueryArgs( url, query );
-			wp.apiFetch( { path, parse: false } );
-		},
-	};
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implemented a part of the "**Integrate new API design with finished implementations**" in #1248.

- Remove the mocking budget recommendation API from the frontend side.

💡  The removed mocking code has no side effects, so the code review could be able to take a quick look or skip it. 😎 

### Screenshots:

![Kapture 2022-03-08 at 17 47 31](https://user-images.githubusercontent.com/17420811/157211921-2e79e63e-de7e-4277-8510-537e33f97b2f.gif)

### Detailed test instructions:

1. Go to create campaign.
1. Select one county.
   - The sentence under the input field should be "Most merchants targeting **United States (US)** set a daily budget of **1225 to 3455 JPY** for approximately 10 conversions a week." with the select county, its range, and your Google ads account currency.
1. Select more than one country.
   - The sentence under the input field should be "Most merchants targeting similar countries set a daily budget of **415 to 1185 JPY** for approximately 10 conversions a week." with the select county, its range, and your Google ads account currency. The country name shown in step 2 should be replaced with *similar countries*.

### Changelog entry
