### PR TITLE
Tree Select Component - Basic Accessibility 

### DIFF
--- a/js/src/components/tree-select-control/constants.js
+++ b/js/src/components/tree-select-control/constants.js
@@ -1,1 +1,2 @@
 export const ROOT_VALUE = '__WC_TREE_SELECT_COMPONENT_ROOT__';
+export const BACKSPACE = 'Backspace';

--- a/js/src/components/tree-select-control/constants.js
+++ b/js/src/components/tree-select-control/constants.js
@@ -1,2 +1,3 @@
 export const ROOT_VALUE = '__WC_TREE_SELECT_COMPONENT_ROOT__';
 export const BACKSPACE = 'Backspace';
+export const ESCAPE = 'Escape';

--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { forwardRef, useRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { forwardRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,71 +25,66 @@ import Tags from './tags';
  * @param {Function} props.onInputChange Callback when the Input value changes
  * @return {JSX.Element} The rendered component
  */
-const Control = forwardRef(
-	(
-		{
-			tags = [],
-			instanceId,
-			placeholder,
-			isExpanded,
-			disabled,
-			maxVisibleTags,
-			onFocus = () => {},
-			onTagsChange = () => {},
-			onInputChange = () => {},
-		},
-		inputRef
-	) => {
-		const hasTags = tags.length > 0;
-		const showPlaceholder = ! hasTags && ! isExpanded;
-
-		return (
-			/*
+const Control = ( {
+	tags = [],
+	instanceId,
+	placeholder,
+	isExpanded,
+	disabled,
+	maxVisibleTags,
+	onFocus = () => {},
+	onTagsChange = () => {},
+	onInputChange = () => {},
+} ) => {
+	const hasTags = tags.length > 0;
+	const showPlaceholder = ! hasTags && ! isExpanded;
+	const inputRef = useRef();
+	return (
+		/*
 		ESLint Disable reason
 		https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/src/select-control/control.js#L200
 		*/
-			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
-			<div
-				className={ classnames(
-					'components-base-control',
-					'woocommerce-tree-select-control__control',
-					{
-						'is-disabled': disabled,
-						'has-tags': hasTags,
-					}
-				) }
-				onClick={ () => {
-					inputRef.current.focus();
-				} }
-			>
-				{ hasTags && (
-					<Tags
-						disabled={ disabled }
-						tags={ tags }
-						maxVisibleTags={ maxVisibleTags }
-						onChange={ onTagsChange }
-					/>
-				) }
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+		<div
+			className={ classnames(
+				'components-base-control',
+				'woocommerce-tree-select-control__control',
+				{
+					'is-disabled': disabled,
+					'has-tags': hasTags,
+				}
+			) }
+			onClick={ () => {
+				inputRef.current.focus();
+			} }
+		>
+			{ hasTags && (
+				<Tags
+					disabled={ disabled }
+					tags={ tags }
+					maxVisibleTags={ maxVisibleTags }
+					onChange={ onTagsChange }
+				/>
+			) }
 
-				<div className="components-base-control__field">
-					<input
-						ref={ inputRef }
-						id={ `woocommerce-tree-select-control-${ instanceId }__control-input` }
-						type="search"
-						placeholder={ showPlaceholder ? placeholder : '' }
-						autoComplete="off"
-						className="woocommerce-tree-select-control__control-input"
-						role="combobox"
-						aria-autocomplete="list"
-						aria-expanded={ isExpanded }
-						disabled={ disabled }
-						onFocus={ onFocus }
-						onChange={ onInputChange }
-					/>
-				</div>
+			<div className="components-base-control__field">
+				<input
+					ref={ inputRef }
+					id={ `woocommerce-tree-select-control-${ instanceId }__control-input` }
+					type="search"
+					placeholder={ showPlaceholder ? placeholder : '' }
+					autoComplete="off"
+					className="woocommerce-tree-select-control__control-input"
+					role="combobox"
+					aria-autocomplete="list"
+					aria-expanded={ isExpanded }
+					disabled={ disabled }
+					onFocus={ onFocus }
+					onChange={ onInputChange }
+				/>
 			</div>
-		);
-	}
-);
+		</div>
+	);
+};
 
 export default Control;

--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -41,9 +41,9 @@ const Control = ( {
 	const inputRef = useRef();
 	return (
 		/**
-			 * ESLint Disable reason
-			 * https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/src/select-control/control.js#L200
-			 */
+		 * ESLint Disable reason
+		 * https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/src/select-control/control.js#L200
+		 */
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 		<div
 			className={ classnames(

--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -44,10 +44,10 @@ const Control = forwardRef(
 		const showPlaceholder = ! hasTags && ! isExpanded;
 
 		return (
-			/*
-		ESLint Disable reason
-		https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/src/select-control/control.js#L200
-		*/
+			/**
+			 * ESLint Disable reason
+			 * https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/src/select-control/control.js#L200
+			 */
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 			<div
 				className={ classnames(

--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useRef } from '@wordpress/element';
+import { forwardRef, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Tags from './tags';
-import { BACKSPACE } from '.~/components/tree-select-control/constants';
 
 /**
  * The Control Component renders a search input and also the Tags.
@@ -26,75 +25,71 @@ import { BACKSPACE } from '.~/components/tree-select-control/constants';
  * @param {Function} props.onInputChange Callback when the Input value changes
  * @return {JSX.Element} The rendered component
  */
-const Control = ( {
-	tags = [],
-	instanceId,
-	placeholder,
-	isExpanded,
-	disabled,
-	maxVisibleTags,
-	onFocus = () => {},
-	onTagsChange = () => {},
-	onInputChange = () => {},
-} ) => {
-	const inputRef = useRef();
-	const hasTags = tags.length > 0;
-	const showPlaceholder = ! hasTags && ! isExpanded;
+const Control = forwardRef(
+	(
+		{
+			tags = [],
+			instanceId,
+			placeholder,
+			isExpanded,
+			disabled,
+			maxVisibleTags,
+			onFocus = () => {},
+			onTagsChange = () => {},
+			onInputChange = () => {},
+		},
+		inputRef
+	) => {
+		const hasTags = tags.length > 0;
+		const showPlaceholder = ! hasTags && ! isExpanded;
 
-	const onKeyDown = ( event ) => {
-		if ( BACKSPACE === event.key && ! inputRef.current.value ) {
-			onTagsChange( tags.slice( 0, -1 ) );
-			event.preventDefault();
-		}
-	};
-
-	return (
-		/*
+		return (
+			/*
 		ESLint Disable reason
 		https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/src/select-control/control.js#L200
 		*/
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
-		<div
-			className={ classnames(
-				'components-base-control',
-				'woocommerce-tree-select-control__control',
-				{
-					'is-disabled': disabled,
-					'has-tags': hasTags,
-				}
-			) }
-			onClick={ () => {
-				inputRef.current.focus();
-			} }
-		>
-			{ hasTags && (
-				<Tags
-					disabled={ disabled }
-					tags={ tags }
-					maxVisibleTags={ maxVisibleTags }
-					onChange={ onTagsChange }
-				/>
-			) }
+			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+			<div
+				className={ classnames(
+					'components-base-control',
+					'woocommerce-tree-select-control__control',
+					{
+						'is-disabled': disabled,
+						'has-tags': hasTags,
+					}
+				) }
+				onClick={ () => {
+					inputRef.current.focus();
+				} }
+			>
+				{ hasTags && (
+					<Tags
+						disabled={ disabled }
+						tags={ tags }
+						maxVisibleTags={ maxVisibleTags }
+						onChange={ onTagsChange }
+					/>
+				) }
 
-			<div className="components-base-control__field">
-				<input
-					ref={ inputRef }
-					id={ `woocommerce-tree-select-control-${ instanceId }__control-input` }
-					type="search"
-					placeholder={ showPlaceholder ? placeholder : '' }
-					autoComplete="off"
-					className="woocommerce-tree-select-control__control-input"
-					role="combobox"
-					aria-autocomplete="list"
-					aria-expanded={ isExpanded }
-					disabled={ disabled }
-					onFocus={ onFocus }
-					onChange={ onInputChange }
-					onKeyDown={ onKeyDown }
-				/>
+				<div className="components-base-control__field">
+					<input
+						ref={ inputRef }
+						id={ `woocommerce-tree-select-control-${ instanceId }__control-input` }
+						type="search"
+						placeholder={ showPlaceholder ? placeholder : '' }
+						autoComplete="off"
+						className="woocommerce-tree-select-control__control-input"
+						role="combobox"
+						aria-autocomplete="list"
+						aria-expanded={ isExpanded }
+						disabled={ disabled }
+						onFocus={ onFocus }
+						onChange={ onInputChange }
+					/>
+				</div>
 			</div>
-		</div>
-	);
-};
+		);
+	}
+);
 
 export default Control;

--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -8,6 +8,7 @@ import { useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import Tags from './tags';
+import { BACKSPACE } from '.~/components/tree-select-control/constants';
 
 /**
  * The Control Component renders a search input and also the Tags.
@@ -39,6 +40,13 @@ const Control = ( {
 	const inputRef = useRef();
 	const hasTags = tags.length > 0;
 	const showPlaceholder = ! hasTags && ! isExpanded;
+
+	const onKeyDown = ( event ) => {
+		if ( BACKSPACE === event.key && ! inputRef.current.value ) {
+			onTagsChange( tags.slice( 0, -1 ) );
+			event.preventDefault();
+		}
+	};
 
 	return (
 		/*
@@ -82,6 +90,7 @@ const Control = ( {
 					disabled={ disabled }
 					onFocus={ onFocus }
 					onChange={ onInputChange }
+					onKeyDown={ onKeyDown }
 				/>
 			</div>
 		</div>

--- a/js/src/components/tree-select-control/control.test.js
+++ b/js/src/components/tree-select-control/control.test.js
@@ -3,6 +3,7 @@
  */
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ describe( 'TreeSelectControl - Control Component', () => {
 	it( 'Renders the tags and calls onTagsChange when they change', () => {
 		const { queryByText, queryByLabelText, rerender } = render(
 			<Control
+				ref={ createRef() }
 				tags={ [ { id: 'es', label: 'Spain' } ] }
 				onTagsChange={ onTagsChange }
 			/>
@@ -27,6 +29,7 @@ describe( 'TreeSelectControl - Control Component', () => {
 
 		rerender(
 			<Control
+				ref={ createRef() }
 				tags={ [ { id: 'es', label: 'Spain' } ] }
 				disabled={ true }
 				onTagsChange={ onTagsChange }
@@ -39,7 +42,7 @@ describe( 'TreeSelectControl - Control Component', () => {
 	} );
 
 	it( 'Renders the input', () => {
-		const { queryByRole } = render( <Control /> );
+		const { queryByRole } = render( <Control ref={ createRef() } /> );
 
 		const input = queryByRole( 'combobox' );
 		expect( input ).toBeTruthy();
@@ -49,7 +52,9 @@ describe( 'TreeSelectControl - Control Component', () => {
 	} );
 
 	it( 'Allows disabled input', () => {
-		const { queryByRole } = render( <Control disabled={ true } /> );
+		const { queryByRole } = render(
+			<Control ref={ createRef() } disabled={ true } />
+		);
 
 		const input = queryByRole( 'combobox' );
 		expect( input ).toBeTruthy();
@@ -60,19 +65,24 @@ describe( 'TreeSelectControl - Control Component', () => {
 
 	it( 'Calls onFocus callback when it is focused', () => {
 		const onFocus = jest.fn().mockName( 'onFocus' );
-		const { queryByRole } = render( <Control onFocus={ onFocus } /> );
+		const { queryByRole } = render(
+			<Control ref={ createRef() } onFocus={ onFocus } />
+		);
 		userEvent.click( queryByRole( 'combobox' ) );
 		expect( onFocus ).toHaveBeenCalled();
 	} );
 
 	it( 'Renders placeholder when there are no tags and is not expanded', () => {
-		const { rerender } = render( <Control placeholder="Select" /> );
+		const { rerender } = render(
+			<Control ref={ createRef() } placeholder="Select" />
+		);
 		let input = screen.queryByRole( 'combobox' );
 		let placeholder = input.getAttribute( 'placeholder' );
 		expect( placeholder ).toBe( 'Select' );
 
 		rerender(
 			<Control
+				ref={ createRef() }
 				placeholder="Select"
 				tags={ [ { id: 'es', label: 'Spain' } ] }
 			/>
@@ -82,7 +92,13 @@ describe( 'TreeSelectControl - Control Component', () => {
 		placeholder = input.getAttribute( 'placeholder' );
 		expect( placeholder ).toBeFalsy();
 
-		rerender( <Control placeholder="Select" isExpanded={ true } /> );
+		rerender(
+			<Control
+				ref={ createRef() }
+				placeholder="Select"
+				isExpanded={ true }
+			/>
+		);
 		input = screen.queryByRole( 'combobox' );
 		placeholder = input.getAttribute( 'placeholder' );
 		expect( placeholder ).toBeFalsy();

--- a/js/src/components/tree-select-control/control.test.js
+++ b/js/src/components/tree-select-control/control.test.js
@@ -3,7 +3,6 @@
  */
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,7 +15,6 @@ describe( 'TreeSelectControl - Control Component', () => {
 	it( 'Renders the tags and calls onTagsChange when they change', () => {
 		const { queryByText, queryByLabelText, rerender } = render(
 			<Control
-				ref={ createRef() }
 				tags={ [ { id: 'es', label: 'Spain' } ] }
 				onTagsChange={ onTagsChange }
 			/>
@@ -29,7 +27,6 @@ describe( 'TreeSelectControl - Control Component', () => {
 
 		rerender(
 			<Control
-				ref={ createRef() }
 				tags={ [ { id: 'es', label: 'Spain' } ] }
 				disabled={ true }
 				onTagsChange={ onTagsChange }
@@ -42,7 +39,7 @@ describe( 'TreeSelectControl - Control Component', () => {
 	} );
 
 	it( 'Renders the input', () => {
-		const { queryByRole } = render( <Control ref={ createRef() } /> );
+		const { queryByRole } = render( <Control /> );
 
 		const input = queryByRole( 'combobox' );
 		expect( input ).toBeTruthy();
@@ -52,9 +49,7 @@ describe( 'TreeSelectControl - Control Component', () => {
 	} );
 
 	it( 'Allows disabled input', () => {
-		const { queryByRole } = render(
-			<Control ref={ createRef() } disabled={ true } />
-		);
+		const { queryByRole } = render( <Control disabled={ true } /> );
 
 		const input = queryByRole( 'combobox' );
 		expect( input ).toBeTruthy();
@@ -65,24 +60,19 @@ describe( 'TreeSelectControl - Control Component', () => {
 
 	it( 'Calls onFocus callback when it is focused', () => {
 		const onFocus = jest.fn().mockName( 'onFocus' );
-		const { queryByRole } = render(
-			<Control ref={ createRef() } onFocus={ onFocus } />
-		);
+		const { queryByRole } = render( <Control onFocus={ onFocus } /> );
 		userEvent.click( queryByRole( 'combobox' ) );
 		expect( onFocus ).toHaveBeenCalled();
 	} );
 
 	it( 'Renders placeholder when there are no tags and is not expanded', () => {
-		const { rerender } = render(
-			<Control ref={ createRef() } placeholder="Select" />
-		);
+		const { rerender } = render( <Control placeholder="Select" /> );
 		let input = screen.queryByRole( 'combobox' );
 		let placeholder = input.getAttribute( 'placeholder' );
 		expect( placeholder ).toBe( 'Select' );
 
 		rerender(
 			<Control
-				ref={ createRef() }
 				placeholder="Select"
 				tags={ [ { id: 'es', label: 'Spain' } ] }
 			/>
@@ -92,13 +82,7 @@ describe( 'TreeSelectControl - Control Component', () => {
 		placeholder = input.getAttribute( 'placeholder' );
 		expect( placeholder ).toBeFalsy();
 
-		rerender(
-			<Control
-				ref={ createRef() }
-				placeholder="Select"
-				isExpanded={ true }
-			/>
-		);
+		rerender( <Control placeholder="Select" isExpanded={ true } /> );
 		input = screen.queryByRole( 'combobox' );
 		placeholder = input.getAttribute( 'placeholder' );
 		expect( placeholder ).toBeFalsy();

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -90,9 +90,8 @@ const TreeSelectControl = ( {
 
 	const [ treeVisible, setTreeVisible ] = useState( false );
 	const [ nodesExpanded, setNodesExpanded ] = useState( [] );
-	const [ filter, setFilter ] = useState( '' );
+	const [ inputControlValue, setInputControlValue ] = useState( '' );
 	const [ filteredOptions, setFilteredOptions ] = useState( [] );
-	const inputRef = useRef();
 
 	// We will save in a REF previous search filter queries to avoid re-query the tree and save performance
 	const filteredOptionsCache = useRef( {} );
@@ -112,6 +111,10 @@ const TreeSelectControl = ( {
 	const focusOutside = useFocusOutside( () => {
 		setTreeVisible( false );
 	} );
+
+	const hasChildren = ( option ) => option.children?.length;
+	const filterQuery = inputControlValue.trim().toLowerCase();
+	const filter = filterQuery.length >= 3 ? filterQuery : '';
 
 	/**
 	 * Perform the search query filter in the Tree options
@@ -169,7 +172,7 @@ const TreeSelectControl = ( {
 	}, [ treeOptions, filter ] );
 
 	const onKeyDown = ( event ) => {
-		if ( inputRef.current.value ) return;
+		if ( inputControlValue ) return;
 
 		if ( BACKSPACE === event.key ) {
 			onChange( value.slice( 0, -1 ) );
@@ -181,8 +184,6 @@ const TreeSelectControl = ( {
 			event.preventDefault();
 		}
 	};
-
-	const hasChildren = ( option ) => option.children?.length;
 
 	/**
 	 * Optimizes the performance for getting the tags info
@@ -310,8 +311,7 @@ const TreeSelectControl = ( {
 	 * @param {Event} e Event returned by the On Change function in the Input control
 	 */
 	const handleOnInputChange = ( e ) => {
-		const search = e.target.value.trim().toLowerCase();
-		setFilter( search.length >= 3 ? search : '' );
+		setInputControlValue( e.target.value );
 	};
 
 	return (
@@ -337,7 +337,6 @@ const TreeSelectControl = ( {
 			) }
 
 			<Control
-				ref={ inputRef }
 				disabled={ disabled }
 				tags={ getTags() }
 				isExpanded={ treeVisible }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -315,6 +315,7 @@ const TreeSelectControl = ( {
 	};
 
 	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
 			{ ...focusOutside }
 			onKeyDown={ onKeyDown }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -18,7 +18,11 @@ import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
 import Control from './control';
 import Options from './options';
 import './index.scss';
-import { ROOT_VALUE } from '.~/components/tree-select-control/constants';
+import {
+	BACKSPACE,
+	ESCAPE,
+	ROOT_VALUE,
+} from '.~/components/tree-select-control/constants';
 
 /**
  * The Option type Object. This is how we send the options to the selector.
@@ -88,6 +92,7 @@ const TreeSelectControl = ( {
 	const [ nodesExpanded, setNodesExpanded ] = useState( [] );
 	const [ filter, setFilter ] = useState( '' );
 	const [ filteredOptions, setFilteredOptions ] = useState( [] );
+	const inputRef = useRef();
 
 	// We will save in a REF previous search filter queries to avoid re-query the tree and save performance
 	const filteredOptionsCache = useRef( {} );
@@ -162,6 +167,20 @@ const TreeSelectControl = ( {
 		filteredOptionsCache.current[ filter ] = filteredTreeOptions;
 		setFilteredOptions( filteredTreeOptions );
 	}, [ treeOptions, filter ] );
+
+	const onKeyDown = ( event ) => {
+		if ( inputRef.current.value ) return;
+
+		if ( BACKSPACE === event.key ) {
+			onChange( value.slice( 0, -1 ) );
+			event.preventDefault();
+		}
+
+		if ( ESCAPE === event.key ) {
+			setTreeVisible( false );
+			event.preventDefault();
+		}
+	};
 
 	const hasChildren = ( option ) => option.children?.length;
 
@@ -298,6 +317,10 @@ const TreeSelectControl = ( {
 	return (
 		<div
 			{ ...focusOutside }
+			onKeyDown={ onKeyDown }
+			onClick={ () => {
+				setTreeVisible( true );
+			} }
 			className={ classnames(
 				'woocommerce-tree-select-control',
 				className
@@ -313,6 +336,7 @@ const TreeSelectControl = ( {
 			) }
 
 			<Control
+				ref={ inputRef }
 				disabled={ disabled }
 				tags={ getTags() }
 				isExpanded={ treeVisible }

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -108,13 +108,14 @@ const Options = ( {
 				<Flex justify="flex-start">
 					{ ! isRoot && (
 						<button
-							onClick={ () => {
-								toggleExpanded( option );
-							} }
 							className={ classnames(
 								'woocommerce-tree-select-control__expander',
 								! hasChildren && 'is-hidden'
 							) }
+							tabIndex="-1"
+							onClick={ () => {
+								toggleExpanded( option );
+							} }
 						>
 							<Icon
 								icon={ isExpanded ? chevronUp : chevronDown }
@@ -129,6 +130,7 @@ const Options = ( {
 								hasSomeChildrenChecked( option ) &&
 								'is-partially-checked'
 						) }
+						tabIndex="-1"
 						value={ option.value }
 						label={ option.label }
 						checked={ optionIsChecked }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements the next accessibility features:

- ESC to close the Tree
- TAB to go to the next Component 
- BACKSPACE to remove tags (if no search text is present) 

### Screenshots:

https://user-images.githubusercontent.com/5908855/158558092-df710b46-5a85-465f-a39d-7205e3ff14f6.mov

### Detailed test instructions:

1. Checkout this branch
2. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcomponent-test`
3. Enter in the Selector and see how it expands
4. Press Tab and see how it goes to the next selector
5. Go back to the selector and see how it opens again
6. Press Escape and see how the tree collapses
7. Type some text. 
8. Press Backspace and see how the text is deleted
9. When there is no text, press again Backspace and see how it removes the last tag
