### PR TITLE
Update PR template, recommend `changelog: none` label,

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Each line should start with change type prefix`(Fix|Add|…) - `, for example:
 > Dev - Developer-facing only change.
 > Doc - Updated customer or developer facing documentation
 
-If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
+If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
 
 Add the `changelog: none` label if no changelog entry is needed.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,9 @@ Each line should start with change type prefix`(Fix|Add|…) - `, for example:
 > Dev - Developer-facing only change.
 > Doc - Updated customer or developer facing documentation
 
-Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
 If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
+
+Add the `changelog: none` label if no changelog entry is needed.
 -->
 ### Changelog entry
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update PR template, recommend `changelog: none` label, instead of leaving completely empty section.

To match with the updated `yo grow` generator
https://github.com/woocommerce/grow/pull/38


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Review[ PR template](https://github.com/woocommerce/google-listings-and-ads/pull/1613/files)


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Dev - Update PR template.
