### PR TITLE
Fix that the states rely on the Google ads account are not updated after the account is disconnected

### DIFF
--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -94,10 +94,6 @@ export function* getGoogleAdsAccount() {
 	yield fetchGoogleAdsAccount();
 }
 
-getGoogleAdsAccount.shouldInvalidate = ( action ) => {
-	return action.type === TYPES.DISCONNECT_ACCOUNTS_GOOGLE_ADS;
-};
-
 export function* getGoogleAdsAccountBillingStatus() {
 	yield fetchGoogleAdsAccountBillingStatus();
 }

--- a/js/src/settings/linked-accounts.js
+++ b/js/src/settings/linked-accounts.js
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-import { recordEvent, queueRecordEvent } from '@woocommerce/tracks';
+import { queueRecordEvent } from '@woocommerce/tracks';
 import { __ } from '@wordpress/i18n';
 import { Flex, Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import { getGetStartedUrl } from '.~/utils/urls';
 import useAdminUrl from '.~/hooks/useAdminUrl';
 import useJetpackAccount from '.~/hooks/useJetpackAccount';
 import useGoogleAccount from '.~/hooks/useGoogleAccount';
@@ -57,23 +57,18 @@ export default function LinkedAccounts() {
 	const openDisconnectAdsAccountModal = () => setOpenedModal( ADS_ACCOUNT );
 	const dismissModal = () => setOpenedModal( null );
 
-	// The re-fetch of Google ads account will be triggered within the resolvers.
-	// Here only need to handle the all accounts disconnection case.
 	const handleDisconnected = () => {
-		const eventArgs = [
-			'gla_disconnected_accounts',
-			{ context: openedModal },
-		];
+		queueRecordEvent( 'gla_disconnected_accounts', {
+			context: openedModal,
+		} );
 
-		if ( openedModal === ALL_ACCOUNTS ) {
-			queueRecordEvent( ...eventArgs );
+		// Reload WC admin page to update the `glaData` initiated from the static script.
+		const nextPage =
+			openedModal === ALL_ACCOUNTS
+				? adminUrl + getGetStartedUrl()
+				: window.location.href;
 
-			// Force reload WC admin page to initiate the Get Started page.
-			const path = getNewPath( null, '/google/start' );
-			window.location.href = adminUrl + path;
-		} else {
-			recordEvent( ...eventArgs );
-		}
+		window.location.href = nextPage;
 	};
 
 	return (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1458 

- Reload the current page once the Google Ads account is disconnected.

### Screenshots:

https://user-images.githubusercontent.com/17420811/165881358-5c7c1772-8e96-4f3f-be1c-6ae24f2b0482.mp4

### Detailed test instructions:

1. Connect GLA to a Google Ads account.
1. Go to GLA Settings: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`
1. Click on the "Disconnect Google Ads account only" text and finish the disconnection processing.
1. Once the Google Ads account is disconnected, the page should be refreshed.
1. Go to other GLA pages. The states that rely on a connected Google Ads account should be shown with unconnected states.

### Changelog entry

> Fix - The page states that rely on a connected Google Ads account are not updated accordingly after the account is disconnected.
