### PR TITLE
Fix the comparison of target audience to avoid the unsaved prompt showing when the country sets are the same

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -121,7 +121,13 @@ export default function EditFreeCampaign() {
 	const { createNotice } = useDispatchCoreNotices();
 
 	// Check what've changed to show prompt, and send requests only to save changed things.
-	const didAudienceChanged = ! isEqual( targetAudience, savedTargetAudience );
+	const didAudienceChanged = ! isEqual(
+		...[ targetAudience, savedTargetAudience ].map( ( el ) => ( {
+			...el,
+			countries: new Set( el?.countries ),
+		} ) )
+	);
+
 	const didSettingsChanged = ! isEqual( settings, savedSettings );
 	const didRatesChanged = hasUnsavedShippingRates(
 		shippingRates,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1431 

- When checking if there are unsaved target audiences, the `countries` array values are compared by whether the value sets are the same.

### Screenshots:

https://user-images.githubusercontent.com/17420811/166906096-4bf8f897-d4fa-4e87-b9d0-0637efe0c848.mp4

### Detailed test instructions:

1. Go to step 1 of the editing free listings page.
   - If there is only one target audience country, it will need to add another one here and save data in step 2, and then go back to step 1.
1. To make the different order of values at the subsequence step, delete the first country, e.g. Japan.
1. Try to reload the page or click on the top left "go back" button. It should pop up a prompt that there are unsaved data.
1. Add back the removed country, e.g. Japan.
1. Try to reload the page or click on the top left "go back" button. It should not pop up the prompt.

### Changelog entry

> Fix - The unsaved prompt might pop up when the countries of the target audience are the same when navigating away from the free listings edit page.
