### PR TITLE
Release 2.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,3 +30,4 @@ wordpress_org_assets export-ignore
 .stylelintrc.json export-ignore
 .nvmrc export-ignore
 storybook export-ignore
+.jsdocrc.json export-ignore

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
+= 2.0.0 - 2022-07-05 =
+* Add - Filter Ads accounts to exclude manager and test accounts.
+* Add - Return account names when retrieving the list of existing accounts.
+* Fix - Normalize image URLs before validation.
+* Tweak - WooCommerce 6.7 compatibility.
+
 = 1.13.6 - 2022-06-21 =
 * Fix - Cannot disconnect Jetpack when other activated plugins are using Jetpack connection.
 * Fix - Compatibility CES prompts with WC 6.6.0.

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google Listings and Ads
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 1.13.6
+ * Version: 2.0.0
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -12,7 +12,7 @@
  * Requires PHP: 7.3
  *
  * WC requires at least: 6.0
- * WC tested up to: 6.6
+ * WC tested up to: 6.7
  * Woo:
  *
  * @package WooCommerce\Admin
@@ -28,7 +28,7 @@ use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '1.13.6' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '2.0.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.3' );
 define( 'WC_GLA_MIN_WC_VER', '6.0' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "1.13.6",
+	"version": "2.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "google-listings-and-ads",
 	"title": "Google Listings and Ads",
 	"license": "GPL-3.0-or-later",
-	"version": "1.13.6",
+	"version": "2.0.0",
 	"description": "google-listings-and-ads",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,12 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 
 == Changelog ==
 
+= 2.0.0 - 2022-07-05 =
+* Add - Filter Ads accounts to exclude manager and test accounts.
+* Add - Return account names when retrieving the list of existing accounts.
+* Fix - Normalize image URLs before validation.
+* Tweak - WooCommerce 6.7 compatibility.
+
 = 1.13.6 - 2022-06-21 =
 * Fix - Cannot disconnect Jetpack when other activated plugins are using Jetpack connection.
 * Fix - Compatibility CES prompts with WC 6.6.0.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, google, listings, ads
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.3
-Stable tag: 1.13.6
+Stable tag: 2.0.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -122,15 +122,4 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 * Tweak - Update copy for Free and Enhanced Listings merge
 * Tweak - WC 6.6 compatibility.
 
-= 1.13.4 - 2022-06-07 =
-* Fix - Adding Github Actions for storybook.
-* Fix - Do not show error notice when Merchant Center review request API call failed.
-* Fix - Do not store URL matches transient until fully connected.
-* Fix - Fix GitHub Workflow paths.
-* Fix - Use commit instead of branch for storybook dependency.
-* Tweak - Always compare site URL hash without trailing slash.
-* Tweak - Compliance Policy links.
-* Tweak - WC 6.6 compatibility.
-
-
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).


### PR DESCRIPTION
### Changelog
* Add - Filter Ads accounts to exclude manager and test accounts.
* Add - Return account names when retrieving the list of existing accounts.
* Fix - Normalize image URLs before validation.
* Tweak - WooCommerce 6.7 compatibility.