### PR TITLE
Free Listings + Paid Ads: Add step 4 to the onboarding flow

### DIFF
--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -21,6 +21,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import SetupAccounts from './setup-accounts';
 import SetupFreeListings from '.~/components/free-listings/setup-free-listings';
 import StoreRequirements from './store-requirements';
+import SetupPaidAds from './setup-paid-ads';
 import './index.scss';
 import stepNameKeyMap from './stepNameKeyMap';
 
@@ -81,7 +82,7 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 			target: 'step1_continue',
 			trigger: 'click',
 		} );
-		setStep( stepNameKeyMap.target_audience );
+		setStep( stepNameKeyMap.product_listings );
 		onRefetchSavedStep();
 	};
 
@@ -91,6 +92,15 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 			trigger: 'click',
 		} );
 		setStep( stepNameKeyMap.store_requirements );
+		onRefetchSavedStep();
+	};
+
+	const handleStoreRequirementsContinue = () => {
+		recordEvent( 'gla_setup_mc', {
+			target: 'step3_continue',
+			trigger: 'click',
+		} );
+		setStep( stepNameKeyMap.paid_ads );
 		onRefetchSavedStep();
 	};
 
@@ -128,7 +138,7 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 					onClick: handleStepClick,
 				},
 				{
-					key: stepNameKeyMap.target_audience,
+					key: stepNameKeyMap.product_listings,
 					label: __(
 						'Configure product listings',
 						'google-listings-and-ads'
@@ -183,7 +193,20 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 						'Confirm store requirements',
 						'google-listings-and-ads'
 					),
-					content: <StoreRequirements />,
+					content: (
+						<StoreRequirements
+							onContinue={ handleStoreRequirementsContinue }
+						/>
+					),
+					onClick: handleStepClick,
+				},
+				{
+					key: stepNameKeyMap.paid_ads,
+					label: __(
+						'Complete your campaign',
+						'google-listings-and-ads'
+					),
+					content: <SetupPaidAds />,
 					onClick: handleStepClick,
 				},
 			] }

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/index.js
@@ -1,0 +1,1 @@
+export { default } from './setup-paid-ads';

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useState } from '@wordpress/element';
+import { Flex } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import useAdminUrl from '.~/hooks/useAdminUrl';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import StepContent from '.~/components/stepper/step-content';
+import StepContentHeader from '.~/components/stepper/step-content-header';
+import StepContentFooter from '.~/components/stepper/step-content-footer';
+import FaqsSection from '.~/components/paid-ads/faqs-section';
+import AppButton from '.~/components/app-button';
+import { getProductFeedUrl } from '.~/utils/urls';
+import { GUIDE_NAMES } from '.~/constants';
+import { API_NAMESPACE } from '.~/data/constants';
+
+export default function SetupPaidAds() {
+	const adminUrl = useAdminUrl();
+	const { createNotice } = useDispatchCoreNotices();
+	const [ completing, setCompleting ] = useState( null );
+
+	const finishFreeListingsSetup = async ( event ) => {
+		setCompleting( event.target.dataset.action );
+
+		try {
+			await apiFetch( {
+				path: `${ API_NAMESPACE }/mc/settings/sync`,
+				method: 'POST',
+			} );
+		} catch ( e ) {
+			setCompleting( null );
+
+			createNotice(
+				'error',
+				__(
+					'Unable to complete your setup.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+
+		// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
+		const query = { guide: GUIDE_NAMES.SUBMISSION_SUCCESS };
+		window.location.href = adminUrl + getProductFeedUrl( query );
+	};
+
+	const handleCompleteClick = async ( event ) => {
+		// TODO: Implement the compaign creation and paid ads completion.
+		await finishFreeListingsSetup( event );
+	};
+
+	return (
+		<StepContent>
+			<StepContentHeader
+				title={ __(
+					'Complete your campaign with paid ads',
+					'google-listings-and-ads'
+				) }
+				description={ __(
+					'As soon as your products are approved, your listings and ads will be live. In the meantime, let’s set up your ads.',
+					'google-listings-and-ads'
+				) }
+			/>
+			<FaqsSection />
+			<StepContentFooter>
+				<Flex justify="right" gap={ 4 }>
+					<AppButton
+						isTertiary
+						data-action="skip-ads"
+						loading={ completing === 'skip-ads' }
+						disabled={ completing === 'complete-ads' }
+						onClick={ finishFreeListingsSetup }
+					>
+						{ __(
+							'Skip paid ads creation',
+							'google-listings-and-ads'
+						) }
+					</AppButton>
+					<AppButton
+						isPrimary
+						data-action="complete-ads"
+						loading={ completing === 'complete-ads' }
+						disabled={ completing === 'skip-ads' }
+						onClick={ handleCompleteClick }
+					>
+						{ __( 'Complete setup', 'google-listings-and-ads' ) }
+					</AppButton>
+				</Flex>
+			</StepContentFooter>
+		</StepContent>
+	);
+}

--- a/js/src/setup-mc/setup-stepper/stepNameKeyMap.js
+++ b/js/src/setup-mc/setup-stepper/stepNameKeyMap.js
@@ -1,12 +1,8 @@
-// TODO:
-// Two keys have the same value '2' temporarily before the overall changes of
-// onboarding steps are completed. They would be mapped/changed to new step keys
-// and values in the subsequent PR.
 const stepNameKeyMap = {
 	accounts: '1',
-	target_audience: '2',
-	shipping_and_taxes: '2',
+	product_listings: '2',
 	store_requirements: '3',
+	paid_ads: '4',
 };
 
 export default stepNameKeyMap;

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -3,15 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
 import { Form } from '@woocommerce/components';
-import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
 import { useAppDispatch } from '.~/data';
-import useAdminUrl from '.~/hooks/useAdminUrl';
 import useStoreAddress from '.~/hooks/useStoreAddress';
 import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
@@ -24,8 +21,13 @@ import AppSpinner from '.~/components/app-spinner';
 import PreLaunchChecklist from './pre-launch-checklist';
 import checkErrors from './pre-launch-checklist/checkErrors';
 
-export default function StoreRequirements() {
-	const adminUrl = useAdminUrl();
+/**
+ * Step for the store requirements in the onboarding flow.
+ *
+ * @param {Object} props React props.
+ * @param {() => void} props.onContinue Callback called once continue button is clicked.
+ */
+export default function StoreRequirements( { onContinue } ) {
 	const { updateGoogleMCContactInformation, saveSettings } = useAppDispatch();
 	const { createNotice } = useDispatchCoreNotices();
 	const { data: address } = useStoreAddress();
@@ -63,25 +65,14 @@ export default function StoreRequirements() {
 			setCompleting( true );
 
 			await updateGoogleMCContactInformation();
-
-			await apiFetch( {
-				path: '/wc/gla/mc/settings/sync',
-				method: 'POST',
-			} );
-
-			// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
-			const path = getNewPath(
-				{ guide: 'submission-success' },
-				'/google/product-feed'
-			);
-			window.location.href = adminUrl + path;
+			onContinue();
 		} catch ( error ) {
 			setCompleting( false );
 
 			createNotice(
 				'error',
 				__(
-					'Unable to complete your setup. Please try again later.',
+					'Unable to update your contact information. Please try again later.',
 					'google-listings-and-ads'
 				)
 			);
@@ -141,7 +132,7 @@ export default function StoreRequirements() {
 									onClick={ handleSubmit }
 								>
 									{ __(
-										'Complete setup',
+										'Continue',
 										'google-listings-and-ads'
 									) }
 								</AppButton>

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -60,6 +60,16 @@ export const getDashboardUrl = () => {
 	return getNewPath( null, dashboardPath, null );
 };
 
+/**
+ * Return product feed URL with query parameters.
+ *
+ * @param {Object} [query=null] object of params to be updated.
+ * @return {string} Product feed URL with specified query parameters.
+ */
+export const getProductFeedUrl = ( query = null ) => {
+	return getNewPath( query, pagePaths.productFeed, null );
+};
+
 export const getSettingsUrl = () => {
 	return getNewPath( null, settingsPath, null );
 };

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -212,13 +212,13 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 		$step = 'accounts';
 		if ( $this->connected_account() ) {
-			$step = 'target_audience';
+			$step = 'product_listings';
 
-			if ( $this->saved_target_audience() ) {
-				$step = 'shipping_and_taxes';
+			if ( $this->saved_target_audience() && $this->saved_shipping_and_tax_options() ) {
+				$step = 'store_requirements';
 
-				if ( $this->saved_shipping_and_tax_options() ) {
-					$step = 'store_requirements';
+				if ( $this->is_mc_contact_information_setup() && $this->checked_pre_launch_checklist() ) {
+					$step = 'paid_ads';
 				}
 			}
 		}
@@ -324,6 +324,34 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		}
 
 		return $is_setup['phone_number'] && $is_setup['address'];
+	}
+
+	/**
+	 * Check if all items in the pre-launch checklist have been checked.
+	 *
+	 * NOTE: This is a temporary method that will be replaced by the Policy Compliance Checks project.
+	 *
+	 * @return bool If all required items in the pre-launch checklist have been checked.
+	 *
+	 * @since x.x.x
+	 */
+	protected function checked_pre_launch_checklist(): bool {
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+		$keys     = [
+			'website_live',
+			'checkout_process_secure',
+			'payment_methods_visible',
+			'refund_tos_visible',
+			'contact_info_visible',
+		];
+
+		foreach ( $keys as $key ) {
+			if ( empty( $settings[ $key ] ) || $settings[ $key ] !== true ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -366,20 +366,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		);
 	}
 
-	public function test_get_setup_status_step_target_audience() {
-		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
-		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
-
-		$this->assertEquals(
-			[
-				'status' => 'incomplete',
-				'step'   => 'product_listings',
-			],
-			$this->mc_service->get_setup_status()
-		);
-	}
-
-	public function test_get_setup_status_step_shipping_and_taxes() {
+	public function test_get_setup_status_step_product_listings() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->options->method( 'get' )

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -373,7 +373,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->assertEquals(
 			[
 				'status' => 'incomplete',
-				'step'   => 'target_audience',
+				'step'   => 'product_listings',
 			],
 			$this->mc_service->get_setup_status()
 		);
@@ -398,7 +398,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->assertEquals(
 			[
 				'status' => 'incomplete',
-				'step'   => 'shipping_and_taxes',
+				'step'   => 'product_listings',
 			],
 			$this->mc_service->get_setup_status()
 		);
@@ -471,6 +471,65 @@ class MerchantCenterServiceTest extends UnitTest {
 			[
 				'status' => 'incomplete',
 				'step'   => 'store_requirements',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
+	public function test_get_setup_status_step_paid_ads() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::TARGET_AUDIENCE ],
+				[ OptionsInterface::MERCHANT_CENTER, [] ],
+				[ OptionsInterface::MERCHANT_CENTER, [] ]
+			)->willReturnOnConsecutiveCalls(
+				false,
+				[
+					'location'  => 'selected',
+					'countries' => [ 'GB' ],
+				],
+				[],
+				[
+					'website_live'            => true,
+					'checkout_process_secure' => true,
+					'payment_methods_visible' => true,
+					'refund_tos_visible'      => true,
+					'contact_info_visible'    => true,
+				]
+			);
+		$this->shipping_time_query->method( 'get_results' )
+			->willReturn(
+				[
+					[
+						'time'    => '1',
+						'country' => 'GB',
+					],
+				]
+			);
+		$this->shipping_rate_query->method( 'get_results' )
+			->willReturn(
+				[
+					[
+						'rate'    => '10',
+						'country' => 'GB',
+					],
+				]
+			);
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'GB' ] );
+		$this->contact_information->method( 'get_contact_information' )
+			->willReturn( $this->get_valid_business_info() );
+		$this->settings->method( 'get_store_address' )
+			->willReturn( $this->get_sample_address() );
+		$this->address_utility->method( 'compare_addresses' )
+			->willReturn( true );
+
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'paid_ads',
 			],
 			$this->mc_service->get_setup_status()
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a part of **📌 Adjust the setting sections in the onboarding steps** in #1610, and adjusts the `mc/setup` API.

- Adjust the logic of `step` value returned by `mc/setup` API to fit with the new 4-step.
- Add step 4 to the onboarding flow with "Skip" and "Complete" buttons.

### Detailed test instructions:

1. Disconnect the Google Merchant Center account via the connection test page: `/wp-admin/admin.php?page=connection-test-admin-page`.
2. Go to the onboarding flow.
3. In each step of steps 2~3, edit settings in each section and refresh the web page to see if the page shows the closest unfinished step after refreshing.
4. Click the "Skip paid ads creation"/"Complete setup" button to check if it completes the setup and then brings you to the Product Feed page.

### Changelog entry
