### PR TITLE
Setup MC - Set initial value 'flat' for shipping time option

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -115,7 +115,7 @@ const SetupFreeListings = ( props ) => {
 			<Form
 				initialValues={ {
 					shipping_rate: settings.shipping_rate || 'automatic',
-					shipping_time: settings.shipping_time,
+					shipping_time: settings.shipping_time || 'flat',
 					tax_rate: settings.tax_rate,
 					shipping_country_rates: dataShippingRates,
 					offer_free_shipping: getOfferFreeShippingInitialValue(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1403.

This PR fixes the issue #1403 by setting initial value 'flat' for shipping time option form field. The 'flat' value works in conjunction with the 'automatic' shipping rate option:

https://github.com/woocommerce/google-listings-and-ads/blob/3a8b949ea3cfd2e58ef6fd6237405582568b3bff/js/src/components/shipping-rate-section/shipping-rate-section.js#L23-L26


### Screenshots:

📹  Demo video with my voice:

https://user-images.githubusercontent.com/417342/161819187-bf9d26a6-7913-4fe0-aadc-f446722c0199.mp4

### Detailed test instructions:

Important note: make sure you disconnect Google MC account in connection test page to clear your existing settings data. Otherwise, you may be using existing settings data and your test on this fix may not be accurate.

1. Disconnect Google MC account in connection test page
2. Go through Setup MC flow.
3. When you reach Step 3, the automatic shipping rate is selected by default. Do not change the option. You should be able to see the shipping times section.
4. Complete the shipping times settings. Select the tax rate option if it is shown. You should be able to proceed to the next step.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Shipping times section not showing up and unable to proceed through the Setup Merchant Center flow.
