### PR TITLE
Tree Select Control - Fix control focus when the selected element is not expanded

### DIFF
--- a/js/src/components/tree-select-control/control.js
+++ b/js/src/components/tree-select-control/control.js
@@ -3,7 +3,7 @@
  */
 import classnames from 'classnames';
 import { noop } from 'lodash';
-import { useRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -29,80 +29,84 @@ import { BACKSPACE } from './constants';
  * @param {Function} [props.onControlClick] Callback when clicking on the control.
  * @return {JSX.Element} The rendered component
  */
-const Control = ( {
-	tags = [],
-	instanceId,
-	placeholder,
-	isExpanded,
-	disabled,
-	maxVisibleTags,
-	value = '',
-	onFocus = () => {},
-	onTagsChange = () => {},
-	onInputChange = () => {},
-	onControlClick = noop,
-} ) => {
-	const hasTags = tags.length > 0;
-	const showPlaceholder = ! hasTags && ! isExpanded;
-	const inputRef = useRef();
+const Control = forwardRef(
+	(
+		{
+			tags = [],
+			instanceId,
+			placeholder,
+			isExpanded,
+			disabled,
+			maxVisibleTags,
+			value = '',
+			onFocus = () => {},
+			onTagsChange = () => {},
+			onInputChange = () => {},
+			onControlClick = noop,
+		},
+		ref
+	) => {
+		const hasTags = tags.length > 0;
+		const showPlaceholder = ! hasTags && ! isExpanded;
 
-	const handleKeydown = ( event ) => {
-		if ( BACKSPACE === event.key ) {
-			if ( value ) return;
-			onTagsChange( tags.slice( 0, -1 ) );
-			event.preventDefault();
-		}
-	};
+		const handleKeydown = ( event ) => {
+			if ( BACKSPACE === event.key ) {
+				if ( value ) return;
+				onTagsChange( tags.slice( 0, -1 ) );
+				event.preventDefault();
+			}
+		};
 
-	return (
-		/**
-		 * ESLint Disable reason
-		 * https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/src/select-control/control.js#L200
-		 */
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
-		<div
-			className={ classnames(
-				'components-base-control',
-				'woocommerce-tree-select-control__control',
-				{
-					'is-disabled': disabled,
-					'has-tags': hasTags,
-				}
-			) }
-			onClick={ ( e ) => {
-				inputRef.current.focus();
-				onControlClick( e );
-			} }
-		>
-			{ hasTags && (
-				<Tags
-					disabled={ disabled }
-					tags={ tags }
-					maxVisibleTags={ maxVisibleTags }
-					onChange={ onTagsChange }
-				/>
-			) }
+		return (
+			/**
+			 * ESLint Disable reason
+			 * https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/src/select-control/control.js#L200
+			 */
+			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+			<div
+				className={ classnames(
+					'components-base-control',
+					'woocommerce-tree-select-control__control',
+					{
+						'is-disabled': disabled,
+						'has-tags': hasTags,
+					}
+				) }
+				onClick={ ( e ) => {
+					ref.current.focus();
+					onControlClick( e );
+				} }
+			>
+				{ hasTags && (
+					<Tags
+						disabled={ disabled }
+						tags={ tags }
+						maxVisibleTags={ maxVisibleTags }
+						onChange={ onTagsChange }
+					/>
+				) }
 
-			<div className="components-base-control__field">
-				<input
-					ref={ inputRef }
-					id={ `woocommerce-tree-select-control-${ instanceId }__control-input` }
-					type="search"
-					placeholder={ showPlaceholder ? placeholder : '' }
-					autoComplete="off"
-					className="woocommerce-tree-select-control__control-input"
-					role="combobox"
-					aria-autocomplete="list"
-					value={ value }
-					aria-expanded={ isExpanded }
-					disabled={ disabled }
-					onFocus={ onFocus }
-					onChange={ onInputChange }
-					onKeyDown={ handleKeydown }
-				/>
+				<div className="components-base-control__field">
+					<input
+						ref={ ref }
+						id={ `woocommerce-tree-select-control-${ instanceId }__control-input` }
+						type="search"
+						placeholder={ showPlaceholder ? placeholder : '' }
+						autoComplete="off"
+						className="woocommerce-tree-select-control__control-input"
+						role="combobox"
+						aria-autocomplete="list"
+						value={ value }
+						aria-expanded={ isExpanded }
+						disabled={ disabled }
+						onFocus={ onFocus }
+						onChange={ onInputChange }
+						onKeyDown={ handleKeydown }
+					/>
+				</div>
 			</div>
-		</div>
-	);
-};
+		);
+	}
+);
 
 export default Control;

--- a/js/src/components/tree-select-control/control.test.js
+++ b/js/src/components/tree-select-control/control.test.js
@@ -11,10 +11,16 @@ import Control from '.~/components/tree-select-control/control';
 
 describe( 'TreeSelectControl - Control Component', () => {
 	const onTagsChange = jest.fn().mockName( 'onTagsChange' );
+	const ref = {
+		current: {
+			focus: jest.fn(),
+		},
+	};
 
 	it( 'Renders the tags and calls onTagsChange when they change', () => {
 		const { queryByText, queryByLabelText, rerender } = render(
 			<Control
+				ref={ ref }
 				tags={ [ { id: 'es', label: 'Spain' } ] }
 				onTagsChange={ onTagsChange }
 			/>
@@ -27,6 +33,7 @@ describe( 'TreeSelectControl - Control Component', () => {
 
 		rerender(
 			<Control
+				ref={ ref }
 				tags={ [ { id: 'es', label: 'Spain' } ] }
 				disabled={ true }
 				onTagsChange={ onTagsChange }
@@ -44,7 +51,7 @@ describe( 'TreeSelectControl - Control Component', () => {
 			.mockName( 'onInputChange' )
 			.mockImplementation( ( e ) => e.target.value );
 		const { queryByRole } = render(
-			<Control onInputChange={ onInputChange } />
+			<Control ref={ ref } onInputChange={ onInputChange } />
 		);
 
 		const input = queryByRole( 'combobox' );
@@ -73,7 +80,9 @@ describe( 'TreeSelectControl - Control Component', () => {
 
 	it( 'Calls onFocus callback when it is focused', () => {
 		const onFocus = jest.fn().mockName( 'onFocus' );
-		const { queryByRole } = render( <Control onFocus={ onFocus } /> );
+		const { queryByRole } = render(
+			<Control ref={ ref } onFocus={ onFocus } />
+		);
 		userEvent.click( queryByRole( 'combobox' ) );
 		expect( onFocus ).toHaveBeenCalled();
 	} );

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -392,6 +392,7 @@ const TreeSelectControl = ( {
 		if ( ! nodesExpanded.includes( option.parent ) ) {
 			controlRef.current.focus();
 		}
+
 	};
 
 	/**

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -111,6 +111,7 @@ const TreeSelectControl = ( {
 	const [ nodesExpanded, setNodesExpanded ] = useState( [] );
 	const [ inputControlValue, setInputControlValue ] = useState( '' );
 
+	const controlRef = useRef();
 	const dropdownRef = useRef();
 	const onDropdownVisibilityChangeRef = useRef();
 	onDropdownVisibilityChangeRef.current = onDropdownVisibilityChange;
@@ -381,7 +382,22 @@ const TreeSelectControl = ( {
 			handleSingleChange( checked, option );
 		}
 
+		clearSearchInput( option );
+	};
+
+	const clearSearchInput = ( option ) => {
 		setInputControlValue( '' );
+		const optionID = option.key || option.value;
+
+		const currentFocusedElement = focus.focusable
+			.find( dropdownRef.current )
+			.filter( ( el ) => el.value === optionID )[ 0 ];
+
+		const treeGroup = currentFocusedElement?.closest( '[role=treegroup]' );
+		const parentId = treeGroup?.querySelector( 'input' );
+		if ( ! nodesExpanded.includes( parentId?.value ) ) {
+			controlRef.current.focus();
+		}
 	};
 
 	/**
@@ -461,6 +477,7 @@ const TreeSelectControl = ( {
 			) }
 
 			<Control
+				ref={ controlRef }
 				disabled={ disabled }
 				tags={ getTags() }
 				isExpanded={ showTree }

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -68,6 +68,7 @@ import { ARROW_DOWN, ARROW_UP, ENTER, ESCAPE, ROOT_VALUE } from './constants';
  * @property {boolean} checked Whether this option is checked.
  * @property {boolean} partialChecked Whether this option is partially checked.
  * @property {boolean} expanded Whether this option is expanded.
+ * @property {boolean} parent The parent of the current option
  *
  * @typedef {CommonOption & BaseInnerOption} InnerOption
  */
@@ -150,8 +151,13 @@ const TreeSelectControl = ( {
 		// Clear cache if options change
 		cacheRef.current.filteredOptionsMap.clear();
 
-		function loadOption( option ) {
-			option.children?.forEach( loadOption );
+		function loadOption( option, parentId ) {
+			option.parent = parentId;
+
+			option.children?.forEach( ( el ) =>
+				loadOption( el, option.value )
+			);
+
 			repository[ option.key ?? option.value ] = option;
 		}
 
@@ -382,20 +388,8 @@ const TreeSelectControl = ( {
 			handleSingleChange( checked, option );
 		}
 
-		clearSearchInput( option );
-	};
-
-	const clearSearchInput = ( option ) => {
 		setInputControlValue( '' );
-		const optionID = option.key || option.value;
-
-		const currentFocusedElement = focus.focusable
-			.find( dropdownRef.current )
-			.filter( ( el ) => el.value === optionID )[ 0 ];
-
-		const treeGroup = currentFocusedElement?.closest( '[role=treegroup]' );
-		const parentId = treeGroup?.querySelector( 'input' );
-		if ( ! nodesExpanded.includes( parentId?.value ) ) {
+		if ( ! nodesExpanded.includes( option.parent ) ) {
 			controlRef.current.focus();
 		}
 	};

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -392,7 +392,6 @@ const TreeSelectControl = ( {
 		if ( ! nodesExpanded.includes( option.parent ) ) {
 			controlRef.current.focus();
 		}
-
 	};
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1561 

This PR fixes an error in Tree Select Control introduced in https://github.com/woocommerce/google-listings-and-ads/pull/1557

When the Search filter shows a node that is not expanded after selecting it, the node is hidden and the Tree Select Control lost the focus.

To solve this a Ref was created and in case the parent Node is not expanded we set the focus in the input, otherwise we maintain the focus in the node.

### Screenshots:

https://user-images.githubusercontent.com/5908855/173116046-52b0eb26-8d58-4b3e-b07e-9d879792a3aa.mov


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Run storybook `npm run storybook`
2. On Tree Select Control without expanding any node search for "Kuala"
3. Kuala Lumpur will appear in the tree
4. Select Kuala Lumpur
5. Input is cleared
6. Focus is  again in input search
7. Expand Europe
8. Search for Spain
9. Click on Spain
10. Input is cleared and focus stays in Spain


### Changelog entry

> Fix - Avoid losing focus when selecting an option in Tree Select Control
