### PR TITLE
Do not store URL matches transient until fully connected

### DIFF
--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -104,6 +104,10 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * @return boolean
 	 */
 	public function is_ready_for_syncing(): bool {
+		if ( ! $this->is_connected() ) {
+			return false;
+		}
+
 		/** @var TransientsInterface $transients */
 		$transients  = $this->container->get( TransientsInterface::class );
 		$url_matches = $transients->get( TransientsInterface::URL_MATCHES );
@@ -115,7 +119,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			$transients->set( TransientsInterface::URL_MATCHES, $url_matches, HOUR_IN_SECONDS * 12 );
 		}
 
-		return $this->is_connected() && 'yes' === $url_matches;
+		return 'yes' === $url_matches;
 	}
 
 	/**

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -170,6 +170,26 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
 	}
 
+	public function test_is_ready_for_syncing_not_setup() {
+		$hash = md5( site_url() );
+		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				false
+			);
+
+		$this->transients->expects( $this->never() )
+			->method( 'get' )
+			->with( TransientsInterface::URL_MATCHES );
+
+		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
+	}
+
 	public function test_is_ready_for_syncing_filter_override() {
 		$hash = md5( 'https://staging-site.test' );
 		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The transient for a matching URL was being retrieved (and updated) before the connected check. Which means that for sites that were not connected it was storing the URL as "non matching" because it wasn't able to retrieve the URL from the account yet. Since it's a transient it is rechecked after 12 hours, but this means that after onboarding the sync would only be able to start 12 hours later.

In this PR we first check if we are connected, and if not it won't check/update the transient to prevent it from being set until onboarding has been fully completed. I also added a test scenario to confirm that the transient is not retrieved when the site is not connected.

Resolves part of #1545

### Detailed test instructions:

#### Reproduce error with develop branch:
1. Go to the Connection Test page and disconnect the Merchant Account (deletes transients and connection details) 
2. Load the page Marketing > Google Listings & Ads
3. Check the `wp_options` table for the option `_transient_gla_url_matches` and confirm it's set to `no`

#### Confirm it's fixed with this PR:
1. Repeat the steps from above, this time the transient should not be set at all
2. Continue with the onboarding process
3. At the end of the onboarding process the transient should appear and it should be set to `yes`

### Changelog entry
* Fix - Do not store URL matches transient until fully connected.
