### PR TITLE
Map Issue Codes with MC issues

### DIFF
--- a/js/src/product-feed/review-request/index.js
+++ b/js/src/product-feed/review-request/index.js
@@ -12,6 +12,7 @@ import ReviewRequestModal from './review-request-modal';
 import ReviewRequestNotice from './review-request-notice';
 import { ISSUE_TYPE_ACCOUNT, REQUEST_REVIEW } from '.~/constants';
 import REVIEW_STATUSES from './review-request-statuses';
+import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
 import './index.scss';
 
 const showNotice = ( status ) =>
@@ -20,9 +21,14 @@ const showNotice = ( status ) =>
 const ReviewRequest = ( { account = {} } ) => {
 	const [ modalActive, setModalActive ] = useState( false );
 	const activeIssueType = useActiveIssueType();
+	const {
+		data: mcData,
+		hasFinishedResolution: mcDataHasFinishedResolution,
+	} = useMCIssuesTypeFilter( ISSUE_TYPE_ACCOUNT, 1, 200 );
 	const { data: accountData, hasFinishedResolution } = account;
 
 	if (
+		! mcDataHasFinishedResolution ||
 		! hasFinishedResolution ||
 		! showNotice( accountData.status ) ||
 		activeIssueType !== ISSUE_TYPE_ACCOUNT
@@ -52,7 +58,9 @@ const ReviewRequest = ( { account = {} } ) => {
 	return (
 		<div className="gla-review-request">
 			<ReviewRequestModal
-				issues={ accountData?.issues }
+				issues={ mcData.issues.filter( ( issue ) =>
+					accountData.issues.includes( issue.code )
+				) }
 				isActive={ modalActive }
 				onClose={ handleModalClose }
 				onSendRequest={ handleReviewRequest }

--- a/js/src/product-feed/review-request/index.test.js
+++ b/js/src/product-feed/review-request/index.test.js
@@ -1,3 +1,14 @@
+jest.mock( '.~/hooks/useMCIssuesTypeFilter', () => ( {
+	__esModule: true,
+	default: jest
+		.fn()
+		.mockName( 'useMCIssuesTypeFilter' )
+		.mockReturnValue( {
+			data: { issues: [] },
+			hasFinishedResolution: true,
+		} ),
+} ) );
+
 jest.mock( '.~/hooks/useActiveIssueType' );
 jest.mock( '@woocommerce/tracks', () => {
 	return {

--- a/js/src/product-feed/review-request/review-request-issues.js
+++ b/js/src/product-feed/review-request/review-request-issues.js
@@ -32,7 +32,7 @@ const ReviewRequestIssues = ( { issues = [] } ) => {
 			</Text>
 			<ul className="gla-review-request-modal__issue-list">
 				{ issuesToRender.map( ( issue ) => (
-					<li key={ issue }>{ issue }</li>
+					<li key={ issue.code }>{ issue.issue }</li>
 				) ) }
 			</ul>
 			{ issues.length > COLLAPSED_ISSUES_SIZE && (

--- a/js/src/product-feed/review-request/review-request-issues.js
+++ b/js/src/product-feed/review-request/review-request-issues.js
@@ -10,6 +10,7 @@ const COLLAPSED_ISSUES_SIZE = 5;
 
 const ReviewRequestIssues = ( { issues = [] } ) => {
 	const [ expanded, setExpanded ] = useState( false );
+	if ( ! issues.length ) return null;
 
 	const toggleExpanded = () => {
 		recordEvent( 'gla_request_review_issue_list_toggle_click', {

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -22,7 +22,7 @@ const ReviewRequestModal = ( {
 } ) => {
 	const [ checkBoxChecked, setCheckBoxChecked ] = useState( false );
 
-	if ( ! issues.length || ! isActive ) {
+	if ( ! isActive ) {
 		return null;
 	}
 

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -50,7 +50,7 @@ const ReviewRequestModal = ( {
 				<AppButton
 					key="primary"
 					isPrimary
-					disabled={ ! checkBoxChecked }
+					disabled={ ! checkBoxChecked && issues.length }
 					onClick={ onSendRequest }
 				>
 					{ __(
@@ -87,15 +87,17 @@ const ReviewRequestModal = ( {
 				</p>
 			</Notice>
 			<ReviewRequestIssues issues={ issues } />
-			<CheckboxControl
-				className="gla-review-request-modal__checkbox"
-				label={ __(
-					'I have resolved all the issue(s) listed above.',
-					'google-listings-and-ads'
-				) }
-				checked={ checkBoxChecked }
-				onChange={ handleCheckboxChange }
-			/>
+			{ issues.length > 0 && (
+				<CheckboxControl
+					className="gla-review-request-modal__checkbox"
+					label={ __(
+						'I have resolved all the issue(s) listed above.',
+						'google-listings-and-ads'
+					) }
+					checked={ checkBoxChecked }
+					onChange={ handleCheckboxChange }
+				/>
+			) }
 		</AppModal>
 	);
 };

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -14,6 +14,16 @@ import AppButton from '.~/components/app-button';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import ReviewRequestIssues from './review-request-issues';
 
+/**
+ * Render a modal showing the issues list and a notice with a remind for
+ * the user to review those issues before requesting the review.
+ *
+ * @param {Object} props Component props
+ * @param {Object[]} [props.issues=[]] Array with issues
+ * @param {boolean} [props.isActive=false] True if the Modal is visible, false otherwise
+ * @param {Function} [props.onClose] Callback function when closing the modal
+ * @param {Function} [props.onSendRequest] Callback function when the user request the review
+ */
 const ReviewRequestModal = ( {
 	issues = [],
 	isActive = false,

--- a/js/src/product-feed/review-request/review-request-modal.test.js
+++ b/js/src/product-feed/review-request/review-request-modal.test.js
@@ -14,10 +14,19 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import ReviewRequestModal from '.~/product-feed/review-request/review-request-modal';
 
+const issues = [
+	{ code: '#1', issue: '#1' },
+	{ code: '#2', issue: '#2' },
+	{ code: '#3', issue: '#3' },
+	{ code: '#4', issue: '#4' },
+	{ code: '#5', issue: '#5' },
+	{ code: '#6', issue: '#6' },
+];
+
 describe( 'Request Review Modal', () => {
 	it( 'Renders when is active and there are issues', () => {
 		const { queryByRole } = render(
-			<ReviewRequestModal issues={ [ '#1', '#2' ] } isActive={ true } />
+			<ReviewRequestModal issues={ issues } isActive={ true } />
 		);
 
 		expect( queryByRole( 'dialog' ) ).toBeTruthy();
@@ -25,15 +34,7 @@ describe( 'Request Review Modal', () => {
 
 	it( "Doesn't render if its not active", () => {
 		const { queryByRole } = render(
-			<ReviewRequestModal issues={ [ '#1', '#2' ] } isActive={ false } />
-		);
-
-		expect( queryByRole( 'dialog' ) ).toBeFalsy();
-	} );
-
-	it( "Doesn't render when no issues", () => {
-		const { queryByRole } = render(
-			<ReviewRequestModal issues={ [] } isActive={ true } />
+			<ReviewRequestModal issues={ issues } isActive={ false } />
 		);
 
 		expect( queryByRole( 'dialog' ) ).toBeFalsy();
@@ -41,10 +42,7 @@ describe( 'Request Review Modal', () => {
 
 	it( 'Shows maximum 5 issues and can expand the list of issues', () => {
 		const { queryByText } = render(
-			<ReviewRequestModal
-				issues={ [ '#1', '#2', '#3', '#4', '#5', '#6' ] }
-				isActive={ true }
-			/>
+			<ReviewRequestModal issues={ issues } isActive={ true } />
 		);
 
 		expect( queryByText( '#1' ) ).toBeTruthy();
@@ -82,7 +80,7 @@ describe( 'Request Review Modal', () => {
 		const onClose = jest.fn().mockName( 'onClose' );
 		const { queryByText } = render(
 			<ReviewRequestModal
-				issues={ [ '#1', '#2', '#3', '#4', '#5', '#6' ] }
+				issues={ issues }
 				isActive={ true }
 				onClose={ onClose }
 			/>
@@ -98,7 +96,7 @@ describe( 'Request Review Modal', () => {
 		const onSendRequest = jest.fn().mockName( 'onSendRequest' );
 		const { queryByRole } = render(
 			<ReviewRequestModal
-				issues={ [ '#1', '#2', '#3', '#4', '#5', '#6' ] }
+				issues={ issues }
 				isActive={ true }
 				onSendRequest={ onSendRequest }
 			/>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1165 

Maps the codes provided by the new API endpoint with the Issues with description obtained in the `useMCIssuesTypeFilter` dispatcher in order to show them in the Request Review Modal.


### Screenshots:

<img width="1525" alt="Screenshot 2022-04-14 at 17 24 55" src="https://user-images.githubusercontent.com/5908855/163400253-bdc93e84-83fe-4fc9-9dc7-a17555186e80.png">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout PR
2. First of all, take a look at `src/API/Site/Controllers/MerchantCenter/AccountReviewController.php::get_review_read_callback` you can see there some issues codes like `#1 Issue one` those are dummy hardcoded Issue codes to be shown in the Request review Modal they should match with any MC Issue (in database). 
4. Probably you want to test with some issues creating them in `wp_gla_merchant_issues` just be sure the code column match with some of the issues in `src/API/Site/Controllers/MerchantCenter/AccountReviewController.php::get_review_read_callback`, in the column "issue" you can write some dummy description.
5. Go to product Feed `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed` 
6. See The notice in the Account Issues section and click over Request Review
7. You will see the description of those reviews matching the database. in the issue list of the modal. 
8. If there is no issue matching a database issue code... no issue list neither checkbox will be shown. 


