### PR TITLE
E2E Fix for redirecting to single product page.

### DIFF
--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -23,6 +23,7 @@ import {
 	relatedProductAddToCart,
 } from '../../utils/cart';
 import { createBlockShopPage } from '../../utils/block-page';
+import { goToSingleProduct } from '../../utils/visit-product-page';
 
 const config = require( 'config' ); // eslint-disable-line import/no-extraneous-dependencies
 const productPrice = config.has( 'products.simple.price' )
@@ -72,7 +73,7 @@ describe( 'GTag events', () => {
 	it( 'View item event is sent on a single product page', async () => {
 		const event = trackGtagEvent( 'view_item' );
 
-		await shopper.goToProduct( simpleProductID );
+		await goToSingleProduct( simpleProductID );
 
 		await event.then( ( request ) => {
 			const data = getEventData( request );
@@ -104,8 +105,7 @@ describe( 'GTag events', () => {
 	it( 'Add to cart event is sent on a single product page', async () => {
 		const event = trackGtagEvent( 'add_to_cart' );
 
-		await shopper.goToProduct( simpleProductID );
-		await page.waitForSelector( 'form.cart' );
+		await goToSingleProduct( simpleProductID );
 		await shopper.addToCart();
 
 		await event.then( ( request ) => {
@@ -121,7 +121,7 @@ describe( 'GTag events', () => {
 		await createSimpleProduct(); // Create an additional product for related to show up.
 		const event = trackGtagEvent( 'add_to_cart' );
 
-		await shopper.goToProduct( simpleProductID );
+		await goToSingleProduct( simpleProductID );
 		const relatedProductID = await relatedProductAddToCart();
 
 		await event.then( ( request ) => {
@@ -164,8 +164,7 @@ describe( 'GTag events', () => {
 
 	it( 'Conversion event is sent on order complete page', async () => {
 		await emptyCart();
-		await shopper.goToProduct( simpleProductID );
-		await page.waitForSelector( 'form.cart' );
+		await goToSingleProduct( simpleProductID );
 		await shopper.addToCart();
 
 		await shopper.goToCheckout();
@@ -186,8 +185,7 @@ describe( 'GTag events', () => {
 
 	it( 'Purchase event is sent on order complete page', async () => {
 		await emptyCart();
-		await shopper.goToProduct( simpleProductID );
-		await page.waitForSelector( 'form.cart' );
+		await goToSingleProduct( simpleProductID );
 		await shopper.addToCart();
 
 		await shopper.goToCheckout();

--- a/tests/e2e/utils/visit-product-page.js
+++ b/tests/e2e/utils/visit-product-page.js
@@ -13,7 +13,7 @@ import {
 
 /**
  * Redirects to a single product page.
- * Waits till the cart form fully loads because shopper.goToProduct uses a
+ * Wait till the cart form fully loads because shopper.goToProduct uses a
  * URL with product ID which leads to a redirect for pretty permalinks.
  *
  * @param {number} productID

--- a/tests/e2e/utils/visit-product-page.js
+++ b/tests/e2e/utils/visit-product-page.js
@@ -1,0 +1,24 @@
+/**
+ * Helper functions for visiting a product page.
+ */
+
+/**
+ * External dependencies
+ */
+import {
+	shopper, // eslint-disable-line import/named
+} from '@woocommerce/e2e-utils';
+
+/* global page */
+
+/**
+ * Redirects to a single product page.
+ * Waits till the cart form fully loads because shopper.goToProduct uses a
+ * URL with product ID which leads to a redirect for pretty permalinks.
+ *
+ * @param {number} productID
+ */
+export async function goToSingleProduct( productID ) {
+	await shopper.goToProduct( productID );
+	await page.waitForSelector( 'body.single-product form.cart' );
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Apparently the E2E tests are still flaky and sometimes fail. I was able to reproduce it some of the times locally, and it seems that the tracking event was being sent from the wrong page. This happened after redirecting to a single product page. We originally used shopper.goToProduct which links to a product page like `?p=<product_id>`, and then waits till `networkIdle`. The problem is that we enabled pretty permalinks, which means this will right away return a redirect to the pretty permalink. In most cases we had resolved this by waiting for the element `form.cart`, however if the previous page also had this element then it would return instantly causing the event to sometimes be sent from the previous page.

This PR resolves this by explicitly waiting for a `form.cart` element on a single product page.

### Detailed test instructions:
1. Test the E2E tests locally and confirm they pass (was able to reproduce the best locally when running tests 5 seconds after docker:up. 
2. Check the E2E tests in the PR and make sure they haven't failed on any runs.

### Changelog entry
* Dev - E2E Fix for redirecting to single product page.
