### PR TITLE
Fix the position and the focus/blur behavior of help text for TreeSelectControl

### DIFF
--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { noop } from 'lodash';
 import { useRef } from '@wordpress/element';
 
 /**
@@ -24,6 +25,7 @@ import { BACKSPACE } from './constants';
  * @param {Function} props.onFocus On Focus Callback
  * @param {Function} props.onTagsChange Callback when the Tags change
  * @param {Function} props.onInputChange Callback when the Input value changes
+ * @param {Function} [props.onControlClick] Callback when clicking on the control.
  * @return {JSX.Element} The rendered component
  */
 const Control = ( {
@@ -36,6 +38,7 @@ const Control = ( {
 	onFocus = () => {},
 	onTagsChange = () => {},
 	onInputChange = () => {},
+	onControlClick = noop,
 } ) => {
 	const hasTags = tags.length > 0;
 	const showPlaceholder = ! hasTags && ! isExpanded;
@@ -64,8 +67,9 @@ const Control = ( {
 					'has-tags': hasTags,
 				}
 			) }
-			onClick={ () => {
+			onClick={ ( e ) => {
 				inputRef.current.focus();
+				onControlClick( e );
 			} }
 		>
 			{ hasTags && (

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -566,10 +566,6 @@ const TreeSelectControl = ( {
 		<div
 			{ ...focusOutside }
 			onKeyDown={ onKeyDown }
-			onClick={ () => {
-				if ( disabled ) return;
-				setTreeVisible( true );
-			} }
 			className={ classnames(
 				'woocommerce-tree-select-control',
 				className
@@ -590,6 +586,10 @@ const TreeSelectControl = ( {
 				isExpanded={ showTree }
 				onFocus={ () => {
 					setFocused( null );
+					setTreeVisible( true );
+				} }
+				onControlClick={ () => {
+					if ( disabled ) return;
 					setTreeVisible( true );
 				} }
 				instanceId={ instanceId }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -599,11 +599,6 @@ const TreeSelectControl = ( {
 				onTagsChange={ handleTagsChange }
 				onInputChange={ handleOnInputChange }
 			/>
-			{ help && (
-				<div className="woocommerce-tree-select-control__help">
-					{ help }
-				</div>
-			) }
 			{ showTree && (
 				<div
 					className="woocommerce-tree-select-control__tree"
@@ -619,6 +614,11 @@ const TreeSelectControl = ( {
 						onNodesExpandedChange={ setNodesExpanded }
 						onOptionFocused={ handleOptionFocused }
 					/>
+				</div>
+			) }
+			{ help && (
+				<div className="woocommerce-tree-select-control__help">
+					{ help }
 				</div>
 			) }
 		</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1468 

- Move the click event listener that opens the dropdown options from the top container to the Control layer.
- Move the position of help to under the dropdown options.

### Screenshots:

![Kapture 2022-05-03 at 12 51 39](https://user-images.githubusercontent.com/17420811/166405880-d9f13300-c5fd-4c0b-842f-9a44a6f002a0.gif)

### Detailed test instructions:

1. Since there is no existing use case to verify this issue, it suggests adding the `help` prop to the `TreeSelectControl` in the [supported-country-select.js file](https://github.com/woocommerce/google-listings-and-ads/blob/25294743db609a06b62f7819043c9cbc97068346/js/src/components/supported-country-select/supported-country-select.js#L43) as follows when testing.
   ```js
   return (
   	<TreeSelectControl
   		// ... omitted
   		options={ treeOptions }
   		{ ...restProps }
   		help="Can’t find a country? Only supported countries can be selected."
   	/>
   );
   ```
1. Go to the campaign creation page.
1. Click on the country selector to open the dropdown. Check if there is no spacing between the input and dropdown.
1. When the input still has the focus, press ESC key to close the dropdown, and then click on the input. It should open the dropdown.
1. Close the dropdown and click on the help text. It should not open the dropdown.

### Additional details:

Since several control components of `@wordpress/components` and `@wocommerce/components` have the `help` prop and considering TreeSelectControl to be pushed upstream, to make it have a consistent interface, I chose to add in TreeSelectControl when adding `help` before.
- [SelectControl](https://github.com/woocommerce/woocommerce-admin/blob/v2.7.2/packages/components/src/select-control/index.js#L438-L441) (WC)
- [SelectControl](https://github.com/WordPress/gutenberg/tree/%40wordpress/components%4012.0.8/packages/components/src/select-control#help) (WP)
- [CheckboxControl](https://github.com/WordPress/gutenberg/tree/%40wordpress/components%4012.0.8/packages/components/src/checkbox-control#help)
- [RadioControl](https://github.com/WordPress/gutenberg/tree/%40wordpress/components%4012.0.8/packages/components/src/radio-control#help)
- [TextControl](https://github.com/WordPress/gutenberg/tree/%40wordpress/components%4012.0.8/packages/components/src/text-control#help)
- [Form](https://github.com/woocommerce/woocommerce-admin/blob/v2.7.2/packages/components/src/form/index.js#L131) shows error messages via `help` prop


### Changelog entry
