### PR TITLE
Check all php files for the phpcs action

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -28,4 +28,4 @@ jobs:
         run: vendor/bin/phpcs -i
 
       - name: Run PHPCS on all files
-        run: vendor/bin/phpcs ./src -q -n --report=checkstyle | cs2pr
+        run: vendor/bin/phpcs ./* -q -n --report=checkstyle | cs2pr

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -28,4 +28,4 @@ jobs:
         run: vendor/bin/phpcs -i
 
       - name: Run PHPCS on all files
-        run: vendor/bin/phpcs ./* -q -n --report=checkstyle | cs2pr
+        run: vendor/bin/phpcs ./* -q --report=checkstyle | cs2pr

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -115,4 +115,5 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>./tests/*</exclude-pattern>
+	<exclude-pattern>./js/*</exclude-pattern>
 </ruleset>

--- a/uninstall.php
+++ b/uninstall.php
@@ -46,7 +46,8 @@ if ( defined( 'WC_GLA_REMOVE_ALL_DATA' ) && true === WC_GLA_REMOVE_ALL_DATA ) {
 
 	// drop custom tables
 	foreach ( TableManager::get_all_table_names() as $table ) {
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . WC_GLA_SLUG . "_{$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL
+		// phpcs:ignore WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . WC_GLA_SLUG . "_{$table}" );
 	}
 
 	// delete options

--- a/views/bulk-edit/shop_coupon.php
+++ b/views/bulk-edit/shop_coupon.php
@@ -21,8 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<select class="change_channel_visibility change_to" name="change_channel_visibility">
 						<?php
 						$options = [
-							''                                    => __( '— No change —', 'google-listings-and-ads' ),
-							ChannelVisibility::SYNC_AND_SHOW      => __( 'Show coupon', 'google-listings-and-ads' ),
+							'' => __( '— No change —', 'google-listings-and-ads' ),
+							ChannelVisibility::SYNC_AND_SHOW => __( 'Show coupon', 'google-listings-and-ads' ),
 							ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t show coupon', 'google-listings-and-ads' ),
 						];
 						foreach ( $options as $key => $value ) {

--- a/views/bulk-edit/shop_coupon.php
+++ b/views/bulk-edit/shop_coupon.php
@@ -16,15 +16,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<div class="inline-edit-group">
 			<label class="alignleft">
-				<span class="title"><?php _e( 'Google visibility', 'google-listings-and-ads' ); ?></span>
+				<span class="title"><?php esc_html_e( 'Google visibility', 'google-listings-and-ads' ); ?></span>
 				<span class="input-text-wrap">
 					<select class="change_channel_visibility change_to" name="change_channel_visibility">
 						<?php
-						$options = array(
+						$options = [
 							''                                    => __( '— No change —', 'google-listings-and-ads' ),
-						    ChannelVisibility::SYNC_AND_SHOW      => __( 'Show coupon', 'google-listings-and-ads' ),
-						    ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t show coupon', 'google-listings-and-ads' ),
-						);
+							ChannelVisibility::SYNC_AND_SHOW      => __( 'Show coupon', 'google-listings-and-ads' ),
+							ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t show coupon', 'google-listings-and-ads' ),
+						];
 						foreach ( $options as $key => $value ) {
 							echo '<option value="' . esc_attr( $key ) . '">' . esc_html( $value ) . '</option>';
 						}
@@ -33,8 +33,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</span>
 			</label>
 		</div>
-			
+
 		<input type="hidden" name="woocommerce_gla_bulk_edit" value="1" />
-		<input type="hidden" name="woocommerce_gla_bulk_edit_nonce" value="<?php echo wp_create_nonce( 'woocommerce_gla_bulk_edit_nonce' ); ?>" />
+		<input type="hidden" name="woocommerce_gla_bulk_edit_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woocommerce_gla_bulk_edit_nonce' ) ); ?>" />
 	</div>
 </fieldset>

--- a/views/meta-box/coupon_channel_visibility.php
+++ b/views/meta-box/coupon_channel_visibility.php
@@ -57,14 +57,14 @@ $get_started_url = $this->get_started_url;
  */
 $is_synced = false;
 if ( SyncStatus::HAS_ERRORS === $this->sync_status ) {
-    $sync_status = __( 'Issues detected', 'google-listings-and-ads' );
-} elseif ( SyncStatus::PENDING === $this->sync_status ){
-    $sync_status = __( 'Pending for sync', 'google-listings-and-ads' );
-} elseif ( SyncStatus::SYNCED === $this->sync_status ){
-    $is_synced = true;
-    $sync_status = __( 'Sent to Google', 'google-listings-and-ads' );
+	$sync_status = __( 'Issues detected', 'google-listings-and-ads' );
+} elseif ( SyncStatus::PENDING === $this->sync_status ) {
+	$sync_status = __( 'Pending for sync', 'google-listings-and-ads' );
+} elseif ( SyncStatus::SYNCED === $this->sync_status ) {
+	$is_synced   = true;
+	$sync_status = __( 'Sent to Google', 'google-listings-and-ads' );
 } elseif ( ! is_null( $this->sync_status ) ) {
-    $sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
+	$sync_status = ucfirst( str_replace( '-', ' ', $this->sync_status ) );
 }
 
 $show_status = $channel_visibility ===
@@ -76,82 +76,87 @@ $check_email_notice = __( 'Check your email for updates.', 'google-listings-and-
  *
  * @var array $issues
  */
-$issues = $this->issues;
+$issues     = $this->issues;
 $has_issues = ! empty( $issues );
 
 $input_description = '';
-$input_disabled = false;
+$input_disabled    = false;
 if ( ! CouponSyncer::is_coupon_supported( $coupon ) ) {
-    $channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
-    $show_status = false;
-    $input_disabled = true;
-    $input_description = __(
-        $coupon->get_virtual() ? 'This coupon cannot be shown on public channel because it is hidden from your store.' : 'This coupon cannot be shown because the coupon restrictions are not supported to share in Google channel.',
-        'google-listings-and-ads' );
-} else if (! $is_channel_supported ) {
-    $channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
-    $show_status = false;
-    $input_disabled = true;
-    $input_description = __(
-        'This coupon visibility channel has not been supported in your store base country yet.',
-        'google-listings-and-ads' );
+	$channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
+	$show_status        = false;
+	$input_disabled     = true;
+	$input_description  = $coupon->get_virtual() ?
+		__( 'This coupon cannot be shown on public channel because it is hidden from your store.', 'google-listings-and-ads' ) :
+		__( 'This coupon cannot be shown because the coupon restrictions are not supported to share in Google channel.', 'google-listings-and-ads' );
+} elseif ( ! $is_channel_supported ) {
+	$channel_visibility = ChannelVisibility::DONT_SYNC_AND_SHOW;
+	$show_status        = false;
+	$input_disabled     = true;
+	$input_description  = __(
+		'This coupon visibility channel has not been supported in your store base country yet.',
+		'google-listings-and-ads'
+	);
 }
 
 $custom_attributes = [];
 if ( $input_disabled ) {
-    $custom_attributes['disabled'] = 'disabled';
+	$custom_attributes['disabled'] = 'disabled';
 }
 ?>
 
 <div class="gla-channel-visibility-box">
 	<?php if ( $is_setup_complete ) : ?>
-        <?php
-    woocommerce_wp_select( 
-        [
-            'id' => $field_id,
-            'value' => $channel_visibility,
-            'label' => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
-            'description' => $input_description,
-            'desc_tip' => false,
-            'options' => [
-                ChannelVisibility::SYNC_AND_SHOW => __( 
-                    'Show coupon on Google',
-                    'google-listings-and-ads' ),
-                ChannelVisibility::DONT_SYNC_AND_SHOW => __( 
-                    'Don\'t show coupon on Google',
-                    'google-listings-and-ads' )],
-            'custom_attributes' => $custom_attributes,
-            'wrapper_class' => 'form-row form-row-full'] );
-    ?>
-    	<?php if ( $show_status ) : ?>
-    		<?php if ( $has_issues ) : ?>
-    		<div class="sync-status notice-alt notice-large notice-warning"
+		<?php
+		woocommerce_wp_select(
+			[
+				'id'                => $field_id,
+				'value'             => $channel_visibility,
+				'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
+				'description'       => $input_description,
+				'desc_tip'          => false,
+				'options'           => [
+					ChannelVisibility::SYNC_AND_SHOW      => __(
+						'Show coupon on Google',
+						'google-listings-and-ads'
+					),
+					ChannelVisibility::DONT_SYNC_AND_SHOW => __(
+						"Don't show coupon on Google",
+						'google-listings-and-ads'
+					),
+				],
+				'custom_attributes' => $custom_attributes,
+				'wrapper_class'     => 'form-row form-row-full',
+			]
+		);
+		?>
+		<?php if ( $show_status ) : ?>
+			<?php if ( $has_issues ) : ?>
+			<div class="sync-status notice-alt notice-large notice-warning"
 				style="border-left-style: solid">
-    			<div class="gla-product-issues">
-        			<p>
-        				<strong><?php esc_html_e( 'Coupon issues', 'google-listings-and-ads' ); ?></strong>
-        			</p>
-        			<ul>
-            					<?php foreach ( $issues as $issue ) : ?>
-            					<li><?php echo esc_html( $issue ); ?></li>
-            					<?php endforeach; ?>
-    				</ul>
+				<div class="gla-product-issues">
+					<p>
+						<strong><?php esc_html_e( 'Coupon issues', 'google-listings-and-ads' ); ?></strong>
+					</p>
+					<ul>
+						<?php foreach ( $issues as $issue ) : ?>
+						<li><?php echo esc_html( $issue ); ?></li>
+						<?php endforeach; ?>
+					</ul>
 				</div>
 			</div>
 			<?php else : ?>
 			<div class="sync-status notice-alt notice-large" style="background-color:#efefef">
 				<p><strong><?php echo esc_html( $sync_status ); ?></strong></p>
 			</div>
-    			<?php if ( $is_synced ) : ?>
-        			<div style="padding: 10px 0px" >
-        				<?php echo esc_html( $check_email_notice); ?>
-        			</div>
-    			<?php endif;?>
-    		<?php endif; ?>
-    	
-    	<?php endif; ?>
+				<?php if ( $is_synced ) : ?>
+				<div style="padding: 10px 0px" >
+					<?php echo esc_html( $check_email_notice ); ?>
+				</div>
+				<?php endif; ?>
+			<?php endif; ?>
+		<?php endif; ?>
 	<?php else : ?>
-		<p>
+	<p>
 		<strong><?php esc_html_e( 'Google Listings & Ads', 'google-listings-and-ads' ); ?></strong>
 	</p>
 	<p><?php esc_html_e( 'Complete setup to get your coupon listed on Google for free.', 'google-listings-and-ads' ); ?></p>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the GitHub action to check phpcs files. Previously only the `./src` folder was checked, but there are quite a few other locations where we store php files, such as the views folder.
Excluded folders can be found in phpcs.xml.dist.

We are quite strict on fixing phpcs warnings in our PR's so since there was only one additional one showing up I fixed it and removed the `-n` parameter so we don't ignore warnings.

Helps to resolve one of the points mentioned in #1047

### Detailed test instructions:
1. Confirm the phpcs action in this PR completed without any errors or warnings
2. Confirm the phpcs action in this PR runs for all files `./*` and without ignoring warnings `-n`
```
vendor/bin/phpcs ./* -q --report=checkstyle | cs2pr
```
3. Run phpcs locally to confirm it doesn't find any errors or warnings
```
vendor/bin/phpcs ./*
```

### Changelog entry
* Fix - Check all php files for the phpcs action.
