### PR TITLE
Free Listings + Paid Ads: Add the ads audience and budget sections

### DIFF
--- a/js/src/components/account-card/index.scss
+++ b/js/src/components/account-card/index.scss
@@ -23,6 +23,7 @@
 	&__description {
 		display: flex;
 		flex-direction: column;
+		align-items: flex-start;
 		gap: 1em;
 		color: $gray-900;
 

--- a/js/src/components/different-currency-notice.js
+++ b/js/src/components/different-currency-notice.js
@@ -11,6 +11,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
 import AppDocumentationLink from '.~/components/app-documentation-link';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
 
 /**
  * Shows warning {@link Notice}
@@ -31,7 +32,7 @@ const DifferentCurrencyNotice = ( { context } ) => {
 	// Do not render if data is not available, account not connected, or the same currencies are used.
 	if (
 		! googleAdsAccount ||
-		googleAdsAccount.status !== 'connected' ||
+		googleAdsAccount.status !== GOOGLE_ADS_ACCOUNT_STATUS.CONNECTED ||
 		googleAdsAccount.currency === storeCurrency
 	) {
 		return null;

--- a/js/src/components/google-ads-account-card/google-ads-account-card.js
+++ b/js/src/components/google-ads-account-card/google-ads-account-card.js
@@ -7,6 +7,7 @@ import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import ConnectedGoogleAdsAccountCard from './connected-google-ads-account-card';
 import NonConnected from './non-connected';
 import AuthorizeAds from './authorize-ads';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
 
 export default function GoogleAdsAccountCard() {
 	const { google, scope } = useGoogleAccount();
@@ -20,7 +21,7 @@ export default function GoogleAdsAccountCard() {
 		return <AuthorizeAds additionalScopeEmail={ google.email } />;
 	}
 
-	if ( googleAdsAccount.status === 'disconnected' ) {
+	if ( googleAdsAccount.status === GOOGLE_ADS_ACCOUNT_STATUS.DISCONNECTED ) {
 		return <NonConnected />;
 	}
 

--- a/js/src/components/paid-ads/audience-section.js
+++ b/js/src/components/paid-ads/audience-section.js
@@ -32,7 +32,10 @@ const AudienceSection = ( props ) => {
 		formProps: { getInputProps },
 		multiple = true,
 		disabled = false,
-		countrySelectHelperText,
+		countrySelectHelperText = __(
+			'You can only choose from countries you’ve selected during product listings configuration.',
+			'google-listings-and-ads'
+		),
 	} = props;
 
 	const countryNameMap = useCountryKeyNameMap();
@@ -40,7 +43,7 @@ const AudienceSection = ( props ) => {
 
 	const selector = multiple ? (
 		<AudienceCountrySelect
-			label={ __( 'Select countries', 'google-listings-and-ads' ) }
+			label={ __( 'Select country/s', 'google-listings-and-ads' ) }
 			help={ countrySelectHelperText }
 			disabled={ disabled }
 			value={ inputProps.value }
@@ -61,11 +64,12 @@ const AudienceSection = ( props ) => {
 
 	return (
 		<Section
-			title={ __( 'Audience', 'google-listings-and-ads' ) }
+			disabled={ disabled }
+			title={ __( 'Ads audience', 'google-listings-and-ads' ) }
 			description={
 				<p>
 					{ __(
-						'Choose where do you want your product ads to appear.',
+						'Choose where you want your product ads to appear',
 						'google-listings-and-ads'
 					) }
 				</p>

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
-import GridiconInfoOutline from 'gridicons/dist/info-outline';
+import { Tip } from '@wordpress/components';
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
 
 /**
  * Internal dependencies
@@ -30,16 +31,16 @@ function getHighestBudget( recommendations ) {
 }
 
 function toRecommendationRange( isMultiple, ...values ) {
-	const conversionMap = { strong: <strong /> };
+	const conversionMap = { strong: <strong />, em: <em />, br: <br /> };
 	const template = isMultiple
 		? // translators: it's a range of recommended budget amount. 1: the low value of the range, 2: the high value of the range, 3: the currency of amount.
 		  __(
-				'Most merchants targeting similar countries set a daily budget of <strong>%1$f to %2$f %3$s</strong> for approximately 10 conversions a week.',
+				'Google will optimize your ads to maximize performance across the country/s you select.<br /><em>Tip: Most merchants targeting similar countries <strong>set a daily budget of %1$f to %2$f %3$s</strong></em>',
 				'google-listings-and-ads'
 		  )
 		: // translators: it's a range of recommended budget amount. 1: the low value of the range, 2: the high value of the range, 3: the currency of amount, 4: a country name selected by the merchant.
 		  __(
-				'Most merchants targeting <strong>%4$s</strong> set a daily budget of <strong>%1$f to %2$f %3$s</strong> for approximately 10 conversions a week.',
+				'Google will optimize your ads to maximize performance across the country/s you select.<br /><em>Tip: Most merchants targeting <strong>%4$s set a daily budget of %1$f to %2$f %3$s</strong></em>',
 				'google-listings-and-ads'
 		  );
 
@@ -78,13 +79,9 @@ const BudgetRecommendation = ( props ) => {
 
 	return (
 		<div className="gla-budget-recommendation">
-			<div className="gla-budget-recommendation__recommendation">
-				<GridiconInfoOutline />
-				<div>{ recommendationRange }</div>
-			</div>
 			{ showLowerBudgetNotice && (
 				<div className="gla-budget-recommendation__low-budget">
-					<GridiconInfoOutline />
+					<GridiconNoticeOutline />
 					<div>
 						{ __(
 							'With a budget lower than your competitor range, your campaign may not get noticeable results.',
@@ -93,6 +90,7 @@ const BudgetRecommendation = ( props ) => {
 					</div>
 				</div>
 			) }
+			<Tip>{ recommendationRange }</Tip>
 		</div>
 	);
 };

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.scss
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.scss
@@ -1,27 +1,38 @@
 .gla-budget-recommendation {
-	font-style: italic;
-
-	&__recommendation,
 	&__low-budget {
 		display: flex;
+		align-items: center;
 		gap: calc(var(--main-gap) / 3);
+		margin-bottom: calc(var(--main-gap) / 2);
+		font-style: italic;
 
 		> svg {
-			flex: 1 0 auto;
+			flex: 0 0 auto;
 		}
 	}
 
-	&__recommendation {
-		margin-bottom: calc(var(--main-gap) / 2);
+	.components-tip {
+		padding: $grid-unit-15 $grid-unit-20;
+		background-color: #f0f6fc;
 
-		svg {
-			fill: $gray-600;
+		> p {
+			line-height: $gla-line-height-medium;
+			font-size: inherit;
+		}
+
+		> svg {
+			align-self: initial;
+			margin: $grid-unit-05 $grid-unit-05 * 2.5 0 0;
 		}
 	}
 
+	.components-tip,
 	&__low-budget {
-		svg {
-			fill: $alert-yellow;
+		font-size: $gla-font-smaller;
+		color: $black;
+
+		> svg {
+			fill: $gray-900;
 		}
 	}
 }

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -53,29 +53,11 @@ const BudgetSection = ( props ) => {
 		<div className="gla-budget-section">
 			<Section
 				disabled={ disabled }
-				title={ __( 'Budget', 'google-listings-and-ads' ) }
-				description={
-					<>
-						<p>
-							{ __(
-								'Enter a daily average cost that works best for your business and the results that you want. You can change your budget or cancel your ad at any time.',
-								'google-listings-and-ads'
-							) }
-						</p>
-						<p>
-							{ __(
-								'You will be billed directly by Google Ads.',
-								'google-listings-and-ads'
-							) }
-						</p>
-						<p>
-							{ __(
-								'Google will optimize your ads to maximize performance across your selected country(s).',
-								'google-listings-and-ads'
-							) }
-						</p>
-					</>
-				}
+				title={ __( 'Set your budget', 'google-listings-and-ads' ) }
+				description={ __(
+					'With Performance Max campaigns, you can set your own budget and Google’s Smart Bidding technology will serve the most appropriate ad, with the optimal bid, to maximize campaign performance.',
+					'google-listings-and-ads'
+				) }
 			>
 				<Section.Card>
 					<Section.Card.Body className="gla-budget-section__card-body">

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -50,3 +50,10 @@ export const ISSUE_TYPE_PRODUCT = 'product';
 export const ISSUE_TYPE_ACCOUNT = 'account';
 export const REQUEST_REVIEW = 'request-review';
 export const ISSUE_TABLE_PER_PAGE = 5;
+
+// Account status related
+export const GOOGLE_ADS_ACCOUNT_STATUS = {
+	CONNECTED: 'connected',
+	DISCONNECTED: 'disconnected',
+	INCOMPLETE: 'incomplete',
+};

--- a/js/src/dashboard/summary-section/paid-campaign-promotion-card.js
+++ b/js/src/dashboard/summary-section/paid-campaign-promotion-card.js
@@ -9,10 +9,12 @@ import { Spinner } from '@woocommerce/components';
  */
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
 
 const PromotionContent = ( { adsAccount } ) => {
 	const showFreeCredit =
-		adsAccount.sub_account || adsAccount.status === 'disconnected';
+		adsAccount.sub_account ||
+		adsAccount.status === GOOGLE_ADS_ACCOUNT_STATUS.DISCONNECTED;
 
 	return (
 		<>

--- a/js/src/settings/linked-accounts.js
+++ b/js/src/settings/linked-accounts.js
@@ -24,6 +24,9 @@ import { ConnectedGoogleAdsAccountCard } from '.~/components/google-ads-account-
 import Section from '.~/wcdl/section';
 import LinkedAccountsSectionWrapper from './linked-accounts-section-wrapper';
 import DisconnectModal, { ALL_ACCOUNTS, ADS_ACCOUNT } from './disconnect-modal';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
+
+const { CONNECTED, INCOMPLETE } = GOOGLE_ADS_ACCOUNT_STATUS;
 
 /**
  * Accounts are disconnected from the Setting page
@@ -48,7 +51,7 @@ export default function LinkedAccounts() {
 		googleMCAccount &&
 		googleAdsAccount
 	);
-	const hasAdsAccount = [ 'connected', 'incomplete' ].includes(
+	const hasAdsAccount = [ CONNECTED, INCOMPLETE ].includes(
 		googleAdsAccount?.status
 	);
 

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -75,6 +75,13 @@ function PaidAdsSectionsGroup( { onCampaignChange } ) {
 	);
 }
 
+const ACTION_COMPLETE = 'complete-ads';
+const ACTION_SKIP = 'skip-ads';
+
+/**
+ * Renders the onboarding step for setting up the paid ads (Google Ads account and paid campaign)
+ * or skipping it, and then completing the onboarding flow.
+ */
 export default function SetupPaidAds() {
 	const adminUrl = useAdminUrl();
 	const { createNotice } = useDispatchCoreNotices();
@@ -115,7 +122,7 @@ export default function SetupPaidAds() {
 	// The status check of Google Ads account connection is included in `campaign.isValid`,
 	// because when there is no connected account, it will disable the budget section and set the `amount` to `undefined`.
 	// TODO: Add a condition to check Billing setup
-	const disabledComplete = completing === 'skip-ads' || ! campaign.isValid;
+	const disabledComplete = completing === ACTION_SKIP || ! campaign.isValid;
 
 	function createSkipButton( text ) {
 		return (
@@ -123,8 +130,8 @@ export default function SetupPaidAds() {
 				isTertiary
 				data-action="skip-ads"
 				text={ text }
-				loading={ completing === 'skip-ads' }
-				disabled={ completing === 'complete-ads' }
+				loading={ completing === ACTION_SKIP }
+				disabled={ completing === ACTION_COMPLETE }
 				onClick={ finishFreeListingsSetup }
 			/>
 		);
@@ -155,7 +162,7 @@ export default function SetupPaidAds() {
 							'Create a paid ad campaign',
 							'google-listings-and-ads'
 						) }
-						disabled={ completing === 'skip-ads' }
+						disabled={ completing === ACTION_SKIP }
 						onClick={ () => setShowPaidAdsSetup( true ) }
 					/>
 				}
@@ -179,7 +186,7 @@ export default function SetupPaidAds() {
 							'Complete setup',
 							'google-listings-and-ads'
 						) }
-						loading={ completing === 'complete-ads' }
+						loading={ completing === ACTION_COMPLETE }
 						disabled={ disabledComplete }
 						onClick={ handleCompleteClick }
 					/>

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -26,8 +26,10 @@ import AudienceSection from '.~/components/paid-ads/audience-section';
 import BudgetSection from '.~/components/paid-ads/budget-section';
 import validateForm from '.~/utils/paid-ads/validateForm';
 import { getProductFeedUrl } from '.~/utils/urls';
-import { GUIDE_NAMES } from '.~/constants';
+import { GUIDE_NAMES, GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
 import { API_NAMESPACE } from '.~/data/constants';
+
+const { CONNECTED } = GOOGLE_ADS_ACCOUNT_STATUS;
 
 function PaidAdsSectionsGroup( { onCampaignChange } ) {
 	const { googleAdsAccount } = useGoogleAdsAccount();
@@ -52,8 +54,7 @@ function PaidAdsSectionsGroup( { onCampaignChange } ) {
 		>
 			{ ( formProps ) => {
 				const { countryCodes } = formProps.values;
-				const disabledAudience =
-					googleAdsAccount?.status !== 'connected';
+				const disabledAudience = googleAdsAccount?.status !== CONNECTED;
 				const disabledBudget =
 					disabledAudience || countryCodes.length === 0;
 

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -128,7 +128,7 @@ export default function SetupPaidAds() {
 		return (
 			<AppButton
 				isTertiary
-				data-action="skip-ads"
+				data-action={ ACTION_SKIP }
 				text={ text }
 				loading={ completing === ACTION_SKIP }
 				disabled={ completing === ACTION_COMPLETE }
@@ -181,7 +181,7 @@ export default function SetupPaidAds() {
 					) }
 					<AppButton
 						isPrimary
-						data-action="complete-ads"
+						data-action={ ACTION_COMPLETE }
 						text={ __(
 							'Complete setup',
 							'google-listings-and-ads'

--- a/js/src/utils/paid-ads/__snapshots__/validateForm.test.js.snap
+++ b/js/src/utils/paid-ads/__snapshots__/validateForm.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validateForm When the amount is not a number, should not pass 1`] = `"Please make sure daily average cost is greater than 0."`;
+
+exports[`validateForm When the amount is not a number, should not pass 2`] = `"Please make sure daily average cost is greater than 0."`;
+
+exports[`validateForm When the amount is not a number, should not pass 3`] = `"Please make sure daily average cost is greater than 0."`;
+
+exports[`validateForm When the amount is not a number, should not pass 4`] = `"Please make sure daily average cost is greater than 0."`;
+
+exports[`validateForm When the amount is ≤ 0, should not pass 1`] = `"Please make sure daily average cost is greater than 0."`;
+
+exports[`validateForm When the amount is ≤ 0, should not pass 2`] = `"Please make sure daily average cost is greater than 0."`;
+
+exports[`validateForm When the country codes array is empty, should not pass 1`] = `"Please select at least one country for your ads campaign."`;

--- a/js/src/utils/paid-ads/validateForm.js
+++ b/js/src/utils/paid-ads/validateForm.js
@@ -25,7 +25,7 @@ const validateForm = ( values ) => {
 		);
 	}
 
-	if ( values.amount <= 0 ) {
+	if ( ! Number.isFinite( values.amount ) || values.amount <= 0 ) {
 		errors.amount = __(
 			'Please make sure daily average cost is greater than 0.',
 			'google-listings-and-ads'

--- a/js/src/utils/paid-ads/validateForm.test.js
+++ b/js/src/utils/paid-ads/validateForm.test.js
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import validateForm from './validateForm';
+
+/**
+ * `validateForm` function returns an object, and if any checks are not passed,
+ * set properties respectively with an error message to indicate it.
+ */
+describe( 'validateForm', () => {
+	let values;
+
+	beforeEach( () => {
+		// Initial values
+		values = { countryCodes: [], amount: 0 };
+	} );
+
+	it( 'When all checks are passed, should return an empty object', () => {
+		const errors = validateForm( {
+			countryCodes: [ 'US' ],
+			amount: 1,
+		} );
+
+		expect( errors ).toStrictEqual( {} );
+	} );
+
+	it( 'should indicate multiple unpassed checks by setting properties in the returned object', () => {
+		const errors = validateForm( values );
+
+		expect( errors ).toHaveProperty( 'countryCodes' );
+		expect( errors ).toHaveProperty( 'amount' );
+	} );
+
+	it( 'When the country codes array is empty, should not pass', () => {
+		const errors = validateForm( values );
+
+		expect( errors ).toHaveProperty( 'countryCodes' );
+		expect( errors.countryCodes ).toMatchSnapshot();
+	} );
+
+	it( 'When the amount is not a number, should not pass', () => {
+		let errors;
+
+		values.amount = '';
+		errors = validateForm( values );
+
+		expect( errors ).toHaveProperty( 'amount' );
+		expect( errors.amount ).toMatchSnapshot();
+
+		values.amount = undefined;
+		errors = validateForm( values );
+
+		expect( errors ).toHaveProperty( 'amount' );
+		expect( errors.amount ).toMatchSnapshot();
+
+		values.amount = new Date();
+		errors = validateForm( values );
+
+		expect( errors ).toHaveProperty( 'amount' );
+		expect( errors.amount ).toMatchSnapshot();
+
+		values.amount = NaN;
+		errors = validateForm( values );
+
+		expect( errors ).toHaveProperty( 'amount' );
+		expect( errors.amount ).toMatchSnapshot();
+	} );
+
+	it( 'When the amount is ≤ 0, should not pass', () => {
+		let errors;
+
+		values.amount = 0;
+		errors = validateForm( values );
+
+		expect( errors ).toHaveProperty( 'amount' );
+		expect( errors.amount ).toMatchSnapshot();
+
+		values.amount = -0.01;
+		errors = validateForm( values );
+
+		expect( errors ).toHaveProperty( 'amount' );
+		expect( errors.amount ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements the **📌 Ads audience and budget sections** in #1610.

- Tweak UI for the `AudienceSection` component and `BudgetSection`-related components.
- Add the ads audience and budget sections to step 4 of the onboarding flow for paid campaign creation.
   - Handle the form data of campaign creation in `PaidAdsSectionsGroup` and forward it to the upper layer.
- Fix that the validation of campaign `amount` should only allow the number type (excluding `NaN`).

### Screenshots:

https://user-images.githubusercontent.com/17420811/186887919-b3fd78e4-2e62-4b26-88f3-9086758ecd15.mp4

### Detailed test instructions:

1. Go to step 4 of the onboarding flow.
1. Disconnect the Google Ads account via the current UI if an account is already connected.
1. Check if both the audience and budget sections are disabled when there is no connected Google Ads account.
1. Create or connect to a Google Ads account.
1. Check if both the audience and budget sections are editable after a Google Ads account is connected.
1. Check if the "Create a paid ad campaign" at the bottom is disabled when the audience countries are empty or the budget amount is ≤ 0.

💡 When re-entering step 4, the previously selected "continue setting up paid ads" state and entered form data are reset. Processing the selected state and entered form data will be developed in another PR.

💡 The disabled style covering the whole section is different from the visual on Figma. This's the expected style and has been confirmed with the Design team.

### Changelog entry
