### PR TITLE
Shipping rates UI changes: Adjust the logic of prompting for unsaved shipping rates

### DIFF
--- a/js/src/edit-free-campaign/hasUnsavedShippingRages.js
+++ b/js/src/edit-free-campaign/hasUnsavedShippingRages.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { isEqual, differenceWith, at } from 'lodash';
+
+/**
+ * @typedef {import('.~/data/actions').ShippingRate} ShippingRate
+ */
+
+/**
+ * This function compares the key fields of two shipping rate arrays
+ * and returns whether there are any unsaved shipping changes.
+ *
+ * - Order:     The order of two arrays does not need to be the same.
+ * - ID:        The `id` is not compared.
+ *              On the UI, if a rate was deleted and then added,
+ *              then the `id` would not exist.
+ * - Threshold: If `options` or `options.free_shipping_threshold` does not exist,
+ *              `free_shipping_threshold` is treated as undefined.
+ *
+ * @param  {Array<ShippingRate>} rates The shipping rates to be compared.
+ * @param  {Array<ShippingRate>} savedRates The saved shipping rates received from API.
+ * @return {boolean} Whether there are any unsaved shipping changes.
+ */
+export default function hasUnsavedShippingRages( rates, savedRates ) {
+	if ( rates.length !== savedRates.length ) {
+		return true;
+	}
+
+	const paths = [
+		'country',
+		'method',
+		'currency',
+		'rate',
+		'options.free_shipping_threshold',
+	];
+
+	const diffRates = differenceWith( rates, savedRates, ( a, b ) => {
+		return isEqual( at( a, paths ), at( b, paths ) );
+	} );
+
+	return diffRates.length > 0;
+}

--- a/js/src/edit-free-campaign/hasUnsavedShippingRates.js
+++ b/js/src/edit-free-campaign/hasUnsavedShippingRates.js
@@ -22,7 +22,7 @@ import { isEqual, differenceWith, at } from 'lodash';
  * @param  {Array<ShippingRate>} savedRates The saved shipping rates received from API.
  * @return {boolean} Whether there are any unsaved shipping changes.
  */
-export default function hasUnsavedShippingRages( rates, savedRates ) {
+export default function hasUnsavedShippingRates( rates, savedRates ) {
 	if ( rates.length !== savedRates.length ) {
 		return true;
 	}

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -24,6 +24,7 @@ import useShippingRates from '.~/hooks/useShippingRates';
 import useShippingTimes from '.~/hooks/useShippingTimes';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import HelpIconButton from '.~/components/help-icon-button';
+import hasUnsavedShippingRages from './hasUnsavedShippingRages';
 
 /**
  * Function use to allow the user to navigate between form steps without the prompt.
@@ -147,7 +148,11 @@ export default function EditFreeCampaign() {
 	// Check what've changed to show prompt, and send requests only to save changed things.
 	const didAudienceChanged = ! isEqual( targetAudience, savedTargetAudience );
 	const didSettingsChanged = ! isEqual( settings, savedSettings );
-	const didRatesChanged = ! isEqual( shippingRates, savedShippingRates );
+	const didRatesChanged = hasUnsavedShippingRages(
+		shippingRates,
+		savedShippingRates
+	);
+
 	const didTimesChanged = ! isEqual( shippingTimes, savedShippingTimes );
 	const didAnythingChanged =
 		didAudienceChanged ||

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -24,7 +24,7 @@ import useShippingRates from '.~/hooks/useShippingRates';
 import useShippingTimes from '.~/hooks/useShippingTimes';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import HelpIconButton from '.~/components/help-icon-button';
-import hasUnsavedShippingRages from './hasUnsavedShippingRages';
+import hasUnsavedShippingRates from './hasUnsavedShippingRates';
 
 /**
  * Function use to allow the user to navigate between form steps without the prompt.
@@ -148,7 +148,7 @@ export default function EditFreeCampaign() {
 	// Check what've changed to show prompt, and send requests only to save changed things.
 	const didAudienceChanged = ! isEqual( targetAudience, savedTargetAudience );
 	const didSettingsChanged = ! isEqual( settings, savedSettings );
-	const didRatesChanged = hasUnsavedShippingRages(
+	const didRatesChanged = hasUnsavedShippingRates(
 		shippingRates,
 		savedShippingRates
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1290 

- Add a new function `hasUnsavedShippingRates` for comparing the saved shipping rates to the one editing via UI.
- Apply `hasUnsavedShippingRates` to check if there are any unsaved shipping rates.

📝  As the implementation is still possible to be adjusted, test cases of the new function will be supplemented with another PR after this one gets merged.

### Screenshots:

💡  To avoid scrolling page all the time, I temporarily removed Hero during the recording

https://user-images.githubusercontent.com/17420811/157431092-ce41d6bc-f1d9-4843-819a-9f80c7a024d5.mp4

### Detailed test instructions:

1. Go to step 2 of the free listings edit page.
2. Make changes to the shipping rates and free shipping threshold.
3. Refresh the current webpage or use other ways to navigate away. There should be a prompt popped-up to ask if you sure want to leave with unsaved changes.
   ![image](https://user-images.githubusercontent.com/17420811/157431829-e952b2f8-598e-4256-861e-cde535e20bb5.png)
4. Revert the changes from step 2.
5. Refresh the current webpage or use other ways to navigate away. It should be able to refresh/leave page directly without prompting.
6. Repeat steps 2-5 with different changes.

### Changelog entry
