### PR TITLE
Refactor dismissible notice PMax and adds URLs for PMax links

### DIFF
--- a/js/src/components/campaign-conversion-notice/conversion-statuses.js
+++ b/js/src/components/campaign-conversion-notice/conversion-statuses.js
@@ -22,8 +22,8 @@ const BEFORE_CONVERSION = {
 		'google-listings-and-ads'
 	),
 	externalLink: {
-		//TODO Update link when it is defined
-		link: '#',
+		link:
+			'https://href.li/?https://support.google.com/google-ads/answer/11576060',
 		linkId: 'campaign-conversion-status-before-migration-read-more',
 		content: __(
 			'Learn more about this upgrade',
@@ -58,8 +58,8 @@ const AFTER_CONVERSION = {
 		}
 	),
 	externalLink: {
-		//TODO Update link when it is defined
-		link: '#',
+		link:
+			'https://href.li/?https://support.google.com/google-ads/answer/11576060',
 		linkId: 'campaign-conversion-status-after-migration-read-more',
 		content: __(
 			'Learn more about this upgrade',
@@ -80,8 +80,7 @@ const REPORTS_CONVERSION = {
 			readMoreLink: (
 				<AppDocumentationLink
 					context="reports-programs"
-					//TODO Update link when it is defined
-					href="#"
+					href="https://href.li/?https://support.google.com/google-ads/answer/11576060"
 					linkId="campaign-conversion-status-after-migration-reports-read-more"
 				/>
 			),

--- a/js/src/components/campaign-conversion-notice/conversion-statuses.js
+++ b/js/src/components/campaign-conversion-notice/conversion-statuses.js
@@ -22,8 +22,7 @@ const BEFORE_CONVERSION = {
 		'google-listings-and-ads'
 	),
 	externalLink: {
-		link:
-			'https://href.li/?https://support.google.com/google-ads/answer/11576060',
+		link: 'https://support.google.com/google-ads/answer/11576060',
 		linkId: 'campaign-conversion-status-before-migration-read-more',
 		content: __(
 			'Learn more about this upgrade',
@@ -58,8 +57,7 @@ const AFTER_CONVERSION = {
 		}
 	),
 	externalLink: {
-		link:
-			'https://href.li/?https://support.google.com/google-ads/answer/11576060',
+		link: 'https://support.google.com/google-ads/answer/11576060',
 		linkId: 'campaign-conversion-status-after-migration-read-more',
 		content: __(
 			'Learn more about this upgrade',
@@ -80,7 +78,7 @@ const REPORTS_CONVERSION = {
 			readMoreLink: (
 				<AppDocumentationLink
 					context="reports-programs"
-					href="https://href.li/?https://support.google.com/google-ads/answer/11576060"
+					href="https://support.google.com/google-ads/answer/11576060"
 					linkId="campaign-conversion-status-after-migration-reports-read-more"
 				/>
 			),

--- a/js/src/components/campaign-conversion-notice/conversion-statuses.js
+++ b/js/src/components/campaign-conversion-notice/conversion-statuses.js
@@ -12,6 +12,8 @@ import { geReportsUrl } from '.~/utils/urls';
 import TrackableLink from '.~/components/trackable-link';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 
+const URL_READ_MORE = 'https://support.google.com/google-ads/answer/11576060';
+
 const BEFORE_CONVERSION = {
 	title: __(
 		'Your Google Listings & Ads campaigns will soon be automatically upgraded',
@@ -22,7 +24,7 @@ const BEFORE_CONVERSION = {
 		'google-listings-and-ads'
 	),
 	externalLink: {
-		link: 'https://support.google.com/google-ads/answer/11576060',
+		link: URL_READ_MORE,
 		linkId: 'campaign-conversion-status-before-migration-read-more',
 		content: __(
 			'Learn more about this upgrade',
@@ -57,7 +59,7 @@ const AFTER_CONVERSION = {
 		}
 	),
 	externalLink: {
-		link: 'https://support.google.com/google-ads/answer/11576060',
+		link: URL_READ_MORE,
 		linkId: 'campaign-conversion-status-after-migration-read-more',
 		content: __(
 			'Learn more about this upgrade',
@@ -78,7 +80,7 @@ const REPORTS_CONVERSION = {
 			readMoreLink: (
 				<AppDocumentationLink
 					context="reports-programs"
-					href="https://support.google.com/google-ads/answer/11576060"
+					href={ URL_READ_MORE }
 					linkId="campaign-conversion-status-after-migration-reports-read-more"
 				/>
 			),

--- a/js/src/components/campaign-conversion-notice/index.js
+++ b/js/src/components/campaign-conversion-notice/index.js
@@ -12,7 +12,6 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import CONVERSION_STATUSES from './conversion-statuses';
 import getConversionCampaignStatusNotice from '.~/utils/getConversionCampaignStatusNotice';
 import DismissibleNotice from '.~/components/dismissible-notice';
-DismissibleNotice;
 import './index.scss';
 
 const ExternalIcon = () => (

--- a/js/src/components/campaign-conversion-notice/index.js
+++ b/js/src/components/campaign-conversion-notice/index.js
@@ -11,7 +11,8 @@ import { glaData } from '.~/constants';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import CONVERSION_STATUSES from './conversion-statuses';
 import getConversionCampaignStatusNotice from '.~/utils/getConversionCampaignStatusNotice';
-import DismissibleNotice from './dismissible-notice';
+import DismissibleNotice from '.~/components/dismissible-notice';
+DismissibleNotice;
 import './index.scss';
 
 const ExternalIcon = () => (

--- a/js/src/components/campaign-conversion-notice/reports-notice.js
+++ b/js/src/components/campaign-conversion-notice/reports-notice.js
@@ -9,7 +9,7 @@ import { __experimentalText as Text } from '@wordpress/components';
 import { glaData } from '.~/constants';
 import CONVERSION_STATUSES from './conversion-statuses';
 import getConversionCampaignStatusNotice from '.~/utils/getConversionCampaignStatusNotice';
-import DismissibleNotice from './dismissible-notice';
+import DismissibleNotice from '.~/components/dismissible-notice';
 import './reports-notice.scss';
 
 /**

--- a/js/src/components/dismissible-notice/index.js
+++ b/js/src/components/dismissible-notice/index.js
@@ -20,7 +20,7 @@ import localStorage from '.~/utils/localStorage';
  * @param {string|null} props.localStorageKey Local Storage Key where is keep the dismiss state.
  * @param {Function} props.onRemove Callback when clicking on remove notice
  * @param {Object} props.restProps Props to be forwarded to Notice Component. Like className.
- * @return {JSX.Element} {@link Notice} element with the info message and the link to the documentation.
+ * @return {JSX.Element} {@link Notice} Dismissible Notice element
  */
 const DismissibleNotice = ( {
 	children,
@@ -29,7 +29,7 @@ const DismissibleNotice = ( {
 	...rest
 } ) => {
 	const defaultDismissedValue = localStorageKey
-		? !! localStorage.get( localStorageKey )
+		? localStorage.get( localStorageKey ) === 'true'
 		: false;
 
 	const [ isDismissed, setIsDismissed ] = useState( defaultDismissedValue );

--- a/js/src/components/dismissible-notice/index.js
+++ b/js/src/components/dismissible-notice/index.js
@@ -28,9 +28,8 @@ const DismissibleNotice = ( {
 	onRemove = noop,
 	...rest
 } ) => {
-	const defaultDismissedValue = localStorageKey
-		? localStorage.get( localStorageKey ) === 'true'
-		: false;
+	const defaultDismissedValue =
+		localStorage.get( localStorageKey ) === 'true';
 
 	const [ isDismissed, setIsDismissed ] = useState( defaultDismissedValue );
 

--- a/js/src/components/dismissible-notice/index.js
+++ b/js/src/components/dismissible-notice/index.js
@@ -3,6 +3,7 @@
  */
 import { Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,14 +17,16 @@ import localStorage from '.~/utils/localStorage';
  *
  * @param {Object} props React props.
  * @param {JSX.Element} props.children Children to render.
- * @param {string} props.className Class to use in the Notice component.
  * @param {string|null} props.localStorageKey Local Storage Key where is keep the dismiss state.
+ * @param {Function} props.onRemove Callback when clicking on remove notice
+ * @param {Object} props.restProps Props to be forwarded to Notice Component. Like className.
  * @return {JSX.Element} {@link Notice} element with the info message and the link to the documentation.
  */
 const DismissibleNotice = ( {
 	children,
-	className,
 	localStorageKey = null,
+	onRemove = noop,
+	...rest
 } ) => {
 	const defaultDismissedValue = localStorageKey
 		? !! localStorage.get( localStorageKey )
@@ -31,10 +34,12 @@ const DismissibleNotice = ( {
 
 	const [ isDismissed, setIsDismissed ] = useState( defaultDismissedValue );
 
-	const onRemove = () => {
+	const handleRemove = () => {
 		if ( localStorageKey ) {
 			localStorage.set( localStorageKey, true );
 		}
+
+		onRemove();
 
 		setIsDismissed( true );
 	};
@@ -44,7 +49,7 @@ const DismissibleNotice = ( {
 	}
 
 	return (
-		<Notice className={ className } onRemove={ onRemove }>
+		<Notice onRemove={ handleRemove } { ...rest }>
 			{ children }
 		</Notice>
 	);

--- a/js/src/components/dismissible-notice/index.test.js
+++ b/js/src/components/dismissible-notice/index.test.js
@@ -63,6 +63,8 @@ describe( 'Dismissible notice', () => {
 		fireEvent.click( removeButton );
 
 		expect( onRemove ).toHaveBeenCalledTimes( 1 );
+
+		//It is not call because the localStorageKey is not set
 		expect( getLocalStorage ).toHaveBeenCalledTimes( 0 );
 
 		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
@@ -101,7 +103,7 @@ describe( 'Dismissible notice', () => {
 		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
 	} );
 
-	it( 'Should not render Dismissible Notice if the localStorageKey is set to true', () => {
+	it( 'Should not render Dismissible Notice if the dismiss state in the localStorage is set to true', () => {
 		const getLocalStorage = localStorage.get.mockImplementation( () => {
 			return 'true';
 		} );
@@ -118,6 +120,7 @@ describe( 'Dismissible notice', () => {
 
 		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
 		expect( getLocalStorage ).toHaveBeenCalledTimes( 1 );
+		expect( getLocalStorage ).toBeCalledWith( localStorageKey );
 		expect( onRemove ).toHaveBeenCalledTimes( 0 );
 	} );
 } );

--- a/js/src/components/dismissible-notice/index.test.js
+++ b/js/src/components/dismissible-notice/index.test.js
@@ -17,7 +17,7 @@ jest.mock( '.~/utils/localStorage', () => {
 	};
 } );
 
-describe( 'Dismissable notice', () => {
+describe( 'Dismissible notice', () => {
 	const onRemove = jest.fn().mockName( 'On remove callback' );
 	const localStorageKey = 'myDismissLocalStorageKey';
 
@@ -25,7 +25,7 @@ describe( 'Dismissable notice', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'Rendering Dismissable Notice', () => {
+	it( 'Rendering Dismissible Notice', () => {
 		//using spokenMessage='' to avoid accessibility message.
 		//See https://make.wordpress.org/accessibility/handbook/markup/wp-a11y-speak/#the-generated-output
 		const { getByText, getByRole, container } = render(
@@ -44,7 +44,7 @@ describe( 'Dismissable notice', () => {
 		expect( removeButton ).toBeTruthy();
 	} );
 
-	it( 'Rendering Dismissable Notice with onRemove callback', () => {
+	it( 'Rendering Dismissible Notice with onRemove callback', () => {
 		const getLocalStorage = localStorage.get.mockImplementation( () => {
 			return null;
 		} );
@@ -68,7 +68,7 @@ describe( 'Dismissable notice', () => {
 		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
 	} );
 
-	it( 'Rendering Dismissable Notice with localStorageKey', () => {
+	it( 'Rendering Dismissible Notice with localStorageKey', () => {
 		const getLocalStorage = localStorage.get.mockImplementation( () => {
 			return null;
 		} );
@@ -101,7 +101,7 @@ describe( 'Dismissable notice', () => {
 		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
 	} );
 
-	it( 'Should not render Dismissable Notice if the localStorageKey is set to true', () => {
+	it( 'Should not render Dismissible Notice if the localStorageKey is set to true', () => {
 		const getLocalStorage = localStorage.get.mockImplementation( () => {
 			return 'true';
 		} );

--- a/js/src/components/dismissible-notice/index.test.js
+++ b/js/src/components/dismissible-notice/index.test.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import DismissibleNotice from '.~/components/dismissible-notice';
+import localStorage from '.~/utils/localStorage';
+
+jest.mock( '.~/utils/localStorage', () => {
+	return {
+		get: jest.fn(),
+		set: jest.fn(),
+	};
+} );
+
+describe( 'Dismissable notice', () => {
+	const onRemove = jest.fn().mockName( 'On remove callback' );
+	const localStorageKey = 'myDismissLocalStorageKey';
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'Rendering Dismissable Notice', () => {
+		//using spokenMessage='' to avoid accessibility message.
+		//See https://make.wordpress.org/accessibility/handbook/markup/wp-a11y-speak/#the-generated-output
+		const { getByText, getByRole, container } = render(
+			<DismissibleNotice spokenMessage="" className="myClassName">
+				<p>My dismissible notice</p>
+			</DismissibleNotice>
+		);
+
+		expect( container.firstChild.classList.contains( 'myClassName' ) ).toBe(
+			true
+		);
+		const noticeContent = getByText( 'My dismissible notice' );
+		const removeButton = getByRole( 'button' );
+
+		expect( noticeContent ).toBeTruthy();
+		expect( removeButton ).toBeTruthy();
+	} );
+
+	it( 'Rendering Dismissable Notice with onRemove callback', () => {
+		const getLocalStorage = localStorage.get.mockImplementation( () => {
+			return null;
+		} );
+
+		const { getByText, getByRole, queryByText } = render(
+			<DismissibleNotice onRemove={ onRemove } spokenMessage="">
+				<p>My dismissible notice</p>
+			</DismissibleNotice>
+		);
+
+		expect( getByText( 'My dismissible notice' ) ).toBeTruthy();
+
+		const removeButton = getByRole( 'button' );
+		expect( removeButton ).toBeTruthy();
+
+		fireEvent.click( removeButton );
+
+		expect( onRemove ).toHaveBeenCalledTimes( 1 );
+		expect( getLocalStorage ).toHaveBeenCalledTimes( 0 );
+
+		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
+	} );
+
+	it( 'Rendering Dismissable Notice with localStorageKey', () => {
+		const getLocalStorage = localStorage.get.mockImplementation( () => {
+			return null;
+		} );
+		const setLocalStorage = localStorage.set.mockImplementation( () => {
+			return null;
+		} );
+
+		const { getByRole, queryByText } = render(
+			<DismissibleNotice
+				onRemove={ onRemove }
+				localStorageKey={ localStorageKey }
+				spokenMessage=""
+			>
+				<p>My dismissible notice</p>
+			</DismissibleNotice>
+		);
+
+		expect( getLocalStorage ).toHaveBeenCalledTimes( 1 );
+		expect( getLocalStorage ).toBeCalledWith( localStorageKey );
+
+		const removeButton = getByRole( 'button' );
+		expect( removeButton ).toBeTruthy();
+
+		fireEvent.click( removeButton );
+
+		expect( onRemove ).toHaveBeenCalledTimes( 1 );
+		expect( setLocalStorage ).toHaveBeenCalledTimes( 1 );
+		expect( setLocalStorage ).toBeCalledWith( localStorageKey, true );
+
+		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
+	} );
+
+	it( 'Should not render Dismissable Notice if the localStorageKey is set', () => {
+		const getLocalStorage = localStorage.get.mockImplementation( () => {
+			return true;
+		} );
+
+		const { queryByText } = render(
+			<DismissibleNotice
+				onRemove={ onRemove }
+				localStorageKey={ localStorageKey }
+				spokenMessage=""
+			>
+				<p>My dismissible notice</p>
+			</DismissibleNotice>
+		);
+
+		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
+		expect( getLocalStorage ).toHaveBeenCalledTimes( 1 );
+		expect( onRemove ).toHaveBeenCalledTimes( 0 );
+	} );
+} );

--- a/js/src/components/dismissible-notice/index.test.js
+++ b/js/src/components/dismissible-notice/index.test.js
@@ -60,12 +60,11 @@ describe( 'Dismissible notice', () => {
 		const removeButton = getByRole( 'button' );
 		expect( removeButton ).toBeTruthy();
 
+		expect( getLocalStorage ).toHaveBeenCalledTimes( 1 );
+
 		fireEvent.click( removeButton );
 
 		expect( onRemove ).toHaveBeenCalledTimes( 1 );
-
-		//It is not call because the localStorageKey is not set
-		expect( getLocalStorage ).toHaveBeenCalledTimes( 0 );
 
 		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
 	} );

--- a/js/src/components/dismissible-notice/index.test.js
+++ b/js/src/components/dismissible-notice/index.test.js
@@ -101,9 +101,9 @@ describe( 'Dismissable notice', () => {
 		expect( queryByText( 'My dismissible notice' ) ).toBeFalsy();
 	} );
 
-	it( 'Should not render Dismissable Notice if the localStorageKey is set', () => {
+	it( 'Should not render Dismissable Notice if the localStorageKey is set to true', () => {
 		const getLocalStorage = localStorage.get.mockImplementation( () => {
-			return true;
+			return 'true';
 		} );
 
 		const { queryByText } = render(

--- a/src/Notes/AfterCampaignMigration.php
+++ b/src/Notes/AfterCampaignMigration.php
@@ -18,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * Shows an inbox notification related to the campaign migration after the migration starts
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
+ *
+ * @since x.x.x
  */
 class AfterCampaignMigration extends AbstractNote implements OptionsAwareInterface, AdsAwareInterface {
 
@@ -56,7 +58,7 @@ class AfterCampaignMigration extends AbstractNote implements OptionsAwareInterfa
 		$note->add_action(
 			'read-more-upgrade-campaign',
 			__( 'Read more about this upgrade', 'google-listings-and-ads' ),
-			'#'
+			'https://support.google.com/google-ads/answer/11576060'
 		);
 
 		return $note;

--- a/src/Notes/BeforeCampaignMigration.php
+++ b/src/Notes/BeforeCampaignMigration.php
@@ -18,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * Shows an inbox notification related to the campaign migration before the migration starts
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
+ *
+ * @since x.x.x
  */
 class BeforeCampaignMigration extends AbstractNote implements OptionsAwareInterface, AdsAwareInterface {
 
@@ -56,7 +58,7 @@ class BeforeCampaignMigration extends AbstractNote implements OptionsAwareInterf
 		$note->add_action(
 			'learn-more-upgrade-campaign',
 			__( 'Learn more about this upgrade', 'google-listings-and-ads' ),
-			'#'
+			'https://support.google.com/google-ads/answer/11576060'
 		);
 
 		return $note;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This is the follow up of https://github.com/woocommerce/google-listings-and-ads/pull/1492#discussion_r869866530, in that conversation we discussed converting the dismissible notice into a more generic component, this PR is refactoring the PMax notice to make it more reusable so it can be used in other parts of this project. 

This PR also adds the URLs for the links "Learn more about this upgrade" as they were pending to be confirmed by the design team.

See more context in the following links:

- [Design Proposal i2: Performance Max Migration (Milestone 2)](https://woodesigngrowconsultants.wordpress.com/2022/04/20/design-proposal-i2-performance-max-migration-milestone-2/#in-reports)
- [Figma File](https://href.li/?https://www.figma.com/file/eQ9O4m2flzrcAiDMXkOW0m/Google-Listings-%26-Ads-v1.x?node-id=7840%3A127644)
- https://github.com/woocommerce/google-listings-and-ads/pull/1472 & https://github.com/woocommerce/google-listings-and-ads/pull/1492
- https://github.com/woocommerce/google-listings-and-ads/pull/1508

### Detailed test instructions:

#### Links for banners and Inbox notifications

##### Unconverted
1. Check the wp_options table if you have the following option `gla_campaign_convert_status`, otherwise refresh the page.
2. If your status is unconverted: `a:2:{s:6:"status";s:11:"unconverted";s:7:"updated";i:1653037558;}` a banner in the dashboard section should be displayed.
3. Check if the link `Learn more about this upgrade` is redirecting to the right page. `https://support.google.com/google-ads/answer/11576060`

![image](https://user-images.githubusercontent.com/2488994/169703295-877a2ca2-19c1-461c-84cc-983f58419258.png)

4. Go to Tools->Scheduled Actions->search for `wc_gla_cron_daily_notes` in the pending tab.
5. Click run for the pending job: `wc_gla_cron_daily_notes`
6. Go to the Woo Dashboard or your inbox notifications and a new inbox notification should be displayed. Click the link `Learn more about this upgrade` and it should redirect to  `https://support.google.com/google-ads/answer/11576060`

![image](https://user-images.githubusercontent.com/2488994/169394103-8ef9f062-c86c-4585-b949-78391c09fd03.png)

##### Converted

1. Update your status to converted. Update the `gla_campaign_convert_status` option to look similar to `a:2:{s:6:"status";s:9:"converted";s:7:"updated";i:1653037558;}` (the updated timestamp is not needed to be updated)
2. A banner in the dashboard section and in the reports section should be displayed. 

![image](https://user-images.githubusercontent.com/2488994/169703922-3bd84a90-d885-4484-a953-40ebe20e6cfb.png)

![image](https://user-images.githubusercontent.com/2488994/169394318-f98f8493-5d9c-4194-956c-38e3df1ca027.png)

3. Check if the links `Learn more about this upgrade` is redirecting to the right page. `https://support.google.com/google-ads/answer/11576060` in both banners.
4. Go to Tools->Scheduled Actions->search for `wc_gla_cron_daily_notes` in the pending tab.
5. Click in run for the pending job: `wc_gla_cron_daily_notes`
6. Go to the Woo Dashboard or your inbox notifications and a new inbox notification should be displayed. Click the link `Read more about this upgrade` and it should redirect to  `https://support.google.com/google-ads/answer/11576060`

![image](https://user-images.githubusercontent.com/2488994/169703952-a90599eb-0fd0-4791-bd41-4adebc62ec38.png)



### Changelog entry

>Tweak - Refactor dismissible notice
