### PR TITLE
Redirect notification to reconnect page

### DIFF
--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -198,8 +198,7 @@ class AccountController extends BaseOptionsController {
 			return false;
 		}
 
-		$token = $this->manager->get_tokens()->get_access_token( false, false, false );
-		return $token && ! is_wp_error( $token );
+		return false !== $this->manager->get_tokens()->get_access_token();
 	}
 
 	/**

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -189,11 +189,17 @@ class AccountController extends BaseOptionsController {
 
 	/**
 	 * Determine whether Jetpack is connected.
+	 * Check if manager is active and we have a valid token.
 	 *
 	 * @return bool
 	 */
 	protected function is_jetpack_connected(): bool {
-		return $this->manager->is_active();
+		if ( ! $this->manager->is_active() ) {
+			return false;
+		}
+
+		$token = $this->manager->get_tokens()->get_access_token( false, false, false );
+		return $token && ! is_wp_error( $token );
 	}
 
 	/**

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -65,7 +65,7 @@ class ReconnectWordPress extends AbstractNote {
 		$note->add_action(
 			'reconnect-wordpress',
 			__( 'Go to Google Listings & Ads', 'google-listings-and-ads' ),
-			$this->get_settings_url()
+			add_query_arg( 'subpath', '/reconnect-wpcom-account', $this->get_settings_url() )
 		);
 
 		return $note;

--- a/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
@@ -135,7 +135,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_connected_invalid_token() {
-		$this->tokens->method( 'get_access_token' )->willReturn( new WP_Error( 'invalid token' ) );
+		$this->tokens->method( 'get_access_token' )->willReturn( false );
 		$this->manager->method( 'is_active' )->willReturn( true );
 		$this->manager->method( 'is_connection_owner' )->willReturn( true );
 		$this->manager->method( 'get_tokens' )->willReturn( $this->tokens );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the redirect link from the settings page directly to the reconnect-wpcom-account subpath.

In addition to this the Jetpack account controller was changed to test both if the manager is active as well as having a valid token. If this is not done then a scenario where Jetpack is connected but the token is invalid will still return connected as true, which prevents us from viewing the reconnect page.

### Detailed test instructions:

1. Disconnect Jetpack using the Connection Test page
2. Send a request to check the Google account status: `GET https://domain.test/wp-json/wc/gla/google/connected`
3. Check WooCommerce > Home > Inbox and confirm we see a notification to reconnect our WordPress.com account
4. Check the link and confirm it redirects to `admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&subpath=%2Freconnnect-wpcom-account`
5. Click on the link and see the reconnect page
![image](https://user-images.githubusercontent.com/11388669/162440745-4b1d57a9-a94f-4f62-99aa-72ae13226521.png)

#### Test connected with invalid token

1. Modify the DB option `jetpack_private_options` and change `blog_token` to `fail_token`. Send a request to check the status:
`GET https://domain.test/wp-json/wc/gla/jetpack/connected`
2. Confirm that `active` returns `no`
3. Go to the settings page and confirm we now redirect to the reconnect page.

### Changelog entry
* Tweak - Redirect notification to WP.com reconnect page.
