### PR TITLE
Fix navigate away prompt showing up when we change `offer_free_shipping` back and forth

### DIFF
--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -19,6 +19,19 @@ import FormContent from './form-content';
  * @typedef {import('.~/data/actions').CountryCode} CountryCode
  */
 
+const getSettings = ( values ) => {
+	return {
+		shipping_rate: values.shipping_rate,
+		shipping_time: values.shipping_time,
+		tax_rate: values.tax_rate,
+		website_live: values.website_live,
+		checkout_process_secure: values.checkout_process_secure,
+		payment_methods_visible: values.payment_methods_visible,
+		refund_tos_visible: values.refund_tos_visible,
+		contact_info_visible: values.contact_info_visible,
+	};
+};
+
 /**
  * Setup step to configure free listings.
  *
@@ -78,7 +91,6 @@ const SetupFreeListings = ( {
 		const {
 			shipping_country_rates: newShippingRates,
 			shipping_country_times: newShippingTimes,
-			...newSettings
 		} = newVals;
 
 		switch ( change.name ) {
@@ -89,7 +101,7 @@ const SetupFreeListings = ( {
 				onShippingTimesChange( newShippingTimes );
 				break;
 			default:
-				onSettingsChange( change, newSettings );
+				onSettingsChange( change, getSettings( newVals ) );
 		}
 	};
 

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -20,6 +20,17 @@ import FormContent from './form-content';
  * @typedef {import('.~/data/actions').CountryCode} CountryCode
  */
 
+const settingsFieldNames = [
+	'shipping_rate',
+	'shipping_time',
+	'tax_rate',
+	'website_live',
+	'checkout_process_secure',
+	'payment_methods_visible',
+	'refund_tos_visible',
+	'contact_info_visible',
+];
+
 /**
  * Get settings object from Form values.
  *
@@ -34,16 +45,7 @@ import FormContent from './form-content';
  * @return {Object} Settings object.
  */
 const getSettings = ( values ) => {
-	return pick( values, [
-		'shipping_rate',
-		'shipping_time',
-		'tax_rate',
-		'website_live',
-		'checkout_process_secure',
-		'payment_methods_visible',
-		'refund_tos_visible',
-		'contact_info_visible',
-	] );
+	return pick( values, settingsFieldNames );
 };
 
 /**
@@ -101,15 +103,12 @@ const SetupFreeListings = ( {
 	};
 
 	const handleChange = ( change, values ) => {
-		switch ( change.name ) {
-			case 'shipping_country_rates':
-				onShippingRatesChange( values.shipping_country_rates );
-				break;
-			case 'shipping_country_times':
-				onShippingTimesChange( values.shipping_country_times );
-				break;
-			default:
-				onSettingsChange( change, getSettings( values ) );
+		if ( change.name === 'shipping_country_rates' ) {
+			onShippingRatesChange( values.shipping_country_rates );
+		} else if ( change.name === 'shipping_country_times' ) {
+			onShippingTimesChange( values.shipping_country_times );
+		} else if ( settingsFieldNames.includes( change.name ) ) {
+			onSettingsChange( change, getSettings( values ) );
 		}
 	};
 

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -92,22 +92,16 @@ const SetupFreeListings = ( {
 		setSaving( false );
 	};
 
-	const handleChange = ( change, newVals ) => {
-		// Un-glue form data.
-		const {
-			shipping_country_rates: newShippingRates,
-			shipping_country_times: newShippingTimes,
-		} = newVals;
-
+	const handleChange = ( change, values ) => {
 		switch ( change.name ) {
 			case 'shipping_country_rates':
-				onShippingRatesChange( newShippingRates );
+				onShippingRatesChange( values.shipping_country_rates );
 				break;
 			case 'shipping_country_times':
-				onShippingTimesChange( newShippingTimes );
+				onShippingTimesChange( values.shipping_country_times );
 				break;
 			default:
-				onSettingsChange( change, getSettings( newVals ) );
+				onSettingsChange( change, getSettings( values ) );
 		}
 	};
 

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -40,9 +40,11 @@ const settingsFieldNames = [
  * Get settings object from Form values.
  *
  * This method is used to pick out form fields that are specific to settings.
- * If we are adding a new settings field, it should be added into `settingsFieldNames`.
+ * If we are adding a new settings field that will be saved via the settings API,
+ * it should be added into `settingsFieldNames`.
  *
- * If a new field is added into the form that is not related to settings (e.g. `offer_free_shipping`),
+ * If a new field is added into the form that is not related to settings (e.g. `offer_free_shipping`)
+ * and will NOT be saved via settings API,
  * we do not need to add the field into `settingsFieldNames`,
  * and things should continue to work as expected (e.g. the navigate away prompt).
  *

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -3,6 +3,7 @@
  */
 import { Form } from '@woocommerce/components';
 import { useState } from '@wordpress/element';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,16 +27,16 @@ import FormContent from './form-content';
  * @return {Object} Settings object.
  */
 const getSettings = ( values ) => {
-	return {
-		shipping_rate: values.shipping_rate,
-		shipping_time: values.shipping_time,
-		tax_rate: values.tax_rate,
-		website_live: values.website_live,
-		checkout_process_secure: values.checkout_process_secure,
-		payment_methods_visible: values.payment_methods_visible,
-		refund_tos_visible: values.refund_tos_visible,
-		contact_info_visible: values.contact_info_visible,
-	};
+	return pick( values, [
+		'shipping_rate',
+		'shipping_time',
+		'tax_rate',
+		'website_live',
+		'checkout_process_secure',
+		'payment_methods_visible',
+		'refund_tos_visible',
+		'contact_info_visible',
+	] );
 };
 
 /**

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -23,6 +23,13 @@ import FormContent from './form-content';
 /**
  * Get settings object from Form values.
  *
+ * This method is used to intentionally pick out form fields that are specific to settings.
+ * If we are adding a new settings field, it should be added into this function.
+ *
+ * If a new field is added into the form that is not related to settings (i.e. `offer_free_shipping`),
+ * we do not need to add the field into the function,
+ * and things should continue to work as expected (e.g. the navigate away prompt).
+ *
  * @param {Object} values Form values.
  * @return {Object} Settings object.
  */
@@ -111,6 +118,7 @@ const SetupFreeListings = ( {
 			<Hero />
 			<Form
 				initialValues={ {
+					// These are the fields for settings.
 					shipping_rate: settings.shipping_rate,
 					shipping_time: settings.shipping_time,
 					tax_rate: settings.tax_rate,

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -20,6 +20,11 @@ import FormContent from './form-content';
  * @typedef {import('.~/data/actions').CountryCode} CountryCode
  */
 
+/**
+ * Field names for settings.
+ *
+ * If we are adding a new settings field, it should be added into this array.
+ */
 const settingsFieldNames = [
 	'shipping_rate',
 	'shipping_time',
@@ -34,11 +39,11 @@ const settingsFieldNames = [
 /**
  * Get settings object from Form values.
  *
- * This method is used to intentionally pick out form fields that are specific to settings.
- * If we are adding a new settings field, it should be added into this function.
+ * This method is used to pick out form fields that are specific to settings.
+ * If we are adding a new settings field, it should be added into `settingsFieldNames`.
  *
- * If a new field is added into the form that is not related to settings (i.e. `offer_free_shipping`),
- * we do not need to add the field into the function,
+ * If a new field is added into the form that is not related to settings (e.g. `offer_free_shipping`),
+ * we do not need to add the field into `settingsFieldNames`,
  * and things should continue to work as expected (e.g. the navigate away prompt).
  *
  * @param {Object} values Form values.

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -19,6 +19,12 @@ import FormContent from './form-content';
  * @typedef {import('.~/data/actions').CountryCode} CountryCode
  */
 
+/**
+ * Get settings object from Form values.
+ *
+ * @param {Object} values Form values.
+ * @return {Object} Settings object.
+ */
 const getSettings = ( values ) => {
 	return {
 		shipping_rate: values.shipping_rate,

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -118,11 +118,12 @@ const SetupFreeListings = ( {
 					payment_methods_visible: settings.payment_methods_visible,
 					refund_tos_visible: settings.refund_tos_visible,
 					contact_info_visible: settings.contact_info_visible,
-					// Glue shipping rates and times together, as the Form does not support nested structures.
-					shipping_country_rates: shippingRates,
+					// This is used in UI only, not used in API.
 					offer_free_shipping: getOfferFreeShippingInitialValue(
 						shippingRates
 					),
+					// Glue shipping rates and times together, as the Form does not support nested structures.
+					shipping_country_rates: shippingRates,
 					shipping_country_times: shippingTimes,
 				} }
 				onChange={ handleChange }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1318.

In Edit Free Listings, when we change the offer free shipping value back and forth, the navigate away prompt would show up. This is because the `offer_free_shipping` value is being grouped as settings, and settings is considered changed.

In this PR, we use a new function `getSettings` here to extract the settings data from the form values object, leaving `offer_free_shipping` out, so changing the offer free shipping value would not be considered as settings changed.

### Screenshots:

📹 Demo video with my voice:

https://user-images.githubusercontent.com/417342/157855292-b31c5f46-dbc8-401a-ad15-6a77ea9883e8.mov

### Detailed test instructions:

1. Go to Edit Free Listings. 
2. Change the offer free shipping value, and then change it back to the original value. 
    - Note: if you change from "yes" to "no", your minimum order amount would have been cleared, and you would have to key in the same minimum order amount again when you change back to "yes".
4. Navigate away by reloading the page. Since all the values are the same and there are no changes, there should be no prompt for you, and you should be able to navigate away.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
