### PR TITLE
Test - Set default timeout

### DIFF
--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -33,7 +33,8 @@ let simpleProductID;
 
 describe( 'GTag events', () => {
 	beforeAll( async () => {
-		page.setDefaultTimeout( 200 );
+		page.setDefaultTimeout( 3000 );
+		jest.setTimeout( 60000 );
 		await saveConversionID();
 		await createBlockShopPage();
 		simpleProductID = await createSimpleProduct();

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -33,8 +33,7 @@ let simpleProductID;
 
 describe( 'GTag events', () => {
 	beforeAll( async () => {
-		page.setDefaultTimeout( 1000 );
-		page.setDefaultNavigationTimeout( 3000 );
+		page.setDefaultTimeout( 3000 );
 		await saveConversionID();
 		await createBlockShopPage();
 		simpleProductID = await createSimpleProduct();

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -34,6 +34,7 @@ let simpleProductID;
 describe( 'GTag events', () => {
 	beforeAll( async () => {
 		page.setDefaultTimeout( 1000 );
+		page.setDefaultNavigationTimeout( 3000 );
 		await saveConversionID();
 		await createBlockShopPage();
 		simpleProductID = await createSimpleProduct();

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -33,6 +33,7 @@ let simpleProductID;
 
 describe( 'GTag events', () => {
 	beforeAll( async () => {
+		page.setDefaultTimeout( 3000 );
 		await saveConversionID();
 		await createBlockShopPage();
 		simpleProductID = await createSimpleProduct();

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -33,8 +33,7 @@ let simpleProductID;
 
 describe( 'GTag events', () => {
 	beforeAll( async () => {
-		page.setDefaultTimeout( 3000 );
-		jest.setTimeout( 60000 );
+		page.setDefaultTimeout( 1000 );
 		await saveConversionID();
 		await createBlockShopPage();
 		simpleProductID = await createSimpleProduct();

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -33,7 +33,7 @@ let simpleProductID;
 
 describe( 'GTag events', () => {
 	beforeAll( async () => {
-		page.setDefaultTimeout( 3000 );
+		page.setDefaultTimeout( 200 );
 		await saveConversionID();
 		await createBlockShopPage();
 		simpleProductID = await createSimpleProduct();

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -14,11 +14,11 @@
  * @return {Promise} Matching request.
  */
 export function trackGtagEvent( eventName ) {
-	const eventURL = 'https://www.google.com/pagead';
+	const eventPath = '/pagead';
 	return page.waitForRequest( ( request ) => {
 		const url = request.url();
 		const match = encodeURIComponent( 'event=' + eventName );
-		return url.startsWith( eventURL ) && url.includes( match );
+		return url.includes( eventPath ) && url.includes( match );
 	} );
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Attempts to fix random timeouts in our e2e tests causing by 2 issues:

1. WaitingFor timeout of 500ms with some selectors -> Solution to increase default timeout to 3000ms
2. Test timeout of 30000ms potentially caused by divergences in google domain in regards `trackGtagEvent` -> Solution to modify the function to check the path instead of the domain.

### Additional details

The reason of using timeout of 3000ms instead of something lower like 1000ms is because the default timeout also have impact in navigationTimeout used by page navigation. 

### Detailed test instructions:

1. Observe the tests in future PR to see if this PR solves the problem
2. Unfortunately there is not a consistent way to test the issue is solved. 

### Changelog entry