### PR TITLE
Filter Ads accounts

### DIFF
--- a/js/src/components/google-ads-account-card/connect-ads/ads-account-select-control.js
+++ b/js/src/components/google-ads-account-card/connect-ads/ads-account-select-control.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import AppSelectControl from '.~/components/app-select-control';
-import toAccountText from '.~/utils/toAccountText';
 
 const AdsAccountSelectControl = ( props ) => {
 	const { accounts, ...rest } = props;
@@ -18,8 +17,13 @@ const AdsAccountSelectControl = ( props ) => {
 			label: __( 'Select one', 'google-listings-and-ads' ),
 		},
 		...accounts.map( ( acc ) => ( {
-			value: acc,
-			label: toAccountText( acc ),
+			value: acc.id,
+			label: sprintf(
+				// translators: 1: account name, 2: account ID.
+				__( '%1$s (%2$s)', 'google-listings-and-ads' ),
+				acc.name,
+				acc.id
+			),
 		} ) ),
 	];
 

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -148,7 +148,7 @@ class Ads implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Check if we have access to the merchant account.
+	 * Check if we have access to the ads account.
 	 *
 	 * @param string $email Email address of the connected account.
 	 *

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAccountQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAccountAccessQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsBillingStatusQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
@@ -164,10 +164,10 @@ class Ads implements OptionsAwareInterface {
 		$ads_id = $this->options->get_ads_id();
 
 		try {
-			$results = ( new AdsAccountQuery() )
-			->set_client( $this->client, $ads_id )
-			->where( 'customer_user_access.email_address', $email )
-			->get_results();
+			$results = ( new AdsAccountAccessQuery() )
+				->set_client( $this->client, $ads_id )
+				->where( 'customer_user_access.email_address', $email )
+				->get_results();
 
 			foreach ( $results->iterateAllElements() as $row ) {
 				$access = $row->getCustomerUserAccess();

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -42,13 +42,6 @@ class Ads implements OptionsAwareInterface {
 	protected $client;
 
 	/**
-	 * Client for fetching accounts details.
-	 *
-	 * @var CustomerServiceClient
-	 */
-	protected $customer_service;
-
-	/**
 	 * Ads constructor.
 	 *
 	 * @param GoogleAdsClient $client
@@ -65,7 +58,7 @@ class Ads implements OptionsAwareInterface {
 	 */
 	public function get_ads_accounts(): array {
 		try {
-			$customers = $this->get_customer_service()->listAccessibleCustomers();
+			$customers = $this->client->getCustomerServiceClient()->listAccessibleCustomers();
 			$return    = [];
 
 			foreach ( $customers->getResourceNames() as $name ) {
@@ -268,18 +261,6 @@ class Ads implements OptionsAwareInterface {
 	 */
 	public function update_billing_url( string $url ): bool {
 		return $this->options->update( OptionsInterface::ADS_BILLING_URL, $url );
-	}
-
-	/**
-	 * Returns the customer service client.
-	 *
-	 * @return CustomerServiceClient
-	 */
-	private function get_customer_service(): CustomerServiceClient {
-		if ( null === $this->customer_service ) {
-			$this->customer_service = $this->client->getCustomerServiceClient();
-		}
-		return $this->customer_service;
 	}
 
 	/**

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -58,17 +58,17 @@ class Ads implements OptionsAwareInterface {
 	public function get_ads_accounts(): array {
 		try {
 			$customers = $this->client->getCustomerServiceClient()->listAccessibleCustomers();
-			$return    = [];
+			$accounts  = [];
 
 			foreach ( $customers->getResourceNames() as $name ) {
 				$account = $this->get_account_details( $name );
 
 				if ( $account ) {
-					$return[] = $account;
+					$accounts[] = $account;
 				}
 			}
 
-			return $return;
+			return $accounts;
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAccountAccessQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAccountQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsBillingStatusQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
@@ -283,9 +284,13 @@ class Ads implements OptionsAwareInterface {
 	 */
 	private function get_account_details( string $account ): ?array {
 		try {
-			$customer = $this->get_customer_service()->getCustomer( $account );
+			$customer = ( new AdsAccountQuery() )
+				->set_client( $this->client, $this->parse_ads_id( $account ) )
+				->where( 'customer.resource_name', $account, '=' )
+				->get_result()
+				->getCustomer();
 
-			if ( $customer->getManager() || $customer->getTestAccount() ) {
+			if ( ! $customer || $customer->getManager() || $customer->getTestAccount() ) {
 				return null;
 			}
 

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -208,8 +208,15 @@ class Ads implements OptionsAwareInterface {
 	 */
 	public function request_ads_currency(): bool {
 		try {
-			$resource = ResourceNames::forCustomer( $this->options->get_ads_id() );
-			$customer = $this->client->getCustomerServiceClient()->getCustomer( $resource );
+			$ads_id   = $this->options->get_ads_id();
+			$account  = ResourceNames::forCustomer( $ads_id );
+			$customer = ( new AdsAccountQuery() )
+				->set_client( $this->client, $ads_id )
+				->columns( [ 'customer.currency_code' ] )
+				->where( 'customer.resource_name', $account, '=' )
+				->get_result()
+				->getCustomer();
+
 			$currency = $customer->getCurrencyCode();
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -17,7 +17,6 @@ use Google\Ads\GoogleAds\Util\V9\ResourceNames;
 use Google\Ads\GoogleAds\V9\Enums\AccessRoleEnum\AccessRole;
 use Google\Ads\GoogleAds\V9\Enums\MerchantCenterLinkStatusEnum\MerchantCenterLinkStatus;
 use Google\Ads\GoogleAds\V9\Resources\MerchantCenterLink;
-use Google\Ads\GoogleAds\V9\Services\CustomerServiceClient;
 use Google\Ads\GoogleAds\V9\Services\MerchantCenterLinkOperation;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;

--- a/src/API/Google/Query/AdsAccountAccessQuery.php
+++ b/src/API/Google/Query/AdsAccountAccessQuery.php
@@ -6,11 +6,11 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class AdsAccountQuery
+ * Class AdsAccountAccessQuery
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
  */
-class AdsAccountQuery extends AdsQuery {
+class AdsAccountAccessQuery extends AdsQuery {
 
 	/**
 	 * Query constructor.

--- a/src/API/Google/Query/AdsAccountQuery.php
+++ b/src/API/Google/Query/AdsAccountQuery.php
@@ -1,0 +1,22 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsAccountQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
+class AdsAccountQuery extends AdsQuery {
+
+	/**
+	 * Query constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'customer' );
+		$this->columns( [ 'customer.id', 'customer.descriptive_name', 'customer.manager', 'customer.test_account' ] );
+	}
+}

--- a/src/API/Google/Query/AdsQuery.php
+++ b/src/API/Google/Query/AdsQuery.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidProperty;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Google\Ads\GoogleAds\V9\Services\GoogleAdsRow;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\PagedListResponse;
 
@@ -57,6 +58,20 @@ abstract class AdsQuery extends Query {
 		$this->id     = $id;
 
 		return $this;
+	}
+
+	/**
+	 * Get the first row from the results.
+	 *
+	 * @return GoogleAdsRow
+	 * @throws ApiException When no results returned or an error occurs.
+	 */
+	public function get_result(): GoogleAdsRow {
+		foreach ( $this->get_results()->iterateAllElements() as $row ) {
+			return $row;
+		}
+
+		throw new ApiException( __( 'No result from query', 'google-listings-and-ads' ) );
 	}
 
 	/**

--- a/src/API/Google/Query/AdsQuery.php
+++ b/src/API/Google/Query/AdsQuery.php
@@ -67,11 +67,15 @@ abstract class AdsQuery extends Query {
 	 * @throws ApiException When no results returned or an error occurs.
 	 */
 	public function get_result(): GoogleAdsRow {
-		foreach ( $this->get_results()->iterateAllElements() as $row ) {
-			return $row;
+		$results = $this->get_results();
+
+		if ( $results ) {
+			foreach ( $results->iterateAllElements() as $row ) {
+				return $row;
+			}
 		}
 
-		throw new ApiException( __( 'No result from query', 'google-listings-and-ads' ) );
+		throw new ApiException( __( 'No result from query', 'google-listings-and-ads' ), 404, '' );
 	}
 
 	/**

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -96,7 +96,7 @@ class AccountController extends BaseController {
 	protected function get_accounts_callback(): callable {
 		return function() {
 			try {
-				return new Response( $this->account->get_account_ids() );
+				return new Response( $this->account->get_accounts() );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -57,13 +57,13 @@ class AccountService implements OptionsAwareInterface, Service {
 	}
 
 	/**
-	 * Get Ads IDs associated with the connected Google account.
+	 * Get Ads accounts associated with the connected Google account.
 	 *
-	 * @return int[]
+	 * @return array
 	 * @throws Exception When an API error occurs.
 	 */
-	public function get_account_ids(): array {
-		return $this->container->get( Ads::class )->get_ads_account_ids();
+	public function get_accounts(): array {
+		return $this->container->get( Ads::class )->get_ads_accounts();
 	}
 
 	/**

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -907,12 +907,12 @@ class ConnectionTest implements Service, Registerable {
 
 		if ( 'wcs-ads-customers-lib' === $_GET['action'] && check_admin_referer( 'wcs-ads-customers-lib' ) ) {
 			try {
-				$accounts = $this->container->get( Ads::class )->get_ads_account_ids();
+				$accounts = $this->container->get( Ads::class )->get_ads_accounts();
 
 				$this->response .= 'Total accounts: ' . count( $accounts ) . "\n";
-				foreach ( $accounts as $id ) {
-					$this->response     .= sprintf( "Ads ID: %d\n", $id );
-					$_GET['customer_id'] = $id;
+				foreach ( $accounts as $account ) {
+					$this->response     .= sprintf( "%d : %s\n", $account['id'], $account['name'] );
+					$_GET['customer_id'] = $account['id'];
 				}
 			} catch ( \Exception $e ) {
 				$this->response .= 'Error: ' . $e->getMessage();

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -213,7 +213,7 @@ trait GoogleAdsClientTrait {
 	}
 
 	/**
-	 * Generates a mocked AdsAccountQuery response.
+	 * Generates a mocked AdsAccountAccessQuery response.
 	 *
 	 * @param bool $has_access
 	 */

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -145,6 +145,20 @@ trait GoogleAdsClientTrait {
 	}
 
 	/**
+	 * Generates a mocked AdsQuery response with a list of mocked rows.
+	 *
+	 * @param array $responses List of responses containing sets of GoogleAdsRow.
+	 */
+	protected function generate_ads_multiple_query_mock( array $responses ) {
+		foreach ( $responses as $key => $rows ) {
+			$responses[ $key ] = $this->createMock( PagedListResponse::class );
+			$responses[ $key ]->method( 'iterateAllElements' )->willReturn( $rows );
+		}
+
+		$this->service_client->method( 'search' )->willReturnOnConsecutiveCalls( ...$responses );
+	}
+
+	/**
 	 * Generates mocked AdsCampaignQuery and AdsCampaignCriterionQuery responses.
 	 *
 	 * @param array $campaigns_responses Set of campaign data to convert.
@@ -315,7 +329,7 @@ trait GoogleAdsClientTrait {
 	}
 
 	/**
-	 * Generates a mocked customer.
+	 * Generates a list of mocked AdsAccountQuery responses.
 	 *
 	 * @param array $customers List of customer data to mock.
 	 */
@@ -337,10 +351,10 @@ trait GoogleAdsClientTrait {
 			if ( isset( $data['currency'] ) ) {
 				$customer->method( 'getCurrencyCode' )->willReturn( $data['currency'] );
 			}
-			$customers[ $key ] = $customer;
+			$customers[ $key ] = [ ( new GoogleAdsRow )->setCustomer( $customer ) ];
 		}
 
-		$this->customer_service->method( 'getCustomer' )->willReturnOnConsecutiveCalls( ...$customers );
+		$this->generate_ads_multiple_query_mock( $customers );
 	}
 
 	/**

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -317,13 +317,30 @@ trait GoogleAdsClientTrait {
 	/**
 	 * Generates a mocked customer.
 	 *
-	 * @param string $currency
+	 * @param array $customers List of customer data to mock.
 	 */
-	protected function generate_customer_mock( string $currency ) {
-		$customer = $this->createMock( Customer::class );
-		$customer->method( 'getCurrencyCode' )->willReturn( $currency );
+	protected function generate_customers_mock( array $customers ) {
+		foreach ( $customers as $key => $data ) {
+			$customer = $this->createMock( Customer::class );
+			if ( isset( $data['id'] ) ) {
+				$customer->method( 'getId' )->willReturn( $data['id'] );
+			}
+			if ( isset( $data['name'] ) ) {
+				$customer->method( 'getDescriptiveName' )->willReturn( $data['name'] );
+			}
+			if ( isset( $data['manager'] ) ) {
+				$customer->method( 'getManager' )->willReturn( $data['manager'] );
+			}
+			if ( isset( $data['test_account'] ) ) {
+				$customer->method( 'getTestAccount' )->willReturn( $data['test_account'] );
+			}
+			if ( isset( $data['currency'] ) ) {
+				$customer->method( 'getCurrencyCode' )->willReturn( $data['currency'] );
+			}
+			$customers[ $key ] = $customer;
+		}
 
-		$this->customer_service->method( 'getCustomer' )->willReturn( $customer );
+		$this->customer_service->method( 'getCustomer' )->willReturnOnConsecutiveCalls( ...$customers );
 	}
 
 	/**

--- a/tests/Unit/API/Google/AdsTest.php
+++ b/tests/Unit/API/Google/AdsTest.php
@@ -233,6 +233,7 @@ class AdsTest extends UnitTest {
 	}
 
 	public function test_request_ads_currency_unavailable() {
+		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
 		$this->generate_customer_mock_exception(
 			new ApiException( 'unavailable', 14, 'UNAVAILABLE' )
 		);

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -26,12 +26,17 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	protected const TEST_ACCOUNT_ID          = 1234567890;
 	protected const TEST_BILLING_URL         = 'https://domain.test/billing/setup/';
 	protected const TEST_BILLING_STATUS      = 'pending';
-	protected const TEST_ACCOUNT_IDS         = [
-		self::TEST_ACCOUNT_ID,
-		2345678901,
-		3456789012,
+	protected const TEST_ACCOUNTS            = [
+		[
+			'id'   => self::TEST_ACCOUNT_ID,
+			'name' => 'Ads Account',
+		],
+		[
+			'id'   => 2345678901,
+			'name' => 'Other Account',
+		],
 	];
-	protected const TEST_ACCOUNT_NO_IDS      = [];
+	protected const TEST_NO_ACCOUNTS         = [];
 	protected const TEST_ACCOUNT_CREATE_DATA = [
 		'id'          => SELF::TEST_ACCOUNT_ID,
 		'billing_url' => SELF::TEST_BILLING_URL,
@@ -68,29 +73,29 @@ class AccountControllerTest extends RESTControllerUnitTest {
 
 	public function test_get_accounts() {
 		$this->account->expects( $this->once() )
-			->method( 'get_account_ids' )
-			->willReturn( self::TEST_ACCOUNT_IDS );
+			->method( 'get_accounts' )
+			->willReturn( self::TEST_ACCOUNTS );
 
 		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
 
-		$this->assertEquals( self::TEST_ACCOUNT_IDS, $response->get_data() );
+		$this->assertEquals( self::TEST_ACCOUNTS, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_get_accounts_with_no_ids() {
 		$this->account->expects( $this->once() )
-			->method( 'get_account_ids' )
-			->willReturn( self::TEST_ACCOUNT_NO_IDS );
+			->method( 'get_accounts' )
+			->willReturn( self::TEST_NO_ACCOUNTS );
 
 		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
 
-		$this->assertEquals( self::TEST_ACCOUNT_NO_IDS, $response->get_data() );
+		$this->assertEquals( self::TEST_NO_ACCOUNTS, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_get_accounts_with_api_exception() {
 		$this->account->expects( $this->once() )
-			->method( 'get_account_ids' )
+			->method( 'get_accounts' )
 			->willThrowException( new Exception( 'error', 401 ) );
 
 		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -82,7 +82,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
-	public function test_get_accounts_with_no_ids() {
+	public function test_get_accounts_empty_set() {
 		$this->account->expects( $this->once() )
 			->method( 'get_accounts' )
 			->willReturn( self::TEST_NO_ACCOUNTS );

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -40,10 +40,15 @@ class AccountServiceTest extends UnitTest {
 	protected const TEST_MERCHANT_ID       = 78123456;
 	protected const TEST_BILLING_URL       = 'https://domain.test/billing/setup/';
 	protected const TEST_CURRENCY          = 'EUR';
-	protected const TEST_ACCOUNT_IDS       = [
-		self::TEST_ACCOUNT_ID,
-		self::TEST_OLD_ACCOUNT_ID,
-		3456789012,
+	protected const TEST_ACCOUNTS          = [
+		[
+			'id'   => self::TEST_ACCOUNT_ID,
+			'name' => 'Ads Account',
+		],
+		[
+			'id'   => self::TEST_OLD_ACCOUNT_ID,
+			'name' => 'Other Account',
+		],
 	];
 	protected const TEST_STEP_DATA         = [
 		'sub_account'       => true,
@@ -98,20 +103,20 @@ class AccountServiceTest extends UnitTest {
 
 	public function test_get_accounts() {
 		$this->ads->expects( $this->once() )
-			->method( 'get_ads_account_ids' )
-			->willReturn( self::TEST_ACCOUNT_IDS );
+			->method( 'get_ads_accounts' )
+			->willReturn( self::TEST_ACCOUNTS );
 
-		$this->assertEquals( self::TEST_ACCOUNT_IDS, $this->account->get_account_ids() );
+		$this->assertEquals( self::TEST_ACCOUNTS, $this->account->get_accounts() );
 	}
 
 	public function test_get_accounts_with_api_exception() {
 		$this->ads->expects( $this->once() )
-			->method( 'get_ads_account_ids' )
+			->method( 'get_ads_accounts' )
 			->willThrowException( new Exception( 'error' ) );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'error' );
-		$this->account->get_account_ids();
+		$this->account->get_accounts();
 	}
 
 	public function test_get_connected_account() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR filters Ads accounts to exclude any test / manager accounts. This is done by sending a separate request to retrieve the account details using a search request. The calls can't be batched because each one needs to send a different account ID. Since we retrieve account details we now also have access to the account name which is included in the response. This changes the responses from an array of integers to an array of account details.

Note: We use search requests instead of GET requests because the latter are limited to a 1000 per day.
Request the account currency was also changed in this PR (although that gets cached so isn't repeated).

When testing I did notice that it's a bit slower and will increase the amount of requests that are sent (one for all account IDs and a request per account). However this is only needed when onboarding/connecting an Ads account, so I think it's still acceptable.

The issue mentions checking if we have ADMIN access to the account which would allow us to link it. In order to do so we would need to expand the query to retrieve data from both `customer` and `customer_user_access`. I haven't included this for now as it could potentially slow down the requests even more.

Closes #317

### Detailed test instructions:

#### Get accounts
`GET https://domain.test/wp-json/wc/gla/ads/accounts`

Response:
```json
[
	{
		"id": 1234567890,
		"name": "Main Ads Account"
	},
	{
		"id": 2345678901,
		"name": "Secondary Ads Account"
	}
]
```

If you have access to any test or manager accounts, they should no longer show up in the list.

### TODO:
- [x] UI still expects a list of account ID's, so it will need to be adjusted to support the new account details.

### Changelog entry
* Add - Filter Ads accounts to exclude manager and test accounts.
* Add - Return account names when retrieving the list of existing accounts.
