### PR TITLE
Migrate free shipping threshold settings to the shipping rates table

### DIFF
--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use wpdb;
 
 defined( 'ABSPATH' ) || exit;
@@ -23,14 +25,21 @@ class Migration20211228T1640692399 extends AbstractMigration {
 	protected $shipping_rate_table;
 
 	/**
+	 * @var OptionsInterface
+	 */
+	protected $options;
+
+	/**
 	 * Migration constructor.
 	 *
 	 * @param wpdb              $wpdb The wpdb object.
 	 * @param ShippingRateTable $shipping_rate_table
+	 * @param OptionsInterface  $options
 	 */
-	public function __construct( wpdb $wpdb, ShippingRateTable $shipping_rate_table ) {
+	public function __construct( wpdb $wpdb, ShippingRateTable $shipping_rate_table, OptionsInterface $options ) {
 		parent::__construct( $wpdb );
 		$this->shipping_rate_table = $shipping_rate_table;
+		$this->options             = $options;
 	}
 
 
@@ -49,11 +58,24 @@ class Migration20211228T1640692399 extends AbstractMigration {
 	 * @return void
 	 */
 	public function apply(): void {
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( $this->shipping_rate_table->exists() ) {
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$this->wpdb->query( "ALTER TABLE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` ALTER COLUMN `method` DROP DEFAULT" );
-			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+			$mc_settings = $this->options->get( Options::MERCHANT_CENTER );
+			if ( isset( $mc_settings['free_shipping_threshold'] ) ) {
+				// Move the free shipping threshold from the options to the shipping rate table.
+				$serialized_options = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
+				$this->wpdb->query( $this->wpdb->prepare( "UPDATE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` SET `options`=%s WHERE 1=1", $serialized_options ) );
+
+				// Remove the free shipping threshold from the options.
+				unset( $mc_settings['free_shipping_threshold'] );
+				unset( $mc_settings['offers_free_shipping'] );
+				$this->options->update( Options::MERCHANT_CENTER, $mc_settings );
+			}
 		}
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 }

--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -64,7 +64,7 @@ class Migration20211228T1640692399 extends AbstractMigration {
 			$this->wpdb->query( "ALTER TABLE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` ALTER COLUMN `method` DROP DEFAULT" );
 
 			$mc_settings = $this->options->get( Options::MERCHANT_CENTER );
-			if ( isset( $mc_settings['free_shipping_threshold'] ) ) {
+			if ( isset( $mc_settings['offers_free_shipping'] ) && false !== boolval( $mc_settings['offers_free_shipping'] ) && isset( $mc_settings['free_shipping_threshold'] ) ) {
 				// Move the free shipping threshold from the options to the shipping rate table.
 				$serialized_options = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
 				$this->wpdb->query( $this->wpdb->prepare( "UPDATE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` SET `options`=%s WHERE `method` = 'flat_rate'", $serialized_options ) );

--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -64,16 +64,17 @@ class Migration20211228T1640692399 extends AbstractMigration {
 			$this->wpdb->query( "ALTER TABLE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` ALTER COLUMN `method` DROP DEFAULT" );
 
 			$mc_settings = $this->options->get( Options::MERCHANT_CENTER );
+
 			if ( isset( $mc_settings['offers_free_shipping'] ) && false !== boolval( $mc_settings['offers_free_shipping'] ) && isset( $mc_settings['free_shipping_threshold'] ) ) {
 				// Move the free shipping threshold from the options to the shipping rate table.
 				$serialized_options = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
 				$this->wpdb->query( $this->wpdb->prepare( "UPDATE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` SET `options`=%s WHERE `method` = 'flat_rate'", $serialized_options ) );
-
-				// Remove the free shipping threshold from the options.
-				unset( $mc_settings['free_shipping_threshold'] );
-				unset( $mc_settings['offers_free_shipping'] );
-				$this->options->update( Options::MERCHANT_CENTER, $mc_settings );
 			}
+
+			// Remove the free shipping threshold from the options.
+			unset( $mc_settings['free_shipping_threshold'] );
+			unset( $mc_settings['offers_free_shipping'] );
+			$this->options->update( Options::MERCHANT_CENTER, $mc_settings );
 		}
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -67,7 +67,7 @@ class Migration20211228T1640692399 extends AbstractMigration {
 			if ( isset( $mc_settings['free_shipping_threshold'] ) ) {
 				// Move the free shipping threshold from the options to the shipping rate table.
 				$serialized_options = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
-				$this->wpdb->query( $this->wpdb->prepare( "UPDATE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` SET `options`=%s WHERE 1=1", $serialized_options ) );
+				$this->wpdb->query( $this->wpdb->prepare( "UPDATE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` SET `options`=%s WHERE `method` = 'flat_rate'", $serialized_options ) );
 
 				// Remove the free shipping threshold from the options.
 				unset( $mc_settings['free_shipping_threshold'] );

--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -58,25 +58,24 @@ class Migration20211228T1640692399 extends AbstractMigration {
 	 * @return void
 	 */
 	public function apply(): void {
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( $this->shipping_rate_table->exists() ) {
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$this->wpdb->query( "ALTER TABLE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` ALTER COLUMN `method` DROP DEFAULT" );
 
 			$mc_settings = $this->options->get( Options::MERCHANT_CENTER );
-
 			if ( isset( $mc_settings['offers_free_shipping'] ) && false !== boolval( $mc_settings['offers_free_shipping'] ) && isset( $mc_settings['free_shipping_threshold'] ) ) {
 				// Move the free shipping threshold from the options to the shipping rate table.
 				$options_json = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
 				$this->wpdb->query( $this->wpdb->prepare( "UPDATE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` SET `options`=%s WHERE `method` = 'flat_rate'", $options_json ) );
 			}
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			// Remove the free shipping threshold from the options.
 			unset( $mc_settings['free_shipping_threshold'] );
 			unset( $mc_settings['offers_free_shipping'] );
 			$this->options->update( Options::MERCHANT_CENTER, $mc_settings );
 		}
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 }

--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -67,8 +67,8 @@ class Migration20211228T1640692399 extends AbstractMigration {
 
 			if ( isset( $mc_settings['offers_free_shipping'] ) && false !== boolval( $mc_settings['offers_free_shipping'] ) && isset( $mc_settings['free_shipping_threshold'] ) ) {
 				// Move the free shipping threshold from the options to the shipping rate table.
-				$serialized_options = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
-				$this->wpdb->query( $this->wpdb->prepare( "UPDATE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` SET `options`=%s WHERE `method` = 'flat_rate'", $serialized_options ) );
+				$options_json = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
+				$this->wpdb->query( $this->wpdb->prepare( "UPDATE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` SET `options`=%s WHERE `method` = 'flat_rate'", $options_json ) );
 			}
 
 			// Remove the free shipping threshold from the options.

--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -42,11 +42,11 @@ class ShippingRateQuery extends Query {
 		}
 
 		if ( 'options' === $column ) {
-			if ( is_array( $value ) ) {
-				$value = maybe_serialize( $value );
-			} else {
+			if ( ! is_array( $value ) ) {
 				throw InvalidQuery::invalid_value( $column );
 			}
+
+			$value = json_encode( $value );
 		}
 
 		return $value;
@@ -60,7 +60,7 @@ class ShippingRateQuery extends Query {
 
 		$this->results = array_map(
 			function ( $row ) {
-				$row['options'] = maybe_unserialize( $row['options'] );
+				$row['options'] = ! empty( $row['options'] ) ? json_decode( $row['options'] ) : $row['options'];
 
 				return $row;
 			},

--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -60,7 +60,7 @@ class ShippingRateQuery extends Query {
 
 		$this->results = array_map(
 			function ( $row ) {
-				$row['options'] = ! empty( $row['options'] ) ? json_decode( $row['options'] ) : $row['options'];
+				$row['options'] = ! empty( $row['options'] ) ? json_decode( $row['options'], true ) : $row['options'];
 
 				return $row;
 			},

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -19,6 +19,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\DefinitionInterface;
@@ -91,7 +92,7 @@ class DBServiceProvider extends AbstractServiceProvider {
 
 		// Share DB migrations
 		$this->share_migration( MigrationVersion141::class, MerchantIssueTable::class );
-		$this->share_migration( Migration20211228T1640692399::class, ShippingRateTable::class );
+		$this->share_migration( Migration20211228T1640692399::class, ShippingRateTable::class, OptionsInterface::class );
 		$this->share_with_tags( Migrator::class, MigrationInterface::class );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a new migration logic to the migrator class introduced in #1171 to move the `free_shipping_threshold` setting stored in the `wp_options` table to the `shipping_rates` table and apply it to all of the flat rates in there.

The values for the options column in the shipping rates table were previously serialized using the PHP serialize function; however, since that value is usually an array of strings/numbers, to simplify things I've changed that to use `json_encode` instead.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm you have the `free_shipping_threshold` set to any value and `offers_free_shipping` is set to true in the `gla_merchant_center` option (in `wp_options` table)
2. Update the WC_GLA_VERSION constant to a higher version than the current one.
3. Go to the Migration20211228T1640692399::get_applicable_version method and modify the x.x.x version to be equal to or greater than the one you set above.
4. Open any page in your website admin
5. Confirm that the `options` column is updated in the `wp_gla_shipping_rates` table for all of the `flat_rate` methods and the value is set to the `free_shipping_threshold` previously set in your options table
6. Confirm that both `free_shipping_threshold` and `offers_free_shipping` keys are removed from the `gla_merchant_center` option in `wp_options` table.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
