### PR TITLE
Attribute Mapping -  List Taxonomies and Global Attributes in sources 

### DIFF
--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -54,6 +54,11 @@ class AttributeMappingHelper implements Service {
 		return $sources;
 	}
 
+	/**
+	 * Gets the taxonomies and global attributes to render them as options in the frontend.
+	 *
+	 * @return array An array with the taxonomies and global attributes
+	 */
 	public static function get_source_taxonomies(): array {
 		$taxonomies = get_object_taxonomies( 'product' );
 		$taxes      = [];

--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -67,30 +67,42 @@ class AttributeMappingHelper implements Service {
 	 * @return array An array with the taxonomies and global attributes
 	 */
 	public static function get_source_taxonomies(): array {
-		$taxonomies = get_object_taxonomies( 'product' );
-		$taxes      = [];
-		$attributes = [];
+		$taxonomies        = get_object_taxonomies( 'product', 'objects' );
+		$parsed_taxonomies = [];
+		$attributes        = [];
+		$sources           = [];
+
 		foreach ( $taxonomies as $taxonomy ) {
-			$tax = get_taxonomy( $taxonomy );
-			if ( taxonomy_is_product_attribute( $taxonomy ) ) {
-				$attributes[ 'tax:' . $taxonomy ] = $tax->labels->name;
+			if ( taxonomy_is_product_attribute( $taxonomy->name ) ) {
+				$attributes[ 'taxonomy:' . $taxonomy->name ] = $taxonomy->label;
 				continue;
 			}
 
-			$taxes[ 'tax:' . $taxonomy ] = $tax->labels->name;
+			$parsed_taxonomies[ 'taxonomy:' . $taxonomy->name ] = $taxonomy->label;
 		}
-		asort( $taxes );
+
+		asort( $parsed_taxonomies );
 		asort( $attributes );
 
-		return array_merge(
-			[
-				'disabled:attributes' => __( '- Global attributes -', 'google-listings-and-ads' ),
-			],
-			$attributes,
-			[
-				'disabled:taxes' => __( '- Taxonomies -', 'google-listings-and-ads' ),
-			],
-			$taxes
-		);
+		if ( ! empty( $attributes ) ) {
+			$sources = array_merge(
+				[
+					'disabled:attributes' => __( '- Global attributes -', 'google-listings-and-ads' ),
+				],
+				$attributes
+			);
+		}
+
+		if ( ! empty( $parsed_taxonomies ) ) {
+			$sources = array_merge(
+				$sources,
+				[
+					'disabled:taxonomies' => __( '- Taxonomies -', 'google-listings-and-ads' ),
+				],
+				$parsed_taxonomies
+			);
+		}
+
+		return $sources;
 	}
 }

--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Adult;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AgeGroup;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Color;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,6 +21,7 @@ class AttributeMappingHelper implements Service {
 	private const ATTRIBUTES_AVAILABLE_FOR_MAPPING = [
 		Adult::class,
 		AgeGroup::class,
+		Color::class,
 	];
 
 	/**
@@ -50,5 +52,33 @@ class AttributeMappingHelper implements Service {
 		}
 
 		return $sources;
+	}
+
+	public static function get_source_taxonomies(): array {
+		$taxonomies = get_object_taxonomies( 'product' );
+		$taxes      = [];
+		$attributes = [];
+		foreach ( $taxonomies as $taxonomy ) {
+			$tax = get_taxonomy( $taxonomy );
+			if ( taxonomy_is_product_attribute( $taxonomy ) ) {
+				$attributes[ 'tax:' . $taxonomy ] = $tax->labels->name;
+				continue;
+			}
+
+			$taxes[ 'tax:' . $taxonomy ] = $tax->labels->name;
+		}
+		asort( $taxes );
+		asort( $attributes );
+
+		return array_merge(
+			[
+				'disabled:attributes' => __( '- Global attributes -', 'google-listings-and-ads' ),
+			],
+			$attributes,
+			[
+				'disabled:taxes' => __( '- Taxonomies -', 'google-listings-and-ads' ),
+			],
+			$taxes
+		);
 	}
 }

--- a/src/Product/Attributes/Color.php
+++ b/src/Product/Attributes/Color.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\ColorInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMappingHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -47,6 +48,24 @@ class Color extends AbstractAttribute {
 	 */
 	public static function get_input_type(): string {
 		return ColorInput::class;
+	}
+
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Color', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns the attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array {
+		return AttributeMappingHelper::get_source_taxonomies();
 	}
 
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -15,8 +15,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUn
 class AttributeMappingControllerTest extends RESTControllerUnitTest {
 
 
-	protected const ROUTE_REQUEST_SOURCES      = '/wc/gla/mc/mapping/sources';
-	protected const ROUTE_REQUEST_ATTRIBUTES   = '/wc/gla/mc/mapping/attributes';
+	protected const ROUTE_REQUEST_SOURCES    = '/wc/gla/mc/mapping/sources';
+	protected const ROUTE_REQUEST_ATTRIBUTES = '/wc/gla/mc/mapping/attributes';
 
 	/**
 	 * @var AttributeMappingHelper


### PR DESCRIPTION
### Changes proposed in this Pull Request:

ℹ️  It includes #1656  . Please review that PR first.

Closes part of #1648.

This PR includes a helper function to get Taxonomies and Global Attributes as a source for a destination.

ℹ️  In the example we used the attribute `Color` in the future should be defined in more attributes when we now exactly the direction to follow.

### Screenshots:

<img width="535" alt="Screenshot 2022-09-02 at 16 24 45" src="https://user-images.githubusercontent.com/5908855/188142970-580047ce-6063-4e69-aa95-f2e1b08bce59.png">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Do `GET /wp-json/wc/gla/mc/attribute-mapping/sources?destination=color`
2. You should get a list with attributes and taxomomies matching your store.
3. Try creating a new attribute in Products --> Attributes and see that it appears in global Attributes
4. Install a plugin like WooCommerce Brands or create a new Taxomomy to see it appears in the Taxonomies group.

