### PR TITLE
Free Listings + Paid Ads: Update product feed API to return the bestselling product

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -87,27 +87,37 @@ class ProductFeedController extends BaseController {
 				'items'       => [
 					'type'       => 'object',
 					'properties' => [
-						'id'      => [
+						'id'        => [
 							'type'        => 'numeric',
 							'description' => __( 'Product ID.', 'google-listings-and-ads' ),
 							'context'     => [ 'view' ],
 						],
-						'title'   => [
+						'title'     => [
 							'type'        => 'string',
 							'description' => __( 'Product title.', 'google-listings-and-ads' ),
 							'context'     => [ 'view' ],
 						],
-						'visible' => [
+						'visible'   => [
 							'type'        => 'boolean',
 							'description' => __( 'Whether the product is set to be visible in the Merchant Center', 'google-listings-and-ads' ),
 							'context'     => [ 'view' ],
 						],
-						'status'  => [
+						'status'    => [
 							'type'        => 'string',
 							'description' => __( 'The current sync status of the product.', 'google-listings-and-ads' ),
 							'context'     => [ 'view' ],
 						],
-						'errors'  => [
+						'image_url' => [
+							'type'        => 'string',
+							'description' => __( 'The image url of the product.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+						'price'     => [
+							'type'        => 'string',
+							'description' => __( 'The price of the product.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+						'errors'    => [
 							'type'        => 'array',
 							'description' => __( 'Errors preventing the product from being synced to the Merchant Center.', 'google-listings-and-ads' ),
 							'context'     => [ 'view' ],

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -129,6 +129,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 				'enableReports'            => $this->enableReports(),
 				'dateFormat'               => get_option( 'date_format' ),
 				'timeFormat'               => get_option( 'time_format' ),
+				'siteLogoUrl'              => wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ), 'full' ),
 
 			]
 		);

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -88,11 +88,13 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 			$errors = $product_helper->get_validation_errors( $product );
 
 			$products[ $id ] = [
-				'id'      => $id,
-				'title'   => $product->get_name(),
-				'visible' => $product_helper->get_channel_visibility( $product ) !== ChannelVisibility::DONT_SYNC_AND_SHOW,
-				'status'  => $product_helper->get_mc_status( $product ) ?: $product_helper->get_sync_status( $product ),
-				'errors'  => array_values( $errors ),
+				'id'        => $id,
+				'title'     => $product->get_name(),
+				'visible'   => $product_helper->get_channel_visibility( $product ) !== ChannelVisibility::DONT_SYNC_AND_SHOW,
+				'status'    => $product_helper->get_mc_status( $product ) ?: $product_helper->get_sync_status( $product ),
+				'image_url' => wp_get_attachment_image_url( $product->get_image_id(), 'full' ),
+				'price'     => $product->get_price(),
+				'errors'    => array_values( $errors ),
 			];
 		}
 

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -165,6 +165,10 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 				$args['meta_key'] = $this->prefix_meta_key( ProductMetaHandler::KEY_MC_STATUS );
 				$args['orderby']  = [ 'meta_value' => $this->get_order() ] + $args['orderby'];
 				break;
+			case 'total_sales':
+				$args['meta_key'] = ProductMetaHandler::KEY_TOTAL_SALES;
+				$args['orderby']  = [ 'meta_value_num' => $this->get_order() ] + $args['orderby'];
+				break;
 			default:
 				throw InvalidValue::not_in_allowed_list( 'orderby', [ 'title', 'id', 'visible', 'status' ] );
 		}

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -172,7 +172,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 				$args['orderby']  = [ 'meta_value_num' => $this->get_order() ] + $args['orderby'];
 				break;
 			default:
-				throw InvalidValue::not_in_allowed_list( 'orderby', [ 'title', 'id', 'visible', 'status' ] );
+				throw InvalidValue::not_in_allowed_list( 'orderby', [ 'title', 'id', 'visible', 'status', 'total_sales' ] );
 		}
 
 		return $args;

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -50,6 +50,11 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 	protected $product_repository;
 
 	/**
+	 * Meta key for total sales.
+	 */
+	protected const META_KEY_TOTAL_SALES = 'total_sales';
+
+	/**
 	 * ProductFeedQueryHelper constructor.
 	 *
 	 * @param wpdb              $wpdb
@@ -168,7 +173,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 				$args['orderby']  = [ 'meta_value' => $this->get_order() ] + $args['orderby'];
 				break;
 			case 'total_sales':
-				$args['meta_key'] = ProductMetaHandler::KEY_TOTAL_SALES;
+				$args['meta_key'] = self::META_KEY_TOTAL_SALES;
 				$args['orderby']  = [ 'meta_value_num' => $this->get_order() ] + $args['orderby'];
 				break;
 			default:

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -58,7 +58,6 @@ class ProductMetaHandler implements Service, Registerable {
 	public const KEY_SYNC_FAILED_AT         = 'sync_failed_at';
 	public const KEY_SYNC_STATUS            = 'sync_status';
 	public const KEY_MC_STATUS              = 'mc_status';
-	public const KEY_TOTAL_SALES            = 'total_sales';
 
 	protected const TYPES = [
 		self::KEY_SYNCED_AT              => 'int',
@@ -70,7 +69,6 @@ class ProductMetaHandler implements Service, Registerable {
 		self::KEY_SYNC_FAILED_AT         => 'int',
 		self::KEY_SYNC_STATUS            => 'string',
 		self::KEY_MC_STATUS              => 'string',
-		self::KEY_TOTAL_SALES            => 'int',
 	];
 
 	/**

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -58,6 +58,7 @@ class ProductMetaHandler implements Service, Registerable {
 	public const KEY_SYNC_FAILED_AT         = 'sync_failed_at';
 	public const KEY_SYNC_STATUS            = 'sync_status';
 	public const KEY_MC_STATUS              = 'mc_status';
+	public const KEY_TOTAL_SALES            = 'total_sales';
 
 	protected const TYPES = [
 		self::KEY_SYNCED_AT              => 'int',
@@ -69,6 +70,7 @@ class ProductMetaHandler implements Service, Registerable {
 		self::KEY_SYNC_FAILED_AT         => 'int',
 		self::KEY_SYNC_STATUS            => 'string',
 		self::KEY_MC_STATUS              => 'string',
+		self::KEY_TOTAL_SALES            => 'int',
 	];
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements the [backend task 4](https://github.com/woocommerce/google-listings-and-ads/issues/1610#be-task4) **_📌 Return merchants key product data (e.g. bestselling)_** from the epic issue #1610. Here are what have changed:

- Extend an existing API `mc/product-feed` by adding a new condition `total_sales` to the parameter `orderby`.
  - `total_sales` is one of the meta keys of a product.
  - Combining with other parameters we can get the product which has the most sales. E.g.
    - `GET mc/product-feed?per_page=1&orderby=total_sales&order=desc`
- Extend an existing API `mc/product-feed` to return price and image url of a product.
- Add `siteLogoUrl` to `glaData` for the frontend.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make a GET request to `mc/product-feed` API with parameters:
    - per_page=1
    - orderby=total_sales
    - order=desc
    - Full example: `GET mc/product-feed?per_page=1&orderby=total_sales&order=desc`
2. The response should contain only one product, with new response data `price` and `image_url`.
3. To verify if the returned product has the most sales, use this query in your local database:
    - `SELECT * FROM wp_postmeta WHERE meta_key = 'total_sales' ORDER BY CAST( meta_value AS unsigned ) DESC;`
4. Go to GLA dashboard, open the dev tool console, and type `window.glaData`
    - You should see there is a new data `siteLogoUrl`.
    - It would be `null` if you did not upload a custom site logo.
5. If the `siteLogoUrl` is `null`, go to `wp-admin/admin.php?page=wc-admin&task=appearance` and upload a logo.
6. Open the dev tool console and type `window.glaData` again, you should see the value of `siteLogoUrl`.

### Changelog entry
