### PR TITLE
Fix the `woocommerce-admin` dependency for PHP unit tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -80,8 +80,8 @@ function install_woocommerce() {
 	WC_Install::install();
 
 	// Initialize the WC API extensions.
-	\Automattic\WooCommerce\Admin\Install::create_tables();
-	\Automattic\WooCommerce\Admin\Install::create_events();
+	\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
+	\Automattic\WooCommerce\Internal\Admin\Install::create_events();
 
 	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
 	$GLOBALS['wp_roles'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `Automattic\WooCommerce\Admin\Install` namespace has been changed after [woocommerce-admin](https://github.com/woocommerce/woocommerce-admin) was merged into [woocommerce](https://github.com/woocommerce/woocommerce). This PR updates the namespace to fix the install processing of PHP unit tests.

Ref:
- https://github.com/woocommerce/woocommerce/blob/c4628b966be16218a99d093cf3672ad79a4f235e/plugins/woocommerce/src/Internal/Admin/Install.php#L6
- https://github.com/woocommerce/woocommerce-admin/pull/8317/files#diff-fe4f6d042955f294a9435960add587d284b232384dc9c5bee164316d501564a3R6

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/159219590-730482b9-53ce-402e-bb62-726788956086.png)

### Detailed test instructions:

Go to the [Checks tab](https://github.com/woocommerce/google-listings-and-ads/pull/1343/checks) of this PR to see if all test cases in each PHP Unit Tests jobs were executed and passed.

### Changelog entry
