### PR TITLE
Adding Github Actions for storybook

### DIFF
--- a/.github/workflows/storybook-workflow.yml
+++ b/.github/workflows/storybook-workflow.yml
@@ -1,0 +1,40 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches:
+      - trunk
+      - develop
+    paths:
+      - "**/js/src/components/**"
+      - package.json
+      - package-lock.json
+      - "storybook/**"
+      - .github/workflows/storybook-workflow.yml
+      - .github/actions/prepare-node/action.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Storybook:
+    name: Deploy Storybook
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Prepare node
+        uses: ./.github/actions/prepare-node
+
+      - name: Build Storybook
+        run: npm run storybook:build
+
+      - name: Deploy to GH Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook/dist

--- a/.github/workflows/storybook-workflow.yml
+++ b/.github/workflows/storybook-workflow.yml
@@ -6,7 +6,7 @@ on:
       - trunk
       - develop
     paths:
-      - "**/js/src/components/**"
+      - "js/src/components/**"
       - package.json
       - package-lock.json
       - "storybook/**"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1518.

Adding a new workflow for StoryBook deployment in GH pages

- The workflow only triggers when pushing to develop/trunk
- The workflow only triggers on the specific paths

Paths:

`package.json`
`package-lock.json`
All files inside `storybook` folder
All files inside `js/src/components`
This worflow file itself
The prepare-node action file


### Detailed test instructions:

1. Check the workflow file
2. Check the successful deployment [here](https://github.com/woocommerce/google-listings-and-ads/runs/6674408021?check_suite_focus=true) in the previous test PR
3. If needed you can create another test PR for testing in Pull Request modifying files

Just replace with the workflow: (notice the pull_request section)

```
name: Deploy Storybook

on:
  push:
    branches:
      - trunk
      - develop
    paths:
      - "js/src/components/**"
      - package.json
      - package-lock.json
      - "storybook/**"
      - .github/workflows/storybook-workflow.yml
      - .github/actions/prepare-node/action.yml
  pull_request:
    paths:
      - "js/src/components/**"
      - package.json
      - package-lock.json
      - "storybook/**"
      - .github/workflows/storybook-workflow.yml
      - .github/actions/prepare-node/action.yml  - 

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true

jobs:
  Storybook:
    name: Deploy Storybook
    runs-on: ubuntu-latest
    env:
      FORCE_COLOR: 2
    steps:
      - name: Checkout repository
        uses: actions/checkout@v2

      - name: Prepare node
        uses: ./.github/actions/prepare-node

      - name: Build Storybook
        run: npm run storybook:build

      - name: Deploy to GH Pages
        uses: peaceiris/actions-gh-pages@v3
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          publish_dir: ./storybook/dist

```
### Additional details:

- We use [peaceiris/actions-gh-pages@v3](https://github.com/marketplace/actions/github-pages-action) in order to deploy the folder `storybook/dist`to `gh-pages`
- Decided to not trigger this in pull_request since that could deploy unvalidated code into the GH Pages. So we only deploy to GH Pages when changes are approved.
- ❓  Wondering if we should also remove -develop from the target branch tho. 