### PR TITLE
Fix a compatibility issue with WC 6.5+ that the store country might be `undefined` and further break the onboarding setup

### DIFF
--- a/tests/unit/wc-admin-dependency.test.js
+++ b/tests/unit/wc-admin-dependency.test.js
@@ -3,7 +3,7 @@
  */
 import { Link } from '@woocommerce/components';
 import CurrencyFactory from '@woocommerce/currency';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { getCurrentDates } from '@woocommerce/date';
 import { getQuery } from '@woocommerce/navigation';
 import { numberFormat } from '@woocommerce/number';
@@ -22,7 +22,7 @@ describe( 'plugin config should be able to run unit-test with dependency on', ()
 	} );
 
 	test( '@woocommerce/data', () => {
-		expect( SETTINGS_STORE_NAME ).toBeDefined();
+		expect( OPTIONS_STORE_NAME ).toBeDefined();
 	} );
 
 	test( '@woocommerce/date', () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1641

- Fix a compatibility issue with WC 6.5+ that the store country might be `undefined` and further break the onboarding setup.

### Detailed test instructions:

1. Install WC with 6.5+ version.
1. Go to the **Advanced Features** tab on WC Settings page: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
1. Turn on the **Analytics** feature and save changes.
1. On the General tab of WC Settings page, set the store country to an unsupported base country like: `Timor-Leste`.
1. Go to the Get Started page. It should show a warning notice on the top of page with the unsupported country name.
   ![2022-08-22 12 30 26](https://user-images.githubusercontent.com/17420811/185840633-61b300b6-b2b7-4e63-81f7-068ccd9d0cfd.png)
1. Set the store country to United States.
1. Proceed with step 3 of the onboarding setup. It should be able to render the page and the "Tax rate (required for U.S. only)" section should be displayed.
   ![image](https://user-images.githubusercontent.com/17420811/185844292-9b30b2a1-f1fb-412b-b098-0adef27c246e.png)
1. Set the store country to a supported country without states like `United Kingdom`.
1. Refresh the page of step 3 of the onboarding setup. It should be able to render the page.

### Additional details:

I thought the compatibility issue with WC 6.5+ had been fixed by WC 6.7 but apparently, it only fixed the undefined index PHP notice and the inconsistent preload settings problem still exists. References:
- https://github.com/woocommerce/woocommerce/issues/33086
- https://github.com/woocommerce/woocommerce/issues/33309
- https://github.com/woocommerce/woocommerce/pull/33154

To reproduce the inconsistent preload settings problem:

1. Go to the **Advanced Features** tab on WC Settings: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
1. Turn on the **Analytics** feature and save changes.
1. Go to the Get Started page of GLA.
1. Open DevTool and run the script on the Console tab
   - `wp.data.select(wc.data.SETTINGS_STORE_NAME).getSetting('general', 'general').woocommerce_default_country` -> country code and maybe with state code like 'GB' or 'US:AL'.
1. Turn off the **Analytics** feature and save changes.
1. Refresh the Get Started page of GLA.
1. Run the scripts on the Console tab
   - `wp.data.select(wc.data.SETTINGS_STORE_NAME).getSetting('general', 'general')` -> an empty array.
   - `wp.data.select(wc.data.SETTINGS_STORE_NAME).getSetting('general', 'general').woocommerce_default_country` -> `undefined`
1. The empty array of the inconsistent preload settings causes the JS code to break on the onboarding setup.

### Changelog entry

> Fix - A compatibility issue with WC 6.5+ that the store country might be undefined and further break the onboarding setup.
