### PR TITLE
Get country code by location ID for get campaigns API

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -436,7 +436,9 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			$location_id         = $this->parse_geo_target_location_id( $geo_target_constant );
 			$country_code        = $this->google_helper->find_country_code_by_id( $location_id );
 
-			$campaigns[ $campaign_id ]['targeted_locations'][] = $country_code;
+			if ( isset( $country_code ) ) {
+				$campaigns[ $campaign_id ]['targeted_locations'][] = $country_code;
+			}
 		}
 
 		return $campaigns;

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCampaignCrit
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCampaignQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -441,7 +441,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			$location_id         = $this->parse_geo_target_location_id( $geo_target_constant );
 			$country_code        = $this->google_helper->find_country_code_by_id( $location_id );
 
-			if ( isset( $country_code ) ) {
+			if ( $country_code ) {
 				$campaigns[ $campaign_id ]['targeted_locations'][] = $country_code;
 			}
 		}

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -72,10 +72,12 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 *
 	 * @param GoogleAdsClient   $client
 	 * @param AdsCampaignBudget $budget
+	 * @param GoogleHelper      $google_helper
 	 */
-	public function __construct( GoogleAdsClient $client, AdsCampaignBudget $budget ) {
-		$this->client = $client;
-		$this->budget = $budget;
+	public function __construct( GoogleAdsClient $client, AdsCampaignBudget $budget, GoogleHelper $google_helper ) {
+		$this->client        = $client;
+		$this->budget        = $budget;
+		$this->google_helper = $google_helper;
 	}
 
 	/**
@@ -432,9 +434,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			$location            = $campaign_criterion->getLocation();
 			$geo_target_constant = $location->getGeoTargetConstant();
 			$location_id         = $this->parse_geo_target_location_id( $geo_target_constant );
-
-			$google_helper = $this->container->get( GoogleHelper::class );
-			$country_code  = $google_helper->find_country_code_by_id( $location_id );
+			$country_code        = $this->google_helper->find_country_code_by_id( $location_id );
 
 			$campaigns[ $campaign_id ]['targeted_locations'][] = $country_code;
 		}

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -68,6 +68,11 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	protected $budget;
 
 	/**
+	 * @var GoogleHelper $google_helper
+	 */
+	protected $google_helper;
+
+	/**
 	 * AdsCampaign constructor.
 	 *
 	 * @param GoogleAdsClient   $client

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -415,6 +415,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			// negative: Whether to target (false) or exclude (true) the criterion.
 			->where( 'campaign_criterion.negative', 'false', '=' )
 			->where( 'campaign_criterion.status', 'REMOVED', '!=' )
+			->where( 'campaign_criterion.location.geo_target_constant', '', 'IS NOT NULL' )
 			->get_results();
 
 		/** @var GoogleAdsRow $row */
@@ -426,15 +427,13 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 
 			// TODO: Convert the geo_traget_constant to the ISO 3166-1 alpha-2 country code
 			// after https://github.com/woocommerce/google-listings-and-ads/issues/1229 is done.
-			$geo_target_constant = $location ? $location->getGeoTargetConstant() : null;
+			$geo_target_constant = $location->getGeoTargetConstant();
 
 			if ( ! isset( $campaigns[ $campaign_id ] ) ) {
 				continue;
 			}
 
-			if ( ! empty( $geo_target_constant ) ) {
-				$campaigns[ $campaign_id ]['targeted_locations'][] = $geo_target_constant;
-			}
+			$campaigns[ $campaign_id ]['targeted_locations'][] = $geo_target_constant;
 		}
 
 		return $campaigns;

--- a/src/API/Google/Query/Query.php
+++ b/src/API/Google/Query/Query.php
@@ -237,6 +237,7 @@ abstract class Query implements QueryInterface {
 			case 'IN':
 			case 'NOT IN':
 			case 'BETWEEN':
+			case 'IS NOT NULL':
 				// These are all valid.
 				return;
 
@@ -333,6 +334,8 @@ abstract class Query implements QueryInterface {
 				);
 			} elseif ( 'BETWEEN' === $compare ) {
 				$value = "'{$this->escape( $where['value'][0] )}' AND '{$this->escape( $where['value'][1] )}'";
+			} elseif ( 'IS NOT NULL' === $compare ) {
+				$value = '';
 			} else {
 				$value = "'{$this->escape( $where['value'] )}'";
 			}

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -20,6 +20,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\WPError;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\WPErrorTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
@@ -100,7 +101,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->add( Settings::class, ContainerInterface::class );
 
 		$this->share( Ads::class, GoogleAdsClient::class );
-		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class );
+		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class, GoogleHelper::class );
 		$this->share( AdsCampaignBudget::class, GoogleAdsClient::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsGroup::class, GoogleAdsClient::class );

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -6,8 +6,10 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignBudget;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsGroup;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
@@ -41,12 +43,15 @@ class AdsCampaignTest extends UnitTest {
 
 		$this->ads_client_setup();
 
-		$this->ad_group    = $this->createMock( AdsGroup::class );
-		$this->budget      = $this->createMock( AdsCampaignBudget::class );
-		$this->options     = $this->createMock( OptionsInterface::class );
+		$this->ad_group      = $this->createMock( AdsGroup::class );
+		$this->budget        = $this->createMock( AdsCampaignBudget::class );
+		$this->options       = $this->createMock( OptionsInterface::class );
+		$this->wc            = $this->createMock( WC::class );
+		$this->google_helper = new GoogleHelper( $this->wc );
 
 		$this->container = new Container();
 		$this->container->share( AdsGroup::class, $this->ad_group );
+		$this->container->share( GoogleHelper::class, $this->google_helper );
 
 		$this->campaign = new AdsCampaign( $this->client, $this->budget );
 		$this->campaign->set_options_object( $this->options );
@@ -83,7 +88,7 @@ class AdsCampaignTest extends UnitTest {
 				'status'  => 'paused',
 				'amount'  => 10,
 				'country' => 'US',
-				'targeted_locations' => ['geoTargetConstants/2158'],
+				'targeted_locations' => ['TW'],
 			],
 			[
 				'id'      => 5678901234,
@@ -91,7 +96,7 @@ class AdsCampaignTest extends UnitTest {
 				'status'  => 'enabled',
 				'amount'  => 20,
 				'country' => 'UK',
-				'targeted_locations' => ['geoTargetConstants/2344', 'geoTargetConstants/2826'],
+				'targeted_locations' => ['HK', 'GB'],
 			],
 		];
 
@@ -128,7 +133,7 @@ class AdsCampaignTest extends UnitTest {
 			'status'  => 'enabled',
 			'amount'  => 10,
 			'country' => 'US',
-			'targeted_locations' => ['geoTargetConstants/2158'],
+			'targeted_locations' => ['TW'],
 		];
 
 		$this->generate_ads_campaign_query_mock( [ $campaign_data ], [ $campaign_criterion_data ] );

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -104,6 +104,45 @@ class AdsCampaignTest extends UnitTest {
 		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
 	}
 
+	public function test_get_campaigns_with_nonexist_location_id() {
+		$campaign_criterion_data = [
+			[
+				'campaign_id'         => self::TEST_CAMPAIGN_ID,
+				'geo_target_constant' => 'geoTargetConstants/999999999',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'geoTargetConstants/999999999',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'geoTargetConstants/999999999',
+			],
+		];
+
+		$campaigns_data = [
+			[
+				'id'      => self::TEST_CAMPAIGN_ID,
+				'name'    => 'Campaign One',
+				'status'  => 'paused',
+				'amount'  => 10,
+				'country' => 'US',
+				'targeted_locations' => [],
+			],
+			[
+				'id'      => 5678901234,
+				'name'    => 'Campaign Two',
+				'status'  => 'enabled',
+				'amount'  => 20,
+				'country' => 'UK',
+				'targeted_locations' => [],
+			],
+		];
+
+		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
+		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
+	}
+
 	public function test_get_campaigns_exception() {
 		$this->generate_ads_query_mock_exception( new ApiException( 'unavailable', 14, 'UNAVAILABLE' ) );
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -67,28 +67,12 @@ class AdsCampaignTest extends UnitTest {
 				'geo_target_constant' => 'geoTargetConstants/2158',
 			],
 			[
-				'campaign_id'         => self::TEST_CAMPAIGN_ID,
-				'geo_target_constant' => '',
-			],
-			[
-				'campaign_id'         => self::TEST_CAMPAIGN_ID,
-				'geo_target_constant' => null,
-			],
-			[
 				'campaign_id'         => 5678901234,
 				'geo_target_constant' => 'geoTargetConstants/2344',
 			],
 			[
 				'campaign_id'         => 5678901234,
-				'geo_target_constant' => '',
-			],
-			[
-				'campaign_id'         => 5678901234,
 				'geo_target_constant' => 'geoTargetConstants/2826',
-			],
-			[
-				'campaign_id'         => 8888877777,
-				'geo_target_constant' => '',
 			],
 		];
 
@@ -108,14 +92,6 @@ class AdsCampaignTest extends UnitTest {
 				'amount'  => 20,
 				'country' => 'UK',
 				'targeted_locations' => ['geoTargetConstants/2344', 'geoTargetConstants/2826'],
-			],
-			[
-				'id'      => 8888877777,
-				'name'    => 'Campaign Three',
-				'status'  => 'enabled',
-				'amount'  => 30,
-				'country' => 'TW',
-				'targeted_locations' => [],
 			],
 		];
 
@@ -143,7 +119,7 @@ class AdsCampaignTest extends UnitTest {
 	public function test_get_campaign() {
 		$campaign_criterion_data = [
 			'campaign_id'         => self::TEST_CAMPAIGN_ID,
-			'geo_target_constant' => '',
+			'geo_target_constant' => 'geoTargetConstants/2158',
 		];
 
 		$campaign_data = [
@@ -152,7 +128,7 @@ class AdsCampaignTest extends UnitTest {
 			'status'  => 'enabled',
 			'amount'  => 10,
 			'country' => 'US',
-			'targeted_locations' => [],
+			'targeted_locations' => ['geoTargetConstants/2158'],
 		];
 
 		$this->generate_ads_campaign_query_mock( [ $campaign_data ], [ $campaign_criterion_data ] );

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAd
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
+use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -141,6 +142,49 @@ class AdsCampaignTest extends UnitTest {
 
 		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
 		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
+	}
+
+	public function test_get_campaigns_with_invalid_location_id() {
+		$campaign_criterion_data = [
+			[
+				'campaign_id'         => self::TEST_CAMPAIGN_ID,
+				'geo_target_constant' => 'unknownResource1/2158',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'unknownResource2/2344',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'unknownResource3/2826',
+			],
+		];
+
+		$campaigns_data = [
+			[
+				'id'      => self::TEST_CAMPAIGN_ID,
+				'name'    => 'Campaign One',
+				'status'  => 'paused',
+				'amount'  => 10,
+				'country' => 'US',
+				'targeted_locations' => [],
+			],
+			[
+				'id'      => 5678901234,
+				'name'    => 'Campaign Two',
+				'status'  => 'enabled',
+				'amount'  => 20,
+				'country' => 'UK',
+				'targeted_locations' => [],
+			],
+		];
+
+		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Invalid geo target location ID' );
+
+		$this->campaign->get_campaigns();
 	}
 
 	public function test_get_campaigns_exception() {

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) || exit;
  * @property MockObject|OptionsInterface  $options
  * @property AdsCampaign                  $campaign
  * @property Container                    $container
+ * @property GoogleHelper                 $google_helper
  */
 class AdsCampaignTest extends UnitTest {
 
@@ -43,17 +44,16 @@ class AdsCampaignTest extends UnitTest {
 
 		$this->ads_client_setup();
 
-		$this->ad_group      = $this->createMock( AdsGroup::class );
-		$this->budget        = $this->createMock( AdsCampaignBudget::class );
-		$this->options       = $this->createMock( OptionsInterface::class );
-		$this->wc            = $this->createMock( WC::class );
-		$this->google_helper = new GoogleHelper( $this->wc );
+		$this->ad_group = $this->createMock( AdsGroup::class );
+		$this->budget   = $this->createMock( AdsCampaignBudget::class );
+		$this->options  = $this->createMock( OptionsInterface::class );
+
+		$this->google_helper = new GoogleHelper( $this->createMock( WC::class ) );
 
 		$this->container = new Container();
 		$this->container->share( AdsGroup::class, $this->ad_group );
-		$this->container->share( GoogleHelper::class, $this->google_helper );
 
-		$this->campaign = new AdsCampaign( $this->client, $this->budget );
+		$this->campaign = new AdsCampaign( $this->client, $this->budget, $this->google_helper );
 		$this->campaign->set_options_object( $this->options );
 		$this->campaign->set_container( $this->container );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1248 and an enhancement for #1280. This PR integrates the work in #1282 to convert `geo_target_constant` in [LocationInfo](https://developers.google.com/google-ads/api/reference/rpc/v9/LocationInfo) (location ID) to country code in ISO 3166-1 alpha-2 format.

Also in this PR it refactors the logic of filtering out the empty geo target constants. Previously it queried lots of campaign criteria with empty geo target constants and filter it out in the application code. The new approach suggested in https://github.com/woocommerce/google-listings-and-ads/pull/1280#discussion_r820747160 is adding the logic as part of [Google Ads Query Language](https://developers.google.com/google-ads/api/docs/query/overview) by using `campaign_criterion.location.geo_target_constant IS NOT NULL`. This reduce the amount of data returned by Google Ads API and also enhance the code readability.

### Screenshots

#### GET ads/camapigns

<img width="1362" alt="Screenshot 2022-03-09 at 17 21 47" src="https://user-images.githubusercontent.com/914406/157411704-583d7531-2e91-45f5-8298-3004321b391b.png">

#### GET ads/camapigns/:campaign-id

<img width="1364" alt="Screenshot 2022-03-09 at 17 21 26" src="https://user-images.githubusercontent.com/914406/157411767-1d91afbf-bd15-4752-8dca-fcb01f90bf2a.png">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create some paid campaigns in GLA's dashboard: `/wp-admin/admin.php?page=wc-admin&path=/google/dashboard`.
2. Go to Google Ads Campaigns Dashboard and add targeted locations in some of the campaigns you created.
    - <img width="2555" alt="Screenshot 2022-03-03 at 13 09 34" src="https://user-images.githubusercontent.com/914406/156500476-8d9e00d5-ff0f-429b-895c-3a4ffedae06d.png">
3. Using Postman, request to `GET ads/campaigns` and `GET ads/campaigns/:campaign-id` like the screenshots in the `Screenshots` section. Remember to add your `wp-cookie` and `x-wp-nonce` in the request headers. 
    - To get the value of `wp-cookie` and `x-wp-nonce`, go to `Marketing -> Google Listings & Ads`, open Chrome dev tool's Network tab, clicks any requests to WP, e.g. `wc/gla/ads/campaigns`, you can get those values in the request headers.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Get country code by location ID for get campaigns API
