### PR TITLE
Cache Yoast SEO values per product

### DIFF
--- a/src/Integration/YoastWooCommerceSeo.php
+++ b/src/Integration/YoastWooCommerceSeo.php
@@ -18,9 +18,9 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 	protected const VALUE_KEY = 'yoast_seo';
 
 	/**
-	 * @var array Meta values stored by Yoast WooCommerce SEO plugin.
+	 * @var array Meta values stored by Yoast WooCommerce SEO plugin (per product).
 	 */
-	protected $yoast_global_identifiers;
+	protected $yoast_global_identifiers = [];
 
 	/**
 	 * Returns whether the integration is active or not.
@@ -122,12 +122,14 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 	 * @return mixed|null
 	 */
 	protected function get_identifier_value( string $key, WC_Product $product ) {
-		if ( ! isset( $this->yoast_global_identifiers ) ) {
+		$product_id = $product->get_id();
+
+		if ( ! isset( $this->yoast_global_identifiers[ $product_id ] ) ) {
 			$product = $product instanceof WC_Product_Variation ? wc_get_product( $product->get_parent_id() ) : $product;
 
-			$this->yoast_global_identifiers = $product->get_meta( 'wpseo_global_identifier_values', true );
+			$this->yoast_global_identifiers[ $product_id ] = $product->get_meta( 'wpseo_global_identifier_values', true );
 		}
 
-		return ! empty( $this->yoast_global_identifiers[ $key ] ) ? $this->yoast_global_identifiers[ $key ] : null;
+		return ! empty( $this->yoast_global_identifiers[ $product_id ][ $key ] ) ? $this->yoast_global_identifiers[ $product_id ][ $key ] : null;
 	}
 }

--- a/tests/Unit/Integration/YoastWooCommerceSeoTest.php
+++ b/tests/Unit/Integration/YoastWooCommerceSeoTest.php
@@ -1,0 +1,135 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use WC_Helper_Product;
+
+/**
+ * Class YoastWooCommerceSeoTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration
+ *
+ * @property YoastWooCommerceSeo $integration
+ */
+class YoastWooCommerceSeoTest extends UnitTest {
+
+	protected const TEST_MPN  = '1234567';
+	protected const TEST_GTIN = '34567890';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->integration = new YoastWooCommerceSeo();
+		$this->integration->init();
+	}
+
+	public function test_mpn_options() {
+		$options = apply_filters( 'woocommerce_gla_product_attribute_value_options_mpn', [] );
+		$this->assertEquals(
+			[ 'yoast_seo' => 'From Yoast WooCommerce SEO' ],
+			$options
+		);
+	}
+
+	public function test_gtin_options() {
+		$options = apply_filters( 'woocommerce_gla_product_attribute_value_options_gtin', [] );
+		$this->assertEquals(
+			[ 'yoast_seo' => 'From Yoast WooCommerce SEO' ],
+			$options
+		);
+	}
+
+	public function test_get_mpn() {
+		$product = WC_Helper_Product::create_simple_product( false );
+		$product->update_meta_data(
+			'wpseo_global_identifier_values',
+			[ 'mpn' => self::TEST_MPN ]
+		);
+		$product->save();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'     => $product,
+				'gla_attributes' => [ 'mpn' => 'yoast_seo' ],
+				'targetCountry'  => 'US',
+			]
+		);
+
+		$this->assertEquals( self::TEST_MPN, $adapted_product->getMpn() );
+	}
+
+	public function test_get_gtin() {
+		$product = WC_Helper_Product::create_simple_product( false );
+		$product->update_meta_data(
+			'wpseo_global_identifier_values',
+			[ 'gtin8' => self::TEST_GTIN ]
+		);
+		$product->save();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'     => $product,
+				'gla_attributes' => [ 'gtin' => 'yoast_seo' ],
+				'targetCountry'  => 'US',
+			]
+		);
+
+		$this->assertEquals( self::TEST_GTIN, $adapted_product->getGtin() );
+	}
+
+	public function test_get_gtin_no_meta() {
+		$product = WC_Helper_Product::create_simple_product( false );
+		$product->save();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'     => $product,
+				'gla_attributes' => [ 'gtin' => 'yoast_seo' ],
+				'targetCountry'  => 'US',
+			]
+		);
+
+		$this->assertNull( $adapted_product->getGtin() );
+	}
+
+	public function test_get_gtin_multiple_products() {
+		$product_one = WC_Helper_Product::create_simple_product( false );
+		$product_one->update_meta_data(
+			'wpseo_global_identifier_values',
+			[ 'gtin8' => self::TEST_GTIN ]
+		);
+		$product_one->save();
+		$adapted_one = new WCProductAdapter(
+			[
+				'wc_product'     => $product_one,
+				'gla_attributes' => [ 'gtin' => 'yoast_seo' ],
+				'targetCountry'  => 'US',
+			]
+		);
+
+		$product_two = WC_Helper_Product::create_simple_product( false );
+		$product_two->update_meta_data(
+			'wpseo_global_identifier_values',
+			[ 'gtin8' => '78901234' ]
+		);
+		$product_two->save();
+		$adapted_two = new WCProductAdapter(
+			[
+				'wc_product'     => $product_two,
+				'gla_attributes' => [ 'gtin' => 'yoast_seo' ],
+				'targetCountry'  => 'US',
+			]
+		);
+
+		$this->assertEquals( self::TEST_GTIN, $adapted_one->getGtin() );
+		$this->assertEquals( '78901234', $adapted_two->getGtin() );
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR caches the Yoast SEO identifiers per product, which prevents duplication issues from showing up when the products get synced to Google.

Closes #1411 

### Detailed test instructions:
1. Set Yoast SEO and add GTIN numbers per product or use the steps from PR #428 to add GTIN values to several products
2. Edit those same products and on the Google Listings & Ads tab, set the GTIN attributes to "From Yoast WooCommerce SEO"
3. Sync the products (in a batch) to the Merchant Center
4. Check the GTIN values in the Merchant Center and confirm that they are unique

Or alternatively use the following code to reproduce the problem (product ID's need to point to existing products):
```php
define( 'WPSEO_WOO_VERSION', '1.2.3' );

$product_one = wc_get_product( 48 );
$product_two = wc_get_product( 49 );
$product_one->update_meta_data(
	'wpseo_global_identifier_values',
	[ 'gtin8' => '12345678' ]
);
$product_two->update_meta_data(
	'wpseo_global_identifier_values',
	[ 'gtin8' => '23456789' ]
);
$adapted_one = new WCProductAdapter(
	[
		'wc_product'     => $product_one,
		'gla_attributes' => [ 'gtin' => 'yoast_seo' ],
		'targetCountry'  => 'US',
	]
);
$adapted_two = new WCProductAdapter(
	[
		'wc_product'     => $product_two,
		'gla_attributes' => [ 'gtin' => 'yoast_seo' ],
		'targetCountry'  => 'US',
	]
);

var_dump(
	$adapted_one->getGtin(),
	$adapted_two->getGtin()
);
```

After this PR, the GTIN numbers should be unique.

### Additional details:

Unit tests for the YoastWooCommerceSeo class where added, including a test which converts multiple products to ensure the GTIN value is unique.

### Changelog entry
* Fix - Cache Yoast SEO values per product, to ensure unique values.