### PR TITLE
Release 2.1.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
+= 2.1.1 - 2022-09-06 =
+* Dev - Run PHPCS checks for unit tests.
+* Fix - A compatibility issue with WooCommerce 6.9 which prevents interaction
+* Fix - Fatal error if a null rate specified for flat rate methods with shipping classes.
+* Tweak - Add a filter to disable GTag tracking.
+* Tweak - Updated plugin icons.
+* with the input field of the paid campaign budget.
+
 = 2.1.0 - 2022-08-23 =
 * Add - Automatically sync WooCommerce shipping settings with Merchant Center.
 * Add - Get shipping rates suggestions for provinces/states and postal codes.

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google Listings and Ads
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 2.1.0
+ * Version: 2.1.1
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -28,7 +28,7 @@ use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '2.1.0' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '2.1.1' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
 define( 'WC_GLA_MIN_WC_VER', '6.0' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "google-listings-and-ads",
 	"title": "Google Listings and Ads",
 	"license": "GPL-3.0-or-later",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "google-listings-and-ads",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,14 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 
 == Changelog ==
 
+= 2.1.1 - 2022-09-06 =
+* Dev - Run PHPCS checks for unit tests.
+* Fix - A compatibility issue with WooCommerce 6.9 which prevents interaction
+* Fix - Fatal error if a null rate specified for flat rate methods with shipping classes.
+* Tweak - Add a filter to disable GTag tracking.
+* Tweak - Updated plugin icons.
+* with the input field of the paid campaign budget.
+
 = 2.1.0 - 2022-08-23 =
 * Add - Automatically sync WooCommerce shipping settings with Merchant Center.
 * Add - Get shipping rates suggestions for provinces/states and postal codes.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, google, listings, ads
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.4
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -124,15 +124,4 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 * Fix - Hide WooCommerce System messages in the plugin screen. .
 * Fix - Onload conflict when tracking events.
 
-= 2.0.3 - 2022-08-09 =
-* Add - Campaign Conversion Status for detecting converted campaigns.
-* Add - Gtag event tracking.
-* Add - Inbox notification for PMax migration.
-* Add - Includes removed campaign in the program report section.
-* Add - Pmax migration banner dashboard.
-* Add - Pmax migration banner reports.
-* Add - Tooltip in reports section for SSC Campaigns.
-* Add - Track add to cart events from all buttons including Gutenberg blocks.
-* Fix - Add Woo gTag remarketing and conversion signals.
-
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).


### PR DESCRIPTION
* Dev - Run PHPCS checks for unit tests.
* Fix - A compatibility issue with WooCommerce 6.9 to prevent the input of the paid campaign budget from being not interactable.
* Fix - Fatal error if a null rate specified for flat rate methods with shipping classes.
* Tweak - Add a filter to disable GTag tracking.
* Tweak - Updated plugin icons.