### PR TITLE
Shipping rates UI changes: Validation for offer free shipping and minimum order amount

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -12,12 +12,7 @@ const validShippingRateSet = new Set( [ 'automatic', 'flat', 'manual' ] );
 const validShippingTimeSet = new Set( [ 'flat', 'manual' ] );
 const validTaxRateSet = new Set( [ 'destination', 'manual' ] );
 
-const checkErrors = (
-	values,
-	shippingRates,
-	shippingTimes,
-	finalCountryCodes
-) => {
+const checkErrors = ( values, shippingTimes, finalCountryCodes ) => {
 	const errors = {};
 
 	/**
@@ -55,8 +50,8 @@ const checkErrors = (
 
 	if (
 		values.shipping_rate === 'flat' &&
-		( shippingRates.length < finalCountryCodes.length ||
-			shippingRates.some( ( el ) => el.rate < 0 ) )
+		( values.shipping_country_rates.length < finalCountryCodes.length ||
+			values.shipping_country_rates.some( ( el ) => el.rate < 0 ) )
 	) {
 		errors.shipping_rate = __(
 			'Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0.',

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -26,6 +26,20 @@ const checkErrors = ( values, shippingTimes, finalCountryCodes ) => {
 	}
 
 	if (
+		values.shipping_rate === 'flat' &&
+		( values.shipping_country_rates.length < finalCountryCodes.length ||
+			values.shipping_country_rates.some( ( el ) => el.rate < 0 ) )
+	) {
+		errors.shipping_rate = __(
+			'Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0.',
+			'google-listings-and-ads'
+		);
+	}
+
+	/**
+	 * Check offer free shipping.
+	 */
+	if (
 		values.offer_free_shipping === undefined &&
 		values.shipping_country_rates.some( isNonFreeFlatShippingRate )
 	) {
@@ -44,17 +58,6 @@ const checkErrors = ( values, shippingTimes, finalCountryCodes ) => {
 	) {
 		errors.offer_free_shipping = __(
 			'Please enter minimum order for free shipping.',
-			'google-listings-and-ads'
-		);
-	}
-
-	if (
-		values.shipping_rate === 'flat' &&
-		( values.shipping_country_rates.length < finalCountryCodes.length ||
-			values.shipping_country_rates.some( ( el ) => el.rate < 0 ) )
-	) {
-		errors.shipping_rate = __(
-			'Please specify shipping rates for all the countries. And the estimated shipping rate cannot be less than 0.',
 			'google-listings-and-ads'
 		);
 	}

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -3,6 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import isNonFreeFlatShippingRate from '.~/utils/isNonFreeFlatShippingRate';
+
 const validShippingRateSet = new Set( [ 'automatic', 'flat', 'manual' ] );
 const validShippingTimeSet = new Set( [ 'flat', 'manual' ] );
 const validTaxRateSet = new Set( [ 'destination', 'manual' ] );
@@ -21,6 +26,29 @@ const checkErrors = (
 	if ( ! validShippingRateSet.has( values.shipping_rate ) ) {
 		errors.shipping_rate = __(
 			'Please select a shipping rate option.',
+			'google-listings-and-ads'
+		);
+	}
+
+	if (
+		values.offer_free_shipping === undefined &&
+		values.shipping_country_rates.some( isNonFreeFlatShippingRate )
+	) {
+		errors.offer_free_shipping = __(
+			'Please select an option for offering free shipping.',
+			'google-listings-and-ads'
+		);
+	}
+
+	if (
+		values.offer_free_shipping === true &&
+		values.shipping_country_rates.every(
+			( shippingRate ) =>
+				shippingRate.options.free_shipping_threshold === undefined
+		)
+	) {
+		errors.offer_free_shipping = __(
+			'Please enter minimum order for free shipping.',
 			'google-listings-and-ads'
 		);
 	}

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -37,29 +37,31 @@ const checkErrors = ( values, shippingTimes, finalCountryCodes ) => {
 	}
 
 	/**
-	 * Check offer free shipping.
+	 * Check offer free shipping, only when shipping_rate is 'flat'.
 	 */
-	if (
-		values.offer_free_shipping === undefined &&
-		values.shipping_country_rates.some( isNonFreeFlatShippingRate )
-	) {
-		errors.offer_free_shipping = __(
-			'Please select an option for whether to offer free shipping.',
-			'google-listings-and-ads'
-		);
-	}
+	if ( values.shipping_rate === 'flat' ) {
+		if (
+			values.offer_free_shipping === undefined &&
+			values.shipping_country_rates.some( isNonFreeFlatShippingRate )
+		) {
+			errors.offer_free_shipping = __(
+				'Please select an option for whether to offer free shipping.',
+				'google-listings-and-ads'
+			);
+		}
 
-	if (
-		values.offer_free_shipping === true &&
-		values.shipping_country_rates.every(
-			( shippingRate ) =>
-				shippingRate.options.free_shipping_threshold === undefined
-		)
-	) {
-		errors.offer_free_shipping = __(
-			'Please enter minimum order for free shipping.',
-			'google-listings-and-ads'
-		);
+		if (
+			values.offer_free_shipping === true &&
+			values.shipping_country_rates.every(
+				( shippingRate ) =>
+					shippingRate.options.free_shipping_threshold === undefined
+			)
+		) {
+			errors.offer_free_shipping = __(
+				'Please enter minimum order for free shipping.',
+				'google-listings-and-ads'
+			);
+		}
 	}
 
 	/**

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -44,7 +44,7 @@ const checkErrors = ( values, shippingTimes, finalCountryCodes ) => {
 		values.shipping_country_rates.some( isNonFreeFlatShippingRate )
 	) {
 		errors.offer_free_shipping = __(
-			'Please select an option for offering free shipping.',
+			'Please select an option for whether to offer free shipping.',
 			'google-listings-and-ads'
 		);
 	}

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -184,56 +184,95 @@ describe( 'checkErrors', () => {
 	} );
 
 	describe( 'Offer free shipping', () => {
-		it( 'When all shipping rates are free, and offer free shipping is undefined, should pass', () => {
-			const values = {
-				...defaultFormValues,
-				shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 0 ] ),
-				offer_free_shipping: undefined,
-			};
-			const codes = [ 'US', 'JP' ];
+		describe( 'With flat shipping rate option', () => {
+			it( 'When all shipping rates are free, and offer free shipping is undefined, should pass', () => {
+				const values = {
+					...defaultFormValues,
+					shipping_rate: 'flat',
+					shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 0 ] ),
+					offer_free_shipping: undefined,
+				};
+				const codes = [ 'US', 'JP' ];
 
-			const errors = checkErrors( values, [], codes );
+				const errors = checkErrors( values, [], codes );
 
-			expect( errors ).not.toHaveProperty( 'offer_free_shipping' );
+				expect( errors ).not.toHaveProperty( 'offer_free_shipping' );
+			} );
+
+			it( 'When there are some non-free shipping rates, and offer free shipping is unchecked, should not pass', () => {
+				const values = {
+					...defaultFormValues,
+					shipping_rate: 'flat',
+					shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 1 ] ),
+					offer_free_shipping: undefined,
+				};
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( values, [], codes );
+
+				expect( errors ).toHaveProperty( 'offer_free_shipping' );
+			} );
+
+			it( 'When there are some non-free shipping rates, and offer free shipping is checked, and there is minimum order amount for non-free shipping rates, should pass', () => {
+				const values = {
+					...defaultFormValues,
+					shipping_rate: 'flat',
+					shipping_country_rates: toRates(
+						[ 'US', 0 ],
+						[ 'JP', 1, 88 ]
+					),
+					offer_free_shipping: true,
+				};
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( values, [], codes );
+
+				expect( errors ).not.toHaveProperty( 'offer_free_shipping' );
+			} );
+
+			it( 'When there are some non-free shipping rates, and offer free shipping is checked, and there is no minimum order amount for non-free shipping rates, should not pass', () => {
+				const values = {
+					...defaultFormValues,
+					shipping_rate: 'flat',
+					shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 1 ] ),
+					offer_free_shipping: true,
+				};
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( values, [], codes );
+
+				expect( errors ).toHaveProperty( 'offer_free_shipping' );
+			} );
 		} );
 
-		it( 'When there are some non-free shipping rates, and offer free shipping is unchecked, should not pass', () => {
-			const values = {
-				...defaultFormValues,
-				shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 1 ] ),
-				offer_free_shipping: undefined,
-			};
-			const codes = [ 'US', 'JP' ];
+		describe( 'With non-flat shipping rate option', () => {
+			it( 'When there are some non-free shipping rates, and offer free shipping is unchecked, should pass', () => {
+				const values = {
+					...defaultFormValues,
+					shipping_rate: 'automatic',
+					shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 1 ] ),
+					offer_free_shipping: undefined,
+				};
+				const codes = [ 'US', 'JP' ];
 
-			const errors = checkErrors( values, [], codes );
+				const errors = checkErrors( values, [], codes );
 
-			expect( errors ).toHaveProperty( 'offer_free_shipping' );
-		} );
+				expect( errors ).not.toHaveProperty( 'offer_free_shipping' );
+			} );
 
-		it( 'When there are some non-free shipping rates, and offer free shipping is checked, and there is minimum order amount for non-free shipping rates, should pass', () => {
-			const values = {
-				...defaultFormValues,
-				shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 1, 88 ] ),
-				offer_free_shipping: true,
-			};
-			const codes = [ 'US', 'JP' ];
+			it( 'When there are some non-free shipping rates, and offer free shipping is checked, and there is no minimum order amount for non-free shipping rates, should pass', () => {
+				const values = {
+					...defaultFormValues,
+					shipping_rate: 'manual',
+					shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 1 ] ),
+					offer_free_shipping: true,
+				};
+				const codes = [ 'US', 'JP' ];
 
-			const errors = checkErrors( values, [], codes );
+				const errors = checkErrors( values, [], codes );
 
-			expect( errors ).not.toHaveProperty( 'offer_free_shipping' );
-		} );
-
-		it( 'When there are some non-free shipping rates, and offer free shipping is checked, and there is no minimum order amount for non-free shipping rates, should not pass', () => {
-			const values = {
-				...defaultFormValues,
-				shipping_country_rates: toRates( [ 'US', 0 ], [ 'JP', 1 ] ),
-				offer_free_shipping: true,
-			};
-			const codes = [ 'US', 'JP' ];
-
-			const errors = checkErrors( values, [], codes );
-
-			expect( errors ).toHaveProperty( 'offer_free_shipping' );
+				expect( errors ).not.toHaveProperty( 'offer_free_shipping' );
+			} );
 		} );
 	} );
 

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -54,17 +54,9 @@ const SetupFreeListings = ( {
 	}
 
 	const handleValidate = ( values ) => {
-		const {
-			shipping_country_rates: shippingRatesData,
-			shipping_country_times: shippingTimesData,
-		} = values;
+		const { shipping_country_times: shippingTimesData } = values;
 
-		return checkErrors(
-			values,
-			shippingRatesData,
-			shippingTimesData,
-			countries
-		);
+		return checkErrors( values, shippingTimesData, countries );
 	};
 
 	const handleSubmit = async () => {

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -128,7 +128,6 @@ const SetupFreeListings = ( props ) => {
 
 					const errors = checkErrors(
 						values,
-						values.shipping_country_rates,
 						shippingTimesData,
 						finalCountryCodesData
 					);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1289.

In this PR, we perform validation on the "offer free shipping" value.

- If there are non-free shipping rates, users are required to choose an offer free shipping value. If users didn't choose an option (the value is `undefined`), we add the `errors.offer_free_shipping` property.
- If the offer free shipping value is yes (`true`), and there are no minimum order amount specified, we will also add the `errors.offer_free_shipping` property.

When there are `errors.offer_free_shipping`, users won't be able to click on the "Save changes" or "Continue" button to proceed.

Technical note: I have also changed the `checkErrors` function signature. I removed the `shippingRates` parameter, since now we can use the same shipping rates value from the `values` object retrieved from Form. In the future when we move the shipping times value into Form, we should also do the same to the `checkErrors`'s `shippingTimes` parameter.

### Screenshots:

📹 Demo video with my voice annotation: 

https://user-images.githubusercontent.com/417342/157692321-f38586e1-0e98-4f58-b125-a577021c2b55.mov


### Detailed test instructions:

You can test this in either Setup MC or Edit Free Listings.

1. Go to shipping rate section. Complete all the fields in the page. The "Save changes" / "Continue" button should be enabled.
2. Put 0 value for all shipping rates for all countries. Offer free shipping card should not be visible. The "Save changes" / "Continue" button should be enabled.
3. Change one shipping rate to non-free. Offer free shipping card should be visible with unchecked options. The "Save changes" / "Continue" button should be disabled.
4. Check "No" for offer free shipping. The "Save changes" / "Continue" button should be enabled.
5. Check "Yes" for offer free shipping, but do not enter any minimum order amount yet. The "Save changes" / "Continue" button should be disabled.
6. Enter at least one minimum order amount. The "Save changes" / "Continue" button should be enabled.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Validation for offer free shipping.
