### PR TITLE
Rename `changeMinimumOrderGroup`

### DIFF
--- a/js/src/components/shipping-rate-section/minimum-order-card/calculateValueFromGroupChange.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/calculateValueFromGroupChange.js
@@ -16,7 +16,7 @@
  * @param {MinimumOrderGroup} [newGroup] New minimum order group.
  * @return {Array<ShippingRate>} New, updated value.
  */
-export const changeMinimumOrderGroup = ( value, oldGroup, newGroup ) => {
+export const calculateValueFromGroupChange = ( value, oldGroup, newGroup ) => {
 	return value.map( ( shippingRate ) => {
 		const newShippingRate = {
 			...shippingRate,

--- a/js/src/components/shipping-rate-section/minimum-order-card/calculateValueFromGroupChange.test.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/calculateValueFromGroupChange.test.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import { changeMinimumOrderGroup } from './changeMinimumOrderGroup';
+import { calculateValueFromGroupChange } from './calculateValueFromGroupChange';
 import { structuredClone } from '.~/utils/structuredClone.js';
 
-describe( 'changeMinimumOrderGroup', () => {
+describe( 'calculateValueFromGroupChange', () => {
 	const value = Object.freeze( [
 		{
 			id: '1',
@@ -47,7 +47,7 @@ describe( 'changeMinimumOrderGroup', () => {
 		const expectedValue = structuredClone( value );
 		expectedValue[ 0 ].options.free_shipping_threshold = 30;
 		expect(
-			changeMinimumOrderGroup( value, null, newGroup )
+			calculateValueFromGroupChange( value, null, newGroup )
 		).toStrictEqual( expectedValue );
 	} );
 	// Pure delete.
@@ -62,9 +62,9 @@ describe( 'changeMinimumOrderGroup', () => {
 		const expectedValue = structuredClone( value );
 		expectedValue[ 1 ].options.free_shipping_threshold = undefined;
 		expectedValue[ 2 ].options.free_shipping_threshold = undefined;
-		expect( changeMinimumOrderGroup( value, oldGroup ) ).toStrictEqual(
-			expectedValue
-		);
+		expect(
+			calculateValueFromGroupChange( value, oldGroup )
+		).toStrictEqual( expectedValue );
 	} );
 	// Update.
 	it( 'returns a new value updated based on changed group threshold', () => {
@@ -83,7 +83,7 @@ describe( 'changeMinimumOrderGroup', () => {
 		expectedValue[ 1 ].options.free_shipping_threshold = 507;
 		expectedValue[ 2 ].options.free_shipping_threshold = 507;
 		expect(
-			changeMinimumOrderGroup( value, oldGroup, newGroup )
+			calculateValueFromGroupChange( value, oldGroup, newGroup )
 		).toStrictEqual( expectedValue );
 	} );
 
@@ -105,7 +105,7 @@ describe( 'changeMinimumOrderGroup', () => {
 		expectedValue[ 0 ].options.free_shipping_threshold = 50;
 		expectedValue[ 1 ].options.free_shipping_threshold = undefined;
 		expect(
-			changeMinimumOrderGroup( value, oldGroup, newGroup )
+			calculateValueFromGroupChange( value, oldGroup, newGroup )
 		).toStrictEqual( expectedValue );
 	} );
 
@@ -130,7 +130,7 @@ describe( 'changeMinimumOrderGroup', () => {
 		expectedValue[ 1 ].options.free_shipping_threshold = undefined;
 		expectedValue[ 2 ].options.free_shipping_threshold = 507;
 		expect(
-			changeMinimumOrderGroup( value, oldGroup, newGroup )
+			calculateValueFromGroupChange( value, oldGroup, newGroup )
 		).toStrictEqual( expectedValue );
 	} );
 } );

--- a/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-card.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-card.js
@@ -20,7 +20,7 @@ import isNonFreeFlatShippingRate from '.~/utils/isNonFreeFlatShippingRate';
 import MinimumOrderInputControl from './minimum-order-input-control';
 import { AddMinimumOrderFormModal } from './minimum-order-form-modals';
 import groupShippingRatesByMethodFreeShippingThreshold from './groupShippingRatesByMethodFreeShippingThreshold';
-import { changeMinimumOrderGroup } from './changeMinimumOrderGroup';
+import { calculateValueFromGroupChange } from './calculateValueFromGroupChange';
 import './minimum-order-card.scss';
 
 const MinimumOrderCard = ( props ) => {
@@ -37,13 +37,15 @@ const MinimumOrderCard = ( props ) => {
 
 		// Event handlers for add, update, delete operations.
 		const addHandler = ( newGroup ) => {
-			onChange( changeMinimumOrderGroup( value, null, newGroup ) );
+			onChange( calculateValueFromGroupChange( value, null, newGroup ) );
 		};
 		const getChangeHandler = ( oldGroup ) => ( newGroup ) => {
-			onChange( changeMinimumOrderGroup( value, oldGroup, newGroup ) );
+			onChange(
+				calculateValueFromGroupChange( value, oldGroup, newGroup )
+			);
 		};
 		const getDeleteHandler = ( oldGroup ) => () => {
-			onChange( changeMinimumOrderGroup( value, oldGroup ) );
+			onChange( calculateValueFromGroupChange( value, oldGroup ) );
 		};
 
 		// If group length is 1, we render the group,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up to https://github.com/woocommerce/google-listings-and-ads/pull/1499#discussion_r876202188.

In this PR, we rename the `changeMinimumOrderGroup` function to `calculateValueFromGroupChange`, as per discussions in the above PR comments.

cc @tomalec , I forgot about the function naming discussion in the PR comments and merged #1499 right after I merged #1410, sorry about that. We can continue in this PR here. 😄 

### Detailed test instructions:

Tests: Run `npm run test:js`, all tests should pass.

Code check: Search for `changeMinimumOrderGroup` in the code base, there should be 0 result.

UI functionality: Smoke test adding, changing, deleting MinimumOrder thresholds, it should work as expected.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
