### PR TITLE
Disable identifier_exists field

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -123,7 +123,6 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			 ->map_wc_product_shipping()
 			 ->map_wc_prices();
 
-		$this->setIdentifierExists( ! empty( $this->getGtin() ) || ! empty( $this->getMpn() ) );
 	}
 
 	/**

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -861,7 +861,7 @@ DESCRIPTION;
 		$this->assertNull( $adapted_product->getShippingWidth() );
 	}
 
-	public function test_identifier_exists_is_false_if_gtin_and_mpn_not_provided() {
+	public function test_identifier_exists_is_null_if_gtin_and_mpn_not_provided() {
 		$product         = WC_Helper_Product::create_simple_product( false );
 		$adapted_product = new WCProductAdapter(
 			[
@@ -869,10 +869,10 @@ DESCRIPTION;
 				'targetCountry' => 'US',
 			]
 		);
-		$this->assertFalse( $adapted_product->getIdentifierExists() );
+		$this->assertNull( $adapted_product->getIdentifierExists() );
 	}
 
-	public function test_identifier_exists_is_true_if_gtin_provided() {
+	public function test_identifier_exists_is_null_if_gtin_provided() {
 		$product         = WC_Helper_Product::create_simple_product( false );
 		$adapted_product = new WCProductAdapter(
 			[
@@ -883,10 +883,10 @@ DESCRIPTION;
 				],
 			]
 		);
-		$this->assertTrue( $adapted_product->getIdentifierExists() );
+		$this->assertNull( $adapted_product->getIdentifierExists() );
 	}
 
-	public function test_identifier_exists_is_true_if_mpn_provided() {
+	public function test_identifier_exists_is_null_if_mpn_provided() {
 		$product         = WC_Helper_Product::create_simple_product( false );
 		$adapted_product = new WCProductAdapter(
 			[
@@ -897,7 +897,7 @@ DESCRIPTION;
 				],
 			]
 		);
-		$this->assertTrue( $adapted_product->getIdentifierExists() );
+		$this->assertNull( $adapted_product->getIdentifierExists() );
 	}
 
 	public function test_product_price_is_set() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1592

This PR disables `identifier_exists` as requested from Google.

TL;DR

This field was true if GTIN or MPN fields were filled up. False otherwise. Now we never send this field anymore.
 

### Screenshots:

<img width="1567" alt="Screenshot 2022-07-14 at 11 46 11" src="https://user-images.githubusercontent.com/5908855/178930634-8939007a-c315-43a3-ada7-81d9d3f60fde.png">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Connect your Google Account and go to one of your Single Products
2. In the Tab google Listing And Ads, fill [GTIN number](https://en.wikipedia.org/wiki/Global_Trade_Item_Number) should be in the right format. Otherwise the product wont sync.   
3. Go to Connection Test page and Sync that product
4. You will see successfully synced with google. 
5. Go to Google MC Dashboard -> All Products 
6. Click on the Product you just synced 
7. At the end of the page you will see a tab "Raw feed attributes: Content API". Click on it
8. Check that  identifier_exists field is not being sent anymore.


### Additional details:

- I found only one lace when we send this field. SO I just removed the statement.
- I updated the tests to assert null 

### Changelog entry

> Fix - Disable identifier_exists field 
