### PR TITLE
Attribute mapping - Endpoints for Sources and Destinations

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingController.php
@@ -1,0 +1,157 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMappingHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class for handling API requests for getting source and destination data for Attribute Mapping
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
+ */
+class AttributeMappingController extends BaseOptionsController {
+
+	/**
+	 * @var AttributeMappingHelper
+	 */
+	private AttributeMappingHelper $attribute_mapping_helper;
+
+
+	/**
+	 * AttributeMappingController constructor.
+	 *
+	 * @param RESTServer             $server
+	 * @param AttributeMappingHelper $attribute_mapping_helper
+	 */
+	public function __construct( RESTServer $server, AttributeMappingHelper $attribute_mapping_helper ) {
+		parent::__construct( $server );
+		$this->attribute_mapping_helper = $attribute_mapping_helper;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		/**
+		 * GET the destination fields for Google Shopping
+		 */
+		$this->register_route(
+			'mc/attribute-mapping/destinations',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_attribute_mapping_destinations_read_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			],
+		);
+
+		/**
+		 * GET for getting the source data for a specific destination
+		 */
+		$this->register_route(
+			'mc/attribute-mapping/sources',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_attribute_mapping_sources_read_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			],
+		);
+	}
+
+	/**
+	 * Get the callback function for returning the destinations data
+	 *
+	 * @return callable
+	 */
+	protected function get_attribute_mapping_destinations_read_callback(): callable {
+		return function ( Request $request ) {
+			try {
+				return $this->prepare_item_for_response( $this->get_destinations(), $request );
+			} catch ( Exception $e ) {
+				return new Response( [ 'message' => $e->getMessage() ], $e->getCode() ?: 400 );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function getting destination data.
+	 *
+	 * @return callable
+	 */
+	protected function get_attribute_mapping_sources_read_callback(): callable {
+		return function( Request $request ) {
+			try {
+				$destination = $request['destination'];
+				return $this->get_sources_for_destination( $destination );
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the item schema properties for the controller.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'data' => [
+				'type'        => 'array',
+				'description' => __( 'The data with the different destinations or sources.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+		];
+	}
+
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'attribute_mapping';
+	}
+
+	/**
+	 * Destinations getter
+	 *
+	 * @return array The destinations
+	 */
+	private function get_destinations(): array {
+		return [
+			'data' => $this->attribute_mapping_helper->get_destinations(),
+		];
+	}
+
+	/**
+	 * Sources getter
+	 *
+	 * @param string $destination The destination to get the sources for
+	 * @return array[] Array with sources
+	 */
+	private function get_sources_for_destination( string $destination ): array {
+		$sources = $this->attribute_mapping_helper->get_sources();
+		return [
+			'data' => $sources[ $destination ] ?? [],
+		];
+	}
+}

--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingController.php
@@ -96,6 +96,13 @@ class AttributeMappingController extends BaseOptionsController {
 		return function( Request $request ) {
 			try {
 				$destination = $request['destination'];
+
+				if ( ! $destination ) {
+					return [
+						'data' => [],
+					];
+				}
+
 				return $this->get_sources_for_destination( $destination );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );

--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingController.php
@@ -102,7 +102,7 @@ class AttributeMappingController extends BaseOptionsController {
 	protected function get_mapping_sources_read_callback(): callable {
 		return function( Request $request ) {
 			try {
-				$attribute = $request['attribute'];
+				$attribute = $request->get_param( 'attribute' );
 
 				if ( ! $attribute ) {
 					return [

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -81,6 +81,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMappingHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
@@ -387,5 +388,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( ShippingZone::class, WC::class, ZoneLocationsParser::class, ZoneMethodsParser::class, LocationRatesProcessor::class );
 		$this->share_with_tags( ShippingSuggestionService::class, ShippingZone::class, WC::class );
 		$this->share_with_tags( RequestReviewStatuses::class );
+		$this->share_with_tags( AttributeMappingHelper::class );
 	}
 }

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -19,6 +19,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\DisconnectC
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Google\AccountController as GoogleAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Jetpack\AccountController as JetpackAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController as MerchantCenterAccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AttributeMappingController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\RequestReviewController as MerchantCenterRequestReviewController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ConnectionController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ContactInformationController as MerchantCenterContactInformationController;
@@ -49,6 +50,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMappingHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -113,6 +115,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( SettingsSyncController::class, Settings::class );
 		$this->share( DisconnectController::class );
 		$this->share( SetupCompleteController::class );
+		$this->share( AttributeMappingController::class, AttributeMappingHelper::class );
 	}
 
 	/**

--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -1,0 +1,54 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Adult;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AgeGroup;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Helper Class for Attribute Mapping
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
+ */
+class AttributeMappingHelper implements Service {
+
+
+	private const ATTRIBUTES_AVAILABLE_FOR_MAPPING = [
+		Adult::class,
+		AgeGroup::class,
+	];
+
+	/**
+	 * Gets all the available destinations
+	 *
+	 * @return array
+	 */
+	public function get_destinations(): array {
+		$destinations = [];
+
+		foreach ( self::ATTRIBUTES_AVAILABLE_FOR_MAPPING as $attribute ) {
+			$destinations[ $attribute::get_id() ] = $attribute::get_name();
+		}
+
+		return $destinations;
+	}
+
+	/**
+	 * Gets all the available sources identified by destination key
+	 *
+	 * @return array
+	 */
+	public function get_sources(): array {
+		$sources = [];
+
+		foreach ( self::ATTRIBUTES_AVAILABLE_FOR_MAPPING as $attribute ) {
+			$sources[ $attribute::get_id() ] = $attribute::get_sources();
+		}
+
+		return $sources;
+	}
+}

--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Adult;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AgeGroup;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeInterface;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -23,13 +24,16 @@ class AttributeMappingHelper implements Service {
 	];
 
 	/**
-	 * Gets all the available destinations
+	 * Gets all the available attributes for mapping
 	 *
 	 * @return array
 	 */
-	public function get_destinations(): array {
+	public function get_attributes(): array {
 		$destinations = [];
 
+		/**
+		 * @var AttributeInterface $attribute
+		 */
 		foreach ( self::ATTRIBUTES_AVAILABLE_FOR_MAPPING as $attribute ) {
 			$destinations[ $attribute::get_id() ] = $attribute::get_name();
 		}
@@ -38,13 +42,16 @@ class AttributeMappingHelper implements Service {
 	}
 
 	/**
-	 * Gets all the available sources identified by destination key
+	 * Gets all the available sources identified by attribute key
 	 *
 	 * @return array
 	 */
 	public function get_sources(): array {
 		$sources = [];
 
+		/**
+		 * @var AttributeInterface $attribute
+		 */
 		foreach ( self::ATTRIBUTES_AVAILABLE_FOR_MAPPING as $attribute ) {
 			$sources[ $attribute::get_id() ] = $attribute::get_sources();
 		}

--- a/src/Product/Attributes/Adult.php
+++ b/src/Product/Attributes/Adult.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
  */
-class Adult extends AbstractAttribute {
+class Adult extends AbstractAttribute implements WithMappingInterface {
 
 	/**
 	 * Returns the attribute ID.
@@ -58,5 +58,26 @@ class Adult extends AbstractAttribute {
 	 */
 	public static function get_input_type(): string {
 		return AdultInput::class;
+	}
+
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Adult', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns the attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array {
+		return [
+			'yes' => __( 'Yes', 'google-listings-and-ads' ),
+			'no'  => __( 'No', 'google-listings-and-ads' ),
+		];
 	}
 }

--- a/src/Product/Attributes/AgeGroup.php
+++ b/src/Product/Attributes/AgeGroup.php
@@ -66,4 +66,22 @@ class AgeGroup extends AbstractAttribute implements WithValueOptionsInterface {
 		return AgeGroupInput::class;
 	}
 
+
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Age group', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns the attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array {
+		return self::get_value_options();
+	}
 }

--- a/src/Product/Attributes/WithMappingInterface.php
+++ b/src/Product/Attributes/WithMappingInterface.php
@@ -3,8 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\AttributeInputInterface;
-
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/src/Product/Attributes/WithMappingInterface.php
+++ b/src/Product/Attributes/WithMappingInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\AttributeInputInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface with specific options for mapping
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ */
+interface WithMappingInterface {
+
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string;
+
+	/**
+	 * Returns the available attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array;
+
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -16,7 +16,7 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 
 
 	protected const ROUTE_REQUEST_SOURCES      = '/wc/gla/mc/mapping/sources';
-	protected const ROUTE_REQUEST_ATTRIBUTES = '/wc/gla/mc/mapping/attributes';
+	protected const ROUTE_REQUEST_ATTRIBUTES   = '/wc/gla/mc/mapping/attributes';
 
 	/**
 	 * @var AttributeMappingHelper

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMappingHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 
 /**
- * Test suit for AttributeMappingController
+ * Test suite for AttributeMappingController
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
  * @group AttributeMapping
@@ -15,8 +15,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUn
 class AttributeMappingControllerTest extends RESTControllerUnitTest {
 
 
-	protected const ROUTE_REQUEST_SOURCES      = '/wc/gla/mc/attribute-mapping/sources';
-	protected const ROUTE_REQUEST_DESTINATIONS = '/wc/gla/mc/attribute-mapping/destinations';
+	protected const ROUTE_REQUEST_SOURCES      = '/wc/gla/mc/mapping/sources';
+	protected const ROUTE_REQUEST_DESTINATIONS = '/wc/gla/mc/mapping/attributes';
 
 	/**
 	 * @var AttributeMappingHelper
@@ -39,12 +39,12 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 
 	public function test_destinations_route() {
 		$this->attribute_mapping_helper->expects( $this->once() )
-			->method( 'get_destinations' );
+			->method( 'get_attributes' );
 
 		$response = $this->do_request( self::ROUTE_REQUEST_DESTINATIONS );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertNotNull( $response->get_data() );
+		$this->assertIsArray( $response->get_data() );
 	}
 
 	public function test_sources_route() {
@@ -59,10 +59,10 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 				],
 			);
 
-		$response = $this->do_request( self::ROUTE_REQUEST_SOURCES, 'GET', [ 'destination' => 'adult' ] );
+		$response = $this->do_request( self::ROUTE_REQUEST_SOURCES, 'GET', [ 'attribute' => 'adult' ] );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertNotNull( $response->get_data() );
+		$this->assertIsArray( $response->get_data() );
 	}
 
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -16,7 +16,7 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 
 
 	protected const ROUTE_REQUEST_SOURCES      = '/wc/gla/mc/mapping/sources';
-	protected const ROUTE_REQUEST_DESTINATIONS = '/wc/gla/mc/mapping/attributes';
+	protected const ROUTE_REQUEST_ATTRIBUTES = '/wc/gla/mc/mapping/attributes';
 
 	/**
 	 * @var AttributeMappingHelper
@@ -33,7 +33,7 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 
 
 	public function test_register_route() {
-		$this->assertArrayHasKey( self::ROUTE_REQUEST_DESTINATIONS, $this->server->get_routes() );
+		$this->assertArrayHasKey( self::ROUTE_REQUEST_ATTRIBUTES, $this->server->get_routes() );
 		$this->assertArrayHasKey( self::ROUTE_REQUEST_SOURCES, $this->server->get_routes() );
 	}
 
@@ -41,7 +41,7 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 		$this->attribute_mapping_helper->expects( $this->once() )
 			->method( 'get_attributes' );
 
-		$response = $this->do_request( self::ROUTE_REQUEST_DESTINATIONS );
+		$response = $this->do_request( self::ROUTE_REQUEST_ATTRIBUTES );
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $response->get_data() );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -62,7 +62,15 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( self::ROUTE_REQUEST_SOURCES, 'GET', [ 'attribute' => 'adult' ] );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertIsArray( $response->get_data() );
+		$this->assertEquals(
+			[
+				'data' => [
+					'yes' => 'Yes',
+					'no'  => 'No',
+				],
+			],
+			$response->get_data()
+		);
 	}
 
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -48,16 +48,15 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_sources_route() {
-
 		$this->attribute_mapping_helper->expects( $this->once() )
 			->method( 'get_sources' )
 			->willReturn(
 				[
 					'adult' => [
 						'yes' => 'Yes',
-						'no' => 'No'
+						'no'  => 'No',
 					],
-				]
+				],
 			);
 
 		$response = $this->do_request( self::ROUTE_REQUEST_SOURCES, 'GET', [ 'destination' => 'adult' ] );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AttributeMappingController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMappingHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+
+/**
+ * Test suit for AttributeMappingController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
+ * @group AttributeMapping
+ */
+class AttributeMappingControllerTest extends RESTControllerUnitTest {
+
+
+	protected const ROUTE_REQUEST_SOURCES      = '/wc/gla/mc/attribute-mapping/sources';
+	protected const ROUTE_REQUEST_DESTINATIONS = '/wc/gla/mc/attribute-mapping/destinations';
+
+	/**
+	 * @var AttributeMappingHelper
+	 */
+	private AttributeMappingHelper $attribute_mapping_helper;
+
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->attribute_mapping_helper = $this->createMock( AttributeMappingHelper::class );
+		$this->controller               = new AttributeMappingController( $this->server, $this->attribute_mapping_helper );
+		$this->controller->register();
+	}
+
+
+	public function test_register_route() {
+		$this->assertArrayHasKey( self::ROUTE_REQUEST_DESTINATIONS, $this->server->get_routes() );
+		$this->assertArrayHasKey( self::ROUTE_REQUEST_SOURCES, $this->server->get_routes() );
+	}
+
+	public function test_destinations_route() {
+		$this->attribute_mapping_helper->expects( $this->once() )
+			->method( 'get_destinations' );
+
+		$response = $this->do_request( self::ROUTE_REQUEST_DESTINATIONS );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNotNull( $response->get_data() );
+	}
+
+	public function test_sources_route() {
+
+		$this->attribute_mapping_helper->expects( $this->once() )
+			->method( 'get_sources' )
+			->willReturn(
+				[
+					'adult' => [
+						'yes' => 'Yes',
+						'no' => 'No'
+					],
+				]
+			);
+
+		$response = $this->do_request( self::ROUTE_REQUEST_SOURCES, 'GET', [ 'destination' => 'adult' ] );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNotNull( $response->get_data() );
+	}
+
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -44,7 +44,7 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( self::ROUTE_REQUEST_ATTRIBUTES );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertArrayHasKey(  'data', $response->get_data() );
+		$this->assertArrayHasKey( 'data', $response->get_data() );
 	}
 
 	public function test_sources_route() {

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -44,7 +44,7 @@ class AttributeMappingControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( self::ROUTE_REQUEST_ATTRIBUTES );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertIsArray( $response->get_data() );
+		$this->assertArrayHasKey(  'data', $response->get_data() );
 	}
 
 	public function test_sources_route() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1648.

This PR implements 2 new endpoints related to Attribute Mapping Feature

**Destinations Endpoint:**

`GET /wp-json/wc/gla/mc/attribute-mapping/destinations`

⚠️  After Review new endpoint is: `GET /wp-json/wc/gla/mc/mapping/attributes`
Gets all the available attributes. This is, all the Google attributes we allow to do a mapping.

(Notice for now we only send 2, as a dummy data, since it is still under discussion which attributes we allow finally) 


**Source Endpoint:**

`GET /wp-json/wc/gla/mc/attribute-mapping/sources?destination={destination}`
⚠️  After Review new endpoint is: `GET /wp-json/wc/gla/mc/mapping/sources?attribute={attribute}`


Param Attribute: String identifying the attribute ID we want to get the sources

Gets all the available sources. This is, all the Custom fields, Taxonomies or options we allow to do a mapping for that destination.

(Notice for now we only send 2, as a dummy data, since it is still under discussion which attributes we allow finally) 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout PR
2. Go to browser and load `/wp-json/wc/gla/mc/mapping/attributes`
3. You should receive the dummy data like

```
{
"data": {
"adult": "Adult",
"ageGroup": "Age group"
}
}
```

4. Go to browser and load `/wp-json/wc/gla/mc/mapping/sources?attribute=adult`
5. You should receive the dummy data like

```
{
"data": {
"yes": "Yes",
"no": "No"
}
}
```

6. Go to browser and load `/wp-json/wc/gla/mc/mapping/sources?attribute=ageGroup`
7. You should receive the dummy data like

```
{
"data": {
"newborn": "Newborn",
"infant": "Infant",
"toddler": "Toddler",
"kids": "Kids",
"adult": "Adult"
}
}
```

8. Go to browser and load `/wp-json/wc/gla/mc/mapping/sources?attribute=nothing`
7. You should receive the dummy data like

```
{
"data": []
}
```

9. Go to browser and load `/wp-json/wc/gla/mc/mapping/sources`
7. You should receive the dummy data like

```
{
"data": []
}
```