### PR TITLE
Replace text "Smart Shoppings" with "Performance Max"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![E2E Tests](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/e2e-tests.yml)
 [![Bundle Size](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/bundle-size.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/bundle-size.yml)
 
-A native integration with Google offering free listings and Smart Shopping ads to WooCommerce merchants.
+A native integration with Google offering free listings and Performance Max ads to WooCommerce merchants.
 
 -   [WooCommerce.com product page](https://woocommerce.com/products/google-listings-and-ads/)
 -   [WordPress.org plugin page](https://wordpress.org/plugins/google-listings-and-ads/)

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js
@@ -51,7 +51,7 @@ const EditProgramPromptModal = ( props ) => {
 		>
 			<p>
 				{ __(
-					'Results typically improve with time with Google’s Free Listing and Smart Shopping campaigns.',
+					'Results typically improve with time with Google’s Free Listing and paid ad campaigns.',
 					'google-listings-and-ads'
 				) }
 			</p>

--- a/js/src/dashboard/all-programs-table-card/program-toggle/pause-program-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/program-toggle/pause-program-modal/index.js
@@ -45,13 +45,13 @@ const PauseProgramModal = ( props ) => {
 		>
 			<p>
 				{ __(
-					'Results typically improve with time with Google’s Smart Shopping campaigns. If you pause, your products won’t be shown to people looking for what you offer.',
+					'Results typically improve with time with Google’s paid ad campaigns. If you pause, your products won’t be shown to people looking for what you offer.',
 					'google-listings-and-ads'
 				) }
 			</p>
 			<p>
 				{ __(
-					'Pausing a Smart Shopping campaign will result in the loss of any optimisations learned from those campaigns.',
+					'Pausing a paid ad campaign will result in the loss of any optimisations learned from those campaigns.',
 					'google-listings-and-ads'
 				) }
 			</p>

--- a/js/src/dashboard/all-programs-table-card/remove-program-button/remove-program-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/remove-program-button/remove-program-modal/index.js
@@ -69,7 +69,7 @@ const RemoveProgramModal = ( props ) => {
 		>
 			<p>
 				{ __(
-					'Results typically improve with time with Google’s Smart Shopping campaigns. Removing a Smart Shopping campaign will result in the loss of any optimisations learned from those campaigns.',
+					'Results typically improve with time with Google’s paid ad campaigns. Removing a paid ad campaign will result in the loss of any optimisations learned from those campaigns.',
 					'google-listings-and-ads'
 				) }
 			</p>

--- a/js/src/dashboard/campaign-creation-success-guide/index.js
+++ b/js/src/dashboard/campaign-creation-success-guide/index.js
@@ -101,7 +101,7 @@ export default function CampaignCreationSuccessGuide( {
 						link: (
 							<ContentLink
 								href="https://support.google.com/google-ads/answer/10724817"
-								context="campaign-creation-smart-shopping"
+								context="campaign-creation-performance-max"
 							/>
 						),
 					}

--- a/js/src/dashboard/campaign-creation-success-guide/index.js
+++ b/js/src/dashboard/campaign-creation-success-guide/index.js
@@ -88,19 +88,19 @@ export default function CampaignCreationSuccessGuide( {
 			</div>
 			<GuidePageContent
 				title={ __(
-					`You've set up a paid Smart Shopping Campaign!`,
+					`You've set up a paid Performance Max Campaign!`,
 					'google-listings-and-ads'
 				) }
 			>
 				{ createInterpolateElement(
 					__(
-						'You can pause or edit your campaign at any time. For best results, we recommend allowing your campaign to run for at least 14 days without pausing or editing. <link>Learn more about Smart Shopping technology.</link>',
+						'You can pause or edit your campaign at any time. For best results, we recommend allowing your campaign to run for at least 14 days without pausing or editing. <link>Learn more about Performance Max technology.</link>',
 						'google-listings-and-ads'
 					),
 					{
 						link: (
 							<ContentLink
-								href="https://support.google.com/google-ads/answer/7674739"
+								href="https://support.google.com/google-ads/answer/10724817"
 								context="campaign-creation-smart-shopping"
 							/>
 						),

--- a/js/src/dashboard/index.test.js
+++ b/js/src/dashboard/index.test.js
@@ -31,7 +31,7 @@ jest.mock( '@woocommerce/navigation', () => {
 jest.mock( '.~/utils/isWCTracksEnabled', () => jest.fn() );
 
 const CAMPAIGN_CREATION_SUCCESS_GUIDE_TEXT =
-	"You've set up a paid Smart Shopping Campaign!";
+	"You've set up a paid Performance Max Campaign!";
 const CES_PROMPT_TEXT = 'How easy was it to create a Google Ad campaign?';
 
 jest.mock( '.~/components/customer-effort-score-prompt', () => () => (

--- a/js/src/get-started-page/faqs.js
+++ b/js/src/get-started-page/faqs.js
@@ -90,7 +90,7 @@ const faqItems = [
 				<p>
 					{ createInterpolateElement(
 						__(
-							'Learn more about supported countries and currencies for Smart Shopping campaigns <link>here</link>.',
+							'Learn more about supported countries and currencies for Performance Max campaigns <link>here</link>.',
 							'google-listings-and-ads'
 						),
 						{
@@ -123,7 +123,7 @@ const faqItems = [
 				</p>
 				<p>
 					{ __(
-						'If you’re running a Smart Shopping campaign, your approved products can appear on Google Search, the Shopping tab, Gmail, Youtube and the Google Display Network.',
+						'If you’re running a Performance Max campaign, your approved products can appear on Google Search, the Shopping tab, Gmail, Youtube and the Google Display Network.',
 						'google-listings-and-ads'
 					) }
 				</p>
@@ -150,33 +150,33 @@ const faqItems = [
 	{
 		trackId: 'what-are-smart-shopping-campaigns',
 		question: __(
-			'What are Smart Shopping campaigns?',
+			'What are Performance Max campaigns?',
 			'google-listings-and-ads'
 		),
 		answer: __(
-			'Smart Shopping campaigns are Google Ads that combine Google’s machine learning with automated bidding and ad placements to maximize conversion value and strategically display your ads to people searching for products like yours, at your given budget. The best part? You only pay when people click on your ad.',
+			'Performance Max campaigns are Google Ads that combine Google’s machine learning with automated bidding and ad placements to maximize conversion value and strategically display your ads to people searching for products like yours, at your given budget. The best part? You only pay when people click on your ad.',
 			'google-listings-and-ads'
 		),
 	},
 	{
 		trackId: 'how-much-do-smart-shopping-campaigns-cost',
 		question: __(
-			'How much do Smart Shopping campaigns cost?',
+			'How much do Performance Max campaigns cost?',
 			'google-listings-and-ads'
 		),
 		answer: __(
-			'Smart Shopping campaigns are pay-per-click, meaning you only pay when someone clicks on your ads. You can customize your daily budget in Google Listings & Ads but we recommend starting off with the suggested minimum budget, and you can change this budget at any time.',
+			'Performance Max campaigns are pay-per-click, meaning you only pay when someone clicks on your ads. You can customize your daily budget in Google Listings & Ads but we recommend starting off with the suggested minimum budget, and you can change this budget at any time.',
 			'google-listings-and-ads'
 		),
 	},
 	{
 		trackId: 'can-i-run-both-free-listings-and-smart-shopping-campaigns',
 		question: __(
-			'Can I run both free listings and Smart Shopping campaigns at the same time?',
+			'Can I run both free listings and Performance Max campaigns at the same time?',
 			'google-listings-and-ads'
 		),
 		answer: __(
-			'Yes, you can run both at the same time, and we recommend it! In the US, advertisers running free listings and ads together have seen an average of over 50% increase in clicks and over 100% increase in impressions on both free listings and ads on the Shopping tab. Your store is automatically opted into free listings automatically and can choose to run a paid Smart Shopping campaign.',
+			'Yes, you can run both at the same time, and we recommend it! In the US, advertisers running free listings and ads together have seen an average of over 50% increase in clicks and over 100% increase in impressions on both free listings and ads on the Shopping tab. Your store is automatically opted into free listings automatically and can choose to run a paid Performance Max campaign.',
 			'google-listings-and-ads'
 		),
 	},

--- a/js/src/get-started-page/faqs.js
+++ b/js/src/get-started-page/faqs.js
@@ -97,7 +97,7 @@ const faqItems = [
 							link: (
 								<AppDocumentationLink
 									context="faqs"
-									linkId="supported-countries-and-currencies-for-smart-shopping-campaigns"
+									linkId="supported-countries-and-currencies-for-performance-max-campaigns"
 									href="https://support.google.com/merchants/answer/160637#countrytable"
 								/>
 							),
@@ -148,7 +148,7 @@ const faqItems = [
 		),
 	},
 	{
-		trackId: 'what-are-smart-shopping-campaigns',
+		trackId: 'what-are-performance-max-campaigns',
 		question: __(
 			'What are Performance Max campaigns?',
 			'google-listings-and-ads'
@@ -159,7 +159,7 @@ const faqItems = [
 		),
 	},
 	{
-		trackId: 'how-much-do-smart-shopping-campaigns-cost',
+		trackId: 'how-much-do-performance-max-campaigns-cost',
 		question: __(
 			'How much do Performance Max campaigns cost?',
 			'google-listings-and-ads'
@@ -170,7 +170,7 @@ const faqItems = [
 		),
 	},
 	{
-		trackId: 'can-i-run-both-free-listings-and-smart-shopping-campaigns',
+		trackId: 'can-i-run-both-free-listings-and-performance-max-campaigns',
 		question: __(
 			'Can I run both free listings and Performance Max campaigns at the same time?',
 			'google-listings-and-ads'

--- a/js/src/get-started-page/features-card/index.js
+++ b/js/src/get-started-page/features-card/index.js
@@ -103,7 +103,7 @@ const FeaturesCard = () => {
 						variant="body"
 					>
 						{ __(
-							'Create a Smart Shopping campaign to promote products across Google Search, Shopping, Gmail, YouTube, and the Display Network.',
+							'Create a Performance Max campaign to promote products across Google Search, Shopping, Gmail, YouTube, and the Display Network.',
 							'google-listings-and-ads'
 						) }
 					</Text>

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -80,7 +80,7 @@ const CreatePaidAdsCampaignForm = () => {
 							) }
 							description={ createInterpolateElement(
 								__(
-									'Paid Smart Shopping campaigns are automatically optimized for you by Google. <link>See what your ads will look like.</link>',
+									'Paid Performance Max campaigns are automatically optimized for you by Google. <link>See what your ads will look like.</link>',
 									'google-listings-and-ads'
 								),
 								{

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -66,10 +66,11 @@ const EditPaidAdsCampaignForm = ( props ) => {
 							) }
 							description={ createInterpolateElement(
 								__(
-									'Paid ad campaigns are automatically optimized for you by Google. <link>See what your ads will look like.</link>',
+									'Paid ad campaigns are automatically optimized for you by Google.<br/><link>See what your ads will look like.</link>',
 									'google-listings-and-ads'
 								),
 								{
+									br: <br />,
 									link: (
 										<AppDocumentationLink
 											context="edit-ads"

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -66,7 +66,7 @@ const EditPaidAdsCampaignForm = ( props ) => {
 							) }
 							description={ createInterpolateElement(
 								__(
-									'Paid Smart Shopping campaigns are automatically optimized for you by Google. <link>See what your ads will look like.</link>',
+									'Paid ad campaigns are automatically optimized for you by Google. <link>See what your ads will look like.</link>',
 									'google-listings-and-ads'
 								),
 								{

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { Form } from '@woocommerce/components';
 import { getHistory } from '@woocommerce/navigation';
 
@@ -64,22 +64,25 @@ const EditPaidAdsCampaignForm = ( props ) => {
 								'Edit your paid campaign',
 								'google-listings-and-ads'
 							) }
-							description={ createInterpolateElement(
-								__(
-									'Paid ad campaigns are automatically optimized for you by Google.<br/><link>See what your ads will look like.</link>',
-									'google-listings-and-ads'
-								),
-								{
-									br: <br />,
-									link: (
-										<AppDocumentationLink
-											context="edit-ads"
-											linkId="see-what-ads-look-like"
-											href="https://support.google.com/google-ads/answer/6275294"
-										/>
-									),
-								}
-							) }
+							description={
+								<>
+									{ __(
+										'Paid ad campaigns are automatically optimized for you by Google.',
+										'google-listings-and-ads'
+									) }
+									<br />
+									<AppDocumentationLink
+										context="edit-ads"
+										linkId="see-what-ads-look-like"
+										href="https://support.google.com/google-ads/answer/6275294"
+									>
+										{ __(
+											'See what your ads will look like.',
+											'google-listings-and-ads'
+										) }
+									</AppDocumentationLink>
+								</>
+							}
 						/>
 						<EditPaidAdsCampaignFormContent
 							formProps={ formProps }

--- a/js/src/setup-ads/ads-stepper/create-campaign/index.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/index.js
@@ -27,7 +27,7 @@ const CreateCampaign = ( props ) => {
 				) }
 				description={ createInterpolateElement(
 					__(
-						'Paid Smart Shopping campaigns are automatically optimized for you by Google. <link>See what your ads will look like.</link>',
+						'Paid Performance Max campaigns are automatically optimized for you by Google. <link>See what your ads will look like.</link>',
 						'google-listings-and-ads'
 					),
 					{

--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.js
@@ -37,7 +37,7 @@ const SetupAccounts = ( props ) => {
 					'google-listings-and-ads'
 				) }
 				description={ __(
-					'Connect your Google account and your Google Ads account to set up a paid Smart Shopping campaign.',
+					'Connect your Google account and your Google Ads account to set up a paid Performance Max campaign.',
 					'google-listings-and-ads'
 				) }
 			/>

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ Sync your store with Google to list products for free, run paid ads, and track p
 With Google Listings & Ads:
 - **Connect your store seamlessly** with Google Merchant Center.
 - **Reach online shoppers** with free listings.
-- **Boost store traffic and sales** with Smart Shopping Campaigns.
+- **Boost store traffic and sales** with Performance Max Campaigns.
 
 = Connect your store seamlessly =
 
@@ -39,11 +39,11 @@ Your products can also appear on Google Search, Google Images, and Gmail if you�
 
 = Boost store traffic and sales with Google Ads =
 
-Grow your business with Smart Shopping campaigns. Create an ad campaign to promote your products across Google Search, Shopping, YouTube, Gmail, and the Display Network.
+Grow your business with Performance Max campaigns. Create an ad campaign to promote your products across Google Search, Shopping, YouTube, Gmail, and the Display Network.
 
 Connect your Google Ads account, choose a budget, and launch your campaign straight from your WooCommerce dashboard. You can also review campaign analytics and access automated reports to easily see how your ads are performing.
 
-*Learn more about supported countries and currencies for Smart Shopping campaigns [here](https://support.google.com/merchants/answer/160637#countrytable).*
+*Learn more about supported countries and currencies for Performance Max campaigns [here](https://support.google.com/merchants/answer/160637#countrytable).*
 
 = Get $500 in Google Ads credit when you spend your first $500! =
 
@@ -88,24 +88,24 @@ The Google Merchant Center helps you sync your store and product data with Googl
 = Which countries are available for Google Listings & Ads? =
 Learn more about supported countries for Google free listings [here](https://support.google.com/merchants/answer/10033607?hl=en).
 
-Learn more about supported countries and currencies for Smart Shopping campaigns [here](https://support.google.com/merchants/answer/160637#countrytable).
+Learn more about supported countries and currencies for Performance Max campaigns [here](https://support.google.com/merchants/answer/160637#countrytable).
 
 = Where will my products appear? =
 If you’re selling in the US, then eligible free listings can appear in search results across Google Search, Google Images, and the Google Shopping tab. If you're selling outside the US, free listings will appear on the Shopping tab.
 
-If you’re running a Smart Shopping campaign, your approved products can appear on Google Search, the Shopping tab, Gmail, Youtube and the Google Display Network.
+If you’re running a Performance Max campaign, your approved products can appear on Google Search, the Shopping tab, Gmail, Youtube and the Google Display Network.
 
 = Will my deals and promotions display on Google? =
 To show your coupons and promotions on Google Shopping listings, make sure you’re using the latest version of Google Listings & Ads.  When you create or update a coupon in your WordPress dashboard under Marketing > Coupons, you’ll see a Channel Visibility settings box on the right: select “Show coupon on Google” to enable. This is currently available in the US only.
 
-= What are Smart Shopping campaigns? =
-Smart Shopping campaigns are Google Ads that combine Google’s machine learning with automated bidding and ad placements to maximize conversion value and strategically display your ads to people searching for products like yours, at your given budget. The best part? You only pay when people click on your ad.
+= What are Performance Max campaigns? =
+Performance Max campaigns are Google Ads that combine Google’s machine learning with automated bidding and ad placements to maximize conversion value and strategically display your ads to people searching for products like yours, at your given budget. The best part? You only pay when people click on your ad.
 
-= How much do Smart Shopping campaigns cost? =
-Smart Shopping campaigns are pay-per-click, meaning you only pay when someone clicks on your ads. You can customize your daily budget in Google Listings & Ads but we recommend starting off with the suggested minimum budget, and you can change this budget at any time.
+= How much do Performance Max campaigns cost? =
+Performance Max campaigns are pay-per-click, meaning you only pay when someone clicks on your ads. You can customize your daily budget in Google Listings & Ads but we recommend starting off with the suggested minimum budget, and you can change this budget at any time.
 
-= Can I run both free listings and Smart Shopping campaigns at the same time? =
-Yes, you can run both at the same time, and we recommend it! In the US, advertisers running free listings and ads together have seen an average of over 50% increase in clicks and over 100% increase in impressions on both free listings and ads on the Shopping tab. Your store is automatically opted into free listings automatically and can choose to run a paid Smart Shopping campaign.
+= Can I run both free listings and Performance Max campaigns at the same time? =
+Yes, you can run both at the same time, and we recommend it! In the US, advertisers running free listings and ads together have seen an average of over 50% increase in clicks and over 100% increase in impressions on both free listings and ads on the Shopping tab. Your store is automatically opted into free listings automatically and can choose to run a paid Performance Max campaign.
 
 == Changelog ==
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR is replacing the mentions of the "Smart Shoppings" with "Performance Max". Except for the following situations where is replaced using "paid ad": 

1. Before Edit campaign.
2. Edit campaign
3. Pause campaign.
4. Remove campaign.

See comment [pcTzPl-jc](https://wp.me/pcTzPl-jc#comment-746) for more context.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check that there are no mentions of Smart Shopping Campaigns.
5. The text is updated accordingly to the comment on [pcTzPl-jc](https://wp.me/pcTzPl-jc#comment-746). 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - replace text with Performance Max.
