### PR TITLE
Remove wc-admin installation from E2E env setup

### DIFF
--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -15,9 +15,6 @@ wp plugin install woocommerce --activate
 # Install basic auth for API requests on http.
 wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 
-# Install and activate WC-admin for GLA.
-wp plugin install woocommerce-admin --activate
-
 # GLA is automatically mapped to the docker container's plugins folder,
 # we just need to activate it here.
 wp plugin activate google-listings-and-ads


### PR DESCRIPTION


### Changes proposed in this Pull Request:

Remove wc-admin installation from E2E env setup, it should be now merged to WooCommerce.

So the step is not needed and potential performance and debugging obstacles.


### Screenshots:


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check E2e run by github actions.
2. Run E2E locally `npm i && npm run dev && npm run docker:up && npm test:e2e`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Remove wc-admin installation from E2E env setup
