### PR TITLE
Get suggested shipping rates for provinces/states and postal codes from WC zones

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -91,7 +91,7 @@ class Settings {
 			if ( isset( $options['free_shipping_threshold'] ) ) {
 				$minimum_order_value = (float) $options['free_shipping_threshold'];
 
-				if ( 0 !== $rate ) {
+				if ( $rate > 0 ) {
 					// Add a conditional free-shipping service if the current rate is not free.
 					$services[] = $this->create_conditional_free_shipping_service( $country, $currency, $minimum_order_value );
 				} else {

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateSuggestionsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateSuggestionsController.php
@@ -109,7 +109,7 @@ class ShippingRateSuggestionsController extends BaseController implements ISO316
 
 						// Set the rate to 0 if it is not set.
 						if ( ! isset( $item['rate'] ) ) {
-							$item['rate'] = 0;
+							$item['rate'] = 0.0;
 						}
 
 						$response = $this->prepare_item_for_response( $item, $request );

--- a/src/API/Site/Controllers/ShippingRateSchemaTrait.php
+++ b/src/API/Site/Controllers/ShippingRateSchemaTrait.php
@@ -3,7 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRateFlat;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRateFree;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -41,7 +42,8 @@ trait ShippingRateSchemaTrait {
 				'type'              => 'string',
 				'description'       => __( 'The shipping method.', 'google-listings-and-ads' ),
 				'enum'              => [
-					ShippingZone::METHOD_FLAT_RATE,
+					ShippingRateFlat::get_method(),
+					ShippingRateFree::get_method(),
 				],
 				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',

--- a/src/Google/GoogleHelper.php
+++ b/src/Google/GoogleHelper.php
@@ -1328,6 +1328,17 @@ class GoogleHelper implements Service {
 	}
 
 	/**
+	 * Check whether the given country code supports regional shipping (i.e. setting up rates for states/provinces and postal codes).
+	 *
+	 * @param string $country_code
+	 *
+	 * @return bool
+	 */
+	public function does_country_support_regional_shipping( string $country_code ): bool {
+		return in_array( $country_code, [ 'AU', 'JP', 'US' ], true );
+	}
+
+	/**
 	 * Returns an array mapping the ID of the Merchant Center supported countries to their respective codes.
 	 *
 	 * @return string[] Array of country codes with location IDs as keys. e.g. [ 2840 => 'US' ]

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -87,7 +87,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\GoogleGtagJs;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks as TracksProxy;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRatesProcessor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneMethodsParser;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneLocationsParser;
 use Automattic\WooCommerce\GoogleListingsAndAds\TaskList\CompleteSetup;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\ActivatedEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteClaimEvents;
@@ -177,6 +180,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		AttributesTab::class          => true,
 		VariationsAttributes::class   => true,
 		DeprecatedFilters::class      => true,
+		ZoneLocationsParser::class    => true,
+		ZoneMethodsParser::class      => true,
+		LocationRatesProcessor::class => true,
 		ShippingZone::class           => true,
 		AdsAccountService::class      => true,
 		MerchantAccountService::class => true,
@@ -359,6 +365,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		$this->share_with_tags( DeprecatedFilters::class );
 
-		$this->share_with_tags( ShippingZone::class, WC::class, GoogleHelper::class );
+		$this->share_with_tags( LocationRatesProcessor::class );
+		$this->share_with_tags( ZoneLocationsParser::class, WC::class, GoogleHelper::class );
+		$this->share_with_tags( ZoneMethodsParser::class, WC::class );
+		$this->share_with_tags( ShippingZone::class, WC::class, ZoneLocationsParser::class, ZoneMethodsParser::class, LocationRatesProcessor::class );
 	}
 }

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -101,7 +101,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share_with_container( MerchantCenterReportsController::class );
 		$this->share( ShippingRateBatchController::class, ShippingRateQuery::class );
 		$this->share( ShippingRateController::class, ShippingRateQuery::class );
-		$this->share( ShippingRateSuggestionsController::class, ShippingZone::class );
+		$this->share( ShippingRateSuggestionsController::class, ShippingZone::class, WC::class );
 		$this->share_with_container( ShippingTimeBatchController::class );
 		$this->share_with_container( ShippingTimeController::class );
 		$this->share( SiteVerificationController::class, SiteVerification::class );

--- a/src/Shipping/Location.php
+++ b/src/Shipping/Location.php
@@ -1,0 +1,120 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Location
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+class Location {
+
+	/**
+	 * @var string
+	 */
+	protected $country;
+
+	/**
+	 * @var string
+	 */
+	protected $state;
+
+	/**
+	 * @var string[]
+	 */
+	protected $postcodes;
+
+	/**
+	 * Location constructor.
+	 *
+	 * @param string        $country
+	 * @param string|null   $state
+	 * @param string[]|null $postcodes
+	 */
+	public function __construct( string $country, ?string $state = null, ?array $postcodes = null ) {
+		$this->country   = $country;
+		$this->state     = $state;
+		$this->postcodes = $postcodes;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function get_country(): string {
+		return $this->country;
+	}
+
+	/**
+	 * @param string $country
+	 *
+	 * @return Location
+	 */
+	public function set_country( string $country ): Location {
+		$this->country = $country;
+
+		return $this;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function get_state(): ?string {
+		return $this->state;
+	}
+
+	/**
+	 * @param string|null $state
+	 *
+	 * @return Location
+	 */
+	public function set_state( ?string $state ): Location {
+		$this->state = $state;
+
+		return $this;
+	}
+
+	/**
+	 * @return string[]|null
+	 */
+	public function get_postcodes(): ?array {
+		return $this->postcodes;
+	}
+
+	/**
+	 * @param string[]|null $postcodes
+	 *
+	 * @return Location
+	 */
+	public function set_postcodes( ?array $postcodes ): Location {
+		$this->postcodes = $postcodes;
+
+		return $this;
+	}
+
+	/**
+	 * Returns the string representation of this Location.
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		$code = $this->get_country();
+		if ( ! empty( $this->get_state() ) ) {
+			$code .= '_' . $this->get_state();
+		}
+
+		return join(
+			'::',
+			[
+				$code,
+				! empty( $this->get_postcodes() ) ? join( ',', $this->get_postcodes() ) : '',
+			]
+		);
+	}
+
+}

--- a/src/Shipping/LocationRate.php
+++ b/src/Shipping/LocationRate.php
@@ -1,0 +1,89 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+use JsonSerializable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class LocationRate
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+class LocationRate implements JsonSerializable {
+
+	/**
+	 * @var Location
+	 */
+	protected $location;
+
+	/**
+	 * @var ShippingRate
+	 */
+	protected $shipping_rate;
+
+	/**
+	 * LocationRate constructor.
+	 *
+	 * @param Location     $location
+	 * @param ShippingRate $shipping_rate
+	 */
+	public function __construct( Location $location, ShippingRate $shipping_rate ) {
+		$this->location      = $location;
+		$this->shipping_rate = $shipping_rate;
+	}
+
+	/**
+	 * @return Location
+	 */
+	public function get_location(): Location {
+		return $this->location;
+	}
+
+	/**
+	 * @param Location $location
+	 *
+	 * @return LocationRate
+	 */
+	public function set_location( Location $location ): LocationRate {
+		$this->location = $location;
+
+		return $this;
+	}
+
+	/**
+	 * @return ShippingRate
+	 */
+	public function get_shipping_rate(): ShippingRate {
+		return $this->shipping_rate;
+	}
+
+	/**
+	 * @param ShippingRate $shipping_rate
+	 *
+	 * @return LocationRate
+	 */
+	public function set_shipping_rate( ShippingRate $shipping_rate ): LocationRate {
+		$this->shipping_rate = $shipping_rate;
+
+		return $this;
+	}
+
+	/**
+	 * Specify data which should be serialized to JSON
+	 */
+	public function jsonSerialize() {
+		$rate_serialized = $this->shipping_rate->jsonSerialize();
+
+		return array_merge(
+			$rate_serialized,
+			[
+				'country' => $this->location->get_country(),
+			]
+		);
+	}
+}

--- a/src/Shipping/LocationRatesProcessor.php
+++ b/src/Shipping/LocationRatesProcessor.php
@@ -1,0 +1,76 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class LocationRatesProcessor
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+class LocationRatesProcessor {
+
+	/**
+	 * Process the shipping rates data for output.
+	 *
+	 * @param LocationRate[] $location_rates Array of shipping rates belonging to a specific location.
+	 *
+	 * @return LocationRate[] Array of processed location rates.
+	 */
+	public function process( array $location_rates ): array {
+		/** @var LocationRate[] $grouped_rates */
+		$grouped_rates = [];
+
+		// Group the rates by shipping method.
+		foreach ( $location_rates as $location_rate ) {
+			$shipping_rate = $location_rate->get_shipping_rate();
+
+			$method = $shipping_rate::get_method();
+			if ( ! isset( $grouped_rates[ $method ] ) || $this->should_rate_be_replaced( $shipping_rate, $grouped_rates[ $method ]->get_shipping_rate() ) ) {
+				$grouped_rates[ $method ] = $location_rate;
+			}
+		}
+
+		// If there is an unconditional free shipping rate available, ignore all other shipping rates and return only the free rate.
+		if ( isset( $grouped_rates[ ShippingRateFree::get_method() ] ) ) {
+			$free_shipping = $grouped_rates[ ShippingRateFree::get_method() ];
+			if ( null === $free_shipping->get_shipping_rate()->get_threshold() ) {
+				return [ $free_shipping ];
+			}
+		}
+
+		return array_values( $grouped_rates );
+	}
+
+
+	/**
+	 * Checks whether the existing shipping rate should be replaced with a more suitable one. Used when grouping the rates.
+	 *
+	 * @param ShippingRate $new_rate
+	 * @param ShippingRate $existing_rate
+	 *
+	 * @return bool
+	 */
+	protected function should_rate_be_replaced( ShippingRate $new_rate, ShippingRate $existing_rate ): bool {
+		$replace = false;
+
+		if ( $new_rate instanceof ShippingRateFlat &&
+			 $existing_rate instanceof ShippingRateFlat &&
+			 $new_rate->get_rate() > $existing_rate->get_rate()
+		) {
+			$replace = true;
+		} elseif ( $new_rate instanceof ShippingRateFree &&
+				   $existing_rate instanceof ShippingRateFree &&
+				   (float) $new_rate->get_threshold() > (float) $existing_rate->get_threshold()
+		) {
+			$replace = true;
+		}
+
+		return $replace;
+	}
+
+}

--- a/src/Shipping/ShippingRate.php
+++ b/src/Shipping/ShippingRate.php
@@ -1,0 +1,35 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+use JsonSerializable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ShippingRate
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+abstract class ShippingRate implements JsonSerializable {
+
+	/**
+	 * Specify data which should be serialized to JSON
+	 */
+	public function jsonSerialize() {
+		return [
+			'method' => static::get_method(),
+		];
+	}
+
+	/**
+	 * @return string
+	 *
+	 * @since x.x.x
+	 */
+	abstract public static function get_method(): string;
+
+}

--- a/src/Shipping/ShippingRateFlat.php
+++ b/src/Shipping/ShippingRateFlat.php
@@ -1,0 +1,97 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ShippingRateFlat
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+class ShippingRateFlat extends ShippingRate {
+
+	/**
+	 * @var float
+	 */
+	protected $rate;
+
+	/**
+	 * @var array
+	 */
+	protected $shipping_class_rates;
+
+	/**
+	 * ShippingRateFlat constructor.
+	 *
+	 * @param float $rate                 The shipping cost in WooCommerce store currency.
+	 * @param array $shipping_class_rates A multidimensional array of shipping class rates. {
+	 *     Array of shipping method arguments.
+	 *
+	 *     @type string $class The shipping class slug/id.
+	 *     @type float  $rate  The cost of the shipping method for the class in WooCommerce store currency.
+	 * }
+	 */
+	public function __construct( float $rate, array $shipping_class_rates = [] ) {
+		$this->rate                 = $rate;
+		$this->shipping_class_rates = $shipping_class_rates;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function get_rate(): float {
+		return $this->rate;
+	}
+
+	/**
+	 * @param float $rate
+	 *
+	 * @return ShippingRateFlat
+	 */
+	public function set_rate( float $rate ): ShippingRateFlat {
+		$this->rate = $rate;
+
+		return $this;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_shipping_class_rates(): array {
+		return $this->shipping_class_rates;
+	}
+
+	/**
+	 * @param array $shipping_class_rates
+	 *
+	 * @return ShippingRateFlat
+	 */
+	public function set_shipping_class_rates( array $shipping_class_rates ): ShippingRateFlat {
+		$this->shipping_class_rates = $shipping_class_rates;
+
+		return $this;
+	}
+
+	/**
+	 * Specify data which should be serialized to JSON
+	 */
+	public function jsonSerialize() {
+		$data = parent::jsonSerialize();
+
+		$data['rate'] = $this->rate;
+
+		return $data;
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function get_method(): string {
+		return 'flat_rate';
+	}
+
+}

--- a/src/Shipping/ShippingRateFree.php
+++ b/src/Shipping/ShippingRateFree.php
@@ -1,0 +1,69 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ShippingRateFree
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+class ShippingRateFree extends ShippingRate {
+
+	/**
+	 * @var float|null
+	 */
+	protected $threshold;
+
+	/**
+	 * ShippingRateFree constructor.
+	 *
+	 * @param float|null $threshold The minimum order amount to qualify for this shipping rate.
+	 */
+	public function __construct( ?float $threshold = null ) {
+		$this->threshold = $threshold;
+	}
+
+	/**
+	 * @return float|null
+	 */
+	public function get_threshold(): ?float {
+		return $this->threshold;
+	}
+
+	/**
+	 * @param float|null $threshold
+	 *
+	 * @return ShippingRateFree
+	 */
+	public function set_threshold( ?float $threshold ): ShippingRateFree {
+		$this->threshold = $threshold;
+
+		return $this;
+	}
+
+	/**
+	 * Specify data which should be serialized to JSON
+	 */
+	public function jsonSerialize() {
+		$data = parent::jsonSerialize();
+
+		if ( ! empty( $this->get_threshold() ) ) {
+			$data['options']['free_shipping_threshold'] = $this->get_threshold();
+		}
+
+		return $data;
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function get_method(): string {
+		return 'free_shipping';
+	}
+
+}

--- a/src/Shipping/ShippingZone.php
+++ b/src/Shipping/ShippingZone.php
@@ -87,13 +87,12 @@ class ShippingZone implements Service {
 	public function get_shipping_rates_for_country( string $country_code ): array {
 		$this->parse_shipping_zones();
 
-		$location_rates = $this->location_rates[ $country_code ];
-		if ( empty( $location_rates ) ) {
+		if ( empty( $this->location_rates[ $country_code ] ) ) {
 			return [];
 		}
 
 		// Process the rates for each country subdivision separately.
-		$location_rates = array_map( [ $this->rates_processor, 'process' ], $location_rates );
+		$location_rates = array_map( [ $this->rates_processor, 'process' ], $this->location_rates[ $country_code ] );
 
 		// Convert the string array keys to integers.
 		$country_rates = array_values( $location_rates );
@@ -117,13 +116,12 @@ class ShippingZone implements Service {
 	public function get_shipping_rates_grouped_by_country( string $country_code ): array {
 		$this->parse_shipping_zones();
 
-		$location_rates = $this->location_rates[ $country_code ];
-		if ( empty( $location_rates ) ) {
+		if ( empty( $this->location_rates[ $country_code ] ) ) {
 			return [];
 		}
 
 		// Convert the string array keys to integers.
-		$country_rates = array_values( $location_rates );
+		$country_rates = array_values( $this->location_rates[ $country_code ] );
 
 		// Flatten and merge the country shipping rates.
 		$country_rates = array_merge( [], ...$country_rates );

--- a/src/Shipping/ShippingZone.php
+++ b/src/Shipping/ShippingZone.php
@@ -3,11 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
-use WC_Shipping_Method;
-use WC_Shipping_Zone;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,33 +17,49 @@ defined( 'ABSPATH' ) || exit;
  */
 class ShippingZone implements Service {
 
-	public const METHOD_FLAT_RATE = 'flat_rate';
-	public const METHOD_FREE      = 'free_shipping';
-
 	/**
 	 * @var WC
 	 */
 	protected $wc;
 
 	/**
-	 * @var array|null Array of shipping methods for each country.
+	 * @var ZoneLocationsParser
 	 */
-	protected $methods_countries = null;
+	protected $locations_parser;
 
 	/**
-	 * @var GoogleHelper
+	 * @var ZoneMethodsParser
 	 */
-	protected $google_helper;
+	protected $methods_parser;
+
+	/**
+	 * @var LocationRatesProcessor
+	 */
+	protected $rates_processor;
+
+	/**
+	 * @var array[][]|null Array of shipping rates for each location.
+	 */
+	protected $location_rates = null;
 
 	/**
 	 * ShippingZone constructor.
 	 *
-	 * @param WC           $wc
-	 * @param GoogleHelper $google_helper
+	 * @param WC                     $wc
+	 * @param ZoneLocationsParser    $location_parser
+	 * @param ZoneMethodsParser      $methods_parser
+	 * @param LocationRatesProcessor $rates_processor
 	 */
-	public function __construct( WC $wc, GoogleHelper $google_helper ) {
-		$this->wc            = $wc;
-		$this->google_helper = $google_helper;
+	public function __construct(
+		WC $wc,
+		ZoneLocationsParser $location_parser,
+		ZoneMethodsParser $methods_parser,
+		LocationRatesProcessor $rates_processor
+	) {
+		$this->wc               = $wc;
+		$this->locations_parser = $location_parser;
+		$this->methods_parser   = $methods_parser;
+		$this->rates_processor  = $rates_processor;
 	}
 
 	/**
@@ -59,423 +72,112 @@ class ShippingZone implements Service {
 	public function get_shipping_countries(): array {
 		$this->parse_shipping_zones();
 
-		$countries = array_keys( $this->methods_countries ?: [] );
-
-		// Match the list of shipping countries with the list of Merchant Center supported countries.
-		$countries = array_intersect( $countries, $this->google_helper->get_mc_supported_countries() );
+		$countries = array_keys( $this->location_rates );
 
 		return array_values( $countries );
 	}
 
 	/**
-	 * Returns the available shipping methods for a country.
+	 * Returns the available shipping rates for a country and its subdivisions.
 	 *
 	 * @param string $country_code
 	 *
-	 * @return array[] Returns an array of shipping methods for the given country.
-	 *
-	 * @see ShippingZone::parse_method() for the format of the returned array.
+	 * @return LocationRate[]
 	 */
-	public function get_shipping_methods_for_country( string $country_code ): array {
+	public function get_shipping_rates_for_country( string $country_code ): array {
 		$this->parse_shipping_zones();
 
-		return ! empty( $this->methods_countries[ $country_code ] ) ? array_values( $this->methods_countries[ $country_code ] ) : [];
+		$location_rates = $this->location_rates[ $country_code ];
+		if ( empty( $location_rates ) ) {
+			return [];
+		}
+
+		// Process the rates for each country subdivision separately.
+		$location_rates = array_map( [ $this->rates_processor, 'process' ], $location_rates );
+
+		// Convert the string array keys to integers.
+		$country_rates = array_values( $location_rates );
+
+		// Flatten and merge the country shipping rates.
+		$country_rates = array_merge( [], ...$country_rates );
+
+		return array_values( $country_rates );
 	}
 
 	/**
 	 * Returns the available shipping rates for a country.
 	 *
+	 * If there are separate rates for the country's subdivisions (e.g. state,province, postcode etc.), they will be
+	 * grouped by their parent country.
+	 *
 	 * @param string $country_code
 	 *
-	 * @return array[] A multidimensional array of shipping rates for the given country. {
-	 *     Array of shipping method arguments.
-	 *
-	 *     @type string $country  The shipping method country.
-	 *     @type string $method   The shipping method ID.
-	 *     @type string $currency The currency which the shipping rate is in. Defaults to the store currency.
-	 *     @type float  $rate     The cost of the shipping method. Only if the method is flat-rate.
-	 *     @type array  $options  Array of options for the shipping method (varies based on the method type). {
-	 *         Array of options for the shipping method.
-	 *
-	 *         @type array[] $shipping_class_rates An array containing the shipping class names and their rates. Only if the method is flat-rate.
-	 *         @type float   $free_shipping_threshold The minimum order amount required to use the shipping method. Only if the method is free shipping.
-	 *
-	 *     }
-	 * }
+	 * @return LocationRate[]
 	 */
-	public function get_shipping_rates_for_country( string $country_code ): array {
-		$methods = $this->get_shipping_methods_for_country( $country_code );
+	public function get_shipping_rates_grouped_by_country( string $country_code ): array {
+		$this->parse_shipping_zones();
 
-		// If the only shipping method is the free shipping method, return it as the only rate.
-		if ( 1 === count( $methods ) && self::METHOD_FREE === $methods[0]['id'] ) {
-			$rate = [
-				'country'  => $country_code,
-				'method'   => $methods[0]['id'],
-				'currency' => $methods[0]['currency'],
-				'rate'     => 0,
-				'options'  => [],
-			];
-			if ( isset( $methods[0]['options']['min_amount'] ) ) {
-				$rate['options']['free_shipping_threshold'] = $methods[0]['options']['min_amount'];
-			}
-
-			return [ $rate ];
+		$location_rates = $this->location_rates[ $country_code ];
+		if ( empty( $location_rates ) ) {
+			return [];
 		}
 
-		$free_shipping = self::find_available_free_shipping_method( $methods );
-		$rates         = [];
-		foreach ( $methods as $method ) {
-			// We process the free shipping method separately.
-			if ( self::METHOD_FREE === $method['id'] ) {
-				continue;
-			}
+		// Convert the string array keys to integers.
+		$country_rates = array_values( $location_rates );
 
-			$rate = [
-				'country'  => $country_code,
-				'method'   => $method['id'],
-				'currency' => $method['currency'],
-				'rate'     => $method['options']['cost'] ?? 0,
-				'options'  => [],
-			];
+		// Flatten and merge the country shipping rates.
+		$country_rates = array_merge( [], ...$country_rates );
 
-			if ( null !== $free_shipping ) {
-				if ( isset( $free_shipping['options']['min_amount'] ) ) {
-					// If there is a free shipping method, and it has a minimum order amount, we set it as an option for all rates.
-					$rate['options']['free_shipping_threshold'] = $free_shipping['options']['min_amount'];
-				} else {
-					// If there is a free shipping method without a minimum order amount, we set the rate to 0 to mark it as free.
-					$rate['rate'] = 0;
-				}
-			}
-
-			if ( ! empty( $method['options']['class_costs'] ) ) {
-				// If there are shipping classes, we set the cost of each class as an option.
-				$rate['options']['shipping_class_rates'] = [];
-				foreach ( $method['options']['class_costs'] as $class_id => $cost ) {
-					$rate['options']['shipping_class_rates'][] = [
-						'class' => $class_id,
-						'rate'  => $cost,
-					];
-				}
-			}
-
-			$rates[] = $rate;
-		}
-
-		return $rates;
+		return $this->rates_processor->process( $country_rates );
 	}
 
 	/**
-	 * Parses the WooCommerce shipping zones and maps the ones that are supported and enabled into the self::$methods_countries array.
+	 * Parses the WooCommerce shipping zones.
 	 */
 	protected function parse_shipping_zones(): void {
 		// Don't parse if already parsed.
-		if ( null !== $this->methods_countries ) {
+		if ( null !== $this->location_rates ) {
 			return;
 		}
-		$this->methods_countries = [];
+		$this->location_rates = [];
 
 		foreach ( $this->wc->get_shipping_zones() as $zone ) {
-			$zone = $this->wc->get_shipping_zone( $zone['zone_id'] );
-			/**
-			 * @var WC_Shipping_Method[] $methods
-			 */
-			$methods = $zone->get_shipping_methods();
+			$zone           = $this->wc->get_shipping_zone( $zone['zone_id'] );
+			$zone_locations = $this->locations_parser->parse( $zone );
+			$shipping_rates = $this->methods_parser->parse( $zone );
+			$this->map_rates_to_locations( $shipping_rates, $zone_locations );
+		}
+	}
 
-			// Skip if no shipping methods.
-			if ( empty( $methods ) ) {
-				continue;
+	/**
+	 * Maps each shipping method to its related shipping locations.
+	 *
+	 * @param ShippingRate[] $shipping_rates The shipping rates.
+	 * @param Location[]     $locations      The shipping locations.
+	 *
+	 * @since x.x.x
+	 */
+	protected function map_rates_to_locations( array $shipping_rates, array $locations ): void {
+		if ( empty( $shipping_rates ) || empty( $locations ) ) {
+			return;
+		}
+
+		foreach ( $locations as $location ) {
+			$location_rates = [];
+			foreach ( $shipping_rates as $shipping_rate ) {
+				$location_rates[] = new LocationRate( $location, $shipping_rate );
 			}
 
-			foreach ( $methods as $method ) {
-				// Skip if the method is unsupported or disabled.
-				if ( ! $method->is_enabled() || ! self::is_shipping_method_supported( $method->id ) ) {
-					continue;
-				}
+			$country_code = $location->get_country();
 
-				$method = $this->parse_method( $method );
-
-				// Skip if method cannot be parsed.
-				if ( null === $method ) {
-					continue;
-				}
-
-				// Add the method to the list of methods for each country in the zone.
-				foreach ( $this->get_shipping_countries_from_zone( $zone ) as $country ) {
-					// Initialize the shipping methods array if it doesn't exist.
-					$this->methods_countries[ $country ] = $this->methods_countries[ $country ] ?? [];
-
-					// Add the method to the array of shipping methods for the country if it doesn't exist.
-					if ( ! isset( $this->methods_countries[ $country ][ $method['id'] ] ) ||
-						 self::should_method_be_replaced( $method, $this->methods_countries[ $country ][ $method['id'] ] )
-					) {
-						$this->methods_countries[ $country ][ $method['id'] ] = $method;
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * Checks whether the shipping method should be replaced with a more suitable one.
-	 *
-	 * @param array $method
-	 * @param array $existing_method
-	 *
-	 * @return bool
-	 */
-	protected static function should_method_be_replaced( array $method, array $existing_method ): bool {
-		if ( $method['id'] !== $existing_method['id'] ) {
-			return false;
-		}
-
-		if (
-			// If a flat-rate method already exists, we replace it with the one with the higher cost.
-			self::does_method_have_higher_cost( $method, $existing_method ) ||
-			// If a free-shipping method already exists, we replace it with the one with the higher required minimum order amount.
-			self::does_method_have_higher_min_amount( $method, $existing_method )
-		) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Checks whether the given method has a higher cost than the existing method.
-	 *
-	 * @param array $method          A shipping method.
-	 * @param array $existing_method Another shipping method to compare with.
-	 *
-	 * @return bool
-	 */
-	protected static function does_method_have_higher_cost( array $method, array $existing_method ): bool {
-		if ( $method['id'] !== $existing_method['id'] ) {
-			return false;
-		}
-
-		return self::METHOD_FLAT_RATE === $method['id'] && $method['options']['cost'] > $existing_method['options']['cost'];
-	}
-
-	/**
-	 * Checks whether the given method has a minimum order amount higher than the existing method.
-	 *
-	 * @param array $method          A shipping method.
-	 * @param array $existing_method Another shipping method to compare with.
-	 *
-	 * @return bool
-	 */
-	protected static function does_method_have_higher_min_amount( array $method, array $existing_method ): bool {
-		if ( self::METHOD_FREE !== $method['id'] || $method['id'] !== $existing_method['id'] ) {
-			return false;
-		}
-
-		// If a free shipping method already exists but doesn't have a minimum order amount, we replace it with the one with the one that has one.
-		if ( isset( $method['options']['min_amount'] ) && ! isset( $existing_method['options']['min_amount'] ) ) {
-			return true;
-		}
-
-		return isset( $method['options']['min_amount'] ) && isset( $existing_method['options']['min_amount'] ) && $method['options']['min_amount'] > $existing_method['options']['min_amount'];
-	}
-
-	/**
-	 * Gets the list of countries defined in a shipping zone.
-	 *
-	 * @param WC_Shipping_Zone $zone
-	 *
-	 * @return string[] Array of country codes.
-	 */
-	protected function get_shipping_countries_from_zone( WC_Shipping_Zone $zone ): array {
-		$countries = [];
-		foreach ( $zone->get_zone_locations() as $location ) {
-			switch ( $location->type ) {
-				case 'country':
-					$countries[ $location->code ] = $location->code;
-					break;
-				case 'continent':
-					$countries = array_merge( $countries, $this->get_countries_from_continent( $location->code ) );
-					break;
-				case 'state':
-					$country_code               = $this->get_country_of_state( $location->code );
-					$countries[ $country_code ] = $country_code;
-					break;
-				default:
-					break;
-			}
-		}
-
-		return $countries;
-	}
-
-	/**
-	 * Parses the given shipping method and returns its properties if it's supported. Returns null otherwise.
-	 *
-	 * @param object|WC_Shipping_Method $method
-	 *
-	 * @return array|null Returns an array with the parsed shipping method or null if the shipping method is not supported. {
-	 *     Array of shipping method arguments.
-	 *
-	 *     @type string $id       The shipping method ID.
-	 *     @type string $title    The user-defined title of the shipping method.
-	 *     @type string $currency The currency which the shipping rate is in. Defaults to the store currency.
-	 *     @type array  $options  Array of options for the shipping method (varies based on the method type). {
-	 *         Array of options for the shipping method.
-	 *
-	 *         @type float   $cost The cost of the shipping method. Only if the method is flat-rate.
-	 *         @type float[] $class_costs An array of costs for each shipping class (with class names used as array keys). Only if the method is flat-rate.
-	 *         @type float   $min_amount The minimum order amount required to use the shipping method. Only if the method is free shipping.
-	 *
-	 *     }
-	 * }
-	 */
-	protected function parse_method( object $method ): ?array {
-		$parsed_method = [
-			'id'       => $method->id,
-			'title'    => $method->title,
-			'currency' => $this->wc->get_woocommerce_currency(),
-			'options'  => [],
-		];
-
-		switch ( $method->id ) {
-			case self::METHOD_FLAT_RATE:
-				$parsed_method['options'] = $this->get_flat_rate_method_options( $method );
-
-				// If the flat-rate method has no cost AND no shipping classes, we don't return it.
-				if ( ! isset( $parsed_method['options']['cost'] ) && ! isset( $parsed_method['options']['class_costs'] ) ) {
-					return null;
-				}
-
-				break;
-			case self::METHOD_FREE:
-				// Check if free shipping requires a minimum order amount.
-				$requires = $method->get_option( 'requires' );
-				if ( in_array( $requires, [ 'min_amount', 'either' ], true ) ) {
-					$parsed_method['options']['min_amount'] = (float) $method->get_option( 'min_amount' );
-				} elseif ( in_array( $requires, [ 'coupon', 'both' ], true ) ) {
-					// We can't sync this method if free shipping requires a coupon.
-					return null;
-				}
-				break;
-			default:
-				// We don't support other shipping methods.
-				return null;
-		}
-
-		return $parsed_method;
-	}
-
-	/**
-	 * Get the array of options of the flat-rate shipping method.
-	 *
-	 * @param object $method
-	 *
-	 * @return array
-	 */
-	protected function get_flat_rate_method_options( object $method ): array {
-		$options = [
-			'cost' => null,
-		];
-
-		$flat_cost = 0;
-		$cost      = $method->get_option( 'cost' );
-		// Check if the cost is a numeric value (and not null or a math expression).
-		if ( is_numeric( $cost ) ) {
-			$flat_cost       = (float) $cost;
-			$options['cost'] = $flat_cost;
-		}
-
-		// Add the no class cost.
-		$no_class_cost = $method->get_option( 'no_class_cost' );
-		if ( is_numeric( $no_class_cost ) ) {
-			$options['cost'] = $flat_cost + (float) $no_class_cost;
-		}
-
-		// Add shipping class costs.
-		$shipping_classes = $this->wc->get_shipping_classes();
-		foreach ( $shipping_classes as $shipping_class ) {
 			// Initialize the array if it doesn't exist.
-			$options['class_costs'] = $options['class_costs'] ?? [];
+			$this->location_rates[ $country_code ] = $this->location_rates[ $country_code ] ?? [];
 
-			$shipping_class_cost = $method->get_option( 'class_cost_' . $shipping_class->term_id );
-			if ( is_numeric( $shipping_class_cost ) ) {
-				// Add the flat rate cost to the shipping class cost.
-				$options['class_costs'][ $shipping_class->slug ] = $flat_cost + (float) $shipping_class_cost;
-			}
+			$location_key = (string) $location;
+
+			// Group the rates by their parent country and a location key. The location key is used to prevent duplicate rates for the same location.
+			$this->location_rates[ $country_code ][ $location_key ] = $location_rates;
 		}
-
-		return $options;
 	}
 
-	/**
-	 * Gets the list of countries from a continent.
-	 *
-	 * @param string $continent_code
-	 *
-	 * @return string[] Returns an array of country codes with each country code used both as the key and value.
-	 *                  For example: [ 'US' => 'US', 'DE' => 'DE' ].
-	 */
-	protected function get_countries_from_continent( string $continent_code ): array {
-		$countries  = [];
-		$continents = $this->wc->get_wc_countries()->get_continents();
-		if ( isset( $continents[ $continent_code ] ) ) {
-			$countries = $continents[ $continent_code ]['countries'];
-			// Use the country code as array keys.
-			$countries = array_combine( $countries, $countries );
-		}
-
-		return $countries;
-	}
-
-	/**
-	 * Gets the country code of a state defined in WooCommerce shipping zone.
-	 *
-	 * @param string $state_code
-	 *
-	 * @return string
-	 */
-	protected function get_country_of_state( string $state_code ): string {
-		$location_codes = explode( ':', $state_code );
-
-		return $location_codes[0];
-	}
-
-	/**
-	 * Checks whether the given shipping method is supported.
-	 *
-	 * @param string $method
-	 *
-	 * @return bool
-	 */
-	public static function is_shipping_method_supported( string $method ): bool {
-		return in_array(
-			$method,
-			[
-				self::METHOD_FLAT_RATE,
-				self::METHOD_FREE,
-			],
-			true
-		);
-	}
-
-	/**
-	 * Finds and returns the free shipping method if it exists in the list of suggested shipping methods.
-	 *
-	 * @param array $methods
-	 *
-	 * @return array|null Array containing the free shipping method properties, or null if it does not exist.
-	 */
-	protected static function find_available_free_shipping_method( array $methods ): ?array {
-		$free_shipping_method = array_filter(
-			$methods,
-			function ( $method ) {
-				return self::METHOD_FREE === $method['id'];
-			}
-		);
-
-		if ( empty( $free_shipping_method ) ) {
-			return null;
-		}
-
-		return array_values( $free_shipping_method )[0];
-	}
 }

--- a/src/Shipping/ZoneLocationsParser.php
+++ b/src/Shipping/ZoneLocationsParser.php
@@ -1,0 +1,136 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use WC_Shipping_Zone;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ZoneLocationsParser
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+class ZoneLocationsParser implements Service {
+
+	/**
+	 * @var WC
+	 */
+	protected $wc;
+
+	/**
+	 * @var GoogleHelper
+	 */
+	protected $google_helper;
+
+	/**
+	 * ZoneLocationsParser constructor.
+	 *
+	 * @param WC           $wc
+	 * @param GoogleHelper $google_helper
+	 */
+	public function __construct( WC $wc, GoogleHelper $google_helper ) {
+		$this->wc            = $wc;
+		$this->google_helper = $google_helper;
+	}
+
+	/**
+	 * Returns the supported locations for the given WooCommerce shipping zone.
+	 *
+	 * @param WC_Shipping_Zone $zone
+	 *
+	 * @return Location[] Array of supported locations.
+	 */
+	public function parse( WC_Shipping_Zone $zone ): array {
+		$locations = [];
+		$postcodes = $this->get_postcodes_from_zone( $zone );
+
+		foreach ( $zone->get_zone_locations() as $location ) {
+			switch ( $location->type ) {
+				case 'country':
+					if ( $this->google_helper->is_country_supported( $location->code ) ) {
+						$locations[ $location->code ] = new Location( $location->code, null, $postcodes );
+					}
+					break;
+				case 'continent':
+					foreach ( $this->get_supported_countries_from_continent( $location->code ) as $country ) {
+						$locations[ $country ] = new Location( $country, null, $postcodes );
+					}
+					break;
+				case 'state':
+					[ $country, $state ] = explode( ':', $location->code );
+
+					// Ignore if the country is not supported.
+					if ( ! $this->google_helper->is_country_supported( $country ) ) {
+						break;
+					}
+
+					// Only add the state if the regional shipping is supported for its country.
+					if ( $this->google_helper->does_country_support_regional_shipping( $country ) ) {
+						$locations[ $location->code ] = new Location( $country, $state, $postcodes );
+					} else {
+						$locations[ $country ] = new Location( $country, null, $postcodes );
+					}
+					break;
+				default:
+					break;
+			}
+		}
+
+		return array_values( $locations );
+	}
+
+	/**
+	 * Returns the applicable postcodes for the given WooCommerce shipping zone.
+	 *
+	 * @param WC_Shipping_Zone $zone
+	 *
+	 * @return string[] Array of postcodes.
+	 */
+	protected function get_postcodes_from_zone( WC_Shipping_Zone $zone ): array {
+		$postcodes = array_filter(
+			$zone->get_zone_locations(),
+			function ( $location ) {
+				return 'postcode' === $location->type;
+			}
+		);
+
+		return array_map(
+			function ( $postcode ) {
+				return $postcode->code;
+			},
+			$postcodes
+		);
+	}
+
+	/**
+	 * Gets the list of supported Merchant Center countries from a continent.
+	 *
+	 * @param string $continent_code
+	 *
+	 * @return string[] Returns an array of country codes with each country code used both as the key and value.
+	 *                  For example: [ 'US' => 'US', 'DE' => 'DE' ].
+	 */
+	protected function get_supported_countries_from_continent( string $continent_code ): array {
+		$countries  = [];
+		$continents = $this->wc->get_wc_countries()->get_continents();
+		if ( isset( $continents[ $continent_code ] ) ) {
+			$countries = $continents[ $continent_code ]['countries'];
+
+			// Match the list of countries with the list of Merchant Center supported countries.
+			$countries = array_intersect( $countries, $this->google_helper->get_mc_supported_countries() );
+
+			// Use the country code as array keys.
+			$countries = array_combine( $countries, $countries );
+		}
+
+		return $countries;
+	}
+
+}

--- a/src/Shipping/ZoneMethodsParser.php
+++ b/src/Shipping/ZoneMethodsParser.php
@@ -1,0 +1,159 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use WC_Shipping_Method;
+use WC_Shipping_Zone;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ZoneMethodsParser
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+class ZoneMethodsParser implements Service {
+
+	public const METHOD_FLAT_RATE = 'flat_rate';
+	public const METHOD_FREE      = 'free_shipping';
+
+	/**
+	 * @var WC
+	 */
+	private $wc;
+
+	/**
+	 * ZoneMethodsParser constructor.
+	 *
+	 * @param WC $wc
+	 */
+	public function __construct( WC $wc ) {
+		$this->wc = $wc;
+	}
+
+	/**
+	 * Parses the given shipping method and returns its properties if it's supported. Returns null otherwise.
+	 *
+	 * @param WC_Shipping_Zone $zone
+	 *
+	 * @return ShippingRate[] Returns an array of parsed shipping rates, or null if the shipping method is not supported.
+	 */
+	public function parse( WC_Shipping_Zone $zone ): array {
+		$parsed_rates = array_map( [ $this, 'shipping_method_to_rate' ], $zone->get_shipping_methods( true ) );
+
+		// Remove null values (i.e. non-parseable methods) and return the rest.
+		return array_filter( $parsed_rates );
+	}
+
+	/**
+	 * Parses the given shipping method and returns its properties if it's supported. Returns null otherwise.
+	 *
+	 * @param object|WC_Shipping_Method $method
+	 *
+	 * @return ShippingRate|null Returns an array of parsed shipping rates, or null if the shipping method is not supported.
+	 */
+	protected function shipping_method_to_rate( object $method ): ?ShippingRate {
+		switch ( $method->id ) {
+			case self::METHOD_FLAT_RATE:
+				$flat_rate            = $this->get_flat_rate_method_rate( $method );
+				$shipping_class_rates = $this->get_flat_rate_method_class_rates( $method );
+
+				// If the flat-rate method has no rate AND no shipping classes, we don't return it.
+				if ( null === $flat_rate && empty( $shipping_class_rates ) ) {
+					return null;
+				}
+
+				$shipping_rate = new ShippingRateFlat( $flat_rate, $shipping_class_rates );
+
+				break;
+			case self::METHOD_FREE:
+				$shipping_rate = new ShippingRateFree();
+
+				// Check if free shipping requires a minimum order amount.
+				$requires = $method->get_option( 'requires' );
+				if ( in_array( $requires, [ 'min_amount', 'either' ], true ) ) {
+					$shipping_rate->set_threshold( (float) $method->get_option( 'min_amount' ) );
+				} elseif ( in_array( $requires, [ 'coupon', 'both' ], true ) ) {
+					// We can't sync this method if free shipping requires a coupon.
+					return null;
+				}
+				break;
+			default:
+				// We don't support other shipping methods.
+				return null;
+		}
+
+		return $shipping_rate;
+	}
+
+	/**
+	 * Get the flat-rate shipping method rate.
+	 *
+	 * @param object|WC_Shipping_Method $method
+	 *
+	 * @return float|null
+	 */
+	protected function get_flat_rate_method_rate( object $method ): ?float {
+		$rate = null;
+
+		$flat_cost = 0;
+		$cost      = $method->get_option( 'cost' );
+		// Check if the cost is a numeric value (and not null or a math expression).
+		if ( is_numeric( $cost ) ) {
+			$flat_cost = (float) $cost;
+			$rate      = $flat_cost;
+		}
+
+		// Add the no class cost.
+		$no_class_cost = $method->get_option( 'no_class_cost' );
+		if ( is_numeric( $no_class_cost ) ) {
+			$rate = $flat_cost + (float) $no_class_cost;
+		}
+
+		return $rate;
+	}
+
+	/**
+	 * Get the array of options of the flat-rate shipping method.
+	 *
+	 * @param object|WC_Shipping_Method $method
+	 *
+	 * @return array A multidimensional array of shipping class rates. {
+	 *     Array of shipping method arguments.
+	 *
+	 *     @type string $class The shipping class slug/id.
+	 *     @type float  $rate  The cost of the shipping method for the class in WooCommerce store currency.
+	 * }
+	 */
+	protected function get_flat_rate_method_class_rates( object $method ): array {
+		$class_rates = [];
+
+		$flat_cost = 0;
+		$cost      = $method->get_option( 'cost' );
+		// Check if the cost is a numeric value (and not null or a math expression).
+		if ( is_numeric( $cost ) ) {
+			$flat_cost = (float) $cost;
+		}
+
+		// Add shipping class costs.
+		$shipping_classes = $this->wc->get_shipping_classes();
+		foreach ( $shipping_classes as $shipping_class ) {
+			$shipping_class_cost = $method->get_option( 'class_cost_' . $shipping_class->term_id );
+			if ( is_numeric( $shipping_class_cost ) ) {
+				// Add the flat rate cost to the shipping class cost.
+				$class_rates[ $shipping_class->slug ] = [
+					'class' => $shipping_class->slug,
+					'rate'  => $flat_cost + (float) $shipping_class_cost,
+				];
+			}
+		}
+
+		return array_values( $class_rates );
+	}
+
+}

--- a/tests/Unit/Shipping/LocationRatesProcessorTest.php
+++ b/tests/Unit/Shipping/LocationRatesProcessorTest.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\Location;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRate;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRatesProcessor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRateFlat;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRateFree;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+
+/**
+ * Class LocationRatesProcessorTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
+ *
+ * @property LocationRatesProcessor $rates_processor
+ */
+class LocationRatesProcessorTest extends UnitTest {
+
+	public function test_process_returns_only_most_expensive_flat_rate() {
+		$location       = new Location( 'US', 'CA' );
+		$location_rates = [
+			new LocationRate( $location, new ShippingRateFlat( 50 ) ),
+			new LocationRate( $location, new ShippingRateFlat( 100 ) ),
+			new LocationRate( $location, new ShippingRateFlat( 200 ) ),
+		];
+		$processed = $this->rates_processor->process( $location_rates );
+		$this->assertEquals( 1, count( $processed ) );
+		/** @var ShippingRateFlat $flat_rate */
+		$flat_rate = $processed[0]->get_shipping_rate();
+		$this->assertInstanceOf( ShippingRateFlat::class, $flat_rate );
+		$this->assertEquals( 200, $flat_rate->get_rate() );
+	}
+
+	public function test_process_returns_only_highest_minimum_order_threshold_free_rate() {
+		$location       = new Location( 'US', 'CA' );
+		$location_rates = [
+			new LocationRate( $location, new ShippingRateFree() ),
+			new LocationRate( $location, new ShippingRateFree( 50 ) ),
+			new LocationRate( $location, new ShippingRateFree( 100 ) ),
+			new LocationRate( $location, new ShippingRateFree( 200 ) ),
+		];
+		$processed = $this->rates_processor->process( $location_rates );
+		$this->assertEquals( 1, count( $processed ) );
+		/** @var ShippingRateFree $free_rate */
+		$free_rate = $processed[0]->get_shipping_rate();
+		$this->assertInstanceOf( ShippingRateFree::class, $free_rate );
+		$this->assertEquals( 200, $free_rate->get_threshold() );
+	}
+
+	public function test_process_returns_only_free_rate_if_it_has_no_threshold() {
+		$location       = new Location( 'US', 'CA' );
+		$location_rates = [
+			new LocationRate( $location, new ShippingRateFree() ),
+			new LocationRate( $location, new ShippingRateFlat( 200 ) ),
+		];
+		$processed = $this->rates_processor->process( $location_rates );
+		$this->assertEquals( 1, count( $processed ) );
+		/** @var ShippingRateFree $free_rate */
+		$free_rate = $processed[0]->get_shipping_rate();
+		$this->assertInstanceOf( ShippingRateFree::class, $free_rate );
+	}
+
+	public function test_process_returns_both_free_rate_and_flat_rate_if_free_rate_has_threshold() {
+		$location       = new Location( 'US', 'CA' );
+		$location_rates = [
+			new LocationRate( $location, new ShippingRateFree() ),
+			new LocationRate( $location, new ShippingRateFree( 50 ) ),
+			new LocationRate( $location, new ShippingRateFlat( 200 ) ),
+		];
+		$processed      = $this->rates_processor->process( $location_rates );
+		$this->assertEquals( 2, count( $processed ) );
+		foreach ( $processed as $location_rate ) {
+			if ( $location_rate->get_shipping_rate() instanceof ShippingRateFlat ) {
+				/** @var ShippingRateFlat $flat_rate */
+				$flat_rate = $location_rate->get_shipping_rate();
+				$this->assertEquals( 200, $flat_rate->get_rate() );
+			} else {
+				/** @var ShippingRateFree $free_rate */
+				$free_rate = $location_rate->get_shipping_rate();
+				$this->assertEquals( 50, $free_rate->get_threshold() );
+			}
+		}
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->rates_processor = new LocationRatesProcessor();
+	}
+}

--- a/tests/Unit/Shipping/ShippingZoneTest.php
+++ b/tests/Unit/Shipping/ShippingZoneTest.php
@@ -3,15 +3,16 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\Location;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRatesProcessor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRateFlat;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRateFree;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneLocationsParser;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneMethodsParser;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
-use WC_Countries;
-use WC_Shipping_Flat_Rate;
-use WC_Shipping_Free_Shipping;
-use WC_Shipping_Method;
 use WC_Shipping_Zone;
 
 /**
@@ -19,1114 +20,110 @@ use WC_Shipping_Zone;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
  *
- * @property MockObject|WC $wc
- * @property GoogleHelper  $google_helper
- * @property ShippingZone  $shipping_zone
+ * @property MockObject|WC                     $wc
+ * @property MockObject|ZoneLocationsParser    $locations_parser
+ * @property MockObject|ZoneMethodsParser      $methods_parser
+ * @property MockObject|LocationRatesProcessor $rates_processor
+ * @property ShippingZone                      $shipping_zone
  */
 class ShippingZoneTest extends UnitTest {
-
-	public function test_returns_supported_shipping_methods() {
-		// Return one sample shipping zone.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( true );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  }
-
-					  return null;
-				  } );
-
-		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( true );
-
-		// Adding one unsupported shipping method. This method should not be returned.
-		$unsupported_method     = $this->createMock( WC_Shipping_Method::class );
-		$unsupported_method->id = 'unsupported_method';
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate, $free_shipping, $unsupported_method ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-
-		$this->assertCount( 2, $methods );
-
-		$methods_ids = array_map(
-			function ( $method ) {
-				return $method['id'];
-			},
-			$methods
-		);
-
-		$this->assertEqualSets(
-			[
-				ShippingZone::METHOD_FLAT_RATE,
-				ShippingZone::METHOD_FREE,
-			],
-			$methods_ids
-		);
-	}
-
-	public function test_ignores_flat_rate_methods_with_null_cost() {
-		// Return one sample shipping zone.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( true );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return null;
-					  }
-				  } );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-
-		$this->assertEmpty( $methods );
-	}
-
-	public function test_returns_shipping_method_properties() {
-		// Return one sample shipping zone.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		// Create a sample flat-rate shipping method with a constant cost.
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->title = 'Flat Rate';
-		$flat_rate->expects( $this->any() )
-					->method( 'is_enabled' )
-					->willReturn( true );
-		$flat_rate->expects( $this->any() )
-					->method( 'get_option' )
-					->willReturnCallback( function ( $option ) {
-						if ( 'cost' === $option ) {
-							return 10;
-						}
-
-						return null;
-					} );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-
-		$this->assertCount( 1, $methods );
-		$this->assertEquals( ShippingZone::METHOD_FLAT_RATE, $methods[0]['id'] );
-		$this->assertEquals( 'Flat Rate', $methods[0]['title'] );
-		$this->assertEquals( 'USD', $methods[0]['currency'] );
-		$this->assertNotEmpty( $methods[0]['options'] );
-		$this->assertEquals( 10, $methods[0]['options']['cost'] );
-	}
-
-	/**
-	 * @param string $requires
-	 *
-	 * @dataProvider return_free_shipping_min_amount_requirements
-	 */
-	public function test_returns_free_shipping_method_requires_min_amount( string $requires ) {
-		// Return one sample shipping zone.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( true );
-		$free_shipping->expects( $this->any() )
-						->method( 'get_option' )
-						->willReturnCallback( function ( $option ) use ( $requires ) {
-							if ( 'requires' === $option ) {
-								return $requires;
-							}
-							if ( 'min_amount' === $option ) {
-								return 99.99;
-							}
-
-							return null;
-						} );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $free_shipping ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-
-		$this->assertCount( 1, $methods );
-		$this->assertEquals( ShippingZone::METHOD_FREE, $methods[0]['id'] );
-		$this->assertNotEmpty( $methods[0]['options'] );
-		$this->assertEquals( 99.99, $methods[0]['options']['min_amount'] );
-	}
-
-	/**
-	 * @param string $requires
-	 *
-	 * @dataProvider return_free_shipping_coupon_requirements
-	 */
-	public function test_ignores_free_shipping_method_requires_coupon( string $requires ) {
-		// Return one sample shipping zone.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-					  ->method( 'is_enabled' )
-					  ->willReturn( true );
-		$free_shipping->expects( $this->any() )
-						->method( 'get_option' )
-						->willReturnCallback( function ( $option ) use ( $requires ) {
-							if ( 'requires' === $option ) {
-								return $requires;
-							}
-
-							return null;
-						} );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $free_shipping ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-
-		$this->assertCount( 0, $methods );
-	}
-
-	public function test_ignores_methods_with_mathematical_cost() {
-		// Return one sample shipping zone.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		// Create a sample flat-rate shipping method with a constant cost.
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->title = 'Flat Rate';
-		$flat_rate->expects( $this->any() )
-					->method( 'is_enabled' )
-					->willReturn( true );
-		$flat_rate->expects( $this->any() )
-					->method( 'get_option' )
-					->willReturnCallback( function ( $option ) {
-						if ( 'cost' === $option ) {
-							return '[qty] * 5';
-						}
-
-						return null;
-					} );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-
-		$this->assertEmpty( $methods );
-	}
-
 	public function test_returns_shipping_countries() {
-		$shipping_zones = [
-			[
-				'id'             => 0,
-				'zone_id'        => 0,
-				'zone_name'      => 'Local',
-				'zone_locations' => [
-					(object)[
-						'code' => 'US:NV',
-						'type' => 'state',
-					],
-					(object) [
-						'code' => 'US:CA',
-						'type' => 'state',
-					],
-				],
-			],
-			[
-				'id'             => 1,
-				'zone_id'        => 1,
-				'zone_name'      => 'EU branches',
-				'zone_locations' =>  [
-					(object) [
-						'code' => 'GB',
-						'type' => 'country',
-					],
-					(object) [
-						'code' => 'FR',
-						'type' => 'country',
-					],
-				],
-			],
-			[
-				'id'             => 2,
-				'zone_id'        => 2,
-				'zone_name'      => 'EU (Other)',
-				'zone_locations' => [
-					(object) [
-						'code' => 'EU',
-						'type' => 'continent',
-					],
-				],
-			],
-		];
-
-		// Mock the get_shipping_zones method to return the above array.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( $shipping_zones );
-
-		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
-					 $zone = $this->createMock( WC_Shipping_Zone::class );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_zone_locations' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
-					 // We need at least one method for each country in order for it to show up in the list.
-					 $free_shipping     = $this->createMock( WC_Shipping_Free_Shipping::class );
-					 $free_shipping->id = ShippingZone::METHOD_FREE;
-					 $free_shipping->expects( $this->any() )
-								   ->method( 'is_enabled' )
-								   ->willReturn( true );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_shipping_methods' )
-						  ->willReturn( [ $free_shipping ] );
-
-					 return $zone;
-				 } );
-
-		// Mock the WC_Countries class to return the list of countries for the EU continent.
-		$wc_countries = $this->createMock( WC_Countries::class );
-		$wc_countries->expects( $this->any() )
-					 ->method( 'get_continents' )
-					 ->willReturn( [
-						 'EU' => [
-							 'name'      => 'Europe',
-							 'countries' => [
-								 // A random country code, not supported by Merchant Center. This should be ignored.
-								 'OO1',
-								 // Another random country code, not supported by Merchant Center. This should be ignored.
-								 'OO2',
-								 'GB',
-								 'FR',
-								 'DE',
-								 'DK',
-								 // And many more ...
-							 ],
-						 ],
-					 ] );
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_wc_countries' )
-				 ->willReturn( $wc_countries );
+		$this->locations_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn(
+								 [
+									 new Location( 'US' ),
+									 new Location( 'DE' ),
+								 ]
+							 );
+		$this->methods_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn( [ new ShippingRateFree() ] );
 
 		$this->assertEqualSets(
 			[
 				'US',
-				'GB',
-				'FR',
 				'DE',
-				'DK',
 			],
 			$this->shipping_zone->get_shipping_countries()
 		);
 	}
 
-	public function test_ignores_shipping_countries_with_no_methods() {
-		$free_shipping     = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-					  ->method( 'is_enabled' )
-					  ->willReturn( true );
-		$shipping_zones = [
-			[
-				'id'             => 0,
-				'zone_id'        => 0,
-				'zone_name'      => 'Local',
-				'zone_locations' => [
-					(object) [
-						'code' => 'GB',
-						'type' => 'country',
-					],
-				],
-				'methods' => [
-					$free_shipping
-				]
-			],
-			[
-				'id'             => 1,
-				'zone_id'        => 1,
-				'zone_name'      => 'France',
-				'zone_locations' => [
-					(object) [
-						'code' => 'FR',
-						'type' => 'country',
-					],
-				],
-				'methods' => [] // No methods for France.
-			],
-		];
+	public function test_returns_shipping_rates_for_country() {
+		$this->locations_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn(
+								 [
+									 new Location( 'US', 'CA', [ '12345', '67890' ] ),
+									 new Location( 'CA', 'BC', [ '12345', '67890' ] ),
+								 ]
+							 );
+		$this->methods_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn( [ new ShippingRateFree() ] );
 
-		// Mock the get_shipping_zones method to return the above array.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( $shipping_zones );
+		$location_rates = $this->shipping_zone->get_shipping_rates_for_country( 'US' );
+		$this->assertCount( 1, $location_rates );
+		$this->assertInstanceOf( ShippingRateFree::class, $location_rates[0]->get_shipping_rate() );
+		$this->assertEquals( 'US', $location_rates[0]->get_location()->get_country() );
+		$this->assertEquals( 'CA', $location_rates[0]->get_location()->get_state() );
+		$this->assertEqualSets( [ '12345', '67890' ], $location_rates[0]->get_location()->get_postcodes() );
 
-		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
-					 $zone = $this->createMock( WC_Shipping_Zone::class );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_zone_locations' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_shipping_methods' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['methods'] );
-
-					 return $zone;
-				 } );
-
-		$this->assertEquals( [ 'GB' ], $this->shipping_zone->get_shipping_countries() );
+		$location_rates = $this->shipping_zone->get_shipping_rates_for_country( 'CA' );
+		$this->assertCount( 1, $location_rates );
+		$this->assertInstanceOf( ShippingRateFree::class, $location_rates[0]->get_shipping_rate() );
+		$this->assertEquals( 'CA', $location_rates[0]->get_location()->get_country() );
+		$this->assertEquals( 'BC', $location_rates[0]->get_location()->get_state() );
+		$this->assertEqualSets( [ '12345', '67890' ], $location_rates[0]->get_location()->get_postcodes() );
 	}
 
-	public function test_returns_shipping_method_with_higher_cost() {
-		// Create a sample flat-rate shipping method with a constant cost.
-		$flat_rate_1 = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate_1->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate_1->expects( $this->any() )
-					  ->method( 'is_enabled' )
-					  ->willReturn( true );
-		$flat_rate_1->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  }
+	public function test_returns_shipping_rates_grouped_by_country() {
+		$this->locations_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn(
+								 [
+									 new Location( 'US', 'CA' ),
+									 new Location( 'CA', 'BC' ),
+								 ]
+							 );
+		$this->methods_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn(
+								 [
+									 new ShippingRateFree(),
+									 new ShippingRateFlat( 10 ),
+								 ]
+							 );
 
-					  return null;
-				  } );
-		// Create another flat-rate shipping method with a higher cost.
-		$flat_rate_2 = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate_2->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate_2->expects( $this->any() )
-					->method( 'is_enabled' )
-					->willReturn( true );
-		$flat_rate_2->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 20;
-					  }
-
-					  return null;
-				  } );
-		$shipping_zones = [
-			[
-				'id'             => 0,
-				'zone_id'        => 0,
-				'zone_name'      => 'Local',
-				'zone_locations' => [
-					(object)[
-						'code' => 'US:NV',
-						'type' => 'state',
-					],
-				],
-				'methods' => [
-					$flat_rate_1
-				]
-			],
-			[
-				'id'             => 1,
-				'zone_id'        => 1,
-				'zone_name'      => 'CA',
-				'zone_locations' => [
-					(object) [
-						'code' => 'US:CA',
-						'type' => 'state',
-					],
-				],
-				'methods' => [
-					$flat_rate_2
-				]
-			],
-		];
-
-		// Mock the get_shipping_zones method to return the above array.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( $shipping_zones );
-
-		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
-					 $zone = $this->createMock( WC_Shipping_Zone::class );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_zone_locations' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_shipping_methods' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['methods'] );
-
-					 return $zone;
-				 } );
-
-		$this->assertEquals( [ 'US' ], $this->shipping_zone->get_shipping_countries() );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-		$this->assertCount( 1, $methods );
-		$this->assertEquals( ShippingZone::METHOD_FLAT_RATE, $methods[0]['id'] );
-		$this->assertEquals( 20, $methods[0]['options']['cost'] );
+		$location_rates = $this->shipping_zone->get_shipping_rates_grouped_by_country( 'US' );
+		$this->assertCount( 2, $location_rates );
+		foreach ( $location_rates as $location_rate ) {
+			if ( ! $location_rate->get_shipping_rate() instanceof ShippingRateFree && ! $location_rate->get_shipping_rate() instanceof ShippingRateFlat ) {
+				$this->fail( 'Expected only free shipping and flat rate shipping rates' );
+			}
+		}
 	}
 
-	public function test_returns_shipping_method_with_higher_min_order_amount() {
-		// Create a sample free-shipping method with a min amount option.
-		$free_shipping_1 = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping_1->id = ShippingZone::METHOD_FREE;
-		$free_shipping_1->expects( $this->any() )
-					->method( 'is_enabled' )
-					->willReturn( true );
-		$free_shipping_1->expects( $this->any() )
-					  ->method( 'get_option' )
-					  ->willReturnCallback( function ( $option ) {
-						  if ( 'requires' === $option ) {
-							  return 'min_amount';
-						  }
-						  if ( 'min_amount' === $option ) {
-							  return 10.99;
-						  }
+	public function test_ignores_zones_with_no_methods() {
+		$this->locations_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn( [ new Location( 'US' ) ] );
+		$this->methods_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn( [] );
 
-						  return null;
-					  } );
-
-		// Create another free-shipping method with a higher min amount option.
-		$free_shipping_2 = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping_2->id = ShippingZone::METHOD_FREE;
-		$free_shipping_2->expects( $this->any() )
-						->method( 'is_enabled' )
-						->willReturn( true );
-		$free_shipping_2->expects( $this->any() )
-					  ->method( 'get_option' )
-					  ->willReturnCallback( function ( $option ) {
-						  if ( 'requires' === $option ) {
-							  return 'min_amount';
-						  }
-						  if ( 'min_amount' === $option ) {
-							  return 50.99;
-						  }
-
-						  return null;
-					  } );
-		$shipping_zones = [
-			[
-				'id'             => 0,
-				'zone_id'        => 0,
-				'zone_name'      => 'Local',
-				'zone_locations' => [
-					(object)[
-						'code' => 'US:NV',
-						'type' => 'state',
-					],
-				],
-				'methods' => [
-					$free_shipping_1
-				]
-			],
-			[
-				'id'             => 1,
-				'zone_id'        => 1,
-				'zone_name'      => 'CA',
-				'zone_locations' => [
-					(object) [
-						'code' => 'US:CA',
-						'type' => 'state',
-					],
-				],
-				'methods' => [
-					$free_shipping_2
-				]
-			],
-		];
-
-		// Mock the get_shipping_zones method to return the above array.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( $shipping_zones );
-
-		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
-					 $zone = $this->createMock( WC_Shipping_Zone::class );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_zone_locations' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_shipping_methods' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['methods'] );
-
-					 return $zone;
-				 } );
-
-		$this->assertEquals( [ 'US' ], $this->shipping_zone->get_shipping_countries() );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-		$this->assertCount( 1, $methods );
-		$this->assertEquals( ShippingZone::METHOD_FREE, $methods[0]['id'] );
-		$this->assertEquals( 50.99, $methods[0]['options']['min_amount'] );
+		$this->assertEmpty( $this->shipping_zone->get_shipping_countries() );
 	}
 
-	public function test_returns_shipping_method_with_existing_min_order_amount() {
-		// Create a sample free-shipping method WITHOUT min amount option.
-		$free_shipping_1 = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping_1->id = ShippingZone::METHOD_FREE;
-		$free_shipping_1->expects( $this->any() )
-						->method( 'is_enabled' )
-						->willReturn( true );
-
-		// Create another free-shipping method with a min amount option specified.
-		$free_shipping_2 = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping_2->id = ShippingZone::METHOD_FREE;
-		$free_shipping_2->expects( $this->any() )
-						->method( 'is_enabled' )
-						->willReturn( true );
-		$free_shipping_2->expects( $this->any() )
-					  ->method( 'get_option' )
-					  ->willReturnCallback( function ( $option ) {
-						  if ( 'requires' === $option ) {
-							  return 'min_amount';
-						  }
-						  if ( 'min_amount' === $option ) {
-							  return 10;
-						  }
-
-						  return null;
-					  } );
-		$shipping_zones = [
-			[
-				'id'             => 0,
-				'zone_id'        => 0,
-				'zone_name'      => 'Local',
-				'zone_locations' => [
-					(object)[
-						'code' => 'US:NV',
-						'type' => 'state',
-					],
-				],
-				'methods' => [
-					$free_shipping_1
-				]
-			],
-			[
-				'id'             => 1,
-				'zone_id'        => 1,
-				'zone_name'      => 'CA',
-				'zone_locations' => [
-					(object) [
-						'code' => 'US:CA',
-						'type' => 'state',
-					],
-				],
-				'methods' => [
-					$free_shipping_2
-				]
-			],
-		];
-
-		// Mock the get_shipping_zones method to return the above array.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( $shipping_zones );
-
-		// Mock the get_shipping_zone method to return the zone locations and methods for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturnCallback( function ( $zone_id ) use ( $shipping_zones ) {
-					 $zone = $this->createMock( WC_Shipping_Zone::class );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_zone_locations' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['zone_locations'] );
-					 $zone->expects( $this->any() )
-						  ->method( 'get_shipping_methods' )
-						  ->willReturn( $shipping_zones[ $zone_id ]['methods'] );
-
-					 return $zone;
-				 } );
-
-		$this->assertEquals( [ 'US' ], $this->shipping_zone->get_shipping_countries() );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-		$this->assertCount( 1, $methods );
-		$this->assertEquals( ShippingZone::METHOD_FREE, $methods[0]['id'] );
-		$this->assertEquals( 10, $methods[0]['options']['min_amount'] );
-	}
-
-	public function test_is_shipping_method_supported() {
-		$this->assertTrue( ShippingZone::is_shipping_method_supported( ShippingZone::METHOD_FLAT_RATE ) );
-		$this->assertFalse( ShippingZone::is_shipping_method_supported( 'some_random_method_that_should_not_be_valid' ) );
-	}
-
-	public function test_returns_shipping_class_costs() {
-		// Return one sample shipping zone.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		// Return three sample shipping classes.
-		$light_class          = new \stdClass();
-		$light_class->term_id = 0;
-		$light_class->slug    = 'light';
-		$heavy_class          = new \stdClass();
-		$heavy_class->term_id = 1;
-		$heavy_class->slug    = 'heavy';
-		$qty_class            = new \stdClass();
-		$qty_class->term_id   = 2;
-		$qty_class->slug      = 'qty';
-		$shipping_classes     = [ $light_class, $heavy_class, $qty_class ];
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_classes' )
-				 ->willReturn( $shipping_classes );
-
-		// Create a sample flat-rate shipping method with a constant cost.
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-						->method( 'is_enabled' )
-						->willReturn( true );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  } elseif ( 'class_cost_0' === $option ) {
-						  return 5;
-					  } elseif ( 'class_cost_1' === $option ) {
-						  return 15;
-					  } elseif ( 'class_cost_2' === $option ) {
-						  // This one has a dynamic price. It should be ignored.
-						  return '[qty] / 10';
-					  } elseif ( 'no_class_cost' === $option ) {
-						  return 2;
-					  }
-
-					  return null;
-				  } );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$methods = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-
-		$this->assertCount( 1, $methods );
-
-		// The shipping class with a dynamic price should be ignored.
-		$this->assertCount( 2, $methods[0]['options']['class_costs'] );
-
-		// The `no_class_cost` should be added to the flat rate method cost (10+2=12).
-		$this->assertEquals( 12, $methods[0]['options']['cost'] );
-
-		// The shipping class costs should be added to the flat rate method cost (10+5=15 and 10+15=25).
-		$this->assertEquals( 15, $methods[0]['options']['class_costs']['light'] );
-		$this->assertEquals( 25, $methods[0]['options']['class_costs']['heavy'] );
-
-	}
-
-	public function test_doesnt_return_disabled_methods() {
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( false );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$rates = $this->shipping_zone->get_shipping_methods_for_country( 'US' );
-
-		$this->assertEmpty( $rates );
-	}
-
-	public function test_doesnt_return_unsupported_rates() {
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( true );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  }
-
-					  return null;
-				  } );
-		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-					  ->method( 'is_enabled' )
-					  ->willReturn( true );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate, $free_shipping ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$rates = $this->shipping_zone->get_shipping_rates_for_country( 'US' );
-
-		$this->assertCount( 1, $rates );
-		$this->assertEquals( ShippingZone::METHOD_FLAT_RATE, $rates[0]['method'] );
-	}
-
-	public function test_doesnt_return_disabled_rates() {
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( false );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  }
-
-					  return null;
-				  } );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$rates = $this->shipping_zone->get_shipping_rates_for_country( 'US' );
-
-		$this->assertEmpty( $rates );
-	}
-
-	public function test_returns_shipping_rate_in_correct_format() {
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( true );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  }
-
-					  return null;
-				  } );
-
-		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-					  ->method( 'is_enabled' )
-					  ->willReturn( true );
-		$free_shipping->expects( $this->any() )
-					  ->method( 'get_option' )
-					  ->willReturnCallback( function ( $option ) {
-						  if ( 'requires' === $option ) {
-							  return 'min_amount';
-						  }
-						  if ( 'min_amount' === $option ) {
-							  return 100;
-						  }
-
-						  return null;
-					  } );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate, $free_shipping ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$rates = $this->shipping_zone->get_shipping_rates_for_country( 'US' );
-
-		$this->assertCount( 1, $rates );
-		$this->assertEquals( 'US', $rates[0]['country'] );
-		$this->assertEquals( 'flat_rate', $rates[0]['method'] );
-		$this->assertEquals( 'USD', $rates[0]['currency'] );
-		$this->assertEquals( 10, $rates[0]['rate'] );
-		$this->assertEquals( 100, $rates[0]['options']['free_shipping_threshold'] );
-	}
-
-	public function test_returns_shipping_rate_with_zero_cost_if_free_shipping_exists() {
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( true );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  }
-
-					  return null;
-				  } );
-		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-					  ->method( 'is_enabled' )
-					  ->willReturn( true );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate, $free_shipping ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$rates = $this->shipping_zone->get_shipping_rates_for_country( 'US' );
-
-		$this->assertCount( 1, $rates );
-		$this->assertEquals( 0, $rates[0]['rate'] );
-	}
-
-	public function test_returns_shipping_rate_with_zero_cost_if_only_free_shipping_enabled() {
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( false );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  }
-
-					  return null;
-				  } );
-		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-					  ->method( 'is_enabled' )
-					  ->willReturn( true );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate, $free_shipping ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$rates = $this->shipping_zone->get_shipping_rates_for_country( 'US' );
-
-		$this->assertCount( 1, $rates );
-		$this->assertEquals( 0, $rates[0]['rate'] );
-	}
-
-	public function test_returns_shipping_rate_with_zero_cost_if_only_free_shipping_exists() {
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		$free_shipping = $this->createMock( WC_Shipping_Free_Shipping::class );
-		$free_shipping->id = ShippingZone::METHOD_FREE;
-		$free_shipping->expects( $this->any() )
-					  ->method( 'is_enabled' )
-					  ->willReturn( true );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $free_shipping ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$rates = $this->shipping_zone->get_shipping_rates_for_country( 'US' );
-
-		$this->assertCount( 1, $rates );
-		$this->assertEquals( 0, $rates[0]['rate'] );
-	}
-
-	public function test_returns_class_shipping_rates() {
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zones' )
-				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
-
-		// Return a sample shipping class.
-		$light_class          = new \stdClass();
-		$light_class->term_id = 0;
-		$light_class->slug    = 'light';
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_classes' )
-				 ->willReturn( [ $light_class ] );
-
-		// Create a sample flat-rate shipping method with a constant cost.
-		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
-		$flat_rate->id = ShippingZone::METHOD_FLAT_RATE;
-		$flat_rate->expects( $this->any() )
-				  ->method( 'is_enabled' )
-				  ->willReturn( true );
-		$flat_rate->expects( $this->any() )
-				  ->method( 'get_option' )
-				  ->willReturnCallback( function ( $option ) {
-					  if ( 'cost' === $option ) {
-						  return 10;
-					  } elseif ( 'class_cost_0' === $option ) {
-						  return 5;
-					  } elseif ( 'no_class_cost' === $option ) {
-						  return 2;
-					  }
-
-					  return null;
-				  } );
-
-		$shipping_zone = $this->create_mock_shipping_zone( 'US', [ $flat_rate ] );
-
-		// Return the zone locations for the given zone id.
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_shipping_zone' )
-				 ->willReturn( $shipping_zone );
-
-		$rates = $this->shipping_zone->get_shipping_rates_for_country( 'US' );
-
-		$this->assertCount( 1, $rates );
-		$this->assertEquals( 12, $rates[0]['rate'] );
-		$this->assertNotEmpty( $rates[0]['options']['shipping_class_rates'] );
-		$this->assertEquals( 'light', $rates[0]['options']['shipping_class_rates'][0]['class'] );
-		$this->assertEquals( 15, $rates[0]['options']['shipping_class_rates'][0]['rate'] );
-	}
-
-	/**
-	 * Creates a mock WooCommerce shipping zone object covering the given country and including the given shipping methods.
-	 *
-	 * @param string $country
-	 * @param array $methods
-	 *
-	 * @return WC_Shipping_Zone|MockObject
-	 */
-	protected function create_mock_shipping_zone( string $country, array $methods ) {
-		$shipping_zone = $this->createMock( WC_Shipping_Zone::class );
-		$shipping_zone->expects( $this->any() )
-					  ->method( 'get_zone_locations' )
-					  ->willReturn(
-					  	[
-							(object) [
-								'code' => $country,
-								'type' => 'country',
-							],
-						]
-					  );
-		$shipping_zone->expects( $this->any() )
-					  ->method( 'get_shipping_methods' )
-					  ->willReturn( $methods );
-
-		return $shipping_zone;
-	}
-
-	/**
-	 * Returns two options for the `requires` options of a free-shipping method that require a minimum order amount.
-	 *
-	 * @return array
-	 */
-	public function return_free_shipping_min_amount_requirements(): array {
-		return [
-			[ 'min_amount' ],
-			[ 'either' ],
-		];
-	}
-
-	/**
-	 * Returns two options for the `requires` options of a free-shipping method that require a coupon.
-	 *
-	 * @return array
-	 */
-	public function return_free_shipping_coupon_requirements(): array {
-		return [
-			[ 'coupon' ],
-			[ 'both' ],
-		];
+	public function test_ignores_zones_with_no_locations() {
+		$this->locations_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn( [] );
+		$this->methods_parser->expects( $this->once() )
+							 ->method( 'parse' )
+							 ->willReturn( [ new ShippingRateFree() ] );
+
+		$this->assertEmpty( $this->shipping_zone->get_shipping_countries() );
 	}
 
 	/**
@@ -1134,14 +131,25 @@ class ShippingZoneTest extends UnitTest {
 	 */
 	public function setUp() {
 		parent::setUp();
-
 		$this->wc = $this->createMock( WC::class );
+
 		$this->wc->expects( $this->any() )
-				 ->method( 'get_woocommerce_currency' )
-				 ->willReturn( 'USD' );
+				 ->method( 'get_shipping_zones' )
+				 ->willReturn( [ [ 'zone_id' => 1 ] ] );
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_zone' )
+				 ->willReturn( $this->createMock( WC_Shipping_Zone::class ) );
 
-		$this->google_helper = new GoogleHelper( $this->wc );
+		$this->locations_parser = $this->createMock( ZoneLocationsParser::class );
+		$this->methods_parser   = $this->createMock( ZoneMethodsParser::class );
 
-		$this->shipping_zone = new ShippingZone( $this->wc, $this->google_helper );
+		$this->rates_processor = $this->createMock( LocationRatesProcessor::class );
+		$this->rates_processor->expects( $this->any() )
+							  ->method( 'process' )
+							  ->willReturnCallback( function ( $location_rates ) {
+								  return $location_rates;
+							  } );
+
+		$this->shipping_zone = new ShippingZone( $this->wc, $this->locations_parser, $this->methods_parser, $this->rates_processor );
 	}
 }

--- a/tests/Unit/Shipping/ShippingZoneTest.php
+++ b/tests/Unit/Shipping/ShippingZoneTest.php
@@ -75,6 +75,10 @@ class ShippingZoneTest extends UnitTest {
 		$this->assertEquals( 'CA', $location_rates[0]->get_location()->get_country() );
 		$this->assertEquals( 'BC', $location_rates[0]->get_location()->get_state() );
 		$this->assertEqualSets( [ '12345', '67890' ], $location_rates[0]->get_location()->get_postcodes() );
+
+		// Test non-existent country.
+		$location_rates = $this->shipping_zone->get_shipping_rates_for_country( 'XX' );
+		$this->assertEmpty( $location_rates );
 	}
 
 	public function test_returns_shipping_rates_grouped_by_country() {

--- a/tests/Unit/Shipping/ZoneLocationsParserTest.php
+++ b/tests/Unit/Shipping/ZoneLocationsParserTest.php
@@ -1,0 +1,282 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\Location;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneLocationsParser;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Countries;
+use WC_Shipping_Zone;
+
+/**
+ * Class ZoneLocationsParserTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
+ *
+ * @property MockObject|WC           $wc
+ * @property MockObject|GoogleHelper $google_helper
+ * @property ZoneLocationsParser     $locations_parser
+ */
+class ZoneLocationsParserTest extends UnitTest {
+	public function test_returns_state_locations_if_regional_shipping_supported() {
+		$zone_locations = [
+			(object) [
+				'code' => 'US:NV',
+				'type' => 'state',
+			],
+		];
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_zone_locations' )
+			 ->willReturn( $zone_locations );
+
+		$this->google_helper->expects( $this->any() )
+							->method( 'is_country_supported' )
+							->with( 'US' )
+							->willReturn( true );
+
+		$this->google_helper->expects( $this->any() )
+							->method( 'does_country_support_regional_shipping' )
+							->with( 'US' )
+							->willReturn( true );
+
+		$parsed_locations = $this->locations_parser->parse( $zone );
+
+		$this->assertCount( 1, $parsed_locations );
+		$this->assertEquals( 'US', $parsed_locations[0]->get_country() );
+		$this->assertEquals( 'NV', $parsed_locations[0]->get_state() );
+	}
+
+	public function test_returns_country_locations_if_regional_shipping_unsupported() {
+		$zone_locations = [
+			(object) [
+				'code' => 'XX:NV',
+				'type' => 'state',
+			],
+		];
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_zone_locations' )
+			 ->willReturn( $zone_locations );
+
+		$this->google_helper->expects( $this->any() )
+							->method( 'is_country_supported' )
+							->with( 'XX' )
+							->willReturn( true );
+		$this->google_helper->expects( $this->any() )
+							->method( 'does_country_support_regional_shipping' )
+							->with( 'XX' )
+							->willReturn( false );
+
+		$parsed_locations = $this->locations_parser->parse( $zone );
+
+		$this->assertCount( 1, $parsed_locations );
+		$this->assertEquals( 'XX', $parsed_locations[0]->get_country() );
+		$this->assertEmpty( $parsed_locations[0]->get_state() );
+	}
+
+	public function test_returns_postcodes_for_all_other_locations() {
+		$zone_locations = [
+			(object) [
+				'code' => 'US:CA',
+				'type' => 'state',
+			],
+			(object) [
+				'code' => 'FR',
+				'type' => 'country',
+			],
+			(object) [
+				'code' => 'EU',
+				'type' => 'continent',
+			],
+			(object) [
+				'code' => '12345',
+				'type' => 'postcode',
+			],
+			(object) [
+				'code' => '67890',
+				'type' => 'postcode',
+			],
+		];
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_zone_locations' )
+			 ->willReturn( $zone_locations );
+
+
+		// Mock the WC_Countries class to return a predefined list of countries for the EU continent.
+		$wc_countries = $this->createMock( WC_Countries::class );
+		$wc_countries->expects( $this->any() )
+					 ->method( 'get_continents' )
+					 ->willReturn( [
+						 'EU' => [
+							 'name'      => 'Europe',
+							 'countries' => [
+								 'DE',
+								 'DK',
+							 ],
+						 ],
+					 ] );
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_wc_countries' )
+				 ->willReturn( $wc_countries );
+
+		$this->google_helper->expects( $this->any() )
+							->method( 'get_mc_supported_countries' )
+							->willReturn(
+								[
+									'DE',
+									'DK',
+								]
+							);
+		$this->google_helper->expects( $this->any() )
+							->method( 'is_country_supported' )
+							->willReturn( true );
+		$this->google_helper->expects( $this->any() )
+							->method( 'does_country_support_regional_shipping' )
+							->willReturn( true );
+
+		$parsed_locations = $this->locations_parser->parse( $zone );
+
+		$this->assertCount( 4, $parsed_locations );
+		foreach ( $parsed_locations as $location ) {
+			$this->assertEqualSets( [ '12345', '67890' ], $location->get_postcodes() );
+		}
+	}
+
+	public function test_returns_only_supported_locations() {
+		$zone_locations = [
+			// State from an unsupported country.
+			(object) [
+				'code' => 'XX:NV',
+				'type' => 'state',
+			],
+			// State from a supported country.
+			(object) [
+				'code' => 'US:NV',
+				'type' => 'state',
+			],
+			// Unsupported country.
+			(object) [
+				'code' => 'YY',
+				'type' => 'country',
+			],
+			// Supported country.
+			(object) [
+				'code' => 'US',
+				'type' => 'country',
+			],
+			// Continent with both supported and unsupported countries.
+			(object) [
+				'code' => 'EU',
+				'type' => 'continent',
+			],
+			// Non-existent continent.
+			(object) [
+				'code' => 'ZZ',
+				'type' => 'continent',
+			],
+		];
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_zone_locations' )
+			 ->willReturn( $zone_locations );
+
+		// Mock the WC_Countries class to return a predefined list of countries for the EU continent.
+		$wc_countries = $this->createMock( WC_Countries::class );
+		$wc_countries->expects( $this->any() )
+					 ->method( 'get_continents' )
+					 ->willReturn( [
+						 'EU' => [
+							 'name'      => 'Europe',
+							 'countries' => [
+								 // Supported country.
+								 'DE',
+								 // Unsupported country.
+								 'AA',
+							 ],
+						 ],
+					 ] );
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_wc_countries' )
+				 ->willReturn( $wc_countries );
+
+		$this->google_helper->expects( $this->any() )
+							->method( 'get_mc_supported_countries' )
+							->willReturn(
+								[
+									'US',
+									'DE'
+								]
+							);
+		$this->google_helper->expects( $this->any() )
+							->method( 'is_country_supported' )
+							->willReturnMap(
+								[
+									[ 'US', true ],
+									[ 'DE', true ],
+									[ 'XX', false ],
+									[ 'YY', false ],
+									[ 'AA', false ],
+								]
+							);
+		$this->google_helper->expects( $this->any() )
+							->method( 'does_country_support_regional_shipping' )
+							->with( 'US' )
+							->willReturn( true );
+
+		$parsed_locations = $this->locations_parser->parse( $zone );
+
+		$this->assertCount( 3, $parsed_locations );
+
+		$location_countries = array_map(
+			function ( Location $location ) {
+				return $location->get_country();
+			},
+			$parsed_locations
+		);
+		$this->assertEqualSets(
+			[
+				'US',
+				// Repeated because of the "US:NV" state location entry.
+				'US',
+				'DE',
+			],
+			$location_countries
+		);
+
+		$states = array_map(
+			function ( Location $location ) {
+				return $location->get_state();
+			},
+			$parsed_locations
+		);
+		$this->assertEquals(
+			[
+				'NV',
+				// Two null entries for the country locations without a state.
+				null,
+				null,
+			],
+			$states
+		);
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->wc               = $this->createMock( WC::class );
+		$this->google_helper    = $this->createMock( GoogleHelper::class );
+		$this->locations_parser = new ZoneLocationsParser( $this->wc, $this->google_helper );
+	}
+}

--- a/tests/Unit/Shipping/ZoneMethodsParserTest.php
+++ b/tests/Unit/Shipping/ZoneMethodsParserTest.php
@@ -1,0 +1,241 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRateFlat;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRateFree;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneMethodsParser;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Shipping_Flat_Rate;
+use WC_Shipping_Free_Shipping;
+use WC_Shipping_Zone;
+
+/**
+ * Class ZoneMethodsParserTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
+ *
+ * @property MockObject|WC     $wc
+ * @property ZoneMethodsParser $methods_parser
+ */
+class ZoneMethodsParserTest extends UnitTest {
+	public function test_returns_flat_rate_methods() {
+		$flat_rate     = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ZoneMethodsParser::METHOD_FLAT_RATE;
+		$flat_rate->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnMap(
+					  [
+						  [ 'cost', null, 10 ],
+					  ]
+				  );
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_shipping_methods' )
+			 ->willReturn( [ $flat_rate ] );
+
+		/** @var ShippingRateFlat[] $shipping_rates */
+		$shipping_rates = $this->methods_parser->parse( $zone );
+		$this->assertCount( 1, $shipping_rates );
+		$this->assertInstanceOf( ShippingRateFlat::class, $shipping_rates[0] );
+		$this->assertEquals( 10, $shipping_rates[0]->get_rate() );
+	}
+
+	public function test_returns_flat_rate_methods_including_shipping_classes() {
+		// Return three sample shipping classes.
+		$light_class          = new \stdClass();
+		$light_class->term_id = 0;
+		$light_class->slug    = 'light';
+		$heavy_class          = new \stdClass();
+		$heavy_class->term_id = 1;
+		$heavy_class->slug    = 'heavy';
+		$qty_class            = new \stdClass();
+		$qty_class->term_id   = 2;
+		$qty_class->slug      = 'qty';
+		$shipping_classes     = [ $light_class, $heavy_class, $qty_class ];
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_shipping_classes' )
+				 ->willReturn( $shipping_classes );
+
+		$flat_rate     = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ZoneMethodsParser::METHOD_FLAT_RATE;
+		$flat_rate->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnMap( [
+					  [ 'cost', null, 10 ],
+					  [ 'class_cost_0', null, 5 ],
+					  [ 'class_cost_1', null, 15 ],
+					  [ 'class_cost_2', null, '[qty] / 10' ],
+					  [ 'no_class_cost', null, 2 ],
+				  ] );
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_shipping_methods' )
+			 ->willReturn( [ $flat_rate ] );
+
+		/** @var ShippingRateFlat[] $shipping_rates */
+		$shipping_rates = $this->methods_parser->parse( $zone );
+		$this->assertCount( 1, $shipping_rates );
+		$this->assertInstanceOf( ShippingRateFlat::class, $shipping_rates[0] );
+
+		// The `no_class_cost` should be added to the flat rate method cost (10+2=12).
+		$this->assertEquals( 12, $shipping_rates[0]->get_rate() );
+
+		// The shipping class with a dynamic price should be ignored.
+		$this->assertCount( 2, $shipping_rates[0]->get_shipping_class_rates() );
+
+		// The shipping class costs should be added to the flat rate method cost (10+5=15 and 10+15=25).
+		$this->assertEqualSets(
+			[
+				[
+					'class' => 'light',
+					'rate'  => 15,
+				],
+				[
+					'class' => 'heavy',
+					'rate'  => 25,
+				],
+			],
+			$shipping_rates[0]->get_shipping_class_rates()
+		);
+
+	}
+
+	/**
+	 * @param string $requires
+	 *
+	 * @dataProvider return_free_shipping_min_amount_requirements
+	 */
+	public function test_returns_free_shipping_methods( string $requires ) {
+		$free_shipping     = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping->id = ZoneMethodsParser::METHOD_FREE;
+		$free_shipping->expects( $this->any() )
+					  ->method( 'get_option' )
+					  ->willReturnMap( [
+						  [ 'requires', null, $requires ],
+						  [ 'min_amount', null, 99.99 ],
+					  ] );
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_shipping_methods' )
+			 ->willReturn( [ $free_shipping ] );
+
+		/** @var ShippingRateFree[] $shipping_rates */
+		$shipping_rates = $this->methods_parser->parse( $zone );
+		$this->assertCount( 1, $shipping_rates );
+		$this->assertInstanceOf( ShippingRateFree::class, $shipping_rates[0] );
+		$this->assertEquals( 99.99, $shipping_rates[0]->get_threshold() );
+	}
+
+	/**
+	 * @param string $requires
+	 *
+	 * @dataProvider return_free_shipping_coupon_requirements
+	 */
+	public function test_ignores_free_shipping_methods_if_they_require_coupons( string $requires ) {
+		$free_shipping     = $this->createMock( WC_Shipping_Free_Shipping::class );
+		$free_shipping->id = ZoneMethodsParser::METHOD_FREE;
+		$free_shipping->expects( $this->any() )
+					  ->method( 'get_option' )
+					  ->willReturnMap( [
+						  [ 'requires', null, $requires ],
+						  [ 'min_amount', null, 99.99 ],
+					  ] );
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_shipping_methods' )
+			 ->willReturn( [ $free_shipping ] );
+
+		$this->assertEmpty( $this->methods_parser->parse( $zone ) );
+	}
+
+	public function test_ignores_unsupported_methods() {
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_shipping_methods' )
+			 ->willReturn( [
+				 (object) [
+					 'enabled' => true,
+					 'title'   => 'Unsupported method',
+					 'id'      => 'a_random_unsupported_method',
+				 ],
+			 ] );
+
+		$this->assertEmpty( $this->methods_parser->parse( $zone ) );
+	}
+
+	public function test_ignores_flat_rate_methods_with_no_rate() {
+		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ZoneMethodsParser::METHOD_FLAT_RATE;
+		$flat_rate->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnMap( [
+					  [ 'cost', null ],
+					  [ 'no_class_cost', null ],
+				  ] );
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_shipping_methods' )
+			 ->willReturn( [ $flat_rate ] );
+
+		$this->assertEmpty( $this->methods_parser->parse( $zone ) );
+	}
+
+	public function test_ignores_flat_rate_methods_with_non_numeric_rate() {
+		$flat_rate = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ZoneMethodsParser::METHOD_FLAT_RATE;
+		$flat_rate->expects( $this->any() )
+				  ->method( 'get_option' )
+				  ->willReturnMap( [
+					  [ 'cost', '[qty] * 5' ],
+				  ] );
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			 ->method( 'get_shipping_methods' )
+			 ->willReturn( [ $flat_rate ] );
+
+		$this->assertEmpty( $this->methods_parser->parse( $zone ) );
+	}
+
+	/**
+	 * Returns two options for the `requires` options of a free-shipping method that require a minimum order amount.
+	 *
+	 * @return array
+	 */
+	public function return_free_shipping_min_amount_requirements(): array {
+		return [
+			[ 'min_amount' ],
+			[ 'either' ],
+		];
+	}
+
+	/**
+	 * Returns two options for the `requires` options of a free-shipping method that require a coupon.
+	 *
+	 * @return array
+	 */
+	public function return_free_shipping_coupon_requirements(): array {
+		return [
+			[ 'coupon' ],
+			[ 'both' ],
+		];
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->wc             = $this->createMock( WC::class );
+		$this->methods_parser = new ZoneMethodsParser( $this->wc );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1230

This PR introduces new services to parse the WooCommerce shipping zones and return the shipping rates for each country and its subdivisions (state, provides, postcodes, etc.).

The `ShippingZone` service functionality is divided into three other classes that handle parsing the locations, methods, and grouping them together.

Instead of mapping the rates as multidimensional arrays, several value classes are introduced to hold `Location`, different types of `ShippingRate`, and a combination of the two: `LocationRate`. This allows us to have a consistent verifiable format when dealing with the suggested shipping rates throughout the codebase.

The `ShippingZone` service has now a new function that returns the rates grouped by countries. This is used in the suggestions API since we currently only suggest rates on a country level.

The previous method `get_shipping_rates_for_country` is now refactored to return the shipping rates for all subdivisions of a country as well.

All shipping rate suggestions are returned as a `LocationRate` object.

I've also removed the `currency` property from suggested shipping rates since they all always have the same currency as WooCommerce. The `currency` for the rates is now directly fetched from WooCommerce in suggestions API and Googe settings sync service.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

The new functionality to return the shipping rates for subdivisions isn't being used anywhere in the code so it's not possible to test it without manually calling the `ShippingZone::get_shipping_rates_for_country` method somewhere and inspecting its output.

1. Define multiple shipping zones each containing various regions, postcodes, shipping methods, and rates for shipping classes.
2. Make a GET request to the `mc/shipping/rates/suggestions` API with the country_codes parameter set to an array of country codes from your defined shipping zones and confirm the rates are returned the same as you defined in your shipping zone settings. Note that the rates will be grouped at a country level.
3. Send a `POST` request to `wc/gla/mc/settings` and include the following data as JSON body: `{ "shipping_rate":"automatic" }`
4. Send a `POST` request to `wc/gla/mc/settings/sync`
5. Confirm that it's successful.
6. Check the shipping rates in your MC account and confirm that they match what you defined in Woo shipping zones. Again, the syncing functionality is still working on a country level so you won't see any state-specific rates synced.

To test that the code also returns rates on a subdivision level, you can call the `ShippingZone::get_shipping_rates_for_country` method anywhere in the code (for example, in the shipping rates suggestions controller) and inspect its output via xDebug or simply `var_dump`. It will return the rates as a flat array but each will have its `location` property set correctly.


### Additional details:

A side effect of these changes is that the `GET mc/shipping/rates/suggestions` API now returns the suggestions differently. Previously, if a `free_shipping` rate with a `free_shipping_threshold` was among the suggestions, this API would return it as a `flat_rate` with a `rate` of `0`. With this PR, the `free_shipping` suggestion will be returned as-is.

The other important change is that the `free_shipping_threshold` is now only expected to be set as an `option` for the `free_shipping` method. A `flat_rate` method no longer should have a `free_shipping_threshold` option.

For example, if the following shipping zones were created in WC settings:
![image](https://user-images.githubusercontent.com/73110514/160553823-0742ef36-0bc3-47ce-9325-2e594021fef2.png)

This would be the response of `GET mc/shipping/rates/suggestions`:
```JSON
[
    {
        "country": "TR",
        "method": "free_shipping",
        "currency": "USD",
        "rate": 0,
        "options": {}
    },
    {
        "country": "US",
        "method": "flat_rate",
        "currency": "USD",
        "rate": 20,
        "options": {}
    },
    {
        "country": "US",
        "method": "free_shipping",
        "currency": "USD",
        "rate": 0,
        "options": {
            "free_shipping_threshold": 4.99
        }
    },
    {
        "country": "ES",
        "method": "free_shipping",
        "currency": "USD",
        "rate": 0,
        "options": {
            "free_shipping_threshold": 100
        }
    }
]
```

Note the suggested shipping rates for US. Previously the "free_shipping_threshold" would be merged with the "flat_rate" method but now it's on a separate "free_shipping" rate.

The `POST mc/shipping/rates` API is also affected in the same way. This means that the `free_shipping_threshold` option is always expected to be set on a `free_shipping` rate and Free Shipping should be defined as a rate with a type equal to `free_shipping`. A flat_rate with a cost of `0` would still work but it cannot have the `free_shipping_threshold` option set on it.

For instance, to set a flat rate of 20 with conditional free shipping of orders above 4.99 for the US, the following rates should be sent to the `POST mc/shipping/rates/batch` API:

```JSON
{
  "rates": [
    {
        "country": "US",
        "method": "flat_rate",
        "currency": "USD",
        "rate": 20,
        "options": {}
    },
    {
        "country": "US",
        "method": "free_shipping",
        "currency": "USD",
        "rate": 0,
        "options": {
            "free_shipping_threshold": 4.99
        }
    }
  ]
}
```

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Get shipping rates suggestions for provinces/states and postal codes
