### PR TITLE
Tree Select Control - Clear search input after an option changes

### DIFF
--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -22,6 +22,7 @@ import { BACKSPACE } from './constants';
  * @param {boolean} props.isExpanded True if the tree is expanded
  * @param {boolean} props.disabled True if the component is disabled
  * @param {number} props.maxVisibleTags The maximum number of tags to show. Undefined, 0 or less than 0 evaluates to "Show All".
+ * @param {string} props.value The current input value
  * @param {Function} props.onFocus On Focus Callback
  * @param {Function} props.onTagsChange Callback when the Tags change
  * @param {Function} props.onInputChange Callback when the Input value changes
@@ -35,6 +36,7 @@ const Control = ( {
 	isExpanded,
 	disabled,
 	maxVisibleTags,
+	value = '',
 	onFocus = () => {},
 	onTagsChange = () => {},
 	onInputChange = () => {},
@@ -46,7 +48,7 @@ const Control = ( {
 
 	const handleKeydown = ( event ) => {
 		if ( BACKSPACE === event.key ) {
-			if ( inputRef.current.value ) return;
+			if ( value ) return;
 			onTagsChange( tags.slice( 0, -1 ) );
 			event.preventDefault();
 		}
@@ -91,6 +93,7 @@ const Control = ( {
 					className="woocommerce-tree-select-control__control-input"
 					role="combobox"
 					aria-autocomplete="list"
+					value={ value }
 					aria-expanded={ isExpanded }
 					disabled={ disabled }
 					onFocus={ onFocus }

--- a/js/src/components/tree-select-control/control.test.js
+++ b/js/src/components/tree-select-control/control.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { screen, render } from '@testing-library/react';
+import { screen, render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -38,24 +38,37 @@ describe( 'TreeSelectControl - Control Component', () => {
 		expect( onTagsChange ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'Renders the input', () => {
-		const { queryByRole } = render( <Control /> );
+	it( 'Calls onInputChange when typing', () => {
+		const onInputChange = jest
+			.fn()
+			.mockName( 'onInputChange' )
+			.mockImplementation( ( e ) => e.target.value );
+		const { queryByRole } = render(
+			<Control onInputChange={ onInputChange } />
+		);
 
 		const input = queryByRole( 'combobox' );
 		expect( input ).toBeTruthy();
 		expect( input.hasAttribute( 'disabled' ) ).toBeFalsy();
-		userEvent.type( input, 'test' );
-		expect( input.value ).toBe( 'test' );
+		userEvent.type( input, 'a' );
+		expect( onInputChange ).toHaveBeenCalledTimes( 1 );
+		expect( onInputChange ).toHaveNthReturnedWith( 1, 'a' );
+		fireEvent.change( input, { target: { value: 'test' } } );
+		expect( onInputChange ).toHaveBeenCalledTimes( 2 );
+		expect( onInputChange ).toHaveNthReturnedWith( 2, 'test' );
 	} );
 
 	it( 'Allows disabled input', () => {
-		const { queryByRole } = render( <Control disabled={ true } /> );
+		const onInputChange = jest.fn().mockName( 'onInputChange' );
+		const { queryByRole } = render(
+			<Control disabled={ true } onInputChange={ onInputChange } />
+		);
 
 		const input = queryByRole( 'combobox' );
 		expect( input ).toBeTruthy();
 		expect( input.hasAttribute( 'disabled' ) ).toBeTruthy();
-		userEvent.type( input, 'test' );
-		expect( input.value ).toBe( '' );
+		userEvent.type( input, 'a' );
+		expect( onInputChange ).not.toHaveBeenCalled();
 	} );
 
 	it( 'Calls onFocus callback when it is focused', () => {

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -380,6 +380,8 @@ const TreeSelectControl = ( {
 		} else {
 			handleSingleChange( checked, option );
 		}
+
+		setInputControlValue( '' );
 	};
 
 	/**
@@ -473,6 +475,7 @@ const TreeSelectControl = ( {
 				placeholder={ placeholder }
 				label={ label }
 				maxVisibleTags={ maxVisibleTags }
+				value={ inputControlValue }
 				onTagsChange={ handleTagsChange }
 				onInputChange={ handleOnInputChange }
 			/>

--- a/js/src/components/tree-select-control/options.test.js
+++ b/js/src/components/tree-select-control/options.test.js
@@ -122,4 +122,20 @@ describe( 'TreeSelectControl - Options Component', () => {
 			unCheckedOptionWrapper.classList.contains( 'is-partially-checked' )
 		).toBeFalsy();
 	} );
+
+	it( 'Clears search input when option changes', () => {
+		const { queryAllByRole, queryByRole } = render(
+			<TreeSelectControl options={ options } />
+		);
+
+		const input = queryByRole( 'combobox' );
+		fireEvent.click( input );
+		fireEvent.change( input, { target: { value: 'Fra' } } );
+		expect( input.value ).toBe( 'Fra' );
+
+		const checkbox = queryAllByRole( 'checkbox' );
+		fireEvent.click( checkbox[ 0 ] );
+
+		expect( input.value ).toBe( '' );
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1489 .

After discussion, this PR removes the filter input after selecting an option. The component still maintains the **user** expanded nodes. 

The Tree Select acts a bit like [Ant Design system does it here](https://ant.design/components/tree-select/)


### Screenshots:

https://user-images.githubusercontent.com/5908855/172848902-86b2c578-2bba-49c8-93e7-5eb615de1e9a.mov


### Detailed test instructions:


1. Checkout this PR and execute `npm run storybook`
2. Go to http://localhost:6006/?path=/story/tree-select-control--base
3. Don't expand any node and just search for a child item (like Kuala Lumpur, typing "Lump")
4. See how Kuala Lumpur appears expanded and other irrelevant nodes are hiden.
5. Select Kuala Lumpur
6. See how the search input filter is cleared, the tag Kuala Lumpur is added and the tree goes back to the initial state
7. Expand some child nodes, Like America
8. Search something including those child nodes (Like Canada)
9. Select Canada
10. See how the tag Canada is added, the search input is cleared and the expanded nodes are still showing America 
11. Search for a selected node (for example again Kuala Lumpur)
12. Deselect the node
13. See how the tag disappears, the tree goes to the previous state and the input is cleared as well.
14. Check the code, check the tests


### Additional details:

### Changelog entry

> Tweak - Clear input search filter after selecting an option
