### PR TITLE
GLA Request Review - Adding Cache to Review Request Controller

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -10,7 +10,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
-use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 use Exception;
@@ -25,30 +24,18 @@ defined( 'ABSPATH' ) || exit;
 class RequestReviewController extends BaseOptionsController {
 
 	/**
-	 * @var ContainerInterface
-	 */
-	protected $container;
-
-	/**
-	 * @var Middleware
-	 */
-	protected $middleware;
-
-	/**
-	 * @var RequestReviewStatuses
-	 */
-	protected $request_review_statuses;
-
-	/**
 	 * RequestReviewController constructor.
 	 *
-	 * @param ContainerInterface $container
+	 * @param RESTServer            $server
+	 * @param Middleware            $middleware
+	 * @param RequestReviewStatuses $request_review_statuses
+	 * @param TransientsInterface   $transient
 	 */
-	public function __construct( ContainerInterface $container ) {
-		$this->container = $container;
-		parent::__construct( $container->get( RESTServer::class ) );
-		$this->middleware              = $container->get( Middleware::class );
-		$this->request_review_statuses = $container->get( RequestReviewStatuses::class );
+	public function __construct( RESTServer $server, Middleware $middleware, RequestReviewStatuses $request_review_statuses, TransientsInterface $transient ) {
+		parent::__construct( $server );
+		$this->middleware              = $middleware;
+		$this->request_review_statuses = $request_review_statuses;
+		$this->transient = $transient;
 	}
 
 	/**
@@ -144,7 +131,7 @@ class RequestReviewController extends BaseOptionsController {
 	 * @param array $value The Account Review Status data to save in the transient
 	 */
 	private function set_cached_review_status( $value ): void {
-		$this->container->get( TransientsInterface::class )->set(
+		$this->transient->set(
 			Transients::MC_ACCOUNT_REVIEW,
 			$value,
 			$this->request_review_statuses->get_account_review_lifetime()
@@ -157,7 +144,7 @@ class RequestReviewController extends BaseOptionsController {
 	 * @return null|array Returns NULL in case no data is available or an array with the Account Review Status data otherwise.
 	 */
 	private function get_cached_review_status(): ?array {
-		return $this->container->get( TransientsInterface::class )->get(
+		return $this->transient->get(
 			Transients::MC_ACCOUNT_REVIEW,
 		);
 	}

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -35,7 +35,7 @@ class RequestReviewController extends BaseOptionsController {
 		parent::__construct( $server );
 		$this->middleware              = $middleware;
 		$this->request_review_statuses = $request_review_statuses;
-		$this->transient = $transient;
+		$this->transient               = $transient;
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -26,7 +26,7 @@ class RequestReviewController extends BaseOptionsController {
 	/**
 	 * @var TransientsInterface
 	 */
-	private TransientsInterface $transients;
+	private $transients;
 
 	/**
 	 * RequestReviewController constructor.

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -27,7 +27,7 @@ class RequestReviewController extends BaseOptionsController {
 	/**
 	 * @var TransientsInterface
 	 */
-	private $transients;
+	private TransientsInterface $transients;
 
 	/**
 	 * RequestReviewController constructor.

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -23,19 +23,25 @@ defined( 'ABSPATH' ) || exit;
  */
 class RequestReviewController extends BaseOptionsController {
 
+
+	/**
+	 * @var TransientsInterface
+	 */
+	private $transients;
+
 	/**
 	 * RequestReviewController constructor.
 	 *
 	 * @param RESTServer            $server
 	 * @param Middleware            $middleware
 	 * @param RequestReviewStatuses $request_review_statuses
-	 * @param TransientsInterface   $transient
+	 * @param TransientsInterface   $transients
 	 */
-	public function __construct( RESTServer $server, Middleware $middleware, RequestReviewStatuses $request_review_statuses, TransientsInterface $transient ) {
+	public function __construct( RESTServer $server, Middleware $middleware, RequestReviewStatuses $request_review_statuses, TransientsInterface $transients ) {
 		parent::__construct( $server );
 		$this->middleware              = $middleware;
 		$this->request_review_statuses = $request_review_statuses;
-		$this->transient               = $transient;
+		$this->transients               = $transients;
 	}
 
 	/**
@@ -131,7 +137,7 @@ class RequestReviewController extends BaseOptionsController {
 	 * @param array $value The Account Review Status data to save in the transient
 	 */
 	private function set_cached_review_status( $value ): void {
-		$this->transient->set(
+		$this->transients->set(
 			Transients::MC_ACCOUNT_REVIEW,
 			$value,
 			$this->request_review_statuses->get_account_review_lifetime()
@@ -144,7 +150,7 @@ class RequestReviewController extends BaseOptionsController {
 	 * @return null|array Returns NULL in case no data is available or an array with the Account Review Status data otherwise.
 	 */
 	private function get_cached_review_status(): ?array {
-		return $this->transient->get(
+		return $this->transients->get(
 			Transients::MC_ACCOUNT_REVIEW,
 		);
 	}

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -7,7 +7,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 use Exception;
@@ -21,18 +24,31 @@ defined( 'ABSPATH' ) || exit;
  */
 class RequestReviewController extends BaseOptionsController {
 
+	/**
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * @var Middleware
+	 */
+	protected $middleware;
+
+	/**
+	 * @var RequestReviewStatuses
+	 */
+	protected $request_review_statuses;
 
 	/**
 	 * RequestReviewController constructor.
 	 *
-	 * @param RESTServer            $server
-	 * @param Middleware            $middleware
-	 * @param RequestReviewStatuses $request_review_statuses
+	 * @param ContainerInterface $container
 	 */
-	public function __construct( RESTServer $server, Middleware $middleware, RequestReviewStatuses $request_review_statuses ) {
-		parent::__construct( $server );
-		$this->middleware              = $middleware;
-		$this->request_review_statuses = $request_review_statuses;
+	public function __construct( ContainerInterface $container ) {
+		$this->container = $container;
+		parent::__construct( $container->get( RESTServer::class ) );
+		$this->middleware              = $container->get( Middleware::class );
+		$this->request_review_statuses = $container->get( RequestReviewStatuses::class );
 	}
 
 	/**
@@ -63,8 +79,13 @@ class RequestReviewController extends BaseOptionsController {
 	protected function get_review_read_callback(): callable {
 		return function ( Request $request ) {
 			try {
-				$response      = $this->middleware->get_account_review_status();
-				$review_status = $this->request_review_statuses->get_statuses_from_response( $response );
+				$review_status = $this->get_cached_review_status();
+
+				if ( is_null( $review_status ) ) {
+					$response      = $this->middleware->get_account_review_status();
+					$review_status = $this->request_review_statuses->get_statuses_from_response( $response );
+					$this->set_cached_review_status( $review_status );
+				}
 
 				return $this->prepare_item_for_response( $review_status, $request );
 			} catch ( Exception $e ) {
@@ -115,5 +136,29 @@ class RequestReviewController extends BaseOptionsController {
 	 */
 	protected function get_schema_title(): string {
 		return 'merchant_account_review';
+	}
+
+	/**
+	 * Save the Account Review Status data inside a transient for caching purposes.
+	 *
+	 * @param array $value The Account Review Status data to save in the transient
+	 */
+	private function set_cached_review_status( $value ): void {
+		$this->container->get( TransientsInterface::class )->set(
+			Transients::MC_ACCOUNT_REVIEW,
+			$value,
+			$this->request_review_statuses->get_account_review_lifetime()
+		);
+	}
+
+	/**
+	 * Get the Account Review Status data inside a transient for caching purposes.
+	 *
+	 * @return null|array Returns NULL in case no data is available or an array with the Account Review Status data otherwise.
+	 */
+	private function get_cached_review_status(): ?array {
+		return $this->container->get( TransientsInterface::class )->get(
+			Transients::MC_ACCOUNT_REVIEW,
+		);
 	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -40,7 +40,7 @@ class RequestReviewController extends BaseOptionsController {
 		parent::__construct( $server );
 		$this->middleware              = $middleware;
 		$this->request_review_statuses = $request_review_statuses;
-		$this->transients               = $transients;
+		$this->transients              = $transients;
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use WP_REST_Request as Request;
@@ -138,7 +137,7 @@ class RequestReviewController extends BaseOptionsController {
 	 */
 	private function set_cached_review_status( $value ): void {
 		$this->transients->set(
-			Transients::MC_ACCOUNT_REVIEW,
+			TransientsInterface::MC_ACCOUNT_REVIEW,
 			$value,
 			$this->request_review_statuses->get_account_review_lifetime()
 		);
@@ -151,7 +150,7 @@ class RequestReviewController extends BaseOptionsController {
 	 */
 	private function get_cached_review_status(): ?array {
 		return $this->transients->get(
-			Transients::MC_ACCOUNT_REVIEW,
+			TransientsInterface::MC_ACCOUNT_REVIEW,
 		);
 	}
 }

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -99,7 +99,7 @@ class RequestReviewStatuses implements Service {
 	 *
 	 * @return int The cooldown in milliseconds and adding the lifetime cache
 	 */
-	private function get_cooldown( $cooldown ) {
+	private function get_cooldown( int $cooldown ) {
 		if ( $cooldown ) {
 			$cooldown = ( $cooldown + self::get_account_review_lifetime() ) * 1000;
 		}

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -80,7 +80,7 @@ class RequestReviewStatuses implements Service {
 
 		return [
 			'issues'   => array_map( 'strtolower', array_unique( $issues ) ),
-			'cooldown' => $cooldown * 1000,
+			'cooldown' => self::parse_cooldown( $cooldown ), // add lifetime cache to cooldown time
 			'status'   => $status,
 		];
 	}
@@ -92,6 +92,19 @@ class RequestReviewStatuses implements Service {
 	 */
 	public function get_account_review_lifetime(): int {
 		return apply_filters( 'woocommerce_gla_mc_account_review_lifetime', self::MC_ACCOUNT_REVIEW_LIFETIME );
+	}
+
+	/**
+	 * @param int $cooldown The cooldown in PHP format (seconds)
+	 *
+	 * @return int The cooldown in miliseconds and adding the lifetime cache
+	 */
+	private function parse_cooldown( $cooldown ) {
+		if ( $cooldown ) {
+			$cooldown = ( $cooldown + self::get_account_review_lifetime() ) * 1000;
+		}
+
+		return $cooldown;
 	}
 
 }

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -80,7 +80,7 @@ class RequestReviewStatuses implements Service {
 
 		return [
 			'issues'   => array_map( 'strtolower', array_unique( $issues ) ),
-			'cooldown' => self::parse_cooldown( $cooldown ), // add lifetime cache to cooldown time
+			'cooldown' => self::get_cooldown( $cooldown ), // add lifetime cache to cooldown time
 			'status'   => $status,
 		];
 	}
@@ -97,9 +97,9 @@ class RequestReviewStatuses implements Service {
 	/**
 	 * @param int $cooldown The cooldown in PHP format (seconds)
 	 *
-	 * @return int The cooldown in miliseconds and adding the lifetime cache
+	 * @return int The cooldown in milliseconds and adding the lifetime cache
 	 */
-	private function parse_cooldown( $cooldown ) {
+	private function get_cooldown( $cooldown ) {
 		if ( $cooldown ) {
 			$cooldown = ( $cooldown + self::get_account_review_lifetime() ) * 1000;
 		}

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -16,6 +16,8 @@ class RequestReviewStatuses implements Service {
 	public const PENDING_REVIEW = 'PENDING_REVIEW';
 	public const ONBOARDING     = 'ONBOARDING';
 
+	public const MC_ACCOUNT_REVIEW_LIFETIME = MINUTE_IN_SECONDS * 20; // 20 minutes
+
 	/**
 	 * Merges the different program statuses based on priority
 	 *
@@ -81,6 +83,15 @@ class RequestReviewStatuses implements Service {
 			'cooldown' => $cooldown * 1000,
 			'status'   => $status,
 		];
+	}
+
+	/**
+	 * Allows a hook to modify the lifetime of the Account review data.
+	 *
+	 * @return int
+	 */
+	public function get_account_review_lifetime(): int {
+		return apply_filters( 'woocommerce_gla_mc_account_review_lifetime', self::MC_ACCOUNT_REVIEW_LIFETIME );
 	}
 
 }

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -99,7 +99,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class, Ads::class );
 		$this->share( PhoneVerificationController::class, PhoneVerification::class );
 		$this->share( MerchantCenterAccountController::class, MerchantAccountService::class );
-		$this->share( MerchantCenterRequestReviewController::class, Middleware::class, RequestReviewStatuses::class );
+		$this->share_with_container( MerchantCenterRequestReviewController::class );
 		$this->share_with_container( MerchantCenterReportsController::class );
 		$this->share( ShippingRateBatchController::class, ShippingRateQuery::class );
 		$this->share( ShippingRateController::class, ShippingRateQuery::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -48,6 +48,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService as
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -99,7 +100,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class, Ads::class );
 		$this->share( PhoneVerificationController::class, PhoneVerification::class );
 		$this->share( MerchantCenterAccountController::class, MerchantAccountService::class );
-		$this->share_with_container( MerchantCenterRequestReviewController::class );
+		$this->share( MerchantCenterRequestReviewController::class, Middleware::class, RequestReviewStatuses::class, TransientsInterface::class );
 		$this->share_with_container( MerchantCenterReportsController::class );
 		$this->share( ShippingRateBatchController::class, ShippingRateQuery::class );
 		$this->share( ShippingRateController::class, ShippingRateQuery::class );

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -13,11 +13,13 @@ interface TransientsInterface {
 	public const ADS_METRICS          = 'ads_metrics';
 	public const FREE_LISTING_METRICS = 'free_listing_metrics';
 	public const MC_STATUSES          = 'mc_statuses';
+	public const MC_ACCOUNT_REVIEW    = 'mc_account_review';
 
 	public const VALID_OPTIONS = [
 		self::ADS_METRICS          => true,
 		self::FREE_LISTING_METRICS => true,
 		self::MC_STATUSES          => true,
+		self::MC_ACCOUNT_REVIEW    => true,
 	];
 
 	/**

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -2,9 +2,12 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\RequestReviewController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Google\Exception;
 
@@ -18,11 +21,15 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 
 	protected const ROUTE_GET_REQUEST = '/wc/gla/mc/review';
 	private $middleware;
+	private $transients;
+	private $request_review_statuses;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->middleware = $this->createMock( Middleware::class );
-		$this->controller = new RequestReviewController( $this->server, $this->middleware, new RequestReviewStatuses() );
+		$this->transients = $this->createMock( TransientsInterface::class );
+		$this->request_review_statuses = new RequestReviewStatuses();
+		$this->controller = new RequestReviewController( $this->server, $this->middleware, $this->request_review_statuses, $this->transients  );
 		$this->controller->register();
 	}
 
@@ -153,7 +160,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( [
 			'status'   => 'DISAPPROVED',
 			'issues'   => [],
-			'cooldown' => 1651057131000 // 27/04/2022
+			'cooldown' => 1651058331000 // 27/04/2022
 		], $response->get_data() );
 	}
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\RequestReviewController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1165 

I decided to implement cache in the responses. The advantages of this will be:

- Avoid hitting unnecessarily the Google API and VIPGO server
- Allowing to save the status after requesting a review. This will be useful since Google takes a few minutes to update between statuses (ie, from ELIGIBLE to UNDER_REVIEW) hence the user would be able to perform several requests. With this cache we can save the new status manually after the request giving google time to update the status.

The way is works is vary basic, just a transient with 20 mins lifetime that stores the response from Google. 

<img width="946" alt="Screenshot 2022-04-29 at 14 53 13" src="https://user-images.githubusercontent.com/5908855/165936947-854650fd-01ef-4491-9869-3764eb126c3c.png">

In case no transient available or expired transients we just perform the response normally and save the status in the transient.

Notice we also added the lifetime to the cooldown period. Since the cooldown period is now showing the time, we want to show the current cooldown + the 20 mins cache to be sure the user is not getting a cached cooldown time in the past. 

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

```

$response = [
				                 'freeListingsProgram' => [
					                 'status' => 200,
					                 'data'   => [
						                 'regionStatuses' => [
							                 [
								                 'regionCodes'                      => [ 'US' ],
								                 'eligibilityStatus'                => 'DISAPPROVED',
								                 'reviewEligibilityStatus'          => 'INELIGIBLE',
								                 'reviewIneligibilityReasonDetails' => [
									                 'cooldownTime' => "2022-04-27T10:58:51Z" // 27/04/2022
								                 ]
							                 ]
						                 ]
					                 ]
				                 ]
			                 ]
```
1. Checkout this PR
2. Go to product feed and wait until the Account status appears.
3. Go to DB and see that `_transient_gla_mc_account_review`  as well as `_transient_timeout_gla_mc_account_review` is present in `wp_options` table 
4. Go to `src/API/Site/Controllers/MerchantCenter/RequestReviewController.php::get_review_read_callback()` 
5. In line 72 Use the response provided above instead of the API call using `$this->middleware->get_account_review_status()`. 
6. Refresh product feed and wait until the Account status appears. You still see the previous response not the new one hardcoded.
7.  Go to DB again and change  `_transient_timeout_gla_mc_account_review` to 0 to force refresh (you can also delete the transients)
8. Refresh product feed again, see that the new response hardcoded appears.
9. Go to DB again and see how the transients were updated.
