### PR TITLE
Patch the inconsistent parameters in the `onChange` callback of Form component for WC 6.9

### DIFF
--- a/js/src/components/form/form.js
+++ b/js/src/components/form/form.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { Form as WCForm } from '@woocommerce/components';
+import { useCallback } from '@wordpress/element';
+
+function alwaysValid() {
+	return {};
+}
+
+/**
+ * Wraps a Form component of @woocommerce/components with patched props
+ * to avoid some compatible issues since WooCommerce 6.9.
+ *
+ * - Patched the dated parameters of the `props.onChange` callback.
+ *
+ * @param {*} props Props to be forwarded to {@link WCForm}.
+ */
+export default function Form( { onChange, ...props } ) {
+	const { validate = alwaysValid } = props;
+
+	const patchedOnChange = useCallback(
+		( change, datedValues ) => {
+			// The changed value in the second parameter is not up-to-date,
+			// and the third parameter uses a wrong reference of `error` variable.
+			// See: https://github.com/woocommerce/woocommerce/blob/78c28ae9f3a70e996e40c4f173c032dfa0d0551a/packages/js/components/src/form/form.tsx#L170-L171
+			const values = { ...datedValues, [ change.name ]: change.value };
+			const isValid = ! Object.keys( validate( values ) ).length;
+			onChange( change, values, isValid );
+		},
+		[ onChange, validate ]
+	);
+
+	if ( onChange ) {
+		props.onChange = patchedOnChange;
+	}
+
+	return <WCForm { ...props } />;
+}

--- a/js/src/components/form/index.js
+++ b/js/src/components/form/index.js
@@ -1,0 +1,1 @@
+export { default } from './form';

--- a/js/src/components/free-listings/choose-audience/index.js
+++ b/js/src/components/free-listings/choose-audience/index.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppSpinner from '.~/components/app-spinner';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -4,11 +4,11 @@
 import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppModal from '.~/components/app-modal';
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -4,11 +4,11 @@
 import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppModal from '.~/components/app-modal';
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { Form } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
 
@@ -10,6 +9,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import validateShippingRateGroup from './validateShippingRateGroup.js';
+import Form from '.~/components/form';
 import AppModal from '.~/components/app-modal';
 import AppInputPriceControl from '.~/components/app-input-price-control/index.js';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';

--- a/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-form-modals/minimum-order-form-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-form-modals/minimum-order-form-modal.js
@@ -3,11 +3,11 @@
  */
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppModal from '.~/components/app-modal';
 import AppInputPriceControl from '.~/components/app-input-price-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';

--- a/js/src/edit-free-campaign/setup-free-listings/index.js
+++ b/js/src/edit-free-campaign/setup-free-listings/index.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { Form } from '@woocommerce/components';
 import { useState } from '@wordpress/element';
 import { pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppSpinner from '.~/components/app-spinner';
 import Hero from '.~/components/free-listings/configure-product-listings/hero';
 import checkErrors from '.~/components/free-listings/configure-product-listings/checkErrors';

--- a/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
+++ b/js/src/pages/create-paid-ads-campaign/create-paid-ads-campaign-form.js
@@ -3,13 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
-import { Form } from '@woocommerce/components';
 import { getHistory } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';

--- a/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
+++ b/js/src/pages/edit-paid-ads-campaign/edit-paid-ads-campaign-form.js
@@ -3,12 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { Form } from '@woocommerce/components';
 import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -4,7 +4,6 @@
 import { isEqual } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { Form } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -14,6 +13,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import useAdminUrl from '.~/hooks/useAdminUrl';
 import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
+import Form from '.~/components/form';
 import SetupAdsFormContent from './setup-ads-form-content';
 import useSetupCompleteCallback from './useSetupCompleteCallback';
 import validateForm from '.~/utils/paid-ads/validateForm';

--- a/js/src/setup-mc/setup-stepper/choose-audience/index.js
+++ b/js/src/setup-mc/setup-stepper/choose-audience/index.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppSpinner from '.~/components/app-spinner';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/index.js
@@ -3,11 +3,11 @@
  */
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppSpinner from '.~/components/app-spinner';
 import Hero from '.~/components/free-listings/configure-product-listings/hero';
 import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -4,11 +4,11 @@
 import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppModal from '.~/components/app-modal';
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';

--- a/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-free-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -4,11 +4,11 @@
 import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import Form from '.~/components/form';
 import AppModal from '.~/components/app-modal';
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { Form } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
 
 /**
@@ -15,6 +14,7 @@ import useAdminUrl from '.~/hooks/useAdminUrl';
 import useStoreAddress from '.~/hooks/useStoreAddress';
 import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import Form from '.~/components/form';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1651 

- Create a wrapped `Form` component to patch the inconsistent parameters in the `onChange` callback of WC's `Form` component for WC 6.9.
- Replace all related `Form` imports with the patched one since all use cases of the Form `onChange` are affected or have this issue potentially.

📌 We could have this PR to be reviewed first but hold on for a while to see if the issue https://github.com/woocommerce/woocommerce/issues/34584 is fixed before WC 6.9 is released. If yes, we may not need this patch to be merged.

### Screenshots:

https://user-images.githubusercontent.com/17420811/188567590-a8015683-7daa-4e51-b5a1-a186534a5f6e.mp4

### Detailed test instructions:

1. Use a WC version under 6.9.0
3. Follow the replication steps in #1651 to test the selected target audiences and shipping settings.
4. Switch to WC 6.9.0-beta.2
5. Repeat the replication steps again
6. Check if this fix is compatible with both WC versions.

### Additional details:

#### Root cause

The `values` in the `setValue` of WC's `Form` are referencing a dated state. Therefore, the second parameter in the `onChange` callback is inconsistent with the first one and the state got from Form's `props.values`. In addition, the third parameter has a similar issue since the `errors` is referencing a dated state as well.

See https://github.com/woocommerce/woocommerce/blob/78c28ae9f3a70e996e40c4f173c032dfa0d0551a/packages/js/components/src/form/form.tsx#L170-L171

### Changelog entry

> Fix - A compatibility issue with WooCommerce 6.9 to prevent the value changes to forms may be inconsistent.
