### PR TITLE
Fix `doc~s~` typo in `release.yml`, add `type: documentation`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -38,7 +38,8 @@ changelog:
 
     - title: "[Doc] Documentation 📚"
       labels:
-        - "changelog: docs"
+        - "changelog: doc"
+        - "type: documentation"
 
     - title: Other Changes
       labels:


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Fix `doc~s~` typo in `release.yml`, add `type: documentation`

Fixes https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/223#pullrequestreview-1061606069


### Screenshots:

<img width="913" alt="Screenshot 2022-08-04 at 13 48 40" src="https://user-images.githubusercontent.com/5908855/182818189-b36c909b-ab0f-43d3-a64d-b3d3358865a4.png">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Add the `changelog: doc` label to one of the latest PRs
2. Try generating GitHub release notes for that PR (see https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/223 for detailed instructions)


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fixed missed `changelog: doc`