### PR TITLE
Account Issues -  Show the resolution steps in the UI 

### DIFF
--- a/js/src/product-feed/issues-table-card/index.scss
+++ b/js/src/product-feed/issues-table-card/index.scss
@@ -35,3 +35,14 @@
 		}
 	}
 }
+
+.gla-issues-table-data-modal {
+	.components-modal__header {
+		border-bottom: 1px solid #ccc;
+	}
+
+	.gridicon {
+		width: 12px;
+		margin-right: 0.5em;
+	}
+}

--- a/js/src/product-feed/issues-table-card/issues-table-data-headers.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data-headers.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const ISSUES_TABLE_DATA_HEADERS = [
+	{
+		key: 'type',
+		label: __( 'Type', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'affectedProduct',
+		label: __( 'Affected product', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'issue',
+		label: __( 'Issue', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'suggestedAction',
+		label: __( 'Suggested action', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{ key: 'action', label: '', required: true },
+];
+
+export default ISSUES_TABLE_DATA_HEADERS;

--- a/js/src/product-feed/issues-table-card/issues-table-data-modal.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data-modal.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import GridiconExternal from 'gridicons/dist/external';
+
+/**
+ * Internal dependencies
+ */
+import AppModal from '.~/components/app-modal';
+import AppButton from '.~/components/app-button';
+
+/**
+ * Renders a modal showing information about a Google Merchant Center issue
+ *
+ * @fires gla_documentation_link_click with { context: 'issues-data-table-modal' }
+ * @param {Object} params Component params
+ * @param {Object} params.issue The issue to be rendered in the modal
+ * @param {Function} params.onRequestClose Onnclose callback function
+ */
+const IssuesTableDataModal = ( { issue, onRequestClose = () => {} } ) => {
+	if ( ! issue ) return null;
+	return (
+		<AppModal
+			className="gla-issues-table-data-modal"
+			title={ issue.issue }
+			onRequestClose={ onRequestClose }
+			buttons={ [
+				<AppButton
+					key="learn-more"
+					isPrimary
+					target="_blank"
+					href={ issue.action_url }
+					text={ __( 'Learn more', 'google-listings-and-ads' ) }
+					eventName={ 'gla_documentation_link_click' }
+					eventProps={ {
+						context: 'issues-data-table-modal',
+						linkId: issue.code,
+						href: issue.action_url,
+					} }
+					icon={ <GridiconExternal /> }
+				/>,
+			] }
+		>
+			<p>
+				<strong>
+					{ __( 'What to do?', 'google-listings-and-ads' ) }
+				</strong>
+			</p>
+			<p>{ issue.action }</p>
+		</AppModal>
+	);
+};
+
+export default IssuesTableDataModal;

--- a/js/src/product-feed/issues-table-card/issues-table-data-modal.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data-modal.js
@@ -14,12 +14,11 @@ import AppButton from '.~/components/app-button';
  * Renders a modal showing information about a Google Merchant Center issue
  *
  * @fires gla_documentation_link_click with { context: 'issues-data-table-modal' }
- * @param {Object} params Component params
- * @param {Object} params.issue The issue to be rendered in the modal
- * @param {Function} params.onRequestClose Onnclose callback function
+ * @param {Object} props React props
+ * @param {Object} props.issue The issue to be rendered in the modal
+ * @param {Function} [props.onRequestClose] Callback function when closing the modal
  */
 const IssuesTableDataModal = ( { issue, onRequestClose = () => {} } ) => {
-	if ( ! issue ) return null;
 	return (
 		<AppModal
 			className="gla-issues-table-data-modal"
@@ -32,7 +31,7 @@ const IssuesTableDataModal = ( { issue, onRequestClose = () => {} } ) => {
 					target="_blank"
 					href={ issue.action_url }
 					text={ __( 'Learn more', 'google-listings-and-ads' ) }
-					eventName={ 'gla_documentation_link_click' }
+					eventName="gla_documentation_link_click"
 					eventProps={ {
 						context: 'issues-data-table-modal',
 						linkId: issue.code,

--- a/js/src/product-feed/issues-table-card/issues-table-data-modal.test.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data-modal.test.js
@@ -37,9 +37,4 @@ describe( 'Issues Data Table Modal', () => {
 			}
 		);
 	} );
-
-	test( 'Not Render if no issue', () => {
-		const { queryByText } = render( <IssuesTableDataModal /> );
-		expect( queryByText( '#issue-1' ) ).toBeFalsy();
-	} );
 } );

--- a/js/src/product-feed/issues-table-card/issues-table-data-modal.test.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data-modal.test.js
@@ -1,0 +1,45 @@
+jest.mock( '@woocommerce/tracks', () => {
+	return {
+		recordEvent: jest.fn(),
+	};
+} );
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import IssuesTableDataModal from './issues-table-data-modal';
+import mockIssue from '.~/tests/mock-issue';
+
+describe( 'Issues Data Table Modal', () => {
+	test( 'Render the issue details', () => {
+		const { queryByText } = render(
+			<IssuesTableDataModal issue={ mockIssue( 1 ) } />
+		);
+		const link = queryByText( 'Learn more' );
+
+		expect( queryByText( '#issue-1' ) ).toBeTruthy();
+		expect( queryByText( 'Action for 1' ) ).toBeTruthy();
+		expect( queryByText( 'What to do?' ) ).toBeTruthy();
+		expect( link ).toHaveAttribute( 'href', 'example.com/1' );
+		fireEvent.click( link );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'gla_documentation_link_click',
+			{
+				context: 'issues-data-table-modal',
+				linkId: '#code-1',
+				href: 'example.com/1',
+			}
+		);
+	} );
+
+	test( 'Not Render if no issue', () => {
+		const { queryByText } = render( <IssuesTableDataModal /> );
+		expect( queryByText( '#issue-1' ) ).toBeFalsy();
+	} );
+} );

--- a/js/src/product-feed/issues-table-card/issues-table-data.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data.js
@@ -69,9 +69,7 @@ const IssuesTableData = ( { data } ) => {
 							button={
 								<AppButton
 									isLink
-									eventName={
-										'gla_click_read_more_about_issue'
-									}
+									eventName="gla_click_read_more_about_issue"
 									eventProps={ {
 										context: 'issues-to-resolve',
 										issue: el.code,

--- a/js/src/product-feed/issues-table-card/issues-table-data.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data.js
@@ -7,25 +7,36 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import WarningIcon from '.~/components/warning-icon';
 import ErrorIcon from '.~/components/error-icon';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import EditProductLink from '.~/components/edit-product-link';
+import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
+import IssuesSolved from './issues-solved';
+import IssuesTableDataModal from './issues-table-data-modal';
 import { ISSUE_TYPE_PRODUCT } from '.~/constants';
-import IssuesSolved from '.~/product-feed/issues-table-card/issues-solved';
+import ISSUES_TABLE_DATA_HEADERS from './issues-table-data-headers';
 
 /**
  * The rows with data for the Issues table
  *
  * @param {Object} args The data and the headers
  * @param {Object} args.data The data containing the issues to render.
- * @param {Object[]} args.headers An array with the different headers
  * @return {JSX.Element} The rendered component with the issues or with an empty table if no data is provided
  */
-const IssuesTableData = ( { data, headers } ) => {
+const IssuesTableData = ( { data } ) => {
+	const readMore = __(
+		'Read more about this issue',
+		'google-listings-and-ads'
+	);
+
 	if ( ! data ) {
 		return (
-			<EmptyTable headers={ headers } numberOfRows={ 1 }>
+			<EmptyTable
+				headers={ ISSUES_TABLE_DATA_HEADERS }
+				numberOfRows={ 1 }
+			>
 				{ __(
 					'An error occurred while retrieving issues. Please try again later.',
 					'google-listings-and-ads'
@@ -37,11 +48,10 @@ const IssuesTableData = ( { data, headers } ) => {
 	if ( ! data.issues?.length ) {
 		return <IssuesSolved />;
 	}
-
 	return (
 		<Table
 			caption={ __( 'Issues to resolve', 'google-listings-and-ads' ) }
-			headers={ headers }
+			headers={ ISSUES_TABLE_DATA_HEADERS }
 			rows={ data.issues.map( ( el ) => [
 				{
 					display:
@@ -54,13 +64,31 @@ const IssuesTableData = ( { data, headers } ) => {
 				{ display: el.product },
 				{ display: el.issue },
 				{
-					display: (
+					display: el.action ? (
+						<AppButtonModalTrigger
+							button={
+								<AppButton
+									isLink
+									eventName={
+										'gla_click_read_more_about_issue'
+									}
+									eventProps={ {
+										context: 'issues-to-resolve',
+										issue: el.code,
+									} }
+								>
+									{ readMore }
+								</AppButton>
+							}
+							modal={ <IssuesTableDataModal issue={ el } /> }
+						/>
+					) : (
 						<AppDocumentationLink
 							context="issues-to-resolve"
 							linkId={ el.code }
 							href={ el.action_url }
 						>
-							{ el.action }
+							{ readMore }
 						</AppDocumentationLink>
 					),
 				},

--- a/js/src/product-feed/issues-table-card/issues-table-data.test.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data.test.js
@@ -1,0 +1,134 @@
+jest.mock( '.~/hooks/useActiveIssueType' );
+jest.mock( '@woocommerce/tracks', () => {
+	return {
+		recordEvent: jest.fn(),
+	};
+} );
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+import { recordEvent } from '@woocommerce/tracks';
+import '@testing-library/jest-dom';
+/**
+ * Internal dependencies
+ */
+import useActiveIssueType from '.~/hooks/useActiveIssueType';
+import mockIssue from '.~/tests/mock-issue';
+import IssuesTableData from './issues-table-data';
+import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '.~/constants';
+
+describe( 'Issues Table data', () => {
+	test( 'Render error if no data', () => {
+		const { queryByText } = render( <IssuesTableData /> );
+		expect(
+			queryByText(
+				'An error occurred while retrieving issues. Please try again later.'
+			)
+		).toBeTruthy();
+	} );
+
+	test( 'Render Issues Solved when no issues', () => {
+		useActiveIssueType.mockReturnValue( ISSUE_TYPE_PRODUCT );
+
+		const { queryByText } = render(
+			<IssuesTableData data={ { issues: [] } } />
+		);
+		expect( queryByText( /All product issues resolved/ ) ).toBeTruthy();
+	} );
+
+	test( 'Render Headers', () => {
+		const { queryByText } = render(
+			<IssuesTableData
+				data={ {
+					issues: [ mockIssue( 1, { type: 'account' } ) ],
+				} }
+			/>
+		);
+
+		expect( queryByText( 'Type' ) ).toBeTruthy();
+		expect( queryByText( 'Affected product' ) ).toBeTruthy();
+		expect( queryByText( 'Issue' ) ).toBeTruthy();
+		expect( queryByText( 'Suggested action' ) ).toBeTruthy();
+	} );
+
+	test( 'Render Account Issues', () => {
+		useActiveIssueType.mockReturnValue( ISSUE_TYPE_ACCOUNT );
+
+		const { queryByText } = render(
+			<IssuesTableData
+				data={ {
+					issues: [ mockIssue( 1, { type: 'account', product: 0 } ) ],
+				} }
+			/>
+		);
+		expect( queryByText( '#issue-1' ) ).toBeTruthy();
+		expect( queryByText( 'Read more about this issue' ) ).toBeTruthy();
+	} );
+
+	test( 'Render Product Issues', () => {
+		useActiveIssueType.mockReturnValue( ISSUE_TYPE_PRODUCT );
+
+		const { queryByText } = render(
+			<IssuesTableData
+				data={ {
+					issues: [ mockIssue( 1 ) ],
+				} }
+			/>
+		);
+		expect( queryByText( '#product-1' ) ).toBeTruthy();
+		expect( queryByText( '#issue-1' ) ).toBeTruthy();
+		expect( queryByText( 'Read more about this issue' ) ).toBeTruthy();
+	} );
+
+	test( 'Open modal when clicking on Action link', () => {
+		useActiveIssueType.mockReturnValue( ISSUE_TYPE_ACCOUNT );
+
+		const { queryByText, queryByRole } = render(
+			<IssuesTableData
+				data={ {
+					issues: [ mockIssue( 1, { type: 'account', product: 0 } ) ],
+				} }
+			/>
+		);
+		const link = queryByText( 'Read more about this issue' );
+		fireEvent.click( link );
+		expect( queryByRole( 'dialog' ) ).toBeTruthy();
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'gla_click_read_more_about_issue',
+			{
+				context: 'issues-to-resolve',
+				issue: '#code-1',
+			}
+		);
+	} );
+
+	test( 'Link instead of modal when action is null', () => {
+		jest.clearAllMocks();
+
+		const { queryByText } = render(
+			<IssuesTableData
+				data={ {
+					issues: [
+						mockIssue( 1, {
+							type: 'account',
+							action: null,
+							product: 0,
+						} ),
+					],
+				} }
+			/>
+		);
+		const link = queryByText( 'Read more about this issue' );
+		expect( link ).toHaveAttribute( 'href', 'example.com/1' );
+		fireEvent.click( link );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'gla_documentation_link_click',
+			{
+				context: 'issues-to-resolve',
+				link_id: '#code-1',
+				href: 'example.com/1',
+			}
+		);
+	} );
+} );

--- a/js/src/product-feed/issues-table-card/issues-table.js
+++ b/js/src/product-feed/issues-table-card/issues-table.js
@@ -9,40 +9,13 @@ import { Pagination, TablePlaceholder } from '@woocommerce/components';
  * Internal dependencies
  */
 import { ISSUE_TABLE_PER_PAGE } from '.~/constants';
+import ISSUES_TABLE_DATA_HEADERS from './issues-table-data-headers';
 import { recordTablePageEvent } from '.~/utils/recordEvent';
-import IssuesTableData from '.~/product-feed/issues-table-card/issues-table-data';
+import IssuesTableData from './issues-table-data';
 import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
 import usePagination from '.~/hooks/usePagination';
 import useActiveIssueType from '.~/hooks/useActiveIssueType';
 import './index.scss';
-
-const headers = [
-	{
-		key: 'type',
-		label: __( 'Type', 'google-listings-and-ads' ),
-		isLeftAligned: true,
-		required: true,
-	},
-	{
-		key: 'affectedProduct',
-		label: __( 'Affected product', 'google-listings-and-ads' ),
-		isLeftAligned: true,
-		required: true,
-	},
-	{
-		key: 'issue',
-		label: __( 'Issue', 'google-listings-and-ads' ),
-		isLeftAligned: true,
-		required: true,
-	},
-	{
-		key: 'suggestedAction',
-		label: __( 'Suggested action', 'google-listings-and-ads' ),
-		isLeftAligned: true,
-		required: true,
-	},
-	{ key: 'action', label: '', required: true },
-];
 
 /**
  * The table rendering the issues data with a paginator.
@@ -77,14 +50,14 @@ const IssuesTable = () => {
 			<CardBody size={ null }>
 				{ ! hasFinishedResolution ? (
 					<TablePlaceholder
-						headers={ headers }
+						headers={ ISSUES_TABLE_DATA_HEADERS }
 						caption={ __(
 							'Loading Issues To Resolve',
 							'google-listings-and-ads'
 						) }
 					/>
 				) : (
-					<IssuesTableData headers={ headers } data={ data } />
+					<IssuesTableData data={ data } />
 				) }
 			</CardBody>
 			{ data?.total > 0 && (

--- a/js/src/product-feed/issues-table-card/issues-table.test.js
+++ b/js/src/product-feed/issues-table-card/issues-table.test.js
@@ -1,17 +1,3 @@
-const mockIssue = ( id, args ) => {
-	return {
-		product_id: id,
-		issue: `#issue-${ id }`,
-		code: `#code-${ id }`,
-		product: `#product-${ id }`,
-		severity: 'warning',
-		action: `Action for ${ id }`,
-		action_url: `example.com/${ id }`,
-		type: 'product',
-		...args,
-	};
-};
-
 jest.mock( '.~/hooks/useActiveIssueType' );
 jest.mock( '.~/hooks/useMCIssuesTypeFilter', () => ( {
 	__esModule: true,
@@ -30,6 +16,7 @@ import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '.~/constants';
 import IssuesTable from '.~/product-feed/issues-table-card/issues-table';
 import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
 import useActiveIssueType from '.~/hooks/useActiveIssueType';
+import mockIssue from '.~/tests/mock-issue';
 
 describe( 'Issues Table', () => {
 	describe( 'Rendering correctly the table', () => {

--- a/js/src/tests/mock-issue.js
+++ b/js/src/tests/mock-issue.js
@@ -1,0 +1,15 @@
+const mockIssue = ( id, args ) => {
+	return {
+		product_id: id,
+		issue: `#issue-${ id }`,
+		code: `#code-${ id }`,
+		product: `#product-${ id }`,
+		severity: 'warning',
+		action: `Action for ${ id }`,
+		action_url: `example.com/${ id }`,
+		type: 'product',
+		...args,
+	};
+};
+
+export default mockIssue;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements the design proposal of having a modal with the issue information instead of a link to the documentation.

Design can be found here https://googleforwooextension.wordpress.com/2022/03/17/gmc-account-review-request-designs-i4/

(In the section 2)

It's related with #1507  (that PR implemented the backend)

### Screenshots:


https://user-images.githubusercontent.com/5908855/169072768-17a8652b-5d90-4eaa-af88-be574cd0cede.mov



### Detailed test instructions:

1.  You need to have an account with 2 issues (doesn't matter for now if they are product or account), also you will need to check track events, so please allow tracking and run `localStorage.setItem( 'debug', 'wc-admin:*' );` in verbose mode in Dev Tools Console.  
2. One issue should have an action as null in database, other with action filled with some content. (Normally product issues has content in action and account issues not) But you can create or update at your own in `wp_gla_merchant_issues` 
3. Go to Product Feed, you will see the `Read ore about this issue` link on both.
4. If you click in the one with null value, it will go to the link provided in action_url column. opening the link in a new tab and triggering `gla_documentation_link_click` event
5. If you click in the one with value, it will open a modal with the issue info. Issue title in the modal header as well as the issue description in the body. Also, the event `gla_click_read_more_about_issue` will be triggered. 
6.  Clicking on Learn more will open the link in a new tab and triggering `gla_documentation_link_click` event


### Additional details:

⚠️ I need to confirm wit Design if they want this functionality with Products and Account or only account issues. But that could be adjusted if so in another PR. 

- Some refactors in the issue table header, since we needed in the testing files I decided to separate it in a new file. 
- Created some tests in Data table and Modal
- Created a mock function inside test. If you have a better suggestion please let me know since I'm not sure where to store it.


### Changelog entry

> Tweak - Show the account issue resolution steps in the UI 
