### PR TITLE
Add a filter to disable GTag tracking

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -460,6 +460,10 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	 * @return bool True if the Global Site Tag framework should be included.
 	 */
 	public static function is_needed(): bool {
+		if ( apply_filters( 'woocommerce_gla_disable_gtag_tracking', false ) ) {
+			return false;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a filter for disabling the internal GTag tracking, the intention is for the filter to only be used when replacement tracking has been enabled. See #1609 for valid scenarios.

Closes #1609

### Detailed test instructions:
1. Ensure Merchant and Ads onboarding has completed (to allow for event tracking).
2. Try viewing various pages and click add to cart buttons.
3. Confirm that for each of these we see a tracking event sent to https://google.com/pagead (URL might vary slightly depending on region).
4. Enable the filter to disable tracking
```php
add_filter( 'woocommerce_gla_disable_gtag_tracking', '__return_true' );
```
5. Confirm that the events are no longer sent when we perform the same actions.
6. Confirm that the frontend script `js/build/gtag-events.js` is no longer loaded.


### Changelog entry
* Tweak - Add a filter to disable GTag tracking.
