### PR TITLE
GLA Attribute Mapping - Add Create Rule Modal

### DIFF
--- a/js/src/attribute-mapping/attribute-mapping-category-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-category-control.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import AppSelectControl from '.~/components/app-select-control';
+import TreeSelectControl from '.~/components/tree-select-control';
+import useCategoryTree from '.~/hooks/useCategoryTree';
+
+const SELECT_TYPES = {
+	ALL: 'ALL',
+	EXCEPT: 'EXCEPT',
+	ONLY: 'ONLY',
+};
+
+const AttributeMappingCategoryControl = () => {
+	const [ selected, setSelected ] = useState();
+	const { data: categories } = useCategoryTree();
+
+	// Todo: Tree Select control to be implemented
+	return (
+		<>
+			<AppSelectControl
+				options={ [
+					{
+						value: SELECT_TYPES.ALL,
+						label: __(
+							'Apply to All categories',
+							'google-listings-and-ads'
+						),
+					},
+					{
+						value: SELECT_TYPES.EXCEPT,
+						label: __(
+							'Apply to All categories EXCEPT',
+							'google-listings-and-ads'
+						),
+					},
+					{
+						value: SELECT_TYPES.ONLY,
+						label: __(
+							'Apply ONLY to this categories',
+							'google-listings-and-ads'
+						),
+					},
+				] }
+				onChange={ setSelected }
+			/>
+		</>
+	);
+};
+
+export default AttributeMappingCategoryControl;

--- a/js/src/attribute-mapping/attribute-mapping-category-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-category-control.js
@@ -24,7 +24,7 @@ const SELECT_TYPES = {
  * @param {Function} [onCategorySelectorOpen] callback when the Category Tree Selector is open
  */
 const AttributeMappingCategoryControl = ( {
-	onCategorySelectorOpen = noop(),
+	onCategorySelectorOpen = noop,
 } ) => {
 	const [ selectedType, setSelectedType ] = useState();
 	const [ selectedCategories, setSelectedCategories ] = useState();

--- a/js/src/attribute-mapping/attribute-mapping-category-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-category-control.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,11 +18,18 @@ const SELECT_TYPES = {
 	ONLY: 'ONLY',
 };
 
-const AttributeMappingCategoryControl = () => {
-	const [ selected, setSelected ] = useState();
+/**
+ * Renders the selectors relative to the categories
+ *
+ * @param {Function} [onCategorySelectorOpen] callback when the Category Tree Selector is open
+ */
+const AttributeMappingCategoryControl = ( {
+	onCategorySelectorOpen = noop(),
+} ) => {
+	const [ selectedType, setSelectedType ] = useState();
+	const [ selectedCategories, setSelectedCategories ] = useState();
 	const { data: categories } = useCategoryTree();
 
-	// Todo: Tree Select control to be implemented
 	return (
 		<>
 			<AppSelectControl
@@ -48,8 +56,21 @@ const AttributeMappingCategoryControl = () => {
 						),
 					},
 				] }
-				onChange={ setSelected }
+				onChange={ setSelectedType }
 			/>
+			{ ( selectedType === SELECT_TYPES.ONLY ||
+				selectedType === SELECT_TYPES.EXCEPT ) && (
+				<TreeSelectControl
+					onDropdownVisibilityChange={ onCategorySelectorOpen }
+					options={ categories }
+					onChange={ setSelectedCategories }
+					value={ selectedCategories }
+					placeholder={ __(
+						'Select categories',
+						'google-listings-and-ads'
+					) }
+				/>
+			) }
 		</>
 	);
 };

--- a/js/src/attribute-mapping/attribute-mapping-category-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-category-control.js
@@ -11,12 +11,7 @@ import { noop } from 'lodash';
 import AppSelectControl from '.~/components/app-select-control';
 import TreeSelectControl from '.~/components/tree-select-control';
 import useCategoryTree from '.~/hooks/useCategoryTree';
-
-const SELECT_TYPES = {
-	ALL: 'ALL',
-	EXCEPT: 'EXCEPT',
-	ONLY: 'ONLY',
-};
+import { CATEGORY_CONDITION_SELECT_TYPES } from '.~/constants';
 
 /**
  * Renders the selectors relative to the categories
@@ -35,21 +30,21 @@ const AttributeMappingCategoryControl = ( {
 			<AppSelectControl
 				options={ [
 					{
-						value: SELECT_TYPES.ALL,
+						value: CATEGORY_CONDITION_SELECT_TYPES.ALL,
 						label: __(
 							'Apply to All categories',
 							'google-listings-and-ads'
 						),
 					},
 					{
-						value: SELECT_TYPES.EXCEPT,
+						value: CATEGORY_CONDITION_SELECT_TYPES.EXCEPT,
 						label: __(
 							'Apply to All categories EXCEPT',
 							'google-listings-and-ads'
 						),
 					},
 					{
-						value: SELECT_TYPES.ONLY,
+						value: CATEGORY_CONDITION_SELECT_TYPES.ONLY,
 						label: __(
 							'Apply ONLY to this categories',
 							'google-listings-and-ads'
@@ -58,8 +53,8 @@ const AttributeMappingCategoryControl = ( {
 				] }
 				onChange={ setSelectedType }
 			/>
-			{ ( selectedType === SELECT_TYPES.ONLY ||
-				selectedType === SELECT_TYPES.EXCEPT ) && (
+			{ ( selectedType === CATEGORY_CONDITION_SELECT_TYPES.ONLY ||
+				selectedType === CATEGORY_CONDITION_SELECT_TYPES.EXCEPT ) && (
 				<TreeSelectControl
 					onDropdownVisibilityChange={ onCategorySelectorOpen }
 					options={ categories }

--- a/js/src/attribute-mapping/attribute-mapping-field-sources-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-field-sources-control.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import AppSelectControl from '.~/components/app-select-control';
@@ -14,12 +19,21 @@ const AttributeMappingFieldSourcesControl = ( { sources = [], help } ) => {
 	return (
 		<>
 			<AppSelectControl
-				options={ sources.map( ( source ) => {
-					return {
-						...source,
-						disabled: source.value.includes( 'disabled:' ),
-					};
-				} ) }
+				options={ [
+					{
+						value: '',
+						label: __(
+							'Select one option',
+							'google-listings-and-ads'
+						),
+					},
+					...sources.map( ( source ) => {
+						return {
+							...source,
+							disabled: source.value.includes( 'disabled:' ),
+						};
+					} ),
+				] }
 			/>
 			{ help }
 		</>

--- a/js/src/attribute-mapping/attribute-mapping-field-sources-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-field-sources-control.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import AppSelectControl from '.~/components/app-select-control';
+
+/**
+ * Renders a selector for choosing the source field.
+ *
+ * @param { Object } props The component props
+ * @param { Array } props.sources The sources available for the selector
+ * @param { JSX.Element } props.help Help text or component to be render at the bottom of the selector
+ */
+const AttributeMappingFieldSourcesControl = ( { sources = [], help } ) => {
+	return (
+		<>
+			<AppSelectControl
+				options={ sources.map( ( source ) => {
+					return {
+						...source,
+						disabled: source.value.includes( 'disabled:' ),
+					};
+				} ) }
+			/>
+			{ help }
+		</>
+	);
+};
+
+export default AttributeMappingFieldSourcesControl;

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -27,6 +27,7 @@ import AttributeMappingCategoryControl from '.~/attribute-mapping/attribute-mapp
  */
 const AttributeMappingRuleModal = ( { rule, onRequestClose = noop() } ) => {
 	const [ selectedAttribute, setSelectedAttribute ] = useState();
+	const [ dropdownVisible, setDropdownVisible ] = useState( false );
 
 	const { data: attributes } = useMappingAttributes();
 	const { data: sources } = useMappingAttributesSources( selectedAttribute );
@@ -35,6 +36,9 @@ const AttributeMappingRuleModal = ( { rule, onRequestClose = noop() } ) => {
 
 	return (
 		<AppModal
+			overflow="visible"
+			shouldCloseOnEsc={ ! dropdownVisible }
+			shouldCloseOnClickOutside={ ! dropdownVisible }
 			onRequestClose={ onRequestClose }
 			className="gla-attribute-mapping__rule-modal"
 			title={
@@ -107,7 +111,9 @@ const AttributeMappingRuleModal = ( { rule, onRequestClose = noop() } ) => {
 						<Subsection.Title>
 							{ __( 'Categories', 'google-listings-and-ads' ) }
 						</Subsection.Title>
-						<AttributeMappingCategoryControl />
+						<AttributeMappingCategoryControl
+							onCategorySelectorOpen={ setDropdownVisible }
+						/>
 					</Subsection>
 				</>
 			) }

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -3,33 +3,39 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Subsection from '.~/wcdl/subsection';
 import AppModal from '.~/components/app-modal';
 import AppButton from '.~/components/app-button';
 import AppSelectControl from '.~/components/app-select-control';
 import useMappingAttributes from '.~/hooks/useMappingAttributes';
 import useMappingAttributesSources from '.~/hooks/useMappingAttributesSources';
+import AttributeMappingFieldSourcesControl from './attribute-mapping-field-sources-control';
+import AttributeMappingSourceTypeSelector from './attribute-mapping-source-type-selector';
+import AttributeMappingCategoryControl from '.~/attribute-mapping/attribute-mapping-category-control';
 
 /**
  * Renders a modal showing a form for editing or creating an Attribute Mapping rule
  *
  * @param {Object} props React props
  * @param {Object} [props.rule] Optional rule to manage
+ * @param {Function} [props.onRequestClose] Callback on closing the modal
  */
-const AttributeMappingRuleModal = ( { rule } ) => {
+const AttributeMappingRuleModal = ( { rule, onRequestClose = noop() } ) => {
 	const [ selectedAttribute, setSelectedAttribute ] = useState();
+
 	const { data: attributes } = useMappingAttributes();
 	const { data: sources } = useMappingAttributesSources( selectedAttribute );
-
-	const handleAttributeChange = ( attribute ) => {
-		setSelectedAttribute( attribute );
-	};
+	const isEnum = attributes?.find( ( { id } ) => id === selectedAttribute )
+		?.enum;
 
 	return (
 		<AppModal
+			onRequestClose={ onRequestClose }
 			className="gla-attribute-mapping__rule-modal"
 			title={
 				rule
@@ -37,6 +43,9 @@ const AttributeMappingRuleModal = ( { rule } ) => {
 					: __( 'Create attribute rule', ' google-listings-and-ads' )
 			}
 			buttons={ [
+				<AppButton key="cancel" isLink onClick={ onRequestClose }>
+					{ __( 'Cancel', 'google-listings-and-ads' ) }
+				</AppButton>,
 				<AppButton
 					key="save-rule"
 					isPrimary
@@ -48,26 +57,59 @@ const AttributeMappingRuleModal = ( { rule } ) => {
 				/>,
 			] }
 		>
-			<AppSelectControl
-				label={ __( 'Target attribute', 'google-listings-and-ads' ) }
-				onChange={ handleAttributeChange }
-				options={ attributes.map( ( attribute ) => {
-					return {
-						value: attribute.id,
-						label: attribute.label,
-					};
-				} ) }
-			/>
-
-			{ sources.length > 0 && (
+			<Subsection>
+				<Subsection.Title>
+					{ __( 'Target attribute', 'google-listings-and-ads' ) }
+				</Subsection.Title>
+				<Subsection.Subtitle className="gla_attribute_mapping_helper-text">
+					{ __(
+						'Select a Google attribute that you want to manage',
+						'google-listings-and-ads'
+					) }
+				</Subsection.Subtitle>
 				<AppSelectControl
-					options={ sources.map( ( source ) => {
+					onChange={ setSelectedAttribute }
+					options={ attributes.map( ( attribute ) => {
 						return {
-							...source,
-							disabled: source.value.includes( 'disabled:' ),
+							value: attribute.id,
+							label: attribute.label,
 						};
 					} ) }
 				/>
+			</Subsection>
+
+			{ sources.length > 0 && (
+				<>
+					<Subsection>
+						<Subsection.Title>
+							{ isEnum
+								? __(
+										'Select default value',
+										'google-listings-and-ads'
+								  )
+								: __(
+										'Assign value',
+										'google-listings-and-ads'
+								  ) }
+						</Subsection.Title>
+
+						{ isEnum ? (
+							<AttributeMappingFieldSourcesControl
+								sources={ sources }
+							/>
+						) : (
+							<AttributeMappingSourceTypeSelector
+								sources={ sources }
+							/>
+						) }
+					</Subsection>
+					<Subsection>
+						<Subsection.Title>
+							{ __( 'Categories', 'google-listings-and-ads' ) }
+						</Subsection.Title>
+						<AttributeMappingCategoryControl />
+					</Subsection>
+				</>
 			) }
 		</AppModal>
 	);

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import AppModal from '.~/components/app-modal';
+import AppButton from '.~/components/app-button';
+import AppSelectControl from '.~/components/app-select-control';
+import useMappingAttributes from '.~/hooks/useMappingAttributes';
+import useMappingAttributesSources from '.~/hooks/useMappingAttributesSources';
+
+/**
+ * Renders a modal showing a form for editing or creating an Attribute Mapping rule
+ *
+ * @param {Object} props React props
+ * @param {Object} [props.rule] Optional rule to manage
+ */
+const AttributeMappingRuleModal = ( { rule } ) => {
+	const [ selectedAttribute, setSelectedAttribute ] = useState();
+	const { data: attributes } = useMappingAttributes();
+	const { data: sources } = useMappingAttributesSources( selectedAttribute );
+
+	const handleAttributeChange = ( attribute ) => {
+		setSelectedAttribute( attribute );
+	};
+
+	return (
+		<AppModal
+			className="gla-attribute-mapping__rule-modal"
+			title={
+				rule
+					? __( 'Manage attribute rule', ' google-listings-and-ads' )
+					: __( 'Create attribute rule', ' google-listings-and-ads' )
+			}
+			buttons={ [
+				<AppButton
+					key="save-rule"
+					isPrimary
+					text={ __( 'Save rule', 'google-listings-and-ads' ) }
+					eventName="gla_attribute_mapping_save_rule"
+					eventProps={ {
+						context: 'attribute-mapping-rule-modal',
+					} }
+				/>,
+			] }
+		>
+			<AppSelectControl
+				label={ __( 'Target attribute', 'google-listings-and-ads' ) }
+				onChange={ handleAttributeChange }
+				options={ attributes.map( ( attribute ) => {
+					return {
+						value: attribute.id,
+						label: attribute.label,
+					};
+				} ) }
+			/>
+
+			{ sources.length > 0 && (
+				<AppSelectControl
+					options={ sources.map( ( source ) => {
+						return {
+							...source,
+							disabled: source.value.includes( 'disabled:' ),
+						};
+					} ) }
+				/>
+			) }
+		</AppModal>
+	);
+};
+
+export default AttributeMappingRuleModal;

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -25,7 +25,7 @@ import AttributeMappingCategoryControl from '.~/attribute-mapping/attribute-mapp
  * @param {Object} [props.rule] Optional rule to manage
  * @param {Function} [props.onRequestClose] Callback on closing the modal
  */
-const AttributeMappingRuleModal = ( { rule, onRequestClose = noop() } ) => {
+const AttributeMappingRuleModal = ( { rule, onRequestClose = noop } ) => {
 	const [ selectedAttribute, setSelectedAttribute ] = useState();
 	const [ dropdownVisible, setDropdownVisible ] = useState( false );
 

--- a/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
+++ b/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
@@ -39,35 +39,33 @@ const AttributeMappingSourceTypeSelector = ( { sources = [] } ) => {
 			</Subsection.Subtitle>
 			<AppRadioContentControl
 				className="gla-attribute-mapping__radio-control"
-				label={ createInterpolateElement(
-					__(
-						'Use value from existing product field. <help />',
-						'google-listings-and-ads'
-					),
-					{
-						help: (
-							<HelpPopover
-								id={ `${ SOURCE_TYPES.FIELD }-helper-popover` }
-							>
-								{ createInterpolateElement(
-									__(
-										'Create a connection between the target attribute and an existing product field to auto-populate the target attribute with with the value of the field it is linked to. <link>Learn more</link>',
-										'google-listings-and-ads'
+				label={
+					<>
+						{ __(
+							'Use value from existing product field.',
+							'google-listings-and-ads'
+						) }
+						<HelpPopover
+							id={ `${ SOURCE_TYPES.FIELD }-helper-popover` }
+						>
+							{ createInterpolateElement(
+								__(
+									'Create a connection between the target attribute and an existing product field to auto-populate the target attribute with with the value of the field it is linked to. <link>Learn more</link>',
+									'google-listings-and-ads'
+								),
+								{
+									link: (
+										<AppDocumentationLink
+											context="attribute-mapping"
+											linkId="learn-more-about-field-values"
+											href="https://example.com" // todo: check link
+										/>
 									),
-									{
-										link: (
-											<AppDocumentationLink
-												context="attribute-mapping"
-												linkId="learn-more-about-field-values"
-												href="https://example.com" // todo: check link
-											/>
-										),
-									}
-								) }
-							</HelpPopover>
-						),
-					}
-				) }
+								}
+							) }
+						</HelpPopover>
+					</>
+				}
 				onChange={ setSourceType }
 				value={ SOURCE_TYPES.FIELD }
 				selected={ sourceType }
@@ -98,35 +96,33 @@ const AttributeMappingSourceTypeSelector = ( { sources = [] } ) => {
 			</AppRadioContentControl>
 			<AppRadioContentControl
 				className="gla-attribute-mapping__radio-control"
-				label={ createInterpolateElement(
-					__(
-						'Set a fixed value. <help />',
-						'google-listings-and-ads'
-					),
-					{
-						help: (
-							<HelpPopover
-								id={ `${ SOURCE_TYPES.FIXED }-helper-popover` }
-							>
-								{ createInterpolateElement(
-									__(
-										'Use fixed values to populate the target attribute with a value you specify. For example, you can enter a fixed value of White to specify a single color for all your products. <link>Learn more about fixed values</link>',
-										'google-listings-and-ads'
+				label={
+					<>
+						{ __(
+							'Set a fixed value.',
+							'google-listings-and-ads'
+						) }
+						<HelpPopover
+							id={ `${ SOURCE_TYPES.FIXED }-helper-popover` }
+						>
+							{ createInterpolateElement(
+								__(
+									'Use fixed values to populate the target attribute with a value you specify. For example, you can enter a fixed value of White to specify a single color for all your products. <link>Learn more about fixed values</link>',
+									'google-listings-and-ads'
+								),
+								{
+									link: (
+										<AppDocumentationLink
+											context="attribute-mapping"
+											linkId="clearn-more-about-fixed-values"
+											href="https://example.com" // Todo: Check link
+										/>
 									),
-									{
-										link: (
-											<AppDocumentationLink
-												context="attribute-mapping"
-												linkId="clearn-more-about-fixed-values"
-												href="https://example.com" // Todo: Check link
-											/>
-										),
-									}
-								) }
-							</HelpPopover>
-						),
-					}
-				) }
+								}
+							) }
+						</HelpPopover>
+					</>
+				}
 				onChange={ setSourceType }
 				value={ SOURCE_TYPES.FIXED }
 				selected={ sourceType }

--- a/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
+++ b/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Subsection from '.~/wcdl/subsection';
+import AppRadioContentControl from '.~/components/app-radio-content-control';
+import AppInputControl from '.~/components/app-input-control';
+import AttributeMappingFieldSourcesControl from '.~/attribute-mapping/attribute-mapping-field-sources-control';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import HelpPopover from '.~/components/help-popover';
+
+const SOURCE_TYPES = {
+	FIXED: 'fixed',
+	FIELD: 'field',
+};
+
+/**
+ * Renders a selector for choosing the source field.
+ *
+ * @param { Object } props The component props
+ * @param { Array } props.sources The sources available for the selector
+ */
+
+const AttributeMappingSourceTypeSelector = ( { sources = [] } ) => {
+	const [ sourceType, setSourceType ] = useState( SOURCE_TYPES.FIELD );
+
+	return (
+		<>
+			<Subsection.Subtitle className="gla_attribute_mapping_helper-text">
+				{ __(
+					'Choose how to assign a value to the target attribute',
+					'google-listings-and-ads'
+				) }
+			</Subsection.Subtitle>
+			<AppRadioContentControl
+				className="gla-attribute-mapping__radio-control"
+				label={ createInterpolateElement(
+					__(
+						'Use value from existing product field. <help />',
+						'google-listings-and-ads'
+					),
+					{
+						help: (
+							<HelpPopover
+								id={ `${ SOURCE_TYPES.FIELD }-helper-popover` }
+							>
+								{ createInterpolateElement(
+									__(
+										'Create a connection between the target attribute and an existing product field to auto-populate the target attribute with with the value of the field it is linked to. <link>Learn more</link>',
+										'google-listings-and-ads'
+									),
+									{
+										link: (
+											<AppDocumentationLink
+												context="attribute-mapping"
+												linkId="learn-more-about-field-values"
+												href="https://example.com" // todo: check link
+											/>
+										),
+									}
+								) }
+							</HelpPopover>
+						),
+					}
+				) }
+				onChange={ setSourceType }
+				value={ SOURCE_TYPES.FIELD }
+				selected={ sourceType }
+				collapsible
+			>
+				<AttributeMappingFieldSourcesControl
+					sources={ sources }
+					help={
+						<Subsection.HelperText className="gla-attribute-mapping__help-text">
+							{ createInterpolateElement(
+								__(
+									'Can’t find an appropriate field?. <link>Create a new attribute</link>',
+									'google-listings-and-ads'
+								),
+								{
+									link: (
+										<AppDocumentationLink
+											context="attribute-mapping"
+											linkId="create-new-attribute"
+											href="/wp-admin/edit.php?post_type=product&page=product_attributes"
+										/>
+									),
+								}
+							) }
+						</Subsection.HelperText>
+					}
+				/>
+			</AppRadioContentControl>
+			<AppRadioContentControl
+				className="gla-attribute-mapping__radio-control"
+				label={ createInterpolateElement(
+					__(
+						'Set a fixed value. <help />',
+						'google-listings-and-ads'
+					),
+					{
+						help: (
+							<HelpPopover
+								id={ `${ SOURCE_TYPES.FIXED }-helper-popover` }
+							>
+								{ createInterpolateElement(
+									__(
+										'Use fixed values to populate the target attribute with a value you specify. For example, you can enter a fixed value of White to specify a single color for all your products. <link>Learn more about fixed values</link>',
+										'google-listings-and-ads'
+									),
+									{
+										link: (
+											<AppDocumentationLink
+												context="attribute-mapping"
+												linkId="clearn-more-about-fixed-values"
+												href="https://example.com" // Todo: Check link
+											/>
+										),
+									}
+								) }
+							</HelpPopover>
+						),
+					}
+				) }
+				onChange={ setSourceType }
+				value={ SOURCE_TYPES.FIXED }
+				selected={ sourceType }
+				collapsible
+			>
+				<AppInputControl
+					placeholder={ __(
+						'Enter a value',
+						'google-listings-and-ads'
+					) }
+				/>
+			</AppRadioContentControl>
+		</>
+	);
+};
+
+export default AttributeMappingSourceTypeSelector;

--- a/js/src/attribute-mapping/attribute-mapping-table-categories.js
+++ b/js/src/attribute-mapping/attribute-mapping-table-categories.js
@@ -7,6 +7,7 @@ import { _n, sprintf, _x, __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import AppTooltip from '.~/components/app-tooltip';
+import { CATEGORY_CONDITION_SELECT_TYPES } from '.~/constants';
 
 const DUMMY_CATEGORIES = [
 	{ id: 1, name: 'Category 1' },
@@ -32,7 +33,7 @@ const CATEGORIES_TO_SHOW = 5;
  * @return {JSX.Element|string} The component
  */
 const AttributeMappingTableCategories = ( { categories, condition } ) => {
-	if ( condition === 'ALL' ) {
+	if ( condition === CATEGORY_CONDITION_SELECT_TYPES.ALL ) {
 		return __( 'All', 'google-listings-and-ads' );
 	}
 
@@ -58,7 +59,7 @@ const AttributeMappingTableCategories = ( { categories, condition } ) => {
 	return (
 		<>
 			<span>
-				{ condition === 'ONLY'
+				{ condition === CATEGORY_CONDITION_SELECT_TYPES.ONLY
 					? __( 'Only in', 'google-listings-and-ads' )
 					: __( 'All except', 'google-listings-and-ads' ) }
 			</span>

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -11,6 +11,8 @@ import { CardBody, CardFooter } from '@wordpress/components';
 import Card from '.~/wcdl/section/card';
 import AppButton from '.~/components/app-button';
 import AppTableCardDiv from '.~/components/app-table-card-div';
+import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
+import AttributeMappingRuleModal from '.~/attribute-mapping/attribute-mapping-rule-modal';
 
 const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
 	{
@@ -60,13 +62,21 @@ const AttributeMappingTable = () => {
 					align="start"
 					className="gla-attribute-mapping__table-footer"
 				>
-					<AppButton
-						isSecondary
-						onClick={ () => {} } // TODO: Implement button logic
-						text={ __(
-							'Add new attribute mapping',
-							'google-listings-and-ads'
-						) }
+					<AppButtonModalTrigger
+						button={
+							<AppButton
+								isSecondary
+								text={ __(
+									'Create attribute rule',
+									'google-listings-and-ads'
+								) }
+								eventName="gla_attribute_mapping_new_rule_click"
+								eventProps={ {
+									context: 'attribute-mapping-table',
+								} }
+							/>
+						}
+						modal={ <AttributeMappingRuleModal /> }
 					/>
 				</CardFooter>
 			</Card>

--- a/js/src/attribute-mapping/index.js
+++ b/js/src/attribute-mapping/index.js
@@ -19,7 +19,7 @@ import './index.scss';
  */
 const AttributeMapping = () => {
 	return (
-		<div className="gla-settings-attribute-mapping">
+		<div className="gla-attribute-mapping">
 			<NavigationClassic />
 			<Section
 				title={ __( 'Attribute Mapping', 'google-listings-and-ads' ) }

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -31,7 +31,8 @@
 		}
 
 		.woocommerce-tree-select-control {
-			&__control, &__tree {
+			&__control,
+			&__tree {
 				padding: $grid-unit-05 $grid-unit;
 				border-color: $gray-700;
 			}
@@ -40,10 +41,10 @@
 				font-size: 11px;
 			}
 
-			&__option, .components-base-control .woocommerce-tree-select-control__control-input {
+			&__option,
+			.components-base-control .woocommerce-tree-select-control__control-input {
 				font-size: $default-font-size;
 			}
 		}
 	}
-
 }

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -7,6 +7,8 @@
 	&__radio-control {
 		margin-top: $grid-unit-20;
 		.help-popover {
+			margin-left: $grid-unit;
+
 			// hack for positioning correctly the popover in the modal radio control
 			.components-popover {
 				position: absolute;

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -3,4 +3,25 @@
 	&__table-footer {
 		padding: $grid-unit-20;
 	}
+
+	&__radio-control {
+		margin-top: $grid-unit-20;
+		.help-popover {
+			// hack for positioning correctly the popover in the modal radio control
+			.components-popover {
+				position: absolute;
+
+				&__content {
+					max-width: 400px;
+					transform: translateX(-100px);
+				}
+			}
+		}
+	}
+
+	&__help-text {
+		margin-top: $grid-unit;
+	}
+
+
 }

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -55,7 +55,7 @@
 		background: $gray-100;
 		padding: $grid-unit-05 $grid-unit-10;
 		border-radius: 2px;
-		font-size: 12px;
+		font-size: $gla-font-smaller;
 		line-height: 16px;
 	}
 

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -20,6 +20,7 @@
 			margin-bottom: $grid-unit;
 			select.components-select-control__input {
 				height: 40px;
+				max-width: 100%;
 			}
 		}
 

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -10,18 +10,40 @@
 			// hack for positioning correctly the popover in the modal radio control
 			.components-popover {
 				position: absolute;
-
-				&__content {
-					max-width: 400px;
-					transform: translateX(-100px);
-				}
 			}
 		}
 	}
 
-	&__help-text {
-		margin-top: $grid-unit;
-	}
+	&__rule-modal {
 
+		.app-select-control {
+			margin-bottom: $grid-unit;
+			select.components-select-control__input {
+				height: 40px;
+			}
+		}
+
+		.app-input-control {
+			margin-bottom: $grid-unit;
+			input.components-input-control__input {
+				height: 40px;
+			}
+		}
+
+		.woocommerce-tree-select-control {
+			&__control, &__tree {
+				padding: $grid-unit-05 $grid-unit;
+				border-color: $gray-700;
+			}
+
+			&__tags {
+				font-size: 11px;
+			}
+
+			&__option, .components-base-control .woocommerce-tree-select-control__control-input {
+				font-size: $default-font-size;
+			}
+		}
+	}
 
 }

--- a/js/src/attribute-mapping/index.test.js
+++ b/js/src/attribute-mapping/index.test.js
@@ -20,7 +20,7 @@ describe( 'Attribute Mapping', () => {
 
 	test( 'Renders Add new Attribute mapping button', () => {
 		const { queryByText } = render( <AttributeMapping /> );
-		expect( queryByText( 'Add new attribute mapping' ) ).toBeTruthy();
+		expect( queryByText( 'Create attribute rule' ) ).toBeTruthy();
 	} );
 
 	test( 'Renders Section title, description and documentation link', () => {

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -50,3 +50,10 @@ export const ISSUE_TYPE_PRODUCT = 'product';
 export const ISSUE_TYPE_ACCOUNT = 'account';
 export const REQUEST_REVIEW = 'request-review';
 export const ISSUE_TABLE_PER_PAGE = 5;
+
+// Attribute Mapping
+export const CATEGORY_CONDITION_SELECT_TYPES = {
+	ALL: 'ALL',
+	EXCEPT: 'EXCEPT',
+	ONLY: 'ONLY',
+};

--- a/js/src/css/abstracts/_variables.scss
+++ b/js/src/css/abstracts/_variables.scss
@@ -6,6 +6,7 @@
 // Typography
 
 $gla-font-smallest: 11px;
+$gla-font-smaller: 12px;
 $gla-font-small: 14px;
 $gla-font-small-medium: 20px;
 $gla-font-medium: 24px;

--- a/js/src/hooks/useCategoryTree.js
+++ b/js/src/hooks/useCategoryTree.js
@@ -1,0 +1,47 @@
+const useCategoryTree = () => {
+	return {
+		data: [
+			// todo: Dummy content. API Call to be implemented
+			{
+				value: 'Category 1',
+				label: 'Category 1',
+				children: [
+					{
+						value: 'Category 1.1',
+						label: 'Category 1.1',
+					},
+					{
+						value: 'Category 1.2',
+						label: 'Category 1.2',
+					},
+				],
+			},
+			{
+				value: 'Category 2',
+				label: 'Category 2',
+				children: [
+					{
+						value: 'Category 2.1',
+						label: 'Category 2.1',
+						children: [
+							{
+								value: 'Category 2.1.1',
+								label: 'Category 2.1.1',
+							},
+							{
+								value: 'Category 2.1.2',
+								label: 'Category 2.1.2',
+							},
+						],
+					},
+					{
+						value: 'Category 2.2',
+						label: 'Category 2.2',
+					},
+				],
+			},
+		],
+	};
+};
+
+export default useCategoryTree;

--- a/js/src/hooks/useMappingAttributes.js
+++ b/js/src/hooks/useMappingAttributes.js
@@ -1,0 +1,18 @@
+/**
+ * Returns the attributes available for mapping
+ *
+ * @return {Object} The attributes available for mapping
+ */
+const useMappingAttributes = () => {
+	// Todo: Replace with API data after approval.
+
+	return {
+		data: [
+			{ id: '', label: 'Select one attribute' },
+			{ id: 'adult', label: 'Adult', enum: true },
+			{ id: 'brand', label: 'Brand', enum: false },
+		],
+	};
+};
+
+export default useMappingAttributes;

--- a/js/src/hooks/useMappingAttributesSources.js
+++ b/js/src/hooks/useMappingAttributesSources.js
@@ -1,0 +1,36 @@
+/**
+ * Returns available source data based on an attribute
+ *
+ * @param {string} attributeKey The key for the attribute we want to get the sources
+ * @return {Object} Object with ths available sources
+ */
+const useMappingAttributesSources = ( attributeKey ) => {
+	// Todo: Replace with API data after approval.
+
+	if ( attributeKey === 'brand' ) {
+		return {
+			data: [
+				{ value: 'disabled:tax', label: 'Product taxonomies' },
+				{ value: 'tax:tax_1', label: 'Taxonomy 1' },
+				{ value: 'disabled:field', label: 'Product fields' },
+				{ value: 'field:product_field_1', label: 'Product field 1' },
+				{ value: 'field:product_field_2', label: 'Product field 2' },
+			],
+		};
+	}
+
+	if ( attributeKey === 'adult' ) {
+		return {
+			data: [
+				{ value: 'yes', label: 'Yes' },
+				{ value: 'no', label: 'No' },
+			],
+		};
+	}
+
+	return {
+		data: [],
+	};
+};
+
+export default useMappingAttributesSources;

--- a/js/src/wcdl/subsection/index.js
+++ b/js/src/wcdl/subsection/index.js
@@ -4,10 +4,7 @@
 import Title from './title';
 import Body from './body';
 import HelperText from './helper-text';
-
-/**
- * Internal dependencies
- */
+import Subtitle from './subtitle';
 import './index.scss';
 
 const Subsection = ( props ) => {
@@ -17,6 +14,7 @@ const Subsection = ( props ) => {
 };
 
 Subsection.Title = Title;
+Subsection.Subtitle = Subtitle;
 Subsection.Body = Body;
 Subsection.HelperText = HelperText;
 

--- a/js/src/wcdl/subsection/subtitle/index.js
+++ b/js/src/wcdl/subsection/subtitle/index.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
+
+const Subtitle = ( props ) => {
+	const { className, ...rest } = props;
+
+	return (
+		<div
+			className={ classnames( 'wcdl-subsection-subtitle', className ) }
+			{ ...rest }
+		/>
+	);
+};
+
+export default Subtitle;

--- a/js/src/wcdl/subsection/subtitle/index.scss
+++ b/js/src/wcdl/subsection/subtitle/index.scss
@@ -1,0 +1,6 @@
+.wcdl-subsection-subtitle {
+	font-size: $gla-font-smaller;
+	line-height: $gla-line-height-smaller;
+	color: $gray-700;
+	margin-bottom: $grid-unit-05;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1648.

This PR ads the modal and the form for adding the new Attachment tribute Mapping rule when the user clicks on "Add new Attribute Mapping rule"

⚠️ The data for the attributes, categories and sources is still dummy until the backend side is finished (soon)
⚠️ The button "Save Rule" doesn't have functionality yet. (in a future PR to save the settings and reload the data in the table)
⚠️  Test will be added once implemented the API endpoints

### Screenshots:

https://user-images.githubusercontent.com/5908855/191014123-1a7fb93e-d73b-4c02-9c31-ad319f8459ff.mov



### Detailed test instructions:

1.   Enter into Attribute Mapping Tab
2.  Click on "Create attribute rule"
3.  See the modal appearing matching the design flow and appearance in Figma (some differences in copy/links are ok since UX it's WIP)
4. Select Adult (an enum field) an see that only default value input and categories selector appear
5. Select Brand and see how Field Type selector appears
6. Select Set Fixed value and see how the view change to text input
7. Check that categories selector works fine
8. Check that the modal close/open works fine
9. Check code quality 

### Additional details:

Project:  https://googleforwooextension.wordpress.com/2022/07/06/project-thread-custom-attribute-mapping/
Figma: https://www.figma.com/file/fqR0EHi63lWahRcVTKCcba/Google-Listings-%26-Ads-v2.x?node-id=1573%3A141294


