### PR TITLE
Update tested to WordPress 6.0 and WooCommerce 6.5

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -8,11 +8,11 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
  * Requires at least: 5.7
- * Tested up to: 5.9
+ * Tested up to: 6.0
  * Requires PHP: 7.3
  *
  * WC requires at least: 5.8
- * WC tested up to: 6.3
+ * WC tested up to: 6.5
  * Woo:
  *
  * @package WooCommerce\Admin


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Bumping the WooCommerce and WordPress tested up to tags after testing with **WooCommerce 6.5.0-rc.1** and **WordPress 6.0.0-beta.1**.


### Changelog entry

> Tweak - WC 6.5 compatibility.
> Tweak - WordPress 6.0 compatibility.
