### PR TITLE
Enhance event name for documentation link and update tracking document.

### DIFF
--- a/js/src/components/app-documentation-link/index.js
+++ b/js/src/components/app-documentation-link/index.js
@@ -29,14 +29,15 @@ import TrackableLink from '../trackable-link';
 const AppDocumentationLink = ( props ) => {
 	const { context, linkId, href, ...rest } = props;
 
+	// Put eventName after spreading `rest` to prevent eventName from being overridden.
 	return (
 		<TrackableLink
-			eventName="gla_documentation_link_click"
 			eventProps={ { context, link_id: linkId, href } }
 			type="external"
 			target="_blank"
 			href={ href }
 			{ ...rest }
+			eventName="gla_documentation_link_click"
 		/>
 	);
 };

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -71,6 +71,7 @@ export function ContactInformationPreview() {
  *
  * @param {Object} props React props.
  * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified.
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information|settings-no-phone-number-notice|settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
  */
 export default function ContactInformation( { onPhoneNumberVerified } ) {
 	const phone = useGoogleMCPhoneNumber();

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -71,7 +71,9 @@ export function ContactInformationPreview() {
  *
  * @param {Object} props React props.
  * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified.
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information|settings-no-phone-number-notice|settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
  */
 const ContactInformation = ( { onPhoneNumberVerified } ) => {
 	const phone = useGoogleMCPhoneNumber();

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -73,7 +73,7 @@ export function ContactInformationPreview() {
  * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified.
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information|settings-no-phone-number-notice|settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
  */
-export default function ContactInformation( { onPhoneNumberVerified } ) {
+const ContactInformation = ( { onPhoneNumberVerified } ) => {
 	const phone = useGoogleMCPhoneNumber();
 
 	/**
@@ -120,4 +120,6 @@ export default function ContactInformation( { onPhoneNumberVerified } ) {
 			</VerticalGapLayout>
 		</Section>
 	);
-}
+};
+
+export default ContactInformation;

--- a/js/src/components/contact-information/phone-number-card/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card.js
@@ -108,13 +108,13 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberVerified } ) {
  *
  * @fires gla_mc_phone_number_edit_button_click
  */
-export default function PhoneNumberCard( {
+const PhoneNumberCard = ( {
 	view,
 	phoneNumber,
 	initEditing = null,
 	onEditClick,
 	onPhoneNumberVerified = noop,
-} ) {
+} ) => {
 	const { loaded, data } = phoneNumber;
 	const [ isEditing, setEditing ] = useState( initEditing );
 
@@ -181,4 +181,6 @@ export default function PhoneNumberCard( {
 			indicator={ indicator }
 		/>
 	);
-}
+};
+
+export default PhoneNumberCard;

--- a/js/src/components/contact-information/store-address-card.js
+++ b/js/src/components/contact-information/store-address-card.js
@@ -36,7 +36,7 @@ import './store-address-card.scss';
  *
  * @return {JSX.Element} Filled AccountCard component.
  */
-export default function StoreAddressCard() {
+const StoreAddressCard = () => {
 	const { loaded, data, refetch } = useStoreAddress();
 	const { subpath } = getQuery();
 	const editButton = (
@@ -119,7 +119,9 @@ export default function StoreAddressCard() {
 			</Section.Card.Body>
 		</AccountCard>
 	);
-}
+};
+
+export default StoreAddressCard;
 
 /**
  * Trigger when store address edit button is clicked.

--- a/js/src/components/different-currency-notice.js
+++ b/js/src/components/different-currency-notice.js
@@ -19,6 +19,8 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
  * @param {Object} props React props.
  * @param {string} props.context Context or page on which the notice is shown, to be forwarded to the link's track event.
  * @return {JSX.Element} {@link Notice} element with the warning message and the link to the documentation.
+ *
+ * @fires gla_documentation_link_click with `{ context: "dashboard|reports-products|reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
  */
 export default function DifferentCurrencyNotice( { context } ) {
 	const { googleAdsAccount } = useGoogleAdsAccount();
@@ -53,7 +55,6 @@ export default function DifferentCurrencyNotice( { context } ) {
 						<AppDocumentationLink
 							className="gla-different-currency-notice__link"
 							href="https://support.google.com/google-ads/answer/9841530"
-							eventName="gla_different_currency_notice_link_click"
 							context={ context }
 							linkId="setting-up-currency"
 						/>

--- a/js/src/components/different-currency-notice.js
+++ b/js/src/components/different-currency-notice.js
@@ -20,7 +20,9 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
  * @param {string} props.context Context or page on which the notice is shown, to be forwarded to the link's track event.
  * @return {JSX.Element} {@link Notice} element with the warning message and the link to the documentation.
  *
- * @fires gla_documentation_link_click with `{ context: "dashboard|reports-products|reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
+ * @fires gla_documentation_link_click with `{ context: "dashboard", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
+ * @fires gla_documentation_link_click with `{ context: "reports-products", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
+ * @fires gla_documentation_link_click with `{ context: "reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
  */
 const DifferentCurrencyNotice = ( { context } ) => {
 	const { googleAdsAccount } = useGoogleAdsAccount();

--- a/js/src/components/different-currency-notice.js
+++ b/js/src/components/different-currency-notice.js
@@ -22,7 +22,7 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
  *
  * @fires gla_documentation_link_click with `{ context: "dashboard|reports-products|reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
  */
-export default function DifferentCurrencyNotice( { context } ) {
+const DifferentCurrencyNotice = ( { context } ) => {
 	const { googleAdsAccount } = useGoogleAdsAccount();
 	const { code: storeCurrency } = useStoreCurrency();
 
@@ -63,4 +63,6 @@ export default function DifferentCurrencyNotice( { context } ) {
 			) }
 		</Notice>
 	);
-}
+};
+
+export default DifferentCurrencyNotice;

--- a/js/src/components/faqs-panel/index.js
+++ b/js/src/components/faqs-panel/index.js
@@ -11,12 +11,22 @@ import classnames from 'classnames';
  */
 import './index.scss';
 
-const getPanelToggleHandler = ( trackName, id ) => ( isOpened ) => {
+const getPanelToggleHandler = ( trackName, id, context ) => ( isOpened ) => {
 	recordEvent( trackName, {
 		id,
 		action: isOpened ? 'expand' : 'collapse',
+		context,
 	} );
 };
+
+/**
+ * Clicking on faq item to collapse or expand it.
+ *
+ * @event gla_faq
+ * @property {string} id FAQ identifier
+ * @property {string} action (`expand`|`collapse`)
+ * @property {string} context Indicates which page / module the FAQ is in
+ */
 
 /**
  * @typedef {Object} FaqItem
@@ -32,8 +42,14 @@ const getPanelToggleHandler = ( trackName, id ) => ( isOpened ) => {
  * @param {string} props.trackName The track event name to be recorded when toggling on FAQ items.
  * @param {Array<FaqItem>} props.faqItems FAQ items for rendering.
  * @param {string} [props.className] The class name for this component.
+ * @param {string} props.context The track event property to be recorded when toggling on FAQ items.
  */
-export default function FaqsPanel( { trackName, faqItems, className } ) {
+export default function FaqsPanel( {
+	trackName,
+	faqItems,
+	className,
+	context,
+} ) {
 	return (
 		<Panel
 			className={ classnames( 'gla-faqs-panel', className ) }
@@ -48,7 +64,11 @@ export default function FaqsPanel( { trackName, faqItems, className } ) {
 						key={ trackId }
 						title={ question }
 						initialOpen={ false }
-						onToggle={ getPanelToggleHandler( trackName, trackId ) }
+						onToggle={ getPanelToggleHandler(
+							trackName,
+							trackId,
+							context
+						) }
 					>
 						<PanelRow>{ answer }</PanelRow>
 					</PanelBody>

--- a/js/src/components/free-listings/choose-audience/form-content.js
+++ b/js/src/components/free-listings/choose-audience/form-content.js
@@ -26,6 +26,7 @@ import '.~/components/free-listings/choose-audience/index.scss';
  * Copied from {@link .~/setup-mc/setup-stepper/choose-audience/form-content.js}.
  *
  * @param {Object} props
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
  */
 const FormContent = ( props ) => {
 	const { formProps } = props;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
@@ -10,6 +10,10 @@ import Section from '.~/wcdl/section';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import ShippingTimeSetup from './shipping-time/shipping-time-setup';
 
+/**
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
+ */
+
 const ShippingTimeSection = ( {
 	formProps,
 	countries: selectedCountryCodes,

--- a/js/src/components/free-listings/configure-product-listings/tax-rate.js
+++ b/js/src/components/free-listings/configure-product-listings/tax-rate.js
@@ -13,6 +13,11 @@ import AppRadioContentControl from '.~/components/app-radio-content-control';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 
+/**
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-read-more', href: 'https://support.google.com/merchants/answer/160162' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
+ */
+
 const TaxRate = ( props ) => {
 	const {
 		formProps: { getInputProps },

--- a/js/src/components/google-account-card/connect-google-account-card.js
+++ b/js/src/components/google-account-card/connect-google-account-card.js
@@ -19,7 +19,7 @@ import useGoogleConnectFlow from './use-google-connect-flow';
  * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'reconnect' | 'setup-mc' }`
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
-export default function ConnectGoogleAccountCard( { disabled } ) {
+const ConnectGoogleAccountCard = ( { disabled } ) => {
 	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';
 	const [ handleConnect, { loading, data } ] = useGoogleConnectFlow(
 		pageName
@@ -68,4 +68,6 @@ export default function ConnectGoogleAccountCard( { disabled } ) {
 			}
 		/>
 	);
-}
+};
+
+export default ConnectGoogleAccountCard;

--- a/js/src/components/google-account-card/connect-google-account-card.js
+++ b/js/src/components/google-account-card/connect-google-account-card.js
@@ -17,6 +17,7 @@ import useGoogleConnectFlow from './use-google-connect-flow';
  * @param {Object} props React props
  * @param {boolean} props.disabled
  * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'reconnect' | 'setup-mc' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
 export default function ConnectGoogleAccountCard( { disabled } ) {
 	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';

--- a/js/src/components/google-account-card/connect-google-account-card.js
+++ b/js/src/components/google-account-card/connect-google-account-card.js
@@ -16,7 +16,8 @@ import useGoogleConnectFlow from './use-google-connect-flow';
 /**
  * @param {Object} props React props
  * @param {boolean} props.disabled
- * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'reconnect' | 'setup-mc' }`
+ * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'reconnect' }`
+ * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'setup-mc' }`
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
 const ConnectGoogleAccountCard = ( { disabled } ) => {

--- a/js/src/components/google-account-card/connected-google-account-card.js
+++ b/js/src/components/google-account-card/connected-google-account-card.js
@@ -29,11 +29,11 @@ import useSwitchGoogleAccount from './useSwitchGoogleAccount';
  *
  * @fires gla_google_account_connect_different_account_button_click
  */
-export default function ConnectedGoogleAccountCard( {
+const ConnectedGoogleAccountCard = ( {
 	googleAccount,
 	helper,
 	hideAccountSwitch = false,
-} ) {
+} ) => {
 	const [ handleSwitch, { loading } ] = useSwitchGoogleAccount();
 
 	return (
@@ -59,4 +59,6 @@ export default function ConnectedGoogleAccountCard( {
 			) }
 		</AccountCard>
 	);
-}
+};
+
+export default ConnectedGoogleAccountCard;

--- a/js/src/components/google-account-card/request-full-access-google-account-card.js
+++ b/js/src/components/google-account-card/request-full-access-google-account-card.js
@@ -19,7 +19,8 @@ import './request-full-access-google-account-card.scss';
  *
  * @param {Object} props React props.
  * @param {string} props.additionalScopeEmail Specify the email to be requested additional permission scopes to Google.
- * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'reconnect' | 'setup-mc' }`
+ * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'reconnect' }`
+ * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'setup-mc' }`
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
 const RequestFullAccessGoogleAccountCard = ( { additionalScopeEmail } ) => {

--- a/js/src/components/google-account-card/request-full-access-google-account-card.js
+++ b/js/src/components/google-account-card/request-full-access-google-account-card.js
@@ -20,6 +20,7 @@ import './request-full-access-google-account-card.scss';
  * @param {Object} props React props.
  * @param {string} props.additionalScopeEmail Specify the email to be requested additional permission scopes to Google.
  * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'reconnect' | 'setup-mc' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
 export default function RequestFullAccessGoogleAccountCard( {
 	additionalScopeEmail,

--- a/js/src/components/google-account-card/request-full-access-google-account-card.js
+++ b/js/src/components/google-account-card/request-full-access-google-account-card.js
@@ -22,9 +22,7 @@ import './request-full-access-google-account-card.scss';
  * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'reconnect' | 'setup-mc' }`
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
-export default function RequestFullAccessGoogleAccountCard( {
-	additionalScopeEmail,
-} ) {
+const RequestFullAccessGoogleAccountCard = ( { additionalScopeEmail } ) => {
 	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';
 	const [ handleConnect, { loading, data } ] = useGoogleConnectFlow(
 		pageName,
@@ -76,4 +74,6 @@ export default function RequestFullAccessGoogleAccountCard( {
 			}
 		/>
 	);
-}
+};
+
+export default RequestFullAccessGoogleAccountCard;

--- a/js/src/components/google-ads-account-card/authorize-ads.js
+++ b/js/src/components/google-ads-account-card/authorize-ads.js
@@ -18,7 +18,7 @@ const pageName = 'setup-ads';
  * @param {string} props.additionalScopeEmail
  * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'setup-ads' }`
  */
-export default function AuthorizeAds( { additionalScopeEmail } ) {
+const AuthorizeAds = ( { additionalScopeEmail } ) => {
 	const { createNotice } = useDispatchCoreNotices();
 	const [ fetchGoogleConnect, { loading, data } ] = useGoogleAuthorization(
 		pageName,
@@ -59,4 +59,6 @@ export default function AuthorizeAds( { additionalScopeEmail } ) {
 			}
 		/>
 	);
-}
+};
+
+export default AuthorizeAds;

--- a/js/src/components/google-ads-account-card/connect-ads/index.js
+++ b/js/src/components/google-ads-account-card/connect-ads/index.js
@@ -29,6 +29,7 @@ import './index.scss';
 
 /**
  * @fires gla_ads_account_connect_button_click when "Connect" button is clicked.
+ * @fires gla_documentation_link_click with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
  * @param {Object} props React props
  * @return {JSX.Element} {@link AccountCard} filled with content.
  */

--- a/js/src/components/google-ads-account-card/terms-modal/index.js
+++ b/js/src/components/google-ads-account-card/terms-modal/index.js
@@ -23,6 +23,8 @@ import './index.scss';
  * Terms and conditions agreement modal.
  *
  * @fires gla_ads_account_create_button_click When agreed by clicking "Create account".
+ * @fires gla_documentation_link_click with `{ context: 'setup-ads', link_id: 'shopping-ads-policies', href: 'https://support.google.com/merchants/answer/6149970' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
  * @param {Object} props React props
  * @param {Function} [props.onCreateAccount] Callback function when account is created
  * @param {Function} [props.onRequestClose] Callback function when the modal is closed

--- a/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
@@ -33,10 +33,10 @@ import { useAppDispatch } from '.~/data';
  * @param {{ id: number }} props.googleMCAccount A data payload object containing the user's Google Merchant Center account ID.
  * @param {boolean} [props.hideAccountSwitch=false] Indicate whether hide the account switch block at the card footer.
  */
-export default function ConnectedGoogleMCAccountCard( {
+const ConnectedGoogleMCAccountCard = ( {
 	googleMCAccount,
 	hideAccountSwitch = false,
-} ) {
+} ) => {
 	const { createNotice, removeNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
 
@@ -114,4 +114,6 @@ export default function ConnectedGoogleMCAccountCard( {
 			) }
 		</AccountCard>
 	);
-}
+};
+
+export default ConnectedGoogleMCAccountCard;

--- a/js/src/components/google-mc-account-card/reclaim-url-card/index.js
+++ b/js/src/components/google-mc-account-card/reclaim-url-card/index.js
@@ -36,6 +36,7 @@ import AppInputLinkControl from '.~/components/app-input-link-control';
  * @param {Function} [props.onSwitchAccount] Callback when clicking on Switch Account
  * @fires gla_mc_account_reclaim_url_button_click
  * @fires gla_mc_account_switch_account_button_click with `context: 'reclaim-url'`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc', link_id: 'claim-url', href: 'https://support.google.com/merchants/answer/176793' }`
  */
 const ReclaimUrlCard = ( { id, websiteUrl, onSwitchAccount = noop } ) => {
 	const { invalidateResolution } = useAppDispatch();

--- a/js/src/components/google-mc-account-card/terms-modal/index.js
+++ b/js/src/components/google-mc-account-card/terms-modal/index.js
@@ -24,6 +24,7 @@ import './index.scss';
  * @param {Function} [props.onCreateAccount] Callback function when the account is created
  * @param {Function} [props.onRequestClose] Callback function when the modal is closed
  * @fires gla_mc_account_create_button_click
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
  */
 const TermsModal = ( {
 	onCreateAccount = () => {},

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -14,6 +14,11 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
 
+/**
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
+ */
+
 const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 	const { getInputProps, values, setValue } = formProps;
 	const inputProps = getInputProps( 'shipping_rate' );

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -61,7 +61,7 @@ function isNotOurStep( location ) {
  *
  * @fires gla_free_campaign_edited
  */
-export default function EditFreeCampaign() {
+const EditFreeCampaign = () => {
 	useLayout( 'full-content' );
 
 	const {
@@ -296,4 +296,6 @@ export default function EditFreeCampaign() {
 			/>
 		</>
 	);
-}
+};
+
+export default EditFreeCampaign;

--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -255,7 +255,24 @@ const faqItems = [
  */
 
 /**
- * @fires gla_get_started_faq
+ * @fires gla_get_started_faq with `{ id: 'what-do-i-need-to-get-started', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'what-do-i-need-to-get-started', action: 'collapse' }`.
+ * @fires gla_get_started_faq with `{ id: 'what-if-i-already-have-free-listings', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'what-if-i-already-have-free-listings', action: 'collapse' }`.
+ * @fires gla_get_started_faq with `{ id: 'is-my-store-ready-to-sync-with-google', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'is-my-store-ready-to-sync-with-google', action: 'collapse' }`.
+ * @fires gla_get_started_faq with `{ id: 'what-is-a-performance-max-campaign', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'what-is-a-performance-max-campaign', action: 'collapse' }`.
+ * @fires gla_get_started_faq with `{ id: 'what-are-free-listings', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'what-are-free-listings', action: 'collapse' }`.
+ * @fires gla_get_started_faq with `{ id: 'where-to-track-free-listings-and-performance-max-campaign-performance', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'where-to-track-free-listings-and-performance-max-campaign-performance', action: 'collapse' }`.
+ * @fires gla_get_started_faq with `{ id: 'how-to-sync-products-to-google-free-listings', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'how-to-sync-products-to-google-free-listings', action: 'collapse' }`.
+ * @fires gla_get_started_faq with `{ id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'collapse' }`.
+ * @fires gla_get_started_faq with `{ id: 'how-can-i-get-the-ad-credit-offer', action: 'expand' }`.
+ * @fires gla_get_started_faq with `{ id: 'how-can-i-get-the-ad-credit-offer', action: 'collapse' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.

--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -247,32 +247,24 @@ const faqItems = [
 ];
 
 /**
- * Clicking on getting started page faq item to collapse or expand it.
- *
- * @event gla_get_started_faq
- * @property {string} id FAQ identifier
- * @property {string} action (`expand`|`collapse`)
- */
-
-/**
- * @fires gla_get_started_faq with `{ id: 'what-do-i-need-to-get-started', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'what-do-i-need-to-get-started', action: 'collapse' }`.
- * @fires gla_get_started_faq with `{ id: 'what-if-i-already-have-free-listings', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'what-if-i-already-have-free-listings', action: 'collapse' }`.
- * @fires gla_get_started_faq with `{ id: 'is-my-store-ready-to-sync-with-google', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'is-my-store-ready-to-sync-with-google', action: 'collapse' }`.
- * @fires gla_get_started_faq with `{ id: 'what-is-a-performance-max-campaign', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'what-is-a-performance-max-campaign', action: 'collapse' }`.
- * @fires gla_get_started_faq with `{ id: 'what-are-free-listings', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'what-are-free-listings', action: 'collapse' }`.
- * @fires gla_get_started_faq with `{ id: 'where-to-track-free-listings-and-performance-max-campaign-performance', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'where-to-track-free-listings-and-performance-max-campaign-performance', action: 'collapse' }`.
- * @fires gla_get_started_faq with `{ id: 'how-to-sync-products-to-google-free-listings', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'how-to-sync-products-to-google-free-listings', action: 'collapse' }`.
- * @fires gla_get_started_faq with `{ id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'collapse' }`.
- * @fires gla_get_started_faq with `{ id: 'how-can-i-get-the-ad-credit-offer', action: 'expand' }`.
- * @fires gla_get_started_faq with `{ id: 'how-can-i-get-the-ad-credit-offer', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'what-do-i-need-to-get-started', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'what-do-i-need-to-get-started', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'what-if-i-already-have-free-listings', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'what-if-i-already-have-free-listings', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'is-my-store-ready-to-sync-with-google', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'is-my-store-ready-to-sync-with-google', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'what-is-a-performance-max-campaign', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'what-is-a-performance-max-campaign', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'what-are-free-listings', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'what-are-free-listings', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'where-to-track-free-listings-and-performance-max-campaign-performance', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'where-to-track-free-listings-and-performance-max-campaign-performance', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'how-to-sync-products-to-google-free-listings', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'how-to-sync-products-to-google-free-listings', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'collapse' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
@@ -285,7 +277,8 @@ const Faqs = () => {
 	return (
 		<FaqsPanel
 			className="gla-get-started-faqs"
-			trackName="gla_get_started_faq"
+			trackName="gla_faq"
+			context="get-started"
 			faqItems={ faqItems }
 		/>
 	);

--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -256,6 +256,13 @@ const faqItems = [
 
 /**
  * @fires gla_get_started_faq
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'terms-and-conditions-of-google-ads-coupons', href: 'https://www.google.com/ads/coupons/terms/' }`.
  */
 const Faqs = () => {
 	return (

--- a/js/src/get-started-page/features-card/index.js
+++ b/js/src/get-started-page/features-card/index.js
@@ -42,6 +42,11 @@ const LearnMoreLink = ( { linkId, href } ) => {
 	);
 };
 
+/*
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-free-listing-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-google-ads-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-dashboard-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+ */
 const FeaturesCard = () => {
 	return (
 		<Card className="gla-get-started-features-card" isBorderless>

--- a/js/src/get-started-page/unsupported-notices/index.js
+++ b/js/src/get-started-page/unsupported-notices/index.js
@@ -23,17 +23,9 @@ const ExternalIcon = () => (
 		size={ 18 }
 	/>
 );
-/**
- * Clicking on a text link within the notice on the Get Started page.
- *
- * @event gla_get_started_notice_link_click
- * @property {string} link_id Link identifier
- * @property {string} context Indicates which link is clicked
- * @property {string} href Link's URL
- */
 
 /**
- * @fires gla_get_started_notice_link_click with `{ context: "get-started", link_id: "supported-languages" }`
+ * @fires gla_documentation_link_click with `{ context: "get-started", link_id: "supported-languages" }`
  */
 const UnsupportedLanguage = () => {
 	const { data } = useTargetAudience();
@@ -66,7 +58,6 @@ const UnsupportedLanguage = () => {
 						<AppDocumentationLink
 							className="gla-get-started-notice__link"
 							href="https://support.google.com/merchants/answer/160637"
-							eventName="gla_get_started_notice_link_click"
 							context="get-started"
 							linkId="supported-languages"
 						/>
@@ -79,7 +70,7 @@ const UnsupportedLanguage = () => {
 };
 
 /**
- * @fires gla_get_started_notice_link_click with `{ context: "get-started", link_id: "supported-countries" }`
+ * @fires gla_documentation_link_click with `{ context: "get-started", link_id: "supported-countries" }`
  */
 const UnsupportedCountry = () => {
 	const { name: countryName } = useStoreCountry();
@@ -112,7 +103,6 @@ const UnsupportedCountry = () => {
 						<AppDocumentationLink
 							className="gla-get-started-notice__link"
 							href="https://support.google.com/merchants/answer/160637"
-							eventName="gla_get_started_notice_link_click"
 							context="get-started"
 							linkId="supported-countries"
 						/>

--- a/js/src/get-started-page/unsupported-notices/index.js
+++ b/js/src/get-started-page/unsupported-notices/index.js
@@ -25,7 +25,7 @@ const ExternalIcon = () => (
 );
 
 /**
- * @fires gla_documentation_link_click with `{ context: "get-started", link_id: "supported-languages" }`
+ * @fires gla_documentation_link_click with `{ context: 'get-started', link_id: 'supported-languages', href: 'https://support.google.com/merchants/answer/160637' }`
  */
 const UnsupportedLanguage = () => {
 	const { data } = useTargetAudience();

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -24,6 +24,7 @@ import { getDashboardUrl } from '.~/utils/urls';
 
 /**
  * @fires gla_launch_paid_campaign_button_click on submit
+ * @fires gla_documentation_link_click with `{ context: 'create-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
  */
 const CreatePaidAdsCampaignForm = () => {
 	const [ loading, setLoading ] = useState( false );

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -19,6 +19,10 @@ import { useAppDispatch } from '.~/data';
 import { getDashboardUrl } from '.~/utils/urls';
 import validateForm from '.~/utils/paid-ads/validateForm';
 
+/**
+ * @fires gla_documentation_link_click with `{ context: 'edit-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
+ */
+
 const EditPaidAdsCampaignForm = ( props ) => {
 	const { campaign } = props;
 	const { amount, allowMultiple, displayCountries: countryCodes } = campaign;

--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -92,6 +92,7 @@ const actions = (
  * @fires gla_edit_product_issue_click
  * @fires gla_table_go_to_page with `context: 'issues-to-resolve'`
  * @fires gla_table_page_click with `context: 'issues-to-resolve'`
+ * @fires gla_documentation_link_click with `{ context: 'product-feed', link_id: 'issues-to-resolve', href: 'https://support.google.com/merchants/answer/6363310' }`
  */
 const IssuesTableCard = () => {
 	const [ page, setPage ] = useState( 1 );

--- a/js/src/product-feed/product-statistics/product-status-help-popover/index.js
+++ b/js/src/product-feed/product-statistics/product-status-help-popover/index.js
@@ -10,6 +10,9 @@ import { __ } from '@wordpress/i18n';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import HelpPopover from '.~/components/help-popover';
 
+/**
+ * @fires gla_documentation_link_click with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`
+ */
 const ProductStatusHelpPopover = () => {
 	const map = {
 		strong: <strong></strong>,

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -157,7 +157,7 @@ const handleGuideFinish = ( e ) => {
  * @fires gla_modal_closed with `action: 'create-paid-campaign' | 'maybe-later' | 'dismiss'`
  * @fires gla_modal_open with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
  */
-export default function SubmissionSuccessGuide() {
+const SubmissionSuccessGuide = () => {
 	useEffect( () => {
 		recordEvent( 'gla_modal_open', {
 			context: GUIDE_NAMES.SUBMISSION_SUCCESS,
@@ -207,4 +207,6 @@ export default function SubmissionSuccessGuide() {
 			onFinish={ handleGuideFinish }
 		/>
 	);
-}
+};
+
+export default SubmissionSuccessGuide;

--- a/js/src/reports/summary-section.js
+++ b/js/src/reports/summary-section.js
@@ -36,13 +36,13 @@ const noValidData = {
  * @param {string} props.trackEventId Report ID used in tracking events.
  * @fires gla_chart_tab_click
  */
-export default function SummarySection( {
+const SummarySection = ( {
 	loaded,
 	metrics,
 	expectedLength = metrics.length,
 	totals,
 	trackEventId,
-} ) {
+} ) => {
 	const query = useUrlQuery();
 	if ( ! loaded ) {
 		return <SummaryListPlaceholder numberOfItems={ expectedLength } />;
@@ -78,7 +78,9 @@ export default function SummarySection( {
 			}
 		</SummaryList>
 	);
-}
+};
+
+export default SummarySection;
 
 /**
  * @typedef {import("./index.js").Metric} Metric

--- a/js/src/settings/edit-phone-number.js
+++ b/js/src/settings/edit-phone-number.js
@@ -26,7 +26,7 @@ const learnMoreUrl =
  * @see PhoneNumberCard
  * @fires gla_documentation_link_click with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
  */
-export default function EditPhoneNumber() {
+const EditPhoneNumber = () => {
 	const phone = useGoogleMCPhoneNumber();
 
 	usePhoneNumberCheckTrackEventEffect( phone );
@@ -76,4 +76,6 @@ export default function EditPhoneNumber() {
 			</div>
 		</>
 	);
-}
+};
+
+export default EditPhoneNumber;

--- a/js/src/settings/edit-phone-number.js
+++ b/js/src/settings/edit-phone-number.js
@@ -24,6 +24,7 @@ const learnMoreUrl =
  * Renders the phone number settings page.
  *
  * @see PhoneNumberCard
+ * @fires gla_documentation_link_click with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
  */
 export default function EditPhoneNumber() {
 	const phone = useGoogleMCPhoneNumber();

--- a/js/src/settings/edit-store-address.js
+++ b/js/src/settings/edit-store-address.js
@@ -38,7 +38,7 @@ const learnMoreUrl =
  * @fires gla_contact_information_save_button_click
  * @fires gla_documentation_link_click with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
  */
-export default function EditStoreAddress() {
+const EditStoreAddress = () => {
 	useLayout( 'full-content' );
 
 	const { updateGoogleMCContactInformation } = useAppDispatch();
@@ -108,4 +108,6 @@ export default function EditStoreAddress() {
 			</div>
 		</>
 	);
-}
+};
+
+export default EditStoreAddress;

--- a/js/src/settings/edit-store-address.js
+++ b/js/src/settings/edit-store-address.js
@@ -36,6 +36,7 @@ const learnMoreUrl =
  *
  * @see StoreAddressCard
  * @fires gla_contact_information_save_button_click
+ * @fires gla_documentation_link_click with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
  */
 export default function EditStoreAddress() {
 	useLayout( 'full-content' );

--- a/js/src/setup-ads/ads-stepper/create-campaign/index.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/index.js
@@ -14,6 +14,10 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
 import AppButton from '.~/components/app-button';
 
+/**
+ * @fires gla_documentation_link_click with `{ context: 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
+ */
+
 const CreateCampaign = ( props ) => {
 	const { formProps, onContinue = () => {} } = props;
 	const { isValidForm } = formProps;

--- a/js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js
@@ -22,6 +22,7 @@ import CountryModal from './country-modal';
 
 /**
  * @fires gla_free_ad_credit_country_click
+ * @fires gla_documentation_link_click with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
  */
 const FreeAdCredit = () => {
 	const [ showModal, setShowModal ] = useState( false );

--- a/js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js
@@ -21,7 +21,7 @@ import CountryModal from './country-modal';
  */
 
 /**
- * @fires gla_free_ad_credit_country_click
+ * @fires gla_free_ad_credit_country_click with `{ context: 'setup-ads' }`.
  * @fires gla_documentation_link_click with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
  */
 const FreeAdCredit = () => {

--- a/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
@@ -26,6 +26,7 @@ import '.~/components/free-listings/choose-audience/index.scss';
  *
  * @see .~/components/free-listings/choose-audience/form-content
  * @param {Object} props
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
  */
 const FormContent = ( props ) => {
 	const { formProps } = props;

--- a/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
@@ -69,6 +69,7 @@ const faqItems = [
 
 /**
  * @fires gla_setup_mc_faq
+ * @fires gla_documentation_link_click with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
  */
 export default function Faqs() {
 	return (

--- a/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
@@ -60,21 +60,20 @@ const faqItems = [
 ];
 
 /**
- * Clicking on faq items to collapse or expand it in the Setup Merchant Center page
- *
- * @event gla_setup_mc_faq
- * @property {string} id FAQ identifier
- * @property {string} action (`expand`|`collapse`)
- */
-
-/**
- * @fires gla_setup_mc_faq
+ * @fires gla_faq with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-wp-account', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-wp-account', action: 'collapse' }`.
+ * @fires gla_faq with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'expand' }`.
+ * @fires gla_faq with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'collapse' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
  */
 const Faqs = () => {
 	return (
 		<Section>
-			<FaqsPanel trackName="gla_setup_mc_faq" faqItems={ faqItems } />
+			<FaqsPanel
+				trackName="gla_faq"
+				context="setup-mc-accounts"
+				faqItems={ faqItems }
+			/>
 		</Section>
 	);
 };

--- a/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
@@ -71,10 +71,12 @@ const faqItems = [
  * @fires gla_setup_mc_faq
  * @fires gla_documentation_link_click with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
  */
-export default function Faqs() {
+const Faqs = () => {
 	return (
 		<Section>
 			<FaqsPanel trackName="gla_setup_mc_faq" faqItems={ faqItems } />
 		</Section>
 	);
-}
+};
+
+export default Faqs;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time-section.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time-section.js
@@ -10,6 +10,9 @@ import Section from '.~/wcdl/section';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import ShippingTimeSetup from './shipping-time/shipping-time-setup';
 
+/*
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
+ */
 const ShippingTimeSection = ( { formProps } ) => {
 	return (
 		<Section

--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
@@ -15,6 +15,9 @@ import Section from '.~/wcdl/section';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import './index.scss';
 
+/*
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-checklist', link_id: 'checklist-requirements', href: 'https://support.google.com/merchants/answer/6363310' }`
+ */
 const PreLaunchChecklist = ( props ) => {
 	const { formProps } = props;
 	const { getInputProps } = formProps;

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -198,15 +198,21 @@ When a documentation link is clicked.
 `href` | `string` | link's URL
 #### Emitters
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
-- [`ContactInformation`](../../js/src/components/contact-information/index.js#L76) with `{ context: 'setup-mc-contact-information|settings-no-phone-number-notice|settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
-- [`DifferentCurrencyNotice`](../../js/src/components/different-currency-notice.js#L25) with `{ context: "dashboard|reports-products|reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
+- [`ContactInformation`](../../js/src/components/contact-information/index.js#L78)
+	- with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+	- with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+	- with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+- [`DifferentCurrencyNotice`](../../js/src/components/different-currency-notice.js#L27)
+	- with `{ context: "dashboard", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
+	- with `{ context: "reports-products", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
+	- with `{ context: "reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 - [`FormContent`](../../js/src/components/free-listings/choose-audience/form-content.js#L31) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
 - [`ShippingTimeSection`](../../js/src/components/free-listings/configure-product-listings/shipping-time-section.js#L17) with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
 - [`TaxRate`](../../js/src/components/free-listings/configure-product-listings/tax-rate.js#L21)
 	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-read-more', href: 'https://support.google.com/merchants/answer/160162' }`
 	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
-- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L22) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
-- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L25) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
 - [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L36) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
 - [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L32)
 	- with `{ context: 'setup-ads', link_id: 'shopping-ads-policies', href: 'https://support.google.com/merchants/answer/6149970' }`
@@ -216,7 +222,7 @@ When a documentation link is clicked.
 - [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L22)
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
-- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L267)
+- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
 	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
 	- with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
 	- with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
@@ -237,7 +243,7 @@ When a documentation link is clicked.
 - [`CreateCampaign`](../../js/src/setup-ads/ads-stepper/create-campaign/index.js#L21) with `{ context: 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
 - [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27) with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
 - [`FormContent`](../../js/src/setup-mc/setup-stepper/choose-audience/form-content.js#L31) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
-- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L74) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
+- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L69) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
 
 ### [`gla_edit_mc_phone_number`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L13)
 Triggered when phone number edit button is clicked.
@@ -291,6 +297,40 @@ Triggered when store address "Edit in WooCommerce Settings" button is clicked.
 #### Emitters
 - [`StoreAddressCard`](../../js/src/components/contact-information/store-address-card.js#L39) Whenever "Edit in WooCommerce Settings" button is clicked.
 
+### [`gla_faq`](../../js/src/components/faqs-panel/index.js#L22)
+Clicking on faq item to collapse or expand it.
+#### Properties
+|   |   |   |
+|---|---|---|
+`id` | `string` | FAQ identifier
+`action` | `string` | (`expand`\|`collapse`)
+`context` | `string` | Indicates which page / module the FAQ is in
+#### Emitters
+- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
+	- with `{ context: 'get-started', id: 'what-do-i-need-to-get-started', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'what-do-i-need-to-get-started', action: 'collapse' }`.
+	- with `{ context: 'get-started', id: 'what-if-i-already-have-free-listings', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'what-if-i-already-have-free-listings', action: 'collapse' }`.
+	- with `{ context: 'get-started', id: 'is-my-store-ready-to-sync-with-google', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'is-my-store-ready-to-sync-with-google', action: 'collapse' }`.
+	- with `{ context: 'get-started', id: 'what-is-a-performance-max-campaign', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'what-is-a-performance-max-campaign', action: 'collapse' }`.
+	- with `{ context: 'get-started', id: 'what-are-free-listings', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'what-are-free-listings', action: 'collapse' }`.
+	- with `{ context: 'get-started', id: 'where-to-track-free-listings-and-performance-max-campaign-performance', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'where-to-track-free-listings-and-performance-max-campaign-performance', action: 'collapse' }`.
+	- with `{ context: 'get-started', id: 'how-to-sync-products-to-google-free-listings', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'how-to-sync-products-to-google-free-listings', action: 'collapse' }`.
+	- with `{ context: 'get-started', id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'collapse' }`.
+	- with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'expand' }`.
+	- with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'collapse' }`.
+- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L69)
+	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-wp-account', action: 'expand' }`.
+	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-wp-account', action: 'collapse' }`.
+	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'expand' }`.
+	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'collapse' }`.
+
 ### [`gla_filter`](../../js/src/utils/recordEvent.js#L64)
 Triggered when changing products & variations filter,
  with data that comes from
@@ -312,22 +352,12 @@ Clicking on the link to view free ad credit value by country.
 |---|---|---|
 `context` | `string` | Indicates which page the link is in.
 #### Emitters
-- [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27)
+- [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27) with `{ context: 'setup-ads' }`.
 
 ### [`gla_free_campaign_edited`](../../js/src/edit-free-campaign/index.js#L48)
 Saving changes to the free campaign.
 #### Emitters
 - [`EditFreeCampaign`](../../js/src/edit-free-campaign/index.js#L64)
-
-### [`gla_get_started_faq`](../../js/src/get-started-page/faqs/index.js#L249)
-Clicking on getting started page faq item to collapse or expand it.
-#### Properties
-|   |   |   |
-|---|---|---|
-`id` | `string` | FAQ identifier
-`action` | `string` | (`expand`\|`collapse`)
-#### Emitters
-- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L267)
 
 ### [`gla_google_account_connect_button_click`](../../js/src/utils/recordEvent.js#L92)
 Clicking on the button to connect Google account.
@@ -337,8 +367,12 @@ Clicking on the button to connect Google account.
 `context` | `string` | (`setup-mc`\|`setup-ads`\|`reconnect`) - indicate the button is clicked from which page.
 `action` | `string` | (`authorization`\|`scope`) 	- `authorization` is used when the plugin has not been authorized yet and requests Google account access and permission scopes from users.   - `scope` is used when requesting required permission scopes from users in order to proceed with more plugin functions. Added with the Partial OAuth feature (aka Incremental Authorization).
 #### Emitters
-- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L22) with `{ action: 'authorization', context: 'reconnect' | 'setup-mc' }`
-- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L25) with `{ action: 'scope', context: 'reconnect' | 'setup-mc' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23)
+	- with `{ action: 'authorization', context: 'reconnect' }`
+	- with `{ action: 'authorization', context: 'setup-mc' }`
+- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26)
+	- with `{ action: 'scope', context: 'reconnect' }`
+	- with `{ action: 'scope', context: 'setup-mc' }`
 - [`AuthorizeAds`](../../js/src/components/google-ads-account-card/authorize-ads.js#L21) with `{ action: 'scope', context: 'setup-ads' }`
 
 ### [`gla_google_account_connect_different_account_button_click`](../../js/src/components/google-account-card/connected-google-account-card.js#L15)
@@ -511,16 +545,6 @@ Setup Merchant Center
 - [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L30) with `{ target: 'set_up_free_listings', trigger: 'click', context: 'get-started-with-video' }`.
 - [`SavedSetupStepper`](../../js/src/setup-mc/setup-stepper/saved-setup-stepper.js#L25) with `{ target: 'step1_continue' | 'step2_continue' | 'step3_continue', trigger: 'click' }`.
 - [`SetupMCTopBar`](../../js/src/setup-mc/top-bar/index.js#L17) with `{ target: 'back', trigger: 'click' }`.
-
-### [`gla_setup_mc_faq`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L62)
-Clicking on faq items to collapse or expand it in the Setup Merchant Center page
-#### Properties
-|   |   |   |
-|---|---|---|
-`id` | `string` | FAQ identifier
-`action` | `string` | (`expand`\|`collapse`)
-#### Emitters
-- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L74)
 
 ### [`gla_table_go_to_page`](../../js/src/utils/recordEvent.js#L10)
 When table pagination is changed by entering page via "Go to page" input.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -91,12 +91,12 @@ Do not edit it manually!
 ### [`gla_ads_account_connect_button_click`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L24)
 Clicking on the button to connect an existing Google Ads account.
 #### Emitters
-- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L35) when "Connect" button is clicked.
+- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L36) when "Connect" button is clicked.
 
 ### [`gla_ads_account_create_button_click`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L16)
 Clicking on the button to create a new Google Ads account, after agreeing to the terms and conditions.
 #### Emitters
-- [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L30) When agreed by clicking "Create account".
+- [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L32) When agreed by clicking "Create account".
 
 ### [`gla_ads_set_up_billing_click`](../../js/src/setup-ads/ads-stepper/setup-billing/setup-card/index.js#L18)
 "Set up billing" button for Google Ads account is clicked.
@@ -148,12 +148,12 @@ Triggered when a chart tab is clicked
 `report` | `string` | Name of the report (e.g. `"reports-programs" \| "reports-products"`)
 `context` | `string` | Metric key of the clicked tab (e.g. `"sales" \| "conversions" \| "clicks" \| "impressions" \| "spend"`).
 #### Emitters
-- [`exports`](../../js/src/reports/summary-section.js#L39)
+- [`SummarySection`](../../js/src/reports/summary-section.js#L39)
 
 ### [`gla_contact_information_save_button_click`](../../js/src/settings/edit-store-address.js#L28)
 Triggered when the save button in contact information page is clicked.
 #### Emitters
-- [`exports`](../../js/src/settings/edit-store-address.js#L40)
+- [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41)
 
 ### [`gla_dashboard_edit_program_click`](../../js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js#L17)
 Triggered when "continue" to edit program button is clicked.
@@ -198,6 +198,46 @@ When a documentation link is clicked.
 `href` | `string` | link's URL
 #### Emitters
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
+- [`ContactInformation`](../../js/src/components/contact-information/index.js#L76) with `{ context: 'setup-mc-contact-information|settings-no-phone-number-notice|settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+- [`DifferentCurrencyNotice`](../../js/src/components/different-currency-notice.js#L25) with `{ context: "dashboard|reports-products|reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
+- [`FormContent`](../../js/src/components/free-listings/choose-audience/form-content.js#L31) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
+- [`ShippingTimeSection`](../../js/src/components/free-listings/configure-product-listings/shipping-time-section.js#L17) with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
+- [`TaxRate`](../../js/src/components/free-listings/configure-product-listings/tax-rate.js#L21)
+	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-read-more', href: 'https://support.google.com/merchants/answer/160162' }`
+	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L22) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L25) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L36) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
+- [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L32)
+	- with `{ context: 'setup-ads', link_id: 'shopping-ads-policies', href: 'https://support.google.com/merchants/answer/6149970' }`
+	- with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
+- [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L41) with `{ context: 'setup-mc', link_id: 'claim-url', href: 'https://support.google.com/merchants/answer/176793' }`
+- [`TermsModal`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L29) with `{ context: 'setup-mc', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
+- [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L22)
+	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
+	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
+- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L267)
+	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
+	- with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
+	- with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
+	- with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+	- with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+	- with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+	- with `{ context: 'faqs', linkId: 'terms-and-conditions-of-google-ads-coupons', href: 'https://www.google.com/ads/coupons/terms/' }`.
+- [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L27) with `{ context: 'get-started', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
+- [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L30) with `{ context: 'get-started-with-video', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
+- [`UnsupportedLanguage`](../../js/src/get-started-page/unsupported-notices/index.js#L30) with `{ context: 'get-started', link_id: 'supported-languages', href: 'https://support.google.com/merchants/answer/160637' }`
+- [`UnsupportedCountry`](../../js/src/get-started-page/unsupported-notices/index.js#L75) with `{ context: "get-started", link_id: "supported-countries" }`
+- [`CreatePaidAdsCampaignForm`](../../js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js#L29) with `{ context: 'create-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
+- [`EditPaidAdsCampaignForm`](../../js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js#L26) with `{ context: 'edit-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
+- [`IssuesTableCard`](../../js/src/product-feed/issues-table-card/index.js#L97) with `{ context: 'product-feed', link_id: 'issues-to-resolve', href: 'https://support.google.com/merchants/answer/6363310' }`
+- [`ProductStatusHelpPopover`](../../js/src/product-feed/product-statistics/product-status-help-popover/index.js#L16) with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`
+- [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
+- [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
+- [`CreateCampaign`](../../js/src/setup-ads/ads-stepper/create-campaign/index.js#L21) with `{ context: 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
+- [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27) with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
+- [`FormContent`](../../js/src/setup-mc/setup-stepper/choose-audience/form-content.js#L31) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
+- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L74) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
 
 ### [`gla_edit_mc_phone_number`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L13)
 Triggered when phone number edit button is clicked.
@@ -209,7 +249,7 @@ Triggered when phone number edit button is clicked.
 #### Emitters
 - [`PhoneNumberCardPreview`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L32) Whenever "Edit" is clicked.
 
-### [`gla_edit_mc_store_address`](../../js/src/components/contact-information/store-address-card.js#L124)
+### [`gla_edit_mc_store_address`](../../js/src/components/contact-information/store-address-card.js#L126)
 Trigger when store address edit button is clicked.
  Before `1.5.0` this name was used for tracking clicking "Edit in settings" to edit the WC address. As of `>1.5.0`, that event is now tracked as `edit_wc_store_address`.
 #### Properties
@@ -218,7 +258,7 @@ Trigger when store address edit button is clicked.
 `path` | `string` | The path used in the page from which the link was clicked, e.g. `"/google/settings"`.
 `subpath` | `string\|undefined` | The subpath used in the page, e.g. `"/edit-store-address"` or `undefined` when there is no subpath.
 #### Emitters
-- [`StoreAddressCardPreview`](../../js/src/components/contact-information/store-address-card.js#L144) Whenever "Edit" is clicked.
+- [`StoreAddressCardPreview`](../../js/src/components/contact-information/store-address-card.js#L146) Whenever "Edit" is clicked.
 
 ### [`gla_edit_product_click`](../../js/src/product-feed/product-feed-table-card/index.js#L50)
 Triggered when edit links are clicked from product feed table.
@@ -238,7 +278,7 @@ Triggered when edit links are clicked from Issues to resolve table.
 `code` | `string` | Issue code returned from Google
 `issue` | `string` | Issue description returned from Google
 #### Emitters
-- [`IssuesTableCard`](../../js/src/product-feed/issues-table-card/index.js#L96)
+- [`IssuesTableCard`](../../js/src/product-feed/issues-table-card/index.js#L97)
 
 ### [`gla_edit_wc_store_address`](../../js/src/components/contact-information/store-address-card.js#L23)
 Triggered when store address "Edit in WooCommerce Settings" button is clicked.
@@ -249,7 +289,7 @@ Triggered when store address "Edit in WooCommerce Settings" button is clicked.
 `path` | `string` | The path used in the page from which the link was clicked, e.g. `"/google/settings"`.
 `subpath` | `string\|undefined` | The subpath used in the page, e.g. `"/edit-store-address"` or `undefined` when there is no subpath.
 #### Emitters
-- [`exports`](../../js/src/components/contact-information/store-address-card.js#L39) Whenever "Edit in WooCommerce Settings" button is clicked.
+- [`StoreAddressCard`](../../js/src/components/contact-information/store-address-card.js#L39) Whenever "Edit in WooCommerce Settings" button is clicked.
 
 ### [`gla_filter`](../../js/src/utils/recordEvent.js#L64)
 Triggered when changing products & variations filter,
@@ -272,14 +312,14 @@ Clicking on the link to view free ad credit value by country.
 |---|---|---|
 `context` | `string` | Indicates which page the link is in.
 #### Emitters
-- [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L26)
+- [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27)
 
 ### [`gla_free_campaign_edited`](../../js/src/edit-free-campaign/index.js#L48)
 Saving changes to the free campaign.
 #### Emitters
-- [`exports`](../../js/src/edit-free-campaign/index.js#L64)
+- [`EditFreeCampaign`](../../js/src/edit-free-campaign/index.js#L64)
 
-### [`gla_get_started_faq`](../../js/src/get-started-page/faqs.js#L219)
+### [`gla_get_started_faq`](../../js/src/get-started-page/faqs/index.js#L249)
 Clicking on getting started page faq item to collapse or expand it.
 #### Properties
 |   |   |   |
@@ -287,21 +327,9 @@ Clicking on getting started page faq item to collapse or expand it.
 `id` | `string` | FAQ identifier
 `action` | `string` | (`expand`\|`collapse`)
 #### Emitters
-- [`Faqs`](../../js/src/get-started-page/faqs.js#L230)
+- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L267)
 
-### [`gla_get_started_notice_link_click`](../../js/src/get-started-page/unsupported-notices/index.js#L26)
-Clicking on a text link within the notice on the Get Started page.
-#### Properties
-|   |   |   |
-|---|---|---|
-`link_id` | `string` | Link identifier
-`context` | `string` | Indicates which link is clicked
-`href` | `string` | Link's URL
-#### Emitters
-- [`UnsupportedLanguage`](../../js/src/get-started-page/unsupported-notices/index.js#L38) with `{ context: "get-started", link_id: "supported-languages" }`
-- [`UnsupportedCountry`](../../js/src/get-started-page/unsupported-notices/index.js#L84) with `{ context: "get-started", link_id: "supported-countries" }`
-
-### [`gla_google_account_connect_button_click`](../../js/src/utils/recordEvent.js#L91)
+### [`gla_google_account_connect_button_click`](../../js/src/utils/recordEvent.js#L92)
 Clicking on the button to connect Google account.
 #### Properties
 |   |   |   |
@@ -309,14 +337,14 @@ Clicking on the button to connect Google account.
 `context` | `string` | (`setup-mc`\|`setup-ads`\|`reconnect`) - indicate the button is clicked from which page.
 `action` | `string` | (`authorization`\|`scope`) 	- `authorization` is used when the plugin has not been authorized yet and requests Google account access and permission scopes from users.   - `scope` is used when requesting required permission scopes from users in order to proceed with more plugin functions. Added with the Partial OAuth feature (aka Incremental Authorization).
 #### Emitters
-- [`exports`](../../js/src/components/google-account-card/connect-google-account-card.js#L21) with `{ action: 'authorization', context: 'reconnect' | 'setup-mc' }`
-- [`exports`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L24) with `{ action: 'scope', context: 'reconnect' | 'setup-mc' }`
-- [`exports`](../../js/src/components/google-ads-account-card/authorize-ads.js#L21) with `{ action: 'scope', context: 'setup-ads' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L22) with `{ action: 'authorization', context: 'reconnect' | 'setup-mc' }`
+- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L25) with `{ action: 'scope', context: 'reconnect' | 'setup-mc' }`
+- [`AuthorizeAds`](../../js/src/components/google-ads-account-card/authorize-ads.js#L21) with `{ action: 'scope', context: 'setup-ads' }`
 
 ### [`gla_google_account_connect_different_account_button_click`](../../js/src/components/google-account-card/connected-google-account-card.js#L15)
 Clicking on the "connect to a different Google account" button.
 #### Emitters
-- [`exports`](../../js/src/components/google-account-card/connected-google-account-card.js#L32)
+- [`ConnectedGoogleAccountCard`](../../js/src/components/google-account-card/connected-google-account-card.js#L32)
 
 ### [`gla_google_ads_account_link_click`](../../js/src/setup-ads/ads-stepper/setup-billing/billing-saved-card/index.js#L19)
 Clicking on a Google Ads account text link.
@@ -329,7 +357,7 @@ Clicking on a Google Ads account text link.
 #### Emitters
 - [`BillingSavedCard`](../../js/src/setup-ads/ads-stepper/setup-billing/billing-saved-card/index.js#L31) with `{ context: 'setup-ads', link_id: 'google-ads-account' }`
 
-### [`gla_google_mc_link_click`](../../js/src/utils/recordEvent.js#L101)
+### [`gla_google_mc_link_click`](../../js/src/utils/recordEvent.js#L102)
 Clicking on a Google Merchant Center link.
 #### Properties
 |   |   |   |
@@ -349,7 +377,7 @@ Clicking on a Google Merchant Center link.
 #### Emitters
 - [`HelpIconButton`](../../js/src/components/help-icon-button.js#L30)
 
-### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/recordEvent.js#L83)
+### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/recordEvent.js#L84)
 Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign
 #### Properties
 |   |   |   |
@@ -357,7 +385,7 @@ Triggered when the "Launch paid campaign" button is clicked to add a new paid ca
 `audiences` | `string` | Country codes of the paid campaign audience countries, e.g. `'US,JP,AU'`. This means the campaign is created with the multi-country targeting feature. Before this feature support, it was implemented as 'audience'.
 `budget` | `string` | Daily average cost of the paid campaign
 #### Emitters
-- [`CreatePaidAdsCampaignForm`](../../js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js#L28) on submit
+- [`CreatePaidAdsCampaignForm`](../../js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js#L29) on submit
 - [`SetupAdsForm`](../../js/src/setup-ads/setup-ads-form.js#L24) on submit
 
 ### [`gla_mc_account_connect_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L25)
@@ -368,17 +396,17 @@ Clicking on the button to connect an existing Google Merchant Center account.
 ### [`gla_mc_account_connect_different_account_button_click`](../../js/src/components/google-mc-account-card/connected-google-mc-account-card.js#L21)
 Clicking on the "connect to a different Google Merchant Center account" button.
 #### Emitters
-- [`exports`](../../js/src/components/google-mc-account-card/connected-google-mc-account-card.js#L36)
+- [`ConnectedGoogleMCAccountCard`](../../js/src/components/google-mc-account-card/connected-google-mc-account-card.js#L36)
 
 ### [`gla_mc_account_create_button_click`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L16)
 Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
 #### Emitters
-- [`TermsModal`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L28)
+- [`TermsModal`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L29)
 
 ### [`gla_mc_account_reclaim_url_button_click`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L26)
 Clicking on the button to reclaim URL for a Google Merchant Center account.
 #### Emitters
-- [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L40)
+- [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L41)
 
 ### [`gla_mc_account_switch_account_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L31)
 Clicking on the "Switch account" button to select a different Google Merchant Center account to connect.
@@ -387,7 +415,7 @@ Clicking on the "Switch account" button to select a different Google Merchant Ce
 |---|---|---|
 `context` | `string` | (`switch-url`\|`reclaim-url`) - indicate the button is clicked from which step.
 #### Emitters
-- [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L40) with `context: 'reclaim-url'`
+- [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L41) with `context: 'reclaim-url'`
 - [`SwitchUrlCard`](../../js/src/components/google-mc-account-card/switch-url-card/index.js#L40) with `context: 'switch-url'`
 
 ### [`gla_mc_account_switch_url_button_click`](../../js/src/components/google-mc-account-card/switch-url-card/index.js#L25)
@@ -418,9 +446,9 @@ Clicking on the Merchant Center phone number edit button.
 |---|---|---|
 `view` | `string` | which view the edit button is in. Possible values: `setup-mc`, `settings`.
 #### Emitters
-- [`exports`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L111)
+- [`PhoneNumberCard`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L111)
 
-### [`gla_modal_closed`](../../js/src/utils/recordEvent.js#L109)
+### [`gla_modal_closed`](../../js/src/utils/recordEvent.js#L110)
 A modal is closed.
 #### Properties
 |   |   |   |
@@ -429,7 +457,7 @@ A modal is closed.
 `action` | `string` | Indicates the modal is closed by what action (e.g. `maybe-later`\|`dismiss` \| `create-another-campaign`)    - `maybe-later` is used when the "Maybe later" button on the modal is clicked    - `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, or pressing ESC    - `create-another-campaign` is used when the button "Create another campaign" is clicked    - `create-paid-campaign` is used when the button "Create paid campaign" is clicked
 #### Emitters
 - [`Dashboard`](../../js/src/dashboard/index.js#L33) when CES modal is closed.
-- [`exports`](../../js/src/product-feed/submission-success-guide/index.js#L160) with `action: 'create-paid-campaign' | 'maybe-later' | 'dismiss'`
+- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L160) with `action: 'create-paid-campaign' | 'maybe-later' | 'dismiss'`
 
 ### [`gla_modal_content_link_click`](../../js/src/components/guide-page-content/index.js#L28)
 Clicking on a text link within the modal content
@@ -448,7 +476,7 @@ A modal is opend
 |---|---|---|
 `context` | `string` | Indicates which modal is opened
 #### Emitters
-- [`exports`](../../js/src/product-feed/submission-success-guide/index.js#L160) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
+- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L160) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
 ### [`gla_setup_ads`](../../js/src/setup-ads/top-bar/index.js#L14)
 Triggered on events during ads setup and editing
@@ -477,8 +505,10 @@ Setup Merchant Center
 |---|---|---|
 `target` | `string` | Button ID
 `trigger` | `string` | Action (e.g. `click`)
+`context` | `string` | Indicates which CTA is clicked
 #### Emitters
-- [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L27) with `{ target: 'set_up_free_listings', trigger: 'click' }`.
+- [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L27) with `{ target: 'set_up_free_listings', trigger: 'click', context: 'get-started' }`.
+- [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L30) with `{ target: 'set_up_free_listings', trigger: 'click', context: 'get-started-with-video' }`.
 - [`SavedSetupStepper`](../../js/src/setup-mc/setup-stepper/saved-setup-stepper.js#L25) with `{ target: 'step1_continue' | 'step2_continue' | 'step3_continue', trigger: 'click' }`.
 - [`SetupMCTopBar`](../../js/src/setup-mc/top-bar/index.js#L17) with `{ target: 'back', trigger: 'click' }`.
 
@@ -490,7 +520,7 @@ Clicking on faq items to collapse or expand it in the Setup Merchant Center page
 `id` | `string` | FAQ identifier
 `action` | `string` | (`expand`\|`collapse`)
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L73)
+- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L74)
 
 ### [`gla_table_go_to_page`](../../js/src/utils/recordEvent.js#L10)
 When table pagination is changed by entering page via "Go to page" input.
@@ -500,7 +530,7 @@ When table pagination is changed by entering page via "Go to page" input.
 `context` | `string` | Name of the table
 `page` | `string` | Page number (starting at 1)
 #### Emitters
-- [`IssuesTableCard`](../../js/src/product-feed/issues-table-card/index.js#L96) with `context: 'issues-to-resolve'`
+- [`IssuesTableCard`](../../js/src/product-feed/issues-table-card/index.js#L97) with `context: 'issues-to-resolve'`
 - [`ProductFeedTableCard`](../../js/src/product-feed/product-feed-table-card/index.js#L66) with `context: 'product-feed'`
 - [`recordTablePageEvent`](../../js/src/utils/recordEvent.js#L38) with the given `{ context, page }`.
 
@@ -524,7 +554,7 @@ When table pagination is clicked
 `context` | `string` | Name of the table
 `direction` | `string` | Direction of page to be changed. `("next" \| "previous")`
 #### Emitters
-- [`IssuesTableCard`](../../js/src/product-feed/issues-table-card/index.js#L96) with `context: 'issues-to-resolve'`
+- [`IssuesTableCard`](../../js/src/product-feed/issues-table-card/index.js#L97) with `context: 'issues-to-resolve'`
 - [`ProductFeedTableCard`](../../js/src/product-feed/product-feed-table-card/index.js#L66) with `context: 'product-feed'`
 - [`recordTablePageEvent`](../../js/src/utils/recordEvent.js#L38) with the given `{ context, direction }`.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1497.

This PR removes the `eventName` prop from the component that uses [AppDocumentationLink](https://github.com/woocommerce/google-listings-and-ads/blob/cbc4a9d3b66279eeee8225d1ae0b97cdc1216d29/js/src/components/app-documentation-link/index.js), to make sure the eventName will always be `gla_documentation_link_click` defined in `AppDocumentationLink`.

This PR also add several missing event JSDocs for the event `gla_documentation_link_click`, as well as refactor some components' default export definition so the tracking doc can be generated correctly. To be clear, replace

```js
export default function SomeComponent {
}
```

with

```js
const SomeComponent = () => {
};

export default SomeComponent;
```

So it will fix the problem that in [Tracking Doc](https://github.com/woocommerce/google-listings-and-ads/blob/c686f6ed423992e1627186bf49e208494027f4e7/src/Tracking/README.md) there are some component name generated as `exports`.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Check event name is sent correctly

1. Open your console and run `localStorage.setItem('debug', 'wc-admin*')`.
2. Enable verbose mode in dev tool's console.
3. Modify [js/src/get-started-page/unsupported-notices/index.js](https://github.com/woocommerce/google-listings-and-ads/blob/c686f6ed423992e1627186bf49e208494027f4e7/js/src/get-started-page/unsupported-notices/index.js) locally so the unsupported notice can show up
    ```diff
   --- a/js/src/get-started-page/unsupported-notices/index.js
   +++ b/js/src/get-started-page/unsupported-notices/index.js
   @@ -119,8 +119,8 @@ export default function UnsupportedNotices() {
   
     return (
       <>
   -     { ! mcSupportedLanguage && <UnsupportedLanguage /> }
   -     { ! mcSupportedCountry && <UnsupportedCountry /> }
   +     { mcSupportedLanguage && <UnsupportedLanguage /> }
   +     { mcSupportedCountry && <UnsupportedCountry /> }
       </>
     );
    }
    ```
4. Modify [js/src/components/different-currency-notice.js](https://github.com/woocommerce/google-listings-and-ads/blob/c686f6ed423992e1627186bf49e208494027f4e7/js/src/components/different-currency-notice.js) locally so the different currency notice can show up
    ```diff
    --- a/js/src/components/different-currency-notice.js
    +++ b/js/src/components/different-currency-notice.js
    @@ -30,7 +30,7 @@ const DifferentCurrencyNotice = ( { context } ) => {
      if (
        ! googleAdsAccount ||
        googleAdsAccount.status !== 'connected' ||
    -   googleAdsAccount.currency === storeCurrency
    +   googleAdsAccount.currency !== storeCurrency
      ) {
        return null;
      }
    ```
5. Go to GLA's get started page: `https://domain.test/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart` 
6. Click on the two `Read more...` links on both notices, the event name should be `wcadmin_gla_documentation_link_click`
    - <img width="1278" alt="Screenshot 2022-05-12 at 18 05 21" src="https://user-images.githubusercontent.com/914406/168051092-e7f6952f-b8a4-4884-8fc6-0a61ffff50ca.png">
7. Connect Google MC account and go to GLA's dashboard and reports page
8. Click on the two `Read more` links on both notices, the event name should be `wcadmin_gla_documentation_link_click`
    - <img width="1703" alt="Screenshot 2022-05-12 at 18 16 26" src="https://user-images.githubusercontent.com/914406/168051487-7d13f4b1-a0dc-41a3-8a50-82cbf807e786.png">

#### Tracking Document

- Check the new tracking doc in the last commit, there shouldn't be `exports` as the component name anymore.
- There are several emitters under `gla_documentation_link_click` event as added by commit 0e7c950.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Enhance event name for documentation link and update tracking document.
