### PR TITLE
Drop support for WooCommerce < 6.0 and clean up workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 We aim to support the latest two minor versions of WordPress, WooCommerce, and PHP. (L-2 policy)
 
 -   WordPress 5.7+
--   WooCommerce 5.8+
+-   WooCommerce 6.0+
 -   PHP 7.3+
 
 ## Browsers supported

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -11,7 +11,7 @@
  * Tested up to: 6.0
  * Requires PHP: 7.3
  *
- * WC requires at least: 5.8
+ * WC requires at least: 6.0
  * WC tested up to: 6.5
  * Woo:
  *
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '1.12.8' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.3' );
-define( 'WC_GLA_MIN_WC_VER', '5.8' );
+define( 'WC_GLA_MIN_WC_VER', '6.0' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/js/src/components/app-sub-nav/index.js
+++ b/js/src/components/app-sub-nav/index.js
@@ -36,11 +36,7 @@ const AppSubNav = ( props ) => {
 				return (
 					<Fragment key={ tab.key }>
 						<Link
-							className={ classnames( {
-								current: isCurrent,
-								// Workaround for https://github.com/woocommerce/woocommerce-admin/issues/7772.
-								'gla-sub-nav__item--current': isCurrent,
-							} ) }
+							className={ classnames( { current: isCurrent } ) }
 							tabIndex={ isCurrent ? null : -1 }
 							id={ `${ tab.key }` }
 							href={ tab.href }

--- a/js/src/components/app-sub-nav/index.scss
+++ b/js/src/components/app-sub-nav/index.scss
@@ -2,16 +2,4 @@
 	float: none;
 	text-align: left;
 	margin: calc(var(--main-gap) * -1 / 3) 0 var(--main-gap) 0;
-
-	// Duplicate WordPress's `.current` styles as `.gla-sub-nav__item--current`,
-	// to wrok around https://github.com/woocommerce/woocommerce-admin/issues/7772
-	// which removes all `current` classes.
-	.gla-sub-nav__item--current {
-		// https://github.com/WordPress/wordpress-develop/blob/5.8.1/src/wp-admin/css/common.css#L448-L451
-		font-weight: 600;
-		border: none;
-
-		// https://github.com/WordPress/wordpress-develop/blob/5.8.1/src/wp-admin/css/common.css#L683-L685
-		color: #000;
-	}
 }

--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -1,17 +1,3 @@
-/**
- * Workaround to hide the initial loading spinner that causes whole page flickering.
- * The flickering issue has been fixed and released with WC-admin 2.9.0.
- *   - https://github.com/woocommerce/woocommerce-admin/pull/7886
- *   - https://github.com/woocommerce/woocommerce-admin/blob/v2.9.0/changelog.txt#L16
- *
- * This workaround can be removed after the L-2 version ≥ WC 6.0, which uses WC-admin 2.9.4
- */
-.woocommerce-layout__primary {
-	> .woocommerce-spinner:first-child {
-		display: none;
-	}
-}
-
 // Used in .~/hooks/useLayout.js
 .gla-full-content {
 	// #wpbody `margin-top` style is set onto DOM node directly in WC Admin.

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -22,10 +22,8 @@ import './data';
 import isWCNavigationEnabled from './utils/isWCNavigationEnabled';
 
 const woocommerceTranslation =
-	// Pre WC 5.8
-	getSetting( 'woocommerceTranslation' ) ||
-	// WC 5.8+
-	getSetting( 'admin' )?.woocommerceTranslation;
+	getSetting( 'admin' )?.woocommerceTranslation ||
+	__( 'WooCommerce', 'google-listings-and-ads' );
 
 addFilter(
 	'woocommerce_admin_pages_list',

--- a/js/src/reports/products/async-requests.js
+++ b/js/src/reports/products/async-requests.js
@@ -62,7 +62,8 @@ export const getProductLabels = getRequestByIdString(
  * @return {string} - formatted variation name
  */
 export function getVariationName( { attributes, name } ) {
-	const separator = getSetting( 'variationTitleAttributesSeparator', ' - ' );
+	const separator =
+		getSetting( 'admin' )?.variationTitleAttributesSeparator || ' - ';
 
 	if ( name.indexOf( separator ) > -1 ) {
 		return name;

--- a/readme.txt
+++ b/readme.txt
@@ -54,7 +54,7 @@ Create a new Google Ads account through Google Listings & Ads and a promotional 
 = Minimum Requirements =
 
 * WordPress 5.7 or greater
-* WooCommerce 5.8 or greater
+* WooCommerce 6.0 or greater
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater
 

--- a/src/TaskList/TaskListTrait.php
+++ b/src/TaskList/TaskListTrait.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\TaskList;
 
-use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\PageController;
@@ -34,10 +33,6 @@ trait TaskListTrait {
 	 * @return bool
 	 */
 	private function check_should_show_tasks(): bool {
-		if ( version_compare( WC_VERSION, '5.9', '<' ) ) {
-			return Onboarding::should_show_tasks();
-		}
-
 		$setup_list    = TaskLists::get_list( 'setup' );
 		$extended_list = TaskLists::get_list( 'extended' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1048, Closes #1311 

- Bump minimum supported WC version to 6.0.
- Remove the workaround that prevents the initial loading spinner from the whole page flickering. (a5e8509020200139384ed11f48302db2d87a1e5a in #1206)
- Remove the workaround that mimics the `current` style for sub-navigation links. (aa86e09df0aeab50658cba72c67e36df4a700154 in #1038)
- Remove the `getSetting` fallbacks of `@woocommerce/settings` ( [`5617619`](https://github.com/woocommerce/google-listings-and-ads/commit/5617619656af9acc13c440762b6eb28bbf1bfb5d#diff-90b42c030ea5cb1461a8ec76773e82934fb5a7bbb86381af9f996842c6492ccdR65) and 947aa89679fd750570bb16b5884d973cca0ca09e)
- Remove the `Onboarding::should_show_tasks` fallback which was deprecated since WC 4.4.

### Screenshots:

#### 📹  Link's current style

![Kapture 2022-05-09 at 18 54 11](https://user-images.githubusercontent.com/17420811/167397743-9b79d7da-5abc-434e-bcee-268ae3e793a1.gif)

#### 📹  Separator in the label of product variations

![Kapture 2022-05-09 at 18 56 23](https://user-images.githubusercontent.com/17420811/167397752-598af647-f856-4eb6-94fd-0006bfbbadb2.gif)

### Detailed test instructions:

💡  Prepare a test site with WC 6.0.

#### Page flickering
1. Reload the page a few times.
1. There should be no flickering caused by a spinner above the navigation tab. The flickering problem looks like this:
   ![Kapture 2022-01-18 at 18 46 06](https://user-images.githubusercontent.com/17420811/150057494-c89d9d62-59c0-4b66-a12f-1332a30f9dcf.gif)

#### Link's current style

1. Go to the Reports page.
1. Switch between the subpages of programs and products. The current viewing link should have the `current` CSS class and style.

#### `getSetting` fallbacks

1. Open any GLA page and check the page title, `document.title`, via the Console in DevTool.
1. It should be "[GLA page name] ‹ Google Listings & Ads ‹ Marketing ‹ **WooCommerce** ‹ [your site name] — WooCommerce".
1. Go to the Products Reports page.
1. Compare a single product variation as in the second demo GIF. The filter label should be displayed with the given variation name if the separator (` - `) is in it.
   ![2022-05-09 19 38 24](https://user-images.githubusercontent.com/17420811/167402414-688a3102-5dd5-49f6-ba9f-341a6e5949a9.png)

#### `Onboarding::should_show_tasks` fallback

1. Go to the WC admin homepage: `/wp-admin/admin.php?page=wc-admin`.
1. Check if GLA still shows in the "Things to do next" list.
   ![image](https://user-images.githubusercontent.com/17420811/167406547-ebb57c55-7c7a-4f62-ad60-88c9e55ad113.png)

### Changelog entry

> Tweak - Drop support for WooCommerce < 6.0.
