### PR TITLE
Update Compliance Policy links

### DIFF
--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
@@ -41,7 +41,7 @@ const PreLaunchChecklist = ( props ) => {
 							<AppDocumentationLink
 								context="setup-mc-checklist"
 								linkId="checklist-requirements"
-								href="https://support.google.com/merchants/answer/6363310"
+								href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy"
 							>
 								{ __(
 									'Read Google Merchant requirements',
@@ -66,9 +66,20 @@ const PreLaunchChecklist = ( props ) => {
 												) }
 											</span>
 											<HelpPopover id="website_live">
-												{ __(
-													'Ensure your store website and products are online and accessible to your customers.',
-													'google-listings-and-ads'
+												{ createInterpolateElement(
+													__(
+														'Ensure your store website and products are online and accessible to your customers. <link>Read more</link>',
+														'google-listings-and-ads'
+													),
+													{
+														link: (
+															<AppDocumentationLink
+																context="setup-mc-checklist"
+																linkId="check-website-is-live"
+																href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#store-is-live"
+															/>
+														),
+													}
 												) }
 											</HelpPopover>
 										</span>
@@ -103,7 +114,7 @@ const PreLaunchChecklist = ( props ) => {
 															<AppDocumentationLink
 																context="setup-mc-checklist"
 																linkId="check-checkout-process"
-																href="https://support.google.com/merchants/answer/2704221#wycd-unsafe-collection-or-use-of-personal-information"
+																href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
 															/>
 														),
 													}
@@ -126,9 +137,20 @@ const PreLaunchChecklist = ( props ) => {
 											) }
 										</span>
 										<HelpPopover id="payment_methods_visible">
-											{ __(
-												'Ensure customers have at least one valid payment method, such as credit card, direct bank transfer, or cash on delivery.',
-												'google-listings-and-ads'
+											{ createInterpolateElement(
+												__(
+													'Ensure customers have at least one valid payment method, such as credit card, direct bank transfer, or cash on delivery. <link>Read more</link>',
+													'google-listings-and-ads'
+												),
+												{
+													link: (
+														<AppDocumentationLink
+															context="setup-mc-checklist"
+															linkId="check-payment-methods"
+															href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#payment-methods"
+														/>
+													),
+												}
 											) }
 										</HelpPopover>
 									</span>
@@ -147,9 +169,20 @@ const PreLaunchChecklist = ( props ) => {
 											) }
 										</span>
 										<HelpPopover id="refund_tos_visible">
-											{ __(
-												'Your site must provide a clear and conspicuous return policy and billing terms to customers.',
-												'google-listings-and-ads'
+											{ createInterpolateElement(
+												__(
+													'Your site must provide a clear and conspicuous return policy and billing terms to customers. <link>Read more</link>',
+													'google-listings-and-ads'
+												),
+												{
+													link: (
+														<AppDocumentationLink
+															context="setup-mc-checklist"
+															linkId="check-payment-methods"
+															href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms"
+														/>
+													),
+												}
 											) }
 										</HelpPopover>
 									</span>
@@ -166,9 +199,20 @@ const PreLaunchChecklist = ( props ) => {
 											) }
 										</span>
 										<HelpPopover id="contact_info_visible">
-											{ __(
-												'Your website must display sufficient and accurate contact information to your customers, including a telephone number and/or email.',
-												'google-listings-and-ads'
+											{ createInterpolateElement(
+												__(
+													'Your website must display sufficient and accurate contact information to your customers, including a telephone number and/or email. <link>Read more</link>',
+													'google-listings-and-ads'
+												),
+												{
+													link: (
+														<AppDocumentationLink
+															context="setup-mc-checklist"
+															linkId="check-phone-numbers"
+															href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#contact-info"
+														/>
+													),
+												}
 											) }
 										</HelpPopover>
 									</span>

--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
@@ -178,7 +178,7 @@ const PreLaunchChecklist = ( props ) => {
 													link: (
 														<AppDocumentationLink
 															context="setup-mc-checklist"
-															linkId="check-payment-methods"
+															linkId="check-refund-policy"
 															href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms"
 														/>
 													),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1530.

This PR is updating the links from the compliance policy section. The links have been updated to redirect to a new documentation in [Woo docs](https://woocommerce.com/document/google-listings-and-ads/compliance-policy/). This PR is also adding the "Read more" link to every helper.

### Screenshots:

![image](https://user-images.githubusercontent.com/2488994/171051262-61437be4-cdce-4754-a556-5b8136fcce5f.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Disconnect all your accounts.
2. Go to the Onboarding process.
3. Go to Step 4: Confirm store requirements.
4. Check that each link is redirected to the right section in [Woo Doc](https://woocommerce.com/document/google-listings-and-ads/compliance-policy/).

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>Tweak - Compliance Policy links
