### PR TITLE
Free Listings + Paid Ads: Add the Google Ads account setup section

### DIFF
--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -91,7 +91,7 @@ const appearanceDict = {
 		icon: googleAdsLogo,
 		title: __( 'Google Ads', 'google-listings-and-ads' ),
 		description: __(
-			'Required to create paid campaigns with your product listings',
+			'Connect with millions of shoppers who are searching for products like yours and drive sales with Google.',
 			'google-listings-and-ads'
 		),
 	},

--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -49,6 +49,7 @@ const AppButton = ( props ) => {
 		onClick( ...args );
 	};
 
+	const disabledButton = disabled || loading;
 	const classes = [ 'app-button', className ];
 	let text;
 
@@ -75,7 +76,8 @@ const AppButton = ( props ) => {
 	return (
 		<Button
 			className={ classnames( ...classes ) }
-			disabled={ disabled || loading }
+			disabled={ disabledButton }
+			aria-disabled={ disabledButton }
 			text={ text }
 			onClick={ handleClick }
 			{ ...rest }

--- a/js/src/components/google-ads-account-card/authorize-ads.js
+++ b/js/src/components/google-ads-account-card/authorize-ads.js
@@ -44,6 +44,7 @@ const AuthorizeAds = ( { additionalScopeEmail } ) => {
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE_ADS }
+			alignIcon="top"
 			indicator={
 				<AppButton
 					isSecondary

--- a/js/src/components/google-ads-account-card/authorize-ads.js
+++ b/js/src/components/google-ads-account-card/authorize-ads.js
@@ -10,8 +10,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import useGoogleAuthorization from '.~/hooks/useGoogleAuthorization';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import AppButton from '.~/components/app-button';
-
-const pageName = 'setup-ads';
+import { glaData } from '.~/constants';
 
 /**
  * @param {Object} props React props
@@ -19,9 +18,10 @@ const pageName = 'setup-ads';
  * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'setup-ads' }`
  */
 const AuthorizeAds = ( { additionalScopeEmail } ) => {
+	const nextPageName = glaData.mcSetupComplete ? 'setup-ads' : 'setup-mc';
 	const { createNotice } = useDispatchCoreNotices();
 	const [ fetchGoogleConnect, { loading, data } ] = useGoogleAuthorization(
-		pageName,
+		nextPageName,
 		additionalScopeEmail
 	);
 
@@ -54,7 +54,7 @@ const AuthorizeAds = ( { additionalScopeEmail } ) => {
 						'google-listings-and-ads'
 					) }
 					eventName="gla_google_account_connect_button_click"
-					eventProps={ { context: pageName, action: 'scope' } }
+					eventProps={ { context: 'setup-ads', action: 'scope' } }
 				/>
 			}
 		/>

--- a/js/src/components/google-ads-account-card/connect-ads/index.js
+++ b/js/src/components/google-ads-account-card/connect-ads/index.js
@@ -79,6 +79,7 @@ const ConnectAds = ( props ) => {
 	return (
 		<AccountCard
 			className="gla-connect-ads"
+			alignIcon="top"
 			appearance={ APPEARANCE.GOOGLE_ADS }
 		>
 			<CardDivider />

--- a/js/src/components/google-ads-account-card/connect-ads/index.js
+++ b/js/src/components/google-ads-account-card/connect-ads/index.js
@@ -3,7 +3,7 @@
  */
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, CardDivider } from '@wordpress/components';
+import { CardDivider } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -135,12 +135,16 @@ const ConnectAds = ( props ) => {
 				</ContentButtonLayout>
 			</Section.Card.Body>
 			<Section.Card.Footer>
-				<Button isLink onClick={ onCreateNew }>
+				<AppButton
+					isTertiary
+					disabled={ isLoading }
+					onClick={ onCreateNew }
+				>
 					{ __(
 						'Or, create a new Google Ads account',
 						'google-listings-and-ads'
 					) }
-				</Button>
+				</AppButton>
 			</Section.Card.Footer>
 		</AccountCard>
 	);

--- a/js/src/components/google-ads-account-card/connected-google-ads-account-card.js
+++ b/js/src/components/google-ads-account-card/connected-google-ads-account-card.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -42,7 +43,11 @@ export default function ConnectedGoogleAdsAccountCard( {
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE_ADS }
-			description={ toAccountText( googleAdsAccount.id ) }
+			description={
+				<ExternalLink href="https://ads.google.com/aw/overview">
+					{ toAccountText( googleAdsAccount.id ) }
+				</ExternalLink>
+			}
 			indicator={ <ConnectedIconLabel /> }
 			{ ...restProps }
 		>

--- a/js/src/components/google-ads-account-card/connected-google-ads-account-card.js
+++ b/js/src/components/google-ads-account-card/connected-google-ads-account-card.js
@@ -1,28 +1,65 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
+import { useAppDispatch } from '.~/data';
 import toAccountText from '.~/utils/toAccountText';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import ConnectedIconLabel from '.~/components/connected-icon-label';
+import AppButton from '.~/components/app-button';
+import Section from '.~/wcdl/section';
 
 /**
  * Renders a Google Ads account card UI with connected account information.
  *
  * @param {Object} props React props.
  * @param {{ id: number }} props.googleAdsAccount A data payload object containing the user's Google Ads account ID.
+ * @param {boolean} [props.hideAccountSwitch=false] Indicate whether hide the account switch block at the card footer.
  * @param {JSX.Element} [props.children] Helper content below the Google account email.
  * @param {Object} props.restProps Props to be forwarded to AccountCard.
  */
 export default function ConnectedGoogleAdsAccountCard( {
 	googleAdsAccount,
+	hideAccountSwitch = false,
+	children,
 	...restProps
 } ) {
+	const { disconnectGoogleAdsAccount } = useAppDispatch();
+	const [ isDisconnecting, setDisconnecting ] = useState( false );
+
+	const handleSwitch = () => {
+		setDisconnecting( true );
+		disconnectGoogleAdsAccount( true ).catch( () =>
+			setDisconnecting( false )
+		);
+	};
+
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE_ADS }
 			description={ toAccountText( googleAdsAccount.id ) }
 			indicator={ <ConnectedIconLabel /> }
 			{ ...restProps }
-		/>
+		>
+			{ children }
+			{ ! hideAccountSwitch && (
+				<Section.Card.Footer>
+					<AppButton
+						isTertiary
+						loading={ isDisconnecting }
+						text={ __(
+							'Or, connect to a different Google Ads account',
+							'google-listings-and-ads'
+						) }
+						onClick={ handleSwitch }
+					/>
+				</Section.Card.Footer>
+			) }
+		</AccountCard>
 	);
 }

--- a/js/src/components/google-ads-account-card/create-account.js
+++ b/js/src/components/google-ads-account-card/create-account.js
@@ -65,6 +65,7 @@ const CreateAccount = ( props ) => {
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE_ADS }
+			alignIcon="top"
 			indicator={ <ClaimTermsAndCreateAccountButton /> }
 		>
 			{ allowShowExisting && (

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -479,7 +479,13 @@ export function* disconnectGoogleAccount() {
 	}
 }
 
-export function* disconnectGoogleAdsAccount() {
+/**
+ * Disconnect the connected Google Ads account.
+ *
+ * @param {boolean} [invalidateRelatedState=false] Whether to invalidate related state in wp-data store.
+ * @throws Will throw an error if the request failed.
+ */
+export function* disconnectGoogleAdsAccount( invalidateRelatedState = false ) {
 	try {
 		yield apiFetch( {
 			path: `${ API_NAMESPACE }/ads/connection`,
@@ -488,6 +494,7 @@ export function* disconnectGoogleAdsAccount() {
 
 		return {
 			type: TYPES.DISCONNECT_ACCOUNTS_GOOGLE_ADS,
+			invalidateRelatedState,
 		};
 	} catch ( error ) {
 		yield handleFetchError(

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -99,6 +99,13 @@ export function* getGoogleAdsAccount() {
 	yield fetchGoogleAdsAccount();
 }
 
+getGoogleAdsAccount.shouldInvalidate = ( action ) => {
+	return (
+		action.type === TYPES.DISCONNECT_ACCOUNTS_GOOGLE_ADS &&
+		action.invalidateRelatedState
+	);
+};
+
 export function* getGoogleAdsAccountBillingStatus() {
 	yield fetchGoogleAdsAccountBillingStatus();
 }
@@ -106,6 +113,9 @@ export function* getGoogleAdsAccountBillingStatus() {
 export function* getExistingGoogleAdsAccounts() {
 	yield fetchExistingGoogleAdsAccounts();
 }
+
+getExistingGoogleAdsAccounts.shouldInvalidate =
+	getGoogleAdsAccount.shouldInvalidate;
 
 export function* getGoogleMCContactInformation() {
 	try {

--- a/js/src/settings/linked-accounts.js
+++ b/js/src/settings/linked-accounts.js
@@ -96,6 +96,7 @@ export default function LinkedAccounts() {
 					{ hasAdsAccount && (
 						<ConnectedGoogleAdsAccountCard
 							googleAdsAccount={ googleAdsAccount }
+							hideAccountSwitch
 						>
 							<Section.Card.Footer>
 								<Button

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/google-ads-account-section.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/google-ads-account-section.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useFreeAdCredit from '.~/hooks/useFreeAdCredit';
+import Section from '.~/wcdl/section';
+import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import GoogleAdsAccountCard from '.~/components/google-ads-account-card';
+import FreeAdCredit from '../../../setup-ads/ads-stepper/setup-accounts/free-ad-credit';
+
+/**
+ * Renders a section layout to connect a Google Ads account or show the connected account.
+ * After completing the connection, it also shows the free ad credit tip if applicable.
+ */
+export default function GoogleAdsAccountSection() {
+	const hasFreeAdCredit = useFreeAdCredit();
+
+	return (
+		<Section
+			title={ __( 'Google Ads', 'google-listings-and-ads' ) }
+			description={ __(
+				'A Google Ads account is required to create paid campaigns with your product listings',
+				'google-listings-and-ads'
+			) }
+		>
+			<VerticalGapLayout size="medium">
+				<GoogleAdsAccountCard />
+				{ hasFreeAdCredit && <FreeAdCredit /> }
+			</VerticalGapLayout>
+		</Section>
+	);
+}

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -18,9 +18,15 @@ import FaqsSection from '.~/components/paid-ads/faqs-section';
 import AppButton from '.~/components/app-button';
 import ProductFeedStatusSection from './product-feed-status-section';
 import PaidAdsFeaturesSection from './paid-ads-features-section';
+import GoogleAdsAccountSection from './google-ads-account-section';
 import { getProductFeedUrl } from '.~/utils/urls';
 import { GUIDE_NAMES } from '.~/constants';
 import { API_NAMESPACE } from '.~/data/constants';
+
+function PaidAdsSectionsGroup() {
+	// TODO: Add audience and budget sections.
+	return <GoogleAdsAccountSection />;
+}
 
 export default function SetupPaidAds() {
 	const adminUrl = useAdminUrl();
@@ -57,6 +63,12 @@ export default function SetupPaidAds() {
 		// TODO: Implement the compaign creation and paid ads completion.
 		await finishFreeListingsSetup( event );
 	};
+
+	// TODO: Add more disabled conditions to check
+	// - Google Ads account connection
+	// - Campaign data
+	// - Billing setup
+	const disabledComplete = completing === 'skip-ads';
 
 	function createSkipButton( text ) {
 		return (
@@ -101,6 +113,7 @@ export default function SetupPaidAds() {
 					/>
 				}
 			/>
+			{ showPaidAdsSetup && <PaidAdsSectionsGroup /> }
 			<FaqsSection />
 			<StepContentFooter hidden={ ! showPaidAdsSetup }>
 				<Flex justify="right" gap={ 4 }>
@@ -118,7 +131,7 @@ export default function SetupPaidAds() {
 							'google-listings-and-ads'
 						) }
 						loading={ completing === 'complete-ads' }
-						disabled={ completing === 'skip-ads' }
+						disabled={ disabledComplete }
 						onClick={ handleCompleteClick }
 					/>
 				</Flex>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements the **📌 Google Ads account section** in #1610.

- Tweak the copywriting and layouts for Google Ads account cards, and add an external link to the connected cards for opening Google Ads management page.
- Handle the page redirection for the `AD_WORDS` authorization of Google account from Google Ads account card in the onboarding flow.
- Add a disconnect button to Google Ads account card for switching accounts.
- Add the Google Ads account setup section to step 4 of the onboarding flow.
- Optional invalidate the related state in **wp-data** store after Google Ads account is disconnected.

This PR also fixes two issues:

- Fix the switch button at the footer is clickable when connecting a Google Ads account.
- Fix the incorrect `:active` CSS style for disabled AppButton

### Screenshots:

https://user-images.githubusercontent.com/17420811/186882683-43f40a92-2baa-48a9-9df4-13c2e51a03fe.mp4

### Detailed test instructions:

1. Use GLA's connection test page to disconnect Google account, and then reconnect it without authorizing the [AD_WORDS](https://www.googleapis.com/auth/adwords) permission.
1. Go to step 4 of the onboarding flow.
1. Test the re-authorizing flow to request the AD_WORDS permission.
1. Create/connect to a Google Ads account.
1. Disconnect the Google Ads account via the current UI.
1. Connect to/create a Google Ads account.

💡 When re-entering step 4, the previously selected "continue setting up paid ads" state is reset. Keeping the selected state will be developed in another PR.

### Changelog entry

> Fix - The "Or, create a new Google Ads account" button at the footer of the Google Ads account setup is clickable when connecting an existing account.
> Fix - The incorrect active status style for a disabled button.

