### PR TITLE
Refactoring product filters to fix filter parameter type.

### DIFF
--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -52,7 +52,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 * @return FilteredProductList
 	 */
 	protected function get_filtered_batch( int $batch_number ): FilteredProductList {
-		return $this->product_repository->find_sync_ready_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+		return $this->product_repository->find_sync_ready_product( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
 	/**

--- a/src/Product/ProductFilter.php
+++ b/src/Product/ProductFilter.php
@@ -34,30 +34,22 @@ class ProductFilter implements Service {
 	 * Filters and returns a list of products that are ready to be submitted to Google Merchant Center.
 	 *
 	 * @param WC_Product[] $products
-	 * @param bool         $return_ids
 	 *
 	 * @return FilteredProductList
 	 */
-	public function filter_sync_ready_products( array $products, bool $return_ids = false ): FilteredProductList {
-		$unfiltered_count = count( $products );
-
+	public function filter_sync_ready_products( array $products ): FilteredProductList {
 		/**
 		 * Filters the list of products ready to be synced (before applying filters to check failures and sync-ready status).
 		 *
 		 * @param WC_Product[] $products Sync-ready WooCommerce products
 		 */
 		$products = apply_filters( 'woocommerce_gla_get_sync_ready_products_pre_filter', $products );
-
-		$results = [];
-		foreach ( $products as $product ) {
-			// skip if it's not sync ready or if syncing has recently failed
-			if ( ! $this->product_helper->is_sync_ready( $product ) || $this->product_helper->is_sync_failed_recently( $product ) ) {
-				continue;
+		$results  = array_filter(
+			$products,
+			function ( $product ) {
+				return $this->product_helper->is_sync_ready( $product ) && ! $this->product_helper->is_sync_failed_recently( $product );
 			}
-
-			$results[] = $return_ids ? $product->get_id() : $product;
-		}
-
+		);
 		/**
 		 * Filters the list of products ready to be synced (after applying filters to check failures and sync-ready status).
 		 *
@@ -65,7 +57,7 @@ class ProductFilter implements Service {
 		 */
 		$results = apply_filters( 'woocommerce_gla_get_sync_ready_products_filter', $results );
 
-		return new FilteredProductList( $results, $unfiltered_count );
+		return new FilteredProductList( $results, count( $products ) );
 	}
 
 	/**
@@ -74,21 +66,17 @@ class ProductFilter implements Service {
 	 * @since x.x.x
 	 *
 	 * @param WC_Product[] $products
-	 * @param boolean      $return_ids
 	 *
-	 * @return array
+	 * @return FilteredProductList
 	 */
-	public function filter_products_for_delete( array $products, bool $return_ids = false ): array {
-		$results = [];
-		foreach ( $products as $product ) {
-			// Skip if the failed threshold has been reached.
-			if ( $this->product_helper->is_delete_failed_threshold_reached( $product ) ) {
-				continue;
+	public function filter_products_for_delete( array $products ): FilteredProductList {
+		$results = array_filter(
+			$products,
+			function ( $product ) {
+				return ! $this->product_helper->is_delete_failed_threshold_reached( $product );
 			}
+		);
 
-			$results[] = $return_ids ? $product->get_id() : $product;
-		}
-
-		return $results;
+		return new FilteredProductList( $results, count( $products ) );
 	}
 }

--- a/src/Product/ProductFilter.php
+++ b/src/Product/ProductFilter.php
@@ -38,6 +38,7 @@ class ProductFilter implements Service {
 	 * @return FilteredProductList
 	 */
 	public function filter_sync_ready_products( array $products ): FilteredProductList {
+		$unfiltered_count = count( $products );
 		/**
 		 * Filters the list of products ready to be synced (before applying filters to check failures and sync-ready status).
 		 *
@@ -59,7 +60,7 @@ class ProductFilter implements Service {
 		 */
 		$results = apply_filters( 'woocommerce_gla_get_sync_ready_products_filter', $results );
 
-		return new FilteredProductList( $results, count( $products ) );
+		return new FilteredProductList( $results, $unfiltered_count );
 	}
 
 	/**

--- a/src/Product/ProductFilter.php
+++ b/src/Product/ProductFilter.php
@@ -44,11 +44,13 @@ class ProductFilter implements Service {
 		 * @param WC_Product[] $products Sync-ready WooCommerce products
 		 */
 		$products = apply_filters( 'woocommerce_gla_get_sync_ready_products_pre_filter', $products );
-		$results  = array_filter(
-			$products,
-			function ( $product ) {
-				return $this->product_helper->is_sync_ready( $product ) && ! $this->product_helper->is_sync_failed_recently( $product );
-			}
+		$results  = array_values(
+			array_filter(
+				$products,
+				function ( $product ) {
+					return $this->product_helper->is_sync_ready( $product ) && ! $this->product_helper->is_sync_failed_recently( $product );
+				}
+			)
 		);
 		/**
 		 * Filters the list of products ready to be synced (after applying filters to check failures and sync-ready status).
@@ -70,11 +72,13 @@ class ProductFilter implements Service {
 	 * @return FilteredProductList
 	 */
 	public function filter_products_for_delete( array $products ): FilteredProductList {
-		$results = array_filter(
-			$products,
-			function ( $product ) {
-				return ! $this->product_helper->is_delete_failed_threshold_reached( $product );
-			}
+		$results = array_values(
+			array_filter(
+				$products,
+				function ( $product ) {
+					return ! $this->product_helper->is_delete_failed_threshold_reached( $product );
+				}
+			)
 		);
 
 		return new FilteredProductList( $results, count( $products ) );

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -148,7 +148,7 @@ class ProductRepository implements Service {
 	public function find_sync_ready_products( array $args = [], int $limit = - 1, int $offset = 0 ): FilteredProductList {
 		$results = $this->find( $this->get_sync_ready_products_query_args( $args ), $limit, $offset );
 
-		return $this->product_filter->filter_sync_ready_products( $results, false );
+		return $this->product_filter->filter_sync_ready_products( $results );
 	}
 
 	/**
@@ -164,7 +164,7 @@ class ProductRepository implements Service {
 	 */
 	public function find_delete_product_ids( array $ids, int $limit = - 1, int $offset = 0 ): array {
 		$results = $this->find_by_ids( $ids, $limit, $offset );
-		return $this->product_filter->filter_products_for_delete( $results, true );
+		return $this->product_filter->filter_products_for_delete( $results )->get_product_ids();
 	}
 
 	/**
@@ -179,7 +179,7 @@ class ProductRepository implements Service {
 	public function find_sync_ready_product_ids( array $args = [], int $limit = - 1, int $offset = 0 ): FilteredProductList {
 		$results = $this->find( $this->get_sync_ready_products_query_args( $args ), $limit, $offset );
 
-		return $this->product_filter->filter_sync_ready_products( $results, true );
+		return $this->product_filter->filter_sync_ready_products( $results )->get_product_ids();
 	}
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -174,12 +174,12 @@ class ProductRepository implements Service {
 	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
 	 * @param int   $offset Amount to offset product results.
 	 *
-	 * @return FilteredProductList List of WooCommerce product IDs after filtering.
+	 * @return FilteredProductList List of WooCommerce products after filtering.
 	 */
 	public function find_sync_ready_product_ids( array $args = [], int $limit = - 1, int $offset = 0 ): FilteredProductList {
 		$results = $this->find( $this->get_sync_ready_products_query_args( $args ), $limit, $offset );
 
-		return $this->product_filter->filter_sync_ready_products( $results )->get_product_ids();
+		return $this->product_filter->filter_sync_ready_products( $results );
 	}
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -168,7 +168,7 @@ class ProductRepository implements Service {
 	}
 
 	/**
-	 * Find and return an array of WooCommerce product IDs ready to be submitted to Google Merchant Center.
+	 * Find and return an array of WooCommerce products ready to be submitted to Google Merchant Center.
 	 *
 	 * @param array $args   Array of WooCommerce args (except 'return'), and product metadata.
 	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
@@ -176,7 +176,7 @@ class ProductRepository implements Service {
 	 *
 	 * @return FilteredProductList List of WooCommerce products after filtering.
 	 */
-	public function find_sync_ready_product_ids( array $args = [], int $limit = - 1, int $offset = 0 ): FilteredProductList {
+	public function find_sync_ready_product( array $args = [], int $limit = - 1, int $offset = 0 ): FilteredProductList {
 		$results = $this->find( $this->get_sync_ready_products_query_args( $args ), $limit, $offset );
 
 		return $this->product_filter->filter_sync_ready_products( $results );

--- a/tests/Unit/Product/ProductFilterTest.php
+++ b/tests/Unit/Product/ProductFilterTest.php
@@ -1,0 +1,126 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFilter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use WC_Helper_Product;
+
+/**
+ * Class ProductFilterTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ */
+class ProductFilterTest extends ContainerAwareUnitTest {
+
+	public function setUp() {
+		parent::setUp();
+
+		remove_all_filters( 'woocommerce_gla_get_sync_ready_products_pre_filter' );
+		remove_all_filters( 'woocommerce_gla_get_sync_ready_products_filter' );
+	}
+
+	public function test_filter_sync_ready_products_with_no_filters() {
+		$product_helper = $this->createMock( ProductHelper::class );
+
+		$product_a = WC_Helper_Product::create_simple_product();
+		$product_b = WC_Helper_Product::create_simple_product();
+		$product_c = WC_Helper_Product::create_simple_product();
+
+		$product_helper->expects( $this->exactly( 3 ) )
+			->method( 'is_sync_ready' )
+			->withConsecutive( [ $product_a ], [ $product_b ], [ $product_c ] )
+			->willReturnOnConsecutiveCalls( false, true, false );
+
+		$product_helper->expects( $this->once() )
+			->method( 'is_sync_failed_recently' )
+			->with( $product_b )
+			->willReturn( false );
+
+		$product_filter = new ProductFilter( $product_helper );
+
+		$filtered_products = $product_filter->filter_sync_ready_products( [ $product_a, $product_b, $product_c ] );
+
+		$this->assertEquals( [ $product_b ], $filtered_products->get() );
+		$this->assertEquals( 3, $filtered_products->get_unfiltered_count() );
+	}
+
+	public function test_filter_sync_ready_products_with_pre_filter() {
+		$product_helper = $this->createMock( ProductHelper::class );
+
+		add_filter(
+			'woocommerce_gla_get_sync_ready_products_pre_filter',
+			function ( $products ) {
+				return [];
+			}
+		);
+
+		$product_a = WC_Helper_Product::create_simple_product();
+		$product_b = WC_Helper_Product::create_simple_product();
+		$product_c = WC_Helper_Product::create_simple_product();
+
+		$product_helper->expects( $this->never() )->method( 'is_sync_ready' );
+		$product_helper->expects( $this->never() )->method( 'is_sync_failed_recently' );
+
+		$product_filter = new ProductFilter( $product_helper );
+
+		$filtered_products = $product_filter->filter_sync_ready_products( [ $product_a, $product_b, $product_c ] );
+
+		$this->assertEmpty( $filtered_products->get() );
+		$this->assertEquals( 3, $filtered_products->get_unfiltered_count() );
+	}
+
+	public function test_filter_sync_ready_products_with_post_filter() {
+		$product_helper = $this->createMock( ProductHelper::class );
+
+		add_filter(
+			'woocommerce_gla_get_sync_ready_products_filter',
+			function ( $products ) {
+				return [];
+			}
+		);
+
+		$product_a = WC_Helper_Product::create_simple_product();
+		$product_b = WC_Helper_Product::create_simple_product();
+		$product_c = WC_Helper_Product::create_simple_product();
+
+		$product_helper->expects( $this->exactly( 3 ) )
+			->method( 'is_sync_ready' )
+			->withConsecutive( [ $product_a ], [ $product_b ], [ $product_c ] )
+			->willReturnOnConsecutiveCalls( false, true, false );
+
+		$product_helper->expects( $this->once() )
+			->method( 'is_sync_failed_recently' )
+			->with( $product_b )
+			->willReturn( false );
+
+		$product_filter = new ProductFilter( $product_helper );
+
+		$filtered_products = $product_filter->filter_sync_ready_products( [ $product_a, $product_b, $product_c ] );
+
+		$this->assertEmpty( $filtered_products->get() );
+		$this->assertEquals( 3, $filtered_products->get_unfiltered_count() );
+	}
+
+	public function test_products_for_delete() {
+		$product_helper = $this->createMock( ProductHelper::class );
+
+		$product_a = WC_Helper_Product::create_simple_product();
+		$product_b = WC_Helper_Product::create_simple_product();
+		$product_c = WC_Helper_Product::create_simple_product();
+
+		$product_helper->expects( $this->exactly( 3 ) )
+			->method( 'is_delete_failed_threshold_reached' )
+			->withConsecutive( [ $product_a ], [ $product_b ], [ $product_c ] )
+			->willReturnOnConsecutiveCalls( false, true, false );
+
+		$product_filter = new ProductFilter( $product_helper );
+
+		$filtered_products = $product_filter->filter_products_for_delete( [ $product_a, $product_b, $product_c ] );
+
+		$this->assertEquals( [ $product_a, $product_c ], $filtered_products->get() );
+		$this->assertEquals( 3, $filtered_products->get_unfiltered_count() );
+	}
+}

--- a/tests/Unit/Product/ProductFilterTest.php
+++ b/tests/Unit/Product/ProductFilterTest.php
@@ -59,6 +59,26 @@ class ProductFilterTest extends ContainerAwareUnitTest {
 		$this->assertEquals( 3, $filtered_products->get_unfiltered_count() );
 	}
 
+	public function test_filter_sync_ready_products_with_no_filters_but_failed_sync() {
+
+		[ $product_a, $product_b, $product_c ] = $this->products;
+
+		$this->product_helper->expects( $this->exactly( 3 ) )
+			->method( 'is_sync_ready' )
+			->withConsecutive( [ $product_a ], [ $product_b ], [ $product_c ] )
+			->willReturnOnConsecutiveCalls( false, true, false );
+
+		$this->product_helper->expects( $this->once() )
+			->method( 'is_sync_failed_recently' )
+			->with( $product_b )
+			->willReturn( true );
+
+		$filtered_products = $this->product_filter->filter_sync_ready_products( $this->products );
+
+		$this->assertEmpty( $filtered_products->get() );
+		$this->assertEquals( 3, $filtered_products->get_unfiltered_count() );
+	}
+
 	public function test_filter_sync_ready_products_with_pre_filter() {
 
 		add_filter(

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -204,7 +204,7 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 		$this->assertEquals(
 			array_merge( [ $simple_product->get_id() ], $variable_product->get_children() ),
-			$this->product_repository->find_sync_ready_product_ids()->get_product_ids()
+			$this->product_repository->find_sync_ready_product()->get_product_ids()
 		);
 	}
 

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -204,7 +204,7 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 		$this->assertEquals(
 			array_merge( [ $simple_product->get_id() ], $variable_product->get_children() ),
-			$this->product_repository->find_sync_ready_product_ids()->get()
+			$this->product_repository->find_sync_ready_product_ids()->get_product_ids()
 		);
 	}
 


### PR DESCRIPTION
A task was to fix filter parameter data type. I also refactored the code to remove `$return_ids` seconds parameter from product filter functions as the one which is not needed. Added product filter unit tests and adjusted the other code which was using filters to make sure it is still consistent with the changes made. Checked those changes to be covered with existing unit tests to make sure we have it tested and no changes passed through unnoticed.

### Changes proposed in this Pull Request:

Closes #1259.

Recently a bug was found with feeding `woocommerce_gla_get_sync_ready_products_filter ` filter with array of product IDs when it was made to process `WC_Product` type of records instead.

### Detailed test instructions:

1. Since GitHub does run tests itself, nothing to check here;

### Changelog entry

> Fix - bug with filter parameter data type.