### PR TITLE
Fix the unit tests for WooCommerce 6.5

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -208,6 +208,13 @@ install_wc() {
     # Install composer for WooCommerce
     cd "${WC_DIR}"
     composer install --ignore-platform-reqs --no-interaction --no-dev
+
+    # Generate feature config for WooCommerce
+    GENERATE_FEATURE_CONFIG=bin/generate-feature-config.php
+    if [ -f $GENERATE_FEATURE_CONFIG ]; then
+      php $GENERATE_FEATURE_CONFIG
+    fi
+
     cd -
   else
     echo "WooCommerce ($WC_VERSION) already installed."

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -74,11 +74,11 @@ function install_woocommerce() {
 
 	WC_Install::install();
 
-	// Initialize the WC API extensions.
+	// Initialize the WC Admin extension.
 	if ( class_exists( '\Automattic\WooCommerce\Internal\Admin\Install' ) ) {
 		\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
 		\Automattic\WooCommerce\Internal\Admin\Install::create_events();
-	} else {
+	} elseif ( class_exists( '\Automattic\WooCommerce\Admin\Install' ) ) {
 		\Automattic\WooCommerce\Admin\Install::create_tables();
 		\Automattic\WooCommerce\Admin\Install::create_events();
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the unit tests to allow them to run with WooCommerce 6.5 (first version with WC Admin fully included). The following two fixes are applied:

- Generate a feature config file if the install script is present
- Do not call the WC Admin install class (database tables are created as part of the regular install)

### Detailed test instructions:

1. Now that WC 6.5 is released it will automatically install it for unit tests since we use `latest` 
2. Check that the unit tests successfully run for this PR.

### Changelog entry
* Fix - Unit tests for WooCommerce 6.5