### PR TITLE
Fix TreeSelectControl label UI to be consistent with other input label

### DIFF
--- a/js/src/components/paid-ads/campaign-form-content.scss
+++ b/js/src/components/paid-ads/campaign-form-content.scss
@@ -25,12 +25,4 @@
 		margin: 0;
 		font-style: italic;
 	}
-
-	.woocommerce-tree-select-control__label {
-		font-size: 13px;
-	}
-
-	.woocommerce-tree-select-control__help {
-		font-style: italic;
-	}
 }

--- a/js/src/components/supported-country-select/supported-country-select.js
+++ b/js/src/components/supported-country-select/supported-country-select.js
@@ -3,12 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import TreeSelectControl from '.~/components/tree-select-control';
 import useMCCountryTreeOptions from './useMCCountryTreeOptions';
+import './supported-country-select.scss';
 
 /**
  * @typedef {import('.~/data/actions').CountryCode} CountryCode
@@ -22,10 +24,11 @@ import useMCCountryTreeOptions from './useMCCountryTreeOptions';
  *
  * @param {Object} props React props.
  * @param {Array<CountryCode>} [props.countryCodes] Country codes for converting to tree-based option structure. It will use all MC supported countries if not specified.
- * @param {Object} props.restProps Props to be forwarded to TreeSelectControl.
+ * @param {string} props.className Class name. Note that when there is a Form's `{...getInputProps('fieldname')}` being passed into this component, the className might be null.
  */
 export default function SupportedCountrySelect( {
 	countryCodes,
+	className,
 	...restProps
 } ) {
 	const maxVisibleTags = useViewportMatch( 'medium', '<' ) ? 5 : 10;
@@ -33,6 +36,10 @@ export default function SupportedCountrySelect( {
 
 	return (
 		<TreeSelectControl
+			className={ classnames(
+				'gla-supported-country-select',
+				className
+			) }
 			placeholder={ __(
 				'Start typing to filter countries…',
 				'google-listings-and-ads'

--- a/js/src/components/supported-country-select/supported-country-select.js
+++ b/js/src/components/supported-country-select/supported-country-select.js
@@ -22,6 +22,8 @@ import './supported-country-select.scss';
  * This component is for selecting countries under Google Merchant Center supported countries.
  * And the selectable countries can be further limited by the `countryCodes` prop.
  *
+ * All other props (except `countryCodes` prop) are forwarded to the underlying TreeSelectControl component.
+ *
  * @param {Object} props React props.
  * @param {Array<CountryCode>} [props.countryCodes] Country codes for converting to tree-based option structure. It will use all MC supported countries if not specified.
  * @param {string} [props.className] Class name. Note that when there is a Form's `{...getInputProps('fieldname')}` being passed into this component, the className might be null.

--- a/js/src/components/supported-country-select/supported-country-select.js
+++ b/js/src/components/supported-country-select/supported-country-select.js
@@ -24,7 +24,7 @@ import './supported-country-select.scss';
  *
  * @param {Object} props React props.
  * @param {Array<CountryCode>} [props.countryCodes] Country codes for converting to tree-based option structure. It will use all MC supported countries if not specified.
- * @param {string} props.className Class name. Note that when there is a Form's `{...getInputProps('fieldname')}` being passed into this component, the className might be null.
+ * @param {string} [props.className] Class name. Note that when there is a Form's `{...getInputProps('fieldname')}` being passed into this component, the className might be null.
  */
 export default function SupportedCountrySelect( {
 	countryCodes,

--- a/js/src/components/supported-country-select/supported-country-select.scss
+++ b/js/src/components/supported-country-select/supported-country-select.scss
@@ -1,6 +1,10 @@
 .gla-supported-country-select {
-	label {
+	.woocommerce-tree-select-control__label {
 		padding-bottom: 4px;
 		font-size: 13px;
+	}
+
+	.woocommerce-tree-select-control__help {
+		font-style: italic;
 	}
 }

--- a/js/src/components/supported-country-select/supported-country-select.scss
+++ b/js/src/components/supported-country-select/supported-country-select.scss
@@ -1,0 +1,6 @@
+.gla-supported-country-select {
+	label {
+		padding-bottom: 4px;
+		font-size: 13px;
+	}
+}

--- a/js/src/components/tree-select-control/index.scss
+++ b/js/src/components/tree-select-control/index.scss
@@ -28,7 +28,6 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
 	&__help {
 		margin-top: $gap-smallest;
 		line-height: 16px;
-		font-style: italic;
 		font-size: 12px;
 		color: $gray-700;
 	}

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -82,20 +82,16 @@ const AddTimeModal = ( props ) => {
 						onRequestClose={ onRequestClose }
 					>
 						<VerticalGapLayout>
-							<div>
-								<div className="label">
-									{ __(
-										'If customer is in',
-										'google-listings-and-ads'
-									) }
-								</div>
-								<AudienceCountrySelect
-									onDropdownVisibilityChange={
-										setDropdownVisible
-									}
-									{ ...getInputProps( 'countryCodes' ) }
-								/>
-							</div>
+							<AudienceCountrySelect
+								label={ __(
+									'If customer is in',
+									'google-listings-and-ads'
+								) }
+								onDropdownVisibilityChange={
+									setDropdownVisible
+								}
+								{ ...getInputProps( 'countryCodes' ) }
+							/>
 							<AppInputNumberControl
 								label={ __(
 									'Then the estimated shipping time displayed in the product listing is',

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -109,20 +109,16 @@ const EditTimeModal = ( props ) => {
 						onRequestClose={ onRequestClose }
 					>
 						<VerticalGapLayout>
-							<div>
-								<div className="label">
-									{ __(
-										'If customer is in',
-										'google-listings-and-ads'
-									) }
-								</div>
-								<AudienceCountrySelect
-									onDropdownVisibilityChange={
-										setDropdownVisible
-									}
-									{ ...getInputProps( 'countryCodes' ) }
-								/>
-							</div>
+							<AudienceCountrySelect
+								label={ __(
+									'If customer is in',
+									'google-listings-and-ads'
+								) }
+								onDropdownVisibilityChange={
+									setDropdownVisible
+								}
+								{ ...getInputProps( 'countryCodes' ) }
+							/>
 							<AppInputNumberControl
 								label={ __(
 									'Then the estimated shipping time displayed in the product listing is',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1453.

In this PR, we fix the TreeSelectControl / SupportedCountrySelect label UI so that it is consistent with other input control label UI, i.e. have the same font-size and padding-bottom.

Impacted areas are in the screenshots below.

### Screenshots:

Shipping rate - modification is done in SupportedCountrySelect component, see commit 7f8d8e65c48a6416d63f1b6ad85f46cd3f1ac24a: 

<img width="633" alt="image" src="https://user-images.githubusercontent.com/417342/165969230-7f3fd737-80fd-4018-b8c6-99cd253b9ffa.png">

Note: 

- Minimum order modals also uses SupportedCountrySelect component.
- Shipping time modals in Edit Free Listings also uses SupportedCountrySelect component.

Shipping times add modal in Setup MC - this is impacted because it was not using the SupportedCountrySelect label, I have changed it in 3a5b89d09f4f075dbd3a7e691f5acaa18d5fd0fc:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/417342/165977929-1d3faa3c-3216-4ab9-b2d5-383f278b1fb1.png">

Shipping times edit modal in Setup MC - this is impacted because it was not using the SupportedCountrySelect label, I have changed it in 3a5b89d09f4f075dbd3a7e691f5acaa18d5fd0fc:

<img width="591" alt="image" src="https://user-images.githubusercontent.com/417342/165977998-59a5d6fc-18ab-4b13-b6ba-3aabfc8184a0.png">

Create paid ads campaign - this is impacted because I have removed the unneeded CSS for the campaign form content in 8b47081160893010a80863cc44610aa96edad1ba:

<img width="918" alt="image" src="https://user-images.githubusercontent.com/417342/165969036-cf66ceeb-55b0-46d2-8e9d-dab9020396a4.png">

Edit paid ads campaign - this is impacted because I have removed the unneeded CSS for the campaign form content in 8b47081160893010a80863cc44610aa96edad1ba:

<img width="922" alt="image" src="https://user-images.githubusercontent.com/417342/165968493-48e08637-da34-4e24-bea9-a79a03bc7b3f.png">

### Detailed test instructions:

1. Go to Setup MC Step 3, look into shipping rate add and edit modals, make sure the labels look consistent as per screenshots above.
2. Look into shipping times add modal, make sure the labels look consistent as per "shipping times add modal" screenshots above.
3. Look into shipping times edit modal, make sure the labels look consistent as per "shipping times edit modal" screenshots above.
4. Complete the Setup MC flow, and go to create a new paid ads campaign. The labels should be as per "create paid ads campaign" screenshot above.
5. Go to edit a paid ads campaign. The labels should be as per "edit paid ads campaign" screenshot above.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Label UI for selecting countries (TreeSelectControl / SupportedCountrySelect).