### PR TITLE
Prevent repeated account url retrieval

### DIFF
--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -262,6 +262,7 @@ class AccountService implements OptionsAwareInterface, Service {
 		$this->container->get( CleanupSyncedProducts::class )->schedule();
 
 		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_ACCOUNT_REVIEW );
+		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::URL_MATCHES );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -104,6 +104,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * @return boolean
 	 */
 	public function is_ready_for_syncing(): bool {
+		/** @var TransientsInterface $transients */
 		$transients  = $this->container->get( TransientsInterface::class );
 		$url_matches = $transients->get( TransientsInterface::URL_MATCHES );
 

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
@@ -38,6 +39,7 @@ defined( 'ABSPATH' ) || exit;
  * - Settings
  * - ShippingRateQuery
  * - ShippingTimeQuery
+ * - TransientsInterface
  * - WC
  * - WP
  * - TargetAudience
@@ -95,15 +97,24 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	/**
 	 * Whether we are able to sync data to the Merchant Center account.
 	 * Account must be connected and the URL we claimed with must match the site URL.
+	 * URL matches is stored in a transient to prevent it from being refetched in cases
+	 * where the site is unable to access account data.
 	 *
 	 * @since 1.13.0
 	 * @return boolean
 	 */
 	public function is_ready_for_syncing(): bool {
-		$claimed_url_hash = $this->container->get( Merchant::class )->get_claimed_url_hash();
-		$site_url_hash    = md5( $this->get_site_url() );
+		$transients  = $this->container->get( TransientsInterface::class );
+		$url_matches = $transients->get( TransientsInterface::URL_MATCHES );
 
-		return $this->is_connected() && apply_filters( 'woocommerce_gla_ready_for_syncing', $claimed_url_hash === $site_url_hash );
+		if ( null === $url_matches ) {
+			$claimed_url_hash = $this->container->get( Merchant::class )->get_claimed_url_hash();
+			$site_url_hash    = md5( $this->get_site_url() );
+			$url_matches      = apply_filters( 'woocommerce_gla_ready_for_syncing', $claimed_url_hash === $site_url_hash ) ? 'yes' : 'no';
+			$transients->set( TransientsInterface::URL_MATCHES, $url_matches, HOUR_IN_SECONDS * 12 );
+		}
+
+		return $this->is_connected() && 'yes' === $url_matches;
 	}
 
 	/**

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -14,12 +14,14 @@ interface TransientsInterface {
 	public const FREE_LISTING_METRICS = 'free_listing_metrics';
 	public const MC_STATUSES          = 'mc_statuses';
 	public const MC_ACCOUNT_REVIEW    = 'mc_account_review';
+	public const URL_MATCHES          = 'url_matches';
 
 	public const VALID_OPTIONS = [
 		self::ADS_METRICS          => true,
 		self::FREE_LISTING_METRICS => true,
 		self::MC_STATUSES          => true,
 		self::MC_ACCOUNT_REVIEW    => true,
+		self::URL_MATCHES          => true,
 	];
 
 	/**

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -686,7 +686,12 @@ class AccountServiceTest extends UnitTest {
 
 		$this->cleanup_synced->expects( $this->once() )->method( 'schedule' );
 
-		$this->transients->expects( $this->once() )->method( 'delete' )->with( TransientsInterface::MC_ACCOUNT_REVIEW );
+		$this->transients->expects( $this->exactly( 2 ) )
+			->method( 'delete' )
+			->withConsecutive(
+				[ TransientsInterface::MC_ACCOUNT_REVIEW ],
+				[ TransientsInterface::URL_MATCHES ]
+			);
 
 		$this->account->disconnect();
 	}

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -40,6 +41,7 @@ defined( 'ABSPATH' ) || exit;
  * @property MockObject|ShippingRateQuery    $shipping_rate_query
  * @property MockObject|ShippingTimeQuery    $shipping_time_query
  * @property MockObject|TargetAudience       $target_audience
+ * @property MockObject|TransientsInterface  $transients
  * @property MockObject|WC                   $wc
  * @property MockObject|WP                   $wp
  * @property MerchantCenterService           $mc_service
@@ -67,6 +69,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->shipping_rate_query    = $this->createMock( ShippingRateQuery::class );
 		$this->shipping_time_query    = $this->createMock( ShippingTimeQuery::class );
 		$this->target_audience        = $this->createMock( TargetAudience::class );
+		$this->transients             = $this->createMock( TransientsInterface::class );
 		$this->wc                     = $this->createMock( WC::class );
 		$this->wp                     = $this->createMock( WP::class );
 		$this->options                = $this->createMock( OptionsInterface::class );
@@ -82,6 +85,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->container->share( ShippingRateQuery::class, $this->shipping_rate_query );
 		$this->container->share( ShippingTimeQuery::class, $this->shipping_time_query );
 		$this->container->share( TargetAudience::class, $this->target_audience );
+		$this->container->share( TransientsInterface::class, $this->transients );
 		$this->container->share( WC::class, $this->wc );
 		$this->container->share( WP::class, $this->wp );
 
@@ -181,6 +185,44 @@ class MerchantCenterServiceTest extends UnitTest {
 
 		add_filter( 'woocommerce_gla_ready_for_syncing', '__return_true' );
 
+		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_ready_for_syncing_fetch_from_transient() {
+		$hash = md5( site_url() );
+		$this->merchant->expects( $this->once() )
+			->method( 'get_claimed_url_hash' )
+			->willReturn( $hash );
+
+		$this->options->expects( $this->exactly( 4 ) )
+			->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED,
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->transients->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->with( TransientsInterface::URL_MATCHES )
+			->willReturnOnConsecutiveCalls(
+				null,
+				'yes'
+			);
+
+		$this->transients->expects( $this->once() )
+			->method( 'set' )
+			->with( TransientsInterface::URL_MATCHES, 'yes', HOUR_IN_SECONDS * 12 );
+
+		// Call twice to ensure we are getting the value from the transient the second time.
+		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
 		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In PR #1503 we implemented the retrieval of account_url to ensure the site name matches before syncing. If the account_url is not previously stored for sites it will need to fetch it from the account data.

However the problem with that change is that it only stores the URL after successfully fetching it from the account. For sites that assume they are connected (mc_setup_completed_at and google_connected are valid), but in reality their token or refresh token is revoked or not available, the site will get an error when trying to fetch the URL from the account.
This scenario then results in it repeatedly retrying, to prevent this the PR adds a transient for storing when the url matches. We store `yes/no` values in the transients because a boolean can be detected as transient not available.

### Detailed test instructions:

#### Reproduce the issue with develop branch
1. Start off with a copy of develop (to reproduce the failure) 
2. If testing with a local WCS then we can temporarily remove the refresh token and set the token as expired in the table `wcc_token`
3. Clear out any saved option with the name `gla_claimed_url_hash`
4. Confirm that with every page request the function `get_claimed_url_hash` is called
5. In your local WCS you should see it return errors
6. In WooCommerce > Settings > Logs you should see an entry get added every time a page is loaded:
```
2022-05-25T12:18:14+00:00 ERROR Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider::handle_unauthorized_error Client error: `GET http://localhost:5500/google/google-mc/content/v2.1/12345678/accounts/12345678` resulted in a `401 Unauthorized` response:
{"statusCode":401,"error":"Unauthorized","message":"Site is not connected to Google account for google-mc"}
```

#### Test the PR
1. Leave the tokens in the local WCS in the invalid state
2. Clear out any saved option with the name `gla_claimed_url_hash`
3. Confirm that the function `get_claimed_url_hash` is called only once even after repeated page refreshes
4. Confirm the error in WooCommerce > Settings > Logs is only added once
5. Clear the transient with the name `gla_url_matches`
6. Refresh a page and confirm the error is again only added once even after multiple refreshes

### Changelog entry
* Fix - Prevent repeated account URL retrievals.
