### PR TITLE
Include ShoppingPerformanceView

### DIFF
--- a/src/API/Google/Query/AdsReportQuery.php
+++ b/src/API/Google/Query/AdsReportQuery.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
 
+use Google\Ads\GoogleAds\V9\Resources\ShoppingPerformanceView;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -16,6 +18,7 @@ abstract class AdsReportQuery extends AdsQuery {
 
 	/**
 	 * Query constructor.
+	 * Uses the resource ShoppingPerformanceView.
 	 *
 	 * @param array $args Query arguments.
 	 */

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -26,6 +26,7 @@ use Google\Ads\GoogleAds\V9\Resources\ConversionAction;
 use Google\Ads\GoogleAds\V9\Resources\Customer;
 use Google\Ads\GoogleAds\V9\Resources\CustomerUserAccess;
 use Google\Ads\GoogleAds\V9\Resources\MerchantCenterLink;
+use Google\Ads\GoogleAds\V9\Resources\ShoppingPerformanceView;
 use Google\Ads\GoogleAds\V9\Services\ConversionActionServiceClient;
 use Google\Ads\GoogleAds\V9\Services\CustomerServiceClient;
 use Google\Ads\GoogleAds\V9\Services\GoogleAdsRow;
@@ -508,6 +509,10 @@ trait GoogleAdsClientTrait {
 			$campaign->method( 'getName' )->willReturn( $row['campaign']['name'] );
 			$campaign->method( 'getStatus' )->willReturn( AdsCampaignStatus::value( $row['campaign']['status'] ) );
 			$ads_row->setCampaign( $campaign );
+
+			// Mock data for ShoppingPerformanceView
+			$shopping_performance_view = $this->createMock( ShoppingPerformanceView::class );
+			$ads_row->setShoppingPerformanceView( $shopping_performance_view );
 		}
 
 		if ( ! empty( $row['metrics'] ) && ! empty( $args['fields'] ) ) {

--- a/tests/proxy/mocks/ads/reports/programs.json
+++ b/tests/proxy/mocks/ads/reports/programs.json
@@ -15,6 +15,9 @@
 			},
 			"segments": {
 				"date": "2021-05-01"
+			},
+			"shoppingPerformanceView": {
+				"resourceName": "customers/1234567890/shoppingPerformanceView"
 			}
 		},
 		{
@@ -32,6 +35,9 @@
 			},
 			"segments": {
 				"date": "2021-05-02"
+			},
+			"shoppingPerformanceView": {
+				"resourceName": "customers/1234567890/shoppingPerformanceView"
 			}
 		},
 		{
@@ -49,6 +55,9 @@
 			},
 			"segments": {
 				"date": "2021-05-03"
+			},
+			"shoppingPerformanceView": {
+				"resourceName": "customers/1234567890/shoppingPerformanceView"
 			}
 		},
 		{
@@ -66,6 +75,9 @@
 			},
 			"segments": {
 				"date": "2021-05-04"
+			},
+			"shoppingPerformanceView": {
+				"resourceName": "customers/1234567890/shoppingPerformanceView"
 			}
 		},
 		{
@@ -83,6 +95,9 @@
 			},
 			"segments": {
 				"date": "2021-05-05"
+			},
+			"shoppingPerformanceView": {
+				"resourceName": "customers/1234567890/shoppingPerformanceView"
 			}
 		},
 		{
@@ -100,6 +115,9 @@
 			},
 			"segments": {
 				"date": "2021-05-06"
+			},
+			"shoppingPerformanceView": {
+				"resourceName": "customers/1234567890/shoppingPerformanceView"
 			}
 		},
 		{
@@ -117,6 +135,9 @@
 			},
 			"segments": {
 				"date": "2021-05-07"
+			},
+			"shoppingPerformanceView": {
+				"resourceName": "customers/1234567890/shoppingPerformanceView"
 			}
 		}
 	]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #1495 the ads library was cleaned up to reduce it's size. However for the reports this fails because of the missing resource ShoppingPerformanceView. We don't directly use any data from this class, but the resource name is included in the reports so it needs to remain in place.

This PR declares it's usage in the AdsReportQuery class so it is not automatically removed. The unit tests were also modified to mock the responses to include the ShoppingPerformanceView so it fails if the class is not present.

Closes #1519

### Detailed test instructions:

1. Remove the vendor directory and run `composer install` to get a cleaned up copy of the ads library
2. Test with an ads account that is fully onboarded and has report data
3. View the dashboard in Marketing > Google Listings & Ads > Dashboard
4. Confirm that there are no errors in the dashboard or the reports page
5. If testing with the test proxy (no account with report data) then the modified file `tests/proxy/mocks/ads/reports/programs.json` is needed to reproduce the error without the fix in this PR.

### Changelog entry
* Fix - Missing ShoppingPerformanceView error when viewing report data.
