### PR TITLE
Add more promotion supported countries

### DIFF
--- a/src/Google/GoogleHelper.php
+++ b/src/Google/GoogleHelper.php
@@ -1197,10 +1197,18 @@ class GoogleHelper implements Service {
 	/**
 	 * Get an array of Google Merchant Center supported countries and currencies for promotions.
 	 *
+	 * Google Promotion Supported Countries -> https://developers.google.com/shopping-content/reference/rest/v2.1/promotions
+	 *
 	 * @return array
 	 */
 	protected function get_mc_promotion_supported_countries_currencies(): array {
 		return [
+			'AU' => 'AUD', // Australia
+			'CA' => 'CAD', // Canada
+			'DE' => 'EUR', // Germany
+			'FR' => 'EUR', // France
+			'GB' => 'GBP', // United Kingdom
+			'IN' => 'INR', // India
 			'US' => 'USD', // United States
 		];
 	}

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -305,8 +305,22 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	public function test_is_promotion_supported_country() {
 		$this->wc->method( 'get_base_country' )->willReturn( 'US' );
-		$this->google_helper->method( 'get_mc_promotion_supported_countries' )->willReturn( [ 'US' ] );
+		$this->google_helper->method( 'get_mc_promotion_supported_countries' )->willReturn( [
+			'AU',
+			'CA',
+			'DE',
+			'FR',
+			'GB',
+			'IN',
+			'US',
+		] );
 		$this->assertTrue( $this->mc_service->is_promotion_supported_country() );
+		$this->assertTrue( $this->mc_service->is_promotion_supported_country( 'AU' ) );
+		$this->assertTrue( $this->mc_service->is_promotion_supported_country( 'CA' ) );
+		$this->assertTrue( $this->mc_service->is_promotion_supported_country( 'DE' ) );
+		$this->assertTrue( $this->mc_service->is_promotion_supported_country( 'FR' ) );
+		$this->assertTrue( $this->mc_service->is_promotion_supported_country( 'GB' ) );
+		$this->assertTrue( $this->mc_service->is_promotion_supported_country( 'IN' ) );
 		$this->assertTrue( $this->mc_service->is_promotion_supported_country( 'US' ) );
 		$this->assertFalse( $this->mc_service->is_promotion_supported_country( 'XX' ) );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1509. This PR add more promotion supported countries that listed in [Google Shopping Content API Reference](https://developers.google.com/shopping-content/reference/rest/v2.1/promotions?hl=en). Originally it only supports `US` but now it supports `AU`, `CA`, `DE`, `FR`, `GB`, `IN`, and `US`.

### Detailed test instructions:

1. Go to `WooCommerce` -> `Marketing` -> `Coupons`, click `Add Coupon`.
2. Check the right-hand side there is a meta box called `Channel visibility`
3. If your shop country is not in one of the countries above, the dropdown menu should be disabled and there is a text under the dropdown menu: `This coupon visibility channel has not been supported in your store base country yet.`
4. Otherwise the dropdown menu should be clickable and the text will not be there.
5. To change the country without went through GLA onboarding setup again, you can edit the code in `src/MerchantCenter/TargetAudience.php`'s `get_main_target_country` function:
    ```diff
    --- a/src/MerchantCenter/TargetAudience.php
    +++ b/src/MerchantCenter/TargetAudience.php
    @@ -76,7 +76,8 @@ class TargetAudience implements Service {
        $target_countries = $this->get_target_countries();
        $shop_country     = $this->wc->get_base_country();
    
    -   return in_array( $shop_country, $target_countries, true ) ? $shop_country : $target_countries[0];
    +   // return in_array( $shop_country, $target_countries, true ) ? $shop_country : $target_countries[0];
    +   return 'GB';
      }
    
     }
    ```

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Add six more promotion supported countries.