### PR TITLE
Add/more tags

### DIFF
--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -19,6 +19,7 @@ import Tags from './tags';
  * @param {string} props.placeholder Placeholder of the search input
  * @param {boolean} props.isExpanded True if the tree is expanded
  * @param {boolean} props.disabled True if the component is disabled
+ * @param {number} props.maxVisibleTags The maximum number of tags to show. Undefined, 0 or less than 0 evaluates to "Show All".
  * @param {Function} props.onFocus On Focus Callback
  * @param {Function} props.onTagsChange Callback when the Tags change
  * @return {JSX.Element} The rendered component
@@ -29,6 +30,7 @@ const Control = ( {
 	placeholder,
 	isExpanded,
 	disabled,
+	maxVisibleTags,
 	onFocus = () => {},
 	onTagsChange = () => {},
 } ) => {
@@ -59,6 +61,7 @@ const Control = ( {
 				<Tags
 					disabled={ disabled }
 					tags={ tags }
+					maxVisibleTags={ maxVisibleTags }
 					onChange={ onTagsChange }
 				/>
 			) }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -64,6 +64,7 @@ import { ROOT_VALUE } from '.~/components/tree-select-control/constants';
  * @param {boolean} props.disabled Disables the component
  * @param {Option[]} props.options Options to show in the component
  * @param {string[]} props.value Selected values
+ * @param {number} props.maxVisibleTags The maximum number of tags to show. Undefined, 0 or less than 0 evaluates to "Show All".
  * @param {Function} props.onChange Callback when the selector changes
  * @return {JSX.Element} The component
  */
@@ -76,6 +77,7 @@ const TreeSelectControl = ( {
 	disabled,
 	options = [],
 	value = [],
+	maxVisibleTags,
 	onChange = () => {},
 } ) => {
 	let instanceId = useInstanceId( TreeSelectControl );
@@ -244,6 +246,7 @@ const TreeSelectControl = ( {
 				instanceId={ instanceId }
 				placeholder={ placeholder }
 				label={ label }
+				maxVisibleTags={ maxVisibleTags }
 				onTagsChange={ handleTagsChange }
 			/>
 			{ treeVisible && (

--- a/js/src/components/tree-select-control/index.scss
+++ b/js/src/components/tree-select-control/index.scss
@@ -119,6 +119,10 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 		}
 	}
 
+	.woocommerce-tree-select-control__show-more {
+		max-height: 24px;
+	}
+
 	.woocommerce-tag {
 		max-height: 24px;
 	}

--- a/js/src/components/tree-select-control/index.scss
+++ b/js/src/components/tree-select-control/index.scss
@@ -89,7 +89,12 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 		}
 
 		&.is-disabled {
-			opacity: 0.5;
+			border: 1px solid rgba(167, 170, 173, 0.5);
+			background: rgba(255, 255, 255, 0.5);
+
+			.components-base-control__field {
+				display: none;
+			}
 			.components-base-control__label {
 				cursor: default;
 			}

--- a/js/src/components/tree-select-control/index.scss
+++ b/js/src/components/tree-select-control/index.scss
@@ -28,8 +28,9 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 	}
 
 	.components-base-control {
-		height: 56px;
+		height: auto;
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
 		border: 1px solid $studio-gray-20;
 		border-radius: 3px;
@@ -42,6 +43,7 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 			display: flex;
 			align-items: center;
 			flex: 1;
+			flex-basis: content;
 			margin-bottom: 0;
 			max-width: 100%;
 		}

--- a/js/src/components/tree-select-control/tags.js
+++ b/js/src/components/tree-select-control/tags.js
@@ -3,6 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Tag } from '@woocommerce/components';
+import { useState } from '@wordpress/element';
+import { Button } from '@wordpress/components';
 
 /**
  * A list of tags to display selected items.
@@ -11,8 +13,19 @@ import { Tag } from '@woocommerce/components';
  * @param {Object[]} props.tags The tags
  * @param {Function} props.onChange The method called when a tag is removed
  * @param {boolean} props.disabled True if the plugin is disabled
+ * @param {number} props.maxVisibleTags The maximum number of tags to show. 0 or less than 0 evaluates to "Show All".
  */
-const Tags = ( { tags, disabled, onChange = () => {} } ) => {
+const Tags = ( {
+	tags = [],
+	disabled,
+	maxVisibleTags = 0,
+	onChange = () => {},
+} ) => {
+	const [ showAll, setShowAll ] = useState( false );
+	const maxTags = Math.max( 0, maxVisibleTags );
+	const shouldShowAll = showAll || ! maxTags;
+	const visibleTags = shouldShowAll ? tags : tags.slice( 0, maxTags );
+
 	if ( ! tags.length ) {
 		return null;
 	}
@@ -36,7 +49,7 @@ const Tags = ( { tags, disabled, onChange = () => {} } ) => {
 
 	return (
 		<div className="woocommerce-tree-select-control__tags">
-			{ tags.map( ( item, i ) => {
+			{ visibleTags.map( ( item, i ) => {
 				if ( ! item.label ) {
 					return null;
 				}
@@ -57,6 +70,23 @@ const Tags = ( { tags, disabled, onChange = () => {} } ) => {
 					/>
 				);
 			} ) }
+
+			{ maxTags > 0 && tags.length > maxTags && (
+				<Button
+					isTertiary
+					onClick={ () => {
+						setShowAll( ! showAll );
+					} }
+				>
+					{ showAll
+						? __( 'Show less', 'google-listing-and-ads' )
+						: sprintf(
+								// translators: %d: The number of extra tags to show
+								__( '+ %d More', 'google-listing-and-ads' ),
+								tags.length - maxTags
+						  ) }
+				</Button>
+			) }
 		</div>
 	);
 };

--- a/js/src/components/tree-select-control/tags.js
+++ b/js/src/components/tree-select-control/tags.js
@@ -74,6 +74,7 @@ const Tags = ( {
 			{ maxTags > 0 && tags.length > maxTags && (
 				<Button
 					isTertiary
+					className="woocommerce-tree-select-control__show-more"
 					onClick={ () => {
 						setShowAll( ! showAll );
 					} }
@@ -82,7 +83,7 @@ const Tags = ( {
 						? __( 'Show less', 'google-listing-and-ads' )
 						: sprintf(
 								// translators: %d: The number of extra tags to show
-								__( '+ %d More', 'google-listing-and-ads' ),
+								__( '+ %d more', 'google-listing-and-ads' ),
 								tags.length - maxTags
 						  ) }
 				</Button>

--- a/js/src/components/tree-select-control/tags.js
+++ b/js/src/components/tree-select-control/tags.js
@@ -10,10 +10,10 @@ import { Button } from '@wordpress/components';
  * A list of tags to display selected items.
  *
  * @param {Object} props The component props
- * @param {Object[]} props.tags The tags
+ * @param {Object[]} [props.tags=[]] The tags
  * @param {Function} props.onChange The method called when a tag is removed
  * @param {boolean} props.disabled True if the plugin is disabled
- * @param {number} props.maxVisibleTags The maximum number of tags to show. 0 or less than 0 evaluates to "Show All".
+ * @param {number} [props.maxVisibleTags=0] The maximum number of tags to show. 0 or less than 0 evaluates to "Show All".
  */
 const Tags = ( {
 	tags = [],

--- a/js/src/components/tree-select-control/tags.test.js
+++ b/js/src/components/tree-select-control/tags.test.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Tags from '.~/components/tree-select-control/tags';
+
+const tags = [
+	{ id: 'ES', label: 'Spain' },
+	{ id: 'FR', label: 'France' },
+];
+
+describe( 'TreeSelectControl - Tags Component', () => {
+	it( 'Shows all tags by default', () => {
+		const { queryAllByRole } = render( <Tags tags={ tags } /> );
+
+		expect( queryAllByRole( 'button' ).length ).toBe( 2 );
+	} );
+
+	it( 'Limit Tags visibility', () => {
+		const { queryByText } = render(
+			<Tags tags={ tags } maxVisibleTags={ 1 } />
+		);
+
+		expect( queryByText( 'Spain' ) ).toBeTruthy();
+		expect( queryByText( 'France' ) ).toBeFalsy();
+
+		const showMore = queryByText( '+ 1 More' );
+		expect( queryByText( 'Show less' ) ).toBeFalsy();
+		expect( showMore ).toBeTruthy();
+		fireEvent.click( showMore );
+
+		expect( queryByText( 'Spain' ) ).toBeTruthy();
+		expect( queryByText( 'France' ) ).toBeTruthy();
+
+		expect( queryByText( 'Show less' ) ).toBeTruthy();
+		fireEvent.click( showMore );
+
+		expect( queryByText( 'Spain' ) ).toBeTruthy();
+		expect( queryByText( 'France' ) ).toBeFalsy();
+
+		expect( queryByText( 'Show less' ) ).toBeFalsy();
+		expect( queryByText( '+ 1 More' ) ).toBeTruthy();
+	} );
+} );

--- a/js/src/components/tree-select-control/tags.test.js
+++ b/js/src/components/tree-select-control/tags.test.js
@@ -28,7 +28,7 @@ describe( 'TreeSelectControl - Tags Component', () => {
 		expect( queryByText( 'Spain' ) ).toBeTruthy();
 		expect( queryByText( 'France' ) ).toBeFalsy();
 
-		const showMore = queryByText( '+ 1 More' );
+		const showMore = queryByText( '+ 1 more' );
 		expect( queryByText( 'Show less' ) ).toBeFalsy();
 		expect( showMore ).toBeTruthy();
 		fireEvent.click( showMore );
@@ -43,6 +43,6 @@ describe( 'TreeSelectControl - Tags Component', () => {
 		expect( queryByText( 'France' ) ).toBeFalsy();
 
 		expect( queryByText( 'Show less' ) ).toBeFalsy();
-		expect( queryByText( '+ 1 More' ) ).toBeTruthy();
+		expect( queryByText( '+ 1 more' ) ).toBeTruthy();
 	} );
 } );

--- a/js/src/pages/component-test/index.js
+++ b/js/src/pages/component-test/index.js
@@ -72,6 +72,7 @@ const ComponentTest = () => {
 			</button>
 			<h2>TreeSelectControl</h2>
 			<TreeSelectControl
+				maxVisibleTags="5"
 				disabled={ disabled }
 				options={ treeSelectControlOptions }
 				value={ selected }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the "X More Tags / Show less" functionality in the Tree Select Control Component

More info -> pcTzPl-fg-p2#comment-725

In brief, we want a parameter to set the maximum number of tags visible in the input, together with a button saying "x more tags" in case there are more tags than that maximum. When we click on that button, all the tags are shown. 

### Screenshots:

https://user-images.githubusercontent.com/5908855/158345132-4fb35b28-f9e9-4e1e-9bb7-73e130e04cea.mov


### Detailed test instructions:

Notice the default limit is set as 5 tags.

1. Checkout this branch
2. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcomponent-test`
3. By default you can see the only Tag selected "Spain" without any button
4. Add countries until 5. Still no button
5. Add one country more and see "+ 1 More"
6. Add another country and see "+ 2 More"
7.  Click on "+ 2 More" and see the 2 tags and "Show less"
8.  Click on "Show less" and you will see again 5 tags and "+ 2 More"

