### PR TITLE
Update copy for Free and Enhanced Listings merge

### DIFF
--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -58,7 +58,7 @@ const ProductStatistics = () => {
 							<SummaryNumber
 								key="active"
 								label={ __(
-									'Active / Partially Active',
+									'Active',
 									'google-listings-and-ads'
 								) }
 								value={ data.statistics.active }

--- a/js/src/product-feed/product-statistics/product-status-help-popover/index.js
+++ b/js/src/product-feed/product-statistics/product-status-help-popover/index.js
@@ -41,7 +41,7 @@ const ProductStatusHelpPopover = () => {
 			<p>
 				{ createInterpolateElement(
 					__(
-						'After submission, Google assigns each product a status: <strong>Active, Partially Active, Expiring, Pending, or Disapproved.</strong>',
+						'After submission, Google assigns each product a status: <strong>Active, Expiring, Pending, or Disapproved.</strong>',
 						'google-listings-and-ads'
 					),
 					map
@@ -50,16 +50,7 @@ const ProductStatusHelpPopover = () => {
 			<p>
 				{ createInterpolateElement(
 					__(
-						'<strong>‘Active’ products</strong> are fully approved and eligible to appear in standard and enhanced listings on Google.',
-						'google-listings-and-ads'
-					),
-					map
-				) }
-			</p>
-			<p>
-				{ createInterpolateElement(
-					__(
-						'<strong>‘Partially active’ products</strong> are fully approved and eligible to appear in standard listings only.',
+						'<strong>‘Active’ products</strong> are fully approved and eligible to appear in free listings on Google.',
 						'google-listings-and-ads'
 					),
 					map

--- a/js/src/product-feed/product-statistics/status-box/feed-status.js
+++ b/js/src/product-feed/product-statistics/status-box/feed-status.js
@@ -53,7 +53,7 @@ function FeedStatus() {
 			label={
 				<span className="gla-success">
 					{ __(
-						'Standard free listings setup completed',
+						'Free listings setup completed',
 						'google-listings-and-ads'
 					) }
 				</span>

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -98,7 +98,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 	/**
 	 * Get the Product Statistics (updating caches if necessary). This is the
-	 * number of product IDs with each status (active and partially active are combined).
+	 * number of product IDs with each status (approved and partially approved are combined as active).
 	 *
 	 * @param bool $force_refresh Force refresh of all product status data.
 	 *

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -819,7 +819,6 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		if ( 'merchant_quality_low' === $issue['code'] || "Account isn't eligible for free listings" === $issue['issue'] ) {
 			$issue['issue']      = 'Show products on additional surfaces across Google through free listings';
 			$issue['severity']   = self::SEVERITY_WARNING;
-			$issue['action']     = 'Read about free listings';
 			$issue['action_url'] = 'https://support.google.com/merchants/answer/9199328?hl=en';
 		}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -806,9 +806,9 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 */
 	private function maybe_override_issue_values( array $issue ): array {
 		if ( 'merchant_quality_low' === $issue['code'] ) {
-			$issue['issue']      = 'Show products on additional surfaces across Google through enhanced free listings';
+			$issue['issue']      = 'Show products on additional surfaces across Google through free listings';
 			$issue['severity']   = self::SEVERITY_WARNING;
-			$issue['action']     = 'Read about enhanced free listings';
+			$issue['action']     = 'Read about free listings';
 			$issue['action_url'] = 'https://support.google.com/merchants/answer/9199328?hl=en';
 		}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -805,7 +805,18 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 * @return array The original issue with any possibly overridden values.
 	 */
 	private function maybe_override_issue_values( array $issue ): array {
-		if ( 'merchant_quality_low' === $issue['code'] ) {
+		/**
+		 * Code 'merchant_quality_low' for matching the original issue.
+		 * Ref: https://developers.google.com/shopping-content/guides/account-issues#merchant_quality_low
+		 *
+		 * Issue string "Account isn't eligible for free listings" for matching
+		 * the updated copy after Free and Enhanced Listings merge.
+		 *
+		 * TODO: Remove the condition of matching the $issue['issue']
+		 *       if its issue code is the same as 'merchant_quality_low'
+		 *       after Free and Enhanced Listings merge.
+		 */
+		if ( 'merchant_quality_low' === $issue['code'] || "Account isn't eligible for free listings" === $issue['issue'] ) {
 			$issue['issue']      = 'Show products on additional surfaces across Google through free listings';
 			$issue['severity']   = self::SEVERITY_WARNING;
 			$issue['action']     = 'Read about free listings';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1296 

- Remove all "Partially Active" wordings or sentences.
- Remove "standard" or "enhanced" listings wordings.

### Screenshots:

#### 📷  Overview statistics

![2022-03-14 16 01 33](https://user-images.githubusercontent.com/17420811/158133645-aaee585e-b16b-4f94-8d5e-78f704b7a84e.png)

#### 📷  Popup of Overview statistics

![2022-03-14 16 00 07](https://user-images.githubusercontent.com/17420811/158133654-e1b02956-1e3a-4745-bff5-ae11c269760d.png)

#### 📷  Issues to resolve table

The new screenshot after adopting the suggestion in https://github.com/woocommerce/google-listings-and-ads/pull/1325#issuecomment-1135936945.

![2022-05-25 19 06 54](https://user-images.githubusercontent.com/17420811/170249302-ff404cbd-b74d-4f28-825a-520638c7ef71.png)

The ~new~ old screenshot after resolving code conflicts and rebasing in https://github.com/woocommerce/google-listings-and-ads/pull/1325#issuecomment-1135753523.
![2022-05-24 18 17 33](https://user-images.githubusercontent.com/17420811/170012562-7ce78f81-ec22-4ff2-8679-f5ffa3f0b3eb.png)

The original screenshot when opening PR.
![2022-03-14 16 03 09](https://user-images.githubusercontent.com/17420811/158133667-8881109e-e341-4b98-9af6-fb0a494ce157.png)

### Detailed test instructions:

1. Go to the Product Feed page.
2. Check if the copies are the same as new copies in the spreadsheet of pcTzPl-nO-p2.
3. Global search `partially`, `standard`, and, `enhanced` in the codebase to check if there are related copies that are still using these wordings.

### Changelog entry

> Tweak - Update copy for Free and Enhanced Listings merge.
