### PR TITLE
Add a script to generate a list of hooks that defined or used in GLA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ languages/*
 coverage
 .phpunit.result.cache
 tests/e2e/test-results.json
-gla_hooks_reference.html
 
 # Directories/files that may appear in your environment
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ languages/*
 coverage
 .phpunit.result.cache
 tests/e2e/test-results.json
+gla_hooks_reference.html
 
 # Directories/files that may appear in your environment
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ To remove the Docker container and images (this will **delete everything** in th
 
 ## Docs
 
--   [Usage Tracking](./src/Tracking/README.md)
+- [Usage Tracking](./src/Tracking/README.md)
+- [Hooks defined or used in GLA](./src/Hooks/README.md)
 
 <p align="center">
 	<br/><br/>

--- a/bin/HooksDocsGenerator.php
+++ b/bin/HooksDocsGenerator.php
@@ -243,7 +243,7 @@ class HooksDocsGenerator {
 		$output  = "# Hooks Reference\n\n";
 		$output .= "A list of hooks, i.e `actions` and `filters`, that are defined or used in this project.\n\n";
 
-		foreach ( $hook_list as $heading => $hooks ) {
+		foreach ( $hook_list as $hooks ) {
 			foreach ( $hooks as $hook => $details ) {
 				$output   .= "## {$hook}\n\n";
 				$output   .= "**Type**: {$details['type']}\n\n";

--- a/bin/HooksDocsGenerator.php
+++ b/bin/HooksDocsGenerator.php
@@ -60,7 +60,6 @@ class HooksDocsGenerator {
 					$files = array_merge( $files, $retrieved_files );
 				}
 			}
-
 		}
 		return $files;
 	}

--- a/bin/HooksDocsGenerator.php
+++ b/bin/HooksDocsGenerator.php
@@ -12,7 +12,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Util;
  *
  * Example: php bin/HooksDocsGenerator.php
  *
- * The HTML output "gla_hooks_reference.html" will be generated in the repo's root directory.
+ * The markdown output will be generated in `src/Hooks/README.md`.
  */
 class HooksDocsGenerator {
 
@@ -28,9 +28,9 @@ class HooksDocsGenerator {
 	protected const GLA_GITHUB_PATH = 'https://github.com/woocommerce/google-listings-and-ads/blob/develop/';
 
 	/**
-	 * Hooks docs HTML output.
+	 * Hooks docs markdown output.
 	 */
-	protected const HOOKS_HTML_OUTPUT = './gla_hooks_reference.html';
+	protected const HOOKS_MARKDOWN_OUTPUT = './src/Hooks/README.md';
 
 	/**
 	 * List of files found.
@@ -230,7 +230,7 @@ class HooksDocsGenerator {
 	 * @return string
 	 */
 	protected static function get_file_link( array $file ): string {
-		return '<a href="' . self::GLA_GITHUB_PATH . self::get_file_url( $file ) . '">' . basename( $file['path'] ) . '</a>';
+		return '<a href="' . self::GLA_GITHUB_PATH . self::get_file_url( $file ) . '">' . basename( $file['path'] ) . "#L{$file['line']}" . '</a>';
 	}
 
 	/**
@@ -240,31 +240,22 @@ class HooksDocsGenerator {
 	 * @param array $files_to_scan List of files to scan.
 	 */
 	protected static function get_delimited_list_output( array $hook_list, array $files_to_scan ): string {
-		$output = '';
+		$output  = "# Hooks Reference\n\n";
+		$output .= "A list of hooks, i.e `actions` and `filters`, that are defined or used in this project.\n\n";
 
-		$index = [];
-		foreach ( $files_to_scan as $heading => $files ) {
-				$index[] = '<a href="#hooks-' . str_replace( ' ', '-', strtolower( $heading ) ) . '">' . $heading . '</a>';
-		}
-
-		$output .= '<p>' . implode( ', ', $index ) . '</p>';
-
-		$output .= '<div class="hooks-reference">';
 		foreach ( $hook_list as $heading => $hooks ) {
-			$output .= '<h2 id="hooks-' . str_replace( ' ', '-', strtolower( $heading ) ) . '">' . $heading . '</h2>';
-			$output .= '<dl class="phpdocumentor-table-of-contents">';
 			foreach ( $hooks as $hook => $details ) {
-				$output   .= '<dt class="phpdocumentor-table-of-contents__entry -' . $details['type'] . '">' . $hook . '</dt>';
+				$output   .= "## {$hook}\n\n";
+				$output   .= "**Type**: {$details['type']}\n\n";
+				$output   .= "**Used in**:\n\n";
 				$link_list = [];
 				foreach ( $details['files'] as $file ) {
-					$link_list[] = self::get_file_link( $file );
+					$link_list[] = '- ' . self::get_file_link( $file );
 				}
-				$output .= '<dd>' . implode( ', ', $link_list ) . '</dd>';
+				$output .= implode( "\n", $link_list );
+				$output .= "\n\n";
 			}
-			$output .= '</dl>';
 		}
-
-		$output .= '</div>';
 
 		return $output;
 	}
@@ -283,7 +274,7 @@ class HooksDocsGenerator {
 		// Add hooks reference content.
 		$output = self::get_delimited_list_output( $hook_list, $files_to_scan );
 
-		file_put_contents( self::HOOKS_HTML_OUTPUT, $output );
+		file_put_contents( self::HOOKS_MARKDOWN_OUTPUT, $output );
 	}
 }
 

--- a/bin/HooksDocsGenerator.php
+++ b/bin/HooksDocsGenerator.php
@@ -33,13 +33,6 @@ class HooksDocsGenerator {
 	protected const HOOKS_MARKDOWN_OUTPUT = './src/Hooks/README.md';
 
 	/**
-	 * List of files found.
-	 *
-	 * @var array
-	 */
-	protected static $found_files = [];
-
-	/**
 	 * Get files.
 	 *
 	 * @param string $pattern Search pattern.
@@ -62,21 +55,12 @@ class HooksDocsGenerator {
 
 		if ( is_array( $paths ) ) {
 			foreach ( $paths as $p ) {
-				$found_files     = [];
 				$retrieved_files = (array) self::get_files( $pattern, $flags, $p . '/' );
-
-				foreach ( $retrieved_files as $file ) {
-					if ( ! in_array( $file, self::$found_files, true ) ) {
-						$found_files[] = $file;
-					}
-				}
-
-				self::$found_files = array_merge( self::$found_files, $found_files );
-
-				if ( is_array( $files ) && is_array( $found_files ) ) {
-					$files = array_merge( $files, $found_files );
+				if ( is_array( $files ) && is_array( $retrieved_files ) ) {
+					$files = array_merge( $files, $retrieved_files );
 				}
 			}
+
 		}
 		return $files;
 	}
@@ -89,7 +73,7 @@ class HooksDocsGenerator {
 	protected static function get_files_to_scan(): array {
 		$files = [];
 
-		$files['Src'] = self::get_files( '*.php', GLOB_MARK, self::SOURCE_PATH );
+		$files['Src'] = array_unique( self::get_files( '*.php', GLOB_MARK, self::SOURCE_PATH ) );
 		return array_filter( $files );
 	}
 

--- a/bin/HooksDocsGenerator.php
+++ b/bin/HooksDocsGenerator.php
@@ -108,7 +108,7 @@ class HooksDocsGenerator {
 
 			foreach ( $files as $f ) {
 				$current_file     = $f;
-				$tokens           = token_get_all( file_get_contents( $f ) );
+				$tokens           = token_get_all( file_get_contents( $f ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 				$token_type       = false;
 				$current_class    = '';
 				$current_function = '';
@@ -274,7 +274,7 @@ class HooksDocsGenerator {
 		// Add hooks reference content.
 		$output = self::get_delimited_list_output( $hook_list, $files_to_scan );
 
-		file_put_contents( self::HOOKS_MARKDOWN_OUTPUT, $output );
+		file_put_contents( self::HOOKS_MARKDOWN_OUTPUT, $output ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 	}
 }
 

--- a/bin/HooksDocsGenerator.php
+++ b/bin/HooksDocsGenerator.php
@@ -1,0 +1,290 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Util;
+
+/**
+ * Generate documentation for hooks in GLA.
+ *
+ * The code is copied from WooCommerce Code Reference repository:
+ * https://github.com/woocommerce/code-reference/blob/trunk/generate-hook-docs.php
+ * with slightly changes to fit GLA's code structure.
+ *
+ * Example: php bin/HooksDocsGenerator.php
+ *
+ * The HTML output "gla_hooks_reference.html" will be generated in the repo's root directory.
+ */
+class HooksDocsGenerator {
+
+	/**
+	 * Source path.
+	 */
+	protected const SOURCE_PATH = 'src/';
+
+
+	/**
+	 * GLA_GITHUB_PATH
+	 */
+	protected const GLA_GITHUB_PATH = 'https://github.com/woocommerce/google-listings-and-ads/blob/develop/';
+
+	/**
+	 * Hooks docs HTML output.
+	 */
+	protected const HOOKS_HTML_OUTPUT = './gla_hooks_reference.html';
+
+	/**
+	 * List of files found.
+	 *
+	 * @var array
+	 */
+	protected static $found_files = [];
+
+	/**
+	 * Get files.
+	 *
+	 * @param string $pattern Search pattern.
+	 * @param int    $flags   Glob flags.
+	 * @param string $path    Directory path.
+	 * @return array
+	 */
+	protected static function get_files( $pattern, $flags = 0, $path = '' ) {
+		$dir = dirname( $pattern );
+		if ( ! $path && $dir !== '.' ) {
+			if ( '\\' === $dir || '/' === $dir ) {
+					$dir = '';
+			}
+
+			return self::get_files( basename( $pattern ), $flags, $dir . '/' );
+		}
+
+		$paths = glob( $path . '*', GLOB_ONLYDIR | GLOB_NOSORT );
+		$files = glob( $path . $pattern, $flags );
+
+		if ( is_array( $paths ) ) {
+			foreach ( $paths as $p ) {
+				$found_files     = [];
+				$retrieved_files = (array) self::get_files( $pattern, $flags, $p . '/' );
+
+				foreach ( $retrieved_files as $file ) {
+					if ( ! in_array( $file, self::$found_files, true ) ) {
+						$found_files[] = $file;
+					}
+				}
+
+				self::$found_files = array_merge( self::$found_files, $found_files );
+
+				if ( is_array( $files ) && is_array( $found_files ) ) {
+					$files = array_merge( $files, $found_files );
+				}
+			}
+		}
+		return $files;
+	}
+
+	/**
+	 * Get files to scan.
+	 *
+	 * @return array
+	 */
+	protected static function get_files_to_scan(): array {
+		$files = [];
+
+		$files['Src'] = self::get_files( '*.php', GLOB_MARK, self::SOURCE_PATH );
+		return array_filter( $files );
+	}
+
+	/**
+	 * Get hooks.
+	 *
+	 * @param array $files_to_scan Files to scan.
+	 * @return array
+	 */
+	protected static function get_hooks( array $files_to_scan ): array {
+		$scanned = [];
+		$results = [];
+
+		foreach ( $files_to_scan as $heading => $files ) {
+			$hooks_found = [];
+
+			foreach ( $files as $f ) {
+				$current_file     = $f;
+				$tokens           = token_get_all( file_get_contents( $f ) );
+				$token_type       = false;
+				$current_class    = '';
+				$current_function = '';
+
+				if ( in_array( $current_file, $scanned, true ) ) {
+					continue;
+				}
+
+				$scanned[] = $current_file;
+
+				foreach ( $tokens as $index => $token ) {
+					if ( is_array( $token ) ) {
+						$trimmed_token_1 = trim( $token[1] );
+						if ( T_CLASS === $token[0] ) {
+							$token_type = 'class';
+						} elseif ( T_FUNCTION === $token[0] ) {
+							$token_type = 'function';
+						} elseif ( 'do_action' === $token[1] ) {
+							$token_type = 'action';
+						} elseif ( 'apply_filters' === $token[1] ) {
+							$token_type = 'filter';
+						} elseif ( $token_type && ! empty( $trimmed_token_1 ) ) {
+							switch ( $token_type ) {
+								case 'class':
+									$current_class = $token[1];
+									break;
+								case 'function':
+									$current_function = $token[1];
+									break;
+								case 'filter':
+								case 'action':
+									$hook = trim( $token[1], "'" );
+									$hook = str_replace( '_FUNCTION_', strtoupper( $current_function ), $hook );
+									$hook = str_replace( '_CLASS_', strtoupper( $current_class ), $hook );
+									$hook = str_replace( '$this', strtoupper( $current_class ), $hook );
+									$hook = str_replace( [ '.', '{', '}', '"', "'", ' ', ')', '(' ], '', $hook );
+									$hook = preg_replace( '/\/\/phpcs:(.*)(\n)/', '', $hook );
+									$loop = 0;
+
+									// Keep adding to hook until we find a comma or colon.
+									while ( 1 ) {
+										$loop++;
+										$prev_hook = is_string( $tokens[ $index + $loop - 1 ] ) ? $tokens[ $index + $loop - 1 ] : $tokens[ $index + $loop - 1 ][1];
+										$next_hook = is_string( $tokens[ $index + $loop ] ) ? $tokens[ $index + $loop ] : $tokens[ $index + $loop ][1];
+
+										if ( in_array( $next_hook, [ '.', '{', '}', '"', "'", ' ', ')', '(' ], true ) ) {
+											continue;
+										}
+
+										if ( in_array( $next_hook, [ ',', ';' ], true ) ) {
+											break;
+										}
+
+										$hook_first = substr( $next_hook, 0, 1 );
+										$hook_last  = substr( $next_hook, -1, 1 );
+
+										if ( '{' === $hook_first || '}' === $hook_last || '$' === $hook_first || ')' === $hook_last || '>' === substr( $prev_hook, -1, 1 ) ) {
+											$next_hook = strtoupper( $next_hook );
+										}
+
+										$next_hook = str_replace( [ '.', '{', '}', '"', "'", ' ', ')', '(' ], '', $next_hook );
+
+										$hook .= $next_hook;
+									}
+
+									$hook = trim( $hook );
+
+									if ( isset( $hooks_found[ $hook ] ) ) {
+										$hooks_found[ $hook ]['files'][] = [
+											'path' => $current_file,
+											'line' => $token[2],
+										];
+									} else {
+										$hooks_found[ $hook ] = [
+											'files'    => [
+												[
+													'path' => $current_file,
+													'line' => $token[2],
+												],
+											],
+											'class'    => $current_class,
+											'function' => $current_function,
+											'type'     => $token_type,
+										];
+									}
+									break;
+							}
+							$token_type = false;
+						}
+					}
+				}
+			}
+
+			ksort( $hooks_found );
+
+			if ( ! empty( $hooks_found ) ) {
+					$results[ $heading ] = $hooks_found;
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Get file URL.
+	 *
+	 * @param array $file File data.
+	 * @return string
+	 */
+	protected static function get_file_url( array $file ): string {
+		$url = str_replace( '.php', '.php#L' . $file['line'], $file['path'] );
+		return $url;
+	}
+
+	/**
+	 * Get file link.
+	 *
+	 * @param array $file File data.
+	 * @return string
+	 */
+	protected static function get_file_link( array $file ): string {
+		return '<a href="' . self::GLA_GITHUB_PATH . self::get_file_url( $file ) . '">' . basename( $file['path'] ) . '</a>';
+	}
+
+	/**
+	 * Get delimited list output.
+	 *
+	 * @param array $hook_list List of hooks.
+	 * @param array $files_to_scan List of files to scan.
+	 */
+	protected static function get_delimited_list_output( array $hook_list, array $files_to_scan ): string {
+		$output = '';
+
+		$index = [];
+		foreach ( $files_to_scan as $heading => $files ) {
+				$index[] = '<a href="#hooks-' . str_replace( ' ', '-', strtolower( $heading ) ) . '">' . $heading . '</a>';
+		}
+
+		$output .= '<p>' . implode( ', ', $index ) . '</p>';
+
+		$output .= '<div class="hooks-reference">';
+		foreach ( $hook_list as $heading => $hooks ) {
+			$output .= '<h2 id="hooks-' . str_replace( ' ', '-', strtolower( $heading ) ) . '">' . $heading . '</h2>';
+			$output .= '<dl class="phpdocumentor-table-of-contents">';
+			foreach ( $hooks as $hook => $details ) {
+				$output   .= '<dt class="phpdocumentor-table-of-contents__entry -' . $details['type'] . '">' . $hook . '</dt>';
+				$link_list = [];
+				foreach ( $details['files'] as $file ) {
+					$link_list[] = self::get_file_link( $file );
+				}
+				$output .= '<dd>' . implode( ', ', $link_list ) . '</dd>';
+			}
+			$output .= '</dl>';
+		}
+
+		$output .= '</div>';
+
+		return $output;
+	}
+
+	/**
+	 * Generate hooks documentation.
+	 */
+	public static function generate_hooks_docs() {
+		$files_to_scan = self::get_files_to_scan();
+		$hook_list     = self::get_hooks( $files_to_scan );
+
+		if ( empty( $hook_list ) ) {
+			return;
+		}
+
+		// Add hooks reference content.
+		$output = self::get_delimited_list_output( $hook_list, $files_to_scan );
+
+		file_put_contents( self::HOOKS_HTML_OUTPUT, $output );
+	}
+}
+
+HooksDocsGenerator::generate_hooks_docs();

--- a/bin/HooksDocsGenerator.php
+++ b/bin/HooksDocsGenerator.php
@@ -72,7 +72,8 @@ class HooksDocsGenerator {
 	protected static function get_files_to_scan(): array {
 		$files = [];
 
-		$files['Src'] = array_unique( self::get_files( '*.php', GLOB_MARK, self::SOURCE_PATH ) );
+		$files['Main'] = [ 'google-listings-and-ads.php' ];
+		$files['Src']  = array_unique( self::get_files( '*.php', GLOB_MARK, self::SOURCE_PATH ) );
 		return array_filter( $files );
 	}
 

--- a/src/Hooks/README.md
+++ b/src/Hooks/README.md
@@ -1,0 +1,501 @@
+# Hooks Reference
+
+A list of hooks, i.e `actions` and `filters`, that are defined or used in this project.
+
+## add_woocommerce_extended_task_list_item
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/TaskList/CompleteSetup.php#L61">CompleteSetup.php#L61</a>
+
+## remove_woocommerce_extended_task_list_item
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/TaskList/CompleteSetup.php#L102">CompleteSetup.php#L102</a>
+
+## woocommerce_gla_batch_deleted_products
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L221">ProductSyncer.php#L221</a>
+
+## woocommerce_gla_batch_retry_delete_products
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L341">ProductSyncer.php#L341</a>
+
+## woocommerce_gla_batch_retry_update_products
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L290">ProductSyncer.php#L290</a>
+
+## woocommerce_gla_batch_updated_products
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L135">ProductSyncer.php#L135</a>
+
+## woocommerce_gla_batched_job_size
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104">AbstractBatchedActionSchedulerJob.php#L104</a>
+
+## woocommerce_gla_coupons_delete_retry_on_failure
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L437">CouponSyncer.php#L437</a>
+
+## woocommerce_gla_coupons_update_retry_on_failure
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L399">CouponSyncer.php#L399</a>
+
+## woocommerce_gla_custom_merchant_issues
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L435">MerchantStatuses.php#L435</a>
+
+## woocommerce_gla_debug_message
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponHelper.php#L255">CouponHelper.php#L255</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponHelper.php#L292">CouponHelper.php#L292</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L102">CouponSyncer.php#L102</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L115">CouponSyncer.php#L115</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L140">CouponSyncer.php#L140</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L154">CouponSyncer.php#L154</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L171">CouponSyncer.php#L171</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L194">CouponSyncer.php#L194</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L259">CouponSyncer.php#L259</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L308">CouponSyncer.php#L308</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L327">CouponSyncer.php#L327</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/SyncerHooks.php#L177">SyncerHooks.php#L177</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/BatchProductHelper.php#L195">BatchProductHelper.php#L195</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/BatchProductHelper.php#L218">BatchProductHelper.php#L218</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L427">ProductHelper.php#L427</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L459">ProductHelper.php#L459</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductRepository.php#L296">ProductRepository.php#L296</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L141">ProductSyncer.php#L141</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L151">ProductSyncer.php#L151</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L227">ProductSyncer.php#L227</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L237">ProductSyncer.php#L237</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/SyncerHooks.php#L197">SyncerHooks.php#L197</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L194">WCProductAdapter.php#L194</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/DB/ProductMetaQueryHelper.php#L92">ProductMetaQueryHelper.php#L92</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/DB/ProductMetaQueryHelper.php#L123">ProductMetaQueryHelper.php#L123</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantCenterService.php#L304">MerchantCenterService.php#L304</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L334">MerchantStatuses.php#L334</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L357">MerchantStatuses.php#L357</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/ActionSchedulerJobMonitor.php#L117">ActionSchedulerJobMonitor.php#L117</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/ActionSchedulerJobMonitor.php#L126">ActionSchedulerJobMonitor.php#L126</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/CleanupSyncedProducts.php#L74">CleanupSyncedProducts.php#L74</a>
+
+## woocommerce_gla_deleted_promotions
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L321">CouponSyncer.php#L321</a>
+
+## woocommerce_gla_dimension_unit
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L409">WCProductAdapter.php#L409</a>
+
+## woocommerce_gla_enable_connection_test
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/ConnectionTest.php#L87">ConnectionTest.php#L87</a>
+
+## woocommerce_gla_enable_debug_logging
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Logging/DebugLogger.php#L33">DebugLogger.php#L33</a>
+
+## woocommerce_gla_enable_reports
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Admin.php#L239">Admin.php#L239</a>
+
+## woocommerce_gla_error
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponMetaHandler.php#L220">CouponMetaHandler.php#L220</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L409">CouponSyncer.php#L409</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L447">CouponSyncer.php#L447</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L465">CouponSyncer.php#L465</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/BatchProductHelper.php#L235">BatchProductHelper.php#L235</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L319">ProductHelper.php#L319</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L501">ProductHelper.php#L501</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductMetaHandler.php#L173">ProductMetaHandler.php#L173</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L293">ProductSyncer.php#L293</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L316">ProductSyncer.php#L316</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L344">ProductSyncer.php#L344</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L359">ProductSyncer.php#L359</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L136">PHPView.php#L136</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L164">PHPView.php#L164</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L208">PHPView.php#L208</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/DB/ProductMetaQueryHelper.php#L139">ProductMetaQueryHelper.php#L139</a>
+
+## woocommerce_gla_exception
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Integration/WooCommercePreOrders.php#L111">WooCommercePreOrders.php#L111</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Integration/WooCommercePreOrders.php#L131">WooCommercePreOrders.php#L131</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L202">CouponSyncer.php#L202</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L292">CouponSyncer.php#L292</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L126">ProductSyncer.php#L126</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L212">ProductSyncer.php#L212</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Notes/NoteInitializer.php#L74">NoteInitializer.php#L74</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Notes/NoteInitializer.php#L116">NoteInitializer.php#L116</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L87">PHPView.php#L87</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Assets/AdminScriptWithBuiltDependenciesAsset.php#L64">AdminScriptWithBuiltDependenciesAsset.php#L64</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Event/ClearProductStatsCache.php#L61">ClearProductStatsCache.php#L61</a>
+
+## woocommerce_gla_force_run_install
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Installer.php#L82">Installer.php#L82</a>
+
+## woocommerce_gla_get_sync_ready_products_filter
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductFilter.php#L61">ProductFilter.php#L61</a>
+
+## woocommerce_gla_get_sync_ready_products_pre_filter
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductFilter.php#L47">ProductFilter.php#L47</a>
+
+## woocommerce_gla_hidden_coupon_types
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L378">CouponSyncer.php#L378</a>
+
+## woocommerce_gla_hidden_product_types
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L267">ProductSyncer.php#L267</a>
+
+## woocommerce_gla_job_failure_rate_threshold
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/ActionSchedulerJobMonitor.php#L186">ActionSchedulerJobMonitor.php#L186</a>
+
+## woocommerce_gla_job_failure_timeframe
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/ActionSchedulerJobMonitor.php#L195">ActionSchedulerJobMonitor.php#L195</a>
+
+## woocommerce_gla_mc_account_review_lifetime
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Google/RequestReviewStatuses.php#L146">RequestReviewStatuses.php#L146</a>
+
+## woocommerce_gla_mc_status_lifetime
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L735">MerchantStatuses.php#L735</a>
+
+## woocommerce_gla_merchant_status_google_ids_chunk
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L191">MerchantStatuses.php#L191</a>
+
+## woocommerce_gla_merchant_status_presync_issues_chunk
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L531">MerchantStatuses.php#L531</a>
+
+## woocommerce_gla_options_deleted_$NAME
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Options/Options.php#L103">Options.php#L103</a>
+
+## woocommerce_gla_options_updated_$NAME
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Options/Options.php#L65">Options.php#L65</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Options/Options.php#L85">Options.php#L85</a>
+
+## woocommerce_gla_product_attribute_value_$ATTRIBUTE_ID
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L866">WCProductAdapter.php#L866</a>
+
+## woocommerce_gla_product_attribute_value_description
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L330">WCProductAdapter.php#L330</a>
+
+## woocommerce_gla_product_attribute_value_price
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L612">WCProductAdapter.php#L612</a>
+
+## woocommerce_gla_product_attribute_value_sale_price
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L662">WCProductAdapter.php#L662</a>
+
+## woocommerce_gla_product_attribute_values
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L158">WCProductAdapter.php#L158</a>
+
+## woocommerce_gla_product_description_apply_shortcodes
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L299">WCProductAdapter.php#L299</a>
+
+## woocommerce_gla_products_delete_retry_on_failure
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L340">ProductSyncer.php#L340</a>
+
+## woocommerce_gla_products_update_retry_on_failure
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L289">ProductSyncer.php#L289</a>
+
+## woocommerce_gla_ready_for_syncing
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantCenterService.php#L118">MerchantCenterService.php#L118</a>
+
+## woocommerce_gla_retry_delete_coupons
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L442">CouponSyncer.php#L442</a>
+
+## woocommerce_gla_retry_update_coupons
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L404">CouponSyncer.php#L404</a>
+
+## woocommerce_gla_site_claim_failure
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L365">AccountService.php#L365</a>
+
+## woocommerce_gla_site_claim_overwrite_required
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L360">AccountService.php#L360</a>
+
+## woocommerce_gla_site_url
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/PluginHelper.php#L180">PluginHelper.php#L180</a>
+
+## woocommerce_gla_supported_coupon_types
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L365">CouponSyncer.php#L365</a>
+
+## woocommerce_gla_supported_product_types
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L256">ProductSyncer.php#L256</a>
+
+## woocommerce_gla_tax_excluded
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L573">WCProductAdapter.php#L573</a>
+
+## woocommerce_gla_updated_coupon
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L168">CouponSyncer.php#L168</a>
+
+## woocommerce_gla_url_switch_required
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L445">AccountService.php#L445</a>
+
+## woocommerce_gla_url_switch_success
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L468">AccountService.php#L468</a>
+
+## woocommerce_gla_use_short_description
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L276">WCProductAdapter.php#L276</a>
+
+## woocommerce_gla_wcs_url
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/PluginHelper.php#L165">PluginHelper.php#L165</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/PluginHelper.php#L169">PluginHelper.php#L169</a>
+
+## woocommerce_gla_weight_unit
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L410">WCProductAdapter.php#L410</a>
+
+## woocommerce_hide_invisible_variations
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L334">ProductHelper.php#L334</a>
+

--- a/src/Hooks/README.md
+++ b/src/Hooks/README.md
@@ -10,6 +10,14 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/TaskList/CompleteSetup.php#L61">CompleteSetup.php#L61</a>
 
+## bulk_edit_save_post
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/BulkEdit/BulkEditInitializer.php#L36">BulkEditInitializer.php#L36</a>
+
 ## remove_woocommerce_extended_task_list_item
 
 **Type**: action
@@ -17,6 +25,75 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 **Used in**:
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/TaskList/CompleteSetup.php#L102">CompleteSetup.php#L102</a>
+
+## woocommerce_admin_disabled
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Internal/Requirements/WCAdminValidator.php#L38">WCAdminValidator.php#L38</a>
+
+## woocommerce_gla_ads_billing_setup_status
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L108">Ads.php#L108</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L117">Ads.php#L117</a>
+
+## woocommerce_gla_ads_client_exception
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L69">Ads.php#L69</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L113">Ads.php#L113</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L168">Ads.php#L168</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L203">Ads.php#L203</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L118">AdsCampaign.php#L118</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L161">AdsCampaign.php#L161</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L221">AdsCampaign.php#L221</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L276">AdsCampaign.php#L276</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L310">AdsCampaign.php#L310</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsConversionAction.php#L95">AdsConversionAction.php#L95</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsConversionAction.php#L137">AdsConversionAction.php#L137</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsReport.php#L90">AdsReport.php#L90</a>
+
+## woocommerce_gla_ads_setup_completed
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/Ads/SetupCompleteController.php#L46">SetupCompleteController.php#L46</a>
+
+## woocommerce_gla_attribute_applicable_product_types_$ATTRIBUTE_ID
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Product/Attributes/AttributesForm.php#L69">AttributesForm.php#L69</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/Attributes/AttributeManager.php#L295">AttributeManager.php#L295</a>
+
+## woocommerce_gla_attribute_hidden_product_types_$ATTRIBUTE_ID
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Product/Attributes/AttributesForm.php#L74">AttributesForm.php#L74</a>
+
+## woocommerce_gla_attributes_tab_applicable_product_types
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Product/Attributes/AttributesTab.php#L190">AttributesTab.php#L190</a>
 
 ## woocommerce_gla_batch_deleted_products
 
@@ -57,6 +134,22 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 **Used in**:
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104">AbstractBatchedActionSchedulerJob.php#L104</a>
+
+## woocommerce_gla_bulk_update_coupon
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/BulkEdit/CouponBulkEdit.php#L134">CouponBulkEdit.php#L134</a>
+
+## woocommerce_gla_conversion_action_name
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsConversionAction.php#L64">AdsConversionAction.php#L64</a>
 
 ## woocommerce_gla_coupons_delete_retry_on_failure
 
@@ -113,6 +206,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L194">WCProductAdapter.php#L194</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/DB/ProductMetaQueryHelper.php#L92">ProductMetaQueryHelper.php#L92</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/DB/ProductMetaQueryHelper.php#L123">ProductMetaQueryHelper.php#L123</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L96">IssuesController.php#L96</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantCenterService.php#L304">MerchantCenterService.php#L304</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L334">MerchantStatuses.php#L334</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L357">MerchantStatuses.php#L357</a>
@@ -178,6 +272,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L316">ProductSyncer.php#L316</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L344">ProductSyncer.php#L344</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L359">ProductSyncer.php#L359</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/Attributes/AttributeManager.php#L269">AttributeManager.php#L269</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L136">PHPView.php#L136</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L164">PHPView.php#L164</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L208">PHPView.php#L208</a>
@@ -191,6 +286,11 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Integration/WooCommercePreOrders.php#L111">WooCommercePreOrders.php#L111</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Integration/WooCommercePreOrders.php#L131">WooCommercePreOrders.php#L131</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Input/DateTime.php#L44">DateTime.php#L44</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Input/DateTime.php#L80">DateTime.php#L80</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L190">ChannelVisibilityMetaBox.php#L190</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197">CouponChannelVisibilityMetaBox.php#L197</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Internal/DependencyManagement/GoogleServiceProvider.php#L216">GoogleServiceProvider.php#L216</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L202">CouponSyncer.php#L202</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L292">CouponSyncer.php#L292</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L126">ProductSyncer.php#L126</a>
@@ -198,6 +298,11 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Notes/NoteInitializer.php#L74">NoteInitializer.php#L74</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Notes/NoteInitializer.php#L116">NoteInitializer.php#L116</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L87">PHPView.php#L87</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L95">Connection.php#L95</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L234">ContactInformationController.php#L234</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193">ProductVisibilityController.php#L193</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L79">SettingsSyncController.php#L79</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/Update/PluginUpdate.php#L75">PluginUpdate.php#L75</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Assets/AdminScriptWithBuiltDependenciesAsset.php#L64">AdminScriptWithBuiltDependenciesAsset.php#L64</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Event/ClearProductStatsCache.php#L61">ClearProductStatsCache.php#L61</a>
 
@@ -224,6 +329,43 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 **Used in**:
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductFilter.php#L47">ProductFilter.php#L47</a>
+
+## woocommerce_gla_guzzle_client_exception
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Internal/DependencyManagement/GoogleServiceProvider.php#L240">GoogleServiceProvider.php#L240</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L70">Connection.php#L70</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L91">Connection.php#L91</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L126">Connection.php#L126</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L80">Middleware.php#L80</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L178">Middleware.php#L178</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L228">Middleware.php#L228</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L273">Middleware.php#L273</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L344">Middleware.php#L344</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L394">Middleware.php#L394</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L418">Middleware.php#L418</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L452">Middleware.php#L452</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L552">Middleware.php#L552</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L611">Middleware.php#L611</a>
+
+## woocommerce_gla_guzzle_invalid_response
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L66">Connection.php#L66</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L121">Connection.php#L121</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L159">Middleware.php#L159</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L223">Middleware.php#L223</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L267">Middleware.php#L267</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L339">Middleware.php#L339</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L389">Middleware.php#L389</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L548">Middleware.php#L548</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L599">Middleware.php#L599</a>
 
 ## woocommerce_gla_hidden_coupon_types
 
@@ -265,6 +407,29 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Google/RequestReviewStatuses.php#L146">RequestReviewStatuses.php#L146</a>
 
+## woocommerce_gla_mc_client_exception
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L91">Merchant.php#L91</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L139">Merchant.php#L139</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L171">Merchant.php#L171</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L190">Merchant.php#L190</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L237">Merchant.php#L237</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L282">Merchant.php#L282</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L335">Merchant.php#L335</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/MerchantReport.php#L95">MerchantReport.php#L95</a>
+
+## woocommerce_gla_mc_settings_sync
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69">SettingsSyncController.php#L69</a>
+
 ## woocommerce_gla_mc_status_lifetime
 
 **Type**: filter
@@ -272,6 +437,14 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 **Used in**:
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L735">MerchantStatuses.php#L735</a>
+
+## woocommerce_gla_merchant_issue_override
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L86">IssuesController.php#L86</a>
 
 ## woocommerce_gla_merchant_status_google_ids_chunk
 
@@ -306,6 +479,22 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Options/Options.php#L65">Options.php#L65</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Options/Options.php#L85">Options.php#L85</a>
 
+## woocommerce_gla_prepared_response_$THIS->GET_ROUTE_NAME$REQUEST
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/BaseController.php#L158">BaseController.php#L158</a>
+
+## woocommerce_gla_product_attribute_types
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/Attributes/AttributeManager.php#L243">AttributeManager.php#L243</a>
+
 ## woocommerce_gla_product_attribute_value_$ATTRIBUTE_ID
 
 **Type**: filter
@@ -321,6 +510,14 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 **Used in**:
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L330">WCProductAdapter.php#L330</a>
+
+## woocommerce_gla_product_attribute_value_options_$ATTRIBUTE::get_id
+
+**Type**: filter
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Product/Attributes/AttributesForm.php#L108">AttributesForm.php#L108</a>
 
 ## woocommerce_gla_product_attribute_value_price
 
@@ -378,6 +575,24 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantCenterService.php#L118">MerchantCenterService.php#L118</a>
 
+## woocommerce_gla_request_review_failure
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L592">Middleware.php#L592</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110">RequestReviewController.php#L110</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122">RequestReviewController.php#L122</a>
+
+## woocommerce_gla_request_review_response
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L545">Middleware.php#L545</a>
+
 ## woocommerce_gla_retry_delete_coupons
 
 **Type**: action
@@ -400,6 +615,9 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L92">Merchant.php#L92</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L268">Middleware.php#L268</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L274">Middleware.php#L274</a>
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L365">AccountService.php#L365</a>
 
 ## woocommerce_gla_site_claim_overwrite_required
@@ -410,6 +628,15 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L360">AccountService.php#L360</a>
 
+## woocommerce_gla_site_claim_success
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L89">Merchant.php#L89</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L263">Middleware.php#L263</a>
+
 ## woocommerce_gla_site_url
 
 **Type**: filter
@@ -417,6 +644,24 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 **Used in**:
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/PluginHelper.php#L180">PluginHelper.php#L180</a>
+
+## woocommerce_gla_site_verify_failure
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L56">SiteVerification.php#L56</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L64">SiteVerification.php#L64</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L85">SiteVerification.php#L85</a>
+
+## woocommerce_gla_site_verify_success
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L83">SiteVerification.php#L83</a>
 
 ## woocommerce_gla_supported_coupon_types
 
@@ -433,6 +678,15 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 **Used in**:
 
 - <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L256">ProductSyncer.php#L256</a>
+
+## woocommerce_gla_sv_client_exception
+
+**Type**: action
+
+**Used in**:
+
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L118">SiteVerification.php#L118</a>
+- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L154">SiteVerification.php#L154</a>
 
 ## woocommerce_gla_tax_excluded
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a script to generate a list of hooks (actions or filters) that is defined or used in this project. The output file is generated in `src/Hooks/README.md`.

The majority of the codes were copied fro [WooCommerce Code Reference](https://github.com/woocommerce/code-reference/blob/331da252e94b3e6529d2d42f6636200ca30dcfe4/generate-hook-docs.php) repo, and they're published in https://woocommerce.github.io/code-reference/hooks/hooks.html.

Since the hooks in GLA project are mostly used internally so generated as a markdown file would be good enough.

### Detailed test instructions:

1. Run `php bin/HooksDocsGenerator.php`
2. See if the script generated a markdown file in `src/Hooks/README.md`

### Changelog entry

> Add - A script to generate a list of hooks that defined or used in GLA.
