### PR TITLE
Free Listings + Paid Ads: Extend product statistics API to return the number of syncable products

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
@@ -110,7 +110,8 @@ class ProductStatisticsController extends BaseOptionsController {
 		try {
 			$response = $this->merchant_statuses->get_product_statistics( $force_refresh );
 
-			$response['scheduled_sync'] = $this->sync_stats->get_count();
+			$response['scheduled_sync']    = $this->sync_stats->get_count();
+			$response['syncable_products'] = $this->sync_stats->get_syncable_products_count();
 
 			return $this->prepare_item_for_response( $response, $request );
 		} catch ( Exception $e ) {
@@ -125,13 +126,13 @@ class ProductStatisticsController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'timestamp'      => [
+			'timestamp'         => [
 				'type'        => 'number',
 				'description' => __( 'Timestamp reflecting when the product status statistics were last generated.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'statistics'     => [
+			'statistics'        => [
 				'type'        => 'object',
 				'description' => __( 'Merchant Center product status statistics.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
@@ -164,9 +165,15 @@ class ProductStatisticsController extends BaseOptionsController {
 					],
 				],
 			],
-			'scheduled_sync' => [
+			'scheduled_sync'    => [
 				'type'        => 'number',
 				'description' => __( 'Amount of scheduled jobs which will sync products to Google.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+			'syncable_products' => [
+				'type'        => 'number',
+				'description' => __( 'Amount of syncable products which will be synced to Google.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],

--- a/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
@@ -173,7 +173,7 @@ class ProductStatisticsController extends BaseOptionsController {
 			],
 			'syncable_products' => [
 				'type'        => 'number',
-				'description' => __( 'Amount of syncable products which will be synced to Google.', 'google-listings-and-ads' ),
+				'description' => __( 'Amount of products which are eligible to be synced to Google.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -33,6 +33,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update\PluginUpdate;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -86,7 +87,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		);
 		$this->share_with_tags( ActionScheduler::class, AsyncActionRunner::class );
 		$this->share_with_tags( ActionSchedulerJobMonitor::class, ActionScheduler::class );
-		$this->share_with_tags( ProductSyncStats::class, ActionScheduler::class, ProductRepository::class );
+		$this->share_with_tags( ProductSyncStats::class, ActionScheduler::class, ProductRepository::class, TransientsInterface::class );
 
 		// share product syncer jobs
 		$this->share_product_syncer_job( UpdateAllProducts::class );

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -86,7 +86,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		);
 		$this->share_with_tags( ActionScheduler::class, AsyncActionRunner::class );
 		$this->share_with_tags( ActionSchedulerJobMonitor::class, ActionScheduler::class );
-		$this->share_with_tags( ProductSyncStats::class, ActionScheduler::class );
+		$this->share_with_tags( ProductSyncStats::class, ActionScheduler::class, ProductRepository::class );
 
 		// share product syncer jobs
 		$this->share_product_syncer_job( UpdateAllProducts::class );

--- a/src/Jobs/ProductSyncStats.php
+++ b/src/Jobs/ProductSyncStats.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -25,6 +26,13 @@ class ProductSyncStats {
 	protected $scheduler;
 
 	/**
+	 * The ProductRepository object.
+	 *
+	 * @var ProductRepository
+	 */
+	protected $product_repository;
+
+	/**
 	 * Job names for syncing products.
 	 */
 	protected const MATCHES = [
@@ -37,10 +45,12 @@ class ProductSyncStats {
 	/**
 	 * ProductSyncStats constructor.
 	 *
-	 * @param ActionScheduler $scheduler
+	 * @param ActionScheduler   $scheduler
+	 * @param ProductRepository $product_repository
 	 */
-	public function __construct( ActionScheduler $scheduler ) {
-		$this->scheduler = $scheduler;
+	public function __construct( ActionScheduler $scheduler, ProductRepository $product_repository ) {
+		$this->scheduler          = $scheduler;
+		$this->product_repository = $product_repository;
 	}
 
 	/**
@@ -81,5 +91,15 @@ class ProductSyncStats {
 		}
 
 		return $count;
+	}
+
+	/**
+	 * Return the amount of products which are ready to be synced.
+	 *
+	 * @return int
+	 */
+	public function get_syncable_products_count(): int {
+		$products = $this->product_repository->find_sync_ready_products()->get();
+		return count( $products );
 	}
 }

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -108,7 +108,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	public function get_product_statistics( bool $force_refresh = false ): array {
 		$this->maybe_refresh_status_data( $force_refresh );
 
-		$counting_stats = is_array( $this->mc_statuses ) ? $this->mc_statuses['statistics'] : null;
+		$counting_stats = isset( $this->mc_statuses['statistics'] ) ? $this->mc_statuses['statistics'] : null;
 
 		if ( is_array( $counting_stats ) ) {
 			$counting_stats = array_merge(

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -10,20 +10,22 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
  */
 interface TransientsInterface {
 
-	public const ADS_METRICS          = 'ads_metrics';
-	public const FREE_LISTING_METRICS = 'free_listing_metrics';
-	public const MC_ACCOUNT_REVIEW    = 'mc_account_review';
-	public const MC_IS_SUBACCOUNT     = 'mc_is_subaccount';
-	public const MC_STATUSES          = 'mc_statuses';
-	public const URL_MATCHES          = 'url_matches';
+	public const ADS_METRICS             = 'ads_metrics';
+	public const FREE_LISTING_METRICS    = 'free_listing_metrics';
+	public const MC_ACCOUNT_REVIEW       = 'mc_account_review';
+	public const MC_IS_SUBACCOUNT        = 'mc_is_subaccount';
+	public const MC_STATUSES             = 'mc_statuses';
+	public const SYNCABLE_PRODUCTS_COUNT = 'syncable_products_count';
+	public const URL_MATCHES             = 'url_matches';
 
 	public const VALID_OPTIONS = [
-		self::ADS_METRICS          => true,
-		self::FREE_LISTING_METRICS => true,
-		self::MC_ACCOUNT_REVIEW    => true,
-		self::MC_IS_SUBACCOUNT     => true,
-		self::MC_STATUSES          => true,
-		self::URL_MATCHES          => true,
+		self::ADS_METRICS             => true,
+		self::FREE_LISTING_METRICS    => true,
+		self::MC_ACCOUNT_REVIEW       => true,
+		self::MC_IS_SUBACCOUNT        => true,
+		self::MC_STATUSES             => true,
+		self::SYNCABLE_PRODUCTS_COUNT => true,
+		self::URL_MATCHES             => true,
 	];
 
 	/**

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -108,7 +108,11 @@ class MerchantStatusesTest extends UnitTest {
 			);
 
 		$this->merchant_center_service->expects( $this->any() )
-			->method( 'is_connected' )
+			->method( 'is_google_connected' )
+			->willReturn( true );
+
+		$this->merchant_center_service->expects( $this->any() )
+			->method( 'is_setup_complete' )
 			->willReturn( true );
 
 		$this->merchant->expects( $this->any() )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR implements the [backend task 1](https://github.com/woocommerce/google-listings-and-ads/issues/1610#be-task1) **_📌 Extends `mc/product-statistics` API to return # of syncable products_** from the epic issue #1610. Here are what have changed:

- Extend an existing API `mc/product-statistics` and return a new data `syncable_products` in the response.
- To calculate `syncable_products`, we use an existing method [find_sync_ready_products](https://href.li/?https://github.com/woocommerce/google-listings-and-ads/blob/c2b0b45bd5d406bcd0c374252387390f76fae521/src/Product/ProductRepository.php#L148-L152) in `src/Product/ProductRepository.php`.

#### Google account connected and Merchant Centre setup complete

Previously when calling `mc/product-statistics` API:

- If Google account is not connected, respond `401` `Google account is not connected`.
  - By checking the option `gla_google_connected`.
- Or, if merchant centre setup is not complete, respond `400` `Merchant Center account is not set up`.
  - By checking the option `gla_mc_setup_completed_at`
  - This option will be set after calling the API `mc/settings/sync`.

In the step 4 of new onboarding flow (fqR0EHi63lWahRcVTKCcba-fi-449%3A80562), we haven't called the API `mc/settings/sync` so the option `gla_mc_setup_completed_at` is not being set. If we call `mc/product-statistics` API at this stage it will respond `400` `Merchant Center account is not set up`.

This PR also modifies the the above behaviour - if the merchant centre account is not set up (i.e. the option `gla_mc_setup_completed_at` is not being set), the API will still respond `200` with the data with `syncable_products` and the empty `statistics`:

```json
{
    "timestamp": null,
    "statistics": null,
    "scheduled_sync": 0,
    "syncable_products": 29
}
```

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Disconnect all of the accounts from the settings page: `wp-admin/admin.php?page=wc-admin&path=/google/settings`.
2. Use Postman, make a `GET` request to `mc/product-statistics`
    - The response should be `401` `Google account is not connected`.
3. Go through the onboarding flow, stop at the step 4 `Complete your campaign with paid ads`.
4. Use Postman, make a `GET` request to `mc/product-statistics`, the response should be something like this:
    ```json
    {
        "timestamp": null,
        "statistics": null,
        "scheduled_sync": 0,
        "syncable_products": 29
    }
    ```
5. Skip the ads setup or complete it, you should be redirected to the GLA home page
6. Make a `GET` request to `mc/product-statistics` again, the response should be something like this:
    ```json
    {
        "timestamp": 1662449383,
        "statistics": {
            "active": 0,
            "expiring": 0,
            "pending": 0,
            "disapproved": 23,
            "not_synced": 10
        },
        "scheduled_sync": 0,
        "syncable_products": 29
    }
    ```

### Bonus test
Repeat the same tests as above on a site with a large amount of products 500+. Can use Smooth Generator to generate a set of test products. Note that this might generate some unsyncable products so the total syncable product count might vary.

The expected result is for the request to take longer, however it should still end up with an accurate count for the syncable products. It's stored in a transient, so the second time round should be faster.

The UI is going to be adjusted to show a message like "calculating product count" so it's not an issue if the request takes a little longer to complete.