### PR TITLE
Update delete campaigns API to remove its campaign criteria

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -303,6 +303,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 
 			// Budget must be removed after the campaign.
 			$operations = array_merge(
+				$this->criterion->delete_operations( $campaign_resource_name ),
 				$this->container->get( AdsGroup::class )->delete_operations( $campaign_resource_name ),
 				[ $this->delete_operation( $campaign_resource_name ) ],
 				[ $this->budget->delete_operation( $campaign_id ) ]
@@ -447,7 +448,6 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			->where( 'campaign.id', array_keys( $campaigns ), 'IN' )
 			// negative: Whether to target (false) or exclude (true) the criterion.
 			->where( 'campaign_criterion.negative', 'false', '=' )
-			->where( 'campaign_criterion.status', 'REMOVED', '!=' )
 			->where( 'campaign_criterion.location.geo_target_constant', '', 'IS NOT NULL' )
 			->get_results();
 

--- a/src/API/Google/AdsCampaignCriterion.php
+++ b/src/API/Google/AdsCampaignCriterion.php
@@ -67,7 +67,6 @@ class AdsCampaignCriterion implements OptionsAwareInterface {
 		$results = ( new AdsCampaignCriterionQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
 			->where( 'campaign_criterion.campaign', $campaign_resource_name )
-			->where( 'campaign_criterion.negative', 'false', '=' )
 			->where( 'campaign_criterion.status', 'REMOVED', '!=' )
 			->where( 'campaign_criterion.location.geo_target_constant', '', 'IS NOT NULL' )
 			->get_results();

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -75,6 +75,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		Ads::class                    => true,
 		AdsCampaign::class            => true,
 		AdsCampaignBudget::class      => true,
+		AdsCampaignCriterion::class   => true,
 		AdsConversionAction::class    => true,
 		AdsGroup::class               => true,
 		AdsReport::class              => true,
@@ -104,7 +105,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( Ads::class, GoogleAdsClient::class );
 		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class, AdsCampaignCriterion::class, GoogleHelper::class );
 		$this->share( AdsCampaignBudget::class, GoogleAdsClient::class );
-		$this->share( AdsCampaignCriterion::class );
+		$this->share( AdsCampaignCriterion::class, GoogleAdsClient::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsGroup::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -154,6 +154,27 @@ trait GoogleAdsClientTrait {
 	}
 
 	/**
+	 * Generates a mocked AdsCampaignCriterionQuery response.
+	 *
+	 * @param string $campaign_criterion_resource_name
+	 */
+	protected function generate_campaign_criterion_query_mock( string $campaign_criterion_resource_name ) {
+		$campaign_criterion = $this->createMock( CampaignCriterion::class );
+		$campaign_criterion->method( 'getResourceName' )->willReturn( $campaign_criterion_resource_name );
+
+		$list_response = $this->createMock( PagedListResponse::class );
+		$list_response->expects( $this->once() )
+			->method( 'iterateAllElements' )
+			->willReturn(
+				[
+					( new GoogleAdsRow )->setCampaignCriterion( $campaign_criterion ),
+				]
+			);
+
+		$this->service_client->method( 'search' )->willReturn( $list_response );
+	}
+
+	/**
 	 * Generates a mocked AdsGroupQuery response.
 	 *
 	 * @param string $ad_group_resource_name
@@ -285,5 +306,15 @@ trait GoogleAdsClientTrait {
 	 */
 	protected function generate_listing_group_resource_name( int $ad_group_id, int $listing_group_id ) {
 		return ResourceNames::forAdGroupCriterion( $this->ads_id, $ad_group_id, $listing_group_id );
+	}
+
+	/**
+	 * Generates a campaign criterion resource name.
+	 *
+	 * @param int $campaign_id
+	 * @param int $campaign_critreion_id
+	 */
+	protected function generate_campaign_criterion_resource_name( int $campaign_id, int $campaign_criterion_id ) {
+		return ResourceNames::forCampaignCriterion( $this->ads_id, $campaign_id, $campaign_criterion_id );
 	}
 }

--- a/tests/Unit/API/Google/AdsCampaignCriterionTest.php
+++ b/tests/Unit/API/Google/AdsCampaignCriterionTest.php
@@ -4,9 +4,11 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignCriterion;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
 use Google\Ads\GoogleAds\V9\Enums\CampaignCriterionStatusEnum\CampaignCriterionStatus;
+use PHPUnit\Framework\MockObject\MockObject;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -15,13 +17,15 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
  *
- * @property AdsCampaignCriterion $campaign_criterion
+ * @property MockObject|OptionsInterface $options
+ * @property AdsCampaignCriterion        $campaign_criterion
  */
 class AdsCampaignCriterionTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
 
 	protected const TEST_CAMPAIGN_ID = 1234567890;
+	protected const TEST_CAMPAIGN_CRITERION_ID = 9876543210;
 
 	/**
 	 * Runs before each test is executed.
@@ -31,7 +35,11 @@ class AdsCampaignCriterionTest extends UnitTest {
 
 		$this->ads_client_setup();
 
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+
 		$this->campaign_criterion = new AdsCampaignCriterion( $this->client );
+		$this->campaign_criterion->set_options_object( $this->options );
 	}
 
 	public function test_create_operations() {
@@ -57,5 +65,21 @@ class AdsCampaignCriterionTest extends UnitTest {
 			$expected_location_id = $location_ids[ $index ];
 			$this->assertEquals( "geoTargetConstants/{$expected_location_id}", $geo_target_constant );
 		}
+	}
+
+	public function test_delete_operations() {
+		$campaign_resource_name           = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
+		$campaign_criterion_resource_name = $this->generate_campaign_criterion_resource_name( self::TEST_CAMPAIGN_ID, self::TEST_CAMPAIGN_CRITERION_ID );
+
+		$this->generate_campaign_criterion_query_mock( $campaign_criterion_resource_name );
+
+		$operations = $this->campaign_criterion->delete_operations( $campaign_resource_name );
+
+		$operation_campaign_criterion = $operations[0]->getCampaignCriterionOperation();
+		$this->assertTrue( $operation_campaign_criterion->hasRemove() );
+		$this->assertEquals(
+			$campaign_criterion_resource_name,
+			$operation_campaign_criterion->getRemove()
+		);
 	}
 }

--- a/tests/Unit/API/Google/AdsCampaignCriterionTest.php
+++ b/tests/Unit/API/Google/AdsCampaignCriterionTest.php
@@ -31,7 +31,7 @@ class AdsCampaignCriterionTest extends UnitTest {
 
 		$this->ads_client_setup();
 
-		$this->campaign_criterion = new AdsCampaignCriterion();
+		$this->campaign_criterion = new AdsCampaignCriterion( $this->client );
 	}
 
 	public function test_create_operations() {

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -51,7 +51,7 @@ class AdsCampaignTest extends UnitTest {
 
 		$this->ad_group  = $this->createMock( AdsGroup::class );
 		$this->budget    = $this->createMock( AdsCampaignBudget::class );
-		$this->criterion = new AdsCampaignCriterion();
+		$this->criterion = $this->createMock( AdsCampaignCriterion::class );
 		$this->options   = $this->createMock( OptionsInterface::class );
 
 		$this->wc            = $this->createMock( WC::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #1248, this PR updates the `DELETE ads/campaigns/:campaign-id` API so it will remove the campaign's criterion as well.

Unlike campaign budget, the removed locations do not exist anymore, even though I used the same `setRemove` operation method. From the Google Ads dashboard, the removed campaign's location is empty either, so I assume this is an expected behaviour.

### Screenshots:

#### 1. Create a campaign with targeted locations

<img width="1282" alt="delete-criterion-1-create" src="https://user-images.githubusercontent.com/914406/158798100-be5d3be3-81f0-4fc3-a37f-0223949e6a4f.png">

#### 2. Get the newly created campaign

The status should be `enabled`.

<img width="1238" alt="delete-criterion-1-get-1" src="https://user-images.githubusercontent.com/914406/158798129-2efce21b-5781-4b99-a98e-ec81c5d4a0c3.png">

#### 3. Delete the campaign

<img width="1244" alt="delete-criterion-1-delete" src="https://user-images.githubusercontent.com/914406/158798154-9659975f-1366-45bf-9bd0-8cfa9a500d25.png">

#### 4. Delete again

The API should respond the error.

<img width="1240" alt="delete-criterion-1-delete-2" src="https://user-images.githubusercontent.com/914406/158798194-ea2d82c5-ea66-43d9-a2d2-e67a3a007dd5.png">

#### 5. Get the same campaign again

The status should be `removed`.

<img width="1248" alt="delete-criterion-1-get-2" src="https://user-images.githubusercontent.com/914406/158798225-5ec22ced-37c9-498b-a4b9-b970cb9f30c6.png">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a campaign by requesting to `POST ads/campaigns` using Postman like the screenshots in the `Screenshots` section. Remember to add your `wp-cookie` and `x-wp-nonce` in the request headers. 
    - To get the value of `wp-cookie` and `x-wp-nonce`, go to `Marketing -> Google Listings & Ads`, open Chrome dev tool's Network tab, clicks any requests to WP, e.g. `wc/gla/ads/campaigns`, you can get those values in the request headers.
2. Get the newly created campaign by requesting to `GET ads/campaigns/:campaign-id`, the campaign's status should be `enabled`.
3. Delete the campaign by requesting `DELETE ads/campaigns/:campaign-id`, the API call should be successful.
4. Delete the campaign again, the API should respond an error: `This campaign has already been deleted`.
5. Get the campaign again by requesting to `GET ads/campaigns/:campaign-id`, the campaign's status should be `removed`.
6. Go to Google Ads dashboard and check the campaign is removed and the locations are empty.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Extend delete campaign API to delete its campaign criteria
