### PR TITLE
Release 1.13.6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
+= 1.13.6 - 2022-06-21 =
+* Fix - Cannot disconnect Jetpack when other activated plugins are using Jetpack connection.
+* Fix - Compatibility CES prompts with WC 6.6.0.
+* Fix - Multiple CES prompts on the Dashboard Page.
+
 = 1.13.5 - 2022-06-15 =
 * Fix - Avoid losing focus when selecting an option in Tree Select Control.
 * Fix - Bump node-forge from 1.2.1 to 1.3.1.

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google Listings and Ads
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 1.13.5
+ * Version: 1.13.6
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -28,7 +28,7 @@ use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '1.13.5' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '1.13.6' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.3' );
 define( 'WC_GLA_MIN_WC_VER', '6.0' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "1.13.5",
+	"version": "1.13.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "google-listings-and-ads",
 	"title": "Google Listings and Ads",
 	"license": "GPL-3.0-or-later",
-	"version": "1.13.5",
+	"version": "1.13.6",
 	"description": "google-listings-and-ads",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,11 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 
 == Changelog ==
 
+= 1.13.6 - 2022-06-21 =
+* Fix - Cannot disconnect Jetpack when other activated plugins are using Jetpack connection.
+* Fix - Compatibility CES prompts with WC 6.6.0.
+* Fix - Multiple CES prompts on the Dashboard Page.
+
 = 1.13.5 - 2022-06-15 =
 * Fix - Avoid losing focus when selecting an option in Tree Select Control.
 * Fix - Bump node-forge from 1.2.1 to 1.3.1.

--- a/readme.txt
+++ b/readme.txt
@@ -127,15 +127,5 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 * Tweak - Compliance Policy links.
 * Tweak - WC 6.6 compatibility.
 
-= 1.13.3 - 2022-05-31 =
-* Add - Add six more promotion supported countries.
-* Fix - Allow unicode for Manufacturer Part Number (MPN) value.
-* Fix - Avoid to show Unsaved Values confirmation in Edit Free Listing when no values has been changed.
-* Fix - Prevent repeated account URL retrievals.
-* Fix - Update tracking docs.
-* Tweak - Replace storybook deps in favor of woocommerce-grow/storybook.
-* Tweak - Simplify and centralize the processing of internal states for the TreeSelectControl component.
-* Update - budget recommendation conversion rate.
-
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, google, listings, ads
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.3
-Stable tag: 1.13.5
+Stable tag: 1.13.6
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
* Fix - Cannot disconnect Jetpack when other activated plugins are using Jetpack connection.
* Fix - Compatibility CES prompts with WC 6.6.0.
* Fix - Multiple CES prompts on the Dashboard Page.
