### PR TITLE
Change shipping time options based on shipping rate options

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
@@ -2,25 +2,18 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Section from '.~/wcdl/section';
-import AppRadioContentControl from '.~/components/app-radio-content-control';
-import RadioHelperText from '.~/wcdl/radio-helper-text';
 import AppDocumentationLink from '.~/components/app-documentation-link';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import ShippingTimeSetup from './shipping-time/shipping-time-setup';
 
 const ShippingTimeSection = ( {
 	formProps,
 	countries: selectedCountryCodes,
 } ) => {
-	const { getInputProps, values } = formProps;
-	const inputProps = getInputProps( 'shipping_time' );
-
 	return (
 		<Section
 			title={ __( 'Shipping times', 'google-listings-and-ads' ) }
@@ -44,66 +37,20 @@ const ShippingTimeSection = ( {
 				</div>
 			}
 		>
-			<VerticalGapLayout size="large">
-				<Section.Card>
-					<Section.Card.Body>
-						<VerticalGapLayout size="large">
-							<AppRadioContentControl
-								{ ...inputProps }
-								label={ __(
-									'My shipping settings are simple. I can manually estimate flat shipping times.',
-									'google-listings-and-ads'
-								) }
-								value="flat"
-								collapsible
-							/>
-							<AppRadioContentControl
-								{ ...inputProps }
-								label={ __(
-									'My shipping settings are complex. I will enter my shipping times manually in Google Merchant Center.',
-									'google-listings-and-ads'
-								) }
-								value="manual"
-								collapsible
-							>
-								<RadioHelperText>
-									{ createInterpolateElement(
-										__(
-											'I understand that if I don’t set this up manually in <link>Google Merchant Center</link>, my products will be disapproved by Google.',
-											'google-listings-and-ads'
-										),
-										{
-											link: (
-												<AppDocumentationLink
-													context="setup-mc-shipping"
-													linkId="shipping-manual"
-													href="https://www.google.com/retail/solutions/merchant-center/"
-												/>
-											),
-										}
-									) }
-								</RadioHelperText>
-							</AppRadioContentControl>
-						</VerticalGapLayout>
-					</Section.Card.Body>
-				</Section.Card>
-				{ values.shipping_time === 'flat' && (
-					<Section.Card>
-						<Section.Card.Body>
-							<Section.Card.Title>
-								{ __(
-									'Estimated shipping times',
-									'google-listings-and-ads'
-								) }
-							</Section.Card.Title>
-							<ShippingTimeSetup
-								selectedCountryCodes={ selectedCountryCodes }
-								formProps={ formProps }
-							/>
-						</Section.Card.Body>
-					</Section.Card>
-				) }
-			</VerticalGapLayout>
+			<Section.Card>
+				<Section.Card.Body>
+					<Section.Card.Title>
+						{ __(
+							'Estimated shipping times',
+							'google-listings-and-ads'
+						) }
+					</Section.Card.Title>
+					<ShippingTimeSetup
+						selectedCountryCodes={ selectedCountryCodes }
+						formProps={ formProps }
+					/>
+				</Section.Card.Body>
+			</Section.Card>
 		</Section>
 	);
 };

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -99,7 +99,7 @@ const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 							<AppRadioContentControl
 								{ ...inputProps }
 								label={ __(
-									'My shipping settings are complex. I will enter my shipping rates manually in Google Merchant Center.',
+									'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.',
 									'google-listings-and-ads'
 								) }
 								value="manual"

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -15,8 +15,23 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
 
 const ShippingRateSection = ( { formProps, audienceCountries } ) => {
-	const { getInputProps, values } = formProps;
+	const { getInputProps, values, setValue } = formProps;
 	const inputProps = getInputProps( 'shipping_rate' );
+
+	const getShippingRateOptionChangeHandler = ( onChange ) => ( value ) => {
+		switch ( value ) {
+			case 'automatic':
+			case 'flat':
+				setValue( 'shipping_time', 'flat' );
+				break;
+
+			case 'manual':
+				setValue( 'shipping_time', 'manual' );
+				break;
+		}
+
+		onChange( value );
+	};
 
 	return (
 		<Section
@@ -58,6 +73,9 @@ const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 								) }
 								value="automatic"
 								collapsible
+								onChange={ getShippingRateOptionChangeHandler(
+									inputProps.onChange
+								) }
 							>
 								<RadioHelperText>
 									{ __(
@@ -74,6 +92,9 @@ const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 								) }
 								value="flat"
 								collapsible
+								onChange={ getShippingRateOptionChangeHandler(
+									inputProps.onChange
+								) }
 							/>
 							<AppRadioContentControl
 								{ ...inputProps }
@@ -83,6 +104,9 @@ const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 								) }
 								value="manual"
 								collapsible
+								onChange={ getShippingRateOptionChangeHandler(
+									inputProps.onChange
+								) }
 							>
 								<RadioHelperText>
 									{ createInterpolateElement(

--- a/js/src/edit-free-campaign/setup-free-listings/form-content.js
+++ b/js/src/edit-free-campaign/setup-free-listings/form-content.js
@@ -36,10 +36,9 @@ const FormContent = ( {
 	saving = false,
 	submitLabel = __( 'Complete setup', 'google-listings-and-ads' ),
 } ) => {
-	const { isValidForm, handleSubmit } = formProps;
-
+	const { values, isValidForm, handleSubmit } = formProps;
 	const shouldDisplayTaxRate = useDisplayTaxRate( countries );
-
+	const shouldDisplayShippingTime = values.shipping_time === 'flat';
 	const isCompleteSetupDisabled =
 		shouldDisplayTaxRate === null || ! isValidForm;
 
@@ -49,10 +48,12 @@ const FormContent = ( {
 				formProps={ formProps }
 				audienceCountries={ countries }
 			/>
-			<ShippingTimeSection
-				formProps={ formProps }
-				countries={ countries }
-			/>
+			{ shouldDisplayShippingTime && (
+				<ShippingTimeSection
+					formProps={ formProps }
+					countries={ countries }
+				/>
+			) }
 			<ConditionalSection show={ shouldDisplayTaxRate }>
 				<TaxRate formProps={ formProps } />
 			</ConditionalSection>

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/form-content.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/form-content.js
@@ -28,6 +28,7 @@ const FormContent = ( props ) => {
 	} = values;
 	const { data: audienceCountries } = useTargetAudienceFinalCountryCodes();
 	const shouldDisplayTaxRate = useDisplayTaxRate( audienceCountries );
+	const shouldDisplayShippingTime = values.shipping_time === 'flat';
 
 	useAutoSaveSettingsEffect( settingsValue );
 	useAutoSaveShippingRatesEffect( shippingRatesValue );
@@ -38,7 +39,9 @@ const FormContent = ( props ) => {
 				formProps={ formProps }
 				audienceCountries={ audienceCountries }
 			/>
-			<ShippingTimeSection formProps={ formProps } />
+			{ shouldDisplayShippingTime && (
+				<ShippingTimeSection formProps={ formProps } />
+			) }
 			<ConditionalSection show={ shouldDisplayTaxRate }>
 				<TaxRate formProps={ formProps } />
 			</ConditionalSection>

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time-section.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time-section.js
@@ -2,22 +2,15 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Section from '.~/wcdl/section';
-import AppRadioContentControl from '.~/components/app-radio-content-control';
-import RadioHelperText from '.~/wcdl/radio-helper-text';
 import AppDocumentationLink from '.~/components/app-documentation-link';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import ShippingTimeSetup from './shipping-time/shipping-time-setup';
 
 const ShippingTimeSection = ( { formProps } ) => {
-	const { getInputProps, values } = formProps;
-	const inputProps = getInputProps( 'shipping_time' );
-
 	return (
 		<Section
 			title={ __( 'Shipping times', 'google-listings-and-ads' ) }
@@ -41,63 +34,17 @@ const ShippingTimeSection = ( { formProps } ) => {
 				</div>
 			}
 		>
-			<VerticalGapLayout size="large">
-				<Section.Card>
-					<Section.Card.Body>
-						<VerticalGapLayout size="large">
-							<AppRadioContentControl
-								{ ...inputProps }
-								label={ __(
-									'My shipping settings are simple. I can manually estimate flat shipping times.',
-									'google-listings-and-ads'
-								) }
-								value="flat"
-								collapsible
-							/>
-							<AppRadioContentControl
-								{ ...inputProps }
-								label={ __(
-									'My shipping settings are complex. I will enter my shipping times manually in Google Merchant Center.',
-									'google-listings-and-ads'
-								) }
-								value="manual"
-								collapsible
-							>
-								<RadioHelperText>
-									{ createInterpolateElement(
-										__(
-											'I understand that if I don’t set this up manually in <link>Google Merchant Center</link>, my products will be disapproved by Google.',
-											'google-listings-and-ads'
-										),
-										{
-											link: (
-												<AppDocumentationLink
-													context="setup-mc-shipping"
-													linkId="shipping-manual"
-													href="https://www.google.com/retail/solutions/merchant-center/"
-												/>
-											),
-										}
-									) }
-								</RadioHelperText>
-							</AppRadioContentControl>
-						</VerticalGapLayout>
-					</Section.Card.Body>
-				</Section.Card>
-				{ values.shipping_time === 'flat' && (
-					<Section.Card>
-						<Section.Card.Body>
-							<Section.Card.Title>
-								{ __(
-									'Estimated shipping times',
-									'google-listings-and-ads'
-								) }
-							</Section.Card.Title>
-							<ShippingTimeSetup formProps={ formProps } />
-						</Section.Card.Body>
-					</Section.Card>
-				) }
-			</VerticalGapLayout>
+			<Section.Card>
+				<Section.Card.Body>
+					<Section.Card.Title>
+						{ __(
+							'Estimated shipping times',
+							'google-listings-and-ads'
+						) }
+					</Section.Card.Title>
+					<ShippingTimeSetup formProps={ formProps } />
+				</Section.Card.Body>
+			</Section.Card>
 		</Section>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Partly addresses issue #1380.
- [Figma](https://www.figma.com/file/eQ9O4m2flzrcAiDMXkOW0m/Google-Listings-%26-Ads-v1.x?node-id=7525%3A121329)

This hotfix PR is the UI part of the solution mentioned in https://github.com/woocommerce/google-listings-and-ads/issues/1380#issuecomment-1084223850. This is to address missing shipping times data when shipping rates option is set to automatic or simple flat option, and shipping times option is set to complex manual option.

The changes introduced in this PR are:

- When users change `settings.shipping_rate`, we programmatically change `settings.shipping_time`.
- Only display the shipping time section when `settings.shipping_time` is `flat` / simple.
- Remove the shipping time radio button options in shipping time section.
- Tweak copy of manual complex shipping rate option.

Technical note: we are still using `settings.shipping_time` here. It is still being used in the API side. In the future, we can consider removing it and consolidating shipping rate and shipping time into one setting.

### Screenshots:

📹  Demo video with my voice:

https://user-images.githubusercontent.com/417342/161083152-f4a4f7f6-2caf-442c-8134-af024de7f6d8.mov

### Detailed test instructions:

1. Go to Setup MC Step 3.
2. In shipping rate section, the third radio button option text should read `"My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center."`.
3. In shipping rate section, when you select automatic or simple shipping rate option, the shipping time section should be displayed. When you select complex shipping rate option, the shipping time section should be hidden. 
4. In shipping time section, you should only see estimated shipping times card. There should not be shipping time radio button options.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Change shipping time options based on shipping rate options, to address missing shipping times data when shipping rates option is set to automatic or simple flat option, and shipping times option is set to complex manual option.
