### PR TITLE
Edit Free Listings: `saveShippingTimes` to delete and upsert shipping times

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -46,11 +46,6 @@ function isNotOurStep( location ) {
 }
 
 /**
- * @typedef {import('.~/data/actions').ShippingRate} ShippingRate
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
- */
-
-/**
  * Page Component to edit free campaigns.
  * Provides two steps:
  *  - Choose your audience

--- a/js/src/hooks/useSaveShippingTimes.js
+++ b/js/src/hooks/useSaveShippingTimes.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useAppDispatch } from '.~/data';
+import useShippingTimes from './useShippingTimes';
+import getDeletedShippingTimes from '.~/utils/getDeletedShippingTimes';
+import getDifferentShippingTimes from '.~/utils/getDifferentShippingTimes';
+
+/**
+ * @typedef { import(".~/data/actions").ShippingTime } ShippingTime
+ * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ */
+
+/**
+ * Get the country codes of the deleted shipping times.
+ *
+ * Deleted shipping times are those that exist in `oldShippingTimes` but not in `newShippingTimes`.
+ *
+ * @param {Array<ShippingTime>} newShippingTimes New shipping times.
+ * @param {Array<ShippingTime>} oldShippingTimes Old shipping times.
+ * @return {Array<string>} Array of country codes.
+ */
+const getDeletedCountryCodes = ( newShippingTimes, oldShippingTimes ) => {
+	const deletedShippingTimes = getDeletedShippingTimes(
+		newShippingTimes,
+		oldShippingTimes
+	);
+
+	return deletedShippingTimes.map(
+		( shippingTime ) => shippingTime.countryCode
+	);
+};
+
+/**
+ * Get aggregated shipping time groups from shipping times.
+ *
+ * @param {Array<ShippingTime>} shippingTimes Array of shipping time.
+ * @return {Array<AggregatedShippingTime>} Array of shipping time group.
+ */
+const getShippingTimesGroups = ( shippingTimes ) => {
+	const timeGroupMap = new Map();
+	shippingTimes.forEach( ( { countryCode, time } ) => {
+		const group = timeGroupMap.get( time ) || { countryCodes: [], time };
+		group.countryCodes.push( countryCode );
+		timeGroupMap.set( time, group );
+	} );
+
+	return Array.from( timeGroupMap.values() );
+};
+
+const useSaveShippingTimes = () => {
+	const { data: oldShippingTimes } = useShippingTimes();
+	const { deleteShippingTimes, upsertShippingTimes } = useAppDispatch();
+
+	const saveShippingTimes = useCallback(
+		/**
+		 * Saves shipping times.
+		 *
+		 * This is done by removing the old shipping times first,
+		 * and then upserting the new shipping times.
+		 *
+		 * @param {Array<ShippingTime>} newShippingTimes
+		 */
+		async ( newShippingTimes ) => {
+			const deletedCountryCodes = getDeletedCountryCodes(
+				newShippingTimes,
+				oldShippingTimes
+			);
+
+			if ( deletedCountryCodes.length ) {
+				await deleteShippingTimes( deletedCountryCodes );
+			}
+
+			const diffShippingTimes = getDifferentShippingTimes(
+				newShippingTimes,
+				oldShippingTimes
+			);
+			if ( diffShippingTimes.length ) {
+				const promises = getShippingTimesGroups(
+					diffShippingTimes
+				).map( ( group ) => {
+					return upsertShippingTimes( group );
+				} );
+
+				await Promise.all( promises );
+			}
+		},
+		[ deleteShippingTimes, oldShippingTimes, upsertShippingTimes ]
+	);
+
+	return { saveShippingTimes };
+};
+
+export default useSaveShippingTimes;

--- a/js/src/utils/getDeletedShippingTimes.js
+++ b/js/src/utils/getDeletedShippingTimes.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { differenceBy } from 'lodash';
+
+/**
+ * @typedef {import('.~/data/actions').ShippingTime	} ShippingTime
+ */
+
+/**
+ * Get deleted shipping times that exist in `oldShippingTimes` but not in `newShippingTimes`.
+ *
+ * @param {Array<ShippingTime>} newShippingTimes New shipping times.
+ * @param {Array<ShippingTime>} oldShippingTimes Old shipping times.
+ * @return {Array<ShippingTime>} Array containing shipping times that exist in oldShippingtimes but not in newShippingTimes.
+ */
+const getDeletedShippingTimes = ( newShippingTimes, oldShippingTimes ) => {
+	return differenceBy( oldShippingTimes, newShippingTimes, 'countryCode' );
+};
+
+export default getDeletedShippingTimes;

--- a/js/src/utils/getDeletedShippingTimes.test.js
+++ b/js/src/utils/getDeletedShippingTimes.test.js
@@ -1,0 +1,93 @@
+/**
+ * Internal dependencies
+ */
+import getDeletedShippingTimes from './getDeletedShippingTimes';
+
+describe( 'getDeletedShippingTimes', () => {
+	it( 'returns empty array when newShippingTimes and oldShippingTimes are the same', () => {
+		const newShippingTimes = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			{
+				countryCode: 'MY',
+				time: 17,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+		];
+
+		const oldShippingTimes = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			{
+				countryCode: 'MY',
+				time: 17,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+		];
+
+		const result = getDeletedShippingTimes(
+			newShippingTimes,
+			oldShippingTimes
+		);
+
+		expect( result ).toStrictEqual( [] );
+	} );
+
+	it( 'returns array containing deleted shipping times only when shipping times have been added, edited and deleted', () => {
+		const newShippingTimes = [
+			// country US is deleted.
+			// country MY is edited.
+			{
+				countryCode: 'MY',
+				time: 27,
+			},
+			// country SG has no change.
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+			// country AU is added.
+			{
+				countryCode: 'AU',
+				time: 18,
+			},
+		];
+
+		const oldShippingTimes = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			{
+				countryCode: 'MY',
+				time: 17,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+		];
+
+		const result = getDeletedShippingTimes(
+			newShippingTimes,
+			oldShippingTimes
+		);
+
+		expect( result ).toStrictEqual( [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+		] );
+	} );
+} );

--- a/js/src/utils/getDifferentShippingTimes.js
+++ b/js/src/utils/getDifferentShippingTimes.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { differenceWith, isEqual } from 'lodash';
+
+/**
+ * @typedef {import('.~/data/actions').ShippingTime	} ShippingTime
+ */
+
+/**
+ * Get shipping times from `shippingTimes1` that are different from shipping times in `shippingTimes2`.
+ *
+ * A shipping time in `shippingTimes1` is considered different when:
+ *
+ * - it is a newly added shipping time and does not exist in `shippingTimes2`, or
+ * - it has been edited and it is different from the one in `shippingTimes2`.
+ *
+ * Note that the term "difference" here relates to the term "set difference" in set theory.
+ * See https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement.
+ *
+ * @param {Array<ShippingTime>} shippingTimes1 Array of shipping times. This will be used to compare against shippingTimes2.
+ * @param {Array<ShippingTime>} shippingTimes2 Array of shipping times.
+ * @return {Array<ShippingTime>} Array containing shipping times from shippingTimes1 that are different from shipping times in shippingTimes2.
+ */
+const getDifferentShippingTimes = ( shippingTimes1, shippingTimes2 ) => {
+	return differenceWith( shippingTimes1, shippingTimes2, isEqual );
+};
+
+export default getDifferentShippingTimes;

--- a/js/src/utils/getDifferentShippingTimes.test.js
+++ b/js/src/utils/getDifferentShippingTimes.test.js
@@ -1,0 +1,139 @@
+/**
+ * Internal dependencies
+ */
+import getDifferentShippingTimes from './getDifferentShippingTimes';
+
+describe( 'getDifferentShippingTimes', () => {
+	it( 'returns empty array when newShippingTimes and oldShippingTimes are the same', () => {
+		const newShippingTimes = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			{
+				countryCode: 'MY',
+				time: 17,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+		];
+
+		const oldShippingTimes = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			{
+				countryCode: 'MY',
+				time: 17,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+		];
+
+		const result = getDifferentShippingTimes(
+			newShippingTimes,
+			oldShippingTimes
+		);
+
+		expect( result ).toStrictEqual( [] );
+	} );
+
+	it( 'returns array containing newly added shipping times from newShippingTimes', () => {
+		const newShippingTimes = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			{
+				countryCode: 'MY',
+				time: 17,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+			// country AU is added.
+			{
+				countryCode: 'AU',
+				time: 18,
+			},
+		];
+
+		const oldShippingTimes = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			{
+				countryCode: 'MY',
+				time: 17,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+		];
+
+		const result = getDifferentShippingTimes(
+			newShippingTimes,
+			oldShippingTimes
+		);
+
+		expect( result ).toStrictEqual( [
+			{
+				countryCode: 'AU',
+				time: 18,
+			},
+		] );
+	} );
+
+	it( 'returns array containing edited shipping times from shippingTimes1', () => {
+		const shipingTimes1 = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			// edited.
+			{
+				countryCode: 'MY',
+				time: 22,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+		];
+
+		const shipingTimes2 = [
+			{
+				countryCode: 'US',
+				time: 16,
+			},
+			{
+				countryCode: 'MY',
+				time: 17,
+			},
+			{
+				countryCode: 'SG',
+				time: 18,
+			},
+		];
+
+		const result = getDifferentShippingTimes(
+			shipingTimes1,
+			shipingTimes2
+		);
+
+		expect( result ).toStrictEqual( [
+			{
+				countryCode: 'MY',
+				time: 22,
+			},
+		] );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/google-listings-and-ads/issues/1416.

This PR fixes #1416 by using a new hook called `useSaveShippingTimes`. It is similar with the `useSaveShippingRates` hook introduced in PR https://github.com/woocommerce/google-listings-and-ads/pull/1313.

- `saveShippingTimes` is a function that that wraps around the existing `deleteShippingTimes` and `upsertShippingTimes` wp.data actions.
- `deleteShippingTimes` will be called for shipping times that have been deleted.
- `upsertShippingTimes` will be called for changed or newly added shipping times.
- There will not be API calls for shipping times that are not changed.

### Screenshots:

📹  Demo video with my voice:

https://user-images.githubusercontent.com/417342/162801404-f8ada1d8-b051-4b1c-9a31-bd396c216a96.mov

### Detailed test instructions:

1. Go to Edit Free Listings.
2. In target audience step, delete an existing country, and add another country.
3. In shipping step, make sure that the shipping rates and shipping times for the deleted country has been removed. You may have to remove them manually.
4. Add shipping rate and shipping time for the newly added country.
5. Click on "Save changes" button.
6. Reload the page.
7. The shipping rates and shipping times setup should be the same as before the reload.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Call API to delete shipping times in Edit Free Listings when users remove the shipping times.
