### PR TITLE
Free Listings + Paid Ads: Store and restore the states of paid ads setup

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/clientSession.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/clientSession.js
@@ -35,24 +35,16 @@ const clientSession = {
 	 * @param {Array<CountryCode>} data.countryCodes Country codes of the campaign.
 	 */
 	setCampaign( { amount, countryCodes } ) {
-		try {
-			const json = JSON.stringify( { amount, countryCodes } );
-			sessionStorage.setItem( KEY_PAID_ADS, json );
-		} catch ( e ) {
-			// noop
-		}
+		const json = JSON.stringify( { amount, countryCodes } );
+		sessionStorage.setItem( KEY_PAID_ADS, json );
 	},
 
 	/**
 	 * @return {CampaignData|null} The stored campaign data. It will return `null` if stored data is not available.
 	 */
 	getCampaign() {
-		try {
-			const json = sessionStorage.getItem( KEY_PAID_ADS );
-			return JSON.parse( json );
-		} catch ( e ) {
-			return null;
-		}
+		const json = sessionStorage.getItem( KEY_PAID_ADS );
+		return json === null ? null : JSON.parse( json );
 	},
 };
 

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/clientSession.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/clientSession.js
@@ -1,0 +1,59 @@
+/**
+ * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ *
+ * @typedef {Object} CampaignData
+ * @property {number|undefined} amount Daily average cost of the paid ads campaign.
+ * @property {Array<CountryCode>} countryCodes Audience country codes of the paid ads campaign. Example: 'US'.
+ */
+
+const KEY_SHOW_PAID_ADS_SETUP = 'gla-onboarding-show-paid-ads-setup';
+const KEY_PAID_ADS = 'gla-onboarding-paid-ads';
+
+const { sessionStorage } = window;
+
+const clientSession = {
+	/**
+	 * @param {boolean} isShowing Whether the paid ads setup is showing.
+	 */
+	setShowPaidAdsSetup( isShowing ) {
+		const showing = Boolean( isShowing ).toString();
+		sessionStorage.setItem( KEY_SHOW_PAID_ADS_SETUP, showing );
+	},
+
+	/**
+	 * @param {boolean} defaultValue The default value to be returned if stored value is not available.
+	 * @return {boolean} Returns the stored value. It will return `defaultValue` if stored value is not available.
+	 */
+	getShowPaidAdsSetup( defaultValue ) {
+		const showing = sessionStorage.getItem( KEY_SHOW_PAID_ADS_SETUP );
+		return showing === null ? defaultValue : showing === 'true';
+	},
+
+	/**
+	 * @param {CampaignData} data Campaign data to be stored.
+	 * @param {number|undefined} data.amount Daily average cost of the campaign.
+	 * @param {Array<CountryCode>} data.countryCodes Country codes of the campaign.
+	 */
+	setCampaign( { amount, countryCodes } ) {
+		try {
+			const json = JSON.stringify( { amount, countryCodes } );
+			sessionStorage.setItem( KEY_PAID_ADS, json );
+		} catch ( e ) {
+			// noop
+		}
+	},
+
+	/**
+	 * @return {CampaignData|null} The stored campaign data. It will return `null` if stored data is not available.
+	 */
+	getCampaign() {
+		try {
+			const json = sessionStorage.getItem( KEY_PAID_ADS );
+			return JSON.parse( json );
+		} catch ( e ) {
+			return null;
+		}
+	},
+};
+
+export default clientSession;

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -40,6 +40,7 @@ const defaultPaidAds = {
 
 /**
  * Resolve the initial paid ads data from the given paid ads data with the loaded target audience.
+ * Parts of the resolved data are used in the `initialValues` prop of `Form` component.
  *
  * @param {PaidAdsData} paidAds The paid ads data as the base to be resolved with other states.
  * @param {Array<CountryCode>} targetAudience Country codes of selected target audience.
@@ -50,6 +51,8 @@ function resolveInitialPaidAds( paidAds, targetAudience ) {
 
 	if ( targetAudience ) {
 		if ( nextPaidAds.countryCodes === defaultPaidAds.countryCodes ) {
+			// Replace the country codes with the loaded target audience only if the reference is
+			// the same as the default because the given country codes might be the restored ones.
 			nextPaidAds.countryCodes = targetAudience;
 		} else {
 			// The selected target audience may be changed back and forth during the onboarding flow.
@@ -79,6 +82,7 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 	onStatesReceivedRef.current = onStatesReceived;
 
 	const [ paidAds, setPaidAds ] = useState( () => {
+		// Resolve the starting paid ads data with the campaign data stored in the client session.
 		const startingPaidAds = {
 			...defaultPaidAds,
 			...clientSession.getCampaign(),

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -116,7 +116,15 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 		clientSession.setCampaign( nextPaidAds );
 	}, [ paidAds, isBillingCompleted ] );
 
-	// Resolve the initial states after the `targetAudience` is loaded.
+	/*
+	  Resolve the initial states after the `targetAudience` is loaded.
+
+	  Please note that the loaded `targetAudience` is NOT expected to have further changes
+	  in the runtime. If it happens one day and it will need to update <Form>'s internal state
+	  with the changed `targetAudience`, please refer to the following practice.
+	  - https://github.com/woocommerce/google-listings-and-ads/blob/5b6522ca10ad75556e6b2de7c120cc712aab70b1/js/src/components/free-listings/setup-free-listings/index.js#L120-L134
+	  - https://github.com/woocommerce/google-listings-and-ads/blob/5b6522ca10ad75556e6b2de7c120cc712aab70b1/js/src/components/free-listings/setup-free-listings/index.js#L172-L186
+	*/
 	useEffect( () => {
 		setPaidAds( ( currentPaidAds ) =>
 			resolveInitialPaidAds( currentPaidAds, targetAudience )

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -22,6 +22,7 @@ import ProductFeedStatusSection from './product-feed-status-section';
 import PaidAdsFeaturesSection from './paid-ads-features-section';
 import PaidAdsSetupSections from './paid-ads-setup-sections';
 import { getProductFeedUrl } from '.~/utils/urls';
+import clientSession from './clientSession';
 import { API_NAMESPACE } from '.~/data/constants';
 import { GUIDE_NAMES } from '.~/constants';
 
@@ -36,9 +37,16 @@ export default function SetupPaidAds() {
 	const adminUrl = useAdminUrl();
 	const { createNotice } = useDispatchCoreNotices();
 	const [ handleSetupComplete ] = useAdsSetupCompleteCallback();
-	const [ showPaidAdsSetup, setShowPaidAdsSetup ] = useState( false );
+	const [ showPaidAdsSetup, setShowPaidAdsSetup ] = useState( () =>
+		clientSession.getShowPaidAdsSetup( false )
+	);
 	const [ paidAds, setPaidAds ] = useState( {} );
 	const [ completing, setCompleting ] = useState( null );
+
+	const handleContinuePaidAdsSetupClick = () => {
+		setShowPaidAdsSetup( true );
+		clientSession.setShowPaidAdsSetup( true );
+	};
 
 	const finishOnboardingSetup = async ( event, onBeforeFinish = noop ) => {
 		setCompleting( event.target.dataset.action );
@@ -118,7 +126,7 @@ export default function SetupPaidAds() {
 							'google-listings-and-ads'
 						) }
 						disabled={ completing === ACTION_SKIP }
-						onClick={ () => setShowPaidAdsSetup( true ) }
+						onClick={ handleContinuePaidAdsSetupClick }
 					/>
 				}
 			/>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements two items of the **📌 Client states management and API integration** in #1610.

- Store/restore the selected countries and the entered budget when leaving/entering step 4.
- Store/restore the switched state of skipping or continuing the paid ads setup when leaving/entering step 4.

### Screenshots:

https://user-images.githubusercontent.com/17420811/191235325-3eeb6a0b-92cf-412e-b8cd-834842dae927.mp4

### Detailed test instructions:

1. Go to step 4 of onboarding flow.
2. Continue the paid ads setup by clicking on the "Create a paid ad campaign" button.
3. Refresh page to see if the paid ads setup keeps showing after page is loaded.
4. Edit the countries of ads audience and campaign budget.
5. Refresh page to see if the countries of ads audience and campaign budget are the same as in step 4 after page is loaded.
6. Switch to step 2 and remove some countries, that were selected as **ads** audience, from **target** audience.
7. Continue to step 4 and check if the removed target audience countries are also removed from the selected countries of ads audience.

### Changelog entry
