### PR TITLE
GMC Request Review - Request a review frontend

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -929,3 +929,25 @@ export function* updateMCProductVisibility( ids, visible ) {
 		throw error;
 	}
 }
+
+/**
+ * Request a new review for the connected account
+ */
+export function* mcRequestReview() {
+	try {
+		const response = yield apiFetch( {
+			path: `${ API_NAMESPACE }/mc/request-review`,
+		} );
+
+		return {
+			type: TYPES.RECEIVE_MC_REVIEW_REQUEST,
+			response,
+		};
+	} catch ( error ) {
+		yield handleFetchError(
+			error,
+			__( 'Unable to request a new review.', 'google-listings-and-ads' )
+		);
+		throw error;
+	}
+}

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -941,13 +941,10 @@ export function* mcRequestReview() {
 
 		return {
 			type: TYPES.RECEIVE_MC_REVIEW_REQUEST,
-			response,
+			mcReviewRequest: response,
 		};
 	} catch ( error ) {
-		yield handleFetchError(
-			error,
-			__( 'Unable to request a new review.', 'google-listings-and-ads' )
-		);
+		yield handleFetchError( error, error?.message );
 		throw error;
 	}
 }

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -950,7 +950,7 @@ export function* sendMCReviewRequest() {
 			method: 'POST',
 		} );
 
-		return receiveMCReviewRequest( response );
+		return yield receiveMCReviewRequest( response );
 	} catch ( error ) {
 		yield handleFetchError( error, error?.message );
 		throw error;

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -63,6 +63,16 @@ export function handleFetchError( error, message ) {
  */
 
 /**
+ * Account status data. Indicates the current status for the Google MC account.
+ *
+ * @typedef {Object} AccountStatus
+ * @property {string} status Account status. See the available statuses here https://developers.google.com/shopping-content/reference/rest/v2.1/State
+ * @property {number} cooldown Cooldown period timestamp indicating how long the user should wait until the next request
+ * @property {Array} issues List of issue keys for this accoun
+ * @property {Array} reviewEligibleRegions List of region codes available for review
+ */
+
+/**
  *
  * @return {Array<ShippingRate>} Array of individual shipping rates.
  */

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -68,7 +68,7 @@ export function handleFetchError( error, message ) {
  * @typedef {Object} AccountStatus
  * @property {string} status Account status. See the available statuses here https://developers.google.com/shopping-content/reference/rest/v2.1/State
  * @property {number} cooldown Cooldown period timestamp indicating how long the user should wait until the next request
- * @property {Array} issues List of issue keys for this accoun
+ * @property {Array} issues List of issue keys for this account
  * @property {Array} reviewEligibleRegions List of region codes available for review
  */
 

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -933,16 +933,14 @@ export function* updateMCProductVisibility( ids, visible ) {
 /**
  * Request a new review for the connected account
  */
-export function* mcRequestReview() {
+export function* sendMCReviewRequest() {
 	try {
 		const response = yield apiFetch( {
-			path: `${ API_NAMESPACE }/mc/request-review`,
+			path: `${ API_NAMESPACE }/mc/review`,
+			method: 'POST',
 		} );
 
-		return {
-			type: TYPES.RECEIVE_MC_REVIEW_REQUEST,
-			mcReviewRequest: response,
-		};
+		return receiveMCReviewRequest( response );
 	} catch ( error ) {
 		yield handleFetchError( error, error?.message );
 		throw error;

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -41,6 +41,7 @@ const DEFAULT_STATE = {
 		status: null,
 		cooldown: null,
 		issues: null,
+		reviewEligibleRegions: [],
 	},
 	mc_product_feed: null,
 	report: {},

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -43,6 +43,7 @@ describe( 'reducer', () => {
 				issues: null,
 				cooldown: null,
 				status: null,
+				reviewEligibleRegions: [],
 			},
 			mc_product_statistics: null,
 			mc_issues: {

--- a/js/src/product-feed/issues-table-card/index.scss
+++ b/js/src/product-feed/issues-table-card/index.scss
@@ -24,7 +24,7 @@
 			margin-bottom: $grid-unit-20;
 			width: $grid-unit-50;
 			height: $grid-unit-50;
-			color: darken($gray-400, 6.5%);
+			color: color.adjust($gray-400, $lightness: -6.5%);
 			font-size: $grid-unit-50;
 		}
 

--- a/js/src/product-feed/product-statistics/index.scss
+++ b/js/src/product-feed/product-statistics/index.scss
@@ -58,7 +58,6 @@
 				.gla-success {
 					fill: $gla-color-green;
 				}
-
 			}
 
 			.gla-status__label {
@@ -80,7 +79,6 @@
 					margin: 0 $grid-unit-10;
 				}
 			}
-
 		}
 
 		.gridicon {

--- a/js/src/product-feed/review-request/index.js
+++ b/js/src/product-feed/review-request/index.js
@@ -17,6 +17,17 @@ import './index.scss';
 
 const showNotice = ( status ) => !! REVIEW_STATUSES[ status ]?.title;
 
+/**
+ * @typedef { import(".~/data/actions").AccountStatus } AccountStatus
+ */
+
+/**
+ * @fires gla_modal_closed with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
+ * @fires gla_modal_open with `context: REQUEST_REVIEW`
+ *
+ * @param {Object} props Component props
+ * @param {AccountStatus} props.account Account object
+ */
 const ReviewRequest = ( { account = {} } ) => {
 	const [ modalActive, setModalActive ] = useState( false );
 	const activeIssueType = useActiveIssueType();

--- a/js/src/product-feed/review-request/index.js
+++ b/js/src/product-feed/review-request/index.js
@@ -35,7 +35,7 @@ const ReviewRequest = ( { account = {} } ) => {
 	if (
 		! mcDataHasFinishedResolution ||
 		! hasFinishedResolution ||
-		! showNotice( accountData.status ) ||
+		! showNotice( accountData?.status ) ||
 		activeIssueType !== ISSUE_TYPE_ACCOUNT
 	) {
 		return null;
@@ -63,7 +63,7 @@ const ReviewRequest = ( { account = {} } ) => {
 				createNotice(
 					'success',
 					__(
-						'Account review was successfully requested.',
+						'Your account review was successfully requested.',
 						'google-listings-and-ads'
 					)
 				);
@@ -71,15 +71,8 @@ const ReviewRequest = ( { account = {} } ) => {
 			} )
 			.catch( ( error ) => {
 				recordEvent( 'gla_request_review_failure', {
-					error: error.toString(),
+					error: error?.message,
 				} );
-				createNotice(
-					'error',
-					__(
-						'And error happened processing the account request review.',
-						'google-listings-and-ads'
-					)
-				);
 			} );
 	};
 

--- a/js/src/product-feed/review-request/index.js
+++ b/js/src/product-feed/review-request/index.js
@@ -26,7 +26,7 @@ const showNotice = ( status ) => !! REVIEW_STATUSES[ status ]?.title;
  * @fires gla_modal_open with `context: REQUEST_REVIEW`
  *
  * @param {Object} props Component props
- * @param {AccountStatus} props.account Account object
+ * @param { { isResolving: boolean, hasFinishedResolution: boolean, data: AccountStatus, invalidateResolution: Function } } props.account Account data payload coming from the data store.
  */
 const ReviewRequest = ( { account = {} } ) => {
 	const [ modalActive, setModalActive ] = useState( false );
@@ -41,7 +41,7 @@ const ReviewRequest = ( { account = {} } ) => {
 	if (
 		! mcDataHasFinishedResolution ||
 		! hasFinishedResolution ||
-		! showNotice( accountData?.status ) ||
+		! showNotice( accountData.status ) ||
 		activeIssueType !== ISSUE_TYPE_ACCOUNT
 	) {
 		return null;

--- a/js/src/product-feed/review-request/index.js
+++ b/js/src/product-feed/review-request/index.js
@@ -3,14 +3,11 @@
  */
 import { useState } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
 import useActiveIssueType from '.~/hooks/useActiveIssueType';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import ReviewRequestModal from './review-request-modal';
 import ReviewRequestNotice from './review-request-notice';
 import { ISSUE_TYPE_ACCOUNT, REQUEST_REVIEW } from '.~/constants';
@@ -23,8 +20,6 @@ const showNotice = ( status ) => !! REVIEW_STATUSES[ status ]?.title;
 const ReviewRequest = ( { account = {} } ) => {
 	const [ modalActive, setModalActive ] = useState( false );
 	const activeIssueType = useActiveIssueType();
-	const { mcRequestReview } = useAppDispatch();
-	const { createNotice } = useDispatchCoreNotices();
 
 	const {
 		data: mcData,
@@ -54,28 +49,6 @@ const ReviewRequest = ( { account = {} } ) => {
 		} );
 	};
 
-	const handleReviewRequest = () => {
-		handleModalClose( 'confirm-request-review' );
-		recordEvent( 'gla_request_review' );
-
-		mcRequestReview()
-			.then( () => {
-				createNotice(
-					'success',
-					__(
-						'Your account review was successfully requested.',
-						'google-listings-and-ads'
-					)
-				);
-				recordEvent( 'gla_request_review_success' );
-			} )
-			.catch( ( error ) => {
-				recordEvent( 'gla_request_review_failure', {
-					error: error?.message,
-				} );
-			} );
-	};
-
 	return (
 		<div className="gla-review-request">
 			<ReviewRequestModal
@@ -84,7 +57,6 @@ const ReviewRequest = ( { account = {} } ) => {
 				) }
 				isActive={ modalActive }
 				onClose={ handleModalClose }
-				onSendRequest={ handleReviewRequest }
 			/>
 			<ReviewRequestNotice
 				account={ accountData }

--- a/js/src/product-feed/review-request/index.test.js
+++ b/js/src/product-feed/review-request/index.test.js
@@ -44,7 +44,7 @@ describe( 'Request Review Component', () => {
 				<ReviewRequest
 					account={ {
 						hasFinishedResolution: true,
-						data: { status },
+						data: { status, reviewEligibleRegions: [] },
 					} }
 				/>
 			);

--- a/js/src/product-feed/review-request/index.test.js
+++ b/js/src/product-feed/review-request/index.test.js
@@ -53,7 +53,11 @@ describe( 'Request Review Component', () => {
 				<ReviewRequest
 					account={ {
 						hasFinishedResolution: true,
-						data: { status, issues: [ '#1', '#2' ] },
+						data: {
+							status,
+							issues: [ '#1', '#2' ],
+							reviewEligibleRegions: [ 'US' ],
+						},
 					} }
 				/>
 			);

--- a/js/src/product-feed/review-request/index.test.js
+++ b/js/src/product-feed/review-request/index.test.js
@@ -16,6 +16,13 @@ jest.mock( '@woocommerce/tracks', () => {
 	};
 } );
 
+jest.mock( '.~/hooks/useDispatchCoreNotices', () => ( {
+	__esModule: true,
+	default: jest.fn().mockName( 'useDispatchCoreNotices' ).mockReturnValue( {
+		createNotice: jest.fn(),
+	} ),
+} ) );
+
 /**
  * External dependencies
  */

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -96,15 +96,13 @@ const ReviewRequestModal = ( {
 						'google-listings-and-ads'
 					)
 				);
-
-				onClose( 'request-review-success' );
+				setIsRequestingReview( false );
 				recordEvent( 'gla_request_review_success' );
+				onClose( 'request-review-success' );
 			} )
 			.catch( () => {
-				recordEvent( 'gla_request_review_failure' );
-			} )
-			.finally( () => {
 				setIsRequestingReview( false );
+				recordEvent( 'gla_request_review_failure' );
 			} );
 	};
 

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -17,8 +17,38 @@ import { useAppDispatch } from '.~/data';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 
 /**
+ * Triggered when request review button is clicked
+ *
+ * @event gla_request_review
+ */
+
+/**
+ * Triggered when the request review is successful
+ *
+ * @event gla_request_review_success
+ */
+
+/**
+ * Triggered when the request review fails
+ *
+ * @event gla_request_review_failure
+ */
+
+/**
+ * Triggered when clicking on the checkbox
+ *
+ * @property {'check'|'uncheck'} action Indicates if the checkbox is checked or unchecked
+ * @event gla_request_review_issues_solved_checkbox_click
+ */
+
+/**
  * Render a modal showing the issues list and a notice with a remind for
  * the user to review those issues before requesting the review.
+ *
+ * @fires gla_request_review_issues_solved_checkbox_click with `action: 'checked' | 'unchecked'
+ * @fires gla_request_review
+ * @fires gla_request_review_success
+ * @fires gla_request_review_failure
  *
  * @param {Object} props Component props
  * @param {Object[]} [props.issues=[]] Array with issues

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -96,7 +96,6 @@ const ReviewRequestModal = ( {
 						'google-listings-and-ads'
 					)
 				);
-				setIsRequestingReview( false );
 				recordEvent( 'gla_request_review_success' );
 				onClose( 'request-review-success' );
 			} )

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -62,7 +62,7 @@ const ReviewRequestModal = ( {
 					)
 				);
 				setIsRequestingReview( false );
-				onClose( 'request-success' );
+				onClose( 'request-review-success' );
 				recordEvent( 'gla_request_review_success' );
 			} )
 			.catch( ( error ) => {

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -62,12 +62,17 @@ const ReviewRequestModal = ( {
 } ) => {
 	const [ checkBoxChecked, setCheckBoxChecked ] = useState( false );
 	const [ isRequestingReview, setIsRequestingReview ] = useState( false );
-	const { mcRequestReview } = useAppDispatch();
+	const { sendMCReviewRequest } = useAppDispatch();
 	const { createNotice } = useDispatchCoreNotices();
 
 	if ( ! isActive ) {
 		return null;
 	}
+
+	const handleOnClose = ( action ) => {
+		if ( isRequestingReview ) return;
+		onClose( action );
+	};
 
 	const handleCheckboxChange = ( checked ) => {
 		setCheckBoxChecked( checked );
@@ -82,7 +87,7 @@ const ReviewRequestModal = ( {
 		setIsRequestingReview( true );
 		recordEvent( 'gla_request_review' );
 
-		mcRequestReview()
+		sendMCReviewRequest()
 			.then( () => {
 				createNotice(
 					'success',
@@ -91,12 +96,15 @@ const ReviewRequestModal = ( {
 						'google-listings-and-ads'
 					)
 				);
-				setIsRequestingReview( false );
+
 				onClose( 'request-review-success' );
 				recordEvent( 'gla_request_review_success' );
 			} )
 			.catch( () => {
 				recordEvent( 'gla_request_review_failure' );
+			} )
+			.finally( () => {
+				setIsRequestingReview( false );
 			} );
 	};
 
@@ -109,7 +117,7 @@ const ReviewRequestModal = ( {
 					key="secondary"
 					isSecondary
 					onClick={ () => {
-						onClose( 'maybe-later' );
+						handleOnClose( 'maybe-later' );
 					} }
 				>
 					{ __( 'Cancel', 'google-listings-and-ads' ) }
@@ -128,7 +136,7 @@ const ReviewRequestModal = ( {
 				</AppButton>,
 			] }
 			onRequestClose={ () => {
-				onClose( 'dismiss' );
+				handleOnClose( 'dismiss' );
 			} }
 		>
 			<Notice

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -65,10 +65,8 @@ const ReviewRequestModal = ( {
 				onClose( 'request-review-success' );
 				recordEvent( 'gla_request_review_success' );
 			} )
-			.catch( ( error ) => {
-				recordEvent( 'gla_request_review_failure', {
-					error: error?.message,
-				} );
+			.catch( () => {
+				recordEvent( 'gla_request_review_failure' );
 			} );
 	};
 

--- a/js/src/product-feed/review-request/review-request-modal.test.js
+++ b/js/src/product-feed/review-request/review-request-modal.test.js
@@ -20,7 +20,7 @@ jest.mock( '.~/data', () => ( {
 	__esModule: true,
 	useAppDispatch: jest.fn( () => {
 		return {
-			mcRequestReview: jest.fn( () => Promise.resolve() ),
+			sendMCReviewRequest: jest.fn( () => Promise.resolve() ),
 		};
 	} ),
 } ) );
@@ -147,7 +147,7 @@ describe( 'Request Review Modal', () => {
 		);
 
 		await act( async () => {
-			// necessary to wait for the millisecond to perform the promise resolve in mcRequestReview
+			// necessary to wait for the millisecond to perform the promise resolve in sendMCReviewRequest
 			await Promise.resolve();
 		} );
 

--- a/js/src/product-feed/review-request/review-request-modal.test.js
+++ b/js/src/product-feed/review-request/review-request-modal.test.js
@@ -3,10 +3,32 @@ jest.mock( '@woocommerce/tracks', () => {
 		recordEvent: jest.fn(),
 	};
 } );
+
+jest.mock( '.~/hooks/useDispatchCoreNotices', () => ( {
+	__esModule: true,
+	default: jest
+		.fn()
+		.mockName( 'useDispatchCoreNotices' )
+		.mockImplementation( () => {
+			return {
+				createNotice: jest.fn(),
+			};
+		} ),
+} ) );
+
+jest.mock( '.~/data', () => ( {
+	__esModule: true,
+	useAppDispatch: jest.fn( () => {
+		return {
+			mcRequestReview: jest.fn( () => Promise.resolve() ),
+		};
+	} ),
+} ) );
+
 /**
  * External dependencies
  */
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -92,29 +114,46 @@ describe( 'Request Review Modal', () => {
 		expect( onClose ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'Request review button is active after checking the checkbox and it calls onSendRequest on click', () => {
-		const onSendRequest = jest.fn().mockName( 'onSendRequest' );
+	it( 'Request review button is active after checking the checkbox and it calls onSendRequest on click', async () => {
+		jest.clearAllMocks();
+
 		const { queryByRole } = render(
-			<ReviewRequestModal
-				issues={ issues }
-				isActive={ true }
-				onSendRequest={ onSendRequest }
-			/>
+			<ReviewRequestModal issues={ issues } isActive={ true } />
 		);
 
 		const button = queryByRole( 'button', {
 			name: 'Request account review',
 		} );
+
 		const checkbox = queryByRole( 'checkbox' );
 		expect( button ).toBeTruthy();
 		fireEvent.click( button );
-		expect( onSendRequest ).not.toHaveBeenCalled();
-
+		expect( recordEvent ).not.toHaveBeenCalled();
 		expect( checkbox ).toBeTruthy();
+
 		expect( checkbox.checked ).toEqual( false );
 		fireEvent.click( checkbox );
 		expect( checkbox.checked ).toEqual( true );
+		expect( recordEvent ).toHaveBeenNthCalledWith(
+			1,
+			'gla_request_review_issues_solved_checkbox_click',
+			{ action: 'check' }
+		);
 		fireEvent.click( button );
-		expect( onSendRequest ).toHaveBeenCalledTimes( 1 );
+
+		expect( recordEvent ).toHaveBeenNthCalledWith(
+			2,
+			'gla_request_review'
+		);
+
+		await act( async () => {
+			// necessary to wait for the millisecond to perform the promise resolve in mcRequestReview
+			await Promise.resolve();
+		} );
+
+		expect( recordEvent ).toHaveBeenNthCalledWith(
+			3,
+			'gla_request_review_success'
+		);
 	} );
 } );

--- a/js/src/product-feed/review-request/review-request-notice.js
+++ b/js/src/product-feed/review-request/review-request-notice.js
@@ -68,7 +68,7 @@ const ReviewRequestNotice = ( {
 			<FlexItem className="gla-review-request-notice__button">
 				{ accountReviewStatus.requestButton &&
 					( account.cooldown ||
-						account.reviewEligibleRegions?.length > 0 ) && (
+						account.reviewEligibleRegions.length > 0 ) && (
 						<AppButton
 							isPrimary
 							onClick={ onRequestReviewClick }

--- a/js/src/product-feed/review-request/review-request-notice.js
+++ b/js/src/product-feed/review-request/review-request-notice.js
@@ -66,17 +66,19 @@ const ReviewRequestNotice = ( {
 				</Flex>
 			</FlexItem>
 			<FlexItem className="gla-review-request-notice__button">
-				{ accountReviewStatus.requestButton && (
-					<AppButton
-						isPrimary
-						onClick={ onRequestReviewClick }
-						disabled={ !! account.cooldown }
-						text={ __(
-							'Request review',
-							'google-listings-and-ads'
-						) }
-					/>
-				) }
+				{ accountReviewStatus.requestButton &&
+					( account.cooldown ||
+						account.reviewEligibleRegions?.length > 0 ) && (
+						<AppButton
+							isPrimary
+							onClick={ onRequestReviewClick }
+							disabled={ !! account.cooldown }
+							text={ __(
+								'Request review',
+								'google-listings-and-ads'
+							) }
+						/>
+					) }
 			</FlexItem>
 		</Flex>
 	);

--- a/js/src/product-feed/review-request/review-request-notice.test.js
+++ b/js/src/product-feed/review-request/review-request-notice.test.js
@@ -19,7 +19,7 @@ describe( 'Request Review Notice', () => {
 
 			const { queryByText, queryByRole } = render(
 				<ReviewRequestNotice
-					account={ { status } }
+					account={ { status, reviewEligibleRegions: [ 'US' ] } }
 					onRequestReviewClick={ onRequestReviewClick }
 				/>
 			);
@@ -66,5 +66,28 @@ describe( 'Request Review Notice', () => {
 
 		fireEvent.click( button );
 		expect( onRequestReviewClick ).not.toBeCalled();
+	} );
+
+	it( 'Doesnt render button if no regions are available and there is no cooldown', () => {
+		const onRequestReviewClick = jest
+			.fn()
+			.mockName( 'onRequestReviewClick' );
+
+		const { queryByText, queryByRole } = render(
+			<ReviewRequestNotice
+				account={ { status: 'DISAPPROVED' } }
+				onRequestReviewClick={ onRequestReviewClick }
+			/>
+		);
+
+		expect(
+			queryByText(
+				'Fix all account suspension issues listed below to request a review of your account.'
+			)
+		).toBeTruthy();
+
+		const button = queryByRole( 'button' );
+
+		expect( button ).toBeFalsy();
 	} );
 } );

--- a/js/src/product-feed/review-request/review-request-notice.test.js
+++ b/js/src/product-feed/review-request/review-request-notice.test.js
@@ -75,7 +75,7 @@ describe( 'Request Review Notice', () => {
 
 		const { queryByText, queryByRole } = render(
 			<ReviewRequestNotice
-				account={ { status: 'DISAPPROVED' } }
+				account={ { status: 'DISAPPROVED', reviewEligibleRegions: [] } }
 				onRequestReviewClick={ onRequestReviewClick }
 			/>
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1165 

This PR implements the call to Google Merchant Account Request Review in the frontend.

### Screenshots:

https://user-images.githubusercontent.com/5908855/167454479-e0c53026-392b-48d8-b496-93357efa2e37.mov




### Detailed test instructions:

You can perform a full request review flow but real data already. However, Google takes time to review the request or reject them, so could be interesting to hardcode the responses.

1. Checkout this PR
2. You should also enable WP Tracking in order to check some Recorded events.
3. Go to `src/API/Site/Controllers/MerchantCenter/RequestReviewController.php::get_review_status()` and return this on the function 

```
return [
   'status' => 'DISAPPROVED',
   'issues' => [ 'custom_label' ],
   'cooldown' => 0,
   'reviewEligibleRegions' => [ 'US' ]
];
 
```

Go also to line 131 and comment that line to avoid the request to Google.

4. Go to Product Feed and you should see the notice with the request review button
5. Click on the button, mark the checkbox and request a new review
6. See the event `wcadmin_gla_request_review` in the console  
7. The request button should show a spinner
8. After finishing, the modal is closed, the notice disappears, a system notice appears and the status is changed to Under Review in the Feed Summary
9. 5. See the event `wcadmin_gla_request_review_success` in the console  as well as `wcadmin_gla_modal_closed` with `request-review-success` as action param
10. Restore the changes in `src/API/Site/Controllers/MerchantCenter/RequestReviewController.php::get_review_status()`  and update the page
11. You should see the Under Review status in the Feed Summary

### Additional details

If you have by chance a Google disapproved account you can avoid all the hardcoded changes in the PHP file and just do the real request review. 