### PR TITLE
Fix `release.yml` syntax - add quotes.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,36 +7,36 @@ changelog:
       - github-actions
 
   categories:
-      # Major level
-    - title: [Breaking] Breaking Changes 🚨
+    # Major level
+    - title: "[Breaking] Breaking Changes 🚨"
       labels:
         - "changelog: breaking"
 
     # Minor level
-    - title: [Add] New Features 🎉
+    - title: "[Add] New Features 🎉"
       labels:
         - "changelog: add"
         - "type: enhancement"
 
-    - title: [Update] Updated ✨
+    - title: "[Update] Updated ✨"
       labels:
         - "changelog: update"
 
     # Patch level
-    - title: [Fix] Fixes 🛠
+    - title: "[Fix] Fixes 🛠"
       labels:
         - "changelog: fix"
         - "type: bug"
 
-    - title: [Tweak] Tweaked 🔧
+    - title: "[Tweak] Tweaked 🔧"
       labels:
         - "changelog: tweak"
 
-    - title: [Dev] Developer-facing changes 🧑‍💻
+    - title: "[Dev] Developer-facing changes 🧑‍💻"
       labels:
         - "changelog: dev"
 
-    - title: [Doc] Documentation 📚
+    - title: "[Doc] Documentation 📚"
       labels:
         - "changelog: docs"
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix `release.yml` syntax - add quotes.

To make it possible to generate the notes, and avoid  the following error
```
Could not parse .github/release.yml: (<unknown>): did not find expected key while parsing a block mapping at line 11 column 7
```


### Screenshots:

![image](https://user-images.githubusercontent.com/17435/178266625-8b539914-86fb-42de-84c8-a810bbf20e8f.png)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to https://github.com/woocommerce/google-listings-and-ads/releases/new?tag=2.0.1&target=develop
2. Click "Generate release notes" - See the error
4. Go to https://github.com/woocommerce/google-listings-and-ads/releases/new?tag=2.0.1&target=fix/release.yml
5. Click "Generate release notes" - See the notes


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

