### PR TITLE
Fix useNavigateAwayPromptEffect for WC Compat with WC 6.7

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -78,6 +78,9 @@ const EditFreeCampaign = () => {
 		savedTargetAudience
 	);
 	const [ settings, updateSettings ] = useState( savedSettings );
+	const [ forceUnblockedNavigation, setForceUnblockedNavigation ] = useState(
+		false
+	);
 
 	const {
 		hasFinishedResolution: hfrShippingRates,
@@ -152,7 +155,7 @@ const EditFreeCampaign = () => {
 			'You have unsaved campaign data. Are you sure you want to leave?',
 			'google-listings-and-ads'
 		),
-		didAnythingChanged,
+		didAnythingChanged && ! forceUnblockedNavigation,
 		isNotOurStep
 	);
 
@@ -193,8 +196,10 @@ const EditFreeCampaign = () => {
 	};
 
 	const handleChooseAudienceContinue = () => {
+		setForceUnblockedNavigation( true );
 		updateShippingAfterChooseAudienceStep();
 		getHistory().push( getNewPath( { pageStep: '2' } ) );
+		setForceUnblockedNavigation( false );
 	};
 
 	const handleSetupFreeListingsContinue = async () => {

--- a/js/src/hooks/useNavigateAwayPromptEffect.js
+++ b/js/src/hooks/useNavigateAwayPromptEffect.js
@@ -18,6 +18,12 @@ export default function useNavigateAwayPromptEffect(
 	blockedLocation = () => true
 ) {
 	useEffect( () => {
+		/**
+		 * Bind beforeunload event for non `woocommerce/navigation` links and reloads.
+		 * history#v5 does bind `beforeunload` automatically, with v4 we need to do it ourselves.
+		 *
+		 * @param {Event} e Before Unload Event
+		 */
 		const eventListener = ( e ) => {
 			// If you prevent default behavior in Mozilla Firefox prompt will always be shown.
 			e.preventDefault();

--- a/js/src/hooks/useNavigateAwayPromptEffect.js
+++ b/js/src/hooks/useNavigateAwayPromptEffect.js
@@ -18,9 +18,20 @@ export default function useNavigateAwayPromptEffect(
 	blockedLocation = () => true
 ) {
 	useEffect( () => {
+		const eventListener = ( e ) => {
+			// If you prevent default behavior in Mozilla Firefox prompt will always be shown.
+			e.preventDefault();
+			// Chrome requires returnValue to be set.
+			e.returnValue = message;
+		};
+
 		// Block woocommerce/navigation in order to show a confirmation prompt in case shouldBlock is true
 		const unblock = getHistory().block( ( transition ) => {
 			let shouldUnblock = true;
+
+			if ( shouldBlock ) {
+				window.addEventListener( 'beforeunload', eventListener );
+			}
 
 			/**
 			 * In history v4 (< WC 6.7) block method only receives one parameter (the location)
@@ -50,6 +61,7 @@ export default function useNavigateAwayPromptEffect(
 
 		return () => {
 			unblock();
+			window.removeEventListener( 'beforeunload', eventListener );
 		};
 	}, [ message, shouldBlock, blockedLocation ] );
 }

--- a/js/src/hooks/useNavigateAwayPromptEffect.js
+++ b/js/src/hooks/useNavigateAwayPromptEffect.js
@@ -31,13 +31,13 @@ export default function useNavigateAwayPromptEffect(
 			e.returnValue = message;
 		};
 
+		if ( shouldBlock ) {
+			window.addEventListener( 'beforeunload', eventListener );
+		}
+
 		// Block woocommerce/navigation in order to show a confirmation prompt in case shouldBlock is true
 		const unblock = getHistory().block( ( transition ) => {
 			let shouldUnblock = true;
-
-			if ( shouldBlock ) {
-				window.addEventListener( 'beforeunload', eventListener );
-			}
 
 			/**
 			 * In history v4 (< WC 6.7) block method only receives one parameter (the location)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1579.

This PR potentially fixes incompatibility issues with WC 6.7

Seems like the new version uses a new version of history API? In any case, the method `useNavigateAwayPromptEffect` breaks the navigation in WC 6.7 


### Screenshots:

Before

https://user-images.githubusercontent.com/417342/176746047-e89ccafe-3e82-49bc-b0a8-edcb7ad75b5a.mov

After

https://user-images.githubusercontent.com/5908855/176930639-bda17e39-8a67-4298-982a-d81d540ab14a.mov

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install WC 6.7 beta-1 or beta-2
2. Check that in Edit Free Listings Page, the navigation as well as the continue button doesn't work. 
3. Checkout this PR
4. See that when no changes happened you can navigate using the top left navigation arrow
5. See that when changes happened a prompt appears when you navigate back using the top left navigation arrow
6. Same behaviour with top stepper navigation
7. Check that the button Conintue works without asking for any confirmation
8. Check that in step 2 it has the same behaviour
9. Check the Continue/back buttons in Setup Ads as well.
10. Roll back to WC < 6.7, for example 6.6
11. The UI has the same behaviour as 6.7 
12. Check other browsers like Mozilla Firefox


### Additional details:
Happy to hear alternative solutions for this 

### Changelog entry

> Fix - Compatibility with History Navigation v5
