### PR TITLE
Don't include the woo-tracking-jsdoc directory in the bundle zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,7 @@ phpunit.xml.dist export-ignore
 webpack.config.js export-ignore
 webpack-development.config.js export-ignore
 jest.config.js export-ignore
+woo-tracking-jsdoc export-ignore
 wordpress_org_assets export-ignore
 .editorconfig export-ignore
 .externalized.json export-ignore


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Don't include the **woo-tracking-jsdoc** directory in the bundle zip.

### Detailed test instructions:

1. `npm run build`.
2. Check if the **woo-tracking-jsdoc** directory is not included in the google-listings-and-ads.zip file.

### Changelog entry
