### PR TITLE
Simplify the implementation of focus navigation for TreeSelectControl

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ const defaultConfig = require( '@wordpress/scripts/config/jest-unit.config' );
 module.exports = {
 	...defaultConfig,
 	testEnvironment: 'jsdom',
+	setupFiles: [ 'core-js' ],
 	moduleNameMapper: {
 		'\\.svg$': '<rootDir>/tests/mocks/assets/svgrMock.js',
 		'\\.scss$': '<rootDir>/tests/mocks/assets/styleMock.js',

--- a/js/src/components/tree-select-control/checkbox.js
+++ b/js/src/components/tree-select-control/checkbox.js
@@ -4,20 +4,19 @@
 import { Icon, check } from '@wordpress/icons';
 
 /**
- * @typedef {import('./index').RepositoryOption} RepositoryOption
+ * @typedef {import('./index').Option} Option
  */
 
 /**
  * Renders a custom Checkbox
  *
  * @param {Object} props Component properties
- * @param {RepositoryOption} props.option Option for the checkbox
- * @param {number} props.index The position in the tree
+ * @param {Option} props.option Option for the checkbox
  * @param {string} props.className The className for the component
  * @param {boolean} props.checked Defines if the checkbox is checked
  * @return {JSX.Element|null} The Checkbox component
  */
-const Checkbox = ( { option, index, checked, className, ...props } ) => {
+const Checkbox = ( { option, checked, className, ...props } ) => {
 	if ( ! option ) return null;
 
 	return (
@@ -25,11 +24,9 @@ const Checkbox = ( { option, index, checked, className, ...props } ) => {
 			<div className="components-base-control__field">
 				<span className="components-checkbox-control__input-container">
 					<input
-						ref={ option.ref }
 						id={ `inspector-checkbox-control-${
 							option.key ?? option.value
 						}` }
-						data-index={ index }
 						className="components-checkbox-control__input"
 						type="checkbox"
 						tabIndex="-1"

--- a/js/src/components/tree-select-control/checkbox.js
+++ b/js/src/components/tree-select-control/checkbox.js
@@ -29,6 +29,7 @@ const Checkbox = ( { option, checked, className, ...props } ) => {
 						}` }
 						className="components-checkbox-control__input"
 						type="checkbox"
+						tabIndex="-1"
 						value={ option.value }
 						checked={ checked }
 						{ ...props }

--- a/js/src/components/tree-select-control/checkbox.js
+++ b/js/src/components/tree-select-control/checkbox.js
@@ -29,7 +29,6 @@ const Checkbox = ( { option, checked, className, ...props } ) => {
 						}` }
 						className="components-checkbox-control__input"
 						type="checkbox"
-						tabIndex="-1"
 						value={ option.value }
 						checked={ checked }
 						{ ...props }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -214,7 +214,9 @@ const TreeSelectControl = ( {
 		const step = stepDict[ event.key ];
 
 		if ( step && dropdownRef.current && filteredOptions.length ) {
-			const elements = focus.tabbable.find( dropdownRef.current );
+			const elements = focus.focusable
+				.find( dropdownRef.current )
+				.filter( ( el ) => el.type === 'checkbox' );
 			const currentIndex = elements.indexOf( event.target );
 			const index = Math.max( currentIndex + step, -1 ) % elements.length;
 			elements.at( index ).focus();

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -3,6 +3,7 @@
  */
 import { cloneDeep, noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
+import { focus } from '@wordpress/dom';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import {
@@ -93,6 +94,7 @@ const TreeSelectControl = ( {
 	const [ inputControlValue, setInputControlValue ] = useState( '' );
 	const [ filteredOptions, setFilteredOptions ] = useState( [] );
 
+	const dropdownRef = useRef();
 	const onDropdownVisibilityChangeRef = useRef();
 	onDropdownVisibilityChangeRef.current = onDropdownVisibilityChange;
 
@@ -204,6 +206,20 @@ const TreeSelectControl = ( {
 			setTreeVisible( true );
 			event.preventDefault();
 		}
+
+		const stepDict = {
+			[ ARROW_UP ]: -1,
+			[ ARROW_DOWN ]: 1,
+		};
+		const step = stepDict[ event.key ];
+
+		if ( step && dropdownRef.current && filteredOptions.length ) {
+			const elements = focus.tabbable.find( dropdownRef.current );
+			const currentIndex = elements.indexOf( event.target );
+			const index = Math.max( currentIndex + step, -1 ) % elements.length;
+			elements.at( index ).focus();
+			event.preventDefault();
+		}
 	};
 
 	useEffect( () => {
@@ -224,6 +240,12 @@ const TreeSelectControl = ( {
 			const option = optionsRepository[ key ];
 			return { id: key, label: option?.label };
 		} );
+	};
+
+	const handleExpanderClick = ( e ) => {
+		const elements = focus.focusable.find( dropdownRef.current );
+		const index = elements.indexOf( e.currentTarget ) + 1;
+		elements.at( index ).focus();
 	};
 
 	/**
@@ -353,6 +375,7 @@ const TreeSelectControl = ( {
 			/>
 			{ showTree && (
 				<div
+					ref={ dropdownRef }
 					className="woocommerce-tree-select-control__tree"
 					role="tree"
 					tabIndex="-1"
@@ -364,6 +387,7 @@ const TreeSelectControl = ( {
 						onChange={ handleOptionsChange }
 						nodesExpanded={ nodesExpanded }
 						onNodesExpandedChange={ setNodesExpanded }
+						onExpanderClick={ handleExpanderClick }
 					/>
 				</div>
 			) }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -3,14 +3,7 @@
  */
 import { cloneDeep, noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
-import {
-	useEffect,
-	useMemo,
-	useState,
-	useRef,
-	createRef,
-	useCallback,
-} from '@wordpress/element';
+import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import {
 	__experimentalUseFocusOutside as useFocusOutside,
@@ -58,13 +51,6 @@ import { ARROW_DOWN, ARROW_UP, ENTER, ESCAPE, ROOT_VALUE } from './constants';
  * @property {string} label The label for the option
  * @property {Option[]} [children] The children Option objects
  * @property {string} [key] Optional unique key for the Option. It will fallback to the value property if not defined
- *
- *
- *
- * @typedef {Object} RepositoryData
- * @property {Object} [ref] React Ref associated to the option. This is for system purposes only.
- *
- * @typedef {Option & RepositoryData} RepositoryOption
  **/
 
 /**
@@ -106,7 +92,6 @@ const TreeSelectControl = ( {
 	const [ nodesExpanded, setNodesExpanded ] = useState( [] );
 	const [ inputControlValue, setInputControlValue ] = useState( '' );
 	const [ filteredOptions, setFilteredOptions ] = useState( [] );
-	const [ focused, setFocused ] = useState( null );
 
 	const onDropdownVisibilityChangeRef = useRef();
 	onDropdownVisibilityChangeRef.current = onDropdownVisibilityChange;
@@ -143,223 +128,15 @@ const TreeSelectControl = ( {
 
 		filteredOptionsCache.current = []; // clear cache if options change
 
-		function loadOption( option, parent ) {
-			option.children?.forEach( ( child ) => {
-				loadOption( child, option );
-			} );
-
-			repository[ option.key ?? option.value ] = {
-				...option,
-				parent,
-				ref: createRef(),
-			};
+		function loadOption( option ) {
+			option.children?.forEach( loadOption );
+			repository[ option.key ?? option.value ] = option;
 		}
 
-		treeOptions.forEach( ( option ) => loadOption( option ) );
+		treeOptions.forEach( loadOption );
 
 		return repository;
 	}, [ treeOptions ] );
-
-	/**
-	 * Check if an Option is expanded
-	 * An option is expanded if the Option value is in the nodesExpanded list or is the ROOT
-	 * or has children and there is a search filter
-	 *
-	 * @param {Option} option The option to check if it's expanded
-	 * @return {boolean} True if it's expanded, false otherwise
-	 */
-	const isOptionExpanded = ( option ) => {
-		return (
-			nodesExpanded.includes( option.value ) ||
-			option.value === ROOT_VALUE ||
-			( hasChildren( option ) && !! filter )
-		);
-	};
-
-	/**
-	 * Get the option parent
-	 *
-	 * @param {Option} option The option to get the parent
-	 * @return {Option} The parent option
-	 */
-	const getOptionParent = ( option ) => {
-		const parent = getOptionFromRepository( option )?.parent;
-		return getOptionFromRepository( parent );
-	};
-
-	/**
-	 * Get the option index based on the Option ref
-	 *
-	 * @param {RepositoryOption} option The option to get the index
-	 * @return {number} The index
-	 */
-	const getOptionIndexFromRef = ( option ) => {
-		return Number( option.ref.current.dataset.index );
-	};
-
-	/**
-	 * Get the option index based on its position relative to its parent
-	 *
-	 * @param {Option} option The option to check the position
-	 * @param {Option} parent The parent option
-	 * @return {number} The index of the option or -1 if not found
-	 */
-	const getOptionIndexFromParent = ( option, parent ) => {
-		return parent.children.findIndex(
-			( el ) => el.key === option.key && el.value === option.value
-		);
-	};
-
-	/**
-	 * Get the Option last child recursively
-	 *
-	 * @param {Option} option The option to get the last child
-	 * @return {Option} The last child in the option
-	 */
-	const getLastChild = ( option ) => {
-		if ( isOptionExpanded( option ) ) {
-			for (
-				let index = option.children.length - 1;
-				index >= 0;
-				index--
-			) {
-				const nextEl = getOptionFromRepository(
-					option.children[ index ]
-				);
-
-				if ( nextEl.ref.current ) {
-					return getLastChild( nextEl );
-				}
-			}
-		}
-
-		return getOptionFromRepository( option );
-	};
-
-	/**
-	 * Get the previous available Option in the tree
-	 *
-	 * @param {Object} option The reference option to get the previous element
-	 * @return {Object} The previous option
-	 */
-	const getPreviousOption = ( option ) => {
-		// if no option is provided means we are focused in the search control.
-		// Hence the element to focus is the last
-		if ( ! option ) {
-			return getLastChild(
-				filteredOptions[ filteredOptions.length - 1 ]
-			);
-		}
-
-		const parent = getOptionParent( option );
-
-		if ( parent ) {
-			let index = getOptionIndexFromParent( option, parent );
-
-			// iterate over the elements until get the last one visible
-			while ( index ) {
-				const nextEl = getOptionFromRepository(
-					parent.children[ index - 1 ]
-				);
-
-				if ( ! nextEl.ref.current ) {
-					index--;
-				} else {
-					return getLastChild( nextEl );
-				}
-			}
-
-			return getOptionFromRepository( parent );
-		}
-
-		const index = getOptionIndexFromRef( option );
-		return getLastChild(
-			filteredOptions[
-				index > 0 ? index - 1 : filteredOptions.length - 1
-			]
-		);
-	};
-
-	/**
-	 * Get the next option available in the tree
-	 *
-	 * The function attempts to get the next option in the current level
-	 * if there is no more options, it tries to get the next option on the upper level.
-	 *
-	 * @param {Option} option The reference option to get the next element
-	 * @param {number} offset The starting index position
-	 * @param {boolean} checkExpanded If true, we check the children in the provided option
-	 * @return {Object} The next available option in the tree
-	 */
-	const getNextOption = ( option, offset = 0, checkExpanded = true ) => {
-		// if no option is provided means we are focused in the search control.
-		// Hence the element to focus is the first
-		if ( ! option ) {
-			return getOptionFromRepository( filteredOptions[ 0 ] );
-		}
-
-		// if the option is expanded and we are checking children...
-		if ( checkExpanded && isOptionExpanded( option ) ) {
-			// if there are still elements to check in the children
-			if ( offset < option.children.length ) {
-				const nextEl = getOptionFromRepository(
-					option.children[ offset ]
-				);
-
-				// if element is not visible, continue checking the next child
-				if ( ! nextEl.ref.current ) {
-					return getNextOption( option, offset + 1 );
-				}
-
-				return nextEl;
-			}
-		}
-
-		const parent = getOptionParent( option );
-
-		if ( parent ) {
-			// get the element position in the parent
-			const index = getOptionIndexFromParent( option, parent );
-
-			const nextEl = getOptionFromRepository(
-				parent.children[ index + offset + 1 ]
-			);
-
-			// if there are no more children, iterate over the next parent
-			if ( ! nextEl ) {
-				return getNextOption( parent, 0, false );
-			}
-
-			// if element is not visible, continue checking the next element
-			if ( ! nextEl.ref.current ) {
-				return getNextOption( option, offset + 1, checkExpanded );
-			}
-
-			return nextEl;
-		}
-
-		// if we are at root level, go to next element
-		return getOptionFromRepository(
-			filteredOptions[
-				( getOptionIndexFromRef( option ) + offset + 1 ) %
-					filteredOptions.length
-			]
-		);
-	};
-
-	/**
-	 * Gets an option from the repository using the option key or the option value
-	 *
-	 * @param {Option} option The option to get from the Repository
-	 * @return {RepositoryOption|undefined} The Repository option or undefined if it's not found
-	 */
-	const getOptionFromRepository = useCallback(
-		( option ) => {
-			if ( ! option ) return;
-			return optionsRepository[ option.key ?? option.value ];
-		},
-		[ optionsRepository ]
-	);
 
 	/**
 	 * Perform the search query filter in the Tree options
@@ -391,8 +168,6 @@ const TreeSelectControl = ( {
 		};
 
 		const filterOption = ( option ) => {
-			option.ref = getOptionFromRepository( option ).ref;
-
 			if ( hasChildren( option ) ) {
 				option.children = option.children.filter( filterOption );
 				return !! option.children.length;
@@ -416,7 +191,7 @@ const TreeSelectControl = ( {
 		filteredTreeOptions = filteredTreeOptions.filter( filterOption );
 		filteredOptionsCache.current[ filter ] = filteredTreeOptions;
 		setFilteredOptions( filteredTreeOptions );
-	}, [ treeOptions, filter, getOptionFromRepository ] );
+	}, [ treeOptions, filter ] );
 
 	const onKeyDown = ( event ) => {
 		if ( disabled ) return;
@@ -429,25 +204,7 @@ const TreeSelectControl = ( {
 			setTreeVisible( true );
 			event.preventDefault();
 		}
-
-		if ( ARROW_UP === event.key ) {
-			if ( ! filteredOptions.length ) return;
-			setFocused( getPreviousOption( focused ) );
-			event.preventDefault();
-		}
-
-		if ( ARROW_DOWN === event.key ) {
-			if ( ! filteredOptions.length ) return;
-			setFocused( getNextOption( focused ) );
-			event.preventDefault();
-		}
 	};
-
-	useEffect( () => {
-		if ( focused ) {
-			focused.ref.current.focus();
-		}
-	}, [ focused ] );
 
 	useEffect( () => {
 		onDropdownVisibilityChangeRef.current( showTree );
@@ -557,10 +314,6 @@ const TreeSelectControl = ( {
 		setInputControlValue( e.target.value );
 	};
 
-	const handleOptionFocused = ( option ) => {
-		setFocused( option );
-	};
-
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
@@ -585,7 +338,6 @@ const TreeSelectControl = ( {
 				tags={ getTags() }
 				isExpanded={ showTree }
 				onFocus={ () => {
-					setFocused( null );
 					setTreeVisible( true );
 				} }
 				onControlClick={ () => {
@@ -612,7 +364,6 @@ const TreeSelectControl = ( {
 						onChange={ handleOptionsChange }
 						nodesExpanded={ nodesExpanded }
 						onNodesExpandedChange={ setNodesExpanded }
-						onOptionFocused={ handleOptionFocused }
 					/>
 				</div>
 			) }

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -12,7 +12,6 @@ import { ARROW_LEFT, ARROW_RIGHT, ROOT_VALUE } from './constants';
 import Checkbox from '.~/components/tree-select-control/checkbox';
 
 /**
- * @typedef {import('./index').RepositoryOption} RepositoryOption
  * @typedef {import('./index').Option} Option
  */
 
@@ -20,13 +19,12 @@ import Checkbox from '.~/components/tree-select-control/checkbox';
  * This component renders a list of options and its children recursively
  *
  * @param {Object} props Component parameters
- * @param {RepositoryOption[]} props.options List of options to be rendered
+ * @param {Option[]} props.options List of options to be rendered
  * @param {string[]} props.value List of selected values
  * @param {string[]} props.nodesExpanded List of expanded nodes.
  * @param {boolean} [props.isFiltered=false] Flag to know if there is a filter applied
  * @param {Function} props.onChange Callback when an option changes
  * @param {Function} props.onNodesExpandedChange Callback when a node is expanded/collapsed
- * @param {Function} props.onOptionFocused Callback when an option get the focus via change or expansion
  */
 const Options = ( {
 	options = [],
@@ -35,7 +33,6 @@ const Options = ( {
 	onChange = () => {},
 	nodesExpanded = [],
 	onNodesExpandedChange = () => {},
-	onOptionFocused = () => {},
 } ) => {
 	/**
 	 * Verifies if an option is checked.
@@ -111,7 +108,7 @@ const Options = ( {
 		}
 	};
 
-	return options.map( ( option, idx ) => {
+	return options.map( ( option ) => {
 		const isRoot = option.value === ROOT_VALUE;
 		const hasChildren = !! option.children?.length;
 		const checked = isChecked( option );
@@ -137,7 +134,6 @@ const Options = ( {
 							) }
 							tabIndex="-1"
 							onClick={ () => {
-								onOptionFocused( option );
 								toggleExpanded( option );
 							} }
 						>
@@ -156,10 +152,8 @@ const Options = ( {
 								'is-partially-checked'
 						) }
 						option={ option }
-						index={ idx }
 						checked={ checked }
 						onChange={ ( e ) => {
-							onOptionFocused( option );
 							onChange( e.target.checked, option );
 						} }
 						onKeyDown={ ( e ) => {
@@ -182,7 +176,6 @@ const Options = ( {
 							onChange={ onChange }
 							nodesExpanded={ nodesExpanded }
 							onNodesExpandedChange={ onNodesExpandedChange }
-							onOptionFocused={ onOptionFocused }
 						/>
 					</div>
 				) }

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { noop } from 'lodash';
 import { Flex } from '@wordpress/components';
 import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -25,6 +26,7 @@ import Checkbox from '.~/components/tree-select-control/checkbox';
  * @param {boolean} [props.isFiltered=false] Flag to know if there is a filter applied
  * @param {Function} props.onChange Callback when an option changes
  * @param {Function} props.onNodesExpandedChange Callback when a node is expanded/collapsed
+ * @param {Function} [props.onExpanderClick] Callback when an expander is clicked.
  */
 const Options = ( {
 	options = [],
@@ -33,6 +35,7 @@ const Options = ( {
 	onChange = () => {},
 	nodesExpanded = [],
 	onNodesExpandedChange = () => {},
+	onExpanderClick = noop,
 } ) => {
 	/**
 	 * Verifies if an option is checked.
@@ -133,7 +136,8 @@ const Options = ( {
 								! hasChildren && 'is-hidden'
 							) }
 							tabIndex="-1"
-							onClick={ () => {
+							onClick={ ( e ) => {
+								onExpanderClick( e );
 								toggleExpanded( option );
 							} }
 						>
@@ -176,6 +180,7 @@ const Options = ( {
 							onChange={ onChange }
 							nodesExpanded={ nodesExpanded }
 							onNodesExpandedChange={ onNodesExpandedChange }
+							onExpanderClick={ onExpanderClick }
 						/>
 					</div>
 				) }

--- a/js/src/components/tree-select-control/options.test.js
+++ b/js/src/components/tree-select-control/options.test.js
@@ -9,6 +9,29 @@ import { fireEvent, render } from '@testing-library/react';
 import TreeSelectControl from '.~/components/tree-select-control/index';
 import Options from '.~/components/tree-select-control/options';
 
+/**
+ * In jsdom, the width and height of all elements are zero,
+ * so setting `offsetWidth` to avoid them to be filtered out
+ * by `isVisible` in focusable.
+ * Ref: https://github.com/WordPress/gutenberg/blob/%40wordpress/dom%403.1.1/packages/dom/src/focusable.js#L42-L48
+ */
+jest.mock( '@wordpress/dom', () => {
+	const { focus } = jest.requireActual( '@wordpress/dom' );
+	const descriptor = { configurable: true, get: () => 1 };
+	function find( context ) {
+		context.querySelectorAll( '*' ).forEach( ( element ) => {
+			Object.defineProperty( element, 'offsetWidth', descriptor );
+		} );
+		return focus.focusable.find( ...arguments );
+	}
+	return {
+		focus: {
+			...focus,
+			focusable: { ...focus.focusable, find },
+		},
+	};
+} );
+
 const options = [
 	{
 		value: 'EU',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Replace the implementation of focus navigation with the `focus` of `@wordpress/dom` for `TreeSelectControl`.
- Fix a "read properties of null" bug that press the Up or Down key when the dropdown is not showing.

   https://user-images.githubusercontent.com/17420811/168525767-b5863d11-304b-4969-bef6-00fbb56eaf28.mp4

### Screenshots:

https://user-images.githubusercontent.com/17420811/168525734-5c20c0d1-c3aa-4229-9ee1-296bf6d914cd.mp4

### Detailed test instructions:

1. Go to the Edit free listings or the local storybook.
2. Click on the input to open the dropdown.
3. Press Esc key to close the dropdown.
4. Press Up or Down key when the input still has focus. It should not cause the "read properties of null" exception.
5. Open the dropdown and use Up or Down to navigate the options to check if the behavior is the same as before.
6. Click on expanders of parent options, and then the corresponding checkbox should get the focus.

### Changelog entry

> Tweak - Adjust the implementation of focus navigation for the TreeSelectControl component.
> Fix - Address a crash problem of TreeSelectControl component when the dropdown is not showing and press the Up or Down key.
