### PR TITLE
Propagate errors for saveTargetAudience 

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -73,6 +73,14 @@ export function handleFetchError( error, message ) {
  */
 
 /**
+ * @typedef {Object} TargetAudienceData
+ * @property {string} locale The locale for the site. Example: 'en_US'.
+ * @property {string} language The language to use for product listings. Example: 'English'.
+ * @property {string} location Type of location, There are two possible values: 'selected' countries or 'all' countries.
+ * @property {Array<CountryCode>} countries Array of audience countries.
+ */
+
+/**
  *
  * @return {Array<ShippingRate>} Array of individual shipping rates.
  */
@@ -706,27 +714,23 @@ export function receiveGoogleAdsAccountBillingStatus( billingStatus ) {
 	};
 }
 
+/**
+ * Save the target audience contries.
+ *
+ * @param {TargetAudienceData} targetAudience with the audience countries
+ * @return {Object} Action object to save target audience.
+ */
 export function* saveTargetAudience( targetAudience ) {
-	try {
-		yield apiFetch( {
-			path: `${ API_NAMESPACE }/mc/target_audience`,
-			method: 'POST',
-			data: targetAudience,
-		} );
+	yield apiFetch( {
+		path: `${ API_NAMESPACE }/mc/target_audience`,
+		method: 'POST',
+		data: targetAudience,
+	} );
 
-		return {
-			type: TYPES.SAVE_TARGET_AUDIENCE,
-			target_audience: targetAudience,
-		};
-	} catch ( error ) {
-		yield handleFetchError(
-			error,
-			__(
-				'There was an error saving target audience data.',
-				'google-listings-and-ads'
-			)
-		);
-	}
+	return {
+		type: TYPES.SAVE_TARGET_AUDIENCE,
+		target_audience: targetAudience,
+	};
 }
 
 export function* fetchAdsCampaigns() {

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -715,9 +715,9 @@ export function receiveGoogleAdsAccountBillingStatus( billingStatus ) {
 }
 
 /**
- * Save the target audience contries.
+ * Save the target audience countries.
  *
- * @param {TargetAudienceData} targetAudience with the audience countries
+ * @param {TargetAudienceData} targetAudience audience countries
  * @return {Object} Action object to save target audience.
  */
 export function* saveTargetAudience( targetAudience ) {

--- a/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
@@ -3,7 +3,7 @@
  */
 import { Button, RadioControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -32,8 +32,12 @@ const FormContent = ( props ) => {
 	const { formProps } = props;
 	const { values, isValidForm, getInputProps, handleSubmit } = formProps;
 	const { locale, language } = values;
+	const [ isAutoSaved, setAutoSaved ] = useState( true );
 
-	useAutoSaveTargetAudienceEffect( values );
+	const autoSaveCallback = ( resultAutoSave ) =>
+		setAutoSaved( resultAutoSave );
+
+	useAutoSaveTargetAudienceEffect( values, autoSaveCallback );
 	useAutoClearShippingEffect( values.location, values.countries );
 
 	return (
@@ -138,7 +142,7 @@ const FormContent = ( props ) => {
 			<StepContentFooter>
 				<Button
 					isPrimary
-					disabled={ ! isValidForm }
+					disabled={ ! isValidForm || ! isAutoSaved }
 					onClick={ handleSubmit }
 				>
 					{ __( 'Continue', 'google-listings-and-ads' ) }

--- a/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/form-content.js
@@ -34,10 +34,7 @@ const FormContent = ( props ) => {
 	const { locale, language } = values;
 	const [ isAutoSaved, setAutoSaved ] = useState( true );
 
-	const autoSaveCallback = ( resultAutoSave ) =>
-		setAutoSaved( resultAutoSave );
-
-	useAutoSaveTargetAudienceEffect( values, autoSaveCallback );
+	useAutoSaveTargetAudienceEffect( values, setAutoSaved );
 	useAutoClearShippingEffect( values.location, values.countries );
 
 	return (

--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoSaveTargetAudienceEffect.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoSaveTargetAudienceEffect.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,8 +23,12 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
  * which has not been saved before yet.
  *
  * @param {TargetAudienceData} targetAudience Target audience value object to be saved.
+ * @param {(autoSaveResult: boolean) => void} autoSaveCallback Callback function when the autosave is called
  */
-const useAutoSaveTargetAudienceEffect = ( targetAudience ) => {
+const useAutoSaveTargetAudienceEffect = (
+	targetAudience,
+	autoSaveCallback = noop
+) => {
 	const { saveTargetAudience } = useAppDispatch();
 	const { createNotice } = useDispatchCoreNotices();
 
@@ -35,6 +40,7 @@ const useAutoSaveTargetAudienceEffect = ( targetAudience ) => {
 	const saveTargetAudienceCallback = async ( value ) => {
 		try {
 			await saveTargetAudience( value );
+			autoSaveCallback( true );
 		} catch ( error ) {
 			createNotice(
 				'error',
@@ -43,6 +49,7 @@ const useAutoSaveTargetAudienceEffect = ( targetAudience ) => {
 					'google-listings-and-ads'
 				)
 			);
+			autoSaveCallback( false );
 		}
 	};
 

--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoSaveTargetAudienceEffect.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoSaveTargetAudienceEffect.js
@@ -1,8 +1,18 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { useAppDispatch } from '.~/data';
 import useDebouncedCallbackEffect from '.~/hooks/useDebouncedCallbackEffect';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+
+/**
+ * @typedef { import(".~/data/actions").TargetAudienceData } TargetAudienceData
+ */
 
 /**
  * Automatically save settings value upon value change with a debounce delay.
@@ -11,12 +21,32 @@ import useDebouncedCallbackEffect from '.~/hooks/useDebouncedCallbackEffect';
  * because the data might be coming from the target audience suggestion API
  * which has not been saved before yet.
  *
- * @param {Object} value Settings value object to be saved.
+ * @param {TargetAudienceData} targetAudience Target audience value object to be saved.
  */
-const useAutoSaveTargetAudienceEffect = ( value ) => {
+const useAutoSaveTargetAudienceEffect = ( targetAudience ) => {
 	const { saveTargetAudience } = useAppDispatch();
+	const { createNotice } = useDispatchCoreNotices();
 
-	useDebouncedCallbackEffect( value, saveTargetAudience, {
+	/**
+	 * A `saveTargetAudienceCallback` callback that catches error and throws the error notice.
+	 *
+	 * @param {TargetAudienceData} value Target audience value object to be saved.
+	 */
+	const saveTargetAudienceCallback = async ( value ) => {
+		try {
+			await saveTargetAudience( value );
+		} catch ( error ) {
+			createNotice(
+				'error',
+				__(
+					'There was an error saving target audience data.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+	};
+
+	useDebouncedCallbackEffect( targetAudience, saveTargetAudienceCallback, {
 		callOnFirstRender: true,
 	} );
 };

--- a/js/src/setup-mc/setup-stepper/choose-audience/useAutoSaveTargetAudienceEffect.test.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/useAutoSaveTargetAudienceEffect.test.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useAutoSaveTargetAudienceEffect from './useAutoSaveTargetAudienceEffect';
+
+const mockSaveTargetAudience = jest.fn().mockName( 'saveTargetAudience' );
+const mockAutoSaveCallback = jest.fn().mockName( 'autoSaveCallbak' );
+const mockCreateNotice = jest.fn().mockName( 'createNotice' );
+
+jest.mock( '.~/data', () => ( {
+	useAppDispatch: () => ( {
+		saveTargetAudience: mockSaveTargetAudience,
+	} ),
+} ) );
+
+jest.mock( '.~/hooks/useDispatchCoreNotices', () => () => ( {
+	createNotice: mockCreateNotice,
+} ) );
+
+describe( 'useAutoSaveTargetAudienceEffect', () => {
+	const values = {
+		countries: [ 'ES', 'IT', 'FR' ],
+		language: 'English',
+		locale: 'en_US',
+		location: 'selected',
+	};
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'Autosaving without errors', async () => {
+		renderHook( () =>
+			useAutoSaveTargetAudienceEffect( values, mockAutoSaveCallback )
+		);
+
+		await waitFor( () => {
+			expect( mockSaveTargetAudience ).toHaveBeenCalledTimes( 1 );
+			expect( mockSaveTargetAudience ).toHaveBeenCalledWith( values );
+
+			expect( mockAutoSaveCallback ).toHaveBeenCalledTimes( 1 );
+			expect( mockAutoSaveCallback ).toHaveBeenCalledWith( true );
+
+			//No errors should be displayed
+			expect( mockCreateNotice ).toHaveBeenCalledTimes( 0 );
+		} );
+	} );
+
+	test( 'Autosaving with errors', async () => {
+		mockSaveTargetAudience.mockImplementation( () => {
+			throw new Error( 'New error!' );
+		} );
+
+		renderHook( () =>
+			useAutoSaveTargetAudienceEffect( values, mockAutoSaveCallback )
+		);
+
+		await waitFor( () => {
+			expect( mockSaveTargetAudience ).toHaveBeenCalledTimes( 1 );
+			expect( mockSaveTargetAudience ).toHaveBeenCalledWith( values );
+
+			expect( mockAutoSaveCallback ).toHaveBeenCalledTimes( 1 );
+			expect( mockAutoSaveCallback ).toHaveBeenCalledWith( false );
+
+			//Errors should be displayed
+			expect( mockCreateNotice ).toHaveBeenCalledTimes( 1 );
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'error',
+				'There was an error saving target audience data.'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This is a follow-up of https://github.com/woocommerce/google-listings-and-ads/issues/1331#issuecomment-1109566842 & https://github.com/woocommerce/google-listings-and-ads/issues/1331#issuecomment-1110084066

This PR removes the `try` and `catch` from `saveTargetAudience`, allowing the error to bubble up and be handled by the consumer.  In the following example:

https://github.com/woocommerce/google-listings-and-ads/blob/189a55a29a368b0a2ce9150deb3ca70c6077de29/js/src/edit-free-campaign/index.js#L203-L208

if `saveTargetAudience` failed, the consumer was not able to tell if `saveTargetAudience` failed because the error was already caught. Using this PR, `saveTargetAudience` will be shown as `rejected`.

For more context see issue #1331.

I found only two places where `saveTargetAudience` is called:

1.  https://github.com/woocommerce/google-listings-and-ads/blob/189a55a29a368b0a2ce9150deb3ca70c6077de29/js/src/edit-free-campaign/index.js#L204 (This error will be handle by a custom hook, see https://github.com/woocommerce/google-listings-and-ads/issues/1331#issuecomment-1109566842

2. https://github.com/woocommerce/google-listings-and-ads/blob/a2e05d7361a86efb33dd6dc2d86053ba62230039/js/src/setup-mc/setup-stepper/choose-audience/useAutoSaveTargetAudienceEffect.js#L26-L27  This PR updates the useAutoSaveTargetAudienceEffect to catch the error.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the onboarding page step 2.

![image](https://user-images.githubusercontent.com/2488994/177545042-1cf4421f-5460-4e29-b4d8-54be23fb7a6d.png)

2. Update the countries, no errors should be shown.
3. If you provoke an error, a notice will be displayed. For example, setting an incorrect URL in the following line: https://github.com/woocommerce/google-listings-and-ads/blob/a892de55a797a0feaf20e2d7b88ad25755614417/js/src/data/actions.js#L725 

![image](https://user-images.githubusercontent.com/2488994/177545337-003976fa-60d3-45cb-af70-1bc973fab0c2.png)


### Additional details:
- The next step will be to remove the try and catch from `saveSettings` so we can handle the errors in situations like the following:

```
const results = await Promise.allSettled( [
	saveTargetAudience( targetAudience ), // remove its try/catch in actions.js. (This PR)
	saveSettings( settings ), // TODO: remove its try/catch in actions.js.
	saveShippingRates( shippingRates ), // already throws error when it fails.
	saveShippingTimes( shippingTimes ), // already throws error when it fails.
] );
```
 <!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>Tweak - Remove try and catch in saveTargetAudience action.
