### PR TITLE
Fix Fatal error when settings are saved - Migration Class

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -132,7 +132,9 @@ class Settings {
 	 * @return bool
 	 */
 	protected function should_sync_shipping(): bool {
-		return in_array( $this->get_settings()['shipping_rate'], [ 'flat', 'automatic' ], true ) && 'flat' === $this->get_settings()['shipping_time'];
+		$shipping_rate = $this->get_settings()['shipping_rate'] ?? '';
+		$shipping_time = $this->get_settings()['shipping_time'] ?? '';
+		return in_array( $shipping_rate, [ 'flat', 'automatic' ], true ) && 'flat' === $shipping_time;
 	}
 
 	/**
@@ -143,7 +145,7 @@ class Settings {
 	 * @since 1.12.0
 	 */
 	protected function should_get_shipping_rates_from_woocommerce(): bool {
-		return 'automatic' === $this->get_settings()['shipping_rate'];
+		return 'automatic' === ( $this->get_settings()['shipping_rate'] ?? '' );
 	}
 
 	/**

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -170,7 +170,7 @@ class Settings {
 			return false;
 		}
 
-		return 'destination' === ( $this->get_options_object()->get( OptionsInterface::MERCHANT_CENTER )['tax_rate'] ?? 'destination' );
+		return 'destination' === ( $this->get_settings()['tax_rate'] ?? 'destination' );
 	}
 
 	/**
@@ -553,6 +553,7 @@ class Settings {
 	 * @return array
 	 */
 	protected function get_settings(): array {
-		return $this->get_options_object()->get( OptionsInterface::MERCHANT_CENTER );
+		$settings = $this->get_options_object()->get( OptionsInterface::MERCHANT_CENTER );
+		return is_array( $settings ) ? $settings : [];
 	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -66,6 +66,10 @@ class SettingsController extends BaseOptionsController {
 		return function( Request $request ) {
 			$schema  = $this->get_schema_properties();
 			$options = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+			if ( ! is_array( $options ) ) {
+				$options = [];
+			}
+
 			foreach ( $schema as $key => $property ) {
 				$options[ $key ] = $request->get_param( $key ) ?? $options[ $key ] ?? $property['default'] ?? null;
 			}

--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -62,7 +62,11 @@ class Migration20211228T1640692399 extends AbstractMigration {
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$this->wpdb->query( "ALTER TABLE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` ALTER COLUMN `method` DROP DEFAULT" );
 
-			$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+			$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER );
+			if ( ! is_array( $mc_settings ) ) {
+				return;
+			}
+
 			if ( isset( $mc_settings['offers_free_shipping'] ) && false !== boolval( $mc_settings['offers_free_shipping'] ) && isset( $mc_settings['free_shipping_threshold'] ) ) {
 				// Move the free shipping threshold from the options to the shipping rate table.
 				$options_json = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );

--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -62,7 +62,7 @@ class Migration20211228T1640692399 extends AbstractMigration {
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$this->wpdb->query( "ALTER TABLE `{$this->wpdb->_escape( $this->shipping_rate_table->get_name() )}` ALTER COLUMN `method` DROP DEFAULT" );
 
-			$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER );
+			$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
 			if ( isset( $mc_settings['offers_free_shipping'] ) && false !== boolval( $mc_settings['offers_free_shipping'] ) && isset( $mc_settings['free_shipping_threshold'] ) ) {
 				// Move the free shipping threshold from the options to the shipping rate table.
 				$options_json = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1396.

The new migration class is updating `gla_merchant_center` options:

https://github.com/woocommerce/google-listings-and-ads/blob/3d5ea83a3d6bdb6da60b5d2901fc45d26344ccbf/src/DB/Migration/Migration20211228T1640692399.php#L77

 however if the option `gla_merchant_center` does not exist is used as default value `null` and then is being updated as an empty string `gla_merchant_center` causing the error.

https://github.com/woocommerce/google-listings-and-ads/blob/3d5ea83a3d6bdb6da60b5d2901fc45d26344ccbf/src/DB/Migration/Migration20211228T1640692399.php#L65

In this PR we are only migrating the shipping settings if it has been stored as an array to prevent any errors. In addition to this there are several other locations where we expect the merchant settings to be an array.

When we update the merchant settings if it's loaded as a string, we still index it to update the values. Which causes some odd behaviour because it uses string indexing instead of indexing the array. The result is that the option `gla_merchant_center` is updated with either one letter, or if we set a boolean a value of 1 (which was what was happening in issue #1396).

If we still leave the merchant settings as a string the next error that's encountered is when we try to sync it to Google. This PR also resolves that issue, by enforcing the settings to be read as a string.

### Detailed test instructions:

#### Succeed through onboarding when starting from scratch

1. Delete all options related to the GLA plugin `DELETE FROM wordpress.wp_options WHERE option_name LIKE '%gla_%' `to simulate a fresh installing.
2. After completing Step 3 of the onboarding process: `Configure your product listings` check that `gla_merchant_center` option is a serialised object and not a string.
3. Complete the onboarding process.
4. No errors should be displayed and the option `gla_merchant_center ` should be a serialised object, not a string.

#### Trigger DB migration with invalid settings

1. Disconnect Merchant center through the connection test page
2. Set the DB option `gla_db_version` to a value older than `1.12.2`
3. Set the DB option `gla_merchant_center` to the value `1`
4. Refresh an admin page to trigger the migration
5. Confirm there are no fatal errors

Before the PR this would have failed with:
```
PHP Fatal error:  Uncaught Error: Cannot unset string offsets in wp-content/plugins/google-listings-and-ads/src/DB/Migration/Migration20211228T1640692399.php:75
Stack trace:
#0 wp-content/plugins/google-listings-and-ads/src/DB/Migration/Migrator.php(47): Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20211228T1640692399->apply()
#1 wp-content/plugins/google-listings-and-ads/src/DB/Installer.php(53): Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migrator->migrate()
#2 wp-content/plugins/google-listings-and-ads/src/Installer.php(103): Automattic\WooCommerce\GoogleListingsAndAds\DB\Installer->install()
#3 wp-content/plugins/google-listings-and-ads/src/Installer.php(83): Automattic\WooCommerce\GoogleListingsAndAds\Installer->install()
#4 wp-content/plugins/google-listings-and-ads/src/Installer.php(66): Automattic\WooCommerce in wp-content/plugins/google-listings-and-ads/src/DB/Migration/Migration20211228T1640692399.php on line 75
```

#### Override invalid merchant settings

Since some merchants failed with previous versions we released, we need to ensure the plugin can recover and save valid settings.

1. Set the DB option `gla_merchant_center` to an empty string
2. Send a request to update the merchant settings

`POST https://domain.test/wp-json/wc/gla/mc/settings`
Body:
```json
{
	"shipping_rate": "automatic",
	"shipping_time": "flat",
	"tax_rate": "destination",
}
```

3. Confirm that the data in the response is the same as the one we sent
4. Check the DB option `gla_merchant_center` and ensure it's saved as a serialized array

Previously this would have used string indexing and the response would have returned the data as just the letter `d`, the option would also be saved with this character. If the last option we passed was a boolean it would have been a 1.

#### Sync settings to Google

The original issue some merchants were experiencing was that it was unable to sync to Google and giving a fatal error that get_settings was not returning an array.

1. Set the DB option `gla_merchant_center` with the value `1`
2. Send a request to sync the settings:

`POST https://domain.test/wp-json/wc/gla/mc/settings/sync`
*with an empty body*

3. Confirm that there are no fatal errors

Before the PR this would have failed with:
```
PHP Fatal error:  Uncaught TypeError: Return value of Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings::get_settings() must be of the type array, string returned in wp-content/plugins/google-listings-and-ads/src/API/Google/Settings.php:556
Stack trace:
#0 wp-content/plugins/google-listings-and-ads/src/API/Google/Settings.php(135): Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings->get_settings()
#1 wp-content/plugins/google-listings-and-ads/src/API/Google/Settings.php(52): Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings->should_sync_shipping()
#2 wp-content/plugins/google-listings-and-ads/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php(67): Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings->sync_shipping()
#3 wp-includes/rest-api/class-wp-rest-server.php(1141): Automattic\WooCommerce\GoogleListingsAndAd in wp-content/plugins/google-listings-and-ads/src/API/Google/Settings.php on line 556
```

### Changelog entry

* Fix - Prevent fatal errors when migrating or syncing merchant settings.
