### PR TITLE
Re-connecting WPCOM Account - Disable menu links during the re-connecting process

### DIFF
--- a/js/src/settings/index.js
+++ b/js/src/settings/index.js
@@ -20,13 +20,14 @@ import EditStoreAddress from './edit-store-address';
 import EditPhoneNumber from './edit-phone-number';
 import './index.scss';
 
+const pageClassName = 'gla-settings';
+
 const Settings = () => {
 	const { subpath } = getQuery();
 	// Make the component highlight GLA entry in the WC legacy menu.
 	useLegacyMenuEffect();
 
 	const { google } = useGoogleAccount();
-	const isReconnectWPComPage = subpath === subpaths.reconnectWPComAccount;
 	const isReconnectGooglePage = subpath === subpaths.reconnectGoogleAccount;
 
 	// This page wouldn't get any 401 response when losing Google account access,
@@ -41,6 +42,12 @@ const Settings = () => {
 
 	// Navigate to subpath is any.
 	switch ( subpath ) {
+		case subpaths.reconnectWPComAccount:
+			return (
+				<div className={ pageClassName }>
+					<ReconnectWPComAccount />
+				</div>
+			);
 		case subpaths.reconnectGoogleAccount:
 			return <ReconnectGoogleAccount />;
 		case subpaths.editPhoneNumber:
@@ -51,16 +58,10 @@ const Settings = () => {
 	}
 
 	return (
-		<div className="gla-settings">
+		<div className={ pageClassName }>
 			<NavigationClassic />
-			{ isReconnectWPComPage ? (
-				<ReconnectWPComAccount />
-			) : (
-				<>
-					<ContactInformationPreview />
-					<LinkedAccounts />
-				</>
-			) }
+			<ContactInformationPreview />
+			<LinkedAccounts />
 		</div>
 	);
 };

--- a/js/src/settings/reconnect-google-account/reconnect-google-account.js
+++ b/js/src/settings/reconnect-google-account/reconnect-google-account.js
@@ -16,6 +16,10 @@ import Section from '.~/wcdl/section';
 import AppSpinner from '.~/components/app-spinner';
 import GoogleAccountCard from '.~/components/google-account-card';
 import DisconnectGoogleAccountCard from './disconnect-google-account-card';
+import {
+	lockInReconnection,
+	unlockFromReconnection,
+} from '../reconnectionLock';
 
 export default function ReconnectGoogleAccount() {
 	const { data } = useAppSelectDispatch( 'getGoogleAccountAccess' );
@@ -34,6 +38,9 @@ export default function ReconnectGoogleAccount() {
 	useEffect( () => {
 		if ( isCompletedReconnection ) {
 			getHistory().replace( getDashboardUrl() );
+			unlockFromReconnection();
+		} else {
+			lockInReconnection();
 		}
 	}, [ isCompletedReconnection ] );
 

--- a/js/src/settings/reconnect-wpcom-account/reconnect-wpcom-account.js
+++ b/js/src/settings/reconnect-wpcom-account/reconnect-wpcom-account.js
@@ -16,6 +16,10 @@ import AccountCard from '.~/components/account-card';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import { ConnectWPComAccountCard } from '.~/components/wpcom-account-card';
 import LinkedAccountsSectionWrapper from '../linked-accounts-section-wrapper';
+import {
+	lockInReconnection,
+	unlockFromReconnection,
+} from '../reconnectionLock';
 import './reconnect-wpcom-account.scss';
 
 export default function ReconnectWPComAccount() {
@@ -25,6 +29,9 @@ export default function ReconnectWPComAccount() {
 	useEffect( () => {
 		if ( isConnected ) {
 			getHistory().replace( getSettingsUrl() );
+			unlockFromReconnection();
+		} else {
+			lockInReconnection();
 		}
 	}, [ isConnected ] );
 

--- a/js/src/settings/reconnectionLock.js
+++ b/js/src/settings/reconnectionLock.js
@@ -29,7 +29,7 @@ let unlockCallback = null;
  * and uses the current link as the locked link. When clicking on the Settings link,
  * it will redirect to the locked link.
  */
-function lockInReconnection() {
+export function lockInReconnection() {
 	if ( unlockCallback ) {
 		return;
 	}
@@ -86,11 +86,9 @@ function lockInReconnection() {
  * Enables the GLA menu links of WC Navigation that are locked by
  * the `lockInReconnection` function.
  */
-function unlockFromReconnection() {
+export function unlockFromReconnection() {
 	if ( unlockCallback ) {
 		unlockCallback();
 		unlockCallback = null;
 	}
 }
-
-export { lockInReconnection, unlockFromReconnection };

--- a/js/src/settings/reconnectionLock.js
+++ b/js/src/settings/reconnectionLock.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { getQueryArgs } from '@wordpress/url';
+import { isEqual } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { pagePaths } from '.~/utils/urls';
+import isWCNavigationEnabled from '.~/utils/isWCNavigationEnabled';
+import './reconnectionLock.scss';
+
+/*
+ * When required accounts were disconnected, the available link is
+ * the corresponding reconnecting subpage under the Settings page.
+ *
+ * But there is no reliable way to disable the menu link of WC Navigation,
+ * so the given workaround is using a pair of singleton locking and unlocking
+ * functions to disable the GLA menu links globally, and lock the current link
+ * as the available link when redirecting.
+ */
+
+let unlockCallback = null;
+
+/**
+ * Disables the GLA menu links of WC Navigation except for the Settings link
+ * and uses the current link as the locked link. When clicking on the Settings link,
+ * it will redirect to the locked link.
+ */
+function lockInReconnection() {
+	if ( unlockCallback ) {
+		return;
+	}
+
+	const lockedQuery = getQueryArgs( document.location.search );
+	const handleClick = ( e ) => {
+		const { target } = e;
+
+		if ( target.tagName !== 'A' ) {
+			return;
+		}
+
+		const paths = [
+			pagePaths.dashboard,
+			pagePaths.reports,
+			pagePaths.productFeed,
+			pagePaths.settings,
+		];
+
+		const targetQuery = getQueryArgs( target.getAttribute( 'href' ) );
+		if ( paths.includes( targetQuery.path ) ) {
+			e.stopPropagation();
+			e.preventDefault();
+
+			/**
+			 * With WC Navigation, the available entry link on menu is the GLA Settings;
+			 * With Classic Navigation, the available entry link is the only one link on menu.
+			 *
+			 * When clicking on the available entry link, redirects to the locked link
+			 * if the current link is not the locked link.
+			 */
+			const isAvailableEntry = isWCNavigationEnabled()
+				? targetQuery.path === pagePaths.settings
+				: true;
+			const currentQuery = getQueryArgs( document.location.search );
+			if ( isAvailableEntry && ! isEqual( lockedQuery, currentQuery ) ) {
+				const { path, ...query } = lockedQuery;
+
+				getHistory().push( getNewPath( query, path, null ) );
+			}
+		}
+	};
+
+	document.defaultView.addEventListener( 'click', handleClick, true );
+	document.body.classList.add( 'gla-reconnection-lock' );
+
+	unlockCallback = () => {
+		document.defaultView.removeEventListener( 'click', handleClick, true );
+		document.body.classList.remove( 'gla-reconnection-lock' );
+	};
+}
+
+/**
+ * Enables the GLA menu links of WC Navigation that are locked by
+ * the `lockInReconnection` function.
+ */
+function unlockFromReconnection() {
+	if ( unlockCallback ) {
+		unlockCallback();
+		unlockCallback = null;
+	}
+}
+
+export { lockInReconnection, unlockFromReconnection };

--- a/js/src/settings/reconnectionLock.scss
+++ b/js/src/settings/reconnectionLock.scss
@@ -1,21 +1,19 @@
 // The workaround for making the GLA menu links of WC Navigation appear as disabled
-// except for the last link - GLA Settings page.
+// except for the GLA Settings link.
 .gla-reconnection-lock {
 	.woocommerce-navigation {
-		ul[aria-labelledby$="google-listings-and-ads-category"] {
-			.components-navigation__item:not(:last-child) {
+		.woocommerce-navigation__wrapper {
+			.components-navigation__item {
 				.components-button {
-					cursor: not-allowed;
-
-					&:focus {
-						box-shadow: none;
-					}
-				}
-
-				&,
-				&:hover {
-					.components-button {
+					&[href*="path=%2Fgoogle%2Fdashboard"],
+					&[href*="path=%2Fgoogle%2Freports"],
+					&[href*="path=%2Fgoogle%2Fproduct-feed"] {
+						cursor: not-allowed;
 						color: $gray-600;
+
+						&:focus {
+							box-shadow: none;
+						}
 					}
 				}
 			}

--- a/js/src/settings/reconnectionLock.scss
+++ b/js/src/settings/reconnectionLock.scss
@@ -1,0 +1,24 @@
+// The workaround for making the GLA menu links of WC Navigation appear as disabled
+// except for the last link - GLA Settings page.
+.gla-reconnection-lock {
+	.woocommerce-navigation {
+		ul[aria-labelledby$="google-listings-and-ads-category"] {
+			.components-navigation__item:not(:last-child) {
+				.components-button {
+					cursor: not-allowed;
+
+					&:focus {
+						box-shadow: none;
+					}
+				}
+
+				&,
+				&:hover {
+					.components-button {
+						color: $gray-600;
+					}
+				}
+			}
+		}
+	}
+}

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -8,9 +8,15 @@ import { getNewPath } from '@woocommerce/navigation';
  */
 import { API_RESPONSE_CODES } from '.~/constants';
 
-const getStartedUrl = '/google/start';
-const dashboardPath = '/google/dashboard';
-const settingsPath = '/google/settings';
+export const pagePaths = {
+	getStarted: '/google/start',
+	setupMC: '/google/setup-mc',
+	setupAds: '/google/setup-ads',
+	dashboard: '/google/dashboard',
+	reports: '/google/reports',
+	productFeed: '/google/product-feed',
+	settings: '/google/settings',
+};
 
 export const subpaths = {
 	editFreeListings: '/free-listings/edit',
@@ -21,6 +27,10 @@ export const subpaths = {
 	reconnectWPComAccount: '/reconnect-wpcom-account',
 	reconnectGoogleAccount: '/reconnect-google-account',
 };
+
+const getStartedPath = pagePaths.getStarted;
+const dashboardPath = pagePaths.dashboard;
+const settingsPath = pagePaths.settings;
 
 export const getEditFreeListingsUrl = () => {
 	return getNewPath( { subpath: subpaths.editFreeListings }, dashboardPath );
@@ -38,7 +48,7 @@ export const getCreateCampaignUrl = () => {
 };
 
 export const getGetStartedUrl = () => {
-	return getNewPath( null, getStartedUrl, null );
+	return getNewPath( null, getStartedPath, null );
 };
 
 export const getDashboardUrl = () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a part of frontend in #775

- Make the GLA menu links of WC Navigation appear disabled.
- When entering the account reconnecting process, lock the available link to the corresponding reconnecting page.
- Don't display the classic navigation tabs during the reconnecting process.
   - The visual design doesn't include how the navigation links should be looked like with the classic navigation. And this change is awaiting confirmation from the design team. If it needs more adjustments, I will create another PR for it.

### Screenshots:

https://user-images.githubusercontent.com/17420811/162701688-638cdd88-b76f-4fe5-989d-75ad47607aba.mp4

### Detailed test instructions:

💡  If you are using a local site for testing, please set the site to be accessible from the public network first.

1. Enable the new WooCommerce navigation on the WC Settings page: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
   - Maybe it needs to install the **WooCommerce Admin** plugin first to have that feature option.
   - ![image](https://user-images.githubusercontent.com/17420811/162713874-37b03b1b-da26-4c89-a99d-31bdd685ec83.png)
1. Go to the Connection Test page `/wp-admin/admin.php?page=connection-test-admin-page`.
1. Click on the "Disconnect Jetpack" button.
1. Go to a GLA page. It should make the GLA menu links of WC Navigation disabled except for the Settings link.
1. Go to another admin page that is rendered by React. For example, the **Marketing > Overview** page.
1. When clicking on the GLA Settings link for going back, it should redirect to the WPCOM account reconnecting page.
1. After the reconnecting process is finished and back to the GLA Settings page, other page links should be enabled.

### Additional details:

Before any 401 error occurs, the GLA menu links of WC Navigation will still be enabled since it only starts locking the re-connecting link as the available link once it enters the re-connecting page.

### Changelog entry
