### PR TITLE
Fix unit test to work with the latest stable version of WooCommerce

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         php: [7.3, 7.4]
-        wp-version: [5.6, 5.7, 5.8]
+        wp-version: [5.7, 5.8, latest]
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 
 We aim to support the latest two minor versions of WordPress, WooCommerce, and PHP. (L-2 policy)
 
--   WordPress 5.6+
+-   WordPress 5.7+
 -   WooCommerce 5.8+
 -   PHP 7.3+
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -192,7 +192,8 @@ install_db() {
 }
 
 install_wc() {
-  if [ ! -f "${WC_DIR}/version-${WC_VERSION}" ]; then
+  WC_VERSION_FILE="${WC_DIR}/version-"$(echo $WC_VERSION | sed -e "s/\//-/")
+  if [ ! -f "$WC_VERSION_FILE" ]; then
     # set up testing suite
     rm -rf "$WC_DIR"
     mkdir -p "$WC_DIR"
@@ -202,7 +203,7 @@ install_wc() {
     rm -rf "${WC_TMPDIR}"
     git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${WC_TMPDIR}"
     mv "${WC_TMPDIR}"/plugins/woocommerce/* "$WC_DIR"
-	touch "${WC_DIR}/version-${WC_VERSION}"
+	touch "$WC_VERSION_FILE"
 
     # Install composer for WooCommerce
     cd "${WC_DIR}"

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-  echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+  echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [wc-version] [skip-database-creation]"
   exit 1
 fi
 
@@ -10,7 +10,8 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
-SKIP_DB_CREATE=${6-false}
+WC_VERSION=${6-latest}
+SKIP_DB_CREATE=${7-false}
 
 TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
@@ -20,7 +21,6 @@ WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
 # Plugin variables.
 PLUGINS_DIR="${WP_CORE_DIR}/wp-content/plugins"
 WC_DIR="${PLUGINS_DIR}/woocommerce"
-WC_VERSION=trunk
 
 download() {
   if [ $(which curl) ]; then
@@ -47,15 +47,27 @@ elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
   WP_TESTS_TAG="trunk"
 else
   # http serves a single offer, whereas https serves multiple. we only want one
-  download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
-  grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
-  LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+  download http://api.wordpress.org/core/version-check/1.7/ "${TMPDIR}/wp-latest.json"
+  grep '[0-9]+\.[0-9]+(\.[0-9]+)?' "${TMPDIR}/wp-latest.json"
+  LATEST_VERSION=$(grep -o '"version":"[^"]*' "${TMPDIR}/wp-latest.json" | sed 's/"version":"//')
   if [[ -z "$LATEST_VERSION" ]]; then
     echo "Latest WordPress version could not be found"
     exit 1
   fi
   WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
+
+# Get latest WC version
+if [[ $WC_VERSION == 'latest' ]]; then
+  download https://api.wordpress.org/plugins/info/1.0/woocommerce.json "${TMPDIR}/wc-latest.json"
+  WC_LATEST_VERSION=$(grep -o '"version":"[^"]*' "${TMPDIR}/wc-latest.json" | sed 's/"version":"//')
+  if [[ -z "$WC_LATEST_VERSION" ]]; then
+    echo "Latest WooCommerce version could not be found"
+    exit 1
+  fi
+  WC_VERSION=$WC_LATEST_VERSION
+fi
+
 set -ex
 
 install_wp() {
@@ -180,19 +192,17 @@ install_db() {
 }
 
 install_wc() {
-  if [ ! -d "$WC_DIR" ]; then
+  if [ ! -f "${WC_DIR}/version-${WC_VERSION}" ]; then
     # set up testing suite
+    rm -rf "$WC_DIR"
     mkdir -p "$WC_DIR"
     echo "Installing WooCommerce ($WC_VERSION)."
     # Grab the necessary plugins.
-    if [ $WC_VERSION == 'trunk' ]; then
-      rm -rf "$TMPDIR"/woocommerce-trunk
-      git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${TMPDIR}/woocommerce-trunk"
-      mv "$TMPDIR"/woocommerce-trunk/plugins/woocommerce/* "$WC_DIR"
-    else
-      echo "Test with specified WooCommerce version ${WC_VERSION} is not yet supported."
-      exit 1
-    fi
+    WC_TMPDIR="${TMPDIR}/woocommerce-${WC_VERSION}"
+    rm -rf "${WC_TMPDIR}"
+    git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${WC_TMPDIR}"
+    mv "${WC_TMPDIR}"/plugins/woocommerce/* "$WC_DIR"
+	touch "${WC_DIR}/version-${WC_VERSION}"
 
     # Install composer for WooCommerce
     cd "${WC_DIR}"

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,7 +7,7 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 5.6
+ * Requires at least: 5.7
  * Tested up to: 5.9
  * Requires PHP: 7.3
  *

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Google Listings & Ads ===
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, listings, ads
-Requires at least: 5.5
+Requires at least: 5.7
 Tested up to: 5.9
 Requires PHP: 7.3
 Stable tag: 1.11.1
@@ -53,7 +53,7 @@ Create a new Google Ads account through Google Listings & Ads and a promotional 
 
 = Minimum Requirements =
 
-* WordPress 5.6 or greater
+* WordPress 5.7 or greater
 * WooCommerce 5.8 or greater
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -80,8 +80,13 @@ function install_woocommerce() {
 	WC_Install::install();
 
 	// Initialize the WC API extensions.
-	\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
-	\Automattic\WooCommerce\Internal\Admin\Install::create_events();
+	if ( class_exists( '\Automattic\WooCommerce\Internal\Admin\Install' ) ) {
+		\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
+		\Automattic\WooCommerce\Internal\Admin\Install::create_events();
+	} else {
+		\Automattic\WooCommerce\Admin\Install::create_tables();
+		\Automattic\WooCommerce\Admin\Install::create_events();
+	}
 
 	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
 	$GLOBALS['wp_roles'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce Admin is being moved into the WooCommerce monorepo repository. Since we were basing our unit tests on the trunk branch this was causing some failures.

This PR changes the install script to support a WC version being passed to the script, by default this will be `latest` which fetches the latest stable version from WP.org

In addition to that the WP test matrix was modified to test latest and L-2.

### Detailed test instructions:

1. Setup the test dependencies as instructed in the [readme ](https://github.com/woocommerce/google-listings-and-ads/blob/develop/README.md#install-test-dependencies): `./bin/install-wp-tests.sh gla_test root root localhost`
2. Check that the latest version is installed in `/tmp/wordpress/wp-content/plugins/woocommerce` (there should be a generated file `version-6.3.1`)
3. Run the unit tests `vendor/bin/phpunit` and confirm there are no errors or warnings
4. Setup the dependencies using a newer version of WC (6.4) `./bin/install-wp-tests.sh gla_test root root localhost latest release/6.4`
5. Check that the specified version is installed in `/tmp/wordpress/wp-content/plugins/woocommerce` (there should be a generated file `version-release-6.4`)
6. Run the unit tests `vendor/bin/phpunit` and confirm there are no errors or warnings

*Note: If we pass the WC_VERSION as trunk the unit tests will still fail, but I think we can wait to support any of those changes until it's stable.*

### Changelog entry
* Fix - Unit tests use latest stable version of WooCommerce
