### PR TITLE
Do not show error notice when MC review request API call failed

### DIFF
--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -180,21 +180,11 @@ export function* getMCProductStatistics() {
 }
 
 export function* getMCReviewRequest() {
-	try {
-		const response = yield apiFetch( {
-			path: `${ API_NAMESPACE }/mc/review`,
-		} );
+	const response = yield apiFetch( {
+		path: `${ API_NAMESPACE }/mc/review`,
+	} );
 
-		yield receiveMCReviewRequest( response );
-	} catch ( error ) {
-		yield handleFetchError(
-			error,
-			__(
-				'There was an error loading your merchant center product review request status.',
-				'google-listings-and-ads'
-			)
-		);
-	}
+	yield receiveMCReviewRequest( response );
 }
 
 export function* getMCIssues( query ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolves part of https://github.com/woocommerce/google-listings-and-ads/issues/1545.

Before this PR, if we use a standalone Google Merchant Center account, upon completing the Setup MC flow and being redirected to the Product Feed page, we will see an error notice at the bottom of the Product Feed page that says `'There was an error loading your merchant center product review request status.'`. See screenshot below:

![image](https://user-images.githubusercontent.com/417342/171666044-6a7e6c5c-cd6b-49c7-96e7-7a1f941c3265.png)

The error notice is shown when the call to `GET /mc/review` API failed.

There are a few problems with this error notice. As we see in the screenshot above, there is a success guide modal that says setup is done successfully. The error notice contradicts with the success guide modal, causing confusion and loss of confidence to the users. When users close the guide modal, they will see "Feed setup" okay and "Sync with Google" okay too. There isn't a guidance to the users on what they can or should do in relation to the error notice.

In this PR, we remove the error notice. When the MC review request API call failed, it will fail silently with no UI.

Note on the standalone Google Merchant Center account: to create a standalone account, you need to use a Google account that has no Merchant Center account yet, and visit https://merchants.google.com/ and create a new account there. It must not be created from within the plugin; otherwise, it would be a sub-account. Once the account is created, go through the Setup MC flow, connect the Google account and the Google Merchant Center account. 

### Screenshots:

#### Before

📹 Demo video of the issue without the code change in this PR:

https://user-images.githubusercontent.com/417342/171664915-a367627c-1e90-460a-997f-d6a11e100b6e.mp4

#### After

📹 Demo video of the fix, with the code change in this PR:

https://user-images.githubusercontent.com/417342/171664816-708d51b7-4bdd-4368-8069-1b1f792f73f0.mp4

### Detailed test instructions:

1. Make sure you have a standalone Google Merchant Center account. See note above on how to create one.  
2. Open browser dev tools network panel.
3. Go through Setup MC flow and connect using the standalone account.
4. Complete the Setup MC flow. You should be redirected to the Product Feed page. In the network panel, you should see `GET /mc/review` API failed, with response body `{ message: "Error getting account review status: User cannot access account <YOUR ACCOUNT NUMBER>" }`. There should be no error notice in the UI.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Do not show error notice when Merchant Center review request API call failed.
