### PR TITLE
Clear `free_shipping_threshold` when shipping rate is changed to `0`

### DIFF
--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
@@ -103,6 +103,17 @@ export default function EstimatedShippingRatesCard( {
 				country,
 				currency,
 				rate: price, // TODO: unify that
+
+				/*
+				 * If the shipping rate is nonfree,
+				 * then we continue use its own old option.
+				 * Else, we reset the option to empty object
+				 * to remove the free_shipping_threshold.
+				 */
+				options:
+					price > 0
+						? oldShippingRate.options
+						: defaultShippingRate.options,
 			};
 
 			actualCountries.set( country, newShippingrate );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/google-listings-and-ads/issues/1291.

In this PR, when users change a shipping rate, we check the rate. If the shipping rate is a free flat shipping rate, we will clear the free shipping threshold value. If users change the free shipping rate to non-free, they would then have to manually key in the free shipping threshold.

### Screenshots:

📹 Demo video with my voice annotation:

https://user-images.githubusercontent.com/417342/157301553-3ff1e91e-3720-4641-bbaa-d1a69db532a8.mov

### Detailed test instructions:

You can test this in either Setup MC or Edit Free Listings.

1. Go to shipping rate section. Set up a shipping rate that is not free.
2. Select offer free shipping "Yes".
3. Enter minimum order amount for the shipping rate countries you set up above.
4. Go back to shipping rate and change the shipping rate price to 0. The minimum order amount should be removed automatically.
5. Modify the same shipping rate so that it is not free shipping. The old minimum order amount should not appear.
6. Key in minimum order amount for the countries. It should work as expected.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
