### PR TITLE
GLA Request Review - Hide warning issues when critical issues

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -43,13 +43,6 @@ class IssuesController extends BaseOptionsController {
 		parent::__construct( $server );
 		$this->merchant_statuses = $merchant_statuses;
 		$this->product_helper    = $product_helper;
-
-		add_filter(
-			'woocommerce_gla_merchant_issue_override',
-			function( $issue ) {
-				return $this->maybe_override_issue_values( $issue );
-			}
-		);
 	}
 
 	/**
@@ -227,25 +220,5 @@ class IssuesController extends BaseOptionsController {
 	 */
 	protected function get_schema_title(): string {
 		return 'merchant_issues';
-	}
-
-
-	/**
-	 * In very rare instances, issue values need to be overridden manually.
-	 *
-	 * @param array $issue
-	 *
-	 * @return array The original issue with any possibly overridden values.
-	 */
-	protected function maybe_override_issue_values( array $issue ): array {
-		$is_account_issue = MerchantStatuses::TYPE_ACCOUNT === $issue['type'];
-		if ( $is_account_issue && "Account isn't eligible for enhanced free listings" === $issue['issue'] ) {
-			$issue['issue']      = 'Show products on additional surfaces across Google through enhanced free listings';
-			$issue['severity']   = MerchantStatuses::SEVERITY_WARNING;
-			$issue['action']     = 'Read about enhanced free listings';
-			$issue['action_url'] = 'https://support.google.com/merchants/answer/9199328?hl=en';
-		}
-
-		return $issue;
 	}
 }

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -124,8 +124,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * Retrieve the Merchant Center issues and total count. Refresh if the cache issues have gone stale.
 	 * Issue details are reduced, and for products, grouped by type.
-	 * Issues can be filtered by type, searched by name or ID (if product type) and paginated.
+	 * Issues can be filtered by type, severity and searched by name or ID (if product type) and paginated.
 	 * Count takes into account the type filter, but not the pagination.
+	 *
+	 * In case there are issues with severity Error we hide the other issues with lower severity.
 	 *
 	 * @param string|null $type To filter by issue type if desired.
 	 * @param int         $per_page The number of issues to return (0 for no limit).
@@ -137,7 +139,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 */
 	public function get_issues( string $type = null, int $per_page = 0, int $page = 1, bool $force_refresh = false ): array {
 		$this->maybe_refresh_status_data( $force_refresh );
-		return $this->fetch_issues( $type, $per_page, $page );
+
+		// Get only critical issues
+		$critical_issues = $this->fetch_issues( $type, $per_page, $page, self::SEVERITY_ERROR );
+
+		// In case there are critical issue we show only those, otherwise we show all the issues.
+		return $critical_issues['total'] > 0 ? $critical_issues : $this->fetch_issues( $type, $per_page, $page );
 	}
 
 	/**
@@ -245,11 +252,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 * @param string|null $type To filter by issue type if desired.
 	 * @param int         $per_page The number of issues to return (0 for no limit).
 	 * @param int         $page The page to start on (1-indexed).
+	 * @param string|null $severity Filters the issues by severity level.
 	 *
 	 * @return array The requested issues and the total count of issues.
 	 * @throws InvalidValue If the type filter is invalid.
 	 */
-	protected function fetch_issues( string $type = null, int $per_page = 0, int $page = 1 ): array {
+	protected function fetch_issues( string $type = null, int $per_page = 0, int $page = 1, string $severity = null ): array {
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 
@@ -269,6 +277,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		if ( $per_page > 0 ) {
 			$issue_query->set_limit( $per_page );
 			$issue_query->set_offset( $per_page * ( $page - 1 ) );
+		}
+
+		if ( $severity ) {
+			$issue_query->where( 'severity', $severity );
 		}
 
 		$issues = [];
@@ -390,6 +402,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 					'source'               => 'mc',
 					'applicable_countries' => [ $issue->getCountry() ],
 				];
+
+				$account_issues[ $key ] = $this->maybe_override_issue_values( $account_issues[ $key ] );
 			}
 		}
 
@@ -781,5 +795,23 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		);
 
 		return $is_warning ? self::SEVERITY_WARNING : self::SEVERITY_ERROR;
+	}
+
+	/**
+	 * In very rare instances, issue values need to be overridden manually.
+	 *
+	 * @param array $issue
+	 *
+	 * @return array The original issue with any possibly overridden values.
+	 */
+	private function maybe_override_issue_values( array $issue ): array {
+		if ( 'merchant_quality_low' === $issue['code'] ) {
+			$issue['issue']      = 'Show products on additional surfaces across Google through enhanced free listings';
+			$issue['severity']   = self::SEVERITY_WARNING;
+			$issue['action']     = 'Read about enhanced free listings';
+			$issue['action_url'] = 'https://support.google.com/merchants/answer/9199328?hl=en';
+		}
+
+		return $issue;
 	}
 }

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -140,7 +140,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	public function get_issues( string $type = null, int $per_page = 0, int $page = 1, bool $force_refresh = false ): array {
 		$this->maybe_refresh_status_data( $force_refresh );
 
-		// Get only critical issues
+		// Get only error issues
 		$severity_error_issues = $this->fetch_issues( $type, $per_page, $page, true );
 
 		// In case there are error issues we show only those, otherwise we show all the issues.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -141,10 +141,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$this->maybe_refresh_status_data( $force_refresh );
 
 		// Get only critical issues
-		$critical_issues = $this->fetch_issues( $type, $per_page, $page, self::SEVERITY_ERROR );
+		$severity_error_issues = $this->fetch_issues( $type, $per_page, $page, true );
 
-		// In case there are critical issue we show only those, otherwise we show all the issues.
-		return $critical_issues['total'] > 0 ? $critical_issues : $this->fetch_issues( $type, $per_page, $page );
+		// In case there are error issues we show only those, otherwise we show all the issues.
+		return $severity_error_issues['total'] > 0 ? $severity_error_issues : $this->fetch_issues( $type, $per_page, $page );
 	}
 
 	/**
@@ -252,12 +252,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 * @param string|null $type To filter by issue type if desired.
 	 * @param int         $per_page The number of issues to return (0 for no limit).
 	 * @param int         $page The page to start on (1-indexed).
-	 * @param string|null $severity Filters the issues by severity level.
+	 * @param bool        $only_errors Filters only the issues with error and critical severity.
 	 *
 	 * @return array The requested issues and the total count of issues.
 	 * @throws InvalidValue If the type filter is invalid.
 	 */
-	protected function fetch_issues( string $type = null, int $per_page = 0, int $page = 1, string $severity = null ): array {
+	protected function fetch_issues( string $type = null, int $per_page = 0, int $page = 1, bool $only_errors = false ): array {
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 
@@ -279,8 +279,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			$issue_query->set_offset( $per_page * ( $page - 1 ) );
 		}
 
-		if ( $severity ) {
-			$issue_query->where( 'severity', $severity );
+		if ( $only_errors ) {
+			$issue_query->where( 'severity', [ 'error', 'critical' ], 'IN' );
 		}
 
 		$issues = [];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1165 .

We want to hide warning issues in case some critical issues are present. 

### Detailed test instructions:

1. Go to database and in `wp_gla_merchant_issues` create some issues, at least one warning and one error.
2. Go to Product Feed
3. Only Critical issues are shown.
4. Go back to database and remove the error one.
5. Go to Product Feed
6. Warning issues are shown.
7. Paginator and issues totals are consistent


### Additional details:

Some issues are overrided in the code: See -> https://github.com/woocommerce/google-listings-and-ads/issues/717

We changed here the moment when we override some issues

This is because the override is happening after we query the issues. Hence we are asking for critical issues but then maybe they are overrided after to warning. 

So now we are doing this when we insert the issue in DB. that way we can filter correctly the issues.

Note that if you have already the issues in your DB maybe you have the previous version of the override issue and it will show a warning issue on critical issues. This will be solved on refresh in that case. 

I didn't delete `woocommerce_gla_merchant_issue_override` filter tho... since we don't know if is being used by a consumer. 
