### PR TITLE
Adding update all product test to catch the bug when scheduled job wa…

### DIFF
--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -129,7 +129,7 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	/**
 	 * Schedule a new "process" action to run immediately.
 	 *
-	 * @param array $items
+	 * @param int[] $items Array of item ids.
 	 */
 	protected function schedule_process_action( array $items ) {
 		if ( ! $this->is_processing( $items ) ) {

--- a/src/Jobs/Update/PluginUpdate.php
+++ b/src/Jobs/Update/PluginUpdate.php
@@ -39,7 +39,7 @@ class PluginUpdate implements Service, InstallableInterface {
 	 * @var array
 	 */
 	private $updates = [
-		'1.0.1' => [
+		'1.0.1'  => [
 			CleanupProductTargetCountriesJob::class,
 			UpdateAllProducts::class,
 		],

--- a/src/Jobs/Update/PluginUpdate.php
+++ b/src/Jobs/Update/PluginUpdate.php
@@ -43,6 +43,9 @@ class PluginUpdate implements Service, InstallableInterface {
 			CleanupProductTargetCountriesJob::class,
 			UpdateAllProducts::class,
 		],
+		'1.12.6' => [
+			UpdateAllProducts::class,
+		],
 	];
 
 	/**

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\FilteredProductList;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncerException;
 use Exception;
+use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -34,7 +35,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
 	 *
-	 * @return array
+	 * @return WC_Product[]
 	 */
 	public function get_batch( int $batch_number ): array {
 		return $this->get_filtered_batch( $batch_number )->get();
@@ -52,7 +53,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 	 * @return FilteredProductList
 	 */
 	protected function get_filtered_batch( int $batch_number ): FilteredProductList {
-		return $this->product_repository->find_sync_ready_product( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+		return $this->product_repository->find_sync_ready_products( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
 	/**
@@ -87,7 +88,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob {
 		} else {
 			// if items, schedule the process action
 			if ( count( $items ) ) {
-				$this->schedule_process_action( $items->get() );
+				$this->schedule_process_action( $items->get_product_ids() );
 			}
 
 			if ( $items->get_unfiltered_count() >= $this->get_batch_size() ) {

--- a/src/Product/FilteredProductList.php
+++ b/src/Product/FilteredProductList.php
@@ -22,9 +22,9 @@ class FilteredProductList implements Countable {
 	/**
 	 * List of product objects or IDs.
 	 *
-	 * @var WC_Product[]|int[]
+	 * @var WC_Product[]
 	 */
-	protected $products;
+	protected $products = [];
 
 	/**
 	 * Count before filtering.
@@ -36,18 +36,18 @@ class FilteredProductList implements Countable {
 	/**
 	 * FilteredProductList constructor.
 	 *
-	 * @param WC_Product[]|int[] $products         List of filtered products.
-	 * @param int                $unfiltered_count Product count before filtering.
+	 * @param WC_Product[] $products         List of filtered products.
+	 * @param int          $unfiltered_count Product count before filtering.
 	 */
-	public function __construct( $products, int $unfiltered_count ) {
-		$this->products         = $products ?? [];
+	public function __construct( array $products, int $unfiltered_count ) {
+		$this->products         = $products;
 		$this->unfiltered_count = $unfiltered_count;
 	}
 
 	/**
 	 * Get the list of products.
 	 *
-	 * @return array
+	 * @return WC_Product[]
 	 */
 	public function get(): array {
 		return $this->products;

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -168,21 +168,6 @@ class ProductRepository implements Service {
 	}
 
 	/**
-	 * Find and return an array of WooCommerce products ready to be submitted to Google Merchant Center.
-	 *
-	 * @param array $args   Array of WooCommerce args (except 'return'), and product metadata.
-	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
-	 * @param int   $offset Amount to offset product results.
-	 *
-	 * @return FilteredProductList List of WooCommerce products after filtering.
-	 */
-	public function find_sync_ready_product( array $args = [], int $limit = - 1, int $offset = 0 ): FilteredProductList {
-		$results = $this->find( $this->get_sync_ready_products_query_args( $args ), $limit, $offset );
-
-		return $this->product_filter->filter_sync_ready_products( $results );
-	}
-
-	/**
 	 * @return array
 	 */
 	protected function get_sync_ready_products_meta_query(): array {

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -312,4 +312,14 @@ trait ProductTrait {
 			'adult'      => false,
 		];
 	}
+
+	/**
+	 * Helper function to create an array filled with product mocks for test purposes
+	 *
+	 * @param int $number Number of elements to fill an array with.
+	 * @return WC_Product[]
+	 */
+	protected function generate_simple_product_mocks_set(int $number ) {
+		return array_fill( 0, $number, $this->generate_simple_product_mock() );
+	}
 }

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -151,9 +151,6 @@ class UpdateAllProductsTest extends UnitTest {
 
 	public function test_process_item() {
 		$filtered_product_list = new FilteredProductList( $this->generate_simple_products_set( 1 ), 1 );
-		$product_id            = $filtered_product_list->get_product_ids()[0];
-		$entry                 = new BatchProductEntry( $product_id );
-		$response              = new BatchProductResponse( array( $entry ), array() );
 
 		$this->product_repository
 			->expects( $this->once() )
@@ -165,9 +162,6 @@ class UpdateAllProductsTest extends UnitTest {
 			->expects( $this->once() )
 			->method( 'update' )
 			->with( $filtered_product_list->get() );
-		$this->product_syncer
-			->method( 'update_by_batch_requests' )
-			->willReturn( $response );
 
 		do_action( self::PROCESS_ITEM_HOOK, $filtered_product_list->get_product_ids() );
 	}

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -5,8 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
@@ -19,7 +17,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\JobTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
 use PHPUnit\Framework\MockObject\MockObject;
-use WC_Product;
 
 /**
  * Class UpdateProductsTest

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -1,0 +1,131 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\FilteredProductList;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\JobTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class UpdateProductsTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ *
+ * @property MockObject|FilteredProductList       $filtered_product_list
+ *
+ * @property MockObject|ActionScheduler           $action_scheduler
+ * @property MockObject|ActionSchedulerJobMonitor $monitor
+ * @property MockObject|ProductSyncer             $product_syncer
+ * @property MockObject|ProductRepository         $product_repository
+ * @property MockObject|BatchProductHelper		  $product_helper
+ * @property MockObject|MerchantCenterService     $merchant_center
+ * @property UpdateAllProducts                    $job
+ */
+class UpdateAllProductsTest extends UnitTest {
+
+	use ProductTrait;
+	use JobTrait;
+
+	protected const JOB_NAME          = 'update_all_products';
+	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->filtered_product_list = $this->createMock( FilteredProductList::class );
+
+		$this->action_scheduler      = $this->createMock( ActionSchedulerInterface::class );
+		$this->monitor               = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer        = $this->createMock( ProductSyncer::class );
+		$this->product_repository    = $this->createMock( ProductRepository::class );
+		$this->product_helper        = $this->createMock( BatchProductHelper::class );
+		$this->merchant_center       = $this->createMock( MerchantCenterService::class );
+		$this->job                   = new UpdateAllProducts(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->product_syncer,
+			$this->product_repository,
+			$this->product_helper,
+			$this->merchant_center
+		);
+
+		$this->job->init();
+	}
+
+	public function test_job_name() {
+		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
+	}
+
+	public function test_schedule_schedules_a_single_batched_job_with_items() {
+		$items = array(
+			$this->generate_simple_product_mock(),
+			$this->generate_simple_product_mock(),
+			$this->generate_simple_product_mock(),
+			$this->generate_simple_product_mock(),
+		);
+
+		$item_ids = array_map(
+			function ( $item ) {
+				return $item->get_id();
+			},
+			$items
+		);
+
+		$this->filtered_product_list->expects( $this->never() )
+			->method( 'get' );
+
+		$this->filtered_product_list->expects( $this->once() )
+			->method( 'get_product_ids' )
+			->willReturn( $item_ids );
+
+		$this->filtered_product_list->expects( $this->once() )
+			->method( 'count' )
+			->willReturn( count( $items ) );
+
+		$this->filtered_product_list->expects( $this->exactly( 2 ) )
+			->method( 'get_unfiltered_count' )
+			->willReturn( count( $items ) );
+
+		$this->action_scheduler->expects( $this->exactly( 2 ) )
+			->method( 'has_scheduled_action' )
+			->withConsecutive(
+				array( self::CREATE_BATCH_HOOK, [ 1 ] ),
+				array( self::PROCESS_ITEM_HOOK, [ $item_ids ] )
+			)
+			->willReturnOnConsecutiveCalls( false, false );
+		$this->action_scheduler->expects( $this->exactly( 2 ) )
+			->method( 'schedule_immediate' )
+			->withConsecutive(
+				array( self::CREATE_BATCH_HOOK, [ 1 ] ),
+				array( self::PROCESS_ITEM_HOOK, [ $item_ids ] )
+			);
+
+		$this->merchant_center->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->product_repository->expects( $this->once() )
+			->method( 'find_sync_ready_products' )
+			->with( [], 100, 0 )
+			->willReturn( $this->filtered_product_list );
+
+		$this->job->schedule();
+
+		do_action( self::CREATE_BATCH_HOOK, 1 );
+	}
+}

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -77,13 +77,9 @@ class UpdateAllProductsTest extends UnitTest {
 
 		$filtered_product_list = new FilteredProductList( $items, count( $items ) );
 
-		$this->action_scheduler->expects( $this->exactly( 2 ) )
+		$this->action_scheduler
 			->method( 'has_scheduled_action' )
-			->withConsecutive(
-				array( self::CREATE_BATCH_HOOK, [ 1 ] ),
-				array( self::PROCESS_ITEM_HOOK, [ $filtered_product_list->get_product_ids() ] )
-			)
-			->willReturnOnConsecutiveCalls( false, false );
+			->willReturn( false );
 		$this->action_scheduler->expects( $this->exactly( 2 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -22,8 +22,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  *
- * @property MockObject|FilteredProductList       $filtered_product_list
- *
  * @property MockObject|ActionScheduler           $action_scheduler
  * @property MockObject|ActionSchedulerJobMonitor $monitor
  * @property MockObject|ProductSyncer             $product_syncer
@@ -46,8 +44,6 @@ class UpdateAllProductsTest extends UnitTest {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-
-		$this->filtered_product_list = $this->createMock( FilteredProductList::class );
 
 		$this->action_scheduler      = $this->createMock( ActionSchedulerInterface::class );
 		$this->monitor               = $this->createMock( ActionSchedulerJobMonitor::class );

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -204,7 +204,7 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 		$this->assertEquals(
 			array_merge( [ $simple_product->get_id() ], $variable_product->get_children() ),
-			$this->product_repository->find_sync_ready_product()->get_product_ids()
+			$this->product_repository->find_sync_ready_products()->get_product_ids()
 		);
 	}
 


### PR DESCRIPTION
With PR https://github.com/woocommerce/google-listings-and-ads/pull/1361 an issue was introduced. Scheduled job began to receive item objects instead of object ids and product stopped syncing.

Test did not catch this behaviour and were missing for update all products.

### Changes proposed in this Pull Request:

Adding corresponding tests and fixing the code so the jobs appear working properly again.

Closes #1450.

### Detailed test instructions:

1. Disconnect and connect again creating a new account in Google.
2. You will see in the Product Feed the Status: “Syncing”
3. After a few minutes, I reload the page and I get the Status “Automatically synced to GoogleLast updated: April 26, 2022, 4:22 pm, containing 0 products”

![screenshot-2022-04-26-at-16 16 06](https://user-images.githubusercontent.com/9010963/165523577-1c5c1a96-dfe8-4e45-ad2f-88b296170139.png)

![screenshot-2022-04-26-at-16 16 10](https://user-images.githubusercontent.com/9010963/165523600-4fae27d9-72fa-4ebc-8343-babc782e8337.png)

4. Apply the fix from PR and see products syncing.

### Changelog entry

> Fix - Update all products job syncing products
