### PR TITLE
Filter out shipping rates suggestions that are not flat_rate method

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-free-listings/useShippingRatesSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/useShippingRatesSuggestions.js
@@ -9,6 +9,7 @@ import { addQueryArgs } from '@wordpress/url';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import useApiFetchEffect from '.~/hooks/useApiFetchEffect';
 import { API_NAMESPACE } from '.~/data/constants';
+import { SHIPPING_RATE_METHOD } from '.~/constants';
 
 /**
  * @typedef {Object} ShippingRatesSuggestionsResult
@@ -21,6 +22,10 @@ import { API_NAMESPACE } from '.~/data/constants';
  *
  * This depends on the `useTargetAudienceFinalCountryCodes` hook,
  * i.e. the target audience countres specified in Setup MC Step 2.
+ *
+ * This will only return shipping rates suggestions with FLAT_RATE method.
+ * Other methods (e.g. free shipping) are filtered out because
+ * they are not well supported in the API and UI yet.
  *
  * @return {ShippingRatesSuggestionsResult} Result object with `loading` and `data`.
  */
@@ -45,9 +50,19 @@ const useShippingRatesSuggestions = () => {
 		}
 	);
 
+	/**
+	 * Shipping rate suggestions data with only FLAT_RATE method.
+	 *
+	 * Other methods (e.g. free shipping) are filtered out because
+	 * they are not well supported in the API and UI yet.
+	 */
+	const data = dataSuggestions?.filter(
+		( el ) => el.method === SHIPPING_RATE_METHOD.FLAT_RATE
+	);
+
 	return {
 		loading: loadingFinalCountryCodes || loadingSuggestions,
-		data: dataSuggestions,
+		data,
 	};
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1332.

In this PR, we filter out shipping rates suggestions that are not "flat_rate" method, so that subsequently we are able to save the shipping rates suggestions successfully, addressing issue #1332.

### Screenshots:

When we get shipping rates suggestions, it might return shipping rates with "free_shipping" method: (total 30 in the screenshot below)

![image](https://user-images.githubusercontent.com/417342/160101512-4336e2b3-32b9-49a0-95ea-2d712f3b4ee7.png)

The PR will filter out those that are not "flat_rate" method, and call save shipping rates API: (total 27 in the screenshot below, all of them are "flat_rate")

![image](https://user-images.githubusercontent.com/417342/160101604-b22efde1-0f93-487c-b046-a5dde872673a.png)

### Detailed test instructions:

1. Go to WC Setting and setup some shipping zones with mix of different methods.
    - You may refer to issue #1332 and https://github.com/woocommerce/google-listings-and-ads/pull/1363#issuecomment-1078779535 for some examples. 
    - There should be some shipping zones containing only one method, and that one method is a free shipping method.
2. Open your browser dev tool to observe network requests. 
3. Go to Setup MC, proceed to shipping rate section. 
4. There should be a suggestions API call. Look into the response. There should be some non flat rate method.
5. If this is your first time visiting Setup MC shipping rates, you would not have any existing shipping rates data, and Setup MC will automatically save the suggestions by calling batch shipping rate API. Look into the API request. It should not contain free shipping / non flat rate methods. 
    - If you already have existing shipping rates data, you can delete all of them and do a page reload to trigger the automatic suggestions saving.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

