### PR TITLE
Always compare site URL hash without trailing slash

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -211,7 +211,7 @@ class Merchant implements OptionsAwareInterface {
 					return null;
 				}
 
-				$claimed_url_hash = md5( $account_url );
+				$claimed_url_hash = md5( untrailingslashit( $account_url ) );
 				$this->options->update( OptionsInterface::CLAIMED_URL_HASH, $claimed_url_hash );
 			} catch ( Exception $e ) {
 				return null;

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -114,7 +114,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 		if ( null === $url_matches ) {
 			$claimed_url_hash = $this->container->get( Merchant::class )->get_claimed_url_hash();
-			$site_url_hash    = md5( $this->get_site_url() );
+			$site_url_hash    = md5( untrailingslashit( $this->get_site_url() ) );
 			$url_matches      = apply_filters( 'woocommerce_gla_ready_for_syncing', $claimed_url_hash === $site_url_hash ) ? 'yes' : 'no';
 			$transients->set( TransientsInterface::URL_MATCHES, $url_matches, HOUR_IN_SECONDS * 12 );
 		}

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -237,6 +237,14 @@ class MerchantTest extends UnitTest {
 		$this->assertNull( $this->merchant->get_claimed_url_hash() );
 	}
 
+	public function test_get_claimed_url_hash_from_account() {
+		$url = 'https://site.test';
+		$this->mock_get_account( $this->get_account_with_url( $url ) );
+		$this->mock_get_account_status( $this->get_status_website_claimed() );
+
+		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
+	}
+
 	public function test_get_claimed_url_hash_with_trailing_slash() {
 		$url = 'https://site.test';
 		$this->mock_get_account( $this->get_account_with_url( trailingslashit( $url ) ) );

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -237,9 +237,9 @@ class MerchantTest extends UnitTest {
 		$this->assertNull( $this->merchant->get_claimed_url_hash() );
 	}
 
-	public function test_get_claimed_url_hash_from_account() {
+	public function test_get_claimed_url_hash_with_trailing_slash() {
 		$url = 'https://site.test';
-		$this->mock_get_account( $this->get_account_with_url( $url ) );
+		$this->mock_get_account( $this->get_account_with_url( trailingslashit( $url ) ) );
 		$this->mock_get_account_status( $this->get_status_website_claimed() );
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR always removes the trailing slash from the URL before calculating the MD5. This is to ensure that we continue syncing even if the account and site URL differ with just a trailing slash.

Closes #1549 

### Detailed test instructions:

1. Go to Settings > General and add a trailing slash to the URL (confirm it's saved that way in the DB since we can't see it on this screen) .
2. Go through the onboarding and verify / claim the URL (if using ngrok you will need to make sure the adjusted URL has a trailing slash define( 'WP_HOME', 'https://' . $_SERVER['HTTP_X_ORIGINAL_HOST'] . '/' );).
3. Wait for the initial sync after onboarding to complete so it doesn't conflict with us testing syncing after changing the URL.
4. Go back to the DB and change the home option in the wp_options table, removing the trailing slash.
5. Go to the Connection Test page and trigger a product sync (all or individual) making sure async is checked.
6. Check the scheduled actions and confirm that they still sync even though the URL's don't fully match.

### Changelog entry
* Tweak - Always compare site URL hash without trailing slash.
