### PR TITLE
Use visibility:hidden to hide the element but preserving offset

### DIFF
--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -10,12 +10,11 @@
 	.woocommerce-layout {
 		padding-top: 0;
 
-		// set the layout header width to 0 to hide it.
 		// do not set the header to display: none,
 		// because we want the offsetHeight value
 		// and set it to wpbody-content margin-top to counter back.
 		.woocommerce-layout__header {
-			width: 0;
+			visibility: hidden;
 
 			// only display the top left WC navigation,
 			// do not display the h1 page title element


### PR DESCRIPTION
### Changes proposed in this Pull Request:


Closes #1625 

This PR implements a fix to avoid the content of the message bar in the header to overflow in the fixed element. Instead of width 0 (initial solution) we use now visibility:hidden. The goal is to preserve the offset of the DOM element without render its content. 

### Screenshots:

before:

<img width="393" alt="Screenshot 2022-08-11 at 11 41 23" src="https://user-images.githubusercontent.com/5908855/184158289-1f1f4b8a-9919-4d2c-a9cc-ec6d5be74e26.png">

after:

<img width="428" alt="Screenshot 2022-08-11 at 16 31 48" src="https://user-images.githubusercontent.com/5908855/184158327-a1f4919f-9dbe-4cd5-bb5d-7f2d44b15b17.png">


### Detailed test instructions:

1.  Create a store in WooCommerce without finishing all the config
2. Go to Edit free listings
3. See that the message appears in code but is invisible. However, the offset preserves.
4. Back button is clickable


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Hide WooCommerce System messages in the plugin screen. 
