### PR TITLE
Fix encoding problems in product issues table

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -463,7 +463,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			}
 
 			$product_issue_template = [
-				'product'              => $this->product_data_lookup[ $wc_product_id ]['name'],
+				'product'              => html_entity_decode( $this->product_data_lookup[ $wc_product_id ]['name'] ),
 				'product_id'           => $wc_product_id,
 				'created_at'           => $created_at,
 				'applicable_countries' => [],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1581 .

This PR as escape function to render correctly the HMLT entities received from Google API.

### Screenshots:

Before
![image](https://user-images.githubusercontent.com/417342/176945485-295c0323-2f47-4984-b45b-fd68d36b5f2e.png)

After
<img width="1451" alt="Screenshot 2022-07-07 at 13 00 14" src="https://user-images.githubusercontent.com/5908855/177734883-ff4102ee-e5e2-4c09-9b7c-c97d2f1e7971.png">

### Detailed test instructions:

1. Checkout this PR
2. Load sample products, or have some variant in your products to force the dash (-) symbol.
3. Go to product Feed, maybe you need to force refresh, You can do that in `src/MerchantCenter/MerchantStatuses.php` changing the line 141 to `$this->maybe_refresh_status_data( true );`
4. Check that’ll  no html entity appears, instead you see the character.


### Additional details:

In brief the problem is that we receive encoded HTML entities from Google API, so they are saved like that in DB. I added a native PHP function to prevent that.

### Changelog entry

> Fix - Encoding product names in Issues Table 
