### PR TITLE
Run partial CI jobs only for JS/SCSS/PHP file changes

### DIFF
--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -5,7 +5,17 @@ on:
     branches:
       - trunk
       - develop
+    paths:
+      - "**.js"
+      - "**.scss"
+      - ./.github/workflows/js-css-linting.yml
+      - ./.github/actions/prepare-node/action.yml
   pull_request:
+    paths:
+      - "**.js"
+      - "**.scss"
+      - ./.github/workflows/js-css-linting.yml
+      - ./.github/actions/prepare-node/action.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -5,7 +5,15 @@ on:
     branches:
       - trunk
       - develop
+    paths:
+      - "**.js"
+      - ./.github/workflows/js-unit-tests.yml
+      - ./.github/actions/prepare-node/action.yml
   pull_request:
+    paths:
+      - "**.js"
+      - ./.github/workflows/js-unit-tests.yml
+      - ./.github/actions/prepare-node/action.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -7,11 +7,15 @@ on:
       - develop
     paths:
       - "**.js"
+      - ./package.json
+      - ./package-lock.json
       - ./.github/workflows/js-unit-tests.yml
       - ./.github/actions/prepare-node/action.yml
   pull_request:
     paths:
       - "**.js"
+      - ./package.json
+      - ./package-lock.json
       - ./.github/workflows/js-unit-tests.yml
       - ./.github/actions/prepare-node/action.yml
 

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -5,7 +5,15 @@ on:
     branches:
       - trunk
       - develop
+    paths:
+      - "**.php"
+      - ./.github/workflows/php-coding-standards.yml
+      - ./.github/actions/prepare-php/action.yml
   pull_request:
+    paths:
+      - "**.php"
+      - ./.github/workflows/php-coding-standards.yml
+      - ./.github/actions/prepare-php/action.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -5,7 +5,15 @@ on:
     branches:
       - trunk
       - develop
+    paths:
+      - "**.php"
+      - ./.github/workflows/php-unit-tests.yml
+      - ./.github/actions/prepare-php/action.yml
   pull_request:
+    paths:
+      - "**.php"
+      - ./.github/workflows/php-unit-tests.yml
+      - ./.github/actions/prepare-php/action.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -7,11 +7,15 @@ on:
       - develop
     paths:
       - "**.php"
+      - ./composer.json
+      - ./composer.lock
       - ./.github/workflows/php-unit-tests.yml
       - ./.github/actions/prepare-php/action.yml
   pull_request:
     paths:
       - "**.php"
+      - ./composer.json
+      - ./composer.lock
       - ./.github/workflows/php-unit-tests.yml
       - ./.github/actions/prepare-php/action.yml
 

--- a/js/src/components/guide-page-content/index.js
+++ b/js/src/components/guide-page-content/index.js
@@ -9,9 +9,6 @@ import classnames from 'classnames';
 import TrackableLink from '.~/components/trackable-link';
 import './index.scss';
 
-// TODO: These components are planned to be reused when implementing the Successful Campaign Creation Modal.
-//       Ref: https://github.com/woocommerce/google-listings-and-ads/issues/180
-
 /**
  * Renders header title and content within a [Guide modal](https://wordpress.github.io/gutenberg/?path=/docs/components-guide--default).
  *

--- a/src/ActionScheduler/ActionScheduler.php
+++ b/src/ActionScheduler/ActionScheduler.php
@@ -90,7 +90,7 @@ class ActionScheduler implements ActionSchedulerInterface, Service {
 	 *
 	 * @return int The action ID.
 	 *
-	 * @see http://en.wikipedia.org/wiki/Cron
+	 * @see https://en.wikipedia.org/wiki/Cron
 	 *   *    *    *    *    *    *
 	 *   ┬    ┬    ┬    ┬    ┬    ┬
 	 *   |    |    |    |    |    |

--- a/src/ActionScheduler/ActionSchedulerInterface.php
+++ b/src/ActionScheduler/ActionSchedulerInterface.php
@@ -71,7 +71,7 @@ interface ActionSchedulerInterface {
 	 *
 	 * @return int The action ID.
 	 *
-	 * @see http://en.wikipedia.org/wiki/Cron
+	 * @see https://en.wikipedia.org/wiki/Cron
 	 *   *    *    *    *    *    *
 	 *   ┬    ┬    ┬    ┬    ┬    ┬
 	 *   |    |    |    |    |    |


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Parts of #1047 

- Only run **JavaScript and CSS Linting** and **JavaScript Unit Tests** jobs when the change files are including `.js` or `.scss` files in pull requests, or in the commits on the primary branches.
- Only run **PHP Coding Standards** and **PHP Unit Tests** jobs when the change files are including `.php` files in pull requests, or in the commits on the primary branches.

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

### Screenshots:

#### 📷  Without any js/scss/php changes

![2022-03-14 17 49 45](https://user-images.githubusercontent.com/17420811/158148656-e5bca07d-a549-4797-aa2c-ffbdf595f04a.png)

#### 📷  Adding js file changes

![2022-03-14 17 52 58](https://user-images.githubusercontent.com/17420811/158148672-9724058b-0eae-49bb-b3e5-a0e35758bc8d.png)

#### 📷  Adding php file changes

![2022-03-14 17 54 20](https://user-images.githubusercontent.com/17420811/158148725-4425ad95-770e-4b7a-a881-eb1fe2a1c8e5.png)

### Detailed test instructions:

Check the three commits triggering jobs below, they should trigger more jobs as more files are changed.

💡  If change the order to commit PHP file changes first, it should expect only the PHP-related jobs to be added to trigger. But I think it should be ok to provide one of the verification flow in this PR.

### Changelog entry
