### PR TITLE
Free Listings + Paid Ads: Add mc setup complete API

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/SetupCompleteController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SetupCompleteController.php
@@ -1,0 +1,68 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\EmptySchemaPropertiesTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SetupCompleteController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
+ */
+class SetupCompleteController extends BaseController {
+
+	use EmptySchemaPropertiesTrait;
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+		$this->register_route(
+			'mc/setup/complete',
+			[
+				[
+					'methods'             => TransportMethods::CREATABLE,
+					'callback'            => $this->get_setup_complete_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the callback function for marking setup complete.
+	 *
+	 * @return callable
+	 */
+	protected function get_setup_complete_callback(): callable {
+		return function( Request $request ) {
+			do_action( 'woocommerce_gla_mc_setup_completed' );
+
+			return new Response(
+				[
+					'status'  => 'success',
+					'message' => __( 'Successfully marked merchant center setup as completed.', 'google-listings-and-ads' ),
+				],
+				201
+			);
+		};
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'mc_setup_complete';
+	}
+}

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -30,6 +30,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ReportsController as MerchantCenterReportsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsSyncController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SetupCompleteController as MerchantCenterSetupCompleteController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingRateBatchController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingRateController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingRateSuggestionsController;
@@ -112,6 +113,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( SettingsSyncController::class, Settings::class );
 		$this->share( DisconnectController::class );
 		$this->share( SetupCompleteController::class );
+		$this->share( MerchantCenterSetupCompleteController::class );
 	}
 
 	/**

--- a/src/Options/MerchantSetupCompleted.php
+++ b/src/Options/MerchantSetupCompleted.php
@@ -27,6 +27,11 @@ class MerchantSetupCompleted implements OptionsAwareInterface, Registerable, Ser
 			'woocommerce_gla_mc_settings_sync',
 			function() {
 				$this->set_contact_information_setup();
+			}
+		);
+		add_action(
+			'woocommerce_gla_mc_setup_completed',
+			function() {
 				$this->set_completed_timestamp();
 			}
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements the [backend task 0](https://github.com/woocommerce/google-listings-and-ads/issues/1610#be-task0) **📌 Add a new API for onboarding completed** in the epic issue #1610.

- Add an API `mc/setup/complete` which will be called at the step 4 of new onboarding flow, no matter the merchant skip or set up a paid campaign.
- This new API does only one thing: set the timestamp to the option `gla_mc_setup_completed_at`.
- This PR also modifies an existing API `mc/settings/sync` by not setting the timestamp to the option `gla_mc_setup_completed_at`.

### Detailed test instructions:

1. Use Postman, make a `POST` request to `mc/setup/complete`.
2. In the database, the value of the option `gla_mc_setup_completed_at` should be added or updated.
3. Use Postman, make a `POST` request to `mc/settings/sync`.
4. In the database, the value of the option `gla_mc_setup_completed_at` should not be added or updated.