### PR TITLE
Reconnect WordPress notification

### DIFF
--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -123,6 +123,7 @@ class AccountController extends BaseOptionsController {
 		return function() {
 			$this->manager->remove_connection();
 			$this->options->delete( OptionsInterface::WP_TOS_ACCEPTED );
+			$this->options->delete( OptionsInterface::JETPACK_CONNECTED );
 
 			return [
 				'status'  => 'success',

--- a/src/HelperTraits/Utilities.php
+++ b/src/HelperTraits/Utilities.php
@@ -67,4 +67,15 @@ trait Utilities {
 
 		return ( ( time() - $gla_completed_setup ) >= $seconds );
 	}
+
+	/**
+	 * Is Jetpack connected?
+	 *
+	 * @since x.x.x
+	 *
+	 * @return boolean
+	 */
+	protected function is_jetpack_connected(): bool {
+		return boolval( $this->options->get( OptionsInterface::JETPACK_CONNECTED, false ) );
+	}
 }

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -17,6 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Variati
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService as AdsAccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection as GoogleConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
@@ -59,6 +60,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ContactInformation as ContactInformationNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\CompleteSetup as CompleteSetupNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\NoteInitializer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReconnectWordPress as ReconnectWordPressNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReviewAfterClicks as ReviewAfterClicksNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReviewAfterConversions as ReviewAfterConversionsNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaign as SetupCampaignNote;
@@ -138,6 +140,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		OptionsInterface::class       => true,
 		TransientsInterface::class    => true,
 		ProductFeed::class            => true,
+		ReconnectWordPressNote::class => true,
 		ReviewAfterClicksNote::class  => true,
 		RESTControllers::class        => true,
 		Service::class                => true,
@@ -265,6 +268,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Inbox Notes
 		$this->share_with_tags( ContactInformationNote::class );
 		$this->share_with_tags( CompleteSetupNote::class );
+		$this->share_with_tags( ReconnectWordPressNote::class, GoogleConnection::class );
 		$this->share_with_tags( ReviewAfterClicksNote::class, MerchantMetrics::class, WP::class );
 		$this->share_with_tags( ReviewAfterConversionsNote::class, MerchantMetrics::class, WP::class );
 		$this->share_with_tags( SetupCampaignNote::class, MerchantStatuses::class );

--- a/src/Notes/AbstractNote.php
+++ b/src/Notes/AbstractNote.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
+use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use WC_Data_Store;
 
@@ -16,6 +17,17 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
 abstract class AbstractNote implements Note, OptionsAwareInterface {
+
+	/**
+	 * Remove the note from the datastore.
+	 *
+	 * @since x.x.x
+	 */
+	public function delete() {
+		if ( class_exists( Notes::class ) ) {
+			Notes::delete_notes_with_name( $this->get_name() );
+		}
+	}
 
 	/**
 	 * Get note data store.

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
 use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -56,7 +56,7 @@ class ReconnectWordPress extends AbstractNote {
 			__( 'Re-connect your store to Google Listings & Ads', 'google-listings-and-ads' )
 		);
 		$note->set_content(
-			__( 'Your WordPress.com account has been disconnected from Google Listings & Ads. Connect your WordPress.com account again to ensure your products stay listed on Google through the Google Listings & Ads extension.<br/><br/>If you do not re-connect, your products can’t be automatically synced to Google, and any existing listings may be removed from Google.', 'google-listings-and-ads' )
+			__( 'Your WordPress.com account has been disconnected from Google Listings & Ads. Connect your WordPress.com account again to ensure your products stay listed on Google through the Google Listings & Ads extension.<br/><br/>If you do not re-connect, any existing listings may be removed from Google.', 'google-listings-and-ads' )
 		);
 		$note->set_content_data( (object) [] );
 		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -1,0 +1,107 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
+
+use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ReconnectWordPress
+ *
+ * @since x.x.x
+ *
+ * Note for prompting to reconnect the WordPress.com account.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
+ */
+class ReconnectWordPress extends AbstractNote {
+
+	use PluginHelper;
+	use Utilities;
+
+	/**
+	 * @var Connection
+	 */
+	protected $connection;
+
+	/**
+	 * ReconnectWordPress constructor.
+	 *
+	 * @param Connection $connection
+	 */
+	public function __construct( Connection $connection ) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Get the note's unique name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'gla-reconnect-wordpress';
+	}
+
+	/**
+	 * Get the note entry.
+	 */
+	public function get_entry(): NoteEntry {
+		$note = new NoteEntry();
+		$note->set_title(
+			__( 'Re-connect your store to Google Listings & Ads', 'google-listings-and-ads' )
+		);
+		$note->set_content(
+			__( 'Your WordPress.com account has been disconnected from Google Listings & Ads. Connect your WordPress.com account again to ensure your products stay listed on Google through the Google Listings & Ads extension.<br/><br/>If you do not re-connect, your products can’t be automatically synced to Google, and any existing listings may be removed from Google.', 'google-listings-and-ads' )
+		);
+		$note->set_content_data( (object) [] );
+		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( $this->get_name() );
+		$note->set_source( $this->get_slug() );
+		$note->add_action(
+			'reconnect-wordpress',
+			__( 'Go to Google Listings & Ads', 'google-listings-and-ads' ),
+			$this->get_settings_url()
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Checks if a note can and should be added.
+	 *
+	 * - Triggers a status check if not already disconnected.
+	 * - Checks if Jetpack is disconnected.
+	 *
+	 * @return bool
+	 */
+	public function should_be_added(): bool {
+		if ( $this->has_been_added() ) {
+			return false;
+		}
+
+		$this->maybe_check_status();
+
+		return ! $this->is_jetpack_connected();
+	}
+
+	/**
+	 * Trigger a status check if we are not already disconnected.
+	 * A request to the server must be sent to detect a disconnect.
+	 */
+	protected function maybe_check_status() {
+		if ( ! $this->is_jetpack_connected() ) {
+			return;
+		}
+
+		try {
+			$this->connection->get_status();
+		} catch ( Exception $e ) {
+			return;
+		}
+	}
+}

--- a/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
@@ -76,9 +76,12 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	public function test_disconnect() {
 		$this->manager->expects( $this->once() )
 			->method( 'remove_connection' );
-		$this->options->expects( $this->once() )
+		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'delete' )
-			->with( OptionsInterface::WP_TOS_ACCEPTED );
+			->withConsecutive(
+				[ OptionsInterface::WP_TOS_ACCEPTED ],
+				[ OptionsInterface::JETPACK_CONNECTED ]
+			);
 
 		$response = $this->do_request( self::ROUTE_CONNECT, 'DELETE' );
 

--- a/tests/Unit/Notes/ReconnectWordPressTest.php
+++ b/tests/Unit/Notes/ReconnectWordPressTest.php
@@ -1,0 +1,87 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReconnectWordPress;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ReconnectWordPressTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes
+ *
+ * @property MockObject|Connection $connection
+ * @property OptionsInterface      $options
+ * @property ReconnectWordPress    $note
+ */
+class ReconnectWordPressTest extends UnitTest {
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->connection = $this->createMock( Connection::class );
+		$this->options    = $this->createMock( OptionsInterface::class );
+
+		$this->note = new ReconnectWordPress( $this->connection );
+		$this->note->set_options_object( $this->options );
+	}
+
+	public function test_name() {
+		$this->assertEquals( 'gla-reconnect-wordpress', $this->note->get_name() );
+	}
+
+	public function test_note_entry() {
+		$note = $this->note->get_entry();
+
+		$this->assertEquals( 'gla-reconnect-wordpress', $note->get_name() );
+		$this->assertEquals( 'gla', $note->get_source() );
+		$this->assertEquals( 'reconnect-wordpress', $note->get_actions()[0]->name );
+	}
+
+	public function test_should_add_already_added() {
+		$this->note->get_entry()->save();
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_add_connected() {
+		$this->options->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->with( OptionsInterface::JETPACK_CONNECTED )
+			->willReturn( true );
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_add_already_disconnected() {
+		$this->options->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->with( OptionsInterface::JETPACK_CONNECTED )
+			->willReturn( false );
+
+		$this->connection->expects( $this->never() )
+			->method( 'get_status' );
+
+		$this->assertTrue( $this->note->should_be_added() );
+	}
+
+	public function test_should_add_disconnected_after_status_check() {
+		$this->options->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->with( OptionsInterface::JETPACK_CONNECTED )
+			->will( $this->onConsecutiveCalls( true, false ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' );
+
+		$this->assertTrue( $this->note->should_be_added() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds an inbox notification when the WordPress.com (Jetpack) account is detected as disconnected. Since we want to detect a disconnect that has been done outside of our extension we check this when a request is sent to the WCS.

The PR has two ways in which the notification will be triggered:
1. When a request is sent and we detect the account is no longer connected, in this case it adds the notification immediately
2. When the daily cron job for notifications is run we send a status request (if not already disconnected) and then trigger the notification, this is to ensure that if they never visit the Google Listings & Ads pages we will still add the notification.

Resolves the inbox notification for #775 

### TODO:
- Note action redirects to the setup page (once the UI part is implemented, this will need to be the reconnect page)

### Detailed test instructions:

#### Trigger notification from a status request
- Disconnect Jetpack using the Connection Test page
- Send a request to check the Google account status:
`GET https://domain.test/wp-json/wc/gla/google/connected`

Expected response:
```json
{
	"message": "Please reconnect your Jetpack account.",
	"status": 401,
	"code": "JETPACK_DISCONNECTED"
}
```
- Check WooCommerce > Home > Inbox and confirm we see a notification to reconnect our WordPress.com account
![image](https://user-images.githubusercontent.com/11388669/157665716-f6e3de47-751b-470e-a5fe-ac1c152ba336.png)

- Reconnect Jetpack on the connection test page (need to use public site URL)
- Resend the previous request:
`GET https://domain.test/wp-json/wc/gla/google/connected`

Expected response:
```json
{
	"active": "yes",
	"email": "john@doe.email",
	"scope": [
		"https://www.googleapis.com/auth/content"
	]
}
```

- Check WooCommerce > Home > Inbox and confirm the notification is no longer there

#### Trigger notification from the daily cron job
- Disconnect Jetpack using the Connection Test page
- Go to WooCommerce > Status > Scheduled Actions > Pending and run the action `wc_gla_cron_daily_notes`
- Check WooCommerce > Home > Inbox and confirm we see a notification to reconnect our WordPress.com account

### Changelog entry
* Add - WordPress.com account inbox notification.
