### PR TITLE
Fix the infinite reloading problem for React Fast Refresh

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -254,7 +254,9 @@ class Admin implements Service, Registerable, Conditional {
 	 * @param WP_Scripts $scripts WP_Scripts instance.
 	 */
 	private function inject_fast_refresh_for_dev( $scripts ) {
-		if ( ! file_exists( "{$this->get_root_dir()}/js/build/runtime.js" ) ) {
+		$runtime_path = "{$this->get_root_dir()}/js/build/runtime.js";
+
+		if ( ! file_exists( $runtime_path ) ) {
 			return;
 		}
 
@@ -275,7 +277,8 @@ class Admin implements Service, Registerable, Conditional {
 		$scripts->add(
 			'gla-webpack-rumtime',
 			"{$plugin_url}/js/build/runtime.js",
-			[]
+			[],
+			(string) filemtime( $runtime_path )
 		);
 		$react_script->deps[] = 'gla-webpack-rumtime';
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use file time as the version string of runtime.js script to prevent the React Fast Refresh from infinite reloading.

### Detailed test instructions:

When developing without checking the "Disable cache" option in the Network tab of DevTool, the infinite reloading problem happens randomly after changing JS code or checking out branches.

The root cause is the runtime.js file is changed but may still be loaded from the local cache, and the React Fast Refresh detects the old version, then triggers the page reloading. However, the runtime.js still be loaded from the local cache, and then the infinite loop occurs.

I didn't find a reliable way to reproduce it but fixed it by this way when I happened to encounter it.

### Changelog entry
