### PR TITLE
Fix deprecated `Loader::is_admin_page()`

### DIFF
--- a/src/TaskList/TaskListTrait.php
+++ b/src/TaskList/TaskListTrait.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\TaskList;
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\PageController;
 
 /**
  * Trait TaskListTrait
@@ -20,6 +21,10 @@ trait TaskListTrait {
 	 * @return bool
 	 */
 	protected function should_register_tasks(): bool {
+		if ( method_exists( PageController::class, 'is_admin_page' ) ) {
+			return PageController::is_admin_page() && $this->check_should_show_tasks();
+		}
+
 		return class_exists( Loader::class ) && Loader::is_admin_page() && $this->check_should_show_tasks();
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As of WooCommerce 6.5, [`Loader::is_admin_page()`](https://github.com/woocommerce/woocommerce/blob/6.5.0-beta.1/plugins/woocommerce/src/Admin/Loader.php#L39-L47) is deprecated in favor of [`PageController::is_admin_page()`](https://github.com/woocommerce/woocommerce/blob/6.5.0-beta.1/plugins/woocommerce/src/Admin/PageController.php#L551-L558).

This PR updates the `is_admin_page()` usage in `TaskListTrait` to use the `PageController` method if it exists (i.e., WooCommerce 6.5+), and continue defaulting to the `Loader` method otherwise.

```
Deprecated:  Function is_admin_page is <strong>deprecated</strong> since version 6.3! Use \Automattic\WooCommerce\Admin\PageController::is_admin_page() instead. in /../wp-includes/functions.php on line 5379
Stack trace:
...
  3. require_once() /../src/wp-admin/admin.php:239
  4. do_action() /../src/wp-admin/admin-header.php:118
  5. WP_Hook->do_action() /../wp-includes/plugin.php:476
  6. WP_Hook->apply_filters() /../wp-includes/class-wp-hook.php:331
  7. Automattic\WooCommerce\GoogleListingsAndAds\TaskList\CompleteSetup->Automattic\WooCommerce\GoogleListingsAndAds\TaskList\{closure:/../wp-content/plugins/google-listings-and-ads/src/TaskList/CompleteSetup.php:53-62}() /../wp-includes/class-wp-hook.php:307
  8. Automattic\WooCommerce\GoogleListingsAndAds\TaskList\CompleteSetup->should_register_tasks() /../wp-content/plugins/google-listings-and-ads/src/TaskList/CompleteSetup.php:54
  9. Automattic\WooCommerce\Admin\Loader::is_admin_page() /../wp-content/plugins/google-listings-and-ads/src/TaskList/TaskListTrait.php:23
 10. wc_deprecated_function() /../wp-content/plugins/woocommerce-monorepo/plugins/woocommerce/src/Admin/Loader.php:45
 11. _deprecated_function() /../wp-content/plugins/woocommerce-monorepo/plugins/woocommerce/includes/wc-deprecated-functions.php:54
 12. trigger_error() /../wp-includes/functions.php:5379
```


### Additional Details
While the deprecated message states `since 6.3`, [WooCommerce 6.3 still uses the independent WooCommerce Admin package](https://github.com/woocommerce/woocommerce/blob/6.3.0/plugins/woocommerce/composer.json#L24) (v3.2.1), which [doesn't actually deprecate the `Loader` method yet](https://github.com/woocommerce/woocommerce-admin/blob/v3.2.1/src/Loader.php#L797-L804).

[WooCommerce 6.4 uses WooCommerce Admin v3.3.2](https://github.com/woocommerce/woocommerce/blob/6.4.0/plugins/woocommerce/composer.json#L24), which [doesn't actually deprecate the `Loader` method, either](https://github.com/woocommerce/woocommerce-admin/blob/v3.3.2/src/Loader.php#L798-L805).

The `main` branch of the **deprecated** WooCommerce admin repo [DOES deprecate the `Loader` method](https://github.com/woocommerce/woocommerce-admin/blob/78d0e10a99676c92650a5248917207e7304f5c1b/src/Loader.php#L39-L47), but this version of `Loader` isn't actually included in WooCommerce until 6.5.0, which [no longer imports the independent WooCommerce Admin package](https://github.com/woocommerce/woocommerce/blob/6.5.0-beta.1/plugins/woocommerce/composer.json#L34-L37), but rather includes WooCommerce Admin in the core plugin.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Use WooCommerce 6.5 beta with the Google Listings & Ads `develop` and load any admin page to see the error.
2. Load this PR to confirm that the error is resolved.
    - The `PageController` method is being used correctly.
4. Use WooCommerce < 6.5 (6.4, for example) with this PR to confirm that the error is still not visible.
    - The `Loader` method is used when the `PageController` method isn't present.
- Bonus: Load WooCommerce < 6.5 with Google Listings & Ads `develop` to see that the error doesn't appear at all with WooCommerce versions prior to 6.5.



### Changelog entry

> Fix - Swap `Loader:is_admin_page` (deprecated in 6.3) for `PageController:is_admin_page`.
