### PR TITLE
Fix an infinite re-rendering loop for the campaign budget input component

### DIFF
--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -38,6 +38,12 @@ const BudgetSection = ( props ) => {
 	// Display the currency code that will be used by Google Ads, but still use the store's currency formatting settings.
 	const currency = googleAdsAccount?.currency;
 
+	// Wrapping `useRef` is because since WC 6.9, the reference of `setValue` may be changed
+	// after calling itself and further leads to an infinite re-rendering loop if used in a
+	// `useEffect`.
+	const setValueRef = useRef();
+	setValueRef.current = setValue;
+
 	/**
 	 * In addition to the initial value setting during initialization, when `disabled` changes
 	 * - from false to true, then clear filled amount to `undefined` for showing a blank <input>.
@@ -46,8 +52,8 @@ const BudgetSection = ( props ) => {
 	const initialAmountRef = useRef( amount );
 	useEffect( () => {
 		const nextAmount = disabled ? undefined : initialAmountRef.current;
-		setValue( 'amount', nextAmount );
-	}, [ disabled, setValue ] );
+		setValueRef.current( 'amount', nextAmount );
+	}, [ disabled ] );
 
 	return (
 		<div className="gla-budget-section">


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1652 

- Fix an infinite re-rendering loop for the campaign budget input component

### Screenshots:

https://user-images.githubusercontent.com/17420811/188428012-d974f233-b7c9-4941-b9f1-e80e45896770.mp4

### Additional details:

#### Root cause

With the `@woocommerce/components`'s \<Form\> component provided by WC 6.9-beta.2, the reference changing of `setValue` function got from \<Form\> will not be the same as before. When \<Form\> values are changed, the reference of `setValue` is also changed. Therefore, it may lead to an infinite re-rendering loop when using it in such case:
1. Have `setValue` in a `useEffect` and it's also one of `useEffect` deps.
1. Call `setValue` to change form values, and then the form passes down a new reference of `setValue` function.
1. The change of `setValue` function triggers that `useEffect` again, and then loops back to the above to call the `setValue` to change form values again.

See: https://github.com/woocommerce/woocommerce/blob/78c28ae9f3a70e996e40c4f173c032dfa0d0551a/packages/js/components/src/form/form.tsx#L176

💡 I searched the codebase of this repo, and it should be the only case that has this issue.

### Detailed test instructions:

1. Use a WC version under 6.9.0
3. Follow the replication steps in #1652 to test the input of campaign budget.
4. Switch to WC 6.9.0-beta.2
5. Repeat the replication steps again
6. Check if this fix is compatible with both WC versions.

### Changelog entry

> Fix - A compatibility issue with WooCommerce 6.9 to prevent the input of the paid campaign budget from being not interactable.
