### PR TITLE
Propagate errors for saveSettings action

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -81,6 +81,21 @@ export function handleFetchError( error, message ) {
  */
 
 /**
+ * Settings Data
+ *
+ * @typedef {Object} SettingsData
+ * @property {boolean} offer_free_shipping Whether if the merchant offers free shipping.
+ * @property {string} shipping_rate Type of the shipping rate. There a three possible values: 'automatic', 'flat' and 'manual'
+ * @property {string} shipping_time Type of the shipping time. There are two possible values: 'flat' and 'manual'.
+ * @property {string|null} tax_rate Type of tax rate, There are two possible values if US is selected: 'destination' and 'manual' otherwise will be null.
+ * @property {boolean} website_live Whether the store website is live.
+ * @property {boolean} checkout_process_secure Whether the checkout process is complete and secure.
+ * @property {boolean} payment_methods_visible Whether the payment methods are visible on the website.
+ * @property {boolean} refund_tos_visible Whether the refund policy and terms of service are visible on the website.
+ * @property {boolean} contact_info_visible Whether the phone number, email, and/or address are visible on the website.
+ */
+
+/**
  *
  * @return {Array<ShippingRate>} Array of individual shipping rates.
  */
@@ -293,27 +308,23 @@ export function* fetchSettings() {
 	}
 }
 
+/**
+ * Save the the MC settings.
+ *
+ * @param {SettingsData} settings settings
+ * @return {Object} Action object to save target audience.
+ */
 export function* saveSettings( settings ) {
-	try {
-		yield apiFetch( {
-			path: `${ API_NAMESPACE }/mc/settings`,
-			method: 'POST',
-			data: settings,
-		} );
+	yield apiFetch( {
+		path: `${ API_NAMESPACE }/mc/settings`,
+		method: 'POST',
+		data: settings,
+	} );
 
-		return {
-			type: TYPES.SAVE_SETTINGS,
-			settings,
-		};
-	} catch ( error ) {
-		yield handleFetchError(
-			error,
-			__(
-				'There was an error trying to save settings. Please try again later.',
-				'google-listings-and-ads'
-			)
-		);
-	}
+	return {
+		type: TYPES.SAVE_SETTINGS,
+		settings,
+	};
 }
 
 export function* fetchJetpackAccount() {

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -85,8 +85,8 @@ export function handleFetchError( error, message ) {
  *
  * @typedef {Object} SettingsData
  * @property {boolean} [offer_free_shipping] Whether if the merchant offers free shipping.
- * @property {string} [shipping_rate] Type of the shipping rate. There a three possible values: 'automatic', 'flat' and 'manual'
- * @property {string} [shipping_time] Type of the shipping time. There are two possible values: 'flat' and 'manual'.
+ * @property {'automatic'|'flat'|'manual'} [shipping_rate] Type of the shipping rate.
+ * @property {'flat'|'manual'} [shipping_time] Type of the shipping time.
  * @property {string|null} [tax_rate] Type of tax rate, There are two possible values if US is selected: 'destination' and 'manual' otherwise will be null.
  * @property {boolean} [website_live] Whether the store website is live.
  * @property {boolean} [checkout_process_secure] Whether the checkout process is complete and secure.

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -84,15 +84,15 @@ export function handleFetchError( error, message ) {
  * Settings Data
  *
  * @typedef {Object} SettingsData
- * @property {boolean} offer_free_shipping Whether if the merchant offers free shipping.
- * @property {string} shipping_rate Type of the shipping rate. There a three possible values: 'automatic', 'flat' and 'manual'
- * @property {string} shipping_time Type of the shipping time. There are two possible values: 'flat' and 'manual'.
- * @property {string|null} tax_rate Type of tax rate, There are two possible values if US is selected: 'destination' and 'manual' otherwise will be null.
- * @property {boolean} website_live Whether the store website is live.
- * @property {boolean} checkout_process_secure Whether the checkout process is complete and secure.
- * @property {boolean} payment_methods_visible Whether the payment methods are visible on the website.
- * @property {boolean} refund_tos_visible Whether the refund policy and terms of service are visible on the website.
- * @property {boolean} contact_info_visible Whether the phone number, email, and/or address are visible on the website.
+ * @property {boolean} [offer_free_shipping] Whether if the merchant offers free shipping.
+ * @property {string} [shipping_rate] Type of the shipping rate. There a three possible values: 'automatic', 'flat' and 'manual'
+ * @property {string} [shipping_time] Type of the shipping time. There are two possible values: 'flat' and 'manual'.
+ * @property {string|null} [tax_rate] Type of tax rate, There are two possible values if US is selected: 'destination' and 'manual' otherwise will be null.
+ * @property {boolean} [website_live] Whether the store website is live.
+ * @property {boolean} [checkout_process_secure] Whether the checkout process is complete and secure.
+ * @property {boolean} [payment_methods_visible] Whether the payment methods are visible on the website.
+ * @property {boolean} [refund_tos_visible] Whether the refund policy and terms of service are visible on the website.
+ * @property {boolean} [contact_info_visible] Whether the phone number, email, and/or address are visible on the website.
  */
 
 /**

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.js
@@ -1,19 +1,50 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { noop } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { useAppDispatch } from '.~/data';
 import useDebouncedCallbackEffect from '.~/hooks/useDebouncedCallbackEffect';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+
+/**
+ * @typedef { import(".~/data/actions").SettingsData } SettingsData
+ */
 
 /**
  * Automatically save settings value upon value change with a debounce delay.
  * It does not save on first render since the first render is the loading of value from API.
  *
- * @param {Object} value Settings value object to be saved.
+ * @param {SettingsData} settings Settings value object to be saved.
  */
-const useAutoSaveSettingsEffect = ( value ) => {
+const useAutoSaveSettingsEffect = ( settings ) => {
 	const { saveSettings } = useAppDispatch();
+	const { createNotice } = useDispatchCoreNotices();
 
-	useDebouncedCallbackEffect( value, saveSettings );
+	/**
+	 * A `saveSettingsCallback` callback that catches error and throws the error notice.
+	 *
+	 * @param {SettingsData} value Target audience value object to be saved.
+	 */
+	const saveSettingsCallback = async ( value ) => {
+		try {
+			await saveSettings( value );
+		} catch ( error ) {
+			createNotice(
+				'error',
+				__(
+					'There was an error trying to save settings. Please try again later.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+	};
+
+	useDebouncedCallbackEffect( settings, saveSettingsCallback );
 };
 
 export default useAutoSaveSettingsEffect;

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.test.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.test.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useAutoSaveSettingsEffect from './useAutoSaveSettingsEffect';
+
+const mockSaveSettings = jest.fn().mockName( 'saveSettings' );
+const mockCreateNotice = jest.fn().mockName( 'createNotice' );
+
+jest.mock( '.~/data', () => ( {
+	useAppDispatch: () => ( {
+		saveSettings: mockSaveSettings,
+	} ),
+} ) );
+
+jest.mock( '.~/hooks/useDispatchCoreNotices', () => () => ( {
+	createNotice: mockCreateNotice,
+} ) );
+
+describe( 'useAutoSaveSettingsEffect', () => {
+	const initialSettings = {
+		shipping_rate: null,
+		tax_rate: null,
+		shipping_time: null,
+	};
+
+	const newSettings = {
+		shipping_rate: 'automatic',
+		tax_rate: null,
+		shipping_time: 'flat',
+	};
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'Autosaving without errors', async () => {
+		const { rerender } = renderHook(
+			( settings ) => useAutoSaveSettingsEffect( settings ),
+			{ initialProps: initialSettings }
+		);
+
+		//Should not be call in the first render
+		await waitFor( () => {
+			expect( mockSaveSettings ).toHaveBeenCalledTimes( 0 );
+			expect( mockCreateNotice ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		rerender( newSettings );
+
+		await waitFor( () => {
+			expect( mockSaveSettings ).toHaveBeenCalledTimes( 1 );
+			//No errors should be displayed
+			expect( mockCreateNotice ).toHaveBeenCalledTimes( 0 );
+		} );
+	} );
+
+	test( 'Autosaving with errors', async () => {
+		mockSaveSettings.mockImplementation( () => {
+			throw new Error( 'New error!' );
+		} );
+
+		const { rerender } = renderHook(
+			( settings ) => useAutoSaveSettingsEffect( settings ),
+			{ initialProps: initialSettings }
+		);
+
+		rerender( newSettings );
+
+		await waitFor( () => {
+			expect( mockSaveSettings ).toHaveBeenCalledTimes( 1 );
+			expect( mockSaveSettings ).toHaveBeenCalledWith( newSettings );
+
+			//Errors should be displayed
+			expect( mockCreateNotice ).toHaveBeenCalledTimes( 1 );
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'error',
+				'There was an error trying to save settings. Please try again later.'
+			);
+		} );
+	} );
+} );

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.test.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.test.js
@@ -55,6 +55,7 @@ describe( 'useAutoSaveSettingsEffect', () => {
 
 		await waitFor( () => {
 			expect( mockSaveSettings ).toHaveBeenCalledTimes( 1 );
+			expect( mockSaveSettings ).toHaveBeenCalledWith( newSettings );
 			//No errors should be displayed
 			expect( mockCreateNotice ).toHaveBeenCalledTimes( 0 );
 		} );

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -36,16 +36,16 @@ export default function StoreRequirements() {
 	 * all onboarding accounts are considered unverified phone numbers.
 	 */
 	const [ isPhoneNumberReady, setPhoneNumberReady ] = useState( false );
-	const [ isSaveSettings, setSaveSettings ] = useState( true );
+	const [ settingsSaved, setSettingsSaved ] = useState( true );
 	const [ completing, setCompleting ] = useState( false );
 
 	const handleChangeCallback = async ( _, values ) => {
 		try {
 			await saveSettings( values );
-			setSaveSettings( true );
+			setSettingsSaved( true );
 		} catch ( error ) {
 			//Create the notice only once
-			if ( isSaveSettings === true ) {
+			if ( settingsSaved === true ) {
 				createNotice(
 					'error',
 					__(
@@ -54,7 +54,7 @@ export default function StoreRequirements() {
 					)
 				);
 			}
-			setSaveSettings( false );
+			setSettingsSaved( false );
 		}
 	};
 
@@ -137,7 +137,7 @@ export default function StoreRequirements() {
 									isPrimary
 									loading={ completing }
 									disabled={
-										! isReadyToComplete || ! isSaveSettings
+										! isReadyToComplete || ! settingsSaved
 									}
 									onClick={ handleSubmit }
 								>

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -36,10 +36,26 @@ export default function StoreRequirements() {
 	 * all onboarding accounts are considered unverified phone numbers.
 	 */
 	const [ isPhoneNumberReady, setPhoneNumberReady ] = useState( false );
+	const [ isSaveSettings, setSaveSettings ] = useState( true );
 	const [ completing, setCompleting ] = useState( false );
 
-	const handleChangeCallback = ( _, values ) => {
-		saveSettings( values );
+	const handleChangeCallback = async ( _, values ) => {
+		try {
+			await saveSettings( values );
+			setSaveSettings( true );
+		} catch ( error ) {
+			//Create the notice only once
+			if ( isSaveSettings === true ) {
+				createNotice(
+					'error',
+					__(
+						'There was an error trying to save settings. Please try again later.',
+						'google-listings-and-ads'
+					)
+				);
+			}
+			setSaveSettings( false );
+		}
 	};
 
 	const handleSubmitCallback = async () => {
@@ -120,7 +136,9 @@ export default function StoreRequirements() {
 								<AppButton
 									isPrimary
 									loading={ completing }
-									disabled={ ! isReadyToComplete }
+									disabled={
+										! isReadyToComplete || ! isSaveSettings
+									}
 									onClick={ handleSubmit }
 								>
 									{ __(

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -45,7 +45,7 @@ export default function StoreRequirements() {
 			setSettingsSaved( true );
 		} catch ( error ) {
 			//Create the notice only once
-			if ( settingsSaved === true ) {
+			if ( settingsSaved ) {
 				createNotice(
 					'error',
 					__(
@@ -122,7 +122,8 @@ export default function StoreRequirements() {
 					const isReadyToComplete =
 						isValidForm &&
 						isPhoneNumberReady &&
-						address.isAddressFilled;
+						address.isAddressFilled &&
+						settingsSaved;
 
 					return (
 						<>
@@ -136,9 +137,7 @@ export default function StoreRequirements() {
 								<AppButton
 									isPrimary
 									loading={ completing }
-									disabled={
-										! isReadyToComplete || ! settingsSaved
-									}
+									disabled={ ! isReadyToComplete }
 									onClick={ handleSubmit }
 								>
 									{ __(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This is a follow-up of https://github.com/woocommerce/google-listings-and-ads/issues/1331#issuecomment-1109566842 , https://github.com/woocommerce/google-listings-and-ads/issues/1331#issuecomment-1110084066 & https://github.com/woocommerce/google-listings-and-ads/pull/1586

This PR removes the try and catch from `saveSettings` action, allowing the error to bubble up and be handled by the consumer. if `saveSettings` were failing, the consumer was not able to tell if `saveSettings` throw an exception because the error was already caught in the action. Using this PR, `saveSettings` will throw an error and the error can be handled. 

I found four places where `saveSettings` was used:


- `handleSubmitCallback` - Step 3 (Configure your product listings).

Before this PR the `saveSettings` could fail and allow to continue to step 4 without saving rates, times or taxes **types**. With this PR if `saveSettings` fails it will not allow to continue as the data has not been saved correctly. 

https://github.com/woocommerce/google-listings-and-ads/blob/0614caa5a6227e5e41b3ae15b3cc7df6442deb57/js/src/setup-mc/setup-stepper/setup-free-listings/index.js#L91-L97

Before this PR:

https://user-images.githubusercontent.com/2488994/179293546-3cc15421-71f5-4dc6-be62-d0a951651e4b.mp4

After this PR

https://user-images.githubusercontent.com/2488994/179300591-b86882ce-7c0f-49b4-8bfe-abe0a7fb08ce.mov

- `handleChangeCallback` - Step 4 (Confirm store requirements). Before this PR, checking the store requirements could fail and allow the user to complete the process. 

https://github.com/woocommerce/google-listings-and-ads/blob/0614caa5a6227e5e41b3ae15b3cc7df6442deb57/js/src/setup-mc/setup-stepper/store-requirements/index.js#L41-L43

Before this PR:

https://user-images.githubusercontent.com/2488994/179303214-78a70c2b-ce41-4ac4-84de-f4759748047f.mp4

After this PR:

https://user-images.githubusercontent.com/2488994/179303657-e02266ab-f34b-4ed3-b019-b5da98c8342a.mp4


- `useAutoSaveSettingsEffect`,    this PR adds the `try` and `catch` in the autosaving function.

https://github.com/woocommerce/google-listings-and-ads/blob/0614caa5a6227e5e41b3ae15b3cc7df6442deb57/js/src/setup-mc/setup-stepper/setup-free-listings/useAutoSaveSettingsEffect.js#L13-L17


- The errors thrown from `allSettled` will be handled by a custom hook that will be created in a future PR, this PR is not changing this behaviour.

https://github.com/woocommerce/google-listings-and-ads/blob/d72e2bd8bca203a8360d74582c082ea14f2b1e88/js/src/edit-free-campaign/index.js#L208-L213

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

### Case 1

1. Checkout `develop` branch or this PR
1. Go to the onboarding process.  
2. Go to step 3 (Configure your product listings). 
2. Provoke an error when saving the settings.  For example, setting an incorrect URL in the following line: 

https://github.com/woocommerce/google-listings-and-ads/blob/d72e2bd8bca203a8360d74582c082ea14f2b1e88/js/src/data/actions.js#L319
3. Choose one of the below options:

![image](https://user-images.githubusercontent.com/2488994/179305207-ac018b2e-66d5-460c-af4e-3fb36ece08ef.png)

4. Click continue.
5. If you are in `develop` branch, it will allow you to go to step 4 without choosing the shipping/rate/tax type. 
6. If you are using this PR, it will not allow you to continue to step 4 because the data has not been saved.

### Case 2

1. Go to the onboarding process.  
2. Go to step 4 (Confirm store requirements).
3. Confirm your phone number.
4. Provoke an error when saving the settings.  For example, setting an incorrect URL in the following line: 

https://github.com/woocommerce/google-listings-and-ads/blob/d72e2bd8bca203a8360d74582c082ea14f2b1e88/js/src/data/actions.js#L319

5. Check all the prelunch options.

![image](https://user-images.githubusercontent.com/2488994/179305958-27b9819a-d507-4c90-bd41-51bb0b28de3d.png)

5. If you are in `develop` branch, it will allow you to complete the process without saving the prelunch options. 
6. If you are using this PR, it will not allow you to complete the process.

### Additional details:
I was thinking to add tests to the "pre-lunch checklist" section but I realized that there is an [ongoing project](pcTzPl-jU-p2) working to update this section so probably those tests will not be valid with the new feature.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Propagate errors for saveSettings