### PR TITLE
Fix the failed test case for MinimumOrderCard

### DIFF
--- a/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-card.test.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-card.test.js
@@ -65,8 +65,7 @@ describe( 'MinimumOrderCard', () => {
 			userEvent.click( rendered.getByRole( 'button', { name: /Add/ } ) );
 			// Input some value.
 			const input = screen.getByRole( 'textbox' );
-			// For some reason it's typed backwards.
-			await userEvent.type( input, '03' );
+			await userEvent.type( input, '30' );
 			// Confirm.
 			await userEvent.click(
 				screen.getByRole( 'button', {
@@ -86,7 +85,6 @@ describe( 'MinimumOrderCard', () => {
 		test( 'When a minimum order value is changed for an existing group, calls the `onChange` callback with the new value containing `shippingRate.options.free_shipping_threshold`s set to the given value', async () => {
 			// Input some value.
 			const input = rendered.getByRole( 'textbox' );
-			// For some reason it's typed backwards.
 			await userEvent.type( input, '7' );
 			// Blur away.
 			await userEvent.tab();
@@ -147,7 +145,6 @@ describe( 'MinimumOrderCard', () => {
 			fireEvent.click( screen.queryByLabelText( 'United States' ) );
 			// Input some value.
 			const input = rendered.getByRole( 'textbox' );
-			// For some reason it's typed backwards.
 			await userEvent.type( input, '7' );
 			// Confirm.
 			await userEvent.click(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In [PR #1499](https://github.com/woocommerce/google-listings-and-ads/pull/1499#discussion_r874909458), somehow it needed to type backward when testing with the \<input\> value, but the mysterious reason is gone. This PR fixes the failure test case by typing forward.

### Detailed test instructions:

1. `npm run test:js`
2. Check if all JS unit tests are passed.

### Changelog entry
