### PR TITLE
Return an empty array when no campaigns exist for GET ads/campaigns API

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -443,6 +443,10 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @return array
 	 */
 	protected function combine_campaigns_and_campaign_criterion_results( array $campaigns ): array {
+		if ( empty( $campaigns ) ) {
+			return [];
+		}
+
 		$campaign_criterion_results = ( new AdsCampaignCriterionQuery() )->set_client( $this->client, $this->options->get_ads_id() )
 			->where( 'campaign.id', array_keys( $campaigns ), 'IN' )
 			// negative: Whether to target (false) or exclude (true) the criterion.

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -118,7 +118,7 @@ trait GoogleAdsClientTrait {
 	}
 
 	/**
-	 * Generates a mocked AdsCampaignQuery response.
+	 * Generates mocked AdsCampaignQuery and AdsCampaignCriterionQuery responses.
 	 *
 	 * @param array $campaigns_responses Set of campaign data to convert.
 	 * @param array $campaign_criterion_responses Set of campaign criterion data to convert.
@@ -132,7 +132,23 @@ trait GoogleAdsClientTrait {
 			$campaigns_row_mock,
 			$campaign_criterion_row_mock
 		);
-		$this->service_client->method( 'search' )->willReturn( $list_response );
+
+		$this->service_client->expects( $this->exactly( 2 ) )
+			->method( 'search' )->willReturn( $list_response );
+	}
+
+	/**
+	 * Generates a mocked empty campaigns response.
+	 */
+	protected function generate_ads_campaign_query_mock_with_no_campaigns() {
+		$list_response = $this->createMock( PagedListResponse::class );
+		$list_response->method( 'iterateAllElements' )->willReturn( [] );
+
+		// Method search() will only being called once by AdsCampaignQuery
+		// since there were no campaigns returned by AdsCampaignQuery, it
+		// won't be calling AdsCampaignCriterionQuery then.
+		$this->service_client->expects( $this->once() )
+			->method( 'search' )->willReturn( $list_response );
 	}
 
 	/**

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -70,6 +70,11 @@ class AdsCampaignTest extends UnitTest {
 
 	public function test_get_campaigns_empty_list() {
 		$this->generate_ads_campaign_query_mock( [], [] );
+
+		// Method search() only being called by AdsCampaignQuery
+		$this->service_client->expects( $this->once() )
+			->method( 'search' );
+
 		$this->assertEquals( [], $this->campaign->get_campaigns() );
 	}
 
@@ -109,6 +114,10 @@ class AdsCampaignTest extends UnitTest {
 		];
 
 		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
+
+		$this->service_client->expects( $this->exactly( 2 ) )
+			->method( 'search' );
+
 		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
 	}
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -69,12 +69,7 @@ class AdsCampaignTest extends UnitTest {
 	}
 
 	public function test_get_campaigns_empty_list() {
-		$this->generate_ads_campaign_query_mock( [], [] );
-
-		// Method search() only being called by AdsCampaignQuery
-		$this->service_client->expects( $this->once() )
-			->method( 'search' );
-
+		$this->generate_ads_campaign_query_mock_with_no_campaigns();
 		$this->assertEquals( [], $this->campaign->get_campaigns() );
 	}
 
@@ -114,10 +109,6 @@ class AdsCampaignTest extends UnitTest {
 		];
 
 		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
-
-		$this->service_client->expects( $this->exactly( 2 ) )
-			->method( 'search' );
-
 		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug that when no campaigns exist the `GET ads/campaigns` API will throw an error. It should return an empty array instead.

Closes #1364.

### Screenshots:

<img width="1250" alt="Screenshot 2022-03-25 at 17 57 23" src="https://user-images.githubusercontent.com/914406/160098617-be657351-75ea-4d0a-a16d-5f1b783e1e2e.png">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Remove all campaigns in your account.
2. Request to the API `GET ads/campaigns`.
3. The API should return an empty array.

### Additional details:

I was struggling to add a unit test for this case as this is an error from the Google API. Might be more suitable to have the integration test for it.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Returns an empty array when no campaigns exist.
