### PR TITLE
Improve the interactive UI for a dropdown inside a modal

### DIFF
--- a/js/src/components/app-modal/index.js
+++ b/js/src/components/app-modal/index.js
@@ -10,6 +10,16 @@ import classnames from 'classnames';
 import './index.scss';
 
 const overflowYStyleName = {
+	/**
+	 * In @wordpress/components 14.2.0, the overflow of Modal container will be
+	 * changed from `auto` to `hidden`, and the change also adds `auto` to Modal body.
+	 * Here using `auto` as the default overflow to make it have a stable overflow style
+	 * across these versions.
+	 *
+	 * References:
+	 * - https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.9/packages/components/src/modal/style.scss#L29
+	 * - https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4014.2.0/packages/components/src/modal/style.scss#L24
+	 */
 	auto: 'app-modal__styled--overflow-y-auto',
 	visible: 'app-modal__styled--overflow-y-visible',
 };

--- a/js/src/components/app-modal/index.js
+++ b/js/src/components/app-modal/index.js
@@ -9,9 +9,16 @@ import classnames from 'classnames';
  */
 import './index.scss';
 
-const AppModal = ( props ) => {
-	const { buttons = [], className, children, ...rest } = props;
-
+/**
+ * Renders a Modal component with additional commonly used features.
+ *
+ * @param {Object} props React props.
+ * @param {string} [props.className] Additional CSS class name to be appended.
+ * @param {Array<JSX.Element>} [props.buttons] Buttons to be rendered at the modal footer.
+ * @param {JSX.Element} props.children Content to be rendered.
+ * @param {Object} props.rest Props to be forwarded to Modal.
+ */
+const AppModal = ( { className, buttons = [], children, ...rest } ) => {
 	return (
 		<Modal className={ classnames( 'app-modal', className ) } { ...rest }>
 			{ children }

--- a/js/src/components/app-modal/index.js
+++ b/js/src/components/app-modal/index.js
@@ -9,19 +9,19 @@ import classnames from 'classnames';
  */
 import './index.scss';
 
-const overflowYStyleName = {
+const overflowStyleName = {
 	/**
 	 * In @wordpress/components 14.2.0, the overflow of Modal container will be
 	 * changed from `auto` to `hidden`, and the change also adds `auto` to Modal body.
-	 * Here using `auto` as the default overflow to make it have a stable overflow style
-	 * across these versions.
+	 * The `auto` is set as the default overflow in this component's CSS to make it
+	 * have a stable overflow style across these versions.
 	 *
 	 * References:
 	 * - https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.9/packages/components/src/modal/style.scss#L29
 	 * - https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4014.2.0/packages/components/src/modal/style.scss#L24
 	 */
-	auto: 'app-modal__styled--overflow-y-auto',
-	visible: 'app-modal__styled--overflow-y-visible',
+	auto: false,
+	visible: 'app-modal__styled--overflow-visible',
 };
 
 /**
@@ -29,21 +29,21 @@ const overflowYStyleName = {
  *
  * @param {Object} props React props.
  * @param {string} [props.className] Additional CSS class name to be appended.
- * @param {'auto'|'visible'} [props.overflowY='auto'] Y-axis overflow style of modal.
+ * @param {'auto'|'visible'} [props.overflow='auto'] Overflow style of modal.
  * @param {Array<JSX.Element>} [props.buttons] Buttons to be rendered at the modal footer.
  * @param {JSX.Element} props.children Content to be rendered.
  * @param {Object} props.rest Props to be forwarded to Modal.
  */
 const AppModal = ( {
 	className,
-	overflowY = 'auto',
+	overflow = 'auto',
 	buttons = [],
 	children,
 	...rest
 } ) => {
 	const modalClassName = classnames(
 		'app-modal',
-		overflowYStyleName[ overflowY ],
+		overflowStyleName[ overflow ],
 		className
 	);
 

--- a/js/src/components/app-modal/index.js
+++ b/js/src/components/app-modal/index.js
@@ -9,18 +9,36 @@ import classnames from 'classnames';
  */
 import './index.scss';
 
+const overflowYStyleName = {
+	auto: 'app-modal__styled--overflow-y-auto',
+	visible: 'app-modal__styled--overflow-y-visible',
+};
+
 /**
  * Renders a Modal component with additional commonly used features.
  *
  * @param {Object} props React props.
  * @param {string} [props.className] Additional CSS class name to be appended.
+ * @param {'auto'|'visible'} [props.overflowY='auto'] Y-axis overflow style of modal.
  * @param {Array<JSX.Element>} [props.buttons] Buttons to be rendered at the modal footer.
  * @param {JSX.Element} props.children Content to be rendered.
  * @param {Object} props.rest Props to be forwarded to Modal.
  */
-const AppModal = ( { className, buttons = [], children, ...rest } ) => {
+const AppModal = ( {
+	className,
+	overflowY = 'auto',
+	buttons = [],
+	children,
+	...rest
+} ) => {
+	const modalClassName = classnames(
+		'app-modal',
+		overflowYStyleName[ overflowY ],
+		className
+	);
+
 	return (
-		<Modal className={ classnames( 'app-modal', className ) } { ...rest }>
+		<Modal className={ modalClassName } { ...rest }>
 			{ children }
 			{ buttons.length >= 1 && (
 				<div className="app-modal__footer">{ buttons }</div>

--- a/js/src/components/app-modal/index.scss
+++ b/js/src/components/app-modal/index.scss
@@ -20,25 +20,20 @@
 	}
 
 	/**
-	 * Set `auto` as the default overflow to make it stable across newer versions of
-	 * @wordpress/components. More details can be found in the AppModal implementation.
+	 * Set `hidden` as the default overflow for container and `auto` for body to
+	 * make them stable across newer versions of @wordpress/components.
+	 * More details can be found in the AppModal implementation.
 	 */
-	&,
+	overflow: hidden;
+
 	.components-modal__content {
-		overflow: inherit;
+		overflow: auto;
 	}
 
-	&__styled--overflow-y-auto {
+	&__styled--overflow-visible {
 		&,
 		.components-modal__content {
-			overflow-y: auto;
-		}
-	}
-
-	&__styled--overflow-y-visible {
-		&,
-		.components-modal__content {
-			overflow-y: visible;
+			overflow: visible;
 		}
 	}
 }

--- a/js/src/components/app-modal/index.scss
+++ b/js/src/components/app-modal/index.scss
@@ -1,6 +1,4 @@
 .app-modal {
-	overflow: inherit;
-
 	@include break-large {
 		width: 600px;
 	}
@@ -21,11 +19,26 @@
 		}
 	}
 
+	/**
+	 * Set `auto` as the default overflow to make it stable across newer versions of
+	 * @wordpress/components. More details can be found in the AppModal implementation.
+	 */
+	&,
+	.components-modal__content {
+		overflow: inherit;
+	}
+
 	&__styled--overflow-y-auto {
-		overflow-y: auto;
+		&,
+		.components-modal__content {
+			overflow-y: auto;
+		}
 	}
 
 	&__styled--overflow-y-visible {
-		overflow-y: visible;
+		&,
+		.components-modal__content {
+			overflow-y: visible;
+		}
 	}
 }

--- a/js/src/components/app-modal/index.scss
+++ b/js/src/components/app-modal/index.scss
@@ -20,4 +20,12 @@
 			justify-content: center;
 		}
 	}
+
+	&__styled--overflow-y-auto {
+		overflow-y: auto;
+	}
+
+	&__styled--overflow-y-visible {
+		overflow-y: visible;
+	}
 }

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -64,7 +64,7 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 
 				return (
 					<AppModal
-						overflowY="visible"
+						overflow="visible"
 						shouldCloseOnEsc={ ! dropdownVisible }
 						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -61,6 +61,7 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 
 				return (
 					<AppModal
+						overflowY="visible"
 						title={ __(
 							'Estimate shipping time',
 							'google-listings-and-ads'

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
@@ -22,6 +23,8 @@ import SupportedCountrySelect from '.~/components/supported-country-select';
  * @param {function(AggregatedShippingTime): void} props.onSubmit Called with submitted value.
  */
 const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
+	const [ dropdownVisible, setDropdownVisible ] = useState( false );
+
 	const handleValidate = ( values ) => {
 		const errors = {};
 
@@ -62,6 +65,8 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 				return (
 					<AppModal
 						overflowY="visible"
+						shouldCloseOnEsc={ ! dropdownVisible }
+						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(
 							'Estimate shipping time',
 							'google-listings-and-ads'
@@ -88,6 +93,9 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 									'google-listings-and-ads'
 								) }
 								countryCodes={ countries }
+								onDropdownVisibilityChange={
+									setDropdownVisible
+								}
 								{ ...getInputProps( 'countries' ) }
 							/>
 							<AppInputNumberControl

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -12,7 +12,6 @@ import AppModal from '.~/components/app-modal';
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import SupportedCountrySelect from '.~/components/supported-country-select';
-import './index.scss';
 
 /**
  *Form to edit time for selected country(-ies).
@@ -83,7 +82,7 @@ const EditTimeModal = ( {
 
 				return (
 					<AppModal
-						className="gla-edit-time-modal"
+						overflowY="visible"
 						title={ __(
 							'Estimate shipping time',
 							'google-listings-and-ads'

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
@@ -30,6 +31,8 @@ const EditTimeModal = ( {
 	onSubmit,
 	onRequestClose,
 } ) => {
+	const [ dropdownVisible, setDropdownVisible ] = useState( false );
+
 	// We actually may have times for more countries than the audience ones.
 	const availableCountries = Array.from(
 		new Set( [ ...time.countries, ...audienceCountries ] )
@@ -83,6 +86,8 @@ const EditTimeModal = ( {
 				return (
 					<AppModal
 						overflowY="visible"
+						shouldCloseOnEsc={ ! dropdownVisible }
+						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(
 							'Estimate shipping time',
 							'google-listings-and-ads'
@@ -117,6 +122,9 @@ const EditTimeModal = ( {
 									'google-listings-and-ads'
 								) }
 								countryCodes={ availableCountries }
+								onDropdownVisibilityChange={
+									setDropdownVisible
+								}
 								{ ...getInputProps( 'countries' ) }
 							/>
 							<AppInputNumberControl

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -85,7 +85,7 @@ const EditTimeModal = ( {
 
 				return (
 					<AppModal
-						overflowY="visible"
+						overflow="visible"
 						shouldCloseOnEsc={ ! dropdownVisible }
 						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.scss
@@ -1,6 +1,0 @@
-.gla-edit-time-modal {
-	.label {
-		color: #757575;
-		padding-bottom: 4px;
-	}
-}

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useState } from '@wordpress/element';
 import { Form } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
@@ -39,6 +40,8 @@ const RateFormModal = ( {
 	onSubmit,
 	onRequestClose,
 } ) => {
+	const [ dropdownVisible, setDropdownVisible ] = useState( false );
+
 	return (
 		<Form
 			initialValues={ initialValues }
@@ -51,6 +54,8 @@ const RateFormModal = ( {
 				return (
 					<AppModal
 						overflowY="visible"
+						shouldCloseOnEsc={ ! dropdownVisible }
+						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(
 							'Estimate a shipping rate',
 							'google-listings-and-ads'
@@ -65,6 +70,9 @@ const RateFormModal = ( {
 									'google-listings-and-ads'
 								) }
 								countryCodes={ countryOptions }
+								onDropdownVisibilityChange={
+									setDropdownVisible
+								}
 								{ ...getInputProps( 'countries' ) }
 							/>
 							<AppInputPriceControl

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
@@ -53,7 +53,7 @@ const RateFormModal = ( {
 
 				return (
 					<AppModal
-						overflowY="visible"
+						overflow="visible"
 						shouldCloseOnEsc={ ! dropdownVisible }
 						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
@@ -50,6 +50,7 @@ const RateFormModal = ( {
 
 				return (
 					<AppModal
+						overflowY="visible"
 						title={ __(
 							'Estimate a shipping rate',
 							'google-listings-and-ads'

--- a/js/src/components/shipping-rate-section/minimum-order-card/add-minimum-order-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/add-minimum-order-modal.js
@@ -63,6 +63,7 @@ const AddMinimumOrderModal = ( props ) => {
 
 				return (
 					<AppModal
+						overflowY="visible"
 						title={ __(
 							'Minimum order to qualify for free shipping',
 							'google-listings-and-ads'

--- a/js/src/components/shipping-rate-section/minimum-order-card/add-minimum-order-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/add-minimum-order-modal.js
@@ -65,7 +65,7 @@ const AddMinimumOrderModal = ( props ) => {
 
 				return (
 					<AppModal
-						overflowY="visible"
+						overflow="visible"
 						shouldCloseOnEsc={ ! dropdownVisible }
 						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(

--- a/js/src/components/shipping-rate-section/minimum-order-card/add-minimum-order-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/add-minimum-order-modal.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
@@ -16,6 +17,7 @@ import SupportedCountrySelect from '.~/components/supported-country-select';
 
 const AddMinimumOrderModal = ( props ) => {
 	const { countryOptions, value, onChange = noop, onRequestClose } = props;
+	const [ dropdownVisible, setDropdownVisible ] = useState( false );
 
 	const handleValidate = ( values ) => {
 		const errors = {};
@@ -64,6 +66,8 @@ const AddMinimumOrderModal = ( props ) => {
 				return (
 					<AppModal
 						overflowY="visible"
+						shouldCloseOnEsc={ ! dropdownVisible }
+						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(
 							'Minimum order to qualify for free shipping',
 							'google-listings-and-ads'
@@ -89,6 +93,9 @@ const AddMinimumOrderModal = ( props ) => {
 									'If customer is in',
 									'google-listings-and-ads'
 								) }
+								onDropdownVisibilityChange={
+									setDropdownVisible
+								}
 								countryCodes={ countryOptions }
 								{ ...getInputProps( 'countries' ) }
 							/>

--- a/js/src/components/shipping-rate-section/minimum-order-card/edit-minimum-order-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/edit-minimum-order-modal.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
@@ -15,6 +16,7 @@ import SupportedCountrySelect from '.~/components/supported-country-select';
 
 const EditMinimumOrderModal = ( props ) => {
 	const { countryOptions, value, onChange, onRequestClose } = props;
+	const [ dropdownVisible, setDropdownVisible ] = useState( false );
 
 	const handleDeleteClick = () => {
 		onRequestClose();
@@ -72,6 +74,8 @@ const EditMinimumOrderModal = ( props ) => {
 				return (
 					<AppModal
 						overflowY="visible"
+						shouldCloseOnEsc={ ! dropdownVisible }
+						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(
 							'Minimum order to qualify for free shipping',
 							'google-listings-and-ads'
@@ -106,6 +110,9 @@ const EditMinimumOrderModal = ( props ) => {
 									'google-listings-and-ads'
 								) }
 								countryCodes={ countryOptions }
+								onDropdownVisibilityChange={
+									setDropdownVisible
+								}
 								{ ...getInputProps( 'countries' ) }
 							/>
 							<AppInputPriceControl

--- a/js/src/components/shipping-rate-section/minimum-order-card/edit-minimum-order-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/edit-minimum-order-modal.js
@@ -71,6 +71,7 @@ const EditMinimumOrderModal = ( props ) => {
 
 				return (
 					<AppModal
+						overflowY="visible"
 						title={ __(
 							'Minimum order to qualify for free shipping',
 							'google-listings-and-ads'

--- a/js/src/components/shipping-rate-section/minimum-order-card/edit-minimum-order-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/edit-minimum-order-modal.js
@@ -73,7 +73,7 @@ const EditMinimumOrderModal = ( props ) => {
 
 				return (
 					<AppModal
-						overflowY="visible"
+						overflow="visible"
 						shouldCloseOnEsc={ ! dropdownVisible }
 						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cloneDeep } from 'lodash';
+import { cloneDeep, noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import {
 	useEffect,
@@ -82,6 +82,7 @@ import { ARROW_DOWN, ARROW_UP, ENTER, ESCAPE, ROOT_VALUE } from './constants';
  * @param {string[]} [props.value] Selected values
  * @param {number} [props.maxVisibleTags] The maximum number of tags to show. Undefined, 0 or less than 0 evaluates to "Show All".
  * @param {Function} [props.onChange] Callback when the selector changes
+ * @param {(visible: boolean) => void} [props.onDropdownVisibilityChange] Callback when the visibility of the dropdown options is changed.
  * @return {JSX.Element} The component
  */
 const TreeSelectControl = ( {
@@ -96,6 +97,7 @@ const TreeSelectControl = ( {
 	value = [],
 	maxVisibleTags,
 	onChange = () => {},
+	onDropdownVisibilityChange = noop,
 } ) => {
 	let instanceId = useInstanceId( TreeSelectControl );
 	instanceId = id ?? instanceId;
@@ -105,6 +107,9 @@ const TreeSelectControl = ( {
 	const [ inputControlValue, setInputControlValue ] = useState( '' );
 	const [ filteredOptions, setFilteredOptions ] = useState( [] );
 	const [ focused, setFocused ] = useState( null );
+
+	const onDropdownVisibilityChangeRef = useRef();
+	onDropdownVisibilityChangeRef.current = onDropdownVisibilityChange;
 
 	// We will save in a REF previous search filter queries to avoid re-query the tree and save performance
 	const filteredOptionsCache = useRef( {} );
@@ -443,6 +448,10 @@ const TreeSelectControl = ( {
 			focused.ref.current.focus();
 		}
 	}, [ focused ] );
+
+	useEffect( () => {
+		onDropdownVisibilityChangeRef.current( showTree );
+	}, [ showTree ] );
 
 	/**
 	 * Get formatted Tags from the selected values.

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
@@ -19,6 +20,7 @@ const AddTimeModal = ( props ) => {
 	const { onRequestClose } = props;
 	const { upsertShippingTimes } = useAppDispatch();
 	const remainingCountryCodes = useGetRemainingCountryCodes();
+	const [ dropdownVisible, setDropdownVisible ] = useState( false );
 
 	const handleValidate = ( values ) => {
 		const errors = {};
@@ -61,6 +63,8 @@ const AddTimeModal = ( props ) => {
 				return (
 					<AppModal
 						overflowY="visible"
+						shouldCloseOnEsc={ ! dropdownVisible }
+						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(
 							'Estimate shipping time',
 							'google-listings-and-ads'
@@ -86,6 +90,9 @@ const AddTimeModal = ( props ) => {
 									) }
 								</div>
 								<AudienceCountrySelect
+									onDropdownVisibilityChange={
+										setDropdownVisible
+									}
 									{ ...getInputProps( 'countryCodes' ) }
 								/>
 							</div>

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -62,7 +62,7 @@ const AddTimeModal = ( props ) => {
 
 				return (
 					<AppModal
-						overflowY="visible"
+						overflow="visible"
 						shouldCloseOnEsc={ ! dropdownVisible }
 						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -60,6 +60,7 @@ const AddTimeModal = ( props ) => {
 
 				return (
 					<AppModal
+						overflowY="visible"
 						title={ __(
 							'Estimate shipping time',
 							'google-listings-and-ads'

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -81,7 +81,7 @@ const EditTimeModal = ( props ) => {
 
 				return (
 					<AppModal
-						overflowY="visible"
+						overflow="visible"
 						shouldCloseOnEsc={ ! dropdownVisible }
 						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -12,7 +12,6 @@ import AppModal from '.~/components/app-modal';
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import AudienceCountrySelect from '.~/components/audience-country-select';
-import './index.scss';
 import { useAppDispatch } from '.~/data';
 
 const EditTimeModal = ( props ) => {
@@ -80,7 +79,7 @@ const EditTimeModal = ( props ) => {
 
 				return (
 					<AppModal
-						className="gla-edit-time-modal"
+						overflowY="visible"
 						title={ __(
 							'Estimate shipping time',
 							'google-listings-and-ads'

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
@@ -17,6 +18,7 @@ import { useAppDispatch } from '.~/data';
 const EditTimeModal = ( props ) => {
 	const { time: groupedTime, onRequestClose } = props;
 	const { upsertShippingTimes, deleteShippingTimes } = useAppDispatch();
+	const [ dropdownVisible, setDropdownVisible ] = useState( false );
 
 	const handleDeleteClick = () => {
 		deleteShippingTimes( groupedTime.countries );
@@ -80,6 +82,8 @@ const EditTimeModal = ( props ) => {
 				return (
 					<AppModal
 						overflowY="visible"
+						shouldCloseOnEsc={ ! dropdownVisible }
+						shouldCloseOnClickOutside={ ! dropdownVisible }
 						title={ __(
 							'Estimate shipping time',
 							'google-listings-and-ads'
@@ -113,6 +117,9 @@ const EditTimeModal = ( props ) => {
 									) }
 								</div>
 								<AudienceCountrySelect
+									onDropdownVisibilityChange={
+										setDropdownVisible
+									}
 									{ ...getInputProps( 'countryCodes' ) }
 								/>
 							</div>

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.scss
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.scss
@@ -1,6 +1,0 @@
-.gla-edit-time-modal {
-	.label {
-		color: #757575;
-		padding-bottom: 4px;
-	}
-}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Address [two addtional UI problems](https://github.com/woocommerce/google-listings-and-ads/issues/1356#issuecomment-1109239892) of #1356 

- Add the `overflowY` prop to \<AppModal\> component for specifying the `overflow-y` of the modal.
- Add the `onDropdownVisibilityChange` callback prop to \<TreeSelectControl\> component for getting the visible state of the dropdown options.
- Make the viewport of all shipping modals not cover the dropdown options.
- Avoid closing the shipping modals by clicking on overlay or pressing ESC when the inside dropdown is opened
- 💡  Extra changes: remove unneeded `classNames` and scss files for two modals:
   1. js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
   2.  js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js

### Screenshots:

#### 📷  The dropdown is not covered by the viewport of modal.

![image](https://user-images.githubusercontent.com/17420811/165211423-b3e54e42-8e20-4d15-b1a5-afc164055340.png)

#### 📹  Improved interaction UI for a dropdown inside a modal.

https://user-images.githubusercontent.com/17420811/165212064-4483c2eb-d015-415b-aa2e-3b1f83ec2c10.mp4

### Detailed test instructions:

1. Go to step 2 of editing the free listings.
1. Check every country selectors of all adding/editing shipping modals (rate, time, and minimum order) with the following steps.
   1. Open a modal and open the inside dropdown options of the tree selector.
   1. Expend some options to see if the dropdown is no longer covered by the viewport of modal.
   1. After clicking on the overlay, which is the outside area of the modal, it should close the opened dropdown only.
   1. After clicking on the overlay again, it should close the modal.
   1. Open that modal and the dropdown again.
   1. After pressing the ESC key, it should close the opened dropdown only.
   1. After pressing the ESC key again, it should close the modal.
1. Go to step 3 of the onboarding setup.
1. Check the country selectors of the adding/editing shipping **time** modals by the same steps in step 2.

### Changelog entry
