### PR TITLE
Revert campaign name suffix

### DIFF
--- a/src/API/Google/AdsReport.php
+++ b/src/API/Google/AdsReport.php
@@ -148,17 +148,7 @@ class AdsReport implements ContainerAwareInterface, OptionsAwareInterface {
 			$campaign_id   = $campaign->getId();
 			$campaign_name = $campaign->getName();
 			$campaign_type = CampaignType::label( $campaign->getAdvertisingChannelType() );
-
-			$is_converted = $this->has_converted && CampaignType::PERFORMANCE_MAX !== $campaign_type;
-
-			// Rename (old converted campaigns).
-			if ( $is_converted ) {
-				$campaign_name = sprintf(
-					// translators: %s: Original campaign name.
-					__( '%s (Old)', 'google-listings-and-ads' ),
-					$campaign_name
-				);
-			}
+			$is_converted  = $this->has_converted && CampaignType::PERFORMANCE_MAX !== $campaign_type;
 
 			$this->increase_report_data(
 				'campaigns',

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -100,18 +100,9 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 		return function( Request $request ) {
 			try {
 				$exclude_removed = $request->get_param( 'exclude_removed' );
-				$has_converted   = 'converted' === $this->ads_campaign->get_campaign_convert_status();
 
 				return array_map(
-					function( $campaign ) use ( $request, $has_converted ) {
-						// Rename (old converted campaigns).
-						if ( $has_converted && CampaignType::PERFORMANCE_MAX !== $campaign['type'] ) {
-							$campaign['name'] = sprintf(
-								// translators: %s: Original campaign name.
-								__( '%s (Old)', 'google-listings-and-ads' ),
-								$campaign['name']
-							);
-						}
+					function( $campaign ) use ( $request ) {
 						$data = $this->prepare_item_for_response( $campaign, $request );
 						return $this->prepare_response_for_collection( $data );
 					},

--- a/tests/Unit/API/Google/AdsReportTest.php
+++ b/tests/Unit/API/Google/AdsReportTest.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -640,7 +639,7 @@ class AdsReportTest extends UnitTest {
 			[
 				'campaign' => [
 					'status' => 'ENABLED',
-					'name'   => 'Test Campaign',
+					'name'   => 'PMax: Test Campaign',
 					'id'     => 2345678901,
 					'type'   => 'PERFORMANCE_MAX',
 				],
@@ -657,7 +656,7 @@ class AdsReportTest extends UnitTest {
 			$report_type => [
 				[
 					'id'          => 1234567890,
-					'name'        => 'Test Campaign (Old)',
+					'name'        => 'Test Campaign',
 					'status'      => 'removed',
 					'isConverted' => true,
 					'subtotals' => [
@@ -666,7 +665,7 @@ class AdsReportTest extends UnitTest {
 				],
 				[
 					'id'           => 2345678901,
-					'name'         => 'Test Campaign',
+					'name'         => 'PMax: Test Campaign',
 					'status'       => 'enabled',
 					'isConverted'  => false,
 					'subtotals' => [

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -89,7 +89,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 			],
 			[
 				'id'                 => 5678901234,
-				'name'               => 'Test Campaign',
+				'name'               => 'PMax: Test Campaign',
 				'status'             => 'enabled',
 				'type'               => 'performance_max',
 				'amount'             => 20,
@@ -101,7 +101,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 		$expected = [
 			[
 				'id'                 => self::TEST_CAMPAIGN_ID,
-				'name'               => 'Test Campaign (Old)',
+				'name'               => 'Test Campaign',
 				'status'             => 'removed',
 				'type'               => 'shopping',
 				'amount'             => 10,
@@ -110,7 +110,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 			],
 			[
 				'id'                 => 5678901234,
-				'name'               => 'Test Campaign',
+				'name'               => 'PMax: Test Campaign',
 				'status'             => 'enabled',
 				'type'               => 'performance_max',
 				'amount'             => 20,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR reverts the campaign name suffix `(Old)` in favour of the prefix which is added to converted campaigns. The suffix was originally added in #1452 so here we are just reverting those changes.

### Detailed test instructions:
- Modify the `gla_campaign_convert_status` in the `wp_options` table, and set the status to `converted`
- Send a request GET https://domain.test/wp-json/wc/gla/ads/campaigns?exclude_removed=0
- We should no longer get the suffix (Old) added to any campaign names that were removed and are a SSC
