### PR TITLE
GLA Request Review - Implement cool down period date

### DIFF
--- a/js/src/product-feed/review-request/review-request-notice.js
+++ b/js/src/product-feed/review-request/review-request-notice.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { format } from '@wordpress/date';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalText as Text,
@@ -20,6 +21,17 @@ const ReviewRequestNotice = ( {
 	onRequestReviewClick = () => {},
 } ) => {
 	const accountReviewStatus = REVIEW_STATUSES[ account.status ];
+
+	const cooldown =
+		account.cooldown &&
+		sprintf(
+			// translators: %s: Cool down period date.
+			__(
+				'Your account is under cool down period. You can request a new review on %s.',
+				'google-listings-and-ads'
+			),
+			format( 'Y-m-d', new Date( parseInt( account.cooldown, 10 ) ) )
+		);
 
 	return (
 		<Flex
@@ -40,7 +52,7 @@ const ReviewRequestNotice = ( {
 							className="gla-review-request-notice__text-body"
 							variant="body"
 						>
-							{ accountReviewStatus.body }
+							{ cooldown || accountReviewStatus.body }
 						</Text>
 					</FlexItem>
 				</Flex>
@@ -50,7 +62,7 @@ const ReviewRequestNotice = ( {
 					<AppButton
 						isPrimary
 						onClick={ onRequestReviewClick }
-						disabled={ accountReviewStatus.requestButton.disabled }
+						disabled={ !! account.cooldown }
 						text={ __(
 							'Request review',
 							'google-listings-and-ads'

--- a/js/src/product-feed/review-request/review-request-notice.js
+++ b/js/src/product-feed/review-request/review-request-notice.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { format } from '@wordpress/date';
+import { format as formatDate } from '@wordpress/date';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalText as Text,
@@ -15,6 +15,7 @@ import {
  */
 import AppButton from '.~/components/app-button';
 import REVIEW_STATUSES from './review-request-statuses';
+import { glaData } from '.~/constants';
 
 const ReviewRequestNotice = ( {
 	account,
@@ -30,7 +31,7 @@ const ReviewRequestNotice = ( {
 				'Your account is under cool down period. You can request a new review on %s.',
 				'google-listings-and-ads'
 			),
-			format( 'Y-m-d', new Date( parseInt( account.cooldown, 10 ) ) )
+			formatDate( glaData.dateFormat, new Date( account.cooldown ) )
 		);
 
 	return (

--- a/js/src/product-feed/review-request/review-request-notice.test.js
+++ b/js/src/product-feed/review-request/review-request-notice.test.js
@@ -36,4 +36,29 @@ describe( 'Request Review Notice', () => {
 			expect( onRequestReviewClick ).toBeCalledTimes( 1 );
 		}
 	);
+
+	it( 'Renders date on cool down period', () => {
+		const onRequestReviewClick = jest
+			.fn()
+			.mockName( 'onRequestReviewClick' );
+
+		const { queryByText, queryByRole } = render(
+			<ReviewRequestNotice
+				account={ { status: 'DISAPPROVED', cooldown: '1651047106000' } }
+				onRequestReviewClick={ onRequestReviewClick }
+			/>
+		);
+		expect(
+			queryByText(
+				'Your account is under cool down period. You can request a new review on 2022-04-27.'
+			)
+		).toBeTruthy();
+
+		const button = queryByRole( 'button' );
+
+		expect( button ).toBeTruthy();
+
+		fireEvent.click( button );
+		expect( onRequestReviewClick ).not.toBeCalled();
+	} );
 } );

--- a/js/src/product-feed/review-request/review-request-notice.test.js
+++ b/js/src/product-feed/review-request/review-request-notice.test.js
@@ -44,13 +44,13 @@ describe( 'Request Review Notice', () => {
 
 		const { queryByText, queryByRole } = render(
 			<ReviewRequestNotice
-				account={ { status: 'DISAPPROVED', cooldown: '1651047106000' } }
+				account={ { status: 'DISAPPROVED', cooldown: 1651047106000 } }
 				onRequestReviewClick={ onRequestReviewClick }
 			/>
 		);
 		expect(
 			queryByText(
-				'Your account is under cool down period. You can request a new review on 2022-04-27.'
+				'Your account is under cool down period. You can request a new review on April 27, 2022.'
 			)
 		).toBeTruthy();
 

--- a/js/src/product-feed/review-request/review-request-statuses.js
+++ b/js/src/product-feed/review-request/review-request-statuses.js
@@ -29,9 +29,7 @@ const DISAPPROVED = {
 		'Fix all account suspension issues listed below to request a review of your account.',
 		'google-listing-and-ads'
 	),
-	requestButton: {
-		disabled: false,
-	},
+	requestButton: true,
 	icon: <ErrorIcon size={ 24 } />,
 };
 

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -88,7 +88,7 @@ class RequestReviewController extends BaseOptionsController {
 				'readonly'    => true,
 			],
 			'cooldown' => [
-				'type'        => 'string',
+				'type'        => 'integer',
 				'description' => __( 'Timestamp indicating if the user is in cool down period.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -81,7 +81,7 @@ class RequestReviewController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'status'        => [
+			'status'   => [
 				'type'        => 'string',
 				'description' => __( 'The status of the last review.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
@@ -93,7 +93,7 @@ class RequestReviewController extends BaseOptionsController {
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'issues'        => [
+			'issues'   => [
 				'type'        => 'array',
 				'description' => __( 'The issues related to the Merchant Center to be reviewed and addressed before approval.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -87,9 +87,9 @@ class RequestReviewController extends BaseOptionsController {
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'reviewAllowed' => [
-				'type'        => 'boolean',
-				'description' => __( 'Indicates if the user can request a new review.', 'google-listings-and-ads' ),
+			'cooldown' => [
+				'type'        => 'string',
+				'description' => __( 'Timestamp indicating if the user is in cool down period.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -25,7 +25,7 @@ class RequestReviewStatuses implements Service {
 	 */
 	public function get_statuses_from_response( array $response ) {
 		$issues   = [];
-		$cooldown = '';
+		$cooldown = 0;
 		$status   = 'APPROVED';
 
 		foreach ( $response as $program_type ) {
@@ -35,7 +35,7 @@ class RequestReviewStatuses implements Service {
 					isset( $region_status['reviewIneligibilityReasonDetails'] ) &&
 					isset( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] )
 				) {
-					$region_cooldown = $region_status['reviewIneligibilityReasonDetails']['cooldownTime'];
+					$region_cooldown = intval( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] );
 					if ( ! $cooldown || $region_cooldown > $cooldown ) {
 						$cooldown = $region_cooldown;
 					}

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -25,20 +25,19 @@ class RequestReviewStatuses implements Service {
 	 */
 	public function get_statuses_from_response( array $response ) {
 		$issues   = [];
-		$cooldown = "";
+		$cooldown = '';
 		$status   = 'APPROVED';
 
 		foreach ( $response as $program_type ) {
 			foreach ( $program_type['data']['regionStatuses'] as $region_status ) {
 
-
 				if (
 					isset( $region_status['reviewIneligibilityReasonDetails'] ) &&
 					isset( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] )
 				) {
-					$regionCooldown = $region_status['reviewIneligibilityReasonDetails']['cooldownTime'];
-					if ( ! $cooldown || $regionCooldown > $cooldown ) {
-						$cooldown = $regionCooldown;
+					$region_cooldown = $region_status['reviewIneligibilityReasonDetails']['cooldownTime'];
+					if ( ! $cooldown || $region_cooldown > $cooldown ) {
+						$cooldown = $region_cooldown;
 					}
 				}
 
@@ -77,7 +76,7 @@ class RequestReviewStatuses implements Service {
 		}
 
 		return [
-			'issues'   =>  array_map( 'strtolower', array_unique( $issues ) ),
+			'issues'   => array_map( 'strtolower', array_unique( $issues ) ),
 			'cooldown' => $cooldown,
 			'status'   => $status,
 		];

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -52,7 +52,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( [
 			'status'   => 'WARNING',
 			'issues'   => [ 'one', 'two' ],
-			'cooldown' => ""
+			'cooldown' => 0
 		], $response->get_data() );
 	}
 
@@ -107,7 +107,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( [
 			'status'   => 'DISAPPROVED',
 			'issues'   => [ 'one', 'two' ],
-			'cooldown' => ""
+			'cooldown' => 0
 		], $response->get_data() );
 	}
 
@@ -153,7 +153,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( [
 			'status'   => 'DISAPPROVED',
 			'issues'   => [],
-			'cooldown' => '1651047106000' // 27/04/2022
+			'cooldown' => 1651047106000 // 27/04/2022
 		], $response->get_data() );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1165 

This issue implement the cool down period date in the request Review Notice.

### Screenshots:

<img width="1059" alt="Screenshot 2022-04-20 at 13 12 34" src="https://user-images.githubusercontent.com/5908855/164194200-1bbcdd06-376c-4f69-97fc-7d9070557ca1.png">


### Detailed test instructions:

```
              $response      = [
					'freeListingsProgram' => [
						'status' => 200,
						'data'   => [
							'regionStatuses' => [
								[
									'regionCodes'                      => [ 'US' ],
									'eligibilityStatus'                => 'DISAPPROVED',
									'reviewEligibilityStatus'          => 'INELIGIBLE',
									'reviewIneligibilityReasonDetails' => [
										'cooldownTime' => "1651047106000" // 27/04/2022
									]
								],
								[
									'regionCodes'                      => [ 'NL' ],
									'eligibilityStatus'                => 'DISAPPROVED',
									'reviewEligibilityStatus'          => 'INELIGIBLE',
									'reviewIneligibilityReasonDetails' => [
										'cooldownTime' => "1650875865000" // 25/04/2022
									]
								],
								[
									'regionCodes'             => [ 'IT' ],
									'eligibilityStatus'       => 'DISAPPROVED',
									'reviewEligibilityStatus' => 'ELIGIBLE',
								],
							]
						]
					]
		];

```

1. Checkout this PR
2. Go to `src/API/Site/Controllers/MerchantCenter/RequestReviewController.php::get_review_read_callback()`  and after the reponse paste the provided mocked response. You could if you want manipulate the `cooldownTime` props with different dates for testing. I use this website for that https://www.epochconverter.com/. EeligibilityStatus  should be DISAPPROVED or WARNING
3. Test that if here is a `cooldownTime` property in any region the button in the request notice will be disabled.
4. Test that in case multiple cooldownTime are present in different regions the latest will be the shown in the notice. 
5. If there is no cool down period  the request button is enabled. 
