### PR TITLE
Multi-country targeting campaign - Pre-populate the audience field

### DIFF
--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -15,6 +15,7 @@ import StepContentFooter from '.~/components/stepper/step-content-footer';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import AppButton from '.~/components/app-button';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import useTargetAudience from '.~/hooks/useTargetAudience';
 import { useAppDispatch } from '.~/data';
 import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
 import validateForm from '.~/utils/paid-ads/validateForm';
@@ -25,6 +26,10 @@ const CreatePaidAdsCampaignForm = () => {
 	const [ loading, setLoading ] = useState( false );
 	const { createAdsCampaign } = useAppDispatch();
 	const { createNotice } = useDispatchCoreNotices();
+	const {
+		hasFinishedResolution: isResolvedTargetAudience,
+		data: targetAudience,
+	} = useTargetAudience();
 
 	const handleValidate = ( values ) => {
 		return validateForm( values );
@@ -55,11 +60,15 @@ const CreatePaidAdsCampaignForm = () => {
 		getHistory().push( getDashboardUrl() );
 	};
 
+	if ( ! isResolvedTargetAudience ) {
+		return null;
+	}
+
 	return (
 		<Form
 			initialValues={ {
 				amount: 0,
-				countryCodes: [],
+				countryCodes: targetAudience.countries,
 			} }
 			validate={ handleValidate }
 			onSubmit={ handleSubmit }

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -15,7 +15,7 @@ import StepContentFooter from '.~/components/stepper/step-content-footer';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import AppButton from '.~/components/app-button';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useTargetAudience from '.~/hooks/useTargetAudience';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import { useAppDispatch } from '.~/data';
 import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
 import validateForm from '.~/utils/paid-ads/validateForm';
@@ -26,10 +26,7 @@ const CreatePaidAdsCampaignForm = () => {
 	const [ loading, setLoading ] = useState( false );
 	const { createAdsCampaign } = useAppDispatch();
 	const { createNotice } = useDispatchCoreNotices();
-	const {
-		hasFinishedResolution: isResolvedTargetAudience,
-		data: targetAudience,
-	} = useTargetAudience();
+	const { data: targetAudience } = useTargetAudienceFinalCountryCodes();
 
 	const handleValidate = ( values ) => {
 		return validateForm( values );
@@ -60,7 +57,7 @@ const CreatePaidAdsCampaignForm = () => {
 		getHistory().push( getDashboardUrl() );
 	};
 
-	if ( ! isResolvedTargetAudience ) {
+	if ( ! targetAudience ) {
 		return null;
 	}
 
@@ -68,7 +65,7 @@ const CreatePaidAdsCampaignForm = () => {
 		<Form
 			initialValues={ {
 				amount: 0,
-				countryCodes: targetAudience.countries,
+				countryCodes: targetAudience,
 			} }
 			validate={ handleValidate }
 			onSubmit={ handleSubmit }

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -12,26 +12,25 @@ import { getNewPath } from '@woocommerce/navigation';
  */
 import useAdminUrl from '.~/hooks/useAdminUrl';
 import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
+import useTargetAudience from '.~/hooks/useTargetAudience';
 import SetupAdsFormContent from './setup-ads-form-content';
 import useSetupCompleteCallback from './useSetupCompleteCallback';
 import validateForm from '.~/utils/paid-ads/validateForm';
 import { recordLaunchPaidCampaignClickEvent } from '.~/utils/recordEvent';
 
-// when amount is null or undefined in an onChange callback,
-// it will cause runtime error with the Form component.
-const initialValues = {
-	amount: 0,
-	countryCodes: [],
-};
-
 const SetupAdsForm = () => {
-	const [ editedValues, setEditedValues ] = useState( initialValues );
+	const [ didFormChanged, setFormChanged ] = useState( false );
 	const [ isSubmitted, setSubmitted ] = useState( false );
 	const [ handleSetupComplete, isSubmitting ] = useSetupCompleteCallback();
 	const adminUrl = useAdminUrl();
+	const {
+		hasFinishedResolution: isResolvedTargetAudience,
+		data: targetAudience,
+	} = useTargetAudience();
 
-	const handleValidate = ( values ) => {
-		return validateForm( values );
+	const initialValues = {
+		amount: 0,
+		countryCodes: targetAudience?.countries,
 	};
 
 	useEffect( () => {
@@ -45,8 +44,7 @@ const SetupAdsForm = () => {
 		}
 	}, [ isSubmitted, adminUrl ] );
 
-	const didCampaignChanged = ! isEqual( initialValues, editedValues );
-	const shouldPreventLeave = didCampaignChanged && ! isSubmitted;
+	const shouldPreventLeave = didFormChanged && ! isSubmitted;
 
 	useNavigateAwayPromptEffect(
 		__(
@@ -67,13 +65,17 @@ const SetupAdsForm = () => {
 	};
 
 	const handleChange = ( _, values ) => {
-		setEditedValues( values );
+		setFormChanged( ! isEqual( initialValues, values ) );
 	};
+
+	if ( ! isResolvedTargetAudience ) {
+		return null;
+	}
 
 	return (
 		<Form
 			initialValues={ initialValues }
-			validate={ handleValidate }
+			validate={ validateForm }
 			onChange={ handleChange }
 			onSubmit={ handleSubmit }
 		>

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -12,7 +12,7 @@ import { getNewPath } from '@woocommerce/navigation';
  */
 import useAdminUrl from '.~/hooks/useAdminUrl';
 import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
-import useTargetAudience from '.~/hooks/useTargetAudience';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import SetupAdsFormContent from './setup-ads-form-content';
 import useSetupCompleteCallback from './useSetupCompleteCallback';
 import validateForm from '.~/utils/paid-ads/validateForm';
@@ -23,14 +23,11 @@ const SetupAdsForm = () => {
 	const [ isSubmitted, setSubmitted ] = useState( false );
 	const [ handleSetupComplete, isSubmitting ] = useSetupCompleteCallback();
 	const adminUrl = useAdminUrl();
-	const {
-		hasFinishedResolution: isResolvedTargetAudience,
-		data: targetAudience,
-	} = useTargetAudience();
+	const { data: targetAudience } = useTargetAudienceFinalCountryCodes();
 
 	const initialValues = {
 		amount: 0,
-		countryCodes: targetAudience?.countries,
+		countryCodes: targetAudience,
 	};
 
 	useEffect( () => {
@@ -68,7 +65,7 @@ const SetupAdsForm = () => {
 		setFormChanged( ! isEqual( initialValues, values ) );
 	};
 
-	if ( ! isResolvedTargetAudience ) {
+	if ( ! targetAudience ) {
 		return null;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implemented the "**Pre-populating the Audience field**" part of #1248 and based on #1299.

- Pre-populate the **Audience** field with the countries that the merchant previously selected as part of their Merchant Center setup in the campaign setup and campaign creation page

### Screenshots:

https://user-images.githubusercontent.com/17420811/157216052-10be698e-4c27-448d-874d-16a1f2739cc2.mp4

### Detailed test instructions:

1. Go to campaign setup directly with path `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads`
   - Even if the setup is completed, it doesn't need to disconnect first, it can be entered directly with the path. 🙈 
1. The **Audience** field should be pre-populated with the countries that were previously selected in the onboarding setup or free listings edit page.
1. Go to the campaign creation page.
1. Same as 2. The **Audience** field should be pre-populated.

### Changelog entry
