### PR TITLE
Adding Last Line Rule on ESLINT 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
 				additionalHooks: 'useSelect',
 			},
 		],
+		'eol-last': 2,
 	},
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a new rule in our ESLINT config in order to show the Linter error when no new line is added at the end of the file.

Context:

Besides the fact we have the rule in the `.editorconfig`  we're still encountering some files with this issue in several PRs which relies on the developer eyes to identify the lack of the new line.

This PR solves that by triggering the ESLINT error. 

### Detailed test instructions:

1. Checkout this PR
2. Go to any JS file and remove the last empty line *
3. Run `npm run lint:js`
4. Error should be shown
5. Add again the empty line
6. Error should be fixed

*In case you editor adds automatically the new line (like my case) you can go to `.editorconfig` and set `insert_final_newline = true` as `false` 



