### PR TITLE
Remove `@woocommerce/api` devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 		"@testing-library/user-event": "^13.5.0",
 		"@types/jest": "^27.4.0",
 		"@types/puppeteer": "^5.4.4",
-		"@woocommerce/api": "^0.2.0",
 		"@woocommerce/e2e-environment": "^0.2.3",
 		"@woocommerce/e2e-utils": "^0.1.6",
 		"@woocommerce/eslint-plugin": "^1.2.0",


### PR DESCRIPTION


### Changes proposed in this Pull Request:

Remove `@woocommerce/api` devDependency,

We no longer need it, we no longer use `@woocommerce/e2e-core-tests` which [needed it as a peer dependency.](https://github.com/woocommerce/google-listings-and-ads/commit/05306ea03db30ca2cb0d6b9e872eb8bb8386648d)

This limits the number of things to track and to resolve in `npm audit`s


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

```
npm i
npm run docker:up
npm run test:e2e
```

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
