### PR TITLE
Polishing Expand Collapse

### DIFF
--- a/js/src/components/tree-select-control/constants.js
+++ b/js/src/components/tree-select-control/constants.js
@@ -1,1 +1,1 @@
-export const ROOT_VALUE = {};
+export const ROOT_VALUE = '__WC_TREE_SELECT_COMPONENT_ROOT__';

--- a/js/src/components/tree-select-control/constants.js
+++ b/js/src/components/tree-select-control/constants.js
@@ -1,0 +1,1 @@
+export const ROOT_VALUE = {};

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -17,6 +17,7 @@ import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
 import Control from './control';
 import Options from './options';
 import './index.scss';
+import { ROOT_VALUE } from '.~/components/tree-select-control/constants';
 
 /**
  * The Option type Object. This is how we send the options to the selector.
@@ -24,7 +25,8 @@ import './index.scss';
  * @typedef {Object} Option
  * @property {string} value The value for the option
  * @property {string} label The label for the option
- * @property {Option[]} [children] The children Option objects.
+ * @property {Option[]} [children] The children Option objects
+ * @property {string} [key] Optional unique key for the Option. It will fallback to the value property if not defined
  *
  * Example of Options data structure:
  *   [
@@ -83,8 +85,14 @@ const TreeSelectControl = ( {
 	const [ nodesExpanded, setNodesExpanded ] = useState( [] );
 
 	const treeOptions = useIsEqualRefValue(
-		selectAllLabel
-			? [ { label: selectAllLabel, value: '', children: options } ]
+		selectAllLabel !== false
+			? [
+					{
+						label: selectAllLabel,
+						value: ROOT_VALUE,
+						children: options,
+					},
+			  ]
 			: options
 	);
 
@@ -168,6 +176,10 @@ const TreeSelectControl = ( {
 	 */
 	const handleParentChange = ( checked, option ) => {
 		const newValue = [ ...value ];
+
+		if ( checked && ! nodesExpanded.includes( option.value ) ) {
+			setNodesExpanded( [ ...nodesExpanded, option.value ] );
+		}
 
 		function loadChildren( parent ) {
 			if ( ! parent.children ) {

--- a/js/src/components/tree-select-control/index.test.js
+++ b/js/src/components/tree-select-control/index.test.js
@@ -80,11 +80,7 @@ describe( 'TreeSelectControl Component', () => {
 	it( 'Renders the All Options', () => {
 		const onChange = jest.fn().mockName( 'onChange' );
 		const { queryByLabelText, queryByRole, rerender } = render(
-			<TreeSelectControl
-				options={ options }
-				label="Select"
-				onChange={ onChange }
-			/>
+			<TreeSelectControl options={ options } onChange={ onChange } />
 		);
 
 		const control = queryByRole( 'combobox' );
@@ -100,7 +96,6 @@ describe( 'TreeSelectControl Component', () => {
 			<TreeSelectControl
 				value={ [ 'ES', 'FR', 'IT', 'AS' ] }
 				options={ options }
-				label="Select"
 				onChange={ onChange }
 			/>
 		);

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -6,6 +6,11 @@ import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
 
 /**
+ * Internal dependencies
+ */
+import { ROOT_VALUE } from './constants';
+
+/**
  * @typedef {import('./').Option} Option
  */
 
@@ -52,15 +57,13 @@ const Options = ( {
 	};
 
 	return options.map( ( option ) => {
-		const isRoot = option.value === '';
-
+		const isRoot = option.value === ROOT_VALUE;
 		const isExpanded = isRoot || nodesExpanded.includes( option.value );
-
 		const hasChildren = !! option.children?.length;
 
 		return (
 			<div
-				key={ `${ option.value }` }
+				key={ `${ option.key ?? option.value }` }
 				role={ hasChildren ? 'treegroup' : 'treeitem' }
 				aria-expanded={ hasChildren ? isExpanded : undefined }
 				className={ classnames(

--- a/js/src/components/tree-select-control/options.test.js
+++ b/js/src/components/tree-select-control/options.test.js
@@ -6,7 +6,7 @@ import { fireEvent, render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import Options from '.~/components/tree-select-control/options';
+import TreeSelectControl from '.~/components/tree-select-control/index';
 
 const options = [
 	{
@@ -18,37 +18,46 @@ const options = [
 			{ value: 'IT', label: 'Italy' },
 		],
 	},
-	{
-		value: 'NA',
-		label: 'North America',
-		children: [
-			{ value: 'US', label: 'United States' },
-			{ value: 'CA', label: 'Canada' },
-		],
-	},
-	{
-		value: 'AS',
-		label: 'Asia',
-	},
 ];
 
 describe( 'TreeSelectControl - Options Component', () => {
 	it( 'Expands and collapses groups', () => {
-		const { queryByText } = render( <Options options={ options } /> );
+		const { queryAllByRole, queryByText, queryByRole } = render(
+			<TreeSelectControl options={ options } />
+		);
 
-		options.forEach( ( option ) => {
-			const optionItem = queryByText( option.label );
-			expect( optionItem ).toBeTruthy();
-			options.children?.forEach( ( child ) => {
-				const childItem = queryByText( child.label );
-				expect( childItem ).toBeFalsy();
-			} );
+		const control = queryByRole( 'combobox' );
+		fireEvent.click( control );
 
-			fireEvent.click( optionItem );
-			options.children?.forEach( ( child ) => {
-				const childItem = queryByText( child.label );
-				expect( childItem ).toBeTruthy();
-			} );
+		const optionItem = queryByText( 'Europe' );
+		const option = options[ 0 ];
+		expect( optionItem ).toBeTruthy();
+
+		option.children.forEach( ( child ) => {
+			const childItem = queryByText( child.label );
+			expect( childItem ).toBeFalsy();
+		} );
+
+		const button = queryAllByRole( 'button' );
+		fireEvent.click( button[ 0 ] );
+
+		option.children.forEach( ( child ) => {
+			const childItem = queryByText( child.label );
+			expect( childItem ).toBeTruthy();
+		} );
+
+		fireEvent.click( button[ 0 ] );
+
+		option.children.forEach( ( child ) => {
+			const childItem = queryByText( child.label );
+			expect( childItem ).toBeFalsy();
+		} );
+
+		fireEvent.click( optionItem );
+
+		option.children.forEach( ( child ) => {
+			const childItem = queryByText( child.label );
+			expect( childItem ).toBeTruthy();
 		} );
 	} );
 } );

--- a/js/src/components/tree-select-control/options.test.js
+++ b/js/src/components/tree-select-control/options.test.js
@@ -7,6 +7,7 @@ import { fireEvent, render } from '@testing-library/react';
  * Internal dependencies
  */
 import TreeSelectControl from '.~/components/tree-select-control/index';
+import Options from '.~/components/tree-select-control/options';
 
 const options = [
 	{
@@ -17,6 +18,11 @@ const options = [
 			{ value: 'FR', label: 'France' },
 			{ value: 'IT', label: 'Italy' },
 		],
+	},
+	{
+		value: 'NA',
+		label: 'North America',
+		children: [ { value: 'US', label: 'United States' } ],
 	},
 ];
 

--- a/js/src/components/tree-select-control/tags.js
+++ b/js/src/components/tree-select-control/tags.js
@@ -37,7 +37,7 @@ const Tags = ( { tags, disabled, onChange = () => {} } ) => {
 	return (
 		<div className="woocommerce-tree-select-control__tags">
 			{ tags.map( ( item, i ) => {
-				if ( ! item.label || ! item.id ) {
+				if ( ! item.label ) {
 					return null;
 				}
 				const screenReaderLabel = sprintf(

--- a/js/src/pages/component-test/index.js
+++ b/js/src/pages/component-test/index.js
@@ -27,7 +27,7 @@ const ComponentTest = () => {
 			children: [
 				{ value: 'ES', label: 'Spain' },
 				{ value: 'FR', label: 'France' },
-				{ value: 'IT', label: 'Italy' },
+				{ key: 'FR-Colonies', value: 'FR', label: 'France (Colonies)' },
 			],
 		},
 		{
@@ -49,10 +49,15 @@ const ComponentTest = () => {
 					children: [
 						{ value: 'NY', label: 'New York' },
 						{ value: 'TX', label: 'Texas' },
+						{ value: 'GE', label: 'Georgia' },
 					],
 				},
 				{ value: 'CA', label: 'Canada' },
 			],
+		},
+		{
+			value: '',
+			label: 'I dont know yet',
 		},
 	];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow up for -> https://github.com/woocommerce/google-listings-and-ads/pull/1281

This PR includes bug/requests in previous PRs.

- Optional Key support 
- Set ROOT_VALUE as {} instead of '' allowing to have values as ''
- Fix tests in Collapse/Expand
- Expand node on selection ([more info](pdkevu-52-p2))

### Detailed test instructions:

1. Checkout the branch
2. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcomponent-test` 
3. Clicking on a continent expand the group
4. You can have empty values in the Options