### PR TITLE
Normalize image urls

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -753,8 +753,17 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$metadata->addPropertyConstraint( 'link', new Assert\Url() );
 
 		$metadata->addPropertyConstraint( 'imageLink', new Assert\NotBlank() );
-		$metadata->addPropertyConstraint( 'imageLink', new Assert\Url() );
-		$metadata->addPropertyConstraint( 'additionalImageLinks', new Assert\All( [ 'constraints' => [ new Assert\Url() ] ] ) );
+		$metadata->addPropertyConstraint( 'imageLink', new Assert\Url( [ 'normalizer' => 'Normalizer::normalize' ] ) );
+		$metadata->addPropertyConstraint(
+			'additionalImageLinks',
+			new Assert\All(
+				[
+					'constraints' => [
+						new Assert\Url( [ 'normalizer' => 'Normalizer::normalize' ] ),
+					],
+				]
+			)
+		);
 
 		$metadata->addGetterConstraint( 'price', new Assert\NotNull() );
 		$metadata->addGetterConstraint( 'price', new GooglePriceConstraint() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In 3 of the linked support issues I was able to find image names with special characters, like:
- `El-viaje-Fantástico-del-Osito-Gominola-Mockup.jpg`
- `Copenhagen-Rags-Cashmere-toerklaede-blåt-closeup.jpeg`
- `Minselfie-50-årsdag-bursdag-photobooth.webp`

By default WordPress will remove accents when uploading an image and replace the name with it's non-accented equivalents. However this is not the case if UTF8-NFD characters (combined accented characters) are used, which seems to be most common on MACOS. WordPress has a long standing bug issue for this (currently scheduled for version 6.1): https://core.trac.wordpress.org/ticket/24661
However until that's resolved we need to make sure that these image URL's are not blocked when validating. According to this [bug report](https://github.com/symfony/symfony/issues/29953) it recommends to normalize the URL's before validating. So this PR ensures they are normalized so the above mentioned images pass validation.

We aren't currently testing the validation rules since this is tested in an external library. However I thought it was important to test these types of URL's since it depends on how we use the library whether it validates or not. So this PR also includes a test to validate the image URL.

Closes #1582

### Detailed test instructions:
1. Create an image with a name like `ïmágê-ñåmè.jpg` (make sure to copy exactly as general UTF8 characters will be converted, [test page](https://minaret.info/test/normalize.msp) for getting the right string).
2. Confirm after uploading that the special characters are still in the image name.
![image](https://user-images.githubusercontent.com/11388669/177188402-70119e96-fe33-4188-89ff-d809da87afab.png)
3. Create a test product with this image (make sure to add description and price to confirm it syncs).
4. On the Connection Test page, sync the product using it's ID (non async).
5. Confirm it syncs without any validation errors (if there are validation errors they need to be retrieved from the log).
6. After a while check the [Google Dashboard](https://merchants.google.com) to confirm the image URL is valid.

### Additional details:
This PR would only resolve the validation error for sites that are actually using accented characters in the image URL's. Looking at the linked issues there were several sites which appeared to be using images with normal characters. However I wasn't able to retrieve additional details from those tickets to track down specific reasons why it might be failing. If after this PR is released we can still find cases where the images are not synced correctly, the issue can be reopened with additional details containing specific image URLs which are failing to validate.

### Changelog entry
* Fix - Normalize image URLs before validation.
