### PR TITLE
Move `get_supported_countries_from_continent` method to GoogleHelper

### DIFF
--- a/src/Google/GoogleHelper.php
+++ b/src/Google/GoogleHelper.php
@@ -1339,7 +1339,7 @@ class GoogleHelper implements Service {
 	 */
 	public function get_supported_countries_from_continent( string $continent_code ): array {
 		$countries  = [];
-		$continents = $this->wc->get_wc_countries()->get_continents();
+		$continents = $this->wc->get_continents();
 		if ( isset( $continents[ $continent_code ] ) ) {
 			$countries = $continents[ $continent_code ]['countries'];
 

--- a/src/Google/GoogleHelper.php
+++ b/src/Google/GoogleHelper.php
@@ -1188,7 +1188,7 @@ class GoogleHelper implements Service {
 	 * WooCommerce Countries -> https://github.com/woocommerce/woocommerce/blob/master/i18n/countries.php
 	 * Google Supported Countries -> https://support.google.com/merchants/answer/160637?hl=en
 	 *
-	 * @return string[]
+	 * @return string[] Array of country codes.
 	 */
 	public function get_mc_supported_countries(): array {
 		return array_keys( $this->get_mc_supported_countries_data() );
@@ -1325,6 +1325,32 @@ class GoogleHelper implements Service {
 	 */
 	public function find_subdivision_id_by_code( string $code, string $country_code ): ?int {
 		return self::COUNTRY_SUBDIVISIONS[ $country_code ][ $code ]['id'] ?? null;
+	}
+
+	/**
+	 * Gets the list of supported Merchant Center countries from a continent.
+	 *
+	 * @param string $continent_code
+	 *
+	 * @return string[] Returns an array of country codes with each country code used both as the key and value.
+	 *                  For example: [ 'US' => 'US', 'DE' => 'DE' ].
+	 *
+	 * @since x.x.x
+	 */
+	public function get_supported_countries_from_continent( string $continent_code ): array {
+		$countries  = [];
+		$continents = $this->wc->get_wc_countries()->get_continents();
+		if ( isset( $continents[ $continent_code ] ) ) {
+			$countries = $continents[ $continent_code ]['countries'];
+
+			// Match the list of countries with the list of Merchant Center supported countries.
+			$countries = array_intersect( $countries, $this->get_mc_supported_countries() );
+
+			// Use the country code as array keys.
+			$countries = array_combine( $countries, $countries );
+		}
+
+		return $countries;
 	}
 
 	/**

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -37,6 +37,11 @@ class WC {
 	protected $wc_countries;
 
 	/**
+	 * @var array
+	 */
+	protected $continents;
+
+	/**
 	 * WC constructor.
 	 *
 	 * @param WC_Countries|null $countries

--- a/src/Shipping/ShippingZone.php
+++ b/src/Shipping/ShippingZone.php
@@ -293,7 +293,7 @@ class ShippingZone implements Service {
 					$countries[ $location->code ] = $location->code;
 					break;
 				case 'continent':
-					$countries = array_merge( $countries, $this->get_countries_from_continent( $location->code ) );
+					$countries = array_merge( $countries, $this->google_helper->get_supported_countries_from_continent( $location->code ) );
 					break;
 				case 'state':
 					$country_code               = $this->get_country_of_state( $location->code );
@@ -404,26 +404,6 @@ class ShippingZone implements Service {
 		}
 
 		return $options;
-	}
-
-	/**
-	 * Gets the list of countries from a continent.
-	 *
-	 * @param string $continent_code
-	 *
-	 * @return string[] Returns an array of country codes with each country code used both as the key and value.
-	 *                  For example: [ 'US' => 'US', 'DE' => 'DE' ].
-	 */
-	protected function get_countries_from_continent( string $continent_code ): array {
-		$countries  = [];
-		$continents = $this->wc->get_wc_countries()->get_continents();
-		if ( isset( $continents[ $continent_code ] ) ) {
-			$countries = $continents[ $continent_code ]['countries'];
-			// Use the country code as array keys.
-			$countries = array_combine( $countries, $countries );
-		}
-
-		return $countries;
 	}
 
 	/**

--- a/tests/Unit/Google/GoogleHelperTest.php
+++ b/tests/Unit/Google/GoogleHelperTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
+use WC_Countries;
 
 /**
  * Class GoogleHelperTest
@@ -89,6 +90,43 @@ class GoogleHelperTest extends UnitTest {
 
 		// If there are no subdivision codes for the country code.
 		$this->assertNull( $this->google_helper->find_subdivision_id_by_code( 'OR', 'LB' ) );
+	}
+
+	public function test_returns_supported_countries_from_continent() {
+		// Mock the WC_Countries class to return the list of countries for the EU continent.
+		$wc_countries = $this->createMock( WC_Countries::class );
+		$wc_countries->expects( $this->any() )
+					 ->method( 'get_continents' )
+					 ->willReturn( [
+						 'EU' => [
+							 'name'      => 'Europe',
+							 'countries' => [
+								 // A random country code, not supported by Merchant Center. This should be ignored.
+								 'OO1',
+								 // Another random country code, not supported by Merchant Center. This should be ignored.
+								 'OO2',
+								 // Countries supported by MC
+								 'GB',
+								 'FR',
+								 'DE',
+								 'DK',
+								 // And many more ...
+							 ],
+						 ],
+					 ] );
+		$this->wc->expects( $this->any() )
+				 ->method( 'get_wc_countries' )
+				 ->willReturn( $wc_countries );
+
+		$this->assertEqualSets(
+			[
+				'GB',
+				'FR',
+				'DE',
+				'DK',
+			],
+			$this->google_helper->get_supported_countries_from_continent( 'EU' )
+		);
 	}
 
 	/**

--- a/tests/Unit/Google/GoogleHelperTest.php
+++ b/tests/Unit/Google/GoogleHelperTest.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
-use WC_Countries;
 
 /**
  * Class GoogleHelperTest
@@ -94,29 +93,25 @@ class GoogleHelperTest extends UnitTest {
 
 	public function test_returns_supported_countries_from_continent() {
 		// Mock the WC_Countries class to return the list of countries for the EU continent.
-		$wc_countries = $this->createMock( WC_Countries::class );
-		$wc_countries->expects( $this->any() )
-					 ->method( 'get_continents' )
-					 ->willReturn( [
-						 'EU' => [
-							 'name'      => 'Europe',
-							 'countries' => [
-								 // A random country code, not supported by Merchant Center. This should be ignored.
-								 'OO1',
-								 // Another random country code, not supported by Merchant Center. This should be ignored.
-								 'OO2',
-								 // Countries supported by MC
-								 'GB',
-								 'FR',
-								 'DE',
-								 'DK',
-								 // And many more ...
-							 ],
-						 ],
-					 ] );
 		$this->wc->expects( $this->any() )
-				 ->method( 'get_wc_countries' )
-				 ->willReturn( $wc_countries );
+				 ->method( 'get_continents' )
+				 ->willReturn( [
+					 'EU' => [
+						 'name'      => 'Europe',
+						 'countries' => [
+							 // A random country code, not supported by Merchant Center. This should be ignored.
+							 'OO1',
+							 // Another random country code, not supported by Merchant Center. This should be ignored.
+							 'OO2',
+							 // Countries supported by MC
+							 'GB',
+							 'FR',
+							 'DE',
+							 'DK',
+							 // And many more ...
+						 ],
+					 ],
+				 ] );
 
 		$this->assertEqualSets(
 			[

--- a/tests/Unit/Shipping/ShippingZoneTest.php
+++ b/tests/Unit/Shipping/ShippingZoneTest.php
@@ -8,7 +8,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
-use WC_Countries;
 use WC_Shipping_Flat_Rate;
 use WC_Shipping_Free_Shipping;
 use WC_Shipping_Method;
@@ -19,9 +18,9 @@ use WC_Shipping_Zone;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
  *
- * @property MockObject|WC $wc
- * @property GoogleHelper  $google_helper
- * @property ShippingZone  $shipping_zone
+ * @property MockObject|WC           $wc
+ * @property MockObject|GoogleHelper $google_helper
+ * @property ShippingZone            $shipping_zone
  */
 class ShippingZoneTest extends UnitTest {
 
@@ -342,29 +341,15 @@ class ShippingZoneTest extends UnitTest {
 					 return $zone;
 				 } );
 
-		// Mock the WC_Countries class to return the list of countries for the EU continent.
-		$wc_countries = $this->createMock( WC_Countries::class );
-		$wc_countries->expects( $this->any() )
-					 ->method( 'get_continents' )
-					 ->willReturn( [
-						 'EU' => [
-							 'name'      => 'Europe',
-							 'countries' => [
-								 // A random country code, not supported by Merchant Center. This should be ignored.
-								 'OO1',
-								 // Another random country code, not supported by Merchant Center. This should be ignored.
-								 'OO2',
-								 'GB',
-								 'FR',
-								 'DE',
-								 'DK',
-								 // And many more ...
-							 ],
-						 ],
-					 ] );
-		$this->wc->expects( $this->any() )
-				 ->method( 'get_wc_countries' )
-				 ->willReturn( $wc_countries );
+		// Mock the GoogleHelper class to return the list of supported countries for the EU continent.
+		$this->google_helper->expects( $this->any() )
+							->method( 'get_supported_countries_from_continent' )
+							->willReturn( [
+								'GB',
+								'FR',
+								'DE',
+								'DK',
+							] );
 
 		$this->assertEqualSets(
 			[
@@ -1140,7 +1125,17 @@ class ShippingZoneTest extends UnitTest {
 				 ->method( 'get_woocommerce_currency' )
 				 ->willReturn( 'USD' );
 
-		$this->google_helper = new GoogleHelper( $this->wc );
+		$this->google_helper = $this->createMock( GoogleHelper::class );
+		// Mock Merchant Center supported countries.
+		$this->google_helper->expects( $this->any() )
+							->method( 'get_mc_supported_countries' )
+							->willReturn( [
+								'US',
+								'GB',
+								'FR',
+								'DE',
+								'DK',
+							] );
 
 		$this->shipping_zone = new ShippingZone( $this->wc, $this->google_helper );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1351.

This PR moves the `get_supported_countries_from_continent` method, which was previously implemented in `ShippingZone` class to get the list of countries from a continent, to the `GoogleHelper` class. This allows it to be reused by other classes.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Nothing much to test except running the related unit tests and confirming that they pass

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Add helper class to obtain supported countries of a continent
