### PR TITLE
Fix PHP two unit tests for the shared branch of re-connecting WPCOM account

### DIFF
--- a/tests/Unit/API/Site/Controllers/Google/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Google/AccountControllerTest.php
@@ -54,7 +54,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_connect_invalid_parameter() {
-		$response = $this->do_request( self::ROUTE_CONNECT, 'GET', [ 'next' => 'invalid' ] );
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET', [ 'next_page_name' => 'invalid' ] );
 
 		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
 		$this->assertEquals( 400, $response->get_status() );

--- a/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
@@ -3,7 +3,7 @@
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Jetpack;
 
 use Automattic\Jetpack\Connection\Manager;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Proxy as Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Jetpack\AccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After merging `develop` branch to `feature/jetpack-disconnect` and resolving the conflicts, there are [two PHP test cases problems](https://github.com/woocommerce/google-listings-and-ads/runs/5785779183?check_suite_focus=true#step:6:31). To fix, this PR:

1. Fix a parameter that has been renamed from `next` to `next_page_name`. It was introduced in https://github.com/woocommerce/google-listings-and-ads/commit/cabe35a5033fec920e3d91bcd96c011569f9cc1a.
2. Follow the changes in e36f7ade791fbc8ba4452370e38168ba7bec7253 to rename the `Proxy` to `Middleware`.

### Screenshots:

![2022-04-01 6 41 14](https://user-images.githubusercontent.com/17420811/161248217-41ae19e6-c69d-49ee-9816-cc0bb46de4ca.png)

### Detailed test instructions:

1. Run PHP unit test locally to see if all tests are passed.
2. Or, check the PHP Unit Tests job of this PR on the GitHub Actions to see if they are passed.

### Changelog entry
