### PR TITLE
Add the Fast Refresh for React development

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 !.eslintrc.js
 !.github
 build
+build-dev
 build-module
 coverage
 languages

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,10 @@ module.exports = {
 		jsdoc: {
 			mode: 'typescript',
 		},
-		'import/core-modules': [ 'webpack' ],
+		'import/core-modules': [
+			'webpack',
+			'@pmmmwh/react-refresh-webpack-plugin',
+		],
 		'import/resolver': { webpack: webpackResolver },
 	},
 	rules: {

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 bin export-ignore
 tests export-ignore
 js/src export-ignore
+js/build-dev export-ignore
 README.md export-ignore
 package.json export-ignore
 package-lock.json export-ignore
@@ -16,6 +17,7 @@ composer.lock export-ignore
 phpcs.xml.dist export-ignore
 phpunit.xml.dist export-ignore
 webpack.config.js export-ignore
+webpack-development.config.js export-ignore
 jest.config.js export-ignore
 wordpress_org_assets export-ignore
 .editorconfig export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules/
 dist
 build
+build-dev
 build-module
 build-style
 languages/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ composer.lock
 
 # from .eslintignore file.
 build
+build-dev
 build-module
 coverage
 languages

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Now you can build the files using one of these commands:
 -   `npm run build` : Build a production version
 -   `npm run dev` : Build a development version
 -   `npm run start` : Build a development version, watch files for changes
--   `npm run start:hot` : Build a development version in Fast Refresh mode, watch files for changes. To use this mode, it requires
-    1. The [`SCRIPT_DEBUG`](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) flag enabled.
+-   `npm run start:hot` : Build a development version in Fast Refresh mode, watch files for changes.
 
 ## Helper Scripts
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Now you can build the files using one of these commands:
 -   `npm run build` : Build a production version
 -   `npm run dev` : Build a development version
 -   `npm run start` : Build a development version, watch files for changes
+-   `npm run start:hot` : Build a development version in Fast Refresh mode, watch files for changes. To use this mode, it requires
+    1. The [`SCRIPT_DEBUG`](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) flag enabled.
+    1. The [Gutenberg](https://wordpress.org/plugins/gutenberg/) plugin activated.
 
 ## Helper Scripts
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Now you can build the files using one of these commands:
 -   `npm run start` : Build a development version, watch files for changes
 -   `npm run start:hot` : Build a development version in Fast Refresh mode, watch files for changes. To use this mode, it requires
     1. The [`SCRIPT_DEBUG`](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) flag enabled.
-    1. The [Gutenberg](https://wordpress.org/plugins/gutenberg/) plugin activated.
 
 ## Helper Scripts
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
 	watchPathIgnorePatterns: [
 		'<rootDir>/.externalized.json',
 		'<rootDir>/js/build/',
+		'<rootDir>/js/build-dev',
 	],
 	globals: {
 		glaData: {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"outdated:nondewp": "npm outdated --color=always | grep --color=never --invert -E \"^(.\\[31m|.\\[33m)?(`cat .externalized.json | sed 's/[][\"]//g'| sed 's/,/|/g'`)\"",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start",
+		"start:hot": "npm start -- --hot --allowed-hosts all",
 		"test:e2e": "npx wc-e2e test:e2e",
 		"test:e2e-dev": "npx wc-e2e test:e2e-dev",
 		"test:js": "wp-scripts test-unit-js --coverage",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"outdated:nondewp": "npm outdated --color=always | grep --color=never --invert -E \"^(.\\[31m|.\\[33m)?(`cat .externalized.json | sed 's/[][\"]//g'| sed 's/,/|/g'`)\"",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start",
-		"start:hot": "npm start -- --hot --allowed-hosts all",
+		"start:hot": "npm run dev -- --config ./webpack-development.config.js && npm start -- --hot --allowed-hosts all",
 		"test:e2e": "npx wc-e2e test:e2e",
 		"test:e2e-dev": "npx wc-e2e test:e2e-dev",
 		"test:js": "wp-scripts test-unit-js --coverage",

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -84,6 +84,13 @@ class Admin implements Service, Registerable, Conditional {
 				return $this->add_plugin_links( $links );
 			}
 		);
+
+		add_action(
+			'admin_enqueue_scripts',
+			function() {
+				$this->enqueue_webpack_runtime_for_dev();
+			}
+		);
 	}
 
 	/**
@@ -229,5 +236,31 @@ class Admin implements Service, Registerable, Conditional {
 	 */
 	protected function enableReports(): bool {
 		return apply_filters( 'woocommerce_gla_enable_reports', true );
+	}
+
+	/**
+	 * This method is ONLY used during development.
+	 *
+	 * The runtime.js file is created when the front-end is developed in Fast Refresh mode
+	 * and must be loaded together to enable the mode.
+	 */
+	private function enqueue_webpack_runtime_for_dev() {
+		if ( ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
+			return;
+		}
+
+		$file_path = "{$this->get_root_dir()}/js/build/runtime.js";
+
+		if ( ! file_exists( $file_path ) ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'gla-webpack-rumtime',
+			"{$this->get_plugin_url()}/js/build/runtime.js",
+			[],
+			(string) filemtime( $file_path ),
+			false
+		);
 	}
 }

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -248,13 +248,12 @@ class Admin implements Service, Registerable, Conditional {
 	 * When Gutenberg is not installed or not activated, the react dependency will not have
 	 * the 'wp-react-refresh-entry' handle, so here injects the Fast Refresh scripts we built.
 	 *
+	 * The Fast Refresh also needs the development version of React and ReactDOM.
+	 * They will be replaced if the SCRIPT_DEBUG flag is not enabled.
+	 *
 	 * @param WP_Scripts $scripts WP_Scripts instance.
 	 */
 	private function inject_fast_refresh_for_dev( $scripts ) {
-		if ( ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
-			return;
-		}
-
 		if ( ! file_exists( "{$this->get_root_dir()}/js/build/runtime.js" ) ) {
 			return;
 		}
@@ -263,6 +262,12 @@ class Admin implements Service, Registerable, Conditional {
 
 		if ( ! $react_script ) {
 			return;
+		}
+
+		if ( ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
+			$react_dom_script      = $scripts->query( 'react-dom', 'registered' );
+			$react_dom_script->src = str_replace( '.min', '', $react_dom_script->src );
+			$react_script->src     = str_replace( '.min', '', $react_script->src );
 		}
 
 		$plugin_url = $this->get_plugin_url();

--- a/webpack-development.config.js
+++ b/webpack-development.config.js
@@ -1,0 +1,46 @@
+/**
+ * This file was copied from the following and has some adjustments for fitting with this repo.
+ * https://github.com/WordPress/gutenberg/blob/%40wordpress/scripts%4022.1.0/tools/webpack/development.js
+ *
+ * More details of how to enable Fast Refresh in WordPress plugin development can be found in this PR:
+ * https://github.com/WordPress/gutenberg/pull/28273
+ */
+const path = require( 'path' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+const sharedConfig = {
+	mode: 'development',
+	target: defaultConfig.target,
+	output: {
+		filename: '[name].js',
+		path: path.join( __dirname, 'js/build-dev' ),
+	},
+};
+
+const reactRefreshEntryConfig = {
+	...sharedConfig,
+	entry: {
+		'react-refresh-entry':
+			'@pmmmwh/react-refresh-webpack-plugin/client/ReactRefreshEntry.js',
+	},
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};
+
+const reactRefreshRuntimeConfig = {
+	...sharedConfig,
+	entry: {
+		'react-refresh-runtime': {
+			import: 'react-refresh/runtime.js',
+			library: {
+				name: 'ReactRefreshRuntime',
+				type: 'window',
+			},
+		},
+	},
+	plugins: [
+		new DependencyExtractionWebpackPlugin( { useDefaults: false } ),
+	],
+};
+
+module.exports = [ reactRefreshEntryConfig, reactRefreshRuntimeConfig ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,9 +105,8 @@ const webpackConfig = {
 		} ),
 		new DependencyExtractionWebpackPlugin( {
 			injectPolyfill: true,
-			externalizedReport: hasReactFastRefresh
-				? false
-				: '../../.externalized.json',
+			externalizedReport:
+				! hasReactFastRefresh && '../../.externalized.json',
 			requestToExternal,
 			requestToHandle,
 		} ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,15 +124,7 @@ const webpackConfig = {
 		new webpack.ProvidePlugin( {
 			process: 'process/browser',
 		} ),
-		/**
-		 * If the development environment uses HTTPS,
-		 * it will fail when first connecting to webpack dev server,
-		 * so turn off the `overlay` option here.
-		 * Ref: https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/v0.5.4/docs/TROUBLESHOOTING.md#component-not-updating-with-bundle-splitting-techniques
-		 */
-		hasReactFastRefresh &&
-			new ReactRefreshWebpackPlugin( { overlay: false } ),
-	].filter( Boolean ),
+	],
 	entry: {
 		index: path.resolve( process.cwd(), 'js/src', 'index.js' ),
 		'task-complete-setup': path.resolve(
@@ -158,6 +150,16 @@ const webpackConfig = {
 };
 
 if ( hasReactFastRefresh ) {
+	/**
+	 * If the development environment uses HTTPS,
+	 * it will fail when first connecting to webpack dev server,
+	 * so turn off the `overlay` option here.
+	 * Ref: https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/v0.5.4/docs/TROUBLESHOOTING.md#component-not-updating-with-bundle-splitting-techniques
+	 */
+	webpackConfig.plugins.push(
+		new ReactRefreshWebpackPlugin( { overlay: false } )
+	);
+
 	webpackConfig.optimization = {
 		...webpackConfig.optimization,
 		// With multiple entries, it will need a webpack runtime to be shared

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const webpack = require( 'webpack' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const { hasArgInCLI } = require( '@wordpress/scripts/utils' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin' );
 const path = require( 'path' );
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -98,6 +99,7 @@ const webpackConfig = {
 			const filteredPlugins = [
 				'DependencyExtractionWebpackPlugin',
 				'CopyPlugin',
+				'ReactRefreshPlugin',
 			];
 			return ! filteredPlugins.includes( plugin.constructor.name );
 		} ),
@@ -123,7 +125,15 @@ const webpackConfig = {
 		new webpack.ProvidePlugin( {
 			process: 'process/browser',
 		} ),
-	],
+		/**
+		 * If the development environment uses HTTPS,
+		 * it will fail when first connecting to webpack dev server,
+		 * so turn off the `overlay` option here.
+		 * Ref: https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/v0.5.4/docs/TROUBLESHOOTING.md#component-not-updating-with-bundle-splitting-techniques
+		 */
+		hasReactFastRefresh &&
+			new ReactRefreshWebpackPlugin( { overlay: false } ),
+	].filter( Boolean ),
 	entry: {
 		index: path.resolve( process.cwd(), 'js/src', 'index.js' ),
 		'task-complete-setup': path.resolve(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's the stage 2 of #1333

- Introduce **Fast Refresh** for React

📌  Before starting the code review, there may be one thing we have to decide on first. I'd like to know your thoughts about them. Please have a look at the next section.

###  Additional details:

This PR contains four implementations at different levels, which are inversely proportional between convenience and degree of monkey patch. 🙈 

1. **Level 1** - The minimum requirements to enable Fast Refresh
   - [Complete code diff](https://github.com/woocommerce/google-listings-and-ads/pull/1345/commits/69dbd3a3eb9d3ab5f1c991593af0101b8ddce52b)
   - It requires the enabled `SCRIPT_DEBUG` flag and activated Gutenberg, which replaces all `@wordpress/*` packages with the versions inside Gutenberg.
   - That is, the `@wordpress/*` packages used through DEWP will be changed to newer versions when developing. Usually, we want to stay with the lowest supported version to avoid misuse of features that don't exist yet.
   - Another problem is that when the development environment uses HTTPS, there is an error that occurs every time the page is reloaded. Fast Refresh works fine, but the error is slightly distracting.
      ![2022-03-21 12 34 20](https://user-images.githubusercontent.com/17420811/159235771-f7b9d081-6c94-411f-b52a-649369102a76.png)
2. **Level 2** - Prevent the first connection from failing if the development environment uses HTTPS
   - Compare to level 1, there is an [additional change](https://github.com/woocommerce/google-listings-and-ads/pull/1345/commits/28bc5c130ce8e907acfad33772961ac4c5246937) to replace the plugin.
3. **Level 3** - Enable it without the need for Gutenberg
   - [Complete code diff](https://github.com/woocommerce/google-listings-and-ads/pull/1345/files/f5c6622c6512b4d989edeb9c9ec652bfb6884c5f)
   - It's still compatible with the activated Gutenberg
   - It still has to switch the `SCRIPT_DEBUG` flag manually
   - It avoids the major concern of level 1.
4. **Level 4** - Enable it without the need for enabling the `SCRIPT_DEBUG` flag
   - Compare to level 3, it requires [another monkey patch](https://github.com/woocommerce/google-listings-and-ads/pull/1345/commits/8dfbeb2a6dced0096243cb9ab5c89bdb83f4499d) to use the development version of React and ReactDOM.
   - It's still compatible with the enabled `SCRIPT_DEBUG` flag
   - This is the most convenient way to use it but has the most code injections.
   - Lower maintainability in the future updates from `@wordpress/scripts`

### Screenshots:

#### 📹 Automatically update changed modules after rebuilding js and scss files

https://user-images.githubusercontent.com/17420811/159233409-eed70a4d-8fcb-42f2-ade5-5bd9d1ac4791.mp4

#### 📹 It works well with the state of React Hooks

https://user-images.githubusercontent.com/17420811/159679953-4df3bded-382f-4760-a36e-72e33b5c92f6.mp4

:warning: However, it is important to note that hooks that have a deps array such as `useEffect` may be triggered after Fast Refresh updating modules.

### Detailed test instructions:

#### Fast Refresh
1. `npm run start:hot`
1. Switching all combinations of the enabled/disabled `SCRIPT_DEBUG` flag and the activated/deactivated Gutenberg. Check if the Fast Refresh works properly as in the above video.

#### The original watch mode
1. `npm start`
1. It should still work correctly as before.

### Changelog entry

> Add - Fast Refresh for React development.
