### PR TITLE
Use a shared helper method to get supported countries of a continent for /mc/countries API

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/SupportedCountriesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SupportedCountriesController.php
@@ -123,17 +123,9 @@ class SupportedCountriesController extends BaseController {
 	 */
 	protected function get_supported_continents(): array {
 		$all_continents = $this->wc->get_continents();
-		$mc_countries   = $this->google_helper->get_mc_supported_countries();
 
-		// TODO: Create a shared function to get supported countries from a continent
-		// in GoogleHelper afer the below PR is merged into develop.
-		// https://github.com/woocommerce/google-listings-and-ads/pull/1341
 		foreach ( $all_continents as $continent_code => $continent ) {
-			$countries_of_continent           = $continent['countries'];
-			$supported_countries_of_continent = array_intersect(
-				$countries_of_continent,
-				$mc_countries
-			);
+			$supported_countries_of_continent = $this->google_helper->get_supported_countries_from_continent( $continent_code );
 
 			if ( empty( $supported_countries_of_continent ) ) {
 				unset( $all_continents[ $continent_code ] );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SupportedCountriesControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SupportedCountriesControllerTest.php
@@ -56,11 +56,11 @@ class SupportedCountriesControllerTest extends RESTControllerUnitTest {
 					'name'     => 'United States',
 					'currency' => 'USD',
 				],
-				'GB' =>[
+				'GB' => [
 					'name'     => 'United Kingdom',
 					'currency' => 'GBP',
 				],
-				'TW' =>[
+				'TW' => [
 					'name'     => 'Taiwan',
 					'currency' => 'TWD',
 				],
@@ -139,11 +139,11 @@ class SupportedCountriesControllerTest extends RESTControllerUnitTest {
 					'name'     => 'United States',
 					'currency' => 'USD',
 				],
-				'GB' =>[
+				'GB' => [
 					'name'     => 'United Kingdom',
 					'currency' => 'GBP',
 				],
-				'TW' =>[
+				'TW' => [
 					'name'     => 'Taiwan',
 					'currency' => 'TWD',
 				],

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SupportedCountriesControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SupportedCountriesControllerTest.php
@@ -93,12 +93,6 @@ class SupportedCountriesControllerTest extends RESTControllerUnitTest {
 			'CN' => 'China',
 		];
 
-		$mc_supported_countries = [
-			'US',
-			'GB',
-			'TW',
-		];
-
 		$mc_supported_countries_currencies_data = [
 			'US' => 'USD',
 			'GB' => 'GBP',
@@ -131,6 +125,12 @@ class SupportedCountriesControllerTest extends RESTControllerUnitTest {
 					'CN',
 				],
 			],
+		];
+
+		$supported_countries_of_continent = [
+			'EU' => [ 'GB' => 'GB' ],
+			'NA' => [ 'US' => 'US' ],
+			'AS' => [ 'TW' => 'TW' ],
 		];
 
 		$expected = [
@@ -174,17 +174,21 @@ class SupportedCountriesControllerTest extends RESTControllerUnitTest {
 			->method( 'get_countries' )
 			->willReturn( $countries_data );
 
+		$this->google_helper->expects( $this->once() )
+			->method( 'get_mc_supported_countries_currencies' )
+			->willReturn( $mc_supported_countries_currencies_data );
+
 		$this->wc->expects( $this->once() )
 			->method( 'get_continents' )
 			->willReturn( $continents_data );
 
-		$this->google_helper->expects( $this->once() )
-			->method( 'get_mc_supported_countries' )
-			->willReturn( $mc_supported_countries );
-
-		$this->google_helper->expects( $this->once() )
-			->method( 'get_mc_supported_countries_currencies' )
-			->willReturn( $mc_supported_countries_currencies_data );
+		$this->google_helper->expects( $this->exactly( 3 ) )
+			->method( 'get_supported_countries_from_continent' )
+			->willReturnOnConsecutiveCalls(
+				$supported_countries_of_continent['EU'],
+				$supported_countries_of_continent['NA'],
+				$supported_countries_of_continent['AS']
+			);
 
 		$response = $this->do_request( self::ROUTE, 'GET', $countries_params );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #1351 and a follow-up of #1476, this PR updates the codes in `/mc/countries` API to use a shared helper method in GoogleHelper in order to get supported countries of a continent.

### Detailed test instructions:

1. Request to the API `/mc/countries`, the response should remain unchanged before this PR.
2. Run the unit tests, the test results should be passed.

### Changelog entry

> Update - Use a shared helper method to get supported countries of a continent for /mc/countries API
