### PR TITLE
MC Account Issues - Populate action with Issue details

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -185,7 +185,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		$this->mc_statuses = [];
 
 		// Update account-level issues.
-		 $this->refresh_account_issues();
+		$this->refresh_account_issues();
 
 		// Update MC product issues and tabulate statistics in batches.
 		$chunk_size = apply_filters( 'woocommerce_gla_merchant_status_google_ids_chunk', 1000 );
@@ -394,7 +394,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 					'product'              => __( 'All products', 'google-listings-and-ads' ),
 					'code'                 => $issue->getId(),
 					'issue'                => $issue->getTitle(),
-					'action'               => __( 'Read more about this account issue', 'google-listings-and-ads' ),
+					'action'               => $issue->getDetail(),
 					'action_url'           => $issue->getDocumentation(),
 					'created_at'           => $created_at,
 					'type'                 => self::TYPE_ACCOUNT,
@@ -813,5 +813,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		}
 
 		return $issue;
+	}
+
+	/**
+	 * Getter for get_cache_created_time
+	 *
+	 * @return DateTime The DateTime stored in cache_created_time
+	 */
+	public function get_cache_created_time(): DateTime {
+		return $this->cache_created_time;
 	}
 }

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -29,7 +29,7 @@ class MerchantStatusesTest extends UnitTest
 	private $merchant_center_service;
 	private $account_status;
 	private $product_meta_query_helper;
-	private MerchantStatuses $merchant_statuses;
+	private $merchant_statuses;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductMetaQueryHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Google\Service\ShoppingContent;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Test Suit for MerchantStatuses
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
+ * @group MerchantCenterStatuses
+ */
+class MerchantStatusesTest extends UnitTest
+{
+	private $merchant;
+	private $merchant_issue_query;
+	private $merchant_center_service;
+	private $account_status;
+	private $product_meta_query_helper;
+	private MerchantStatuses $merchant_statuses;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->merchant = $this->createMock(Merchant::class);
+		$this->merchant_issue_query = $this->createMock(MerchantIssueQuery::class);
+		$this->merchant_center_service = $this->createMock(MerchantCenterService::class);
+		$this->account_status = $this->createMock(ShoppingContent\AccountStatus::class);
+		$this->product_meta_query_helper = $this->createMock(ProductMetaQueryHelper::class);
+
+		$product_repository = $this->createMock(ProductRepository::class);
+		$transients = $this->createMock(TransientsInterface::class);
+		$merchant_issue_table = $this->createMock(MerchantIssueTable::class);
+
+		$container = new Container();
+		$container->share(Merchant::class, $this->merchant);
+		$container->share(MerchantIssueQuery::class, $this->merchant_issue_query);
+		$container->share(MerchantCenterService::class, $this->merchant_center_service);
+		$container->share(TransientsInterface::class, $transients);
+		$container->share(ProductRepository::class, $product_repository);
+		$container->share(ProductMetaQueryHelper::class, $this->product_meta_query_helper);
+		$container->share(MerchantIssueTable::class, $merchant_issue_table);
+
+		$this->merchant_statuses = new MerchantStatuses();
+		$this->merchant_statuses->set_container($container);
+	}
+
+	public function test_refresh_account_issues()
+	{
+
+		$this->product_meta_query_helper->expects($this->any())->method('get_all_values')->willReturn([]);
+
+
+		$this->account_status->expects($this->any())
+			->method('getAccountLevelIssues')
+			->willReturn([
+				'one' => new ShoppingContent\AccountStatusAccountLevelIssue([
+					'id' => 'id',
+					'title' => 'title',
+					'country' => 'US',
+					'destination' => 'destination',
+					'detail' => 'detail',
+					'documentation' => 'https://example.com',
+					'severity' => 'critical'
+				]),
+				'two' => new ShoppingContent\AccountStatusAccountLevelIssue([
+					'id' => 'id2',
+					'title' => 'title2',
+					'country' => 'CA',
+					'destination' => 'destination2',
+					'detail' => 'detail2',
+					'documentation' => 'https://example.com/2',
+					'severity' => 'error'
+				]),
+				'three' => new ShoppingContent\AccountStatusAccountLevelIssue([
+					'id' => 'id2',
+					'title' => 'title2',
+					'country' => 'US',
+					'destination' => 'destination2',
+					'detail' => 'detail2',
+					'documentation' => 'https://example.com/2',
+					'severity' => 'error'
+				]),
+			]);
+
+		$this->merchant_center_service->expects($this->any())
+			->method('is_connected')
+			->willReturn(true);
+
+		$this->merchant->expects($this->any())
+			->method('get_accountstatus')
+			->willReturn($this->account_status);
+
+		$issues = [
+			md5('title') => [
+				'product_id' => 0,
+				'product' => 'All products',
+				'code' => 'id',
+				'issue' => 'title',
+				'action' => 'detail',
+				'action_url' => 'https://example.com',
+				'created_at' => $this->merchant_statuses->get_cache_created_time()->format('Y-m-d H:i:s'),
+				'type' => 'account',
+				'severity' => 'critical',
+				'source' => 'mc',
+				'applicable_countries' => '["US"]'
+			],
+			md5('title2') => [
+				'product_id' => 0,
+				'product' => 'All products',
+				'code' => 'id2',
+				'issue' => 'title2',
+				'action' => 'detail2',
+				'action_url' => 'https://example.com/2',
+				'created_at' => $this->merchant_statuses->get_cache_created_time()->format('Y-m-d H:i:s'),
+				'type' => 'account',
+				'severity' => 'error',
+				'source' => 'mc',
+				'applicable_countries' => '["CA","US"]'
+			],
+		];
+
+
+		$this->merchant_issue_query->expects($this->exactly(2))->method('update_or_insert')->withConsecutive([$issues], []);
+		$this->merchant_statuses->maybe_refresh_status_data(true);
+	}
+}

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -18,7 +18,12 @@ use Google\Service\ShoppingContent;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Test Suit for MerchantStatuses
+ * @property Merchant $merchant
+ * @property MerchantIssueQuery $merchant_issue_query
+ * @property MerchantCenterService $merchant_center_service
+ * @property ShoppingContent\AccountStatus $account_status
+ * @property ProductMetaQueryHelper $product_meta_query_helper
+ * @property MerchantStatuses $merchant_statuses
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
  * @group MerchantCenterStatuses
  */

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -15,15 +15,15 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Google\Service\ShoppingContent;
 
-defined('ABSPATH') || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Test Suit for MerchantStatuses
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
  * @group MerchantCenterStatuses
  */
-class MerchantStatusesTest extends UnitTest
-{
+class MerchantStatusesTest extends UnitTest {
+
 	private $merchant;
 	private $merchant_issue_query;
 	private $merchant_center_service;
@@ -34,109 +34,112 @@ class MerchantStatusesTest extends UnitTest
 	/**
 	 * Runs before each test is executed.
 	 */
-	public function setUp(): void
-	{
+	public function setUp(): void {
 		parent::setUp();
-		$this->merchant = $this->createMock(Merchant::class);
-		$this->merchant_issue_query = $this->createMock(MerchantIssueQuery::class);
-		$this->merchant_center_service = $this->createMock(MerchantCenterService::class);
-		$this->account_status = $this->createMock(ShoppingContent\AccountStatus::class);
-		$this->product_meta_query_helper = $this->createMock(ProductMetaQueryHelper::class);
+		$this->merchant                  = $this->createMock( Merchant::class );
+		$this->merchant_issue_query      = $this->createMock( MerchantIssueQuery::class );
+		$this->merchant_center_service   = $this->createMock( MerchantCenterService::class );
+		$this->account_status            = $this->createMock( ShoppingContent\AccountStatus::class );
+		$this->product_meta_query_helper = $this->createMock( ProductMetaQueryHelper::class );
 
-		$product_repository = $this->createMock(ProductRepository::class);
-		$transients = $this->createMock(TransientsInterface::class);
-		$merchant_issue_table = $this->createMock(MerchantIssueTable::class);
+		$product_repository   = $this->createMock( ProductRepository::class );
+		$transients           = $this->createMock( TransientsInterface::class );
+		$merchant_issue_table = $this->createMock( MerchantIssueTable::class );
 
 		$container = new Container();
-		$container->share(Merchant::class, $this->merchant);
-		$container->share(MerchantIssueQuery::class, $this->merchant_issue_query);
-		$container->share(MerchantCenterService::class, $this->merchant_center_service);
-		$container->share(TransientsInterface::class, $transients);
-		$container->share(ProductRepository::class, $product_repository);
-		$container->share(ProductMetaQueryHelper::class, $this->product_meta_query_helper);
-		$container->share(MerchantIssueTable::class, $merchant_issue_table);
+		$container->share( Merchant::class, $this->merchant );
+		$container->share( MerchantIssueQuery::class, $this->merchant_issue_query );
+		$container->share( MerchantCenterService::class, $this->merchant_center_service );
+		$container->share( TransientsInterface::class, $transients );
+		$container->share( ProductRepository::class, $product_repository );
+		$container->share( ProductMetaQueryHelper::class, $this->product_meta_query_helper );
+		$container->share( MerchantIssueTable::class, $merchant_issue_table );
 
 		$this->merchant_statuses = new MerchantStatuses();
-		$this->merchant_statuses->set_container($container);
+		$this->merchant_statuses->set_container( $container );
 	}
 
-	public function test_refresh_account_issues()
-	{
+	public function test_refresh_account_issues() {
+		$this->product_meta_query_helper->expects( $this->any() )->method( 'get_all_values' )->willReturn( array() );
 
-		$this->product_meta_query_helper->expects($this->any())->method('get_all_values')->willReturn([]);
+		$this->account_status->expects( $this->any() )
+			->method( 'getAccountLevelIssues' )
+			->willReturn(
+				array(
+					'one'   => new ShoppingContent\AccountStatusAccountLevelIssue(
+						array(
+							'id'            => 'id',
+							'title'         => 'title',
+							'country'       => 'US',
+							'destination'   => 'destination',
+							'detail'        => 'detail',
+							'documentation' => 'https://example.com',
+							'severity'      => 'critical',
+						)
+					),
+					'two'   => new ShoppingContent\AccountStatusAccountLevelIssue(
+						array(
+							'id'            => 'id2',
+							'title'         => 'title2',
+							'country'       => 'CA',
+							'destination'   => 'destination2',
+							'detail'        => 'detail2',
+							'documentation' => 'https://example.com/2',
+							'severity'      => 'error',
+						)
+					),
+					'three' => new ShoppingContent\AccountStatusAccountLevelIssue(
+						array(
+							'id'            => 'id2',
+							'title'         => 'title2',
+							'country'       => 'US',
+							'destination'   => 'destination2',
+							'detail'        => 'detail2',
+							'documentation' => 'https://example.com/2',
+							'severity'      => 'error',
+						)
+					),
+				)
+			);
 
+		$this->merchant_center_service->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
 
-		$this->account_status->expects($this->any())
-			->method('getAccountLevelIssues')
-			->willReturn([
-				'one' => new ShoppingContent\AccountStatusAccountLevelIssue([
-					'id' => 'id',
-					'title' => 'title',
-					'country' => 'US',
-					'destination' => 'destination',
-					'detail' => 'detail',
-					'documentation' => 'https://example.com',
-					'severity' => 'critical'
-				]),
-				'two' => new ShoppingContent\AccountStatusAccountLevelIssue([
-					'id' => 'id2',
-					'title' => 'title2',
-					'country' => 'CA',
-					'destination' => 'destination2',
-					'detail' => 'detail2',
-					'documentation' => 'https://example.com/2',
-					'severity' => 'error'
-				]),
-				'three' => new ShoppingContent\AccountStatusAccountLevelIssue([
-					'id' => 'id2',
-					'title' => 'title2',
-					'country' => 'US',
-					'destination' => 'destination2',
-					'detail' => 'detail2',
-					'documentation' => 'https://example.com/2',
-					'severity' => 'error'
-				]),
-			]);
+		$this->merchant->expects( $this->any() )
+			->method( 'get_accountstatus' )
+			->willReturn( $this->account_status );
 
-		$this->merchant_center_service->expects($this->any())
-			->method('is_connected')
-			->willReturn(true);
+		$issues = array(
+			md5( 'title' )  => array(
+				'product_id'           => 0,
+				'product'              => 'All products',
+				'code'                 => 'id',
+				'issue'                => 'title',
+				'action'               => 'detail',
+				'action_url'           => 'https://example.com',
+				'created_at'           => $this->merchant_statuses->get_cache_created_time()->format( 'Y-m-d H:i:s' ),
+				'type'                 => 'account',
+				'severity'             => 'critical',
+				'source'               => 'mc',
+				'applicable_countries' => '["US"]',
+			),
+			md5( 'title2' ) => array(
+				'product_id'           => 0,
+				'product'              => 'All products',
+				'code'                 => 'id2',
+				'issue'                => 'title2',
+				'action'               => 'detail2',
+				'action_url'           => 'https://example.com/2',
+				'created_at'           => $this->merchant_statuses->get_cache_created_time()->format( 'Y-m-d H:i:s' ),
+				'type'                 => 'account',
+				'severity'             => 'error',
+				'source'               => 'mc',
+				'applicable_countries' => '["CA","US"]',
+			),
+		);
 
-		$this->merchant->expects($this->any())
-			->method('get_accountstatus')
-			->willReturn($this->account_status);
-
-		$issues = [
-			md5('title') => [
-				'product_id' => 0,
-				'product' => 'All products',
-				'code' => 'id',
-				'issue' => 'title',
-				'action' => 'detail',
-				'action_url' => 'https://example.com',
-				'created_at' => $this->merchant_statuses->get_cache_created_time()->format('Y-m-d H:i:s'),
-				'type' => 'account',
-				'severity' => 'critical',
-				'source' => 'mc',
-				'applicable_countries' => '["US"]'
-			],
-			md5('title2') => [
-				'product_id' => 0,
-				'product' => 'All products',
-				'code' => 'id2',
-				'issue' => 'title2',
-				'action' => 'detail2',
-				'action_url' => 'https://example.com/2',
-				'created_at' => $this->merchant_statuses->get_cache_created_time()->format('Y-m-d H:i:s'),
-				'type' => 'account',
-				'severity' => 'error',
-				'source' => 'mc',
-				'applicable_countries' => '["CA","US"]'
-			],
-		];
-
-
-		$this->merchant_issue_query->expects($this->exactly(2))->method('update_or_insert')->withConsecutive([$issues], []);
-		$this->merchant_statuses->maybe_refresh_status_data(true);
+		$this->merchant_issue_query->expects( $this->exactly( 2 ) )->method( 'update_or_insert' )->withConsecutive( array( $issues ), array() );
+		$this->merchant_statuses->maybe_refresh_status_data( true );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Design team and Google requested to show the Issue details (if any) in a modal instead of directly link to their documentation. The idea is to replace `action` column content in `wp_gla_merchant_issues` with the issue details provided by Google. Since `action` column was always hardcoded as "Read more about this account issue"  we can replace that with the details with no problem. This means `action` column will be the string with the details field or null.

In the frontend, in case the `issue.action` is null, we will show "Read more about this account issue" linking to the docs. (Same behaviour as now). Otherwise, the link will open a modal with the issue description as well as a "read more" link to the documentation. 

This PR implements the backend part with the following changes:

- Populate `action` column in `wp_gla_merchant_issues` with the Issue details, or null. (This depends on Google response)
- Added some Test for Merchant Statuses relative to the account issues.

### Detailed test instructions:

1.  Create an account with Account Issues. In case you have already account issues you can just delete the transient `gla_mc_statuses` in `wp_options` to force refresh.
2.  Go to and check that action column is null (no value available from google) or its filled with the issue details (I only was able to localise one issue with details `editorial_and_professional_standards_destination_url_down_policy`). 