### PR TITLE
Attribute Mapping - Add API Enums

### DIFF
--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -45,11 +45,14 @@ class AttributeMappingHelper implements Service {
 		 * @var AttributeInterface $attribute
 		 */
 		foreach ( self::ATTRIBUTES_AVAILABLE_FOR_MAPPING as $attribute ) {
-			array_push($destinations, [
-				'id' => $attribute::get_id(),
-				'label' => $attribute::get_name(),
-				'enum' => $attribute::is_enum()
-			]);
+			array_push(
+				$destinations,
+				[
+					'id'    => $attribute::get_id(),
+					'label' => $attribute::get_name(),
+					'enum'  => $attribute::is_enum(),
+				]
+			);
 		}
 
 		return $destinations;

--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -7,6 +7,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Adult;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AgeGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Condition;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Gender;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\IsBundle;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\SizeSystem;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\SizeType;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -21,6 +26,11 @@ class AttributeMappingHelper implements Service {
 	private const ATTRIBUTES_AVAILABLE_FOR_MAPPING = [
 		Adult::class,
 		AgeGroup::class,
+		Condition::class,
+		Gender::class,
+		IsBundle::class,
+		SizeSystem::class,
+		SizeType::class,
 	];
 
 	/**
@@ -35,7 +45,11 @@ class AttributeMappingHelper implements Service {
 		 * @var AttributeInterface $attribute
 		 */
 		foreach ( self::ATTRIBUTES_AVAILABLE_FOR_MAPPING as $attribute ) {
-			$destinations[ $attribute::get_id() ] = $attribute::get_name();
+			array_push($destinations, [
+				'id' => $attribute::get_id(),
+				'label' => $attribute::get_name(),
+				'enum' => $attribute::is_enum()
+			]);
 		}
 
 		return $destinations;

--- a/src/Product/Attributes/Adult.php
+++ b/src/Product/Attributes/Adult.php
@@ -70,6 +70,15 @@ class Adult extends AbstractAttribute implements WithMappingInterface {
 	}
 
 	/**
+	 * Returns true if the attribute is an enum
+	 *
+	 * @return bool
+	 */
+	public static function is_enum(): bool {
+		return true;
+	}
+
+	/**
 	 * Returns the attribute sources
 	 *
 	 * @return array

--- a/src/Product/Attributes/Adult.php
+++ b/src/Product/Attributes/Adult.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Adult extends AbstractAttribute implements WithMappingInterface {
 
+	use IsEnumTrait;
+
 	/**
 	 * Returns the attribute ID.
 	 *
@@ -67,15 +69,6 @@ class Adult extends AbstractAttribute implements WithMappingInterface {
 	 */
 	public static function get_name(): string {
 		return __( 'Adult', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns true if the attribute is an enum
-	 *
-	 * @return bool
-	 */
-	public static function is_enum(): bool {
-		return true;
 	}
 
 	/**

--- a/src/Product/Attributes/AgeGroup.php
+++ b/src/Product/Attributes/AgeGroup.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class AgeGroup extends AbstractAttribute implements WithValueOptionsInterface {
 
+	use IsEnumTrait;
+
 	/**
 	 * Returns the attribute ID.
 	 *
@@ -74,15 +76,6 @@ class AgeGroup extends AbstractAttribute implements WithValueOptionsInterface {
 	 */
 	public static function get_name(): string {
 		return __( 'Age group', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns true if the attribute is an enum
-	 *
-	 * @return bool
-	 */
-	public static function is_enum(): bool {
-		return true;
 	}
 
 	/**

--- a/src/Product/Attributes/AgeGroup.php
+++ b/src/Product/Attributes/AgeGroup.php
@@ -77,6 +77,15 @@ class AgeGroup extends AbstractAttribute implements WithValueOptionsInterface {
 	}
 
 	/**
+	 * Returns true if the attribute is an enum
+	 *
+	 * @return bool
+	 */
+	public static function is_enum(): bool {
+		return true;
+	}
+
+	/**
 	 * Returns the attribute sources
 	 *
 	 * @return array

--- a/src/Product/Attributes/Condition.php
+++ b/src/Product/Attributes/Condition.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Condition extends AbstractAttribute implements WithValueOptionsInterface, WithMappingInterface {
 
+	use IsEnumTrait;
+
 	/**
 	 * Returns the attribute ID.
 	 *
@@ -73,14 +75,6 @@ class Condition extends AbstractAttribute implements WithValueOptionsInterface, 
 		return __( 'Condition', 'google-listings-and-ads' );
 	}
 
-	/**
-	 * Returns true if the attribute is an enum
-	 *
-	 * @return bool
-	 */
-	public static function is_enum(): bool {
-		return true;
-	}
 
 	/**
 	 * Returns the attribute sources

--- a/src/Product/Attributes/Condition.php
+++ b/src/Product/Attributes/Condition.php
@@ -64,4 +64,31 @@ class Condition extends AbstractAttribute implements WithValueOptionsInterface {
 		return ConditionInput::class;
 	}
 
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Condition', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns true if the attribute is an enum
+	 *
+	 * @return bool
+	 */
+	public static function is_enum(): bool {
+		return true;
+	}
+
+	/**
+	 * Returns the attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array {
+		return self::get_value_options();
+	}
+
 }

--- a/src/Product/Attributes/Condition.php
+++ b/src/Product/Attributes/Condition.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
  */
-class Condition extends AbstractAttribute implements WithValueOptionsInterface {
+class Condition extends AbstractAttribute implements WithValueOptionsInterface, WithMappingInterface {
 
 	/**
 	 * Returns the attribute ID.

--- a/src/Product/Attributes/Gender.php
+++ b/src/Product/Attributes/Gender.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Gender extends AbstractAttribute implements WithValueOptionsInterface, WithMappingInterface {
 
+	use IsEnumTrait;
+
 	/**
 	 * Returns the attribute ID.
 	 *
@@ -71,15 +73,6 @@ class Gender extends AbstractAttribute implements WithValueOptionsInterface, Wit
 	 */
 	public static function get_name(): string {
 		return __( 'Gender', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns true if the attribute is an enum
-	 *
-	 * @return bool
-	 */
-	public static function is_enum(): bool {
-		return true;
 	}
 
 	/**

--- a/src/Product/Attributes/Gender.php
+++ b/src/Product/Attributes/Gender.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
  */
-class Gender extends AbstractAttribute implements WithValueOptionsInterface {
+class Gender extends AbstractAttribute implements WithValueOptionsInterface, WithMappingInterface {
 
 	/**
 	 * Returns the attribute ID.

--- a/src/Product/Attributes/Gender.php
+++ b/src/Product/Attributes/Gender.php
@@ -64,4 +64,30 @@ class Gender extends AbstractAttribute implements WithValueOptionsInterface {
 		return GenderInput::class;
 	}
 
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Gender', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns true if the attribute is an enum
+	 *
+	 * @return bool
+	 */
+	public static function is_enum(): bool {
+		return true;
+	}
+
+	/**
+	 * Returns the attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array {
+		return self::get_value_options();
+	}
 }

--- a/src/Product/Attributes/IsBundle.php
+++ b/src/Product/Attributes/IsBundle.php
@@ -60,4 +60,34 @@ class IsBundle extends AbstractAttribute {
 		return IsBundleInput::class;
 	}
 
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Is Bundle', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns true if the attribute is an enum
+	 *
+	 * @return bool
+	 */
+	public static function is_enum(): bool {
+		return true;
+	}
+
+	/**
+	 * Returns the attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array {
+		return [
+			'yes' => __( 'Yes', 'google-listings-and-ads' ),
+			'no'  => __( 'No', 'google-listings-and-ads' ),
+		];
+	}
+
 }

--- a/src/Product/Attributes/IsBundle.php
+++ b/src/Product/Attributes/IsBundle.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class IsBundle extends AbstractAttribute implements WithMappingInterface {
 
+	use IsEnumTrait;
+
 	/**
 	 * Returns the attribute ID.
 	 *
@@ -69,14 +71,6 @@ class IsBundle extends AbstractAttribute implements WithMappingInterface {
 		return __( 'Is Bundle', 'google-listings-and-ads' );
 	}
 
-	/**
-	 * Returns true if the attribute is an enum
-	 *
-	 * @return bool
-	 */
-	public static function is_enum(): bool {
-		return true;
-	}
 
 	/**
 	 * Returns the attribute sources

--- a/src/Product/Attributes/IsBundle.php
+++ b/src/Product/Attributes/IsBundle.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
  */
-class IsBundle extends AbstractAttribute {
+class IsBundle extends AbstractAttribute implements WithMappingInterface {
 
 	/**
 	 * Returns the attribute ID.

--- a/src/Product/Attributes/IsEnumTrait.php
+++ b/src/Product/Attributes/IsEnumTrait.php
@@ -1,0 +1,24 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait for enums
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
+ */
+trait IsEnumTrait {
+
+	/**
+	 * Returns true for the is_enum property
+	 *
+	 * @return true
+	 */
+	public static function is_enum(): bool {
+		return true;
+	}
+
+}

--- a/src/Product/Attributes/SizeSystem.php
+++ b/src/Product/Attributes/SizeSystem.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
  */
-class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface {
+class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface, WithMappingInterface {
 
 	/**
 	 * Returns the attribute ID.

--- a/src/Product/Attributes/SizeSystem.php
+++ b/src/Product/Attributes/SizeSystem.php
@@ -72,4 +72,31 @@ class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface 
 		return SizeSystemInput::class;
 	}
 
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Size System', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns true if the attribute is an enum
+	 *
+	 * @return bool
+	 */
+	public static function is_enum(): bool {
+		return true;
+	}
+
+	/**
+	 * Returns the attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array {
+		return self::get_value_options();
+	}
+
 }

--- a/src/Product/Attributes/SizeSystem.php
+++ b/src/Product/Attributes/SizeSystem.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface, WithMappingInterface {
 
+	use IsEnumTrait;
+
 	/**
 	 * Returns the attribute ID.
 	 *
@@ -79,15 +81,6 @@ class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface,
 	 */
 	public static function get_name(): string {
 		return __( 'Size System', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns true if the attribute is an enum
-	 *
-	 * @return bool
-	 */
-	public static function is_enum(): bool {
-		return true;
 	}
 
 	/**

--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -67,4 +67,31 @@ class SizeType extends AbstractAttribute implements WithValueOptionsInterface {
 		return SizeTypeInput::class;
 	}
 
+	/**
+	 * Returns the attribute name
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return __( 'Size Type', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Returns true if the attribute is an enum
+	 *
+	 * @return bool
+	 */
+	public static function is_enum(): bool {
+		return true;
+	}
+
+	/**
+	 * Returns the attribute sources
+	 *
+	 * @return array
+	 */
+	public static function get_sources(): array {
+		return self::get_value_options();
+	}
+
 }

--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class SizeType extends AbstractAttribute implements WithValueOptionsInterface, WithMappingInterface {
 
+	use IsEnumTrait;
+
 	/**
 	 * Returns the attribute ID.
 	 *
@@ -74,15 +76,6 @@ class SizeType extends AbstractAttribute implements WithValueOptionsInterface, W
 	 */
 	public static function get_name(): string {
 		return __( 'Size Type', 'google-listings-and-ads' );
-	}
-
-	/**
-	 * Returns true if the attribute is an enum
-	 *
-	 * @return bool
-	 */
-	public static function is_enum(): bool {
-		return true;
 	}
 
 	/**

--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
  */
-class SizeType extends AbstractAttribute implements WithValueOptionsInterface {
+class SizeType extends AbstractAttribute implements WithValueOptionsInterface, WithMappingInterface {
 
 	/**
 	 * Returns the attribute ID.

--- a/src/Product/Attributes/WithMappingInterface.php
+++ b/src/Product/Attributes/WithMappingInterface.php
@@ -20,6 +20,13 @@ interface WithMappingInterface {
 	public static function get_name(): string;
 
 	/**
+	 * Returns true if the attribute is enum type
+	 *
+	 * @return boolean
+	 */
+	public static function is_enum(): bool;
+
+	/**
 	 * Returns the available attribute sources
 	 *
 	 * @return array

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AttributeMappingControllerTest.php
@@ -15,8 +15,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUn
 class AttributeMappingControllerTest extends RESTControllerUnitTest {
 
 
-	protected const ROUTE_REQUEST_SOURCES      = '/wc/gla/mc/mapping/sources';
-	protected const ROUTE_REQUEST_ATTRIBUTES   = '/wc/gla/mc/mapping/attributes';
+	protected const ROUTE_REQUEST_SOURCES    = '/wc/gla/mc/mapping/sources';
+	protected const ROUTE_REQUEST_ATTRIBUTES = '/wc/gla/mc/mapping/attributes';
 
 	/**
 	 * @var AttributeMappingHelper


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1648 .

This PR adds enum prop in the API Response

Also registers all the ENUMS in the Available Attributes 

### Detailed test instructions:

1. Checkout PR and request `GET /wp-json/wc/gla/mc/mapping/attributes`
2. See you receive all the ENUM values with enum prop set as true.
3. Check each of them with `GET wp-json/wc/gla/mc/mapping/sources?attribute={attribute_name}` and see they return the enum values
