### PR TITLE
Revert filtering only Shopping destination for account issues

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -204,13 +204,7 @@ class Merchant implements OptionsAwareInterface {
 		$id = $id ?: $this->options->get_merchant_id();
 
 		try {
-			$mc_account_status = $this->service->accountstatuses->get(
-				$id,
-				$id,
-				[
-					'destinations' => 'Shopping',
-				]
-			);
+			$mc_account_status = $this->service->accountstatuses->get( $id, $id );
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
 			throw new Exception( __( 'Unable to retrieve Merchant Center account status.', 'google-listings-and-ads' ), $e->getCode() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In PR #1312 we added some logic to filter the request to `accountstatuses` to only Shopping. However it appears that there are certain circumstances where there are no Shopping errors available. For example when they haven't connected an Ads account yet.

Destinations in this context are equivalent to Google Shopping programs.
- Shopping = Shopping Ads
- SurfacesAcrossGoogle = Free Listings

In the same PR we also added functionality to combine the account issues by title and even if it finds duplicate countries it uses `array_unique` to make them unique. So it's not strictly necessary to filter the errors to only a specific destination. So in this PR we revert the destinations filter so it returns both types of errors. Any duplicate issues will be combined by title so they will only be stored once in the table `wp_gla_merchant_issues`.

Closes #1462 

### Detailed test instructions:
I'm not able to reproduce the original error mentioned in issue #1462, even with an account that doesn't have an Ads account linked I receive a 200 response with a list of account issues (regardless of whether I filter for a destination or not):
```json
  "accountLevelIssues": [
    {
      "id": "merchant_quality_low",
      "title": "Account isn't eligible for enhanced free listings",
      "severity": "error",
      "documentation": "https://support.google.com/merchants/answer/9849758"
    },
    {
      "id": "missing_ad_words_link",
      "title": "No Google Ads account linked",
      "severity": "error",
      "documentation": "https://support.google.com/merchants/answer/6159060"
    },
```

1. Go to https://developers.google.com/shopping-content/reference/rest/v2.1/accountstatuses/get and test the request with an account that has multiple issues (add same account ID to both ID fields)
2. Confirm that we get multiple account issues (with duplicates for Shopping and SurfacesAcrossGoogle)
3. Clear the status cache on the Connection Test page
4. View the Product Feed page and wait for it to refresh the list of issues
5. Confirm that we don't have any duplicate issues

### Changelog entry
* Fix - Revert filtering only Shopping destination for account issues
