### PR TITLE
Onload conflict when tracking events

### DIFF
--- a/js/src/gtag-events/index.js
+++ b/js/src/gtag-events/index.js
@@ -66,7 +66,7 @@ const singleAddToCartClick = function ( event ) {
 };
 
 // Register for add_to_cart click events.
-window.onload = function () {
+window.addEventListener( 'load', function () {
 	document
 		.querySelectorAll(
 			'.add_to_cart_button:not( .product_type_variable ):not( .product_type_grouped )'
@@ -80,7 +80,7 @@ window.onload = function () {
 		.forEach( ( button ) => {
 			button.addEventListener( 'click', singleAddToCartClick );
 		} );
-};
+} );
 
 // Register for jQuery event to update product data.
 if ( typeof jQuery === 'function' ) {

--- a/js/src/gtag-events/index.js
+++ b/js/src/gtag-events/index.js
@@ -66,7 +66,7 @@ const singleAddToCartClick = function ( event ) {
 };
 
 // Register for add_to_cart click events.
-window.addEventListener( 'load', function () {
+document.defaultView.addEventListener( 'DOMContentLoaded', function () {
 	document
 		.querySelectorAll(
 			'.add_to_cart_button:not( .product_type_variable ):not( .product_type_grouped )'

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -293,7 +293,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $order->get_currency() ),
 			esc_js( $order->get_id() ),
 		);
-		$this->print_inline_gtag_script( $conversion_gtag_info );
+		wp_print_inline_script_tag( $conversion_gtag_info );
 
 		// Get the item info in the order
 		$item_info = [];
@@ -354,7 +354,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $language ),
 			join( ',', $item_info ),
 		);
-		$this->print_inline_gtag_script( $purchase_page_gtag );
+		wp_print_inline_script_tag( $purchase_page_gtag );
 	}
 
 	/**
@@ -386,7 +386,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $product->get_name() ),
 			esc_js( join( ' & ', $this->product_helper->get_categories( $product ) ) ),
 		);
-		$this->print_inline_gtag_script( $view_item_gtag );
+		wp_print_inline_script_tag( $view_item_gtag );
 	}
 
 	/**
@@ -394,7 +394,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	 */
 	private function display_page_view_event_snippet(): void {
 		if ( ! is_cart() ) {
-			$this->print_inline_gtag_script(
+			wp_print_inline_script_tag(
 				'gtag("event", "page_view", {send_to: "GLA"});'
 			);
 			return;
@@ -437,7 +437,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			$value,
 			join( ',', $item_info ),
 		);
-		$this->print_inline_gtag_script( $page_view_gtag );
+		wp_print_inline_script_tag( $page_view_gtag );
 	}
 
 	/**
@@ -452,21 +452,6 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			'name'  => $product->get_name(),
 			'price' => wc_get_price_to_display( $product ),
 		];
-	}
-
-	/**
-	 * Outputs the gtag tracking snippet and wraps it to run on page load.
-	 *
-	 * @param string $script JavaScript to print.
-	 */
-	protected function print_inline_gtag_script( string $script ) {
-		wp_print_inline_script_tag(
-			"
-			window.addEventListener( 'load', function () {
-				{$script}
-			} );
-			"
-		);
 	}
 
 	/**

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -293,7 +293,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $order->get_currency() ),
 			esc_js( $order->get_id() ),
 		);
-		wp_print_inline_script_tag( $conversion_gtag_info );
+		$this->print_inline_gtag_script( $conversion_gtag_info );
 
 		// Get the item info in the order
 		$item_info = [];
@@ -354,7 +354,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $language ),
 			join( ',', $item_info ),
 		);
-		wp_print_inline_script_tag( $purchase_page_gtag );
+		$this->print_inline_gtag_script( $purchase_page_gtag );
 	}
 
 	/**
@@ -386,7 +386,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $product->get_name() ),
 			esc_js( join( ' & ', $this->product_helper->get_categories( $product ) ) ),
 		);
-		wp_print_inline_script_tag( $view_item_gtag );
+		$this->print_inline_gtag_script( $view_item_gtag );
 	}
 
 	/**
@@ -394,7 +394,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	 */
 	private function display_page_view_event_snippet(): void {
 		if ( ! is_cart() ) {
-			wp_print_inline_script_tag(
+			$this->print_inline_gtag_script(
 				'gtag("event", "page_view", {send_to: "GLA"});'
 			);
 			return;
@@ -437,7 +437,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			$value,
 			join( ',', $item_info ),
 		);
-		wp_print_inline_script_tag( $page_view_gtag );
+		$this->print_inline_gtag_script( $page_view_gtag );
 	}
 
 	/**
@@ -452,6 +452,21 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			'name'  => $product->get_name(),
 			'price' => wc_get_price_to_display( $product ),
 		];
+	}
+
+	/**
+	 * Outputs the gtag tracking snippet and wraps it to run on page load.
+	 *
+	 * @param string $script JavaScript to print.
+	 */
+	protected function print_inline_gtag_script( string $script ) {
+		wp_print_inline_script_tag(
+			"
+			window.addEventListener( 'load', function () {
+				{$script}
+			} );
+			"
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the onload function to use addEventListener, there were various sites which reported broken behaviour because `window.onload` can only be defined once. I was able to confirm that three out of the four linked issues contained code which assigned a function to `window.onload`. On the fourth site I wasn't able to find the explicit usage of the code, but there are still chances it's what caused the conflict.

The PR also changes the inline code snippets to be wrapped in a loading function so the event is run when the page has loaded.

Closes #1630

### Detailed test instructions:
1. Test on a site with a theme that overrides `window.onload` or use a code snippet like this:
```
add_action(
	'wp_head',
	function () {
		wp_print_inline_script_tag( 'window.onload = function() { console.log("running"); }' );
	},
	1
);
```
2. Ensure Merchant and Ads onboarding has completed (to allow for event tracking).
3. Confirm that with latest develop we don't see the console output "running". 
4. Try again with this PR (rebuild the JS after switching) and confirm that the console output is shown.
5. Try viewing various pages and click add to cart buttons.
6. Confirm that for each of these we see a tracking event sent to `https://google.com/pagead` (URL might vary slightly depending on region).

### Changelog entry
* Fix - Onload conflict when tracking events.