### PR TITLE
Add useEffect to avoid multiple CES prompts on the Dashboard Page

### DIFF
--- a/js/src/components/customer-effort-score-prompt/customer-effort-unmountable-notice.js
+++ b/js/src/components/customer-effort-score-prompt/customer-effort-unmountable-notice.js
@@ -15,9 +15,9 @@ import useCESNotice from '.~/hooks/useCESNotice';
  *
  * ## Motivation
  *
- * The CustomerEffortScore component include in the package @woocommerce/customer-effort-score does not remove the notice
+ * The CustomerEffortScore component included in the package @woocommerce/customer-effort-score does not remove the notice
  * when the component has been unmounted, throwing an error when the "Give Feedback" button has been clicked. This new
- * component is removing the notice if the CES component does not exist.
+ * component removes the notice if the CES component does not exist.
  *
  * @param {Object} props                               Component props.
  * @param {string} props.label                         The label displayed in the modal.

--- a/js/src/components/customer-effort-score-prompt/customer-effort-unmountable-notice.js
+++ b/js/src/components/customer-effort-score-prompt/customer-effort-unmountable-notice.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import CustomerFeedbackModal from '@woocommerce/customer-effort-score/build/customer-feedback-modal';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import useCESNotice from '.~/hooks/useCESNotice';
+
+/**
+ * Renders an unmountable CES notice to gather a customer effort score.
+ *
+ * ## Motivation
+ *
+ * The CustomerEffortScore component include in the package @woocommerce/customer-effort-score does not remove the notice
+ * when the component has been unmounted, throwing an error when the "Give Feedback" button has been clicked. This new
+ * component is removing the notice if the CES component does not exist.
+ *
+ * @param {Object} props                               Component props.
+ * @param {string} props.label                         The label displayed in the modal.
+ * @param {JSX.Element} props.icon                     Icon (React component) to be shown on the notice.
+ * @param {Function} [props.recordScoreCallback]       Function to call when the score should be recorded.
+ * @param {Function} [props.onNoticeShownCallback]     Function to call when the notice is shown.
+ * @param {Function} [props.onNoticeDismissedCallback] Function to call when the notice is dismissed.
+ * @param {Function} [props.onModalShownCallback]      Function to call when the modal is shown.
+ */
+const CustomerEffortScoreUnmountableNotice = ( {
+	label,
+	icon,
+	recordScoreCallback = noop,
+	onNoticeShownCallback = noop,
+	onNoticeDismissedCallback = noop,
+	onModalShownCallback = noop,
+} ) => {
+	const [ shouldCreateNotice, setShouldCreateNotice ] = useState( true );
+	const [ visible, setVisible ] = useState( false );
+	const onClickFeedBack = () => {
+		setVisible( true );
+		onModalShownCallback();
+	};
+
+	const createCESNotice = useCESNotice(
+		label,
+		icon,
+		onClickFeedBack,
+		onNoticeDismissedCallback
+	);
+
+	useEffect( () => {
+		if ( ! shouldCreateNotice ) {
+			return;
+		}
+
+		createCESNotice();
+		setShouldCreateNotice( false );
+		onNoticeShownCallback();
+	}, [ shouldCreateNotice, createCESNotice, onNoticeShownCallback ] );
+
+	if ( shouldCreateNotice || ! visible ) {
+		return null;
+	}
+
+	return (
+		<CustomerFeedbackModal
+			label={ label }
+			recordScoreCallback={ recordScoreCallback }
+		/>
+	);
+};
+
+export default CustomerEffortScoreUnmountableNotice;

--- a/js/src/components/customer-effort-score-prompt/customer-effort-unmountable-notice.test.js
+++ b/js/src/components/customer-effort-score-prompt/customer-effort-unmountable-notice.test.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import useCESNotice from '.~/hooks/useCESNotice';
+import CustomerEffortScoreUnmountableNotice from '.~/components/customer-effort-score-prompt/customer-effort-unmountable-notice';
+
+const mockCreateCESNoticeShowModal = jest
+	.fn()
+	.mockImplementation( ( onClickCallBack ) => onClickCallBack() );
+
+const mockCreateCESNotice = jest.fn();
+
+jest.mock( '.~/hooks/useCESNotice', () => {
+	return jest.fn();
+} );
+
+describe( 'Customer Effort Notice component', () => {
+	let defaultProps;
+
+	beforeEach( () => {
+		defaultProps = {
+			label: 'label test',
+			icon: <span>my icon</span>,
+			recordScoreCallback: jest.fn(),
+			onNoticeDismissedCallback: jest.fn(),
+			onNoticeShownCallback: jest.fn(),
+			onModalShownCallback: jest.fn(),
+		};
+	} );
+
+	test( 'Rendering the CES Notice without the CES modal', async () => {
+		useCESNotice.mockImplementation( () => mockCreateCESNotice );
+
+		const { queryByText } = render(
+			<CustomerEffortScoreUnmountableNotice { ...defaultProps } />
+		);
+
+		//Creates the notice
+		expect( mockCreateCESNotice ).toHaveBeenCalledTimes( 1 );
+		expect( defaultProps.onNoticeShownCallback ).toHaveBeenCalledTimes( 1 );
+		expect( defaultProps.onModalShownCallback ).toHaveBeenCalledTimes( 0 );
+
+		expect( useCESNotice ).toHaveBeenLastCalledWith(
+			defaultProps.label,
+			defaultProps.icon,
+			expect.any( Function ),
+			defaultProps.onNoticeDismissedCallback
+		);
+
+		//The modal should not be displayed
+		expect(
+			queryByText( 'Please share your feedback' )
+		).not.toBeInTheDocument();
+
+		expect( defaultProps.recordScoreCallback ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	test( 'Rendering the CES Notice with the CES modal', async () => {
+		useCESNotice.mockImplementation(
+			( label, icon, onClickCallBack ) => () =>
+				mockCreateCESNoticeShowModal( onClickCallBack )
+		);
+
+		const { getByText } = render(
+			<CustomerEffortScoreUnmountableNotice { ...defaultProps } />
+		);
+
+		//Creates the notice
+		expect( mockCreateCESNotice ).toHaveBeenCalledTimes( 1 );
+		expect( defaultProps.onModalShownCallback ).toHaveBeenCalledTimes( 1 );
+		expect( useCESNotice ).toHaveBeenLastCalledWith(
+			defaultProps.label,
+			defaultProps.icon,
+			expect.any( Function ),
+			defaultProps.onNoticeDismissedCallback
+		);
+
+		//The modal should be displayed
+		expect( getByText( 'Please share your feedback' ) ).toBeInTheDocument();
+
+		//record score
+		const score = getByText( 'Very easy' );
+		const send = getByText( 'Send' );
+
+		expect( score ).toBeInTheDocument();
+		expect( send ).toBeInTheDocument();
+
+		userEvent.click( score );
+		userEvent.click( send );
+		expect( defaultProps.recordScoreCallback ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import CustomerEffortScore from '@woocommerce/customer-effort-score';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -10,6 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { LOCAL_STORAGE_KEYS } from '.~/constants';
 import localStorage from '.~/utils/localStorage';
+import CustomerEffortScoreUnmountableNotice from './customer-effort-unmountable-notice';
 
 /**
  * CES prompt snackbar open
@@ -81,7 +81,7 @@ const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
 	};
 
 	return (
-		<CustomerEffortScore
+		<CustomerEffortScoreUnmountableNotice
 			label={ label }
 			recordScoreCallback={ recordScore }
 			onNoticeShownCallback={ onNoticeShown }

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -26,14 +26,12 @@ import EditFreeCampaign from '.~/edit-free-campaign';
 import EditPaidAdsCampaign from '.~/pages/edit-paid-ads-campaign';
 import CreatePaidAdsCampaign from '.~/pages/create-paid-ads-campaign';
 import { CTA_CREATE_ANOTHER_CAMPAIGN, CTA_CONFIRM } from './constants';
-import useUrlQuery from '.~/hooks/useUrlQuery';
 
 /**
  * @fires gla_modal_closed when CES modal is closed.
  */
 const Dashboard = () => {
 	const [ isCESPromptOpen, setCESPromptOpen ] = useState( false );
-	const query = useUrlQuery();
 
 	const handleCampaignCreationSuccessGuideClose = useCallback(
 		( e, specifiedAction ) => {
@@ -58,6 +56,7 @@ const Dashboard = () => {
 		[ setCESPromptOpen ]
 	);
 
+	const query = getQuery();
 	switch ( query.subpath ) {
 		case subpaths.editFreeListings:
 			return <EditFreeCampaign />;

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
-import { useState, useCallback, useEffect } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 import { getNewPath, getQuery, getHistory } from '@woocommerce/navigation';
@@ -34,10 +34,6 @@ import useUrlQuery from '.~/hooks/useUrlQuery';
 const Dashboard = () => {
 	const [ isCESPromptOpen, setCESPromptOpen ] = useState( false );
 	const query = useUrlQuery();
-
-	useEffect( () => {
-		setCESPromptOpen( false );
-	}, [ query.subpath ] );
 
 	const handleCampaignCreationSuccessGuideClose = useCallback(
 		( e, specifiedAction ) => {

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 import { getNewPath, getQuery, getHistory } from '@woocommerce/navigation';
@@ -26,12 +26,18 @@ import EditFreeCampaign from '.~/edit-free-campaign';
 import EditPaidAdsCampaign from '.~/pages/edit-paid-ads-campaign';
 import CreatePaidAdsCampaign from '.~/pages/create-paid-ads-campaign';
 import { CTA_CREATE_ANOTHER_CAMPAIGN, CTA_CONFIRM } from './constants';
+import useUrlQuery from '.~/hooks/useUrlQuery';
 
 /**
  * @fires gla_modal_closed when CES modal is closed.
  */
 const Dashboard = () => {
 	const [ isCESPromptOpen, setCESPromptOpen ] = useState( false );
+	const query = useUrlQuery();
+
+	useEffect( () => {
+		setCESPromptOpen( false );
+	}, [ query.subpath ] );
 
 	const handleCampaignCreationSuccessGuideClose = useCallback(
 		( e, specifiedAction ) => {
@@ -56,7 +62,6 @@ const Dashboard = () => {
 		[ setCESPromptOpen ]
 	);
 
-	const query = getQuery();
 	switch ( query.subpath ) {
 		case subpaths.editFreeListings:
 			return <EditFreeCampaign />;

--- a/js/src/hooks/useCESNotice.js
+++ b/js/src/hooks/useCESNotice.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import useUnmountableNotice from '.~/hooks/useUnmountableNotice';
+
+/**
+ * Hook to create a CES notice
+ *
+ * @param {string} label CES prompt label.
+ * @param {JSX.Element} icon Icon (React component) to be shown on the notice.
+ * @param {Function} [onClickCallBack] Function to call when Give feedback is clicked.
+ * @param {Function} [onNoticeDismissedCallback] Function to call when the notice is dismissed.
+ *
+ * @return {Function} a function that will create the CES notice.
+ */
+const useCESNotice = (
+	label,
+	icon,
+	onClickCallBack = noop,
+	onNoticeDismissedCallback = noop
+) => {
+	return useUnmountableNotice( 'success', label, {
+		actions: [
+			{
+				label: __( 'Give feedback', 'woocommerce-admin' ),
+				onClick: onClickCallBack,
+			},
+		],
+		icon,
+		explicitDismiss: true,
+		onDismiss: onNoticeDismissedCallback,
+	} );
+};
+
+export default useCESNotice;

--- a/js/src/hooks/useCESNotice.js
+++ b/js/src/hooks/useCESNotice.js
@@ -28,7 +28,7 @@ const useCESNotice = (
 	return useUnmountableNotice( 'success', label, {
 		actions: [
 			{
-				label: __( 'Give feedback', 'woocommerce-admin' ),
+				label: __( 'Give feedback', 'google-listings-and-ads' ),
 				onClick: onClickCallBack,
 			},
 		],

--- a/js/src/hooks/useCESNotice.test.js
+++ b/js/src/hooks/useCESNotice.test.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useCESNotice from './useCESNotice';
+import useUnmountableNotice from './useUnmountableNotice';
+
+const mockOnClickCallBack = jest.fn();
+const mockOnNoticeDismissedCallback = jest.fn();
+const mockUnmountableNotice = jest.fn();
+
+jest.mock( '.~/hooks/useUnmountableNotice', () => {
+	return jest.fn();
+} );
+
+const Icon = <span>My Icon</span>;
+
+describe( 'useCESNotice', () => {
+	test( 'Should return function with the CES values', () => {
+		useUnmountableNotice.mockImplementation(
+			( type, label, options ) => () =>
+				mockUnmountableNotice( type, label, options )
+		);
+
+		const { result } = renderHook( () =>
+			useCESNotice(
+				'my label',
+				Icon,
+				mockOnClickCallBack,
+				mockOnNoticeDismissedCallback
+			)
+		);
+
+		result.current();
+
+		expect( mockUnmountableNotice ).toHaveBeenCalledTimes( 1 );
+
+		const type = mockUnmountableNotice.mock.calls[ 0 ][ 0 ];
+		const label = mockUnmountableNotice.mock.calls[ 0 ][ 1 ];
+		const options = mockUnmountableNotice.mock.calls[ 0 ][ 2 ];
+
+		expect( type ).toBe( 'success' );
+		expect( label ).toBe( 'my label' );
+		expect( options.icon ).toBe( Icon );
+		expect( options.onDismiss ).toBe( mockOnNoticeDismissedCallback );
+		expect( options.actions[ 0 ].onClick ).toBe( mockOnClickCallBack );
+	} );
+} );

--- a/js/src/hooks/useUnmountableNotice.js
+++ b/js/src/hooks/useUnmountableNotice.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import { uniqueId } from 'lodash';
+
+/**
+ * Hook to create a wp notice that will be removed when the parent component is unmounted
+ *
+ * @param {import('@wordpress/notices').Status} type Notice status.
+ * @param {string} content Notice content.
+ * @param {import('@wordpress/notices').Options} [options] Notice options.
+ *
+ * @return {Function} a function that will create the notice.
+ */
+const useUnmountableNotice = ( type, content, options = {} ) => {
+	const { createNotice, removeNotice } = dispatch( 'core/notices2' );
+	const idRef = useRef( options.id || uniqueId() );
+
+	//remove notice when the component is unmounted
+	useEffect( () => () => removeNotice( idRef.current ), [ removeNotice ] );
+
+	return () =>
+		createNotice( type, content, { ...options, id: idRef.current } );
+};
+
+export default useUnmountableNotice;

--- a/js/src/hooks/useUnmountableNotice.test.js
+++ b/js/src/hooks/useUnmountableNotice.test.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useUnmountableNotice from './useUnmountableNotice';
+
+const mockCreateNotice = jest.fn();
+const mockRemoveNotice = jest.fn();
+
+jest.mock( '@wordpress/data', () => {
+	return {
+		dispatch: jest.fn().mockImplementation( () => ( {
+			createNotice: mockCreateNotice,
+			removeNotice: mockRemoveNotice,
+		} ) ),
+	};
+} );
+
+describe( 'useUnmountableNotice', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'Should return function with createNotice', () => {
+		const { result } = renderHook( () =>
+			useUnmountableNotice( 'success', 'test label' )
+		);
+
+		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 0 );
+
+		expect( result.current ).toEqual( expect.any( Function ) );
+
+		result.current();
+
+		expect( mockCreateNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateNotice ).toHaveBeenCalledWith(
+			'success',
+			'test label',
+			{ id: expect.any( String ) }
+		);
+	} );
+
+	test( 'Should remove notice when the hook is unmounted', () => {
+		const { result, unmount } = renderHook( () =>
+			useUnmountableNotice( 'success', 'test label' )
+		);
+
+		unmount();
+
+		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateNotice ).toHaveBeenCalledTimes( 0 );
+		expect( result.current ).toEqual( expect.any( Function ) );
+	} );
+
+	test( 'Should remove with custom ID', () => {
+		const myID = 'my_custom_id';
+		const { result, unmount } = renderHook( () =>
+			useUnmountableNotice( 'success', 'test label', {
+				id: myID,
+			} )
+		);
+
+		unmount();
+
+		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( myID );
+		expect( mockCreateNotice ).toHaveBeenCalledTimes( 0 );
+		expect( result.current ).toEqual( expect.any( Function ) );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1428 .

This PR fixes the issue with the CES prompts in the dashboard page after the campaign creation success modal is shown. The issue was caused because the status `isCESPromptOpen` stays always `true` when navigating through the dashboard sub-components such as `EditFreeCampaign`, `EditPaidAdsCampaign` and `CreatePaidAdsCampaign`, therefore dispatching a new CustomerEffortScore notice when returns to the dashboard page.

https://github.com/woocommerce/google-listings-and-ads/blob/74949bc72a41ff79d47138c9e319739ff4ba36aa/js/src/dashboard/index.js#L35

### Before this PR

https://user-images.githubusercontent.com/2488994/171261339-72fdff1a-c1da-4e02-ab9a-63ef19bd2022.mp4

### After this PR


https://user-images.githubusercontent.com/2488994/171262126-d2165848-1dca-47d7-9518-6a5bb476de5e.mov



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to `wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&guide=campaign-creation-success`
2. Click in "Got it"
3. One CES prompt should be displayed.
4. Visit Edit free listings, Edit Ads Campaigns and Create Ads campaigns and return to the dashboard page and it should show only one CES prompt.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Multiple CES prompts in the Dashboard Page
