### PR TITLE
Fix WC 6.7 compatibility issues about navigating away prompt without saving data

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -37,9 +37,9 @@ import createErrorMessageForRejectedPromises from '.~/utils/createErrorMessageFo
  */
 function isNotOurStep( location ) {
 	const allowList = new Set( [
-		'/' + getNewPath( { pageStep: undefined } ),
-		'/' + getNewPath( { pageStep: 1 } ),
-		'/' + getNewPath( { pageStep: 2 } ),
+		getNewPath( { pageStep: undefined } ),
+		getNewPath( { pageStep: 1 } ),
+		getNewPath( { pageStep: 2 } ),
 	] );
 	// TODO: Explore if we can make thich check cleaner given `history`'s API.
 	const destination = location.pathname + location.search;

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -79,9 +79,6 @@ const EditFreeCampaign = () => {
 		savedTargetAudience
 	);
 	const [ settings, updateSettings ] = useState( savedSettings );
-	const [ forceUnblockedNavigation, setForceUnblockedNavigation ] = useState(
-		false
-	);
 
 	const {
 		hasFinishedResolution: hfrShippingRates,
@@ -156,7 +153,7 @@ const EditFreeCampaign = () => {
 			'You have unsaved campaign data. Are you sure you want to leave?',
 			'google-listings-and-ads'
 		),
-		didAnythingChanged && ! forceUnblockedNavigation,
+		didAnythingChanged,
 		isNotOurStep
 	);
 
@@ -197,10 +194,8 @@ const EditFreeCampaign = () => {
 	};
 
 	const handleChooseAudienceContinue = () => {
-		setForceUnblockedNavigation( true );
 		updateShippingAfterChooseAudienceStep();
 		getHistory().push( getNewPath( { pageStep: '2' } ) );
-		setForceUnblockedNavigation( false );
 	};
 
 	const handleSetupFreeListingsContinue = async () => {

--- a/js/src/hooks/useNavigateAwayPromptEffect.js
+++ b/js/src/hooks/useNavigateAwayPromptEffect.js
@@ -5,6 +5,8 @@ import { useEffect } from '@wordpress/element';
 import { getHistory } from '@woocommerce/navigation';
 import { noop } from 'lodash';
 
+const alwaysTrue = () => true;
+
 /**
  * Returns a normalized location to handle the inconsistent pathname between history v5 (≥ WC 6.7) and v4 (< WC 6.7).
  *
@@ -43,7 +45,7 @@ function normalizeLocation( location ) {
 export default function useNavigateAwayPromptEffect(
 	message,
 	shouldBlock,
-	blockedLocation = () => true
+	blockedLocation = alwaysTrue
 ) {
 	// history#v5 compatibility: As one of useEffect deps for triggering a new blocking after history is changed.
 	const { key } = getHistory().location;

--- a/js/src/hooks/useNavigateAwayPromptEffect.js
+++ b/js/src/hooks/useNavigateAwayPromptEffect.js
@@ -3,6 +3,7 @@
  */
 import { useEffect } from '@wordpress/element';
 import { getHistory } from '@woocommerce/navigation';
+import { noop } from 'lodash';
 
 /**
  * Show prompt when the user tries to unload/leave the page.
@@ -17,6 +18,9 @@ export default function useNavigateAwayPromptEffect(
 	shouldBlock,
 	blockedLocation = () => true
 ) {
+	// history#v5 compatibility: As one of useEffect deps for triggering a new blocking after history is changed.
+	const { key } = getHistory().location;
+
 	useEffect( () => {
 		/**
 		 * Bind beforeunload event for non `woocommerce/navigation` links and reloads.
@@ -31,43 +35,37 @@ export default function useNavigateAwayPromptEffect(
 			e.returnValue = message;
 		};
 
+		let unblock = noop;
+
 		if ( shouldBlock ) {
+			// Block navigation in order to show a confirmation prompt.
+			unblock = getHistory().block( ( transition ) => {
+				// In history v4 (< WC 6.7) block method receives two parameter (the location and action).
+				// In v5 (>= WC 6.7) it has only one parameter that is a transition object with location, retry and action properties.
+				const { location = transition, retry = noop } = transition;
+				let shouldUnblock = true;
+
+				if ( blockedLocation( location ) ) {
+					// Show prompt to confirm if the user wants to navigate away
+					shouldUnblock = window.confirm( message ); // eslint-disable-line no-alert
+				}
+
+				// v5 compatibility requires the calls to unblock and retry functions.
+				if ( shouldUnblock ) {
+					unblock();
+					retry();
+				}
+
+				// v4 compatibility requires a return boolean to tell whether actually to unblock the navigation.
+				return shouldUnblock;
+			} );
+
 			window.addEventListener( 'beforeunload', eventListener );
 		}
-
-		// Block woocommerce/navigation in order to show a confirmation prompt in case shouldBlock is true
-		const unblock = getHistory().block( ( transition ) => {
-			let shouldUnblock = true;
-
-			/**
-			 * In history v4 (< WC 6.7) block method only receives one parameter (the location)
-			 * In v5 (>= WC 6.7) its a transition object with location, retry and action props
-			 */
-			const location = transition?.location || transition;
-
-			// show prompt if we want to block the navigation
-			if ( shouldBlock && blockedLocation( location ) ) {
-				// eslint-disable-next-line no-alert
-				shouldUnblock = window.confirm( message );
-			}
-
-			// if it is not blocked unblock the navigation and retry (v5) or return true (v4) ...
-			if ( shouldUnblock ) {
-				unblock();
-				if ( typeof transition?.retry !== 'undefined' ) {
-					transition.retry();
-				} else {
-					return true;
-				}
-			}
-
-			// v4 compatibility requires return false to actually block the navigation
-			return false;
-		} );
 
 		return () => {
 			unblock();
 			window.removeEventListener( 'beforeunload', eventListener );
 		};
-	}, [ message, shouldBlock, blockedLocation ] );
+	}, [ key, message, shouldBlock, blockedLocation ] );
 }

--- a/js/src/setup-ads/setup-ads-form.js
+++ b/js/src/setup-ads/setup-ads-form.js
@@ -68,7 +68,14 @@ const SetupAdsForm = () => {
 	};
 
 	const handleChange = ( _, values ) => {
-		setFormChanged( ! isEqual( initialValues, values ) );
+		const args = [ initialValues, values ].map(
+			( { countryCodes, ...v } ) => {
+				v.countrySet = new Set( countryCodes );
+				return v;
+			}
+		);
+
+		setFormChanged( ! isEqual( ...args ) );
 	};
 
 	if ( ! targetAudience ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1640 

- Fix the compatibility issues of the `history` dependency between v4 and v5 for the `useNavigateAwayPromptEffect` hook.
- Update the allowList of the `blockedLocation` callback in the `EditFreeCampaign` component to fit with the normalized `location.pathname`.
- Fix the comparison of campaign data for the navigating away prompt in the `SetupAdsForm` component.
- Extra change: Use a stable reference for the fallback of `blockedLocation` parameter of the `useNavigateAwayPromptEffect` hook.

### Screenshots:

#### 📹 Edit free listings

https://user-images.githubusercontent.com/17420811/189300042-00e9f663-dc05-4485-a96e-f79f552d1d5d.mp4

#### 📹 Paid campaign setup

https://user-images.githubusercontent.com/17420811/189315401-d49ba647-2f04-448e-afd0-ebb23599dab0.mp4

### Detailed test instructions:

1. Use a version < WC 6.7.
2. Follow the steps of each replication in [this comment](https://github.com/woocommerce/google-listings-and-ads/issues/1640#issuecomment-1241715058) to verify if all issues are fixed.
3. Ramdonly change the form values, leave page, change the values back, and leave page to see if all behaviors of navigation away prompt work as expected.
4. Use a version >= WC 6.7.
5. Repeat steps 2-3 of this test instruction to see if all issues are not present.

### Changelog entry

> Fix - WooCommerce 6.7 compatibility issues about navigating away prompt without saving data.
