### PR TITLE
Don't take in consideration order when comparing Shipping Rate objects

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -134,7 +134,7 @@ const EditFreeCampaign = () => {
 		savedShippingRates
 	);
 
-	// Dont take in consideration the order of the rules when comparing the Shipping times.
+	// Check what've changed to show prompt. Dont take in consideration the order when comparing the Shipping times.
 	const didTimesChanged = ! isEqual(
 		new Set( shippingTimes ),
 		new Set( savedShippingTimes )

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -134,7 +134,12 @@ const EditFreeCampaign = () => {
 		savedShippingRates
 	);
 
-	const didTimesChanged = ! isEqual( shippingTimes, savedShippingTimes );
+	// Dont take in consideration the order when comparing objects
+	const didTimesChanged = ! isEqual(
+		new Set( shippingTimes ),
+		new Set( savedShippingTimes )
+	);
+
 	const didAnythingChanged =
 		didAudienceChanged ||
 		didSettingsChanged ||

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -134,7 +134,7 @@ const EditFreeCampaign = () => {
 		savedShippingRates
 	);
 
-	// Dont take in consideration the order when comparing objects
+	// Dont take in consideration the order of the rules when comparing the Shipping times.
 	const didTimesChanged = ! isEqual(
 		new Set( shippingTimes ),
 		new Set( savedShippingTimes )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1433.

Avoiding to show the Unsaved Data prompt in case the values of Shipping rates are the same.

This bug happens for example when the user deletes a Shipping rate row and add it again. Since the order is different the isEqual function considers them different objects.

### Screenshots:

https://user-images.githubusercontent.com/5908855/170033769-cd2efac2-4c8c-4c20-91f0-db9fe2f8e333.mov

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout PR and go to Edit Free Listings
2. Setup a target audience of at least 2 countries
3. In the step 2, in shipping rates you should have at least 2 different shipping times rules.
4. Save the changes
5. Check that you can go back without any prompt after saving changes
6. Go again to Edit free listings step 2
7. Modify the first row value in Shipping times
8. Try to go back, and see that the prompt appears
9. Click cancel
10. Modify the first row again in Shipping Times to the original value
11. Try to go back, you don't see any prompt
12. Go again to Edit free listings step 2
13. Remove the first row in Shipping Times
14. Try to go back, and see that the prompt appears
15. Add a new row with the same value as the original 
16. Try to go back, you don't see any prompt

### Additional details:

We use `new Set()` in order to ignore the order of elements.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Avoid to show Unsaved Values confirmation in Edit Free Listing when no values has been changed.  
