### PR TITLE
Fix - CES Prompts Showing Several Times

### DIFF
--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -10,6 +10,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { LOCAL_STORAGE_KEYS } from '.~/constants';
 import localStorage from '.~/utils/localStorage';
+import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
 
 /**
  * CES prompt snackbar open
@@ -47,6 +48,8 @@ import localStorage from '.~/utils/localStorage';
  * @return {JSX.Element} Rendered element.
  */
 const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
+	useEffectRemoveNotice( label, 'core/notices2' );
+
 	const removeCESPromptFlagFromLocal = () => {
 		localStorage.remove(
 			LOCAL_STORAGE_KEYS.CAN_ONBOARDING_SETUP_CES_PROMPT_OPEN

--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -49,8 +49,8 @@ import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
  */
 const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
 	// NOTE: Currently CES Prompts uses core/notices2 as a store key, this seems something temporal
-	//and probably will be needed to change back to core/notices.
-	//See: https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/notices/src/store/index.js
+	// and probably will be needed to change back to core/notices.
+	// See: https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/notices/src/store/index.js
 	useEffectRemoveNotice( label, 'core/notices2' );
 
 	const removeCESPromptFlagFromLocal = () => {

--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -48,6 +48,9 @@ import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
  * @return {JSX.Element} Rendered element.
  */
 const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
+	// NOTE: Currently CES Prompts uses core/notices2 as a store key, this seems something temporal
+	//and probably will be needed to change back to core/notices2.
+	//See: https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/notices/src/store/index.js
 	useEffectRemoveNotice( label, 'core/notices2' );
 
 	const removeCESPromptFlagFromLocal = () => {

--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -49,7 +49,7 @@ import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
  */
 const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
 	// NOTE: Currently CES Prompts uses core/notices2 as a store key, this seems something temporal
-	//and probably will be needed to change back to core/notices2.
+	//and probably will be needed to change back to core/notices.
 	//See: https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/notices/src/store/index.js
 	useEffectRemoveNotice( label, 'core/notices2' );
 

--- a/js/src/data/constants.js
+++ b/js/src/data/constants.js
@@ -1,3 +1,3 @@
 export const STORE_KEY = 'wc/gla';
 export const API_NAMESPACE = '/wc/gla';
-export const NOTICES_KEY = 'core/notices';
+export const NOTICES_STORE_KEY = 'core/notices';

--- a/js/src/data/constants.js
+++ b/js/src/data/constants.js
@@ -1,2 +1,3 @@
 export const STORE_KEY = 'wc/gla';
 export const API_NAMESPACE = '/wc/gla';
+export const NOTICES_KEY = 'core/notices';

--- a/js/src/hooks/useEffectRemoveNotice.js
+++ b/js/src/hooks/useEffectRemoveNotice.js
@@ -11,7 +11,7 @@ import useNotices from '.~/hooks/useNotices';
 import { STORE_KEY } from '.~/data/constants';
 
 /**
- * Removes a wp notice using its label when the component it is unmounted
+ * Search for a notice with specific label and remove it if the component is unmounted.
  *
  * @param {string} label the notice label
  * @param {string} [storeKey] the store

--- a/js/src/hooks/useEffectRemoveNotice.js
+++ b/js/src/hooks/useEffectRemoveNotice.js
@@ -8,7 +8,7 @@ import { dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import useNotices from '.~/hooks/useNotices';
-import { STORE_KEY } from '.~/data/constants';
+import { NOTICES_KEY } from '.~/data/constants';
 
 /**
  * Search for a notice with specific label and remove it if the component is unmounted.
@@ -18,7 +18,7 @@ import { STORE_KEY } from '.~/data/constants';
  *
  * @return {import('@wordpress/notices').Notice|null} The notice to be removed otherwise null if it is not found
  */
-const useEffectRemoveNotice = ( label, storeKey = STORE_KEY ) => {
+const useEffectRemoveNotice = ( label, storeKey = NOTICES_KEY ) => {
 	const notices = useNotices( storeKey );
 	const notice = notices.find( ( el ) => el.content === label );
 

--- a/js/src/hooks/useEffectRemoveNotice.js
+++ b/js/src/hooks/useEffectRemoveNotice.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useNotices from '.~/hooks/useNotices';
+import { STORE_KEY } from '.~/data/constants';
+
+/**
+ * Removes a wp notice using its label when the component it is unmounted
+ *
+ * @param {string} label the notice label
+ * @param {string} [storeKey] the store
+ *
+ * @return {import('@wordpress/notices').Notice|null} The notice to be removed otherwise null if it is not found
+ */
+const useEffectRemoveNotice = ( label, storeKey = STORE_KEY ) => {
+	const notices = useNotices( storeKey );
+	const notice = notices.find( ( el ) => el.content === label );
+
+	useEffect( () => {
+		const { removeNotice } = dispatch( storeKey );
+
+		return () => {
+			if ( notice ) {
+				removeNotice( notice.id );
+			}
+		};
+	}, [ label, notice, storeKey ] );
+
+	return notice || null;
+};
+
+export default useEffectRemoveNotice;

--- a/js/src/hooks/useEffectRemoveNotice.js
+++ b/js/src/hooks/useEffectRemoveNotice.js
@@ -30,7 +30,7 @@ const useEffectRemoveNotice = ( label, storeKey = STORE_KEY ) => {
 				removeNotice( notice.id );
 			}
 		};
-	}, [ label, notice, storeKey ] );
+	}, [ notice, storeKey ] );
 
 	return notice || null;
 };

--- a/js/src/hooks/useEffectRemoveNotice.js
+++ b/js/src/hooks/useEffectRemoveNotice.js
@@ -8,7 +8,7 @@ import { dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import useNotices from '.~/hooks/useNotices';
-import { NOTICES_KEY } from '.~/data/constants';
+import { NOTICES_STORE_KEY } from '.~/data/constants';
 
 /**
  * Search for a notice with specific label and remove it if the component is unmounted.
@@ -18,7 +18,7 @@ import { NOTICES_KEY } from '.~/data/constants';
  *
  * @return {import('@wordpress/notices').Notice|null} The notice to be removed otherwise null if it is not found
  */
-const useEffectRemoveNotice = ( label, storeKey = NOTICES_KEY ) => {
+const useEffectRemoveNotice = ( label, storeKey = NOTICES_STORE_KEY ) => {
 	const notices = useNotices( storeKey );
 	const notice = notices.find( ( el ) => el.content === label );
 

--- a/js/src/hooks/useEffectRemoveNotice.test.js
+++ b/js/src/hooks/useEffectRemoveNotice.test.js
@@ -8,7 +8,7 @@ import { renderHook } from '@testing-library/react-hooks';
  */
 import useEffectRemoveNotice from './useEffectRemoveNotice';
 import useNotices from '.~/hooks/useNotices';
-import { NOTICES_KEY } from '.~/data/constants';
+import { NOTICES_STORE_KEY } from '.~/data/constants';
 
 const mockRemoveNotice = jest.fn();
 
@@ -42,7 +42,7 @@ describe( 'useEffectRemoveNotice', () => {
 		);
 
 		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 0 );
-		expect( useNotices ).toHaveBeenCalledWith( NOTICES_KEY );
+		expect( useNotices ).toHaveBeenCalledWith( NOTICES_STORE_KEY );
 
 		expect( result.current ).toEqual( notice );
 	} );
@@ -57,7 +57,7 @@ describe( 'useEffectRemoveNotice', () => {
 		);
 
 		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 0 );
-		expect( useNotices ).toHaveBeenCalledWith( NOTICES_KEY );
+		expect( useNotices ).toHaveBeenCalledWith( NOTICES_STORE_KEY );
 
 		expect( result.current ).toEqual( null );
 	} );

--- a/js/src/hooks/useEffectRemoveNotice.test.js
+++ b/js/src/hooks/useEffectRemoveNotice.test.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useEffectRemoveNotice from './useEffectRemoveNotice';
+import useNotices from '.~/hooks/useNotices';
+import { STORE_KEY } from '.~/data/constants';
+
+const mockRemoveNotice = jest.fn();
+
+jest.mock( '.~/hooks/useNotices', () => {
+	return jest.fn();
+} );
+
+jest.mock( '@wordpress/data', () => {
+	return {
+		dispatch: jest.fn().mockImplementation( () => ( {
+			removeNotice: mockRemoveNotice,
+		} ) ),
+	};
+} );
+
+describe( 'useEffectRemoveNotice', () => {
+	const testLabel = 'test_label';
+	const notice = {
+		id: 1,
+		content: testLabel,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useNotices.mockImplementation( () => [ notice ] );
+	} );
+
+	test( 'Should return with the notice', () => {
+		const { result } = renderHook( () =>
+			useEffectRemoveNotice( testLabel )
+		);
+
+		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 0 );
+		expect( useNotices ).toHaveBeenCalledWith( STORE_KEY );
+
+		expect( result.current ).toEqual( notice );
+	} );
+
+	test( 'Should return with null if the notice is not found', () => {
+		useNotices.mockImplementation( () => [
+			{ ...notice, content: 'different_labels' },
+		] );
+
+		const { result } = renderHook( () =>
+			useEffectRemoveNotice( testLabel )
+		);
+
+		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 0 );
+		expect( useNotices ).toHaveBeenCalledWith( STORE_KEY );
+
+		expect( result.current ).toEqual( null );
+	} );
+
+	test( 'Should remove notice when the hook is unmounted', () => {
+		const { result, unmount } = renderHook( () =>
+			useEffectRemoveNotice( testLabel )
+		);
+
+		unmount();
+
+		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( notice.id );
+		expect( result.current ).toEqual( notice );
+	} );
+} );

--- a/js/src/hooks/useEffectRemoveNotice.test.js
+++ b/js/src/hooks/useEffectRemoveNotice.test.js
@@ -8,7 +8,7 @@ import { renderHook } from '@testing-library/react-hooks';
  */
 import useEffectRemoveNotice from './useEffectRemoveNotice';
 import useNotices from '.~/hooks/useNotices';
-import { STORE_KEY } from '.~/data/constants';
+import { NOTICES_KEY } from '.~/data/constants';
 
 const mockRemoveNotice = jest.fn();
 
@@ -42,7 +42,7 @@ describe( 'useEffectRemoveNotice', () => {
 		);
 
 		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 0 );
-		expect( useNotices ).toHaveBeenCalledWith( STORE_KEY );
+		expect( useNotices ).toHaveBeenCalledWith( NOTICES_KEY );
 
 		expect( result.current ).toEqual( notice );
 	} );
@@ -57,7 +57,7 @@ describe( 'useEffectRemoveNotice', () => {
 		);
 
 		expect( mockRemoveNotice ).toHaveBeenCalledTimes( 0 );
-		expect( useNotices ).toHaveBeenCalledWith( STORE_KEY );
+		expect( useNotices ).toHaveBeenCalledWith( NOTICES_KEY );
 
 		expect( result.current ).toEqual( null );
 	} );

--- a/js/src/hooks/useNotices.js
+++ b/js/src/hooks/useNotices.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { NOTICES_KEY } from '.~/data/constants';
+import { NOTICES_STORE_KEY } from '.~/data/constants';
 
 /**
  * @typedef {import('@wordpress/notices').Notice} Notice
@@ -19,7 +19,7 @@ import { NOTICES_KEY } from '.~/data/constants';
  *
  * @return {Array<Notice>} Returns the Notices
  */
-const useNotices = ( storeKey = NOTICES_KEY ) => {
+const useNotices = ( storeKey = NOTICES_STORE_KEY ) => {
 	return useSelect(
 		( select ) => {
 			const selector = select( storeKey );

--- a/js/src/hooks/useNotices.js
+++ b/js/src/hooks/useNotices.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
+import { NOTICES_KEY } from '.~/data/constants';
 
 /**
  * @typedef {import('@wordpress/notices').Notice} Notice
@@ -19,7 +19,7 @@ import { STORE_KEY } from '.~/data/constants';
  *
  * @return {Array<Notice>} Returns the Notices
  */
-const useNotices = ( storeKey = STORE_KEY ) => {
+const useNotices = ( storeKey = NOTICES_KEY ) => {
 	return useSelect(
 		( select ) => {
 			const selector = select( storeKey );

--- a/js/src/hooks/useNotices.js
+++ b/js/src/hooks/useNotices.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '.~/data/constants';
+
+/**
+ * @typedef {import('@wordpress/notices').Notice} Notice
+ */
+
+/**
+ * A hook that returns the WP notices
+ *
+ * @param {string} [storeKey] The store key
+ *
+ * @return {Array<Notice>} Returns the Notices
+ */
+const useNotices = ( storeKey = STORE_KEY ) => {
+	return useSelect(
+		( select ) => {
+			const selector = select( storeKey );
+			return selector.getNotices();
+		},
+		[ storeKey ]
+	);
+};
+
+export default useNotices;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up of https://github.com/woocommerce/google-listings-and-ads/pull/1543#issuecomment-1154703602

The PR https://github.com/woocommerce/google-listings-and-ads/pull/1543, implemented a solution for the issue #1428, however, we found an issue with the bundle size and the package `@woocommerce/customer-effort-score` so we decided to hold the PR until the CES package is exporting the `CustomerFeedbackModal`, see more context here: https://github.com/woocommerce/google-listings-and-ads/pull/1543#issuecomment-1154241021 & https://github.com/woocommerce/google-listings-and-ads/pull/1543#issuecomment-1154703602

This PR implements a workaround to fix:
- Showing multiple CES prompts (See issue #1428)
-  Modal not working after going to a subpath (See @ianlin comment: https://github.com/woocommerce/google-listings-and-ads/pull/1543#issuecomment-1144518273

### Screenshots:

Before this PR:

https://user-images.githubusercontent.com/2488994/173612820-85630103-e853-4cfe-89c9-57076c5bc53d.mp4

With this PR:

https://user-images.githubusercontent.com/2488994/173611670-15be6657-8953-46fc-8392-19925449df7e.mp4

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to `wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&guide=campaign-creation-success`
2. Click on "Got it"
3. One CES prompt should be displayed.
4. Visit Edit free listings/Edit Ads Campaigns/Create Ads campaigns (the CES prompt should be gone)
5. Return to the dashboard page and it should show only one CES prompt. 
6. Click on "Give Feedback", and the modal should be displayed

### Additional details
Ideally, the CES prompt should be displayed on every page, as was mentioned in the following comment: https://github.com/woocommerce/google-listings-and-ads/pull/1543#issuecomment-1154784615, unfortunately, this is not yet possible in the GLA app however we are looking into possible solutions like an AppShell https://github.com/woocommerce/google-listings-and-ads/issues/1548

cc: @ecgan @ianlin 

### Changelog entry

>Fix - Multiple CES prompts on the Dashboard Page