### PR TITLE
Release 2.1.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
+= 2.1.0 - 2022-08-23 =
+* Add - Automatically sync WooCommerce shipping settings with Merchant Center.
+* Add - Get shipping rates suggestions for provinces/states and postal codes.
+* Add - Option to automatically sync the shipping rates based on the store shipping zone configurations.
+* Add - Sync the shipping rates for states/provinces and postal codes to Merchant Center.
+* Fix - A compatibility issue with WC 6.5+ that the store country might be undefined and further break the onboarding setup.
+* Tweak - Generate random ID for postcode regions when syncing shipping settings.
+
 = 2.0.4 - 2022-08-16 =
 * Dev - E2E Fix for redirecting to single product page.
 * Dev - Remove wc-admin installation from E2E env setup.

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google Listings and Ads
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 2.0.4
+ * Version: 2.1.0
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -28,7 +28,7 @@ use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '2.0.4' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '2.1.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
 define( 'WC_GLA_MIN_WC_VER', '6.0' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "2.0.4",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "google-listings-and-ads",
 	"title": "Google Listings and Ads",
 	"license": "GPL-3.0-or-later",
-	"version": "2.0.4",
+	"version": "2.1.0",
 	"description": "google-listings-and-ads",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,14 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 
 == Changelog ==
 
+= 2.1.0 - 2022-08-23 =
+* Add - Automatically sync WooCommerce shipping settings with Merchant Center.
+* Add - Get shipping rates suggestions for provinces/states and postal codes.
+* Add - Option to automatically sync the shipping rates based on the store shipping zone configurations.
+* Add - Sync the shipping rates for states/provinces and postal codes to Merchant Center.
+* Fix - A compatibility issue with WC 6.5+ that the store country might be undefined and further break the onboarding setup.
+* Tweak - Generate random ID for postcode regions when syncing shipping settings.
+
 = 2.0.4 - 2022-08-16 =
 * Dev - E2E Fix for redirecting to single product page.
 * Dev - Remove wc-admin installation from E2E env setup.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, google, listings, ads
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.4
-Stable tag: 2.0.4
+Stable tag: 2.1.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -127,23 +127,4 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 * Add - Track add to cart events from all buttons including Gutenberg blocks.
 * Fix - Add Woo gTag remarketing and conversion signals.
 
-= 2.0.2 - 2022-07-29 =
-* Fix - Disable identifier_exists field.
-* Tweak - Propagate errors for saveSettings.
-* Tweak - Refactor SCSS variables.
-* Tweak - Remove PHP 8.0 specific code of Symfony polyfills.
-* Tweak - Revert migration applicable version value.
-* Tweak - Update change log records type.
-* Tweak - WC 6.8 compatibility.
-* Update - Google Ads library to API V11.
-
-= 2.0.1 - 2022-07-12 =
-* Dev - A script to generate a list of hooks that defined or used in GLA.
-* Dev - GH workflow to set PR labels.
-* Add - Normalizer Polyfill.
-* Dev - changed the changelog types list.
-* Fix - Compatibility with History Navigation v5.
-* Fix - Encoding product names in Issues Table .
-* Tweak - Remove try and catch in saveTargetAudience action.
-
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -86,7 +86,7 @@ class Settings {
 	 *
 	 * @return ShippingSettings
 	 *
-	 * @since x.x.x
+	 * @since 2.1.0
 	 */
 	protected function generate_shipping_settings(): ShippingSettings {
 		$times = $this->get_shipping_times();

--- a/src/Google/GoogleHelper.php
+++ b/src/Google/GoogleHelper.php
@@ -1368,7 +1368,7 @@ class GoogleHelper implements Service {
 	 *
 	 * @return bool
 	 *
-	 * @since x.x.x
+	 * @since 2.1.0
 	 */
 	public function does_country_support_regional_shipping( string $country_code ): bool {
 		return in_array( $country_code, [ 'AU', 'JP', 'US' ], true );

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class UpdateShippingSettings extends AbstractActionSchedulerJob {
 	/**

--- a/src/Shipping/CountryRatesCollection.php
+++ b/src/Shipping/CountryRatesCollection.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 class CountryRatesCollection extends LocationRatesCollection {
 	/**

--- a/src/Shipping/GoogleAdapter/AbstractRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractRateGroupAdapter.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 abstract class AbstractRateGroupAdapter extends RateGroup {
 	/**

--- a/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 	/**

--- a/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	/**

--- a/src/Shipping/GoogleAdapter/PostcodesRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/PostcodesRateGroupAdapter.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 class PostcodesRateGroupAdapter extends AbstractRateGroupAdapter {
 	/**

--- a/src/Shipping/GoogleAdapter/StatesRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/StatesRateGroupAdapter.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 class StatesRateGroupAdapter extends AbstractRateGroupAdapter {
 	/**

--- a/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	/**

--- a/src/Shipping/LocationRate.php
+++ b/src/Shipping/LocationRate.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class LocationRate implements JsonSerializable {
 	/**

--- a/src/Shipping/LocationRatesCollection.php
+++ b/src/Shipping/LocationRatesCollection.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 abstract class LocationRatesCollection {
 	/**

--- a/src/Shipping/LocationRatesProcessor.php
+++ b/src/Shipping/LocationRatesProcessor.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class LocationRatesProcessor {
 

--- a/src/Shipping/PostcodeRange.php
+++ b/src/Shipping/PostcodeRange.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class PostcodeRange {
 

--- a/src/Shipping/ServiceRatesCollection.php
+++ b/src/Shipping/ServiceRatesCollection.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 class ServiceRatesCollection extends CountryRatesCollection {
 	/**

--- a/src/Shipping/ShippingLocation.php
+++ b/src/Shipping/ShippingLocation.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since   x.x.x
+ * @since   2.1.0
  */
 class ShippingLocation {
 	public const COUNTRY_AREA  = 'country_area';

--- a/src/Shipping/ShippingRate.php
+++ b/src/Shipping/ShippingRate.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class ShippingRate implements JsonSerializable {
 

--- a/src/Shipping/ShippingRegion.php
+++ b/src/Shipping/ShippingRegion.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class ShippingRegion {
 

--- a/src/Shipping/ShippingSuggestionService.php
+++ b/src/Shipping/ShippingSuggestionService.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class ShippingSuggestionService implements Service {
 

--- a/src/Shipping/ShippingZone.php
+++ b/src/Shipping/ShippingZone.php
@@ -153,7 +153,7 @@ class ShippingZone implements Service {
 	 * @param ShippingRate[]     $shipping_rates The shipping rates.
 	 * @param ShippingLocation[] $locations      The shipping locations.
 	 *
-	 * @since x.x.x
+	 * @since 2.1.0
 	 */
 	protected function map_rates_to_locations( array $shipping_rates, array $locations ): void {
 		if ( empty( $shipping_rates ) || empty( $locations ) ) {

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class SyncerHooks implements Service, Registerable {
 

--- a/src/Shipping/ZoneLocationsParser.php
+++ b/src/Shipping/ZoneLocationsParser.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class ZoneLocationsParser implements Service {
 

--- a/src/Shipping/ZoneMethodsParser.php
+++ b/src/Shipping/ZoneMethodsParser.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
- * @since x.x.x
+ * @since 2.1.0
  */
 class ZoneMethodsParser implements Service {
 


### PR DESCRIPTION
## What's Changed
### [Add] New Features 🎉
* Get suggested shipping rates for provinces/states and postal codes from WC zones by @nima-karimi in https://github.com/woocommerce/google-listings-and-ads/pull/1341
* Changes to the shipping rates and suggestions API by @nima-karimi in https://github.com/woocommerce/google-listings-and-ads/pull/1422
* Shipping Integration - Sync shipping rates for subdivisions of a country by @nima-karimi in https://github.com/woocommerce/google-listings-and-ads/pull/1455
* Automatically sync WooCommerce shipping settings with Merchant Center by @nima-karimi in https://github.com/woocommerce/google-listings-and-ads/pull/1560
* Generate random ID for postcode regions when syncing shipping settings by @nima-karimi in https://github.com/woocommerce/google-listings-and-ads/pull/1574
* Shipping Integration - Syncing rates for states/provinces and postal codes by @nima-karimi in https://github.com/woocommerce/google-listings-and-ads/pull/1494
### [Fix] Fixes 🛠
* Fix a compatibility issue with WC 6.5+ that the store country might be `undefined` and further break the onboarding setup by @eason9487 in https://github.com/woocommerce/google-listings-and-ads/pull/1642
### Other Changes
* Remove shipping rate method by @ecgan in https://github.com/woocommerce/google-listings-and-ads/pull/1445


**Full Changelog**: https://github.com/woocommerce/google-listings-and-ads/compare/2.0.4...2.1.0