### PR TITLE
End to End tests for Gtag Events

### DIFF
--- a/js/src/gtag-events/index.js
+++ b/js/src/gtag-events/index.js
@@ -69,7 +69,7 @@ const singleAddToCartClick = function ( event ) {
 window.onload = function () {
 	document
 		.querySelectorAll(
-			'.add_to_cart_button:not( .product_type_variable, .product_type_grouped )'
+			'.add_to_cart_button:not( .product_type_variable ):not( .product_type_grouped )'
 		)
 		.forEach( ( button ) => {
 			button.addEventListener( 'click', addToCartClick );

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -624,6 +624,29 @@ class ConnectionTest implements Service, Registerable {
 					<input name="action" value="wcs-cleanup-products" type="hidden" />
 				</form>
 			<?php } ?>
+
+			<?php if ( ! empty( $_GET['e2e'] ) ) { ?>
+				<h2 class="title">E2E testing</h2>
+
+				<table class="form-table" role="presentation">
+					<tr>
+						<th>Save test conversion ID:</th>
+						<td>
+							<p>
+								<a class="button" id="e2e-test-conversion-id" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'e2e-test-conversion-id' ], $url ), 'e2e-test-conversion-id' ) ); ?>">Save</a>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<th>Clear conversion ID:</th>
+						<td>
+							<p>
+								<a class="button" id="e2e-clear-conversion-id" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'e2e-clear-conversion-id' ], $url ), 'e2e-clear-conversion-id' ) ); ?>">Clear</a>
+							</p>
+						</td>
+					</tr>
+				</table>
+			<?php } ?>
 		</div>
 		<?php
 	}
@@ -1096,6 +1119,26 @@ class ConnectionTest implements Service, Registerable {
 				$delete_job->schedule();
 				$this->response = 'Successfully scheduled a job to cleanup all products!';
 			}
+		}
+
+		if ( 'e2e-test-conversion-id' === $_GET['action'] && check_admin_referer( 'e2e-test-conversion-id' ) ) {
+			/** @var OptionsInterface $options */
+			$options = $this->container->get( OptionsInterface::class );
+			$options->update(
+				OptionsInterface::ADS_CONVERSION_ACTION,
+				[
+					'conversion_id'    => 'AW-123456',
+					'conversion_label' => 'aB_cdEFgh',
+				]
+			);
+			$this->response .= 'Saved test conversion ID.';
+		}
+
+		if ( 'e2e-clear-conversion-id' === $_GET['action'] && check_admin_referer( 'e2e-clear-conversion-id' ) ) {
+			/** @var OptionsInterface $options */
+			$options = $this->container->get( OptionsInterface::class );
+			$options->delete( OptionsInterface::ADS_CONVERSION_ACTION );
+			$this->response .= 'Cleared conversion ID.';
 		}
 	}
 

--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -28,3 +28,6 @@ wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=pas
 
 # Skip activation redirect, so it will not interrupt our tests.
 wp transient delete _wc_activation_redirect
+
+# Initialize pretty permalinks.
+wp rewrite structure /%postname%/

--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -12,6 +12,9 @@ wp config set WP_DEBUG_DISPLAY false --raw
 wp config set JETPACK_AUTOLOAD_DEV true --raw
 wp plugin install woocommerce --activate
 
+# Install basic auth for API requests on http.
+wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
+
 # Install and activate WC-admin for GLA.
 wp plugin install woocommerce-admin --activate
 

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -157,4 +157,28 @@ describe( 'GTag events', () => {
 			expect( data.currency_code ).toEqual( 'USD' );
 		} );
 	} );
+
+	it( 'Purchase event is sent on order complete page', async () => {
+		await emptyCart();
+		await shopper.goToProduct( simpleProductID );
+		await page.waitForSelector( 'form.cart' );
+		await shopper.addToCart();
+
+		await shopper.goToCheckout();
+		await shopper.fillBillingDetails(
+			config.get( 'addresses.customer.billing' )
+		);
+		await uiUnblocked();
+
+		const event = trackGtagEvent( 'purchase' );
+		await shopper.placeOrder();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request );
+			expect( data.value ).toEqual( productPrice );
+			expect( data.ecomm_pagetype ).toEqual( 'purchase' );
+			expect( data.currency_code ).toEqual( 'USD' );
+			expect( data.country ).toEqual( 'US' );
+		} );
+	} );
 } );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -13,7 +13,11 @@ import {
 	clearConversionID,
 	saveConversionID,
 } from '../../utils/connection-test-page';
-import { getEventData, trackGtagEvent } from '../../utils/track-event';
+import {
+	getEventData,
+	relatedProductAddToCart,
+	trackGtagEvent,
+} from '../../utils/track-event';
 
 let simpleProductID;
 
@@ -68,6 +72,22 @@ describe( 'GTag events', () => {
 		await event.then( ( request ) => {
 			const data = getEventData( request );
 			expect( data.id ).toEqual( 'gla_' + simpleProductID );
+			expect( data.ecomm_pagetype ).toEqual( 'cart' );
+			expect( data.event_category ).toEqual( 'ecommerce' );
+			expect( data.google_business_vertical ).toEqual( 'retail' );
+		} );
+	} );
+
+	it( 'Add to cart event is sent from related product on single product page', async () => {
+		await createSimpleProduct(); // Create an additional product for related to show up.
+		const event = trackGtagEvent( 'add_to_cart' );
+
+		await shopper.goToProduct( simpleProductID );
+		const relatedProductID = await relatedProductAddToCart();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request );
+			expect( data.id ).toEqual( 'gla_' + relatedProductID );
 			expect( data.ecomm_pagetype ).toEqual( 'cart' );
 			expect( data.event_category ).toEqual( 'ecommerce' );
 			expect( data.google_business_vertical ).toEqual( 'retail' );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import {
+	shopper, // eslint-disable-line import/named
+} from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+	clearConversionID,
+	saveConversionID,
+} from '../../utils/connection-test-page';
+
+describe( 'GTag events', () => {
+	beforeAll( async () => {
+		await saveConversionID();
+	} );
+
+	afterAll( async () => {
+		await clearConversionID();
+	} );
+
+	it( 'Global GTag snippet appears on a frontend page', async () => {
+		await shopper.goToShop();
+
+		await expect(
+			page.$$eval( 'head', ( elements ) =>
+				elements.some( ( el ) =>
+					el.innerHTML.includes( 'Global site tag (gtag.js)' )
+				)
+			)
+		).resolves.toBeTruthy();
+	} );
+} );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -58,4 +58,19 @@ describe( 'GTag events', () => {
 			expect( data.google_business_vertical ).toEqual( 'retail' );
 		} );
 	} );
+
+	it( 'Add to cart event is sent on a single product page', async () => {
+		const event = trackGtagEvent( 'add_to_cart' );
+
+		await shopper.goToProduct( simpleProductID );
+		await shopper.addToCart();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request );
+			expect( data.id ).toEqual( 'gla_' + simpleProductID );
+			expect( data.ecomm_pagetype ).toEqual( 'cart' );
+			expect( data.event_category ).toEqual( 'ecommerce' );
+			expect( data.google_business_vertical ).toEqual( 'retail' );
+		} );
+	} );
 } );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -13,11 +13,8 @@ import {
 	clearConversionID,
 	saveConversionID,
 } from '../../utils/connection-test-page';
-import {
-	getEventData,
-	relatedProductAddToCart,
-	trackGtagEvent,
-} from '../../utils/track-event';
+import { getEventData, trackGtagEvent } from '../../utils/track-event';
+import { relatedProductAddToCart } from '../../utils/cart';
 
 let simpleProductID;
 

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -67,6 +67,7 @@ describe( 'GTag events', () => {
 		const event = trackGtagEvent( 'add_to_cart' );
 
 		await shopper.goToProduct( simpleProductID );
+		await page.waitForSelector( 'form.cart' );
 		await shopper.addToCart();
 
 		await event.then( ( request ) => {
@@ -88,6 +89,21 @@ describe( 'GTag events', () => {
 		await event.then( ( request ) => {
 			const data = getEventData( request );
 			expect( data.id ).toEqual( 'gla_' + relatedProductID );
+			expect( data.ecomm_pagetype ).toEqual( 'cart' );
+			expect( data.event_category ).toEqual( 'ecommerce' );
+			expect( data.google_business_vertical ).toEqual( 'retail' );
+		} );
+	} );
+
+	it( 'Add to cart event is sent from the shop page', async () => {
+		const event = trackGtagEvent( 'add_to_cart' );
+
+		await shopper.goToShop();
+		await shopper.addToCartFromShopPage( simpleProductID );
+
+		await event.then( ( request ) => {
+			const data = getEventData( request );
+			expect( data.id ).toEqual( 'gla_' + simpleProductID );
 			expect( data.ecomm_pagetype ).toEqual( 'cart' );
 			expect( data.event_category ).toEqual( 'ecommerce' );
 			expect( data.google_business_vertical ).toEqual( 'retail' );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -12,6 +12,7 @@ import {
 	clearConversionID,
 	saveConversionID,
 } from '../../utils/connection-test-page';
+import { trackGtagEvent } from '../../utils/track-event';
 
 describe( 'GTag events', () => {
 	beforeAll( async () => {
@@ -32,5 +33,12 @@ describe( 'GTag events', () => {
 				)
 			)
 		).resolves.toBeTruthy();
+	} );
+
+	it( 'Page view event is sent on a frontend page', async () => {
+		const event = trackGtagEvent( 'page_view' );
+
+		await shopper.goToShop();
+		await expect( event ).resolves.toBeTruthy();
 	} );
 } );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -109,4 +109,15 @@ describe( 'GTag events', () => {
 			expect( data.google_business_vertical ).toEqual( 'retail' );
 		} );
 	} );
+
+	it( 'Cart page view event is sent from the cart page', async () => {
+		const event = trackGtagEvent( 'page_view' );
+		await shopper.goToCart();
+
+		await event.then( ( request ) => {
+			const data = getEventData( request );
+			expect( data.ecomm_pagetype ).toEqual( 'cart' );
+			expect( data.google_business_vertical ).toEqual( 'retail' );
+		} );
+	} );
 } );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -2,10 +2,11 @@
  * External dependencies
  */
 import {
-	shopper, // eslint-disable-line import/named
 	createSimpleProduct,
+	SHOP_PAGE, // eslint-disable-line import/named
+	shopper, // eslint-disable-line import/named
 	uiUnblocked,
-	withRestApi,
+	withRestApi, // eslint-disable-line import/named
 } from '@woocommerce/e2e-utils';
 
 /**
@@ -18,7 +19,7 @@ import {
 import { getEventData, trackGtagEvent } from '../../utils/track-event';
 import { emptyCart, relatedProductAddToCart } from '../../utils/cart';
 
-const config = require( 'config' );
+const config = require( 'config' ); // eslint-disable-line import/no-extraneous-dependencies
 const productPrice = config.has( 'products.simple.price' )
 	? config.get( 'products.simple.price' )
 	: '9.99';
@@ -109,7 +110,10 @@ describe( 'GTag events', () => {
 	it( 'Add to cart event is sent from the shop page', async () => {
 		const event = trackGtagEvent( 'add_to_cart' );
 
-		await shopper.goToShop();
+		// Go to shop page (newest first)
+		await page.goto( SHOP_PAGE + '?orderby=date', {
+			waitUntil: 'networkidle0',
+		} );
 		await shopper.addToCartFromShopPage( simpleProductID );
 
 		await event.then( ( request ) => {

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -56,14 +56,14 @@ describe( 'At setup page', () => {
 
 				jetpackConnectMock = requestMock
 					// Match "connect" not "connected".
-					.mock( /%2Fwc%2Fgla%2Fjetpack%2Fconnect\b/ )
+					.mock( /\/wc\/gla\/jetpack\/connect\b/ )
 					.mockImplementation( ( interceptedRequest ) => {
 						// Mock connected
 						interceptedRequest.respond( {
 							content: 'application/json',
 							headers: { 'Access-Control-Allow-Origin': '*' },
 							body: JSON.stringify( {
-								url: createURL( '/auth/url/' ),
+								url: createURL( '', 'auth_url' ),
 							} ),
 						} );
 						return true;
@@ -85,7 +85,7 @@ describe( 'At setup page', () => {
 				// Expect Jetpack call to be executed.
 				expect( jetpackConnectMock ).toBeCalled();
 				// Expect the user to be redirected
-				expect( page.url() ).toEqual( createURL( '/auth/url/' ) );
+				expect( page.url() ).toEqual( createURL( '', 'auth_url' ) );
 			} );
 		} );
 	} );
@@ -94,7 +94,7 @@ describe( 'At setup page', () => {
 			// Mock Jetpack as connected
 			await requestMock.observe( page );
 			requestMock
-				.mock( /%2Fwc%2Fgla%2Fjetpack%2Fconnected\b/ )
+				.mock( /\/wc\/gla\/jetpack\/connected\b/ )
 				.mockImplementation( ( interceptedRequest ) => {
 					interceptedRequest.respond( {
 						content: 'application/json',
@@ -114,7 +114,7 @@ describe( 'At setup page', () => {
 			// If not mocked will fail and render nothing,
 			// as Jetpack is mocked only on the client-side.
 			requestMock
-				.mock( /%2Fwc%2Fgla%2Fgoogle%2Fconnected\b/ )
+				.mock( /\/wc\/gla\/google\/connected\b/ )
 				.mockImplementation( ( interceptedRequest ) => {
 					interceptedRequest.respond( {
 						content: 'application/json',
@@ -153,13 +153,13 @@ describe( 'At setup page', () => {
 			beforeEach( async function mockGoogleConnect() {
 				// Spy on Google connection request.
 				googleConnectMock = requestMock
-					.mock( /%2Fwc%2Fgla%2Fgoogle%2Fconnect\b/ )
+					.mock( /\/wc\/gla\/google\/connect\b/ )
 					.mockImplementation( ( interceptedRequest ) => {
 						interceptedRequest.respond( {
 							content: 'application/json',
 							headers: { 'Access-Control-Allow-Origin': '*' },
 							body: JSON.stringify( {
-								url: createURL( '/google/auth/' ),
+								url: createURL( '', 'google_auth' ),
 							} ),
 						} );
 						return true;
@@ -180,7 +180,7 @@ describe( 'At setup page', () => {
 				// Expect Google call to be executed.
 				expect( googleConnectMock ).toBeCalled();
 				// Expect the user to be redirected
-				expect( page.url() ).toEqual( createURL( '/google/auth/' ) );
+				expect( page.url() ).toEqual( createURL( '', 'google_auth' ) );
 			} );
 		} );
 	} );

--- a/tests/e2e/utils/cart.js
+++ b/tests/e2e/utils/cart.js
@@ -2,6 +2,14 @@
  * Helper functions for handling the cart.
  */
 
+/**
+ * External dependencies
+ */
+import {
+	SHOP_CART_PAGE, // eslint-disable-line import/named
+	uiUnblocked,
+} from '@woocommerce/e2e-utils';
+
 /* global page */
 
 /**
@@ -17,5 +25,32 @@ export async function relatedProductAddToCart() {
 
 	return await page.$eval( addToCart, ( el ) => {
 		return el.getAttribute( 'data-product_id' );
+	} );
+}
+
+/**
+ * Empty the cart.
+ *
+ * Needed until this issue is included in the @woocommerce/e2e-utils package:
+ * https://github.com/woocommerce/woocommerce/pull/31977
+ */
+export async function emptyCart() {
+	await page.goto( SHOP_CART_PAGE, {
+		waitUntil: 'networkidle0',
+	} );
+
+	// Remove products if they exist
+	if ( ( await page.$( '.remove' ) ) !== null ) {
+		let products = await page.$$( '.remove' );
+		while ( products && products.length > 0 ) {
+			await page.click( '.remove' );
+			await uiUnblocked();
+			products = await page.$$( '.remove' );
+		}
+	}
+
+	await page.waitForSelector( '.woocommerce-info' );
+	await expect( page ).toMatchElement( '.woocommerce-info', {
+		text: 'Your cart is currently empty.',
 	} );
 }

--- a/tests/e2e/utils/cart.js
+++ b/tests/e2e/utils/cart.js
@@ -1,0 +1,21 @@
+/**
+ * Helper functions for handling the cart.
+ */
+
+/* global page */
+
+/**
+ * Adds a related product to the cart.
+ *
+ * @return {number} Product ID of the added product.
+ */
+export async function relatedProductAddToCart() {
+	const addToCart = '.related.products .add_to_cart_button';
+
+	await page.click( addToCart );
+	await expect( page ).toMatchElement( addToCart + '.added' );
+
+	return await page.$eval( addToCart, ( el ) => {
+		return el.getAttribute( 'data-product_id' );
+	} );
+}

--- a/tests/e2e/utils/connection-test-page.js
+++ b/tests/e2e/utils/connection-test-page.js
@@ -1,0 +1,59 @@
+/**
+ * Save test connection details on the Connection Test page.
+ */
+/* global page */
+/**
+ * External dependencies
+ */
+import {
+	WP_ADMIN_DASHBOARD, // eslint-disable-line import/named
+	isCurrentURL,
+	loginUser,
+	getPageError,
+} from '@woocommerce/e2e-utils';
+
+/**
+ * Visits the connection test page; if user is not logged in, then it logs in first.
+ */
+export async function visitConnectionTestPage() {
+	const connectionTestURL =
+		WP_ADMIN_DASHBOARD + 'admin.php?page=connection-test-admin-page&e2e=1';
+
+	await page.goto( connectionTestURL, {
+		waitUntil: 'networkidle0',
+	} );
+
+	// Handle upgrade required screen
+	if ( isCurrentURL( 'wp-admin/upgrade.php' ) ) {
+		// Click update
+		await page.click( '.button.button-large.button-primary' );
+		// Click continue
+		await page.click( '.button.button-large' );
+	}
+
+	if ( isCurrentURL( 'wp-login.php' ) ) {
+		await loginUser();
+		await visitConnectionTestPage();
+	}
+
+	const error = await getPageError();
+	if ( error ) {
+		throw new Error( 'Unexpected error in page content: ' + error );
+	}
+}
+
+export async function saveConversionID() {
+	await visitConnectionTestPage();
+	await Promise.all( [
+		expect( page ).toClick( '#e2e-test-conversion-id' ),
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	] );
+}
+
+export async function clearConversionID() {
+	await visitConnectionTestPage();
+	await Promise.all( [
+		expect( page ).toClick( '#e2e-clear-conversion-id' ),
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	] );
+}

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -26,7 +26,7 @@ export function trackGtagEvent( eventName ) {
  * Retrieve data from a gtag event and convert it to key / value pairs.
  *
  * @param {HTTPRequest} request
- * @return {Array} Key / value pairs.
+ * @return {Object} Data sent with the event.
  */
 export function getEventData( request ) {
 	const url = new URL( request.url() );
@@ -35,4 +35,20 @@ export function getEventData( request ) {
 	return Object.fromEntries(
 		data.split( ';' ).map( ( pair ) => pair.split( '=' ) )
 	);
+}
+
+/**
+ * Adds a related product to the cart.
+ *
+ * @return {number} Product ID of the added product.
+ */
+export async function relatedProductAddToCart() {
+	const addToCart = '.related.products .add_to_cart_button';
+
+	await page.click( addToCart );
+	await expect( page ).toMatchElement( addToCart + '.added' );
+
+	return await page.$eval( addToCart, ( el ) => {
+		return el.getAttribute( 'data-product_id' );
+	} );
 }

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -4,6 +4,10 @@
 /* global page */
 
 /**
+ * @typedef {import('puppeteer').HTTPRequest} HTTPRequest
+ */
+
+/**
  * Tracks when the Gtag Event request matching a specific name is sent.
  *
  * @param {string} eventName Event name to match.
@@ -16,4 +20,19 @@ export function trackGtagEvent( eventName ) {
 		const match = encodeURIComponent( 'event=' + eventName );
 		return url.startsWith( eventURL ) && url.includes( match );
 	} );
+}
+
+/**
+ * Retrieve data from a gtag event and convert it to key / value pairs.
+ *
+ * @param {HTTPRequest} request
+ * @return {Array} Key / value pairs.
+ */
+export function getEventData( request ) {
+	const url = new URL( request.url() );
+	const data = new URLSearchParams( url.search ).get( 'data' );
+
+	return Object.fromEntries(
+		data.split( ';' ).map( ( pair ) => pair.split( '=' ) )
+	);
 }

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -14,7 +14,7 @@
  * @return {Promise} Matching request.
  */
 export function trackGtagEvent( eventName ) {
-	const eventURL = 'https://www.google.com/pagead/1p-user-list/';
+	const eventURL = 'https://www.google.com/pagead';
 	return page.waitForRequest( ( request ) => {
 		const url = request.url();
 		const match = encodeURIComponent( 'event=' + eventName );
@@ -23,16 +23,25 @@ export function trackGtagEvent( eventName ) {
 }
 
 /**
- * Retrieve data from a gtag event and convert it to key / value pairs.
+ * Retrieve data from a Gtag event.
  *
  * @param {HTTPRequest} request
  * @return {Object} Data sent with the event.
  */
 export function getEventData( request ) {
 	const url = new URL( request.url() );
-	const data = new URLSearchParams( url.search ).get( 'data' );
-
-	return Object.fromEntries(
-		data.split( ';' ).map( ( pair ) => pair.split( '=' ) )
+	const params = new URLSearchParams( url.search );
+	const data = Object.fromEntries(
+		params.get( 'data' ).split( ';' ).map( ( pair ) => pair.split( '=' ) )
 	);
+
+	if ( params.get( 'value' ) ) {
+		data.value = params.get( 'value' );
+	}
+
+	if ( params.get( 'currency_code' ) ) {
+		data.currency_code = params.get( 'currency_code' );
+	}
+
+	return data;
 }

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -1,0 +1,19 @@
+/**
+ * Tracking of Gtag events.
+ */
+/* global page */
+
+/**
+ * Tracks when the Gtag Event request matching a specific name is sent.
+ *
+ * @param {string} eventName Event name to match.
+ * @return {Promise} Matching request.
+ */
+export function trackGtagEvent( eventName ) {
+	const eventURL = 'https://www.google.com/pagead/1p-user-list/';
+	return page.waitForRequest( ( request ) => {
+		const url = request.url();
+		const match = encodeURIComponent( 'event=' + eventName );
+		return url.startsWith( eventURL ) && url.includes( match );
+	} );
+}

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -32,7 +32,10 @@ export function getEventData( request ) {
 	const url = new URL( request.url() );
 	const params = new URLSearchParams( url.search );
 	const data = Object.fromEntries(
-		params.get( 'data' ).split( ';' ).map( ( pair ) => pair.split( '=' ) )
+		params
+			.get( 'data' )
+			.split( ';' )
+			.map( ( pair ) => pair.split( '=' ) )
 	);
 
 	if ( params.get( 'value' ) ) {

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -36,19 +36,3 @@ export function getEventData( request ) {
 		data.split( ';' ).map( ( pair ) => pair.split( '=' ) )
 	);
 }
-
-/**
- * Adds a related product to the cart.
- *
- * @return {number} Product ID of the added product.
- */
-export async function relatedProductAddToCart() {
-	const addToCart = '.related.products .add_to_cart_button';
-
-	await page.click( addToCart );
-	await expect( page ).toMatchElement( addToCart + '.added' );
-
-	return await page.$eval( addToCart, ( el ) => {
-		return el.getAttribute( 'data-product_id' );
-	} );
-}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds End to End tests to confirm that the following Gtag events are sent on the frontend pages:

- Page view
- View item on a single product page
- Add to cart on a single product page
- Add related product to cart from a single product page
- Add to cart from a shop page
- Cart page view
- Conversion on order completed
- Purchase on order completed

### Detailed test instructions:
1. Confirm the e2e run in this PR without errors 
2. Run the e2e tests locally and confirm they run without errors

### Additional details:
Still to be added is to confirm the experimental hook is fired when products are added to cart from the all products block (will add in a followup PR).

To be able to visit shop/cart pages using the `@woocommerce/e2e-utils` functions we needed to switch to pretty permalinks. This had the site affect that the tests in `setup-mc` where failing because the API URLs changed from using `%2F` to regular `/`. So the matching patterns had to be altered. Also we can't redirect to links like `/google/auth/` because this returns a 404, so instead a query parameter link was used.

### Changelog entry
- Add - End to end tests for Gtag events.
