### PR TITLE
Tree Select Component - Keyboard navigation with Search 

### DIFF
--- a/js/src/components/tree-select-control/constants.js
+++ b/js/src/components/tree-select-control/constants.js
@@ -2,7 +2,6 @@ export const ROOT_VALUE = '__WC_TREE_SELECT_COMPONENT_ROOT__';
 export const BACKSPACE = 'Backspace';
 export const ESCAPE = 'Escape';
 export const ENTER = 'Enter';
-export const SPACE = ' ';
 export const ARROW_UP = 'ArrowUp';
 export const ARROW_DOWN = 'ArrowDown';
 export const ARROW_LEFT = 'ArrowLeft';

--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -8,6 +8,7 @@ import { useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import Tags from './tags';
+import { BACKSPACE } from './constants';
 
 /**
  * The Control Component renders a search input and also the Tags.
@@ -39,6 +40,15 @@ const Control = ( {
 	const hasTags = tags.length > 0;
 	const showPlaceholder = ! hasTags && ! isExpanded;
 	const inputRef = useRef();
+
+	const handleKeydown = ( event ) => {
+		if ( BACKSPACE === event.key ) {
+			if ( inputRef.current.value ) return;
+			onTagsChange( tags.slice( 0, -1 ) );
+			event.preventDefault();
+		}
+	};
+
 	return (
 		/**
 		 * ESLint Disable reason
@@ -81,6 +91,7 @@ const Control = ( {
 					disabled={ disabled }
 					onFocus={ onFocus }
 					onChange={ onInputChange }
+					onKeyDown={ handleKeydown }
 				/>
 			</div>
 		</div>

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -25,14 +25,7 @@ import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
 import Control from './control';
 import Options from './options';
 import './index.scss';
-import {
-	ARROW_DOWN,
-	ARROW_UP,
-	BACKSPACE,
-	ENTER,
-	ESCAPE,
-	ROOT_VALUE,
-} from '.~/components/tree-select-control/constants';
+import { ARROW_DOWN, ARROW_UP, ENTER, ESCAPE, ROOT_VALUE } from './constants';
 
 /**
  * Example of Options data structure:
@@ -435,12 +428,6 @@ const TreeSelectControl = ( {
 		if ( ARROW_DOWN === event.key ) {
 			if ( ! filteredOptions.length ) return;
 			setFocused( getNextOption( focused ) );
-			event.preventDefault();
-		}
-
-		if ( BACKSPACE === event.key ) {
-			if ( inputControlValue ) return;
-			onChange( value.slice( 0, -1 ) );
 			event.preventDefault();
 		}
 	};

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -505,6 +505,10 @@ const TreeSelectControl = ( {
 	const handleParentChange = ( checked, option ) => {
 		const newValue = [ ...value ];
 
+		if ( checked && ! nodesExpanded.includes( option.value ) ) {
+			setNodesExpanded( [ ...nodesExpanded, option.value ] );
+		}
+
 		function loadChildren( parent ) {
 			if ( ! parent.children ) {
 				return;

--- a/js/src/components/tree-select-control/index.scss
+++ b/js/src/components/tree-select-control/index.scss
@@ -93,7 +93,7 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 			background: rgba(255, 255, 255, 0.5);
 
 			.components-base-control__field {
-				display: none;
+				visibility: hidden;
 			}
 			.components-base-control__label {
 				cursor: default;

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { ARROW_LEFT, ARROW_RIGHT, ROOT_VALUE, SPACE } from './constants';
+import { ARROW_LEFT, ARROW_RIGHT, ROOT_VALUE } from './constants';
 import Checkbox from '.~/components/tree-select-control/checkbox';
 
 /**

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -95,20 +95,6 @@ const Options = ( {
 	};
 
 	/**
-	 * Expands the option
-	 *
-	 * @param {Option} option The option to expand
-	 */
-	const expand = ( option ) => {
-		if (
-			! option.children?.length ||
-			nodesExpanded.includes( option.value )
-		)
-			return;
-		onNodesExpandedChange( [ ...nodesExpanded, option.value ] );
-	};
-
-	/**
 	 * Alters the node with some keys for accessibility
 	 * ArrowRight - Expands the node
 	 * ArrowLeft - Collapses the node
@@ -123,8 +109,6 @@ const Options = ( {
 			toggleExpanded( option );
 		} else if ( event.key === ARROW_LEFT && isExpanded ) {
 			toggleExpanded( option );
-		} else if ( event.key === SPACE ) {
-			onChange( event.target.checked, option );
 		}
 	};
 
@@ -178,9 +162,6 @@ const Options = ( {
 						onChange={ ( e ) => {
 							onOptionFocused( option );
 							onChange( e.target.checked, option );
-							if ( e.target.checked ) {
-								expand( option );
-							}
 						} }
 						onKeyDown={ ( e ) => {
 							handleKeyDown( e, option, isExpanded );

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -98,7 +98,6 @@ const Options = ( {
 	 * Alters the node with some keys for accessibility
 	 * ArrowRight - Expands the node
 	 * ArrowLeft - Collapses the node
-	 * Space - Checks/Unchecks the node
 	 *
 	 * @param {Event} event The KeyDown event
 	 * @param {Option} option The option where the event happened

--- a/js/src/pages/component-test/index.js
+++ b/js/src/pages/component-test/index.js
@@ -68,7 +68,6 @@ const ComponentTest = () => {
 						{ value: 'NY', label: 'New York' },
 						{ value: 'TX', label: 'Texas' },
 						{ value: 'GE', label: 'Georgia' },
-						{ value: 'TX2', label: 'Tex 123' },
 					],
 				},
 				{
@@ -76,14 +75,6 @@ const ComponentTest = () => {
 					label: 'Canada',
 				},
 			],
-		},
-		{
-			value: 'XXX',
-			label: 'KKK',
-		},
-		{
-			value: '',
-			label: 'Latex',
 		},
 	];
 

--- a/js/src/pages/component-test/index.js
+++ b/js/src/pages/component-test/index.js
@@ -68,14 +68,24 @@ const ComponentTest = () => {
 						{ value: 'NY', label: 'New York' },
 						{ value: 'TX', label: 'Texas' },
 						{ value: 'GE', label: 'Georgia' },
+						{ value: 'TX2', label: 'Tex 123' },
 					],
 				},
-				{ value: 'CA', label: 'Canada' },
+				{
+					value: 'CA',
+					label: 'Canada',
+					children: [ { value: 'ZZZ', label: 'Texxxxxx' } ],
+				},
 			],
 		},
 		{
+			value: 'XXX',
+			label: 'KKK',
+			children: [ { value: 'VVVV', label: 'Texxxx' } ],
+		},
+		{
 			value: '',
-			label: 'I dont know yet',
+			label: 'Latex',
 		},
 	];
 

--- a/js/src/pages/component-test/index.js
+++ b/js/src/pages/component-test/index.js
@@ -74,14 +74,12 @@ const ComponentTest = () => {
 				{
 					value: 'CA',
 					label: 'Canada',
-					children: [ { value: 'ZZZ', label: 'Texxxxxx' } ],
 				},
 			],
 		},
 		{
 			value: 'XXX',
 			label: 'KKK',
-			children: [ { value: 'VVVV', label: 'Texxxx' } ],
 		},
 		{
 			value: '',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- This PR implements the Keyboard navigation also when the search filter is applied. 
- This PR improves the SPACE key down using the default handler based on @eason9487 [suggestion](https://github.com/woocommerce/google-listings-and-ads/pull/1336#discussion_r831787504) 

### Screenshots:

https://user-images.githubusercontent.com/5908855/159465552-2776dc1b-43dd-4781-886b-becd93cda689.mov



### Detailed test instructions:


1.   Checkout this branch
2.  Go to `wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fcomponent-test` 
3.  Check that the normal keyboard navigation is working  (navigate up and down over the elements, start from the search control and also in a specific element)
4. Insert some search and check that it's working the same
5.  Check that the SPACE selector is working and selects the Nodes
6. Check with and without root node


### Aditional details

The work was mainly to update `getPreviousOption` and `getNextOption` in order to check if actually, the found option has its ref available.  We established an extra pointer in order to iterate over the next/prev nodes if the found node is not visible. 
