### PR TITLE
Tree Select Component - Add Partially checked feature

### DIFF
--- a/js/src/components/tree-select-control/index.scss
+++ b/js/src/components/tree-select-control/index.scss
@@ -76,8 +76,8 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 		}
 
 		&.is-active {
-			box-shadow: 0 0 0 1px $studio-wordpress-blue-50;
-			border-color: $studio-wordpress-blue-50;
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color);
 		}
 
 		&.with-value .components-base-control__label,
@@ -179,8 +179,19 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 
 		&.is-selected,
 		&:hover {
-			color: $studio-wordpress-blue-50;
+			color: var(--wp-admin-theme-color);
 		}
+
+		&.is-partially-checked {
+
+			.components-checkbox-control__input:not(:checked) {
+				background: var(--wp-admin-theme-color);
+				border: $gap-smallest solid $studio-white;
+				box-shadow: 0 0 0 1px #1e1e1e;
+			}
+
+		}
+
 	}
 
 	.woocommerce-tree-select-control__expander {

--- a/js/src/components/tree-select-control/index.scss
+++ b/js/src/components/tree-select-control/index.scss
@@ -184,7 +184,7 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 
 		&.is-partially-checked {
 
-			.components-checkbox-control__input:not(:checked) {
+			.components-checkbox-control__input {
 				background: var(--wp-admin-theme-color);
 				border: $gap-smallest solid $studio-white;
 				box-shadow: 0 0 0 1px #1e1e1e;

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -40,19 +40,18 @@ const Options = ( {
 	};
 
 	/**
-	 * Verifies if an option is partially checked.
-	 * An option is partially checked if any of their children is checked or partially checked
+	 * Verifies if an option has some children checked.
 	 *
-	 * @param {Option} parent the Option to verify if its partially checked
-	 * @return {boolean} True if it's partially Checked, false otherwise
+	 * @param {Option} parent the Option to verify
+	 * @return {boolean} True if any at least one of the children is checked, false otherwsie
 	 */
-	const isPartiallyChecked = ( parent ) => {
+	const hasSomeChildrenChecked = ( parent ) => {
 		if ( ! parent.children?.length ) {
 			return false;
 		}
 
 		return parent.children.some(
-			( child ) => isChecked( child ) || isPartiallyChecked( child )
+			( child ) => isChecked( child ) || hasSomeChildrenChecked( child )
 		);
 	};
 
@@ -79,10 +78,9 @@ const Options = ( {
 
 	return options.map( ( option ) => {
 		const isRoot = option.value === '';
-
 		const isExpanded = isRoot || nodesExpanded.includes( option.value );
-
 		const hasChildren = !! option.children?.length;
+		const optionIsChecked = isChecked( option );
 
 		return (
 			<div
@@ -114,12 +112,13 @@ const Options = ( {
 					<CheckboxControl
 						className={ classnames(
 							'woocommerce-tree-select-control__option',
-							isPartiallyChecked( option ) &&
+							! optionIsChecked &&
+								hasSomeChildrenChecked( option ) &&
 								'is-partially-checked'
 						) }
 						value={ option.value }
 						label={ option.label }
-						checked={ isChecked( option ) }
+						checked={ optionIsChecked }
 						onChange={ ( checked ) => {
 							onChange( checked, option );
 						} }

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -27,6 +27,36 @@ const Options = ( {
 	onNodesExpandedChange = () => {},
 } ) => {
 	/**
+	 * Verifies if an option is checked.
+	 * An option is checked if their value is selected or all of their children are selected
+	 *
+	 * @param {Option} option The option to verify if is checked
+	 * @return {boolean} True if checked, false otherwise
+	 */
+	const isChecked = ( option ) => {
+		return (
+			value.includes( option.value ) || isEveryChildrenSelected( option )
+		);
+	};
+
+	/**
+	 * Verifies if an option is partially checked.
+	 * An option is partially checked if any of their children is checked or partially checked
+	 *
+	 * @param {Option} parent the Option to verify if its partially checked
+	 * @return {boolean} True if it's partially Checked, false otherwise
+	 */
+	const isPartiallyChecked = ( parent ) => {
+		if ( ! parent.children?.length ) {
+			return false;
+		}
+
+		return parent.children.some(
+			( child ) => isChecked( child ) || isPartiallyChecked( child )
+		);
+	};
+
+	/**
 	 * Returns true if all the children for the parent are selected
 	 *
 	 * @param {Option} parent The parent option to check
@@ -36,11 +66,7 @@ const Options = ( {
 			return false;
 		}
 
-		return parent.children.every(
-			( child ) =>
-				value.includes( child.value ) ||
-				isEveryChildrenSelected( child )
-		);
+		return parent.children.every( ( child ) => isChecked( child ) );
 	};
 
 	const toggleExpanded = ( option ) => {
@@ -86,13 +112,14 @@ const Options = ( {
 					) }
 
 					<CheckboxControl
-						className={ 'woocommerce-tree-select-control__option' }
+						className={ classnames(
+							'woocommerce-tree-select-control__option',
+							isPartiallyChecked( option ) &&
+								'is-partially-checked'
+						) }
 						value={ option.value }
 						label={ option.label }
-						checked={
-							value.includes( option.value ) ||
-							isEveryChildrenSelected( option )
-						}
+						checked={ isChecked( option ) }
 						onChange={ ( checked ) => {
 							onChange( checked, option );
 						} }

--- a/js/src/components/tree-select-control/options.test.js
+++ b/js/src/components/tree-select-control/options.test.js
@@ -51,4 +51,36 @@ describe( 'TreeSelectControl - Options Component', () => {
 			} );
 		} );
 	} );
+
+	it( 'Partially selects groups', () => {
+		const { queryByText } = render(
+			<Options options={ options } value={ [ 'ES' ] } />
+		);
+
+		const partiallyCheckedOption = queryByText( 'Europe' );
+		const unCheckedOption = queryByText( 'North America' );
+
+		expect( partiallyCheckedOption ).toBeTruthy();
+		expect( unCheckedOption ).toBeTruthy();
+
+		const partiallyCheckedOptionWrapper = partiallyCheckedOption.closest(
+			'.woocommerce-tree-select-control__option'
+		);
+		const unCheckedOptionWrapper = unCheckedOption.closest(
+			'.woocommerce-tree-select-control__option'
+		);
+
+		expect( partiallyCheckedOptionWrapper ).toBeTruthy();
+		expect( unCheckedOptionWrapper ).toBeTruthy();
+
+		expect(
+			partiallyCheckedOptionWrapper.classList.contains(
+				'is-partially-checked'
+			)
+		).toBeTruthy();
+
+		expect(
+			unCheckedOptionWrapper.classList.contains( 'is-partially-checked' )
+		).toBeFalsy();
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a new feature in Tree Select Component for having a Partially Checked Group. 

A partially checked group is a group (node with children) in which any of their children is selected. 

If a node is not checked but is partially checked. Then it shows a different UI like this.

<img width="447" alt="Screenshot 2022-03-11 at 13 18 37" src="https://user-images.githubusercontent.com/5908855/157838394-bac74ecc-d50d-4b7e-9254-1d8522088872.png">

### Screenshots:

https://user-images.githubusercontent.com/5908855/157838414-0c67d971-ac35-4841-8716-d9985c359072.mov

### Detailed test instructions:

1. Check out this branch and go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcomponent-test`
2. In the selector you can see how Spain is selected by default
3. Open the selector and You will see how All Countries and Europe groups are partially selected.
4. If you check Europe, it turns to checked and selects all the options
5. If you deselect an item on that group. For example Italy. It turns to partially Checked
6. If you go to North America, United States and Select NY it will partially check United States, North America and All Countries.


### Additional details:

- We use Array.protoType.some() in order to check if any of the children are checked or partially checked.
- In case a node is partially checked we apply a className `is-partially-checked`
- When a node is not checked and has that class, we apply some styles on it
