### PR TITLE
GLA Request review - Add Onboarding notice

### DIFF
--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -38,7 +38,7 @@ const DEFAULT_STATE = {
 	},
 	mc_review_request: {
 		status: null,
-		nextAttempt: null,
+		cooldown: null,
 		issues: null,
 	},
 	mc_product_feed: null,

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -40,7 +40,7 @@ describe( 'reducer', () => {
 			mc_setup: null,
 			mc_review_request: {
 				issues: null,
-				nextAttempt: null,
+				cooldown: null,
 				status: null,
 			},
 			mc_product_statistics: null,

--- a/js/src/product-feed/product-statistics/status-box/account-status.test.js
+++ b/js/src/product-feed/product-statistics/status-box/account-status.test.js
@@ -29,4 +29,15 @@ describe( 'Account Status', () => {
 			).toBeTruthy();
 		}
 	);
+
+	it( 'Doesnt render unknown statuses', () => {
+		useAppSelectDispatch.mockReturnValue( {
+			hasFinishedResolution: true,
+			data: { status: 'unknown' },
+		} );
+
+		const { queryByText } = render( <AccountStatus /> );
+
+		expect( queryByText( /Account status:/ ) ).toBeFalsy();
+	} );
 } );

--- a/js/src/product-feed/review-request/index.test.js
+++ b/js/src/product-feed/review-request/index.test.js
@@ -76,16 +76,19 @@ describe( 'Request Review Component', () => {
 	);
 
 	// eslint-disable-next-line jest/expect-expect
-	it.each( [ 'APPROVED', 'DISAPPROVED', 'WARNING' ] )(
-		'Status %s not rendering the notice',
-		( status ) => {
-			useActiveIssueType.mockReturnValue( status );
-			isNotRendering( {
-				hasFinishedResolution: true,
-				data: { status },
-			} );
-		}
-	);
+	it.each( [
+		'APPROVED',
+		'ONBOARDING',
+		'UNDER_REVIEW',
+		'PENDING_REVIEW',
+		'UNKNOWN',
+	] )( 'Status %s not rendering the notice', ( status ) => {
+		useActiveIssueType.mockReturnValue( 'account' );
+		isNotRendering( {
+			hasFinishedResolution: true,
+			data: { status },
+		} );
+	} );
 
 	// eslint-disable-next-line jest/expect-expect
 	it( "Doesn't render if it is resolving", () => {

--- a/js/src/product-feed/review-request/review-request-statuses.js
+++ b/js/src/product-feed/review-request/review-request-statuses.js
@@ -74,12 +74,22 @@ const APPROVED = {
 	icon: <SuccessIcon size={ 24 } />,
 };
 
+const ONBOARDING = {
+	status: __( 'No products added', 'google-listing-and-ads' ),
+	statusDescription: __(
+		'Add and sync products to Google.',
+		'google-listing-and-ads'
+	),
+	icon: <WarningIcon size={ 24 } />,
+};
+
 const REVIEW_STATUSES = {
 	UNDER_REVIEW,
 	PENDING_REVIEW,
 	DISAPPROVED,
 	WARNING,
 	APPROVED,
+	ONBOARDING,
 };
 
 export default REVIEW_STATUSES;

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -125,7 +125,7 @@ class RequestReviewStatuses implements Service {
 	 */
 	private function get_cooldown( int $cooldown ) {
 		if ( $cooldown ) {
-			$cooldown = ( $cooldown + self::get_account_review_lifetime() ) * 1000;
+			$cooldown = ( $cooldown + $this->get_account_review_lifetime() ) * 1000;
 		}
 
 		return $cooldown;

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -50,14 +50,14 @@ class RequestReviewStatuses implements Service {
 			// otherwise we compute the new status, issues and cooldown period
 			foreach ( $program_type['data']['regionStatuses'] as $region_status ) {
 				$issues = array_merge( $issues, $region_status['reviewIssues'] ?? [] );
-				self::maybe_update_cooldown_period( $region_status, $cooldown );
-				self::maybe_update_status( $region_status['eligibilityStatus'], $status );
+				$this->maybe_update_cooldown_period( $region_status, $cooldown );
+				$this->maybe_update_status( $region_status['eligibilityStatus'], $status );
 			}
 		}
 
 		return [
 			'issues'   => array_map( 'strtolower', array_values( array_unique( $issues ) ) ),
-			'cooldown' => self::get_cooldown( $cooldown ), // add lifetime cache to cooldown time
+			'cooldown' => $this->get_cooldown( $cooldown ), // add lifetime cache to cooldown time
 			'status'   => $status,
 		];
 	}

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -97,7 +97,7 @@ class RequestReviewStatuses implements Service {
 		];
 
 		$current_status_priority = array_search( $status, $status_priority_list, true );
-		$new_status_priority = array_search( $new_status, $status_priority_list, true );
+		$new_status_priority     = array_search( $new_status, $status_priority_list, true );
 
 		if ( $new_status_priority === false ) {
 			return;

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -9,78 +9,96 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
  */
 class RequestReviewStatuses implements Service {
 
-	public const DISAPPROVED    = 'DISAPPROVED';
-	public const WARNING        = 'WARNING';
-	public const ELIGIBLE       = 'ELIGIBLE';
-	public const UNDER_REVIEW   = 'UNDER_REVIEW';
+	public const DISAPPROVED = 'DISAPPROVED';
+	public const WARNING = 'WARNING';
+	public const ELIGIBLE = 'ELIGIBLE';
+	public const UNDER_REVIEW = 'UNDER_REVIEW';
 	public const PENDING_REVIEW = 'PENDING_REVIEW';
-	public const ONBOARDING     = 'ONBOARDING';
+	public const ONBOARDING = 'ONBOARDING';
+	public const APPROVED = 'APPROVED';
+	public const NO_OFFERS = 'NO_OFFERS_UPLOADED';
+
 
 	/**
-	 * Merges the different program statuses based on priority
+	 * Merges the different program statuses, issues and cooldown period date.
 	 *
-	 * @param array $response
-	 *
-	 * @return array
+	 * @param array $response Associative array containing the response data from Google API
+	 * @return array The computed status, with the issues and cooldown period.
 	 */
 	public function get_statuses_from_response( array $response ) {
 		$issues   = [];
 		$cooldown = 0;
-		$status   = 'APPROVED';
+		$status   = null;
+
+		$valid_program_states = array( 'ENABLED', self::NO_OFFERS );
 
 		foreach ( $response as $program_type ) {
+
+			// In case any Program is with no offers we consider it Onboarding
+			if ( $program_type['data']['globalState'] == self::NO_OFFERS ) {
+				$status = self::ONBOARDING;
+				break;
+			}
+
+			// In case any Program is not enabled or there are no regionStatuses we return null status
+			if ( ! isset( $program_type['data']['regionStatuses'] ) || ! in_array( $program_type['data']['globalState'], $valid_program_states ) ) {
+				$status = null;
+				break;
+			}
+
+			// otherwise we compute the new status, issues and cooldown period
 			foreach ( $program_type['data']['regionStatuses'] as $region_status ) {
-
-				if (
-					isset( $region_status['reviewIneligibilityReasonDetails'] ) &&
-					isset( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] )
-				) {
-					$region_cooldown = intval( strtotime( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] ) );
-
-					if ( ! $cooldown || $region_cooldown > $cooldown ) {
-						$cooldown = $region_cooldown;
-					}
-				}
-
-				if ( $region_status['eligibilityStatus'] === self::DISAPPROVED || $region_status['eligibilityStatus'] === self::WARNING ) {
-					if ( $status !== self::DISAPPROVED ) {
-						$status = $region_status['eligibilityStatus'];
-					}
-
-					$issues = array_merge( $issues, $region_status['reviewIssues'] ?? [] );
-				}
-
-				if ( $status === self::DISAPPROVED ) {
-					continue;
-				}
-
-				if ( $region_status['eligibilityStatus'] === self::UNDER_REVIEW ) {
-					$status = self::UNDER_REVIEW;
-				}
-
-				if ( $status === self::UNDER_REVIEW ) {
-					continue;
-				}
-
-				if ( $region_status['eligibilityStatus'] === self::PENDING_REVIEW ) {
-					$status = self::PENDING_REVIEW;
-				}
-
-				if ( $status === self::PENDING_REVIEW ) {
-					continue;
-				}
-
-				if ( $region_status['eligibilityStatus'] === self::ONBOARDING ) {
-					$status = self::ONBOARDING;
-				}
+				$issues = array_merge( $issues, $region_status['reviewIssues'] ?? [] );
+				self::maybe_update_cooldown_period( $region_status, $cooldown );
+				self::maybe_update_status( $region_status['eligibilityStatus'], $status );
 			}
 		}
 
 		return [
-			'issues'   => array_map( 'strtolower', array_unique( $issues ) ),
+			'issues'   => array_map( 'strtolower', array_values( array_unique( $issues ) ) ),
 			'cooldown' => $cooldown * 1000,
 			'status'   => $status,
 		];
 	}
+	/**
+	 * Updates the cooldown period in case the new cooldown period date is available and later than the current cooldown period.
+	 *
+	 * @param array $region_status Associative array containing (maybe) a cooldown date property.
+	 * @param int $cooldown Referenced current cooldown to compare with
+	 */
+	private function maybe_update_cooldown_period( $region_status, &$cooldown ) {
+		if (
+			isset( $region_status['reviewIneligibilityReasonDetails'] ) &&
+			isset( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] )
+		) {
+			$region_cooldown = intval( strtotime( $region_status['reviewIneligibilityReasonDetails']['cooldownTime'] ) );
+
+			if ( ! $cooldown || $region_cooldown > $cooldown ) {
+				$cooldown = $region_cooldown;
+			}
+		}
+	}
+
+	/**
+	 * Updates the status reference in case the new status has more priority.
+	 *
+	 * @param String $new_status New status to check has more priority than the current one
+	 * @param String $status Referenced current status
+	 */
+	private function maybe_update_status( $new_status, &$status ) {
+		$status_priority_list = array(
+			self::ONBOARDING, // highest priority
+			self::DISAPPROVED,
+			self::WARNING,
+			self::UNDER_REVIEW,
+			self::PENDING_REVIEW,
+			self::APPROVED,
+		);
+
+		if ( is_null( $status ) || array_search( $status, $status_priority_list ) > array_search( $new_status, $status_priority_list ) ) {
+			$status = $new_status;
+		}
+	}
+
 
 }

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -9,14 +9,13 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
  */
 class RequestReviewStatuses implements Service {
 
-	public const DISAPPROVED = 'DISAPPROVED';
-	public const WARNING = 'WARNING';
-	public const ELIGIBLE = 'ELIGIBLE';
-	public const UNDER_REVIEW = 'UNDER_REVIEW';
+	public const DISAPPROVED    = 'DISAPPROVED';
+	public const WARNING        = 'WARNING';
+	public const UNDER_REVIEW   = 'UNDER_REVIEW';
 	public const PENDING_REVIEW = 'PENDING_REVIEW';
-	public const ONBOARDING = 'ONBOARDING';
-	public const APPROVED = 'APPROVED';
-	public const NO_OFFERS = 'NO_OFFERS_UPLOADED';
+	public const ONBOARDING     = 'ONBOARDING';
+	public const APPROVED       = 'APPROVED';
+	public const NO_OFFERS      = 'NO_OFFERS_UPLOADED';
 
 
 	/**
@@ -30,18 +29,18 @@ class RequestReviewStatuses implements Service {
 		$cooldown = 0;
 		$status   = null;
 
-		$valid_program_states = array( 'ENABLED', self::NO_OFFERS );
+		$valid_program_states = [ 'ENABLED', self::NO_OFFERS ];
 
 		foreach ( $response as $program_type ) {
 
 			// In case any Program is with no offers we consider it Onboarding
-			if ( $program_type['data']['globalState'] == self::NO_OFFERS ) {
+			if ( $program_type['data']['globalState'] === self::NO_OFFERS ) {
 				$status = self::ONBOARDING;
 				break;
 			}
 
 			// In case any Program is not enabled or there are no regionStatuses we return null status
-			if ( ! isset( $program_type['data']['regionStatuses'] ) || ! in_array( $program_type['data']['globalState'], $valid_program_states ) ) {
+			if ( ! isset( $program_type['data']['regionStatuses'] ) || ! in_array( $program_type['data']['globalState'], $valid_program_states, true ) ) {
 				$status = null;
 				break;
 			}
@@ -64,7 +63,7 @@ class RequestReviewStatuses implements Service {
 	 * Updates the cooldown period in case the new cooldown period date is available and later than the current cooldown period.
 	 *
 	 * @param array $region_status Associative array containing (maybe) a cooldown date property.
-	 * @param int $cooldown Referenced current cooldown to compare with
+	 * @param int   $cooldown Referenced current cooldown to compare with
 	 */
 	private function maybe_update_cooldown_period( $region_status, &$cooldown ) {
 		if (
@@ -86,16 +85,16 @@ class RequestReviewStatuses implements Service {
 	 * @param String $status Referenced current status
 	 */
 	private function maybe_update_status( $new_status, &$status ) {
-		$status_priority_list = array(
+		$status_priority_list = [
 			self::ONBOARDING, // highest priority
 			self::DISAPPROVED,
 			self::WARNING,
 			self::UNDER_REVIEW,
 			self::PENDING_REVIEW,
 			self::APPROVED,
-		);
+		];
 
-		if ( is_null( $status ) || array_search( $status, $status_priority_list ) > array_search( $new_status, $status_priority_list ) ) {
+		if ( is_null( $status ) || array_search( $status, $status_priority_list, true ) > array_search( $new_status, $status_priority_list, true ) ) {
 			$status = $new_status;
 		}
 	}

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -44,8 +44,7 @@ class RequestReviewStatuses implements Service {
 
 			// In case any Program is not enabled or there are no regionStatuses we return null status
 			if ( ! isset( $program_type['data']['regionStatuses'] ) || ! in_array( $program_type['data']['globalState'], $valid_program_states, true ) ) {
-				$status = null;
-				break;
+				continue;
 			}
 
 			// otherwise we compute the new status, issues and cooldown period

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
  */
 class RequestReviewStatuses implements Service {
 
+	public const ENABLED        = 'ENABLED';
 	public const DISAPPROVED    = 'DISAPPROVED';
 	public const WARNING        = 'WARNING';
 	public const UNDER_REVIEW   = 'UNDER_REVIEW';
@@ -31,7 +32,7 @@ class RequestReviewStatuses implements Service {
 		$cooldown = 0;
 		$status   = null;
 
-		$valid_program_states = [ 'ENABLED', self::NO_OFFERS ];
+		$valid_program_states = [ self::ENABLED, self::NO_OFFERS ];
 
 		foreach ( $response as $program_type ) {
 

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -96,7 +96,14 @@ class RequestReviewStatuses implements Service {
 			self::APPROVED,
 		];
 
-		if ( is_null( $status ) || array_search( $status, $status_priority_list, true ) > array_search( $new_status, $status_priority_list, true ) ) {
+		$current_status_priority = array_search( $status, $status_priority_list, true );
+		$new_status_priority = array_search( $new_status, $status_priority_list, true );
+
+		if ( $new_status_priority === false ) {
+			return;
+		}
+
+		if ( is_null( $status ) || $current_status_priority > $new_status_priority ) {
 			$status = $new_status;
 		}
 	}

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -49,9 +49,9 @@ class RequestReviewStatuses implements Service {
 
 			// otherwise we compute the new status, issues and cooldown period
 			foreach ( $program_type['data']['regionStatuses'] as $region_status ) {
-				$issues = array_merge( $issues, $region_status['reviewIssues'] ?? [] );
+				$issues   = array_merge( $issues, $region_status['reviewIssues'] ?? [] );
 				$cooldown = $this->maybe_update_cooldown_period( $region_status, $cooldown );
-				$status = $this->maybe_update_status( $region_status['eligibilityStatus'], $status );
+				$status   = $this->maybe_update_status( $region_status['eligibilityStatus'], $status );
 			}
 		}
 
@@ -104,7 +104,6 @@ class RequestReviewStatuses implements Service {
 
 		$current_status_priority = array_search( $status, $status_priority_list, true );
 		$new_status_priority     = array_search( $new_status, $status_priority_list, true );
-
 
 		if ( $new_status_priority !== false && ( is_null( $status ) || $current_status_priority > $new_status_priority ) ) {
 			return $new_status;

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -40,7 +40,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programType' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState" =>  "ENABLED",
+						                 "globalState" =>  RequestReviewStatuses::ENABLED,
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
@@ -71,7 +71,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeA' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState" =>  "ENABLED",
+						                 "globalState" =>  RequestReviewStatuses::ENABLED,
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
@@ -88,7 +88,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeB' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState" =>  "ENABLED",
+						                 "globalState" =>  RequestReviewStatuses::ENABLED,
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
@@ -128,7 +128,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeA' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState" =>  "ENABLED",
+						                 "globalState" =>  RequestReviewStatuses::ENABLED,
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
@@ -205,7 +205,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeB' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState"    => "ENABLED",
+						                 "globalState"    => RequestReviewStatuses::ENABLED,
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
@@ -241,7 +241,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeA' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState"    => "ENABLED",
+						                 "globalState"    => RequestReviewStatuses::ENABLED,
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'UNKNOWN',
@@ -280,7 +280,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeA' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState"    => "TEST",
+						                 "globalState"    => RequestReviewStatuses::ENABLED,
 					                 ]
 				                 ]
 			                 ]
@@ -304,7 +304,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'freeListingsProgram' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState" =>  "ENABLED",
+						                 "globalState" =>  RequestReviewStatuses::ENABLED,
 						                 'regionStatuses' => [
 							                 [
 								                 'regionCodes'                      => [ 'US' ],

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -173,7 +173,6 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 							                 [
 								                 'reviewEligibilityStatus' => 'ELIGIBLE',
 								                 'eligibilityStatus'       => 'DISAPPROVED',
-								                 'reviewIssues'            => [ 'one' ]
 							                 ],
 						                 ]
 					                 ]

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -35,6 +35,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programType' => [
 					                 'status' => 200,
 					                 'data'   => [
+						                 "globalState" =>  "ENABLED",
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
@@ -65,6 +66,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeA' => [
 					                 'status' => 200,
 					                 'data'   => [
+						                 "globalState" =>  "ENABLED",
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
@@ -81,6 +83,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeB' => [
 					                 'status' => 200,
 					                 'data'   => [
+						                 "globalState" =>  "ENABLED",
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
@@ -111,6 +114,88 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		], $response->get_data() );
 	}
 
+	public function test_no_offers_reponse() {
+
+		$this->middleware->expects( $this->once() )
+		                 ->method( 'get_account_review_status' )
+		                 ->willReturn(
+			                 [
+				                 'programTypeA' => [
+					                 'status' => 200,
+					                 'data'   => [
+						                 "globalState" =>  "ENABLED",
+						                 'regionStatuses' => [
+							                 [
+								                 'reviewEligibilityStatus' => 'INELIGIBLE',
+								                 'eligibilityStatus'       => 'APPROVED',
+							                 ],
+							                 [
+								                 'reviewEligibilityStatus' => 'ELIGIBLE',
+								                 'eligibilityStatus'       => 'DISAPPROVED',
+								                 'reviewIssues'            => [ 'one' ]
+							                 ],
+						                 ]
+					                 ]
+				                 ],
+				                 'programTypeB' => [
+					                 'status' => 200,
+					                 'data'   => [
+						                 "globalState" =>  "NO_OFFERS_UPLOADED"
+					                 ]
+				                 ]
+			                 ]
+		                 );
+
+		$response = $this->do_request( self::ROUTE_GET_REQUEST );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [
+			'status'   => 'ONBOARDING',
+			'issues'   => [],
+			'cooldown' => 0
+		], $response->get_data() );
+	}
+
+	public function test_unexpected_state_reponse() {
+
+		$this->middleware->expects( $this->once() )
+		                 ->method( 'get_account_review_status' )
+		                 ->willReturn(
+			                 [
+				                 'programTypeA' => [
+					                 'status' => 200,
+					                 'data'   => [
+						                 "globalState" =>  "ENABLED",
+						                 'regionStatuses' => [
+							                 [
+								                 'reviewEligibilityStatus' => 'INELIGIBLE',
+								                 'eligibilityStatus'       => 'APPROVED',
+							                 ],
+							                 [
+								                 'reviewEligibilityStatus' => 'ELIGIBLE',
+								                 'eligibilityStatus'       => 'DISAPPROVED',
+								                 'reviewIssues'            => [ 'one' ]
+							                 ],
+						                 ]
+					                 ]
+				                 ],
+				                 'programTypeB' => [
+					                 'status' => 200,
+					                 'data'   => [
+						                 "globalState" =>  "UNKNOWN"
+					                 ]
+				                 ]
+			                 ]
+		                 );
+
+		$response = $this->do_request( self::ROUTE_GET_REQUEST );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [
+			'status'   => null,
+			'issues'   => [],
+			'cooldown' => 0
+		], $response->get_data() );
+	}
+
 	public function test_cooldown() {
 
 		$this->middleware->expects( $this->once() )
@@ -120,6 +205,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'freeListingsProgram' => [
 					                 'status' => 200,
 					                 'data'   => [
+						                 "globalState" =>  "ENABLED",
 						                 'regionStatuses' => [
 							                 [
 								                 'regionCodes'                      => [ 'US' ],

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -44,7 +44,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
-								                 'eligibilityStatus'       => 'WARNING',
+								                 'eligibilityStatus'       => RequestReviewStatuses::WARNING,
 								                 'reviewIssues'            => [ 'one', 'two' ],
 							                 ]
 						                 ]
@@ -56,7 +56,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( self::ROUTE_GET_REQUEST );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( [
-			'status'   => 'WARNING',
+			'status'   => RequestReviewStatuses::WARNING,
 			'issues'   => [ 'one', 'two' ],
 			'cooldown' => 0
 		], $response->get_data() );
@@ -75,11 +75,11 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
-								                 'eligibilityStatus'       => 'APPROVED',
+								                 'eligibilityStatus'       => RequestReviewStatuses::APPROVED,
 							                 ],
 							                 [
 								                 'reviewEligibilityStatus' => 'ELIGIBLE',
-								                 'eligibilityStatus'       => 'DISAPPROVED',
+								                 'eligibilityStatus'       => RequestReviewStatuses::DISAPPROVED,
 								                 'reviewIssues'            => [ 'one' ]
 							                 ],
 						                 ]
@@ -92,17 +92,17 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
-								                 'eligibilityStatus'       => 'WARNING',
+								                 'eligibilityStatus'       => RequestReviewStatuses::WARNING,
 								                 'reviewIssues'            => [ 'two' ]
 							                 ],
 							                 [
 								                 'reviewEligibilityStatus' => 'ELIGIBLE',
-								                 'eligibilityStatus'       => 'DISAPPROVED',
+								                 'eligibilityStatus'       => RequestReviewStatuses::DISAPPROVED,
 								                 'reviewIssues'            => [ 'one' ]
 							                 ],
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
-								                 'eligibilityStatus'       => 'UNDER_REVIEW'
+								                 'eligibilityStatus'       => RequestReviewStatuses::UNDER_REVIEW
 							                 ],
 						                 ]
 					                 ]
@@ -113,7 +113,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( self::ROUTE_GET_REQUEST );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( [
-			'status'   => 'DISAPPROVED',
+			'status'   => RequestReviewStatuses::DISAPPROVED,
 			'issues'   => [ 'one', 'two' ],
 			'cooldown' => 0
 		], $response->get_data() );
@@ -132,11 +132,11 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
-								                 'eligibilityStatus'       => 'APPROVED',
+								                 'eligibilityStatus'       => RequestReviewStatuses::APPROVED,
 							                 ],
 							                 [
 								                 'reviewEligibilityStatus' => 'ELIGIBLE',
-								                 'eligibilityStatus'       => 'DISAPPROVED',
+								                 'eligibilityStatus'       => RequestReviewStatuses::DISAPPROVED,
 								                 'reviewIssues'            => [ 'one' ]
 							                 ],
 						                 ]
@@ -145,7 +145,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				                 'programTypeB' => [
 					                 'status' => 200,
 					                 'data'   => [
-						                 "globalState" =>  "NO_OFFERS_UPLOADED"
+						                 "globalState" =>  RequestReviewStatuses::NO_OFFERS
 					                 ]
 				                 ]
 			                 ]
@@ -173,11 +173,11 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 						                 'regionStatuses' => [
 							                 [
 								                 'reviewEligibilityStatus' => 'INELIGIBLE',
-								                 'eligibilityStatus'       => 'APPROVED',
+								                 'eligibilityStatus'       => RequestReviewStatuses::APPROVED,
 							                 ],
 							                 [
 								                 'reviewEligibilityStatus' => 'ELIGIBLE',
-								                 'eligibilityStatus'       => 'DISAPPROVED',
+								                 'eligibilityStatus'       => RequestReviewStatuses::DISAPPROVED,
 							                 ],
 						                 ]
 					                 ]
@@ -213,7 +213,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 						                 'regionStatuses' => [
 							                 [
 								                 'regionCodes'                      => [ 'US' ],
-								                 'eligibilityStatus'                => 'DISAPPROVED',
+								                 'eligibilityStatus'                => RequestReviewStatuses::DISAPPROVED,
 								                 'reviewEligibilityStatus'          => 'INELIGIBLE',
 								                 'reviewIneligibilityReasonDetails' => [
 									                 'cooldownTime' => "2022-04-27T10:58:51Z" // 27/04/2022
@@ -221,7 +221,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 							                 ],
 							                 [
 								                 'regionCodes'                      => [ 'NL' ],
-								                 'eligibilityStatus'                => 'DISAPPROVED',
+								                 'eligibilityStatus'                => RequestReviewStatuses::DISAPPROVED,
 								                 'reviewEligibilityStatus'          => 'INELIGIBLE',
 								                 'reviewIneligibilityReasonDetails' => [
 									                 'cooldownTime' => "2022-04-25T10:58:51Z" // 25/04/2022
@@ -229,7 +229,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 							                 ],
 							                 [
 								                 'regionCodes'             => [ 'IT' ],
-								                 'eligibilityStatus'       => 'DISAPPROVED',
+								                 'eligibilityStatus'       => RequestReviewStatuses::DISAPPROVED,
 								                 'reviewEligibilityStatus' => 'ELIGIBLE',
 							                 ],
 						                 ]
@@ -241,7 +241,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( self::ROUTE_GET_REQUEST );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( [
-			'status'   => 'DISAPPROVED',
+			'status'   => RequestReviewStatuses::DISAPPROVED,
 			'issues'   => [],
 			'cooldown' => 1651058331000 // 27/04/2022
 		], $response->get_data() );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -150,7 +150,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( [
 			'status'   => 'ONBOARDING',
-			'issues'   => [],
+			'issues'   => [ 'one' ],
 			'cooldown' => 0
 		], $response->get_data() );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the Onboarding Status to the Account Status as well as other minor refactoring. 

- The onboarding status will be there when the status of any of the program regions is Onboarding or if any of the global states is `NO_OFFERS_UPLOADED`

Its present in the frontend like this
<img width="1164" alt="Screenshot 2022-04-28 at 17 26 42" src="https://user-images.githubusercontent.com/5908855/165762817-5fa4b76f-6c9b-49fe-850b-a1034a63fd64.png">

- The statuses calculation was refactored in a less verbose way. 
- Fixed an error in which array_unique returned an associative version of the issues array sometimes. This was making Frontend part to fail because associative array is parsed as an object in JSON instead of an array. 
- Tweak: In case we find unknown statues or disabled global states we will hide the notice and the status.
- Fix: Added cooldown property instead of `nextAttempt` in the default state that was missed in the last PR. 


```
$response = [
				                 'programTypeA' => [
					                 'status' => 200,
					                 'data'   => [
						                 "globalState" =>  "ENABLED",
						                 'regionStatuses' => [
							                 [
								                 'reviewEligibilityStatus' => 'INELIGIBLE',
								                 'eligibilityStatus'       => 'APPROVED',
							                 ],
							                 [
								                 'reviewEligibilityStatus' => 'ELIGIBLE',
								                 'eligibilityStatus'       => 'DISAPPROVED',
								                 'reviewIssues'            => [ 'one' ]
							                 ],
						                 ]
					                 ]
				                 ],
				                 'programTypeB' => [
					                 'status' => 200,
					                 'data'   => [
						                 "globalState" =>  "ENABLED",
						                 'regionStatuses' => [
							                 [
								                 'reviewEligibilityStatus' => 'INELIGIBLE',
								                 'eligibilityStatus'       => 'WARNING',
								                 'reviewIssues'            => [ 'two' ]
							                 ],
							                 [
								                 'reviewEligibilityStatus' => 'ELIGIBLE',
								                 'eligibilityStatus'       => 'DISAPPROVED',
								                 'reviewIssues'            => [ 'one' ]
							                 ],
							                 [
								                 'reviewEligibilityStatus' => 'INELIGIBLE',
								                 'eligibilityStatus'       => 'UNDER_REVIEW'
							                 ],
						                 ]
					                 ]
				                 ]
			                 ];
```
### Detailed test instructions:
1. Checkout this issue and run `npm run dev` to generate the assets
2. In `src/API/Site/Controllers/MerchantCenter/RequestReviewController.php::get_review_read_callback()` you can hardcode the response with something like the provided above 
3. Test that if any globalState is NO_OFFERS_UPLOADED we get ONBOARDING status
4. Check that if any statues has ONBOARDING as eligibilityStatus we show ONBOARDING as status
5. Check that if any statues has DISAPPROVED as eligibilityStatus, and no ONBOARDING in any of them we show DISAPPROVED as status
6. Check that if any statues has WARNING as eligibilityStatus, and no ONBOARDING or DISAPPROVED in any of them we show WARNING as status
7. Check that if any statues has UNDER_REVIEW as eligibilityStatus, and no ONBOARDING or DISAPPROVED or WARNING in any of them we show UNDER_REVIEW as status
8. Check that if any statues has PENDING_REVIEW as eligibilityStatus, and no ONBOARDING or DISAPPROVED or WARNING or UNDER_REVIEW in any of them we show PENDING_REVIEW as status
9.  Check that if any statues has APPROVED as eligibilityStatus, and no ONBOARDING or DISAPPROVED or WARNING or UNDER_REVIEW or PENDING_REVIEW in any of them we show APPROVED as status
10. Rest of cases will show null as status. this could be tested by adding for example "globalState" =>  "UNKNOWN" in any of the programs inside the response. 
