### PR TITLE
Generate random ID for postcode regions when syncing shipping settings

### DIFF
--- a/src/Shipping/GoogleAdapter/PostcodesRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/PostcodesRateGroupAdapter.php
@@ -30,7 +30,12 @@ class PostcodesRateGroupAdapter extends AbstractRateGroupAdapter {
 		$postal_codes = [];
 		$rows         = [];
 		foreach ( $location_rates as $location_rate ) {
-			$postcode_name                  = $location_rate->get_location()->get_postcode_group_name();
+			$region = $location_rate->get_location()->get_shipping_region();
+			if ( empty( $region ) ) {
+				continue;
+			}
+
+			$postcode_name                  = $region->get_id();
 			$postal_codes[ $postcode_name ] = $postcode_name;
 
 			$rows[ $postcode_name ] = new Row( [ 'cells' => [ $this->create_value_object( $location_rate->get_shipping_rate()->get_rate(), $currency ) ] ] );

--- a/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
@@ -188,12 +188,13 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 
 		foreach ( $location_rates as $location_rate ) {
 			$location = $location_rate->get_location();
-			if ( empty( $location->get_postcodes() ) ) {
+			if ( empty( $location->get_shipping_region() ) ) {
 				continue;
 			}
+			$region = $location->get_shipping_region();
 
 			$postcode_ranges = [];
-			foreach ( $location->get_postcodes() as $postcode_range ) {
+			foreach ( $region->get_postcode_ranges() as $postcode_range ) {
 				$postcode_ranges[] = new PostalCodeRange(
 					[
 						'postalCodeRangeBegin' => $postcode_range->get_start_code(),
@@ -202,10 +203,9 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 				);
 			}
 
-			$postcode_name                     = $location->get_postcode_group_name();
-			$postcode_groups[ $postcode_name ] = new PostalCodeGroup(
+			$postcode_groups[ $region->get_id() ] = new PostalCodeGroup(
 				[
-					'name'             => $postcode_name,
+					'name'             => $region->get_id(),
 					'country'          => $location->get_country(),
 					'postalCodeRanges' => $postcode_ranges,
 				]

--- a/src/Shipping/ShippingLocation.php
+++ b/src/Shipping/ShippingLocation.php
@@ -108,7 +108,7 @@ class ShippingLocation {
 		if ( ! empty( $this->get_shipping_region() ) ) {
 			// We assume that each postcode is unique within any supported country (a requirement set by Google API).
 			// Therefore, there is no need to include the state name in the location string even if it's provided.
-			$code .= '::' . $this->get_shipping_region()->get_id();
+			$code .= '::' . $this->get_shipping_region();
 		} elseif ( ! empty( $this->get_state() ) ) {
 			$code .= '_' . $this->get_state();
 		}

--- a/src/Shipping/ShippingLocation.php
+++ b/src/Shipping/ShippingLocation.php
@@ -33,23 +33,23 @@ class ShippingLocation {
 	protected $state;
 
 	/**
-	 * @var PostcodeRange[]
+	 * @var ShippingRegion
 	 */
-	protected $postcodes;
+	protected $shipping_region;
 
 	/**
 	 * ShippingLocation constructor.
 	 *
-	 * @param int                  $google_id
-	 * @param string               $country
-	 * @param string|null          $state
-	 * @param PostcodeRange[]|null $postcodes
+	 * @param int                 $google_id
+	 * @param string              $country
+	 * @param string|null         $state
+	 * @param ShippingRegion|null $shipping_region
 	 */
-	public function __construct( int $google_id, string $country, ?string $state = null, ?array $postcodes = null ) {
-		$this->google_id = $google_id;
-		$this->country   = $country;
-		$this->state     = $state;
-		$this->postcodes = $postcodes;
+	public function __construct( int $google_id, string $country, ?string $state = null, ShippingRegion $shipping_region = null ) {
+		$this->google_id       = $google_id;
+		$this->country         = $country;
+		$this->state           = $state;
+		$this->shipping_region = $shipping_region;
 	}
 
 	/**
@@ -74,27 +74,10 @@ class ShippingLocation {
 	}
 
 	/**
-	 * @return PostcodeRange[]|null
+	 * @return ShippingRegion|null
 	 */
-	public function get_postcodes(): ?array {
-		return $this->postcodes;
-	}
-
-	/**
-	 * Return the postcode group name for this location.
-	 *
-	 * @return string Serialized string representation of the postcodes, or an empty string if the location doesn't have any postcodes.
-	 */
-	public function get_postcode_group_name(): string {
-		if ( empty( $this->get_postcodes() ) ) {
-			return '';
-		}
-
-		return sprintf(
-			'%s - %s',
-			$this->get_country(),
-			join( ',', $this->get_postcodes() )
-		);
+	public function get_shipping_region(): ?ShippingRegion {
+		return $this->shipping_region;
 	}
 
 	/**
@@ -103,7 +86,7 @@ class ShippingLocation {
 	 * @return string
 	 */
 	public function get_applicable_area(): string {
-		if ( ! empty( $this->get_postcodes() ) ) {
+		if ( ! empty( $this->get_shipping_region() ) ) {
 			// ShippingLocation applies to a select postal code ranges of a country
 			return self::POSTCODE_AREA;
 		} elseif ( ! empty( $this->get_state() ) ) {
@@ -122,10 +105,10 @@ class ShippingLocation {
 	 */
 	public function __toString() {
 		$code = $this->get_country();
-		if ( ! empty( $this->get_postcodes() ) ) {
+		if ( ! empty( $this->get_shipping_region() ) ) {
 			// We assume that each postcode is unique within any supported country (a requirement set by Google API).
 			// Therefore, there is no need to include the state name in the location string even if it's provided.
-			$code .= '::' . join( ',', $this->get_postcodes() );
+			$code .= '::' . $this->get_shipping_region()->get_id();
 		} elseif ( ! empty( $this->get_state() ) ) {
 			$code .= '_' . $this->get_state();
 		}

--- a/src/Shipping/ShippingRegion.php
+++ b/src/Shipping/ShippingRegion.php
@@ -1,0 +1,81 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ShippingRegion
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
+ *
+ * @since x.x.x
+ */
+class ShippingRegion {
+
+	/**
+	 * @var string
+	 */
+	protected $id;
+
+	/**
+	 * @var string
+	 */
+	protected $country;
+
+	/**
+	 * @var PostcodeRange[]
+	 */
+	protected $postcode_ranges;
+
+	/**
+	 * ShippingRegion constructor.
+	 *
+	 * @param string          $id
+	 * @param string          $country
+	 * @param PostcodeRange[] $postcode_ranges
+	 */
+	public function __construct( string $id, string $country, array $postcode_ranges ) {
+		$this->id              = $id;
+		$this->country         = $country;
+		$this->postcode_ranges = $postcode_ranges;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_id(): string {
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_country(): string {
+		return $this->country;
+	}
+
+	/**
+	 * @return PostcodeRange[]
+	 */
+	public function get_postcode_ranges(): array {
+		return $this->postcode_ranges;
+	}
+
+	/**
+	 * Generate a random ID for the region.
+	 *
+	 * For privacy reasons, the region ID value must be a randomized set of numbers (minimum 6 digits)
+	 *
+	 * @return int
+	 *
+	 * @throws \Exception If generating a random ID fails.
+	 *
+	 * @link https://support.google.com/merchants/answer/9698880?hl=en#requirements
+	 */
+	public static function generate_random_id(): string {
+		return (string) random_int( 100000, PHP_INT_MAX );
+	}
+
+}

--- a/src/Shipping/ShippingRegion.php
+++ b/src/Shipping/ShippingRegion.php
@@ -78,4 +78,13 @@ class ShippingRegion {
 		return (string) random_int( 100000, PHP_INT_MAX );
 	}
 
+	/**
+	 * Returns the string representation of this object.
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		return $this->get_country() . join( ',', $this->get_postcode_ranges() );
+	}
+
 }

--- a/src/Shipping/ShippingRegion.php
+++ b/src/Shipping/ShippingRegion.php
@@ -68,7 +68,7 @@ class ShippingRegion {
 	 *
 	 * For privacy reasons, the region ID value must be a randomized set of numbers (minimum 6 digits)
 	 *
-	 * @return int
+	 * @return string
 	 *
 	 * @throws \Exception If generating a random ID fails.
 	 *

--- a/tests/Unit/Shipping/CountryRatesCollectionTest.php
+++ b/tests/Unit/Shipping/CountryRatesCollectionTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\CountryRatesCollection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\PostcodeRange;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ServiceRatesCollection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRate;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRegion;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 
 /**
@@ -44,6 +45,7 @@ class CountryRatesCollectionTest extends UnitTest {
 	public function test_returns_rates_grouped_by_service() {
 		$min_order_rate = new ShippingRate( 0 );
 		$min_order_rate->set_min_order_amount( 1000 );
+		$region_1       = new ShippingRegion( '123456', 'US', [ new PostcodeRange( '4000', '4001' ) ] );
 		$location_rates = [
 			// Country level
 			new LocationRate( new ShippingLocation( 0, 'US' ), $min_order_rate ),
@@ -52,7 +54,7 @@ class CountryRatesCollectionTest extends UnitTest {
 			new LocationRate( new ShippingLocation( 1, 'US', 'CA' ), new ShippingRate( 100 ) ),
 			new LocationRate( new ShippingLocation( 1, 'US', 'CA' ), new ShippingRate( 0 ) ),
 			// Country post code level
-			new LocationRate( new ShippingLocation( 0, 'US', null, [ new PostcodeRange( '4000', '4001' ) ] ), new ShippingRate( 110 ) ),
+			new LocationRate( new ShippingLocation( 0, 'US', null, $region_1 ), new ShippingRate( 110 ) ),
 		];
 
 		$collection = new CountryRatesCollection( 'US', $location_rates );
@@ -63,12 +65,15 @@ class CountryRatesCollectionTest extends UnitTest {
 	}
 
 	public function test_returns_rates_applicable_to_both_states_and_postcode_under_same_service_as_country_postcodes() {
+		$region_1       = new ShippingRegion( '123456', 'US', [ new PostcodeRange( '4000', '4001' ) ] );
+		$region_2       = new ShippingRegion( '123456', 'US', [ new PostcodeRange( '9000', '9001' ) ] );
+		$region_3       = new ShippingRegion( '123456', 'US', [ new PostcodeRange( '2000', '2001' ) ] );
 		$location_rates = [
 			// Country post code level
-			new LocationRate( new ShippingLocation( 0, 'US', null, [ new PostcodeRange( '4000', '4001' ) ] ), new ShippingRate( 110 ) ),
+			new LocationRate( new ShippingLocation( 0, 'US', null, $region_1 ), new ShippingRate( 110 ) ),
 			// State post code level
-			new LocationRate( new ShippingLocation( 1, 'US', 'CA', [ new PostcodeRange( '9000', '9001' ) ] ), new ShippingRate( 10 ) ),
-			new LocationRate( new ShippingLocation( 1, 'US', 'NV', [ new PostcodeRange( '2000', '2001' ) ] ), new ShippingRate( 10 ) ),
+			new LocationRate( new ShippingLocation( 1, 'US', 'CA', $region_2 ), new ShippingRate( 10 ) ),
+			new LocationRate( new ShippingLocation( 1, 'US', 'NV', $region_3 ), new ShippingRate( 10 ) ),
 		];
 
 		$collection = new CountryRatesCollection( 'US', $location_rates );

--- a/tests/Unit/Shipping/GoogleAdapter/PostcodesRateGroupAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/PostcodesRateGroupAdapterTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingLocation;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\PostcodeRange;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRate;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRegion;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Google\Service\ShoppingContent\Row;
 
@@ -20,9 +21,12 @@ use Google\Service\ShoppingContent\Row;
 class PostcodesRateGroupAdapterTest extends UnitTest {
 
 	public function test_maps_location_rates() {
+		$region_1 = new ShippingRegion( '123456', 'US', [ new PostcodeRange( '4000', '4001' ) ] );
+		$region_2 = new ShippingRegion( '234567', 'AU', [ new PostcodeRange( '1000', '1001' ) ] );
+
 		$location_rates = [
-			new LocationRate( new ShippingLocation( 0, 'US', null, [ new PostcodeRange( '4000', '4001' ) ] ), new ShippingRate( 110 ) ),
-			new LocationRate( new ShippingLocation( 4, 'AU', null, [ new PostcodeRange( '1000', '1001' ) ] ), new ShippingRate( 410 ) ),
+			new LocationRate( new ShippingLocation( 0, 'US', null, $region_1 ), new ShippingRate( 110 ) ),
+			new LocationRate( new ShippingLocation( 4, 'AU', null, $region_2 ), new ShippingRate( 410 ) ),
 		];
 
 		$rate_group = new PostcodesRateGroupAdapter(
@@ -39,8 +43,8 @@ class PostcodesRateGroupAdapterTest extends UnitTest {
 
 		$this->assertEqualSets(
 			[
-				'US - 4000...4001',
-				'AU - 1000...1001',
+				'123456',
+				'234567',
 			],
 			$table->getRowHeaders()->getPostalCodeGroupNames()
 		);
@@ -76,10 +80,12 @@ class PostcodesRateGroupAdapterTest extends UnitTest {
 	public function test_fails_if_no_currency_provided() {
 		$this->expectException( InvalidValue::class );
 
+		$region_1 = new ShippingRegion( '123456', 'US', [ new PostcodeRange( '4000', '4001' ) ] );
+
 		new PostcodesRateGroupAdapter(
 			[
 				'location_rates' => [
-					new LocationRate( new ShippingLocation( 0, 'US', null, [ new PostcodeRange( '4000', '4001' ) ] ), new ShippingRate( 110 ) ),
+					new LocationRate( new ShippingLocation( 0, 'US', null, $region_1 ), new ShippingRate( 110 ) ),
 				],
 			]
 		);

--- a/tests/Unit/Shipping/ShippingRegionTest.php
+++ b/tests/Unit/Shipping/ShippingRegionTest.php
@@ -1,0 +1,18 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRegion;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+
+/**
+ * Class ShippingRegionTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
+ */
+class ShippingRegionTest extends UnitTest {
+	public function test_generated_random_id_length_has_equal_to_or_more_than_six_digits() {
+		$this->assertGreaterThanOrEqual( 6, strlen( ShippingRegion::generate_random_id() ) );
+	}
+}

--- a/tests/Unit/Shipping/ShippingZoneTest.php
+++ b/tests/Unit/Shipping/ShippingZoneTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingLocation;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRatesProcessor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\PostcodeRange;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRate;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRegion;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneLocationsParser;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneMethodsParser;
@@ -50,16 +51,23 @@ class ShippingZoneTest extends UnitTest {
 	}
 
 	public function test_returns_shipping_rates_for_country() {
-		$postcodes = [
+		$postcodes_1 = [
 			new PostcodeRange( '12345' ),
 			new PostcodeRange( '67890' ),
 		];
+		$region_1 = new ShippingRegion('123456', 'US', $postcodes_1);
+
+		$postcodes_2 = [
+			new PostcodeRange( '23456' ),
+			new PostcodeRange( '78901' ),
+		];
+		$region_2 = new ShippingRegion('234567', 'AU', $postcodes_2);
 		$this->locations_parser->expects( $this->once() )
 							 ->method( 'parse' )
 							 ->willReturn(
 								 [
-									 new ShippingLocation( 21137, 'US', 'CA', $postcodes ),
-									 new ShippingLocation( 20035, 'AU', 'NSW', $postcodes ),
+									 new ShippingLocation( 21137, 'US', 'CA', $region_1 ),
+									 new ShippingLocation( 20035, 'AU', 'NSW', $region_2 ),
 								 ]
 							 );
 		$this->methods_parser->expects( $this->once() )
@@ -71,14 +79,14 @@ class ShippingZoneTest extends UnitTest {
 		$this->assertEquals( 0, $location_rates[0]->get_shipping_rate()->get_rate() );
 		$this->assertEquals( 'US', $location_rates[0]->get_location()->get_country() );
 		$this->assertEquals( 'CA', $location_rates[0]->get_location()->get_state() );
-		$this->assertEqualSets( $postcodes, $location_rates[0]->get_location()->get_postcodes() );
+		$this->assertEquals( $region_1, $location_rates[0]->get_location()->get_shipping_region() );
 
 		$location_rates = $this->shipping_zone->get_shipping_rates_for_country( 'AU' );
 		$this->assertCount( 1, $location_rates );
 		$this->assertEquals( 0, $location_rates[0]->get_shipping_rate()->get_rate() );
 		$this->assertEquals( 'AU', $location_rates[0]->get_location()->get_country() );
 		$this->assertEquals( 'NSW', $location_rates[0]->get_location()->get_state() );
-		$this->assertEqualSets( $postcodes, $location_rates[0]->get_location()->get_postcodes() );
+		$this->assertEquals( $region_2, $location_rates[0]->get_location()->get_shipping_region() );
 
 		// Test non-existent country.
 		$location_rates = $this->shipping_zone->get_shipping_rates_for_country( 'XX' );

--- a/tests/Unit/Shipping/ZoneLocationsParserTest.php
+++ b/tests/Unit/Shipping/ZoneLocationsParserTest.php
@@ -206,8 +206,12 @@ class ZoneLocationsParserTest extends UnitTest {
 							);
 		$this->google_helper->expects( $this->any() )
 							->method( 'does_country_support_regional_shipping' )
-							->with( 'US' )
-							->willReturn( true );
+							->willReturnMap(
+								[
+									[ 'US', true ],
+									[ 'DE', false ],
+								]
+							);
 
 		$parsed_locations = $this->locations_parser->parse( $zone );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

To sync the shipping rates for postal codes of a country, we need to define them as "[regions](https://developers.google.com/shopping-content/reference/rest/v2.1/regions#Region)" through the Google API. Even though we do not need to do this explicitly, Google automatically creates "[regions](https://developers.google.com/shopping-content/reference/rest/v2.1/regions#Region)" when we present the postal codes as part of the [ShippingSettings API under `postalCodeGroups`](https://developers.google.com/shopping-content/guides/shippingsettings#set_postal_code_groups). 

The ["name" property of PostalCodeGroup](https://developers.google.com/shopping-content/reference/rest/v2.1/shippingsettings#PostalCodeGroup) does not have any explicit requirements defined for it. However, since Google maps PostalCodeGroups to Regions, the [PostalCodeGroup's](https://developers.google.com/shopping-content/reference/rest/v2.1/shippingsettings#PostalCodeGroup) `name` parameter maps directly to a [Region's](https://developers.google.com/shopping-content/reference/rest/v2.1/regions#Region) `regionId` parameter.

The `regionId` parameter has some [requirements defined by Google](https://support.google.com/merchants/answer/9698880?hl=en#requirements). One of the main requirements is the following:

> For privacy reasons, the region ID value must be a randomized set of numbers (minimum 6 digits), rather than a readable name, such as "NY_City". Readable names or names that look like postal codes aren't accepted.

Previously, we added the country and state information in all region IDs. However, in this PR, the `regionId` parameter is set to a randomly generated number containing >= 6 digits.

Note that this random ID is generated on the fly whenever the user syncs their shipping settings and we do not store this ID in the local DB. This means that whenever the shipping settings are updated, a new random ID will be generated for each region. 

The above won't affect our current functionality because we do not use this ID to identify a region in our code. However, another [requirement](https://support.google.com/merchants/answer/9698880?hl=en#requirements) is:

> You’re able to accept the region ID parameter passed by Google into your product landing pages and render the correct regional product pages with corresponding regional pricing and availability.

This functionality is not implemented right now and I don't believe we have any plans for it. Moreover, all shipping data is stored on the Google side and we can retrieve them from the [`regions` API](https://developers.google.com/shopping-content/reference/rest/v2.1/regions) if we ever need to identify the regions.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make sure you have a shipping zone for the "US" country that includes zip codes and a flat rate method.
2. Edit your GLA free listings settings and choose the "Recommended" settings for the shipping option.
3. Save the free listing so that the shipping settings are synced to MC.
4. Open your MC and go to the shipping & return settings.
5. Check the details of the shipping service that was just synced. It will have a name similar to "[63a5] Google Listings and Ads generated service - US"
6. Go to the "Cost" section and click on "All products"
7. Under the "Destination" column of "Shipping rate table" there should be a random number with more than 6 digits.
8. Click on the pencil mark (Edit) right next to that random number to open the "Edit destination" popup.
9. Confirm that the postcodes you entered in your shipping zone all appear under "Postal codes" in that popup.  


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Generate random ID for postcode regions when syncing shipping settings
