### PR TITLE
Allow unicode for Manufacturer Part Number (MPN ) value

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -764,7 +764,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$metadata->addConstraint( new Assert\Callback( 'validate_availability' ) );
 
 		$metadata->addPropertyConstraint( 'gtin', new Assert\Regex( '/^\d{8}(?:\d{4,6})?$/' ) );
-		$metadata->addPropertyConstraint( 'mpn', new Assert\Type( 'alnum' ) ); // alphanumeric
+		$metadata->addPropertyConstraint( 'mpn', new Assert\Type( 'string' ) );
 		$metadata->addPropertyConstraint( 'mpn', new Assert\Length( null, 0, 70 ) ); // maximum 70 characters
 
 		$metadata->addPropertyConstraint(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1510. This PR adds unicode support for the [MPN](https://support.google.com/merchants/answer/6324482) value. Originally it only allows alphanumeric but from the document we can see it should supports unicode characters as well.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Reproduction Steps

1. Use the latest version as of now `1.13.2`.
2. In the admin page, go to WooCommerce Products `/wp-admin/edit.php?post_type=product`.
3. Update an existing product's price under `Product data` -> `General`.
4. Add a MPN number with unicode characters (e.g. `MPN-TEST-123`) under `Product data` -> `Google Listings and Ads`.
5. Click `Update`
6. Wait for a few moments and go to Google Merchant Centre's [All products](https://merchants.google.com/mc/items) section, the product you updated for the price shouldn't be synced to it, i.e. the price remain unchanged.

#### Test this PR

1. Follow the steps above but using the branch of this PR, you should see the price is synced to the Google Merchant Centre.

### Additional details:

I spent quite a few time trying to add automated tests to this one-line code change PR, but couldn't find a way to implement it. I think since the Type string are already tested in [Symfony's Constraints](https://github.com/symfony/symfony/blob/a10071bd657c350bb8f995361643072a97ff5819/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php) and we have already tested when the product has validation error (see below code), we don't need to test if the provided value is actually a string or not.

https://github.com/woocommerce/google-listings-and-ads/blob/82d8e5fe6b2dfcdf7ea3a8274a84519523aeded8/tests/Unit/Product/BatchProductHelperTest.php#L215-L227

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Allow unicode for Manufacturer Part Number (MPN ) value