### PR TITLE
Workaround for CES component to be compatible with WC 6.6.0 and older versions

### DIFF
--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -14,9 +14,10 @@ import { LOCAL_STORAGE_KEYS } from '.~/constants';
 import localStorage from '.~/utils/localStorage';
 import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
 
-// WC 6.6.0 uses @woocommerce/customer-effort-score v2.0.1 which does not include a default export, therefore
+// WC 6.6.0 updated the package @woocommerce/customer-effort-score, which does not include a default export anymore, therefore
 // breaking the page for older versions of WC. This is a temporal workaround to be compatible with older WC versions
 // and with our L-2 policy.
+// See  https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/customer-effort-score/src/index.ts
 const CESComponent = CustomerEffortScoreDefault || CustomerEffortScore;
 
 /**

--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import CustomerEffortScore from '@woocommerce/customer-effort-score';
+import CustomerEffortScoreDefault, {
+	CustomerEffortScore,
+} from '@woocommerce/customer-effort-score';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -11,6 +13,11 @@ import { recordEvent } from '@woocommerce/tracks';
 import { LOCAL_STORAGE_KEYS } from '.~/constants';
 import localStorage from '.~/utils/localStorage';
 import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
+
+// WC 6.6.0 uses @woocommerce/customer-effort-score v2.0.1 which does not include a default export, therefore
+// breaking the page for older versions of WC. This is a temporal workaround to be compatible with older WC versions
+// and with our L-2 policy.
+const CESComponent = CustomerEffortScoreDefault || CustomerEffortScore;
 
 /**
  * CES prompt snackbar open
@@ -87,7 +94,7 @@ const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
 	};
 
 	return (
-		<CustomerEffortScore
+		<CESComponent
 			label={ label }
 			recordScoreCallback={ recordScore }
 			onNoticeShownCallback={ onNoticeShown }

--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -15,7 +15,7 @@ import localStorage from '.~/utils/localStorage';
 import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
 
 // WC 6.6.0 updated the package @woocommerce/customer-effort-score, which does not include a default export anymore, therefore
-// breaking the page for older versions of WC. This is a temporal workaround to be compatible with older WC versions
+// breaking the page for newer versions of WC. This is a temporal workaround to be compatible with older WC versions
 // and with our L-2 policy.
 // See  https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/customer-effort-score/src/index.ts
 const CESComponent = CustomerEffortScoreDefault || CustomerEffortScore;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

While I was testing other PR with WC 6.6.0 (which was released last week), I realized that the new version of WC was breaking the GLA app, the reason for this is that the package `@woocommerce/customer-effort-score` does not have a default export anymore. Currently, we are importing the component as a default: 

https://github.com/woocommerce/google-listings-and-ads/blob/43ab87ae36c7b1a94147d20af567145766844767/js/src/components/customer-effort-score-prompt/index.js#L5

The usage instructions of `@woocommerce/customer-effort-score` are incorrect too:
https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/customer-effort-score/README.md#customereffortscore-component

See here the difference between versions:

- WC 6.6.0 - https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/customer-effort-score/src/index.ts
- WC 6.5.1 - https://github.com/woocommerce/woocommerce/blob/6.5.1/packages/js/customer-effort-score/src/index.js

### Screenshots:


https://user-images.githubusercontent.com/2488994/174679022-bb2eaac1-2857-461c-ad77-65aba8042569.mp4



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check out this branch.
2. Install the latest version of WC [6.6.0](https://downloads.wordpress.org/plugin/woocommerce.6.6.0.zip) 
3. Go to wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&guide=campaign-creation-success
4. Click on "Got it"
5. No errors should be displayed.

Repeat the same process with [WC 6.5.1](https://downloads.wordpress.org/plugin/woocommerce.6.5.1.zip)

You would get the error using develop branch with the latest WC 6.6.0

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Compatibility CES prompts with WC 6.6.0
