### PR TITLE
Fix fatal error if a null rate specified for flat rate methods with shipping classes

### DIFF
--- a/src/Shipping/ZoneMethodsParser.php
+++ b/src/Shipping/ZoneMethodsParser.php
@@ -71,7 +71,7 @@ class ZoneMethodsParser implements Service {
 					return [];
 				}
 
-				$shipping_rates[] = new ShippingRate( $flat_rate );
+				$shipping_rates[] = new ShippingRate( (float) $flat_rate );
 
 				if ( ! empty( $shipping_class_rates ) ) {
 					foreach ( $shipping_class_rates as ['class' => $class, 'rate' => $rate] ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1657.

This will prevent a fatal error on the shipping suggestions API (`GET mc/shipping/rates/suggestions?country_codes[]=...`), which was thrown if the user has entered a null value for their Flat rate shipping in WooCommerce shipping zone settings while specifying a rate for their shipping classes.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check the steps described in #1657 and confirm that the error no longer exists.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fatal error if a null rate specified for flat rate methods with shipping classes
