### PR TITLE
Fix edit shipping rate modal disappears after auto-save shipping rate in Setup MC

### DIFF
--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
@@ -21,7 +21,6 @@ import getHandlers from './getHandlers';
 /**
  * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
  * @typedef { import(".~/data/actions").CountryCode } CountryCode
- * @typedef { import("./typedefs").ShippingRateGroup } ShippingRateGroup
  */
 
 /**

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
@@ -14,7 +14,7 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import groupShippingRatesByMethodCurrencyRate from './groupShippingRatesByMethodCurrencyRate';
 import ShippingRateInputControl from './shipping-rate-input-control';
-import { AddRateFormModal, EditRateFormModal } from './rate-form-modals';
+import { AddRateFormModal } from './rate-form-modals';
 import { SHIPPING_RATE_METHOD } from '.~/constants';
 import getHandlers from './getHandlers';
 
@@ -46,33 +46,6 @@ export default function EstimatedShippingRatesCard( {
 	} = getHandlers( { value, onChange } );
 
 	/**
-	 * An Edit button that displays EditRateFormModal to edit shipping rate group upon clicking on the Edit button.
-	 *
-	 * @param {Object} props Props.
-	 * @param {Array<CountryCode>} props.countryOptions Country options to be passed to EditRateFormModal.
-	 * @param {ShippingRateGroup} props.group Shipping rate group to be edited.
-	 */
-	const GroupEditModalButton = ( { countryOptions, group } ) => {
-		return (
-			<AppButtonModalTrigger
-				button={
-					<Button isTertiary>
-						{ __( 'Edit', 'google-listings-and-ads' ) }
-					</Button>
-				}
-				modal={
-					<EditRateFormModal
-						countryOptions={ countryOptions }
-						initialValues={ group }
-						onSubmit={ getChangeHandler( group ) }
-						onDelete={ getDeleteHandler( group ) }
-					/>
-				}
-			/>
-		);
-	};
-
-	/**
 	 * Function to render the shipping rate groups from `value`.
 	 *
 	 * If there is no group, we render a `ShippingRateInputControl`
@@ -95,14 +68,10 @@ export default function EstimatedShippingRatesCard( {
 
 			return (
 				<ShippingRateInputControl
-					labelButton={
-						<GroupEditModalButton
-							countryOptions={ audienceCountries }
-							group={ prefilledGroup }
-						/>
-					}
+					countryOptions={ audienceCountries }
 					value={ prefilledGroup }
 					onChange={ getChangeHandler( prefilledGroup ) }
+					onDelete={ getDeleteHandler( prefilledGroup ) }
 				/>
 			);
 		}
@@ -126,14 +95,10 @@ export default function EstimatedShippingRatesCard( {
 					return (
 						<ShippingRateInputControl
 							key={ group.countries.join( '-' ) }
-							labelButton={
-								<GroupEditModalButton
-									countryOptions={ audienceCountries }
-									group={ group }
-								/>
-							}
+							countryOptions={ audienceCountries }
 							value={ group }
 							onChange={ getChangeHandler( group ) }
+							onDelete={ getDeleteHandler( group ) }
 						/>
 					);
 				} ) }

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/shipping-rate-input-control.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/shipping-rate-input-control.js
@@ -26,7 +26,7 @@ import './shipping-rate-input-control.scss';
  * This is meant to display an "Edit" button.
  *
  * @param {Object} props
- * @param {Array<CountryCode>} props.countryOptions Country options to be passed to EditMinimumOrderFormModal.
+ * @param {Array<CountryCode>} props.countryOptions Country options to be passed to EditRateFormModal.
  * @param {ShippingRateGroup} props.value Shipping rate group value.
  * @param {(newGroup: ShippingRateGroup) => void} props.onChange Called when shipping rate group changes.
  * @param {() => void} props.onDelete Called when delete button in EditRateFormModal is clicked.

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/shipping-rate-input-control.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/shipping-rate-input-control.js
@@ -3,12 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Pill } from '@woocommerce/components';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import AppInputPriceControl from '.~/components/app-input-price-control';
+import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
+import AppButton from '.~/components/app-button';
+import { EditRateFormModal } from './rate-form-modals';
 import ShippingRateInputControlLabelText from './shipping-rate-input-control-label-text';
 import './shipping-rate-input-control.scss';
 
@@ -24,14 +26,16 @@ import './shipping-rate-input-control.scss';
  * This is meant to display an "Edit" button.
  *
  * @param {Object} props
- * @param {JSX.Element} props.labelButton Button to be displayed after the label text.
+ * @param {Array<CountryCode>} props.countryOptions Country options to be passed to EditMinimumOrderFormModal.
  * @param {ShippingRateGroup} props.value Shipping rate group value.
  * @param {(newGroup: ShippingRateGroup) => void} props.onChange Called when shipping rate group changes.
+ * @param {() => void} props.onDelete Called when delete button in EditRateFormModal is clicked.
  */
 const ShippingRateInputControl = ( {
-	labelButton,
+	countryOptions,
 	value,
-	onChange = noop,
+	onChange,
+	onDelete,
 } ) => {
 	const { countries, currency, rate } = value;
 
@@ -54,7 +58,21 @@ const ShippingRateInputControl = ( {
 						<ShippingRateInputControlLabelText
 							countries={ countries }
 						/>
-						{ labelButton }
+						<AppButtonModalTrigger
+							button={
+								<AppButton isTertiary>
+									{ __( 'Edit', 'google-listings-and-ads' ) }
+								</AppButton>
+							}
+							modal={
+								<EditRateFormModal
+									countryOptions={ countryOptions }
+									initialValues={ value }
+									onSubmit={ onChange }
+									onDelete={ onDelete }
+								/>
+							}
+						/>
 					</div>
 				}
 				suffix={ currency }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1483.

This PR fixes the issue of shipping rate modal disappearing after auto-save in Setup MC. This is done by moving the `EditRateFormModal` back into `ShippingRateInputControl`; it was previously moved out in PR https://github.com/woocommerce/google-listings-and-ads/pull/1424.

### Screenshots:

📹 Demo video:

https://user-images.githubusercontent.com/417342/167009758-7efe7126-339c-454e-8cea-06845eb94b5f.mov

### Detailed test instructions:

1. Open browser dev tools network panel to observe this auto-save shipping rate network call. You can use the dev tools to change the network speed throttling.
2. Go to Setup MC shipping rate section.
3. Change a shipping rate. This should trigger the shipping rate auto-save.
4. Before the auto-save shipping rate API call is completed, open the edit shipping rate modal by clicking on an edit button.
5. When the auto-save shipping rate API call is completed, the edit shipping rate modal should remain open and should not disappear.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Edit shipping rate modal disappears after auto-save shipping rate in Setup MC.
