### PR TITLE
Fix the slow GitHub actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
 			}
 		},
 		"@automattic/puppeteer-utils": {
-			"version": "github:Automattic/puppeteer-utils#0f3ec50fc22d7bd2a4bd69fc172e8a66d958ef2d",
-			"from": "github:Automattic/puppeteer-utils#0f3ec50",
+			"version": "git+https://github.com/Automattic/puppeteer-utils.git#0f3ec50fc22d7bd2a4bd69fc172e8a66d958ef2d",
+			"from": "git+https://github.com/Automattic/puppeteer-utils.git#0f3ec50",
 			"dev": true,
 			"requires": {
 				"@babel/cli": "^7.8.3",
@@ -13935,7 +13935,7 @@
 			"integrity": "sha512-TPzkfQXZr86nep0dlfVokBq5ISD32N/NBvUc9i4yUMXmc/opQaufE4bVxgRVUiHCG91UkKFaTPqtcLn2ZsKxVw==",
 			"dev": true,
 			"requires": {
-				"@automattic/puppeteer-utils": "github:Automattic/puppeteer-utils#0f3ec50",
+				"@automattic/puppeteer-utils": "git+https://github.com/Automattic/puppeteer-utils.git#0f3ec50",
 				"@jest/test-sequencer": "^25.5.4",
 				"@slack/web-api": "^6.1.0",
 				"@woocommerce/api": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32466,8 +32466,8 @@
 			}
 		},
 		"jsdoc-advanced-types-plugin": {
-			"version": "github:tomalec/jsdoc-advanced-types-plugin#41faf076a685851765b3a648b88cff0c289363bc",
-			"from": "github:tomalec/jsdoc-advanced-types-plugin#add/return-support",
+			"version": "git+https://github.com/tomalec/jsdoc-advanced-types-plugin.git#41faf076a685851765b3a648b88cff0c289363bc",
+			"from": "git+https://github.com/tomalec/jsdoc-advanced-types-plugin.git#add/return-support",
 			"dev": true
 		},
 		"jsdoc-plugin-intersection": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"h2o2": "^8.2.0",
 		"jest-environment-jsdom": "^27.5.1",
 		"jsdoc": "^3.6.10",
-		"jsdoc-advanced-types-plugin": "github:tomalec/jsdoc-advanced-types-plugin#add/return-support",
+		"jsdoc-advanced-types-plugin": "git+https://github.com/tomalec/jsdoc-advanced-types-plugin.git#add/return-support",
 		"jsdoc-plugin-intersection": "^1.0.4",
 		"jsdoc-plugin-typescript": "^2.0.6",
 		"path-browserify": "^1.0.1",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To fix the unsupported protocol used in `npm ci` that causes timeout and retry, this repo replaces the unsupported protocol of unencrypted `git://` with `https://` for:
- `jsdoc-advanced-types-plugin` package
- `@automattic/puppeteer-utils` dependency of `@woocommerce/e2e-environment` package

### Screenshots:

![2022-05-30 13 44 27](https://user-images.githubusercontent.com/17420811/170925151-82413946-90ca-462a-8284-ab86ad9cad3c.png)

![2022-05-30 13 45 31](https://user-images.githubusercontent.com/17420811/170925157-8d73ed9e-d84f-4ac2-98c0-35113b9968c7.png)

### Detailed test instructions:

1. Run `npm ci --ignore-scripts`. It should be faster than the 82d8e5fe6b2dfcdf7ea3a8274a84519523aeded8 revision.
2. Go to the Check tab of this PR to see if the **Bundle Size** and **E2E Tests** are faster than before.

### Additional details:

Since Friday, May 13, 2022, the time required to finish GitHub actions that run `npm ci`  is significantly slower. The reason for this should be that [GitHub had formally turned off the unencrypted `git://` protocol](https://github.blog/2021-09-01-improving-git-protocol-security-github/).

When running `npm ci`, if there are packages installed directly from GitHub, it will fetch the heads and tags of those packages by `git ls-remote`. And the terminated protocol causes `git ls-remote` to attempt three times and spend 75 seconds each until timeout. The timeout protocol and alternative protocols can be verified with these commands:

- `git ls-remote -h -t git://github.com/Automattic/puppeteer-utils.git` (timeout)
- `git ls-remote -h -t ssh://github.com/Automattic/puppeteer-utils.git` (works)
- `git ls-remote -h -t https://github.com/Automattic/puppeteer-utils.git` (works and faster)

### Changelog entry

>
