### PR TITLE
Allow setting free shipping rates (WIP)

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -86,20 +86,14 @@ class Settings {
 			if ( isset( $options['free_shipping_threshold'] ) ) {
 				$minimum_order_value = (float) $options['free_shipping_threshold'];
 
-				if ( 0 !== $rate ) {
-					// Add a conditional free-shipping service if the current rate is not free.
-					$services[] = $this->create_conditional_free_shipping_service( $country, $currency, $minimum_order_value );
-				} else {
-					// Set the minimum order value if the current rate is free.
-					$service->setMinimumOrderValue(
-						new Price(
-							[
-								'value'    => $minimum_order_value,
-								'currency' => $currency,
-							]
-						)
-					);
-				}
+				$service->setMinimumOrderValue(
+					new Price(
+						[
+							'value'    => $minimum_order_value,
+							'currency' => $currency,
+						]
+					)
+				);
 			}
 
 			$services[] = $service;
@@ -346,31 +340,6 @@ class Settings {
 		if ( array_key_exists( $country, $times ) ) {
 			$service->setDeliveryTime( $this->create_time_object( intval( $times[ $country ] ) ) );
 		}
-
-		return $service;
-	}
-
-	/**
-	 * Create a free shipping service.
-	 *
-	 * @param string $country
-	 * @param string $currency
-	 * @param float  $minimum_order_value
-	 *
-	 * @return Service
-	 */
-	protected function create_conditional_free_shipping_service( string $country, string $currency, float $minimum_order_value ): Service {
-		$service = $this->create_shipping_service( $country, ShippingZone::METHOD_FREE, $currency, 0 );
-
-		// Set the minimum order value to be eligible for free shipping.
-		$service->setMinimumOrderValue(
-			new Price(
-				[
-					'value'    => $minimum_order_value,
-					'currency' => $currency,
-				]
-			)
-		);
 
 		return $service;
 	}

--- a/src/API/Site/Controllers/ShippingRateSchemaTrait.php
+++ b/src/API/Site/Controllers/ShippingRateSchemaTrait.php
@@ -42,6 +42,7 @@ trait ShippingRateSchemaTrait {
 				'description'       => __( 'The shipping method.', 'google-listings-and-ads' ),
 				'enum'              => [
 					ShippingZone::METHOD_FLAT_RATE,
+					ShippingZone::METHOD_FREE,
 				],
 				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingRateControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingRateControllerTest.php
@@ -42,9 +42,6 @@ class ShippingRateControllerTest extends RESTControllerUnitTest {
 											  'currency' => 'USD',
 											  'rate'     => '5.00',
 											  'method'   => 'flat_rate',
-											  'options'  => [
-												  'free_shipping_threshold' => '100',
-											  ],
 										  ],
 									  ]
 								  );
@@ -60,7 +57,6 @@ class ShippingRateControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'USD', $data[0]['currency'] );
 		$this->assertEquals( '5.00', $data[0]['rate'] );
 		$this->assertEquals( 'flat_rate', $data[0]['method'] );
-		$this->assertEquals( 100, $data[0]['options']['free_shipping_threshold'] );
 	}
 
 	public function test_empty_options_array_is_returned_as_object() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a work-in-progress because even though the backend changes are complete, we need to confirm that the UI works with the API changes. @ecgan, can you please check if the API changes will work with the current UI?

Closes #1332.

This PR changes the shipping rates API schema to allow setting free shipping rates. Previously, the API assumed that a free shipping rate would be sent as a `flat_rate` with a cost of 0 and if it had a minimum order threshold, that would've also been sent as part of the flat_rate method options. However, since this might get confusing and not similar to how WooCommerce stores shipping rates, I've decided to change this logic.

Now, if the user checks the "I offer free shipping for orders over a certain price" option in UI, another "free_shipping" rate must be sent to the API that includes the "free_shipping_threshold" set by the user and a rate of 0.

The `free_shipping_threshold` option should only be sent for a "free_shipping" rate and NOT a "flat_rate".

The suggestions API is also modified to include a "free_shipping" rate when a free_shipping method with a minimum order amount exists in the WooCommerce zones for the country. Previously, if there was a free shipping method for the country, the suggestions API would still return a "flat_rate" method but set the "free_shipping_threshold" option for it.

The DB migration is also changed so that it creates new "free_shipping" methods for all countries if the user had previously set the "offers_free_shipping" and "free_shipping_threshold" globally.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

**Test the DB migration**:

1. Change the global MC settings by modifying the `gla_merchant_center` option in `wp_options` and set `offers_free_shipping` set to 1 and `free_shipping_threshold` set to any value.
1. Update the `WC_GLA_VERSION` constant to a higher version than the current one.
2. Go to the `Migration20211228T1640692399::get_applicable_version` method and modify the `x.x.x` version to be equal to or greater than the one you set above.
3. Open any page in your website admin
4. Confirm that the `wp_gla_shipping_rates` table is updated and includes the options and method columns. The method column must be set by default to `flat_rate` but the table should also include rows with the `free_shipping` method that includes a `free_shipping_threshold` in the `options` column.

**Test APIs**

1. Define multiple shipping zones each containing various regions and shipping methods. Make sure you have at least one free shipping method with a minimum order amount option.
2. Make a `GET` request to the `mc/shipping/rates/suggestions` API with a `country_codes[]` parameter and confirm the rate that is returned is the same that you defined in your shipping zone settings.
3. Confirm that the returned shipping rates suggestions include a "free_shipping" rate with the correct "free_shipping_threshold"
4. Make a POST request to the mc/shipping/rates containing the following JSON data
```JSON
{
  "country_code":"DE",
  "rates":[
    {
      "method":"flat_rate",
      "currency":"USD",
      "rate":50
    },
    {
      "method":"free_shipping",
      "currency":"USD",
      "rate":0,
      "options":{
        "free_shipping_threshold":"100"
      }
    }
  ]
}
```
5. Make a GET requests to the `mc/shipping/rates` APIs and confirm the shipping rate you set above is returned correctly.
6. Make a POST request to the `wc/gla/mc/settings/sync` API
7. Confirm that the shipping rates you have just set are reflected in your Merchant Center account (https://merchants.google.com/mc/shipping/services). Check the minimum order value as well.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
