### PR TITLE
Simplify and centralize the processing of internal states for TreeSelectControl

### DIFF
--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -297,6 +297,19 @@ const TreeSelectControl = ( {
 	};
 
 	/**
+	 * Expands/Collapses the Option
+	 *
+	 * @param {InnerOption} option The option to be expanded or collapsed.
+	 */
+	const handleToggleExpanded = ( option ) => {
+		setNodesExpanded(
+			option.expanded
+				? nodesExpanded.filter( ( el ) => option.value !== el )
+				: [ ...nodesExpanded, option.value ]
+		);
+	};
+
+	/**
 	 * Handles a change on the Tree options. Could be a click on a parent option
 	 * or a child option
 	 *
@@ -432,9 +445,8 @@ const TreeSelectControl = ( {
 						options={ filteredOptions }
 						value={ value }
 						onChange={ handleOptionsChange }
-						nodesExpanded={ nodesExpanded }
-						onNodesExpandedChange={ setNodesExpanded }
 						onExpanderClick={ handleExpanderClick }
+						onToggleExpanded={ handleToggleExpanded }
 					/>
 				</div>
 			) }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -195,6 +195,11 @@ const TreeSelectControl = ( {
 		};
 
 		const descriptors = {
+			hasChildren: {
+				get() {
+					return this.children?.length > 0;
+				},
+			},
 			allLeaves: {
 				/**
 				 * Returns all (filtered) leaf options under this option.
@@ -263,27 +268,22 @@ const TreeSelectControl = ( {
 		};
 
 		const reduceOptions = ( acc, { children = [], ...option } ) => {
-			option.hasChildren = children.length > 0;
-
-			if ( option.hasChildren ) {
+			if ( children.length ) {
 				option.children = children.reduce( reduceOptions, [] );
 
-				if ( option.children.length ) {
-					Object.defineProperties( option, descriptors );
-					acc.push( option );
+				if ( ! option.children.length ) {
+					return acc;
 				}
-			} else {
-				if ( isFiltered ) {
-					const match = option.label.toLowerCase().indexOf( filter );
-					if ( match === -1 ) {
-						return acc;
-					}
-					option.label = highlightOptionLabel( option.label, match );
+			} else if ( isFiltered ) {
+				const match = option.label.toLowerCase().indexOf( filter );
+				if ( match === -1 ) {
+					return acc;
 				}
-
-				Object.defineProperties( option, descriptors );
-				acc.push( option );
+				option.label = highlightOptionLabel( option.label, match );
 			}
+
+			Object.defineProperties( option, descriptors );
+			acc.push( option );
 
 			return acc;
 		};

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -169,8 +169,8 @@ const TreeSelectControl = ( {
 	 * 5. Finally we set the cache with the obtained results and apply the filters
 	 */
 	const filteredOptions = useMemo( () => {
-		const { current } = cacheRef;
-		const cachedFilteredOptions = current.filteredOptionsMap.get( filter );
+		const { current: cache } = cacheRef;
+		const cachedFilteredOptions = cache.filteredOptionsMap.get( filter );
 
 		if ( cachedFilteredOptions ) {
 			return cachedFilteredOptions;
@@ -232,7 +232,7 @@ const TreeSelectControl = ( {
 					if ( this.hasChildren ) {
 						return this.leaves.every( ( opt ) => opt.checked );
 					}
-					return current.selectedValues.includes( this.value );
+					return cache.selectedValues.includes( this.value );
 				},
 			},
 			partialChecked: {
@@ -266,7 +266,7 @@ const TreeSelectControl = ( {
 					return (
 						isSearching ||
 						this.value === ROOT_VALUE ||
-						current.expandedValues.includes( this.value )
+						cache.expandedValues.includes( this.value )
 					);
 				},
 			},
@@ -294,7 +294,7 @@ const TreeSelectControl = ( {
 		};
 
 		const filteredTreeOptions = treeOptions.reduce( reduceOptions, [] );
-		current.filteredOptionsMap.set( filter, filteredTreeOptions );
+		cache.filteredOptionsMap.set( filter, filteredTreeOptions );
 
 		return filteredTreeOptions;
 	}, [ treeOptions, filter ] );

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -138,7 +138,6 @@ const TreeSelectControl = ( {
 		setTreeVisible( false );
 	} );
 
-	const hasChildren = ( option ) => option.children?.length;
 	const filterQuery = inputControlValue.trim().toLowerCase();
 	const filter = filterQuery.length >= 3 ? filterQuery : '';
 
@@ -368,10 +367,10 @@ const TreeSelectControl = ( {
 	 * or a child option
 	 *
 	 * @param {boolean} checked Indicates if the item should be checked
-	 * @param {Option} option The option to change
+	 * @param {InnerOption} option The option to change
 	 */
 	const handleOptionsChange = ( checked, option ) => {
-		if ( hasChildren( option ) ) {
+		if ( option.hasChildren ) {
 			handleParentChange( checked, option );
 		} else {
 			handleSingleChange( checked, option );
@@ -382,7 +381,7 @@ const TreeSelectControl = ( {
 	 * Handles a change of a child element.
 	 *
 	 * @param {boolean} checked Indicates if the item should be checked
-	 * @param {Option} option The option to change
+	 * @param {InnerOption} option The option to change
 	 */
 	const handleSingleChange = ( checked, option ) => {
 		const newValue = checked
@@ -396,39 +395,23 @@ const TreeSelectControl = ( {
 	 * Handles a change of a Parent element.
 	 *
 	 * @param {boolean} checked Indicates if the item should be checked
-	 * @param {Option} option The option to change
+	 * @param {InnerOption} option The option to change
 	 */
 	const handleParentChange = ( checked, option ) => {
-		const newValue = [ ...value ];
+		let newValue;
+		const changedValues = option.allLeaves
+			.filter( ( opt ) => opt.checked !== checked )
+			.map( ( opt ) => opt.value );
 
-		if ( checked && ! nodesExpanded.includes( option.value ) ) {
-			setNodesExpanded( [ ...nodesExpanded, option.value ] );
-		}
-
-		function loadChildren( parent ) {
-			if ( ! parent.children ) {
-				return;
+		if ( checked ) {
+			if ( ! option.expanded ) {
+				handleToggleExpanded( option );
 			}
-
-			parent.children.forEach( ( child ) => {
-				if ( hasChildren( child ) ) {
-					loadChildren( child );
-					return;
-				}
-
-				const childPosition = newValue.indexOf( child.value );
-
-				if ( ! checked && childPosition >= 0 ) {
-					newValue.splice( childPosition, 1 );
-				}
-
-				if ( checked && childPosition < 0 ) {
-					newValue.push( child.value );
-				}
-			} );
+			newValue = value.concat( changedValues );
+		} else {
+			newValue = value.filter( ( el ) => ! changedValues.includes( el ) );
 		}
 
-		loadChildren( option );
 		onChange( newValue );
 	};
 

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -64,6 +64,9 @@ import { ARROW_DOWN, ARROW_UP, ENTER, ESCAPE, ROOT_VALUE } from './constants';
  * @property {string|JSX.Element} label The label string or label with highlighted react element for the option.
  * @property {InnerOption[]|undefined} children The (filtered) children options.
  * @property {boolean} hasChildren Whether this option has children.
+ * @property {InnerOption[]} allLeaves All (filtered) leaf options under this option.
+ * @property {boolean} checked Whether this option is checked.
+ * @property {boolean} partialChecked Whether this option is partially checked.
  * @property {boolean} expanded Whether this option is expanded.
  *
  * @typedef {CommonOption & BaseInnerOption} InnerOption
@@ -116,6 +119,7 @@ const TreeSelectControl = ( {
 	const filteredOptionsCache = useRef( {} );
 	const cacheStatesRef = useRef( {} );
 	cacheStatesRef.current.expandedValues = nodesExpanded;
+	cacheStatesRef.current.selectedValues = value;
 
 	const showTree = ! disabled && treeVisible;
 
@@ -192,6 +196,56 @@ const TreeSelectControl = ( {
 		};
 
 		const descriptors = {
+			allLeaves: {
+				/**
+				 * Returns all (filtered) leaf options under this option.
+				 *
+				 * @return {InnerOption[]} All (filtered) leaf options under this option.
+				 */
+				get() {
+					if ( ! this.hasChildren ) {
+						return [];
+					}
+					return this.children.flatMap( ( option ) => {
+						return option.hasChildren ? option.allLeaves : option;
+					} );
+				},
+			},
+			checked: {
+				/**
+				 * Returns whether this option is checked.
+				 * A child option is checked its value is selected.
+				 * A parent option is checked if all leaves are checked.
+				 *
+				 * @return {boolean} True if checked, false otherwise.
+				 */
+				get() {
+					if ( this.hasChildren ) {
+						return this.allLeaves.every( ( opt ) => opt.checked );
+					}
+					return current.selectedValues.includes( this.value );
+				},
+			},
+			partialChecked: {
+				/**
+				 * Returns whether this option is partially checked.
+				 * A child option always returns false.
+				 * A parent option is partially checked if at least one but not all leaves are checked.
+				 *
+				 * @return {boolean} True if partially checked, false otherwise.
+				 */
+				get() {
+					if ( ! this.hasChildren ) {
+						return false;
+					}
+					return (
+						! this.checked &&
+						this.allLeaves.some(
+							( opt ) => opt.checked || opt.partialChecked
+						)
+					);
+				},
+			},
 			expanded: {
 				/**
 				 * Returns whether this option is expanded.
@@ -443,7 +497,6 @@ const TreeSelectControl = ( {
 				>
 					<Options
 						options={ filteredOptions }
-						value={ value }
 						onChange={ handleOptionsChange }
 						onExpanderClick={ handleExpanderClick }
 						onToggleExpanded={ handleToggleExpanded }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -176,12 +176,12 @@ const TreeSelectControl = ( {
 			return cachedFilteredOptions;
 		}
 
-		const isFiltered = Boolean( filter );
+		const isSearching = Boolean( filter );
 
 		const highlightOptionLabel = ( optionLabel, matchPosition ) => {
 			const matchLength = matchPosition + filter.length;
 
-			if ( ! isFiltered ) return optionLabel;
+			if ( ! isSearching ) return optionLabel;
 
 			return (
 				<span>
@@ -259,7 +259,7 @@ const TreeSelectControl = ( {
 				 */
 				get() {
 					return (
-						isFiltered ||
+						isSearching ||
 						this.value === ROOT_VALUE ||
 						current.expandedValues.includes( this.value )
 					);
@@ -274,7 +274,7 @@ const TreeSelectControl = ( {
 				if ( ! option.children.length ) {
 					return acc;
 				}
-			} else if ( isFiltered ) {
+			} else if ( isSearching ) {
 				const match = option.label.toLowerCase().indexOf( filter );
 				if ( match === -1 ) {
 					return acc;

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -62,9 +62,9 @@ import { ARROW_DOWN, ARROW_UP, ENTER, ESCAPE, ROOT_VALUE } from './constants';
 /**
  * @typedef {Object} BaseInnerOption
  * @property {string|JSX.Element} label The label string or label with highlighted react element for the option.
- * @property {InnerOption[]|undefined} children The (filtered) children options.
+ * @property {InnerOption[]|undefined} children The children options. The options are filtered if in searching.
  * @property {boolean} hasChildren Whether this option has children.
- * @property {InnerOption[]} allLeaves All (filtered) leaf options under this option.
+ * @property {InnerOption[]} leaves All leaf options that are flattened under this option. The options are filtered if in searching.
  * @property {boolean} checked Whether this option is checked.
  * @property {boolean} partialChecked Whether this option is partially checked.
  * @property {boolean} expanded Whether this option is expanded.
@@ -200,32 +200,32 @@ const TreeSelectControl = ( {
 					return this.children?.length > 0;
 				},
 			},
-			allLeaves: {
+			leaves: {
 				/**
-				 * Returns all (filtered) leaf options under this option.
+				 * Return all leaf options flattened under this option. The options are filtered if in searching.
 				 *
-				 * @return {InnerOption[]} All (filtered) leaf options under this option.
+				 * @return {InnerOption[]} All leaf options that are flattened under this option. The options are filtered if in searching.
 				 */
 				get() {
 					if ( ! this.hasChildren ) {
 						return [];
 					}
 					return this.children.flatMap( ( option ) => {
-						return option.hasChildren ? option.allLeaves : option;
+						return option.hasChildren ? option.leaves : option;
 					} );
 				},
 			},
 			checked: {
 				/**
 				 * Returns whether this option is checked.
-				 * A child option is checked its value is selected.
+				 * A leaf option is checked if its value is selected.
 				 * A parent option is checked if all leaves are checked.
 				 *
 				 * @return {boolean} True if checked, false otherwise.
 				 */
 				get() {
 					if ( this.hasChildren ) {
-						return this.allLeaves.every( ( opt ) => opt.checked );
+						return this.leaves.every( ( opt ) => opt.checked );
 					}
 					return current.selectedValues.includes( this.value );
 				},
@@ -233,7 +233,7 @@ const TreeSelectControl = ( {
 			partialChecked: {
 				/**
 				 * Returns whether this option is partially checked.
-				 * A child option always returns false.
+				 * A leaf option always returns false.
 				 * A parent option is partially checked if at least one but not all leaves are checked.
 				 *
 				 * @return {boolean} True if partially checked, false otherwise.
@@ -244,7 +244,7 @@ const TreeSelectControl = ( {
 					}
 					return (
 						! this.checked &&
-						this.allLeaves.some(
+						this.leaves.some(
 							( opt ) => opt.checked || opt.partialChecked
 						)
 					);
@@ -253,7 +253,7 @@ const TreeSelectControl = ( {
 			expanded: {
 				/**
 				 * Returns whether this option is expanded.
-				 * A child option always returns false.
+				 * A leaf option always returns false.
 				 *
 				 * @return {boolean} True if expanded, false otherwise.
 				 */
@@ -399,7 +399,7 @@ const TreeSelectControl = ( {
 	 */
 	const handleParentChange = ( checked, option ) => {
 		let newValue;
-		const changedValues = option.allLeaves
+		const changedValues = option.leaves
 			.filter( ( opt ) => opt.checked !== checked )
 			.map( ( opt ) => opt.value );
 

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -196,6 +196,11 @@ const TreeSelectControl = ( {
 
 		const descriptors = {
 			hasChildren: {
+				/**
+				 * Returns whether this option has children.
+				 *
+				 * @return {boolean} True if has children, false otherwise.
+				 */
 				get() {
 					return this.children?.length > 0;
 				},

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -23,7 +23,6 @@ import Checkbox from '.~/components/tree-select-control/checkbox';
  * @param {InnerOption[]} props.options List of options to be rendered
  * @param {string[]} props.value List of selected values
  * @param {string[]} props.nodesExpanded List of expanded nodes.
- * @param {boolean} [props.isFiltered=false] Flag to know if there is a filter applied
  * @param {Function} props.onChange Callback when an option changes
  * @param {Function} props.onNodesExpandedChange Callback when a node is expanded/collapsed
  * @param {Function} [props.onExpanderClick] Callback when an expander is clicked.
@@ -31,7 +30,6 @@ import Checkbox from '.~/components/tree-select-control/checkbox';
 const Options = ( {
 	options = [],
 	value = [],
-	isFiltered = false,
 	onChange = () => {},
 	nodesExpanded = [],
 	onNodesExpandedChange = () => {},
@@ -101,28 +99,28 @@ const Options = ( {
 	 *
 	 * @param {Event} event The KeyDown event
 	 * @param {InnerOption} option The option where the event happened
-	 * @param {boolean} isExpanded True if the node is expanded, false otherwise
 	 */
-	const handleKeyDown = ( event, option, isExpanded ) => {
-		if ( event.key === ARROW_RIGHT && ! isExpanded ) {
+	const handleKeyDown = ( event, option ) => {
+		if ( ! option.hasChildren ) {
+			return;
+		}
+		if ( event.key === ARROW_RIGHT && ! option.expanded ) {
 			toggleExpanded( option );
-		} else if ( event.key === ARROW_LEFT && isExpanded ) {
+		} else if ( event.key === ARROW_LEFT && option.expanded ) {
 			toggleExpanded( option );
 		}
 	};
 
 	return options.map( ( option ) => {
 		const isRoot = option.value === ROOT_VALUE;
-		const hasChildren = !! option.children?.length;
+		const { hasChildren, expanded } = option;
 		const checked = isChecked( option );
-		const isExpanded =
-			isFiltered || isRoot || nodesExpanded.includes( option.value );
 
 		return (
 			<div
 				key={ `${ option.key ?? option.value }` }
 				role={ hasChildren ? 'treegroup' : 'treeitem' }
-				aria-expanded={ hasChildren ? isExpanded : undefined }
+				aria-expanded={ hasChildren ? expanded : undefined }
 				className={ classnames(
 					'woocommerce-tree-select-control__node',
 					hasChildren && 'has-children'
@@ -141,9 +139,7 @@ const Options = ( {
 								toggleExpanded( option );
 							} }
 						>
-							<Icon
-								icon={ isExpanded ? chevronUp : chevronDown }
-							/>
+							<Icon icon={ expanded ? chevronUp : chevronDown } />
 						</button>
 					) }
 
@@ -161,12 +157,12 @@ const Options = ( {
 							onChange( e.target.checked, option );
 						} }
 						onKeyDown={ ( e ) => {
-							handleKeyDown( e, option, isExpanded );
+							handleKeyDown( e, option );
 						} }
 					/>
 				</Flex>
 
-				{ hasChildren && isExpanded && (
+				{ hasChildren && expanded && (
 					<div
 						className={ classnames(
 							'woocommerce-tree-select-control__children',
@@ -175,7 +171,6 @@ const Options = ( {
 					>
 						<Options
 							options={ option.children }
-							isFiltered={ isFiltered }
 							value={ value }
 							onChange={ onChange }
 							nodesExpanded={ nodesExpanded }

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -13,14 +13,14 @@ import { ARROW_LEFT, ARROW_RIGHT, ROOT_VALUE } from './constants';
 import Checkbox from '.~/components/tree-select-control/checkbox';
 
 /**
- * @typedef {import('./index').Option} Option
+ * @typedef {import('./index').InnerOption} InnerOption
  */
 
 /**
  * This component renders a list of options and its children recursively
  *
  * @param {Object} props Component parameters
- * @param {Option[]} props.options List of options to be rendered
+ * @param {InnerOption[]} props.options List of options to be rendered
  * @param {string[]} props.value List of selected values
  * @param {string[]} props.nodesExpanded List of expanded nodes.
  * @param {boolean} [props.isFiltered=false] Flag to know if there is a filter applied
@@ -100,7 +100,7 @@ const Options = ( {
 	 * ArrowLeft - Collapses the node
 	 *
 	 * @param {Event} event The KeyDown event
-	 * @param {Option} option The option where the event happened
+	 * @param {InnerOption} option The option where the event happened
 	 * @param {boolean} isExpanded True if the node is expanded, false otherwise
 	 */
 	const handleKeyDown = ( event, option, isExpanded ) => {

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -22,18 +22,16 @@ import Checkbox from '.~/components/tree-select-control/checkbox';
  * @param {Object} props Component parameters
  * @param {InnerOption[]} props.options List of options to be rendered
  * @param {string[]} props.value List of selected values
- * @param {string[]} props.nodesExpanded List of expanded nodes.
  * @param {Function} props.onChange Callback when an option changes
- * @param {Function} props.onNodesExpandedChange Callback when a node is expanded/collapsed
  * @param {Function} [props.onExpanderClick] Callback when an expander is clicked.
+ * @param {(option: InnerOption) => void} [props.onToggleExpanded] Callback when requesting an expander to be toggled.
  */
 const Options = ( {
 	options = [],
 	value = [],
 	onChange = () => {},
-	nodesExpanded = [],
-	onNodesExpandedChange = () => {},
 	onExpanderClick = noop,
+	onToggleExpanded = noop,
 } ) => {
 	/**
 	 * Verifies if an option is checked.
@@ -78,21 +76,6 @@ const Options = ( {
 	};
 
 	/**
-	 * Expands/Collapses the Option
-	 *
-	 * @param {Option} option The option to be expanded or collapsed
-	 */
-	const toggleExpanded = ( option ) => {
-		if ( ! option.children?.length ) return;
-
-		onNodesExpandedChange(
-			nodesExpanded.includes( option.value )
-				? nodesExpanded.filter( ( el ) => option.value !== el )
-				: [ ...nodesExpanded, option.value ]
-		);
-	};
-
-	/**
 	 * Alters the node with some keys for accessibility
 	 * ArrowRight - Expands the node
 	 * ArrowLeft - Collapses the node
@@ -105,9 +88,9 @@ const Options = ( {
 			return;
 		}
 		if ( event.key === ARROW_RIGHT && ! option.expanded ) {
-			toggleExpanded( option );
+			onToggleExpanded( option );
 		} else if ( event.key === ARROW_LEFT && option.expanded ) {
-			toggleExpanded( option );
+			onToggleExpanded( option );
 		}
 	};
 
@@ -136,7 +119,7 @@ const Options = ( {
 							tabIndex="-1"
 							onClick={ ( e ) => {
 								onExpanderClick( e );
-								toggleExpanded( option );
+								onToggleExpanded( option );
 							} }
 						>
 							<Icon icon={ expanded ? chevronUp : chevronDown } />
@@ -173,9 +156,8 @@ const Options = ( {
 							options={ option.children }
 							value={ value }
 							onChange={ onChange }
-							nodesExpanded={ nodesExpanded }
-							onNodesExpandedChange={ onNodesExpandedChange }
 							onExpanderClick={ onExpanderClick }
+							onToggleExpanded={ onToggleExpanded }
 						/>
 					</div>
 				) }

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -21,60 +21,16 @@ import Checkbox from '.~/components/tree-select-control/checkbox';
  *
  * @param {Object} props Component parameters
  * @param {InnerOption[]} props.options List of options to be rendered
- * @param {string[]} props.value List of selected values
  * @param {Function} props.onChange Callback when an option changes
  * @param {Function} [props.onExpanderClick] Callback when an expander is clicked.
  * @param {(option: InnerOption) => void} [props.onToggleExpanded] Callback when requesting an expander to be toggled.
  */
 const Options = ( {
 	options = [],
-	value = [],
 	onChange = () => {},
 	onExpanderClick = noop,
 	onToggleExpanded = noop,
 } ) => {
-	/**
-	 * Verifies if an option is checked.
-	 * An option is checked if their value is selected or all of their children are selected
-	 *
-	 * @param {Option} option The option to verify if is checked
-	 * @return {boolean} True if checked, false otherwise
-	 */
-	const isChecked = ( option ) => {
-		return (
-			value.includes( option.value ) || isEveryChildrenSelected( option )
-		);
-	};
-
-	/**
-	 * Verifies if an option has some children checked.
-	 *
-	 * @param {Option} parent the Option to verify
-	 * @return {boolean} True if any at least one of the children is checked, false otherwsie
-	 */
-	const hasSomeChildrenChecked = ( parent ) => {
-		if ( ! parent.children?.length ) {
-			return false;
-		}
-
-		return parent.children.some(
-			( child ) => isChecked( child ) || hasSomeChildrenChecked( child )
-		);
-	};
-
-	/**
-	 * Returns true if all the children for the parent are selected
-	 *
-	 * @param {Option} parent The parent option to check
-	 */
-	const isEveryChildrenSelected = ( parent ) => {
-		if ( ! parent.children?.length ) {
-			return false;
-		}
-
-		return parent.children.every( ( child ) => isChecked( child ) );
-	};
-
 	/**
 	 * Alters the node with some keys for accessibility
 	 * ArrowRight - Expands the node
@@ -96,8 +52,7 @@ const Options = ( {
 
 	return options.map( ( option ) => {
 		const isRoot = option.value === ROOT_VALUE;
-		const { hasChildren, expanded } = option;
-		const checked = isChecked( option );
+		const { hasChildren, checked, partialChecked, expanded } = option;
 
 		return (
 			<div
@@ -130,9 +85,7 @@ const Options = ( {
 						className={ classnames(
 							'components-base-control',
 							'woocommerce-tree-select-control__option',
-							! checked &&
-								hasSomeChildrenChecked( option ) &&
-								'is-partially-checked'
+							partialChecked && 'is-partially-checked'
 						) }
 						option={ option }
 						checked={ checked }
@@ -154,7 +107,6 @@ const Options = ( {
 					>
 						<Options
 							options={ option.children }
-							value={ value }
 							onChange={ onChange }
 							onExpanderClick={ onExpanderClick }
 							onToggleExpanded={ onToggleExpanded }

--- a/js/src/components/tree-select-control/options.test.js
+++ b/js/src/components/tree-select-control/options.test.js
@@ -7,7 +7,6 @@ import { fireEvent, render } from '@testing-library/react';
  * Internal dependencies
  */
 import TreeSelectControl from '.~/components/tree-select-control/index';
-import Options from '.~/components/tree-select-control/options';
 
 /**
  * In jsdom, the width and height of all elements are zero,
@@ -91,9 +90,11 @@ describe( 'TreeSelectControl - Options Component', () => {
 	} );
 
 	it( 'Partially selects groups', () => {
-		const { queryByText } = render(
-			<Options options={ options } value={ [ 'ES' ] } />
+		const { queryByRole, queryByText } = render(
+			<TreeSelectControl options={ options } value={ [ 'ES' ] } />
 		);
+
+		fireEvent.click( queryByRole( 'combobox' ) );
 
 		const partiallyCheckedOption = queryByText( 'Europe' );
 		const unCheckedOption = queryByText( 'North America' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To simplify and centralize the processing of updating expanded, checked, and partially checked states, this PR:
- Replace `cloneDeep` with array `reduce` when generating filtered options.
- Calculate the expanded, checked, and partially checked states of options in the main component.
- Move the processing of updating the expanded state to the main component.
- Simplify the handling of updating the state of selected values.

### Detailed test instructions:

1. Go to the Edit free listings or the local storybook.
2. Test if the states and functionality of checking/unchecking options work correctly.
3. Test if the states and functionality of expanding/collapsing options work correctly.

### Changelog entry

> Tweak - Simplify and centralize the processing of internal states for the TreeSelectControl component.
