### PR TITLE
GLA Request Review - Fix Cooldown Format

### DIFF
--- a/js/src/product-feed/product-statistics/status-box/account-status.js
+++ b/js/src/product-feed/product-statistics/status-box/account-status.js
@@ -19,11 +19,15 @@ import REVIEW_STATUSES from '.~/product-feed/review-request/review-request-statu
 const AccountStatus = () => {
 	const account = useAppSelectDispatch( 'getMCReviewRequest' );
 
-	if ( ! account.hasFinishedResolution || ! account.data ) {
+	if ( ! account.hasFinishedResolution || ! account.data?.status ) {
 		return null;
 	}
 
 	const accountStatus = REVIEW_STATUSES[ account.data.status ];
+
+	if ( ! accountStatus ) {
+		return null;
+	}
 
 	return (
 		<Status

--- a/js/src/product-feed/review-request/review-request-notice.js
+++ b/js/src/product-feed/review-request/review-request-notice.js
@@ -23,6 +23,10 @@ const ReviewRequestNotice = ( {
 } ) => {
 	const accountReviewStatus = REVIEW_STATUSES[ account.status ];
 
+	if ( ! accountReviewStatus ) {
+		return null;
+	}
+
 	const cooldown =
 		account.cooldown &&
 		sprintf(

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -79,7 +79,7 @@ class RequestReviewStatuses implements Service {
 		return [
 			'issues'   => array_map( 'strtolower', array_unique( $issues ) ),
 			'cooldown' => $cooldown * 1000,
-			'status'   => $status
+			'status'   => $status,
 		];
 	}
 

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -35,7 +35,8 @@ class RequestReviewStatuses implements Service {
 					isset( $region_status['reviewIneligibilityReasonDetails'] ) &&
 					isset( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] )
 				) {
-					$region_cooldown = intval( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] );
+					$region_cooldown = intval( strtotime( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] ) );
+
 					if ( ! $cooldown || $region_cooldown > $cooldown ) {
 						$cooldown = $region_cooldown;
 					}
@@ -77,8 +78,8 @@ class RequestReviewStatuses implements Service {
 
 		return [
 			'issues'   => array_map( 'strtolower', array_unique( $issues ) ),
-			'cooldown' => $cooldown,
-			'status'   => $status,
+			'cooldown' => $cooldown * 1000,
+			'status'   => $status
 		];
 	}
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -126,7 +126,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 								                 'eligibilityStatus'                => 'DISAPPROVED',
 								                 'reviewEligibilityStatus'          => 'INELIGIBLE',
 								                 'reviewIneligibilityReasonDetails' => [
-									                 'cooldownTime' => "1651047106000" // 27/04/2022
+									                 'cooldownTime' => "2022-04-27T10:58:51Z" // 27/04/2022
 								                 ]
 							                 ],
 							                 [
@@ -134,7 +134,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 								                 'eligibilityStatus'                => 'DISAPPROVED',
 								                 'reviewEligibilityStatus'          => 'INELIGIBLE',
 								                 'reviewIneligibilityReasonDetails' => [
-									                 'cooldownTime' => "1650875865000" // 25/04/2022
+									                 'cooldownTime' => "2022-04-25T10:58:51Z" // 25/04/2022
 								                 ]
 							                 ],
 							                 [
@@ -153,7 +153,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( [
 			'status'   => 'DISAPPROVED',
 			'issues'   => [],
-			'cooldown' => 1651047106000 // 27/04/2022
+			'cooldown' => 1651057131000 // 27/04/2022
 		], $response->get_data() );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #1436 

As discussed with @jorgemd24 was not clear which would be the date format returned by google for the Cooldown period.  Today I received the response with cooldown and I can confirm the format is TZ

<img width="1051" alt="Screenshot 2022-04-26 at 11 09 15" src="https://user-images.githubusercontent.com/5908855/165252053-4c6a257d-9787-4f10-858b-9da8e226ad4e.png">

This PR adjust the code for parsing and comparing cooldown dates. 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

```
$response = [
				                 'freeListingsProgram' => [
					                 'status' => 200,
					                 'data'   => [
						                 'regionStatuses' => [
							                 [
								                 'regionCodes'                      => [ 'US' ],
								                 'eligibilityStatus'                => 'DISAPPROVED',
								                 'reviewEligibilityStatus'          => 'INELIGIBLE',
								                 'reviewIneligibilityReasonDetails' => [
									                 'cooldownTime' => "2022-04-27T10:58:51Z" // 27/04/2022
								                 ]
							                 ],
							                 [
								                 'regionCodes'                      => [ 'NL' ],
								                 'eligibilityStatus'                => 'DISAPPROVED',
								                 'reviewEligibilityStatus'          => 'INELIGIBLE',
								                 'reviewIneligibilityReasonDetails' => [
									                 'cooldownTime' => "2022-04-25T10:58:51Z" // 25/04/2022
								                 ]
							                 ],
							                 [
								                 'regionCodes'             => [ 'IT' ],
								                 'eligibilityStatus'       => 'DISAPPROVED',
								                 'reviewEligibilityStatus' => 'ELIGIBLE',
							                 ],
						                 ]
					                 ]
				                 ]
			                 ]
```
1. Checkout this PR
2. Go to `src/API/Site/Controllers/MerchantCenter/RequestReviewController.php::get_review_read_callback()` And hardocde the response with the one provided above in order to give you 2 statuses with cooldown period
3. Check that the latest cooldown period (27 April in the example) is shown in the Product Feed - Account disapproved Notice in the correct format

### Additional details:

I also added two super small fixes btw in order to prevent the Account status and Notice to render in case something is wrong with the status (bad data or unknown status)


