### PR TITLE
Add `release.yml` - set changelog entry categories

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,11 +25,14 @@ _Replace this with a good description of your changes & reasoning._
 <!--
 Optional.
 Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
-Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
-> Fix - I took care of something that wasn't working.
-> Add - I added something new that's pretty cool.
-> Tweak - I made a small change.
-> Update - I made big changes to something that wasn't broken.
+Each line should start with change type prefix`(Fix|Add|…) - `, for example:
+> Break - A change breaking previous API or functionality.
+> Add - A new feature, function or functionality was added.
+> Update - Big changes to something that wasn't broken.
+> Fix - Took care of something that wasn't working.
+> Tweak - Small change, that isn't actually very important.
+> Dev - Developer-facing only change.
+> Doc - Updated customer or developer facing documentation
 
 Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
 If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    labels:
+      - "changelog: none"
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: Fixes 🛠
+      labels:
+        - "changelog: fix"
+        - "type: bug"
+    - title: New Features 🎉
+      labels:
+        - "changelog: add"
+        - "type: enhancement"
+    - title: Updated
+      labels:
+        - "changelog: update"
+    - title: Tweaked
+      labels:
+        - "changelog: tweak"
+        - "type: technical debt"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,21 +7,21 @@ changelog:
       - github-actions
 
   categories:
-    - title: Fixes 🛠
-      labels:
-        - "changelog: fix"
-        - "type: bug"
-
-    - title: New Features 🎉
+    - title: [Add] New Features 🎉
       labels:
         - "changelog: add"
         - "type: enhancement"
 
-    - title: Updated ✨
+    - title: [Update] Updated ✨
       labels:
         - "changelog: update"
 
-    - title: Tweaked 🔧
+    - title: [Fix] Fixes 🛠
+      labels:
+        - "changelog: fix"
+        - "type: bug"
+
+    - title: [Tweak] Tweaked 🔧
       labels:
         - "changelog: tweak"
         - "type: technical debt"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -31,7 +31,10 @@ changelog:
     - title: [Tweak] Tweaked 🔧
       labels:
         - "changelog: tweak"
-        - "type: technical debt"
+
+    - title: [Dev] Developer-facing changes 🧑‍💻
+      labels:
+        - "changelog: dev"
 
     - title: [Doc] Documentation 📚
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,12 @@ changelog:
       - github-actions
 
   categories:
+      # Major level
+    - title: [Breaking] Breaking Changes 🚨
+      labels:
+        - "changelog: breaking"
+
+    # Minor level
     - title: [Add] New Features 🎉
       labels:
         - "changelog: add"
@@ -16,6 +22,7 @@ changelog:
       labels:
         - "changelog: update"
 
+    # Patch level
     - title: [Fix] Fixes 🛠
       labels:
         - "changelog: fix"
@@ -25,6 +32,10 @@ changelog:
       labels:
         - "changelog: tweak"
         - "type: technical debt"
+
+    - title: [Doc] Documentation 📚
+      labels:
+        - "changelog: docs"
 
     - title: Other Changes
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,7 +3,8 @@ changelog:
     labels:
       - "changelog: none"
     authors:
-      - dependabot[bot]
+      - dependabot
+      - github-actions
 
   categories:
     - title: Fixes 🛠

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,22 +4,27 @@ changelog:
       - "changelog: none"
     authors:
       - dependabot[bot]
+
   categories:
     - title: Fixes 🛠
       labels:
         - "changelog: fix"
         - "type: bug"
+
     - title: New Features 🎉
       labels:
         - "changelog: add"
         - "type: enhancement"
-    - title: Updated
+
+    - title: Updated ✨
       labels:
         - "changelog: update"
-    - title: Tweaked
+
+    - title: Tweaked 🔧
       labels:
         - "changelog: tweak"
         - "type: technical debt"
+
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a simple release config, to use automatically (https://github.com/woocommerce/grow/pull/14) or manually set PR labels to categorize release notes' entries.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
It could be hard to test this config, without merging it and merging a few other PRs after.
You can take a look at a test repo at https://github.com/woorelease-bugs/past-release/ which uses the same setup.

1. Open https://github.com/woorelease-bugs/past-release/releases/edit/1.0.1 
2. Click "Generate release notes"
3. Fork the repo
4. Create a new PR, attach `changelog: fix` label (or any other mentioned in the config)
5. Merge the PR
6. Generate new release notes as in 1-2.


### Additional details:

- This PR uses a new set of categories. The one that was agreed on below. That amis to unify but is different from current
   - set of changelog entry types (from PR template) `(Fix|Add|Tweak|Update) - `
   - branches name prefixes mentioned in wiki and P2 `(add/fix/update/remove)/(issue-number)-short-slug`
- Once we agree and merge this PR, I'll update wikis, create PRs to boilerplate generator, and other repos to match the same convention, to be ready to merge once we're happy with the GLA test-ride

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Dev - changed the changelog types list.
