### PR TITLE
Combine duplicate account issues per country

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -203,7 +203,13 @@ class Merchant implements OptionsAwareInterface {
 		$id = $id ?: $this->options->get_merchant_id();
 
 		try {
-			$mc_account_status = $this->service->accountstatuses->get( $id, $id );
+			$mc_account_status = $this->service->accountstatuses->get(
+				$id,
+				$id,
+				[
+					'destinations' => 'Shopping',
+				]
+			);
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to retrieve Merchant Center account status.', 'google-listings-and-ads' ), $e->getCode() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR resolves the duplicate account issues by applying two changes:

1. Merge account issues with identical text and store each country in an array, which populates the applicable_countries column (note that this column is not visible in the UI)
2. Pass the destinations parameter when requesting the account status so we only get issues with `destintation = Shopping`

Closes #1198

*Note: While creating this PR I also noticed there were duplicates for variable products, since that's outside of the scope of this PR I logged it in #1316*

### Detailed test instructions:

1. Test with a merchant account that has multiple account issues  
2. Go to Connection Test > More Merchant Center > Clear Status Cache and clear it
3. Go to Marketing > Google Listings & Ads > Product Feed and confirm the issue list doesn't have lots of duplicate account issues 
4. Check the database table `wp_gla_merchant_issues` and confirm any account issues has a list of countries which apply to the issue 

### Changelog entry
* Fix - Combine duplicate account issues per country.
