### PR TITLE
Confirm we are connected before checking statuses

### DIFF
--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -95,8 +95,8 @@ class TrackerSnapshot implements Conditional, ContainerAwareInterface, OptionsAw
 			'shipping_rate'                   => $mc_settings['shipping_rate'] ?? '',
 			'shipping_time'                   => $mc_settings['shipping_time'] ?? '',
 			'tax_rate'                        => $mc_settings['tax_rate'] ?? '',
-			'has_account_issue'               => $mc_service->has_account_issues() ? 'yes' : 'no',
-			'has_at_least_one_synced_product' => $mc_service->has_at_least_one_synced_product() ? 'yes' : 'no',
+			'has_account_issue'               => $mc_service->is_connected() && $mc_service->has_account_issues() ? 'yes' : 'no',
+			'has_at_least_one_synced_product' => $mc_service->is_connected() && $mc_service->has_at_least_one_synced_product() ? 'yes' : 'no',
 			'ads_setup_started'               => $ads_service->is_setup_started() ? 'yes' : 'no',
 		];
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR checks if the Merchant Center account is connected before retrieving data about it's status. This prevents an uncaught exception when the WooCommerce tracker snapshot is sent.

Closes #1397

### Detailed test instructions:
1. Disconnect the Merchant account using the connection test page
2. Add a code snippet to temporarily log tracker snapshot data
```php
add_action(

	'admin_init',
	function() {
		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
		error_log( json_encode( $tracks, JSON_PRETTY_PRINT ) );
	}
);
```
3. Refresh an admin page to trigger the logging of the track snapshot  
4. Confirm there is no critical error or uncaught exception
5. Reconnect the Merchant account and trigger the tracker snapshot again
6. Confirm that it still logs without issues

### Changelog entry
* Fix - Prevent uncaught exception when Merchant account is not connected and we send a tracker snapshot.