### PR TITLE
Disable Review Request in Standalone Accounts

### DIFF
--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -180,11 +180,21 @@ export function* getMCProductStatistics() {
 }
 
 export function* getMCReviewRequest() {
-	const response = yield apiFetch( {
-		path: `${ API_NAMESPACE }/mc/review`,
-	} );
+	try {
+		const response = yield apiFetch( {
+			path: `${ API_NAMESPACE }/mc/review`,
+		} );
 
-	yield receiveMCReviewRequest( response );
+		yield receiveMCReviewRequest( response );
+	} catch ( error ) {
+		yield handleFetchError(
+			error,
+			__(
+				'There was an error loading your merchant center product review request status.',
+				'google-listings-and-ads'
+			)
+		);
+	}
 }
 
 export function* getMCIssues( query ) {

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -348,20 +348,4 @@ class Merchant implements OptionsAwareInterface {
 	public function update_merchant_id( int $id ): bool {
 		return $this->options->update( OptionsInterface::MERCHANT_ID, $id );
 	}
-
-	/**
-	 * A standalone account is an account created directly in MC without using our plugin.
-	 * Standalone accounts have no access to WCS proxy and other features.
-	 *
-	 * This function detects if the account is standalone
-	 * We use this API for that https://developers.google.com/shopping-content/reference/rest/v2.1/accounts/authinfo
-	 *
-	 * We consider an accou t standalone if no aggregatorId is present or no accountIdentifiers are available.
-	 *
-	 * @return bool True if it's a standalone account.
-	 */
-	public function is_standalone(): bool {
-		$type = $this->service->accounts->authinfo();
-		return ! isset( $type['accountIdentifiers'] ) || empty( $type['accountIdentifiers'] ) || is_null( $type['accountIdentifiers'][0]['aggregatorId'] );
-	}
 }

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -348,4 +348,20 @@ class Merchant implements OptionsAwareInterface {
 	public function update_merchant_id( int $id ): bool {
 		return $this->options->update( OptionsInterface::MERCHANT_ID, $id );
 	}
+
+	/**
+	 * A standalone account is an account created directly in MC without using our plugin.
+	 * Standalone accounts have no access to WCS proxy and other features.
+	 *
+	 * This function detects if the account is standalone
+	 * We use this API for that https://developers.google.com/shopping-content/reference/rest/v2.1/accounts/authinfo
+	 *
+	 * We consider an accou t standalone if no aggregatorId is present or no accountIdentifiers are available.
+	 *
+	 * @return bool True if it's a standalone account.
+	 */
+	public function is_standalone(): bool {
+		$type = $this->service->accounts->authinfo();
+		return ! isset( $type['accountIdentifiers'] ) || empty( $type['accountIdentifiers'] ) || is_null( $type['accountIdentifiers'][0]['aggregatorId'] );
+	}
 }

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -540,16 +540,15 @@ class Middleware implements OptionsAwareInterface {
 				$this->get_manager_url( 'account-review-status/' . $this->options->get_merchant_id() ),
 			);
 
-			 $response = json_decode( $result->getBody()->getContents(), true );
+			$response = json_decode( $result->getBody()->getContents(), true );
 
 			if ( 200 === $result->getStatusCode() && isset( $response['freeListingsProgram'] ) && isset( $response['shoppingAdsProgram'] ) ) {
 				do_action( 'woocommerce_gla_request_review_response', $response );
 				return $response;
 			}
-
-			 do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
-			 $error = $response['message'] ?? __( 'Invalid response getting account review status', 'google-listings-and-ads' );
-			 throw new Exception( $error, $result->getStatusCode() );
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+			$error = $response['message'] ?? __( 'Invalid response getting account review status', 'google-listings-and-ads' );
+			throw new Exception( $error, $result->getStatusCode() );
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -36,7 +36,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Middleware implements OptionsAwareInterface {
 
-
 	use ApiExceptionTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -529,13 +529,9 @@ class Middleware implements OptionsAwareInterface {
 	 */
 	public function get_account_review_status() {
 		try {
-			/** @var Merchant $merchant */
-			$merchant = $this->container->get( Merchant::class );
 
-			if ( $merchant->is_standalone() ) {
-				$response = [];
-				do_action( 'woocommerce_gla_request_review_standalone', $response );
-				return $response;
+			if ( ! $this->is_subaccount() ) {
+				return [];
 			}
 
 			/** @var Client $client */
@@ -621,5 +617,23 @@ class Middleware implements OptionsAwareInterface {
 				$e->getCode()
 			);
 		}
+	}
+
+	/**
+	 * This function detects if the current account is a sub-account
+	 *
+	 * @return bool True if it's a standalone account.
+	 */
+	public function is_subaccount(): bool {
+		$merchant_id = $this->options->get_merchant_id();
+		$accounts    = $this->get_merchant_accounts();
+
+		foreach ( $accounts as $account ) {
+			if ( $account['id'] === $merchant_id && $account['subaccount'] ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -498,7 +498,7 @@ class Middleware implements OptionsAwareInterface {
 	 */
 	protected function default_account_name(): string {
 		return sprintf(
-		/* translators: 1: current date in the format Y-m-d */
+			/* translators: 1: current date in the format Y-m-d */
 			__( 'Account %1$s', 'google-listings-and-ads' ),
 			( new DateTime() )->format( 'Y-m-d' )
 		);

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -645,7 +645,7 @@ class Middleware implements OptionsAwareInterface {
 			$transients->set( $transients::MC_IS_SUBACCOUNT, $is_subaccount );
 		}
 
-		// since transients doesn't support booleans, we save them as 0/1 and do the conversion here
+		// since transients don't support booleans, we save them as 0/1 and do the conversion here
 		return boolval( $is_subaccount );
 	}
 }

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -529,6 +529,15 @@ class Middleware implements OptionsAwareInterface {
 	 */
 	public function get_account_review_status() {
 		try {
+			/** @var Merchant $merchant */
+			$merchant = $this->container->get( Merchant::class );
+
+			if ( $merchant->is_standalone() ) {
+				$response = [];
+				do_action( 'woocommerce_gla_request_review_standalone', $response );
+				return $response;
+			}
+
 			/** @var Client $client */
 			$client = $this->container->get( Client::class );
 			$result = $client->get(

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -263,6 +263,7 @@ class AccountService implements OptionsAwareInterface, Service {
 
 		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_ACCOUNT_REVIEW );
 		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::URL_MATCHES );
+		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_IS_SUBACCOUNT );
 	}
 
 	/**

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -12,15 +12,17 @@ interface TransientsInterface {
 
 	public const ADS_METRICS          = 'ads_metrics';
 	public const FREE_LISTING_METRICS = 'free_listing_metrics';
-	public const MC_STATUSES          = 'mc_statuses';
 	public const MC_ACCOUNT_REVIEW    = 'mc_account_review';
+	public const MC_IS_SUBACCOUNT     = 'mc_is_subaccount';
+	public const MC_STATUSES          = 'mc_statuses';
 	public const URL_MATCHES          = 'url_matches';
 
 	public const VALID_OPTIONS = [
 		self::ADS_METRICS          => true,
 		self::FREE_LISTING_METRICS => true,
-		self::MC_STATUSES          => true,
 		self::MC_ACCOUNT_REVIEW    => true,
+		self::MC_IS_SUBACCOUNT     => true,
+		self::MC_STATUSES          => true,
 		self::URL_MATCHES          => true,
 	];
 

--- a/tests/Tools/HelperTrait/GuzzleClientTrait.php
+++ b/tests/Tools/HelperTrait/GuzzleClientTrait.php
@@ -155,4 +155,35 @@ trait GuzzleClientTrait {
 			400
 		);
 	}
+
+	/**
+	 * Generates two mocked request for when we request a review status
+	 * 1. Get Merchant accounts
+	 * 2. Get Account Review statuses
+	 *
+	 * @param array $merchant_accounts_response The mocked response for the merchant_accounts call
+	 * @param array $account_review_response The mocked response for the account_review call
+	 */
+	protected function generate_account_review_mock( $merchant_accounts_response, $account_review_response ) {
+		$body = $this->createMock( StreamInterface::class );
+		$body->method( 'getContents' )
+			->will(
+				$this->onConsecutiveCalls(
+					json_encode( $merchant_accounts_response ),
+					json_encode( $account_review_response )
+				)
+			);
+
+		$result = $this->createMock( ResponseInterface::class );
+		$result->method( 'getBody' )->willReturn( $body );
+		$result->method( 'getStatusCode' )->willReturn( 200 );
+
+		$this->client->method( 'get' )->will(
+			$this->onConsecutiveCalls(
+				$result,
+				$result,
+			)
+		);
+
+	}
 }

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -360,7 +360,7 @@ class MiddlewareTest extends UnitTest {
 
 	public function test_get_account_review_status() {
 
-		$this->options->expects( $this->exactly( 2 ) )->method('get_merchant_id')->willReturn(self::TEST_MERCHANT_ID);
+		$this->options->expects( $this->exactly( 2 ) )->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
 
 		$accounts = [
 			[
@@ -373,16 +373,16 @@ class MiddlewareTest extends UnitTest {
 			]
 		];
 
-		$review_status = [ 'freeListingsProgram' => 'freeListingsProgram', 'shoppingAdsProgram' => 'shoppingAdsProgram'];
+		$review_status = [ 'freeListingsProgram' => 'freeListingsProgram', 'shoppingAdsProgram' => 'shoppingAdsProgram' ];
 
-		$this->generate_account_review_mock( $accounts,  $review_status);
+		$this->generate_account_review_mock( $accounts,  $review_status );
 
 
-		$this->assertEquals( $this->middleware->get_account_review_status(), $review_status);
+		$this->assertEquals( $this->middleware->get_account_review_status(), $review_status );
 	}
 
 	public function test_get_account_review_status_standalone() {
-		$this->options->expects( $this->once() )->method('get_merchant_id')->willReturn(self::TEST_MERCHANT_ID);
+		$this->options->expects( $this->once() )->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
 
 		$accounts = [
 			[
@@ -401,7 +401,7 @@ class MiddlewareTest extends UnitTest {
 
 
 	public function test_get_account_review_status_exception() {
-		$this->options->expects( $this->once() )->method('get_merchant_id')->willReturn(self::TEST_MERCHANT_ID);
+		$this->options->expects( $this->once() )->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
 
 		$this->generate_request_mock_exception( 'Some exception' );
 
@@ -414,7 +414,7 @@ class MiddlewareTest extends UnitTest {
 
 
 	public function test_get_account_review_status_error() {
-		$this->options->expects( $this->exactly( 2 ) )->method('get_merchant_id')->willReturn(self::TEST_MERCHANT_ID);
+		$this->options->expects( $this->exactly( 2 ) )->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
 
 		$accounts = [
 			[
@@ -425,7 +425,7 @@ class MiddlewareTest extends UnitTest {
 
 		$review_status = [];
 
-		$this->generate_account_review_mock( $accounts,  $review_status);
+		$this->generate_account_review_mock( $accounts,  $review_status );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Invalid response getting account review status' );

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -355,31 +355,73 @@ class MiddlewareTest extends UnitTest {
 	}
 
 	public function test_get_account_review_status() {
-		$this->merchant->expects( $this->once() )->method( 'is_standalone' )->willReturn( false );
-		$this->generate_request_mock( [ 'freeListingsProgram' => 'freeListingsProgram', 'shoppingAdsProgram' => 'shoppingAdsProgram'] );
 
-		$this->assertEquals( $this->middleware->get_account_review_status(), [ 'freeListingsProgram' => 'freeListingsProgram', 'shoppingAdsProgram' => 'shoppingAdsProgram'] );
+		$this->options->expects( $this->exactly( 2 ) )->method('get_merchant_id')->willReturn(self::TEST_MERCHANT_ID);
+
+		$accounts = [
+			[
+				'id'         => self::TEST_MERCHANT_ID,
+				'subaccount' => true,
+			],
+			[
+				'id'         => 34567812,
+				'subaccount' => false,
+			]
+		];
+
+		$review_status = [ 'freeListingsProgram' => 'freeListingsProgram', 'shoppingAdsProgram' => 'shoppingAdsProgram'];
+
+		$this->generate_account_review_mock( $accounts,  $review_status);
+
+
+		$this->assertEquals( $this->middleware->get_account_review_status(), $review_status);
 	}
 
 	public function test_get_account_review_status_standalone() {
-		$this->merchant->expects( $this->once() )->method( 'is_standalone' )->willReturn( true );
+		$this->options->expects( $this->once() )->method('get_merchant_id')->willReturn(self::TEST_MERCHANT_ID);
+
+		$accounts = [
+			[
+				'id'         => self::TEST_MERCHANT_ID,
+				'subaccount' => false,
+			],
+			[
+				'id'         => 34567812,
+				'subaccount' => true,
+			]
+		];
+
+		$this->generate_request_mock( $accounts );
 		$this->assertEquals( $this->middleware->get_account_review_status(), [] );
 	}
 
+
 	public function test_get_account_review_status_exception() {
-		$this->merchant->expects( $this->once() )->method( 'is_standalone' )->willReturn( false );
+		$this->options->expects( $this->once() )->method('get_merchant_id')->willReturn(self::TEST_MERCHANT_ID);
+
 		$this->generate_request_mock_exception( 'Some exception' );
 
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Error getting account review status' );
+		$this->expectExceptionMessage( 'Error retrieving accounts' );
 		$this->expectExceptionCode( 400 );
 
 		$this->middleware->get_account_review_status();
 	}
 
+
 	public function test_get_account_review_status_error() {
-		$this->merchant->expects( $this->once() )->method( 'is_standalone' )->willReturn( false );
-		$this->generate_request_mock( [] );
+		$this->options->expects( $this->exactly( 2 ) )->method('get_merchant_id')->willReturn(self::TEST_MERCHANT_ID);
+
+		$accounts = [
+			[
+				'id'         => self::TEST_MERCHANT_ID,
+				'subaccount' => true,
+			]
+		];
+
+		$review_status = [];
+
+		$this->generate_account_review_mock( $accounts,  $review_status);
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Invalid response getting account review status' );

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidDomainName;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GuzzleClientTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -25,14 +26,15 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
  * @group Middleware
  *
- * @property MockObject|Ads               $ads
- * @property MockObject|DateTimeUtility   $date_utility
- * @property MockObject|GoogleHelper      $google_helper
- * @property MockObject|Merchant          $merchant
- * @property MockObject|WP                $wp
- * @property MockObject|OptionsInterface  $options
- * @property Middleware                   $middleware
- * @property Container                    $container
+ * @property MockObject|Ads                  $ads
+ * @property MockObject|DateTimeUtility      $date_utility
+ * @property MockObject|GoogleHelper         $google_helper
+ * @property MockObject|Merchant             $merchant
+ * @property MockObject|WP                   $wp
+ * @property MockObject|OptionsInterface     $options
+ * @property MockObject|TransientsInterface  $transients
+ * @property Middleware                      $middleware
+ * @property Container                       $container
  */
 class MiddlewareTest extends UnitTest {
 
@@ -56,12 +58,14 @@ class MiddlewareTest extends UnitTest {
 		$this->google_helper = $this->createMock( GoogleHelper::class );
 		$this->merchant      = $this->createMock( Merchant::class );
 		$this->options       = $this->createMock( OptionsInterface::class );
+		$this->transients    = $this->createMock( TransientsInterface::class );
 		$this->wp            = $this->createMock( WP::class );
 
 		$this->container->share( Ads::class, $this->ads );
 		$this->container->share( DateTimeUtility::class, $this->date_utility );
 		$this->container->share( GoogleHelper::class, $this->google_helper );
 		$this->container->share( Merchant::class, $this->merchant );
+		$this->container->share( TransientsInterface::class, $this->transients );
 		$this->container->share( WP::class, $this->wp );
 
 		$this->middleware = new Middleware( $this->container );

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -686,11 +686,12 @@ class AccountServiceTest extends UnitTest {
 
 		$this->cleanup_synced->expects( $this->once() )->method( 'schedule' );
 
-		$this->transients->expects( $this->exactly( 2 ) )
+		$this->transients->expects( $this->exactly( 3 ) )
 			->method( 'delete' )
 			->withConsecutive(
 				[ TransientsInterface::MC_ACCOUNT_REVIEW ],
-				[ TransientsInterface::URL_MATCHES ]
+				[ TransientsInterface::URL_MATCHES ],
+				[ TransientsInterface::MC_IS_SUBACCOUNT ]
 			);
 
 		$this->account->disconnect();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1545 

This PR checks if the account is standalone, if so, returns null in the status hiding the request review feature. That prevent to show a notice dialog indicating that there was an error requesting Account review status. 

### Detailed test instructions:

1. Checkout PR
2. Disconnect all your google account in settings to clear the cache 
3. Connect GLA with a Standalone account (this is an account created outside the plugin)
4. When you finish the setup you wont see the Account status in product feed summary anymore, neither any error notice.
5. Disconnect again the accounts
6. Connect a normal account (created in GLA plugin)
7. After completing setup you will see the account status in product feed summary.


### Additional details:

- Added Test suit for Account Review Status Middleware (get)
- Restore changes made in resolvers hiding all the errors. 
- Created  helper in Merchant.php to check if the account is standalone following indications [in here](https://developers.google.com/shopping-content/reference/rest/v2.1/accounts/authinfo). It seems that Standalone account doesn't have the `aggregatorId` field set

### Changelog entry

> Tweak - Disable Review Request in Standalone Accounts
