### PR TITLE
Fixing change log records for release 2.0.1 and reverting migration file

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,13 +1,12 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
 = 2.0.1 - 2022-07-12 =
-* Add - A script to generate a list of hooks that defined or used in GLA.
-* Add - GH workflow to set PR labels.
+* Dev - A script to generate a list of hooks that defined or used in GLA.
+* Dev - GH workflow to set PR labels.
 * Add - Normalizer Polyfill.
 * Dev - changed the changelog types list.
 * Fix - Compatibility with History Navigation v5.
 * Fix - Encoding product names in Issues Table .
-* Fix - Release 2.0.0.
 * Tweak - Remove try and catch in saveTargetAudience action.
 
 = 2.0.0 - 2022-07-05 =

--- a/readme.txt
+++ b/readme.txt
@@ -110,13 +110,12 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 == Changelog ==
 
 = 2.0.1 - 2022-07-12 =
-* Add - A script to generate a list of hooks that defined or used in GLA.
-* Add - GH workflow to set PR labels.
+* Dev - A script to generate a list of hooks that defined or used in GLA.
+* Dev - GH workflow to set PR labels.
 * Add - Normalizer Polyfill.
 * Dev - changed the changelog types list.
 * Fix - Compatibility with History Navigation v5.
 * Fix - Encoding product names in Issues Table .
-* Fix - Release 2.0.0.
 * Tweak - Remove try and catch in saveTargetAudience action.
 
 = 2.0.0 - 2022-07-05 =

--- a/src/DB/Migration/Migration20220524T1653383133.php
+++ b/src/DB/Migration/Migration20220524T1653383133.php
@@ -39,7 +39,7 @@ class Migration20220524T1653383133 extends AbstractMigration {
 	 * @return string A version number. For example: 1.4.1
 	 */
 	public function get_applicable_version(): string {
-		return '2.0.1';
+		return '1.13.3';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adding some tweaks to Release 2.0.1 by reverting mistakenly updated migration applicable version value and change log records types.

### Changelog entry

> Tweak - Update change log records type.
> Tweak - Revert migration applicable version value.
