### PR TITLE
Require URL to match when syncing data to Merchant Center

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -194,6 +194,34 @@ class Merchant implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Get hash of the site URL we used during onboarding.
+	 * If not available in a local option, it's fetched from the Merchant Center account.
+	 *
+	 * @since x.x.x
+	 * @return string|null
+	 */
+	public function get_claimed_url_hash(): ?string {
+		$claimed_url_hash = $this->options->get( OptionsInterface::CLAIMED_URL_HASH );
+
+		if ( empty( $hashclaimed_url_ ) && $this->options->get_merchant_id() ) {
+			try {
+				$account_url = $this->get_account()->getWebsiteUrl();
+
+				if ( empty( $account_url ) || ! $this->get_accountstatus()->getWebsiteClaimed() ) {
+					return null;
+				}
+
+				$claimed_url_hash = md5( $account_url );
+				$this->options->update( OptionsInterface::CLAIMED_URL_HASH, $claimed_url_hash );
+			} catch ( Exception $e ) {
+				return null;
+			}
+		}
+
+		return $claimed_url_hash;
+	}
+
+	/**
 	 * Retrieve the user's Merchant Center account information.
 	 *
 	 * @param int $id Optional - the Merchant Center account to retrieve

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -203,7 +203,7 @@ class Merchant implements OptionsAwareInterface {
 	public function get_claimed_url_hash(): ?string {
 		$claimed_url_hash = $this->options->get( OptionsInterface::CLAIMED_URL_HASH );
 
-		if ( empty( $hashclaimed_url_ ) && $this->options->get_merchant_id() ) {
+		if ( empty( $claimed_url_hash ) && $this->options->get_merchant_id() ) {
 			try {
 				$account_url = $this->get_account()->getWebsiteUrl();
 

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -460,7 +460,7 @@ class CouponSyncer implements Service {
 	 * @throws CouponSyncerException If Google Merchant Center is not set up and connected.
 	 */
 	protected function validate_merchant_center_setup(): void {
-		if ( ! $this->merchant_center->is_connected() ) {
+		if ( ! $this->merchant_center->is_ready_for_syncing() ) {
 			do_action(
 				'woocommerce_gla_error',
 				'Cannot sync any coupons before setting up Google Merchant Center.',

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -99,8 +99,8 @@ class SyncerHooks implements Service, Registerable {
 	 * Register a service.
 	 */
 	public function register(): void {
-		// only register the hooks if Merchant Center is set up and connected.
-		if ( ! $this->merchant_center->is_connected() ) {
+		// only register the hooks if Merchant Center is set up and ready for syncing data.
+		if ( ! $this->merchant_center->is_ready_for_syncing() ) {
 			return;
 		}
 

--- a/src/Jobs/AbstractCouponSyncerJob.php
+++ b/src/Jobs/AbstractCouponSyncerJob.php
@@ -64,12 +64,12 @@ abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob implem
 	}
 
 	/**
-	 * Get whether Merchant Center is connected.
+	 * Get whether Merchant Center is connected and ready for syncing data.
 	 *
 	 * @return bool
 	 */
-	public function is_mc_connected(): bool {
-		return $this->merchant_center->is_connected();
+	public function is_mc_ready_for_syncing(): bool {
+		return $this->merchant_center->is_ready_for_syncing();
 	}
 
 	/**
@@ -80,6 +80,6 @@ abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob implem
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->is_mc_connected();
+		return ! $this->is_running( $args ) && $this->is_mc_ready_for_syncing();
 	}
 }

--- a/src/Jobs/AbstractProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractProductSyncerBatchedJob.php
@@ -64,12 +64,12 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	}
 
 	/**
-	 * Get whether Merchant Center is connected.
+	 * Get whether Merchant Center is connected and ready for syncing data.
 	 *
 	 * @return bool
 	 */
-	public function is_mc_connected(): bool {
-		return $this->merchant_center->is_connected();
+	public function is_mc_ready_for_syncing(): bool {
+		return $this->merchant_center->is_ready_for_syncing();
 	}
 
 	/**
@@ -80,6 +80,6 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->is_mc_connected();
+		return ! $this->is_running( $args ) && $this->is_mc_ready_for_syncing();
 	}
 }

--- a/src/Jobs/AbstractProductSyncerJob.php
+++ b/src/Jobs/AbstractProductSyncerJob.php
@@ -55,12 +55,12 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob imple
 	}
 
 	/**
-	 * Get whether Merchant Center is connected.
+	 * Get whether Merchant Center is connected and ready for syncing data.
 	 *
 	 * @return bool
 	 */
-	public function is_mc_connected(): bool {
-		return $this->merchant_center->is_connected();
+	public function is_mc_ready_for_syncing(): bool {
+		return $this->merchant_center->is_ready_for_syncing();
 	}
 
 	/**
@@ -71,6 +71,6 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob imple
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->is_mc_connected();
+		return ! $this->is_running( $args ) && $this->is_mc_ready_for_syncing();
 	}
 }

--- a/src/Jobs/CleanupSyncedProducts.php
+++ b/src/Jobs/CleanupSyncedProducts.php
@@ -20,6 +20,15 @@ defined( 'ABSPATH' ) || exit;
 class CleanupSyncedProducts extends AbstractProductSyncerBatchedJob {
 
 	/**
+	 * Get whether Merchant Center is connected.
+	 *
+	 * @return bool
+	 */
+	public function is_mc_connected(): bool {
+		return $this->merchant_center->is_connected();
+	}
+
+	/**
 	 * Get the name of the job.
 	 *
 	 * @return string

--- a/src/Jobs/ProductSyncerJobInterface.php
+++ b/src/Jobs/ProductSyncerJobInterface.php
@@ -13,10 +13,11 @@ defined( 'ABSPATH' ) || exit;
 interface ProductSyncerJobInterface {
 
 	/**
-	 * Get whether Merchant Center setup is connected.
+	 * Get whether Merchant Center is connected and ready for syncing data.
 	 *
+	 * @since x.x.x
 	 * @return bool
 	 */
-	public function is_mc_connected(): bool;
+	public function is_mc_ready_for_syncing(): bool;
 
 }

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -250,6 +250,7 @@ class AccountService implements OptionsAwareInterface, Service {
 		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
 		$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
+		$this->options->delete( OptionsInterface::CLAIMED_URL_HASH );
 
 		$this->container->get( MerchantStatuses::class )->delete();
 
@@ -455,6 +456,9 @@ class AccountService implements OptionsAwareInterface, Service {
 
 			$account->setWebsiteUrl( $site_url );
 			$merchant->update_account( $account );
+
+			// Clear previous hashed URL.
+			$this->options->delete( OptionsInterface::CLAIMED_URL_HASH );
 
 			do_action( 'woocommerce_gla_url_switch_success', [] );
 		}

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -36,6 +36,8 @@ defined( 'ABSPATH' ) || exit;
  * - MerchantAccountState
  * - MerchantStatuses
  * - Settings
+ * - ShippingRateQuery
+ * - ShippingTimeQuery
  * - WC
  * - WP
  * - TargetAudience
@@ -94,7 +96,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * Whether we are able to sync data to the Merchant Center account.
 	 * Account must be connected and the URL we claimed with must match the site URL.
 	 *
-	 * @since x.x.xis_mc_connected
+	 * @since x.x.x
 	 * @return boolean
 	 */
 	public function is_ready_for_syncing(): bool {

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
@@ -31,6 +32,7 @@ defined( 'ABSPATH' ) || exit;
  * ContainerAware used to access:
  * - AddressUtility
  * - ContactInformation
+ * - Merchant
  * - MerchantAccountState
  * - MerchantStatuses
  * - Settings
@@ -86,6 +88,20 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 */
 	public function is_google_connected(): bool {
 		return boolval( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) );
+	}
+
+	/**
+	 * Whether we are able to sync data to the Merchant Center account.
+	 * Account must be connected and the URL we claimed with must match the site URL.
+	 *
+	 * @since x.x.xis_mc_connected
+	 * @return boolean
+	 */
+	public function is_ready_for_syncing(): bool {
+		$claimed_url_hash = $this->container->get( Merchant::class )->get_claimed_url_hash();
+		$site_url_hash    = md5( $this->get_site_url() );
+
+		return $this->is_connected() && apply_filters( 'woocommerce_gla_ready_for_syncing', $claimed_url_hash === $site_url_hash );
 	}
 
 	/**

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -18,6 +18,7 @@ interface OptionsInterface {
 	public const ADS_ID                 = 'ads_id';
 	public const ADS_CONVERSION_ACTION  = 'ads_conversion_action';
 	public const ADS_SETUP_COMPLETED_AT = 'ads_setup_completed_at';
+	public const CLAIMED_URL_HASH       = 'claimed_url_hash';
 	public const CONTACT_INFO_SETUP     = 'contact_info_setup';
 	public const DELAYED_ACTIVATE       = 'delayed_activate';
 	public const DB_VERSION             = 'db_version';
@@ -43,6 +44,7 @@ interface OptionsInterface {
 		self::ADS_ID                 => true,
 		self::ADS_CONVERSION_ACTION  => true,
 		self::ADS_SETUP_COMPLETED_AT => true,
+		self::CLAIMED_URL_HASH       => true,
 		self::CONTACT_INFO_SETUP     => true,
 		self::DB_VERSION             => true,
 		self::FILE_VERSION           => true,

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -350,12 +350,12 @@ class ProductSyncer implements Service {
 	}
 
 	/**
-	 * Validates whether Merchant Center is set up and connected.
+	 * Validates whether Merchant Center is connected and ready for syncing data.
 	 *
-	 * @throws ProductSyncerException If Google Merchant Center is not set up and connected.
+	 * @throws ProductSyncerException If the Google Merchant Center connection is not ready.
 	 */
 	protected function validate_merchant_center_setup(): void {
-		if ( ! $this->merchant_center->is_connected() ) {
+		if ( ! $this->merchant_center->is_ready_for_syncing() ) {
 			do_action( 'woocommerce_gla_error', 'Cannot sync any products before setting up Google Merchant Center.', __METHOD__ );
 
 			throw new ProductSyncerException( __( 'Google Merchant Center has not been set up correctly. Please review your configuration.', 'google-listings-and-ads' ) );

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -103,8 +103,8 @@ class SyncerHooks implements Service, Registerable {
 	 * Register a service.
 	 */
 	public function register(): void {
-		// only register the hooks if Merchant Center is set up and connected.
-		if ( ! $this->merchant_center->is_connected() ) {
+		// only register the hooks if Merchant Center is connected and ready for syncing data.
+		if ( ! $this->merchant_center->is_ready_for_syncing() ) {
 			return;
 		}
 

--- a/tests/Tools/HelperTrait/MerchantTrait.php
+++ b/tests/Tools/HelperTrait/MerchantTrait.php
@@ -55,9 +55,9 @@ trait MerchantTrait {
 		return $account;
 	}
 
-	public function get_status_website_claimed(): AccountStatus {
+	public function get_status_website_claimed( bool $claimed = true ): AccountStatus {
 		$status = new AccountStatus();
-		$status->setWebsiteClaimed( true );
+		$status->setWebsiteClaimed( $claimed );
 
 		return $status;
 	}

--- a/tests/Tools/HelperTrait/MerchantTrait.php
+++ b/tests/Tools/HelperTrait/MerchantTrait.php
@@ -40,12 +40,17 @@ trait MerchantTrait {
 
 	public function get_valid_account(): Account {
 		$account       = new Account();
+		$account->setBusinessInformation( $this->get_valid_business_info() );
+
+		return $account;
+	}
+
+	public function get_valid_business_info(): AccountBusinessInformation {
 		$business_info = new AccountBusinessInformation();
 		$business_info->setPhoneNumber( $this->valid_account_phone_number );
 		$business_info->setAddress( $this->get_sample_address() );
-		$account->setBusinessInformation( $business_info );
 
-		return $account;
+		return $business_info;
 	}
 
 	public function get_account_with_url( string $url ): Account {

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
 use Exception;
 use Google\Exception as GoogleException;
 use Google\Service\Exception as GoogleServiceException;
@@ -39,6 +40,8 @@ defined( 'ABSPATH' ) || exit;
  * @property  Merchant                    $merchant
  */
 class MerchantTest extends UnitTest {
+
+	use MerchantTrait;
 
 	/**
 	 * Runs before each test is executed.
@@ -204,52 +207,59 @@ class MerchantTest extends UnitTest {
 
 	public function test_get_account() {
 		$account = $this->createMock( Account::class );
-
-		$this->service->accounts->expects( $this->once() )
-			->method( 'get' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->willReturn( $account );
+		$this->mock_get_account( $account );
 
 		$this->assertEquals( $account, $this->merchant->get_account() );
 	}
 
 	public function test_get_account_failure() {
-		$this->service->accounts->expects( $this->once() )
-			->method( 'get' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleException( 'error', 400 )
-				)
-			);
+		$this->mock_get_account_exception( new GoogleException( 'error', 400 ) );
 
 		$this->expectException( MerchantApiException::class );
         $this->expectExceptionCode( 400 );
 		$this->merchant->get_account();
 	}
 
+	public function test_get_claimed_url_hash_from_cache() {
+		$url = 'https://site.test';
+		$this->options->method( 'get' )
+			->with( OptionsInterface::CLAIMED_URL_HASH )
+			->willReturn( md5( $url ) );
+
+		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
+	}
+
+	public function test_get_claimed_url_hash_not_claimed() {
+		$url = 'https://site.test';
+		$this->mock_get_account( $this->get_account_with_url( $url  ) );
+		$this->mock_get_account_status( $this->get_status_website_claimed( false ) );
+
+		$this->assertNull( $this->merchant->get_claimed_url_hash() );
+	}
+
+	public function test_get_claimed_url_hash_from_account() {
+		$url = 'https://site.test';
+		$this->mock_get_account( $this->get_account_with_url( $url ) );
+		$this->mock_get_account_status( $this->get_status_website_claimed() );
+
+		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
+	}
+
+	public function test_get_claimed_url_hash_from_account_failure() {
+		$this->mock_get_account_exception( new GoogleException( 'error', 400 ) );
+
+		$this->assertNull( $this->merchant->get_claimed_url_hash() );
+	}
+
 	public function test_get_accountstatuses() {
 		$account_status = $this->createMock( AccountStatus::class );
-
-		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
-		$this->service->accountstatuses->expects( $this->once() )
-			->method( 'get' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->willReturn( $account_status );
+		$this->mock_get_account_status( $account_status );
 
 		$this->assertEquals( $account_status, $this->merchant->get_accountstatus() );
 	}
 
 	public function test_get_accountstatus_failure() {
-		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
-		$this->service->accountstatuses->expects( $this->once() )
-			->method( 'get' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleException( 'error', 400 )
-				)
-			);
+		$this->mock_get_account_status_exception( new GoogleException( 'error', 400 ) );
 
 		$this->expectException( Exception::class );
         $this->expectExceptionCode( 400 );
@@ -344,10 +354,7 @@ class MerchantTest extends UnitTest {
 				)
 			);
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'get' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->willReturn( $account );
+		$this->mock_get_account( $account );
 
 		$this->service->accounts->expects( $this->once() )
 			->method( 'update' )
@@ -371,10 +378,7 @@ class MerchantTest extends UnitTest {
 			->method( 'getAdsLinks' )
 			->willReturn( [ $ads_link ] );
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'get' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->willReturn( $account );
+		$this->mock_get_account( $account );
 
 		$this->assertFalse(
 			$this->merchant->link_ads_id( $ads_id )
@@ -398,10 +402,7 @@ class MerchantTest extends UnitTest {
 			->method( 'getUsers' )
 			->willReturn( [ $user ] );
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'get' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->willReturn( $account );
+		$this->mock_get_account( $account );
 
 		$this->assertTrue(
 			$this->merchant->has_access( $email )
@@ -411,14 +412,7 @@ class MerchantTest extends UnitTest {
 	public function test_no_access_to_account() {
 		$email = 'john@doe.email';
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'get' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleException( 'no access', 403 )
-				)
-			);
+		$this->mock_get_account_exception( new GoogleException( 'no access', 403 ) );
 
 		$this->assertFalse(
 			$this->merchant->has_access( $email )
@@ -431,6 +425,36 @@ class MerchantTest extends UnitTest {
 			->with( OptionsInterface::MERCHANT_ID, $this->merchant_id )
 			->willReturn( true );
 		$this->assertTrue( $this->merchant->update_merchant_id( $this->merchant_id ) );
+	}
+
+	private function mock_get_account( Account $account ) {
+		$this->service->accounts->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
+			->willReturn( $account );
+	}
+
+	private function mock_get_account_exception( GoogleException $exception ) {
+		$this->service->accounts->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
+			->will( $this->throwException( $exception ) );
+	}
+
+	private function mock_get_account_status( AccountStatus $account_status ) {
+		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
+		$this->service->accountstatuses->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
+			->willReturn( $account_status );
+	}
+
+	private function mock_get_account_status_exception( GoogleException $exception ) {
+		$this->service->accountstatuses = $this->createMock( Accountstatuses::class );
+		$this->service->accountstatuses->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->merchant_id, $this->merchant_id )
+			->will( $this->throwException( $exception ) );
 	}
 
 }

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -144,7 +144,7 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
         parent::setUp();
         $this->merchant_center = $this->createMock( MerchantCenterService::class );
         $this->merchant_center->expects( $this->any() )
-            ->method( 'is_connected' )
+            ->method( 'is_ready_for_syncing' )
             ->willReturn( true );
         $this->merchant_center->expects( $this->any() )
             ->method( 'is_promotion_supported_country' )

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -20,7 +20,7 @@ use WC_Coupon;
  * Class SyncerHooksTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *         
+ *
  * @property MockObject|MerchantCenterService $merchant_center
  * @property MockObject|JobRepository $job_repository
  * @property MockObject|UpdateCoupon $update_coupon_job
@@ -73,7 +73,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
         $adapted_coupon = new WCCouponAdapter( [ 'wc_coupon' => $coupon ] );
         $adapted_coupon->disable_promotion( $coupon );
-        $expected_coupon_entry = new DeleteCouponEntry( 
+        $expected_coupon_entry = new DeleteCouponEntry(
             $coupon->get_id(),
             $adapted_coupon,
             ['US' => 'google_id'] );
@@ -91,7 +91,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
         $adapted_coupon = new WCCouponAdapter( [ 'wc_coupon' => $coupon ] );
         $adapted_coupon->disable_promotion( $coupon );
-        $expected_coupon_entry = new DeleteCouponEntry( 
+        $expected_coupon_entry = new DeleteCouponEntry(
             $coupon->get_id(),
             $adapted_coupon,
             ['US' => 'google_id'] );
@@ -123,7 +123,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
         $post = $this->factory()->post->create_and_get();
         // update post
-        $this->factory()->post->update_object( 
+        $this->factory()->post->update_object(
             $post->ID,
             ['post_title' => 'Sample title'] );
         // trash post
@@ -140,10 +140,10 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
         $this->login_as_administrator();
 
-        $this->merchant_center = $this->createMock( 
+        $this->merchant_center = $this->createMock(
             MerchantCenterService::class );
         $this->merchant_center->expects( $this->any() )
-            ->method( 'is_connected' )
+            ->method( 'is_ready_for_syncing' )
             ->willReturn( true );
 
         $this->update_coupon_job = $this->createMock( UpdateCoupon::class );
@@ -151,14 +151,14 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
         $this->job_repository = $this->createMock( JobRepository::class );
         $this->job_repository->expects( $this->any() )
             ->method( 'get' )
-            ->willReturnMap( 
+            ->willReturnMap(
             [
                 [DeleteCoupon::class,$this->delete_coupon_job],
                 [UpdateCoupon::class,$this->update_coupon_job]] );
 
         $this->wc = $this->container->get( WC::class );
         $this->coupon_helper = $this->container->get( CouponHelper::class );
-        $this->syncer_hooks = new SyncerHooks( 
+        $this->syncer_hooks = new SyncerHooks(
             $this->coupon_helper,
             $this->job_repository,
             $this->merchant_center,

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -66,7 +66,7 @@ class UpdateAllProductsTest extends UnitTest {
 			->willReturn( false );
 
 		$this->merchant_center
-			->method( 'is_connected' )
+			->method( 'is_ready_for_syncing' )
 			->willReturn( true );
 
 		/* adding a filter to make batch smaller for testing */

--- a/tests/Unit/Jobs/UpdateProductsTest.php
+++ b/tests/Unit/Jobs/UpdateProductsTest.php
@@ -87,7 +87,7 @@ class UpdateProductsTest extends UnitTest {
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
 		$this->merchant_center
-			->method( 'is_connected' )
+			->method( 'is_ready_for_syncing' )
 			->willReturn( true );
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -552,6 +552,10 @@ class AccountServiceTest extends UnitTest {
 			->method( 'update_account' )
 			->with( $this->get_account_with_url( get_home_url() ) );
 
+		$this->options->expects( $this->once() )
+			->method( 'delete')
+			->with( OptionsInterface::CLAIMED_URL_HASH );
+
 		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->switch_url( self::TEST_ACCOUNT_ID ) );
 	}
 

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -658,7 +658,7 @@ class AccountServiceTest extends UnitTest {
 	}
 
 	public function test_disconnect() {
-		$this->options->expects( $this->exactly( 7 ) )
+		$this->options->expects( $this->exactly( 8 ) )
 			->method( 'delete' )
 			->withConsecutive(
 				[ OptionsInterface::CONTACT_INFO_SETUP ],
@@ -667,7 +667,8 @@ class AccountServiceTest extends UnitTest {
 				[ OptionsInterface::MERCHANT_CENTER ],
 				[ OptionsInterface::SITE_VERIFICATION ],
 				[ OptionsInterface::TARGET_AUDIENCE ],
-				[ OptionsInterface::MERCHANT_ID ]
+				[ OptionsInterface::MERCHANT_ID ],
+				[ OptionsInterface::CLAIMED_URL_HASH ]
 			);
 
 		$this->merchant_statuses->expects( $this->once() )->method( 'delete' );

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -1,0 +1,437 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\AddressUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use DateTime;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MerchantCenterServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
+ *
+ * @property MockObject|AddressUtility       $address_utility
+ * @property MockObject|ContactInformation   $contact_information
+ * @property MockObject|GoogleHelper         $google_helper
+ * @property MockObject|Merchant             $merchant
+ * @property MockObject|MerchantAccountState $merchant_account_state
+ * @property MockObject|MerchantStatuses     $merchant_statuses
+ * @property MockObject|Settings             $settings
+ * @property MockObject|ShippingRateQuery    $shipping_rate_query
+ * @property MockObject|ShippingTimeQuery    $shipping_time_query
+ * @property MockObject|TargetAudience       $target_audience
+ * @property MockObject|WC                   $wc
+ * @property MockObject|WP                   $wp
+ * @property MerchantCenterService           $mc_service
+ * @property Container                       $container
+ * @property OptionsInterface                $options
+ */
+class MerchantCenterServiceTest extends UnitTest {
+
+	use MerchantTrait;
+
+	protected const TEST_SETUP_COMPLETED = 1641038400;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->address_utility        = $this->createMock( AddressUtility::class );
+		$this->contact_information    = $this->createMock( ContactInformation::class );
+		$this->google_helper          = $this->createMock( GoogleHelper::class );
+		$this->merchant               = $this->createMock( Merchant::class );
+		$this->merchant_account_state = $this->createMock( MerchantAccountState::class );
+		$this->merchant_statuses      = $this->createMock( MerchantStatuses::class );
+		$this->settings               = $this->createMock( Settings::class );
+		$this->shipping_rate_query    = $this->createMock( ShippingRateQuery::class );
+		$this->shipping_time_query    = $this->createMock( ShippingTimeQuery::class );
+		$this->target_audience        = $this->createMock( TargetAudience::class );
+		$this->wc                     = $this->createMock( WC::class );
+		$this->wp                     = $this->createMock( WP::class );
+		$this->options                = $this->createMock( OptionsInterface::class );
+
+		$this->container = new Container();
+		$this->container->share( AddressUtility::class, $this->address_utility );
+		$this->container->share( ContactInformation::class, $this->contact_information );
+		$this->container->share( GoogleHelper::class, $this->google_helper );
+		$this->container->share( Merchant::class, $this->merchant );
+		$this->container->share( MerchantAccountState::class, $this->merchant_account_state );
+		$this->container->share( MerchantStatuses::class, $this->merchant_statuses );
+		$this->container->share( Settings::class, $this->settings );
+		$this->container->share( ShippingRateQuery::class, $this->shipping_rate_query );
+		$this->container->share( ShippingTimeQuery::class, $this->shipping_time_query );
+		$this->container->share( TargetAudience::class, $this->target_audience );
+		$this->container->share( WC::class, $this->wc );
+		$this->container->share( WP::class, $this->wp );
+
+		$this->mc_service = new MerchantCenterService();
+		$this->mc_service->set_container( $this->container );
+		$this->mc_service->set_options_object( $this->options );
+	}
+
+	public function test_is_setup_complete() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MC_SETUP_COMPLETED_AT, false )
+			->willReturn( self::TEST_SETUP_COMPLETED );
+
+		$this->assertTrue( $this->mc_service->is_setup_complete() );
+	}
+
+	public function test_is_not_setup_complete() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MC_SETUP_COMPLETED_AT, false )
+			->willReturn( false );
+
+		$this->assertFalse( $this->mc_service->is_setup_complete() );
+	}
+
+	public function test_is_connected() {
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->assertTrue( $this->mc_service->is_connected() );
+	}
+
+	public function test_is_not_connected() {
+		$this->options->method( 'get' )
+		->withConsecutive(
+			[ OptionsInterface::GOOGLE_CONNECTED, false ],
+			[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+		)
+		->willReturnOnConsecutiveCalls(
+			true,
+			false
+		);
+
+		$this->assertFalse( $this->mc_service->is_connected() );
+	}
+
+	public function test_is_google_connected() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::GOOGLE_CONNECTED, false )
+			->willReturn( true );
+
+		$this->assertTrue( $this->mc_service->is_google_connected() );
+	}
+
+	public function test_is_not_google_connected() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::GOOGLE_CONNECTED, false )
+			->willReturn( false );
+
+		$this->assertFalse( $this->mc_service->is_google_connected() );
+	}
+
+	public function test_is_store_country_supported() {
+		$this->wc->method( 'get_base_country' )->willReturn( 'US' );
+		$this->google_helper->method( 'is_country_supported' )->with( 'US' )->willReturn( true );
+		$this->assertTrue( $this->mc_service->is_store_country_supported() );
+	}
+
+	public function test_is_not_store_country_supported() {
+		$this->wc->method( 'get_base_country' )->willReturn( 'XX' );
+		$this->google_helper->method( 'is_country_supported' )->with( 'XX' )->willReturn( false );
+		$this->assertFalse( $this->mc_service->is_store_country_supported() );
+	}
+
+	public function test_is_language_supported() {
+		$this->wp->method( 'get_locale' )->willReturn( 'en_US' );
+		$this->google_helper->method( 'get_mc_supported_languages' )->willReturn( [ 'en' => 'en' ] );
+		$this->assertTrue( $this->mc_service->is_language_supported() );
+		$this->assertTrue( $this->mc_service->is_language_supported( 'en' ) );
+		$this->assertFalse( $this->mc_service->is_language_supported( 'xx' ) );
+	}
+
+	public function test_is_contact_information_setup() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::CONTACT_INFO_SETUP, false )
+			->willReturn( true );
+
+		$this->assertTrue( $this->mc_service->is_contact_information_setup() );
+	}
+
+	public function test_is_not_contact_information_setup() {
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::CONTACT_INFO_SETUP, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				false
+			);
+
+		$this->assertFalse( $this->mc_service->is_contact_information_setup() );
+	}
+
+	public function test_is_contact_information_setup_already_completed_onboarding() {
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::CONTACT_INFO_SETUP, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->contact_information->method( 'get_contact_information' )
+			->willReturn( $this->get_valid_business_info() );
+		$this->settings->method( 'get_store_address' )
+			->willReturn( $this->get_sample_address() );
+		$this->address_utility->method( 'compare_addresses' )
+			->willReturn( true );
+
+		$this->assertTrue( $this->mc_service->is_contact_information_setup() );
+	}
+
+	public function test_is_not_contact_information_setup_already_completed_onboarding() {
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::CONTACT_INFO_SETUP, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->assertFalse( $this->mc_service->is_contact_information_setup() );
+	}
+
+	public function test_is_promotion_supported_country() {
+		$this->wc->method( 'get_base_country' )->willReturn( 'US' );
+		$this->google_helper->method( 'get_mc_promotion_supported_countries' )->willReturn( [ 'US' ] );
+		$this->assertTrue( $this->mc_service->is_promotion_supported_country() );
+		$this->assertTrue( $this->mc_service->is_promotion_supported_country( 'US' ) );
+		$this->assertFalse( $this->mc_service->is_promotion_supported_country( 'XX' ) );
+	}
+
+	public function test_get_setup_status_complete() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MC_SETUP_COMPLETED_AT, false )
+			->willReturn( self::TEST_SETUP_COMPLETED );
+
+		$this->assertEquals(
+			[ 'status' => 'complete' ],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
+	public function test_get_setup_status_step_accounts() {
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'accounts',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
+	public function test_get_setup_status_step_target_audience() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'target_audience',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
+	public function test_get_setup_status_step_shipping_and_taxes() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::TARGET_AUDIENCE ]
+			)->willReturnOnConsecutiveCalls(
+				false,
+				[
+					'location' => 'selected',
+					'countries' => [ 'US' ],
+				]
+			);
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US' ] );
+
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'shipping_and_taxes',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
+	public function test_get_setup_status_step_store_requirements() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::TARGET_AUDIENCE ],
+				[ OptionsInterface::MERCHANT_CENTER, [] ]
+			)->willReturnOnConsecutiveCalls(
+				false,
+				[
+					'location' => 'selected',
+					'countries' => [ 'US' ],
+				],
+				[
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'manual',
+				]
+			);
+
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'store_requirements',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
+	public function test_get_setup_status_shipping_selected_rates() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::TARGET_AUDIENCE ]
+			)->willReturnOnConsecutiveCalls(
+				false,
+				[
+					'location' => 'selected',
+					'countries' => [ 'US' ],
+				]
+			);
+		$this->shipping_time_query->method( 'get_results' )
+			->willReturn(
+				[
+					[
+						'time'    => '1',
+						'country' => 'GB',
+					],
+				]
+			);
+		$this->shipping_rate_query->method( 'get_results' )
+			->willReturn(
+				[
+					[
+						'rate'    => '10',
+						'country' => 'GB',
+					],
+				]
+			);
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'GB' ] );
+
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'store_requirements',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
+	public function test_filter_contact_info_issue() {
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::CONTACT_INFO_SETUP, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				self::TEST_SETUP_COMPLETED,
+				false,
+				false
+			);
+
+		$issues = apply_filters( 'woocommerce_gla_custom_merchant_issues', [], new DateTime() );
+		$this->assertEquals( 'missing_contact_information', $issues[0]['code'] );
+		$this->assertEquals( 'account', $issues[0]['type'] );
+		$this->assertEquals( 'error', $issues[0]['severity'] );
+	}
+
+	public function test_filter_contact_info_already_added() {
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::CONTACT_INFO_SETUP, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				self::TEST_SETUP_COMPLETED,
+				true
+			);
+
+		$this->assertTrue( has_filter( 'woocommerce_gla_custom_merchant_issues' ) );
+		$this->assertEquals(
+			[],
+			apply_filters( 'woocommerce_gla_custom_merchant_issues', [], new DateTime() )
+		);
+	}
+
+	public function test_has_account_issues() {
+		$this->merchant_statuses->method( 'get_issues' )
+			->with( MerchantStatuses::TYPE_ACCOUNT )
+			->willReturn(
+				[
+					'issues' => [
+						'code'     => 'issue_code',
+						'type'     => 'account',
+						'severity' => 'error',
+					],
+				]
+			);
+
+		$this->assertTrue( $this->mc_service->has_account_issues() );
+	}
+
+	public function test_has_at_least_one_synced_product() {
+		$this->merchant_statuses->method( 'get_product_statistics' )
+			->willReturn(
+				[
+					'statistics' => [
+						'active'     => 1,
+						'pending'    => 4,
+						'not_synced' => 5,
+					],
+				]
+			);
+
+		$this->assertTrue( $this->mc_service->has_at_least_one_synced_product() );
+	}
+
+}

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -150,6 +150,40 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->assertFalse( $this->mc_service->is_google_connected() );
 	}
 
+	public function test_is_ready_for_syncing() {
+		$hash = md5( site_url() );
+		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_ready_for_syncing_filter_override() {
+		$hash = md5( 'https://staging-site.test' );
+		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		add_filter( 'woocommerce_gla_ready_for_syncing', '__return_true' );
+
+		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
+	}
+
 	public function test_is_store_country_supported() {
 		$this->wc->method( 'get_base_country' )->willReturn( 'US' );
 		$this->google_helper->method( 'is_country_supported' )->with( 'US' )->willReturn( true );

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -362,7 +362,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->target_audience = $this->createMock( TargetAudience::class );
 		$this->merchant_center = $this->createMock( MerchantCenterService::class );
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
+							  ->method( 'is_ready_for_syncing' )
 							  ->willReturn( true );
 
 		$this->google_service = $this->createMock( GoogleProductService::class );

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -258,7 +258,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 		$this->merchant_center = $this->createMock( MerchantCenterService::class );
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
+							  ->method( 'is_ready_for_syncing' )
 							  ->willReturn( true );
 
 		$this->update_products_job = $this->createMock( UpdateProducts::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the product sync behaviour and requires the URL to match to the one we used to claim the website with. This ensures that the products are only able to sync on the original site, any staging site or copy of the site will not sync product data.

If the user wishes to change the site URL then the onboarding process must be completed again to perform a new site verification/claim.

Closes #1399

### Detailed test instructions:
1. Start with a live site that's fully onboarded and synced all products to the Merchant Center
2. Create a staging site (can use a plugin like [WP Staging](https://wordpress.org/plugins/wp-staging/))
3. Update a product on the staging site
4. Check the action scheduler logs and confirm that the product was not synced
5. Check the same product in the Merchant Center (might need to wait a while before it's updated) and confirm that the URL's are still from the original site
6. Use the filter `add_filter( 'woocommerce_gla_ready_for_syncing', '__return_true' );`
7. Update a product on the staging site
8. Check the action scheduler logs and confirm that this time the product did sync
9. Check the original site and confirm that product syncing continues to function as it was when updating products

### Additional details:

In addition to the tests for the added / changed code. There was no unit test present for the MerchantCenterService class, so I added it in this PR before adding the additional tests for this class.

### Changelog entry
* Fix - Prevent product sync if the site URL does not match the originally claimed URL.