### PR TITLE
Free Listings + Paid Ads: Return null statistics when onboarding is not finished

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -108,15 +108,18 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	public function get_product_statistics( bool $force_refresh = false ): array {
 		$this->maybe_refresh_status_data( $force_refresh );
 
-		$counting_stats = $this->mc_statuses['statistics'];
-		$counting_stats = array_merge(
-			[ 'active' => $counting_stats[ MCStatus::PARTIALLY_APPROVED ] + $counting_stats[ MCStatus::APPROVED ] ],
-			$counting_stats
-		);
-		unset( $counting_stats[ MCStatus::PARTIALLY_APPROVED ], $counting_stats[ MCStatus::APPROVED ] );
+		$counting_stats = isset( $this->mc_statuses['statistics'] ) ? $this->mc_statuses['statistics'] : null;
+
+		if ( is_array( $counting_stats ) ) {
+			$counting_stats = array_merge(
+				[ 'active' => $counting_stats[ MCStatus::PARTIALLY_APPROVED ] + $counting_stats[ MCStatus::APPROVED ] ],
+				$counting_stats
+			);
+			unset( $counting_stats[ MCStatus::PARTIALLY_APPROVED ], $counting_stats[ MCStatus::APPROVED ] );
+		}
 
 		return array_merge(
-			$this->mc_statuses,
+			$this->mc_statuses ?: [],
 			[ 'statistics' => $counting_stats ]
 		);
 	}
@@ -166,20 +169,20 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	public function maybe_refresh_status_data( bool $force_refresh = false ): void {
 		// Only refresh if the current data has expired.
 		$this->mc_statuses = $this->container->get( TransientsInterface::class )->get( Transients::MC_STATUSES );
-		if ( ! $force_refresh && null !== $this->mc_statuses ) {
+
+		if ( ! $force_refresh && ! empty( $this->mc_statuses ) ) {
 			return;
 		}
 
 		// Save a request if accounts are not connected.
 		$mc_service = $this->container->get( MerchantCenterService::class );
-		if ( ! $mc_service->is_connected() ) {
-
-			// Return a 401 to redirect to reconnect flow if the Google account is not connected.
-			if ( ! $mc_service->is_google_connected() ) {
-				throw new Exception( __( 'Google account is not connected.', 'google-listings-and-ads' ), 401 );
-			}
-
-			throw new Exception( __( 'Merchant Center account is not set up.', 'google-listings-and-ads' ) );
+		// Return a 401 to redirect to reconnect flow if the Google account is not connected.
+		if ( ! $mc_service->is_google_connected() ) {
+			throw new Exception( __( 'Google account is not connected.', 'google-listings-and-ads' ), 401 );
+		}
+		// Return empty statistics if the Google account is connected but haven't finished the onboarding flow.
+		if ( ! $mc_service->is_setup_complete() ) {
+			return;
 		}
 
 		$this->mc_statuses = [];

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -46,17 +46,17 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_center_service   = $this->createMock( MerchantCenterService::class );
 		$this->account_status            = $this->createMock( ShoppingContent\AccountStatus::class );
 		$this->product_meta_query_helper = $this->createMock( ProductMetaQueryHelper::class );
+		$this->product_repository        = $this->createMock( ProductRepository::class );
+		$this->transients                = $this->createMock( TransientsInterface::class );
 
-		$product_repository   = $this->createMock( ProductRepository::class );
-		$transients           = $this->createMock( TransientsInterface::class );
 		$merchant_issue_table = $this->createMock( MerchantIssueTable::class );
 
 		$container = new Container();
 		$container->share( Merchant::class, $this->merchant );
 		$container->share( MerchantIssueQuery::class, $this->merchant_issue_query );
 		$container->share( MerchantCenterService::class, $this->merchant_center_service );
-		$container->share( TransientsInterface::class, $transients );
-		$container->share( ProductRepository::class, $product_repository );
+		$container->share( TransientsInterface::class, $this->transients );
+		$container->share( ProductRepository::class, $this->product_repository );
 		$container->share( ProductMetaQueryHelper::class, $this->product_meta_query_helper );
 		$container->share( MerchantIssueTable::class, $merchant_issue_table );
 
@@ -108,7 +108,11 @@ class MerchantStatusesTest extends UnitTest {
 			);
 
 		$this->merchant_center_service->expects( $this->any() )
-			->method( 'is_connected' )
+			->method( 'is_google_connected' )
+			->willReturn( true );
+
+		$this->merchant_center_service->expects( $this->any() )
+			->method( 'is_setup_complete' )
 			->willReturn( true );
 
 		$this->merchant->expects( $this->any() )
@@ -148,5 +152,24 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'update_or_insert' )
 			->withConsecutive( [ $issues ], [] );
 		$this->merchant_statuses->maybe_refresh_status_data( true );
+	}
+
+	public function test_get_product_statistics_when_google_is_connected_but_not_finish_onboarding() {
+		$this->merchant_center_service->expects( $this->any() )
+			->method( 'is_google_connected' )
+			->willReturn( true );
+
+		$this->merchant_center_service->expects( $this->any() )
+			->method( 'is_setup_complete' )
+			->willReturn( false );
+
+		$this->product_repository->expects( $this->exactly( 0 ) )->method( 'find_mc_not_synced_product_ids' );
+		$this->transients->expects( $this->exactly( 0 ) )->method( 'set' );
+
+		$product_statistics = $this->merchant_statuses->get_product_statistics( true );
+		$this->assertEquals(
+			[ 'statistics' => null ],
+			$product_statistics
+		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up for #1681 and found by @eason9487. In this PR it modifies the `MerchantStatuses`'s `maybe_refresh_status_data()` method so it will not return `400` error when the onboarding flow is not finished (i.e. the option `gla_mc_setup_completed_at` is not being set). The PR also modifies `get_product_statistics()` method to return `null` statistics if the onboarding flow is not finished.

The reason we add this is the API `GET mc/product-feed` will be called during the step 4 of the new onboarding flow, in `mc/product-feed` it will call `maybe_refresh_status_data()` from `MerchantStatuses`, and the previous behaviour would return `400` if the option `gla_mc_setup_completed_at` is not being set.

The code this PR added was actually added in a closed PR #1667's 8bf41533833b3763ac9055ebde220688a70dbe66 commit. In that PR `mc/product-statistics` needs to be called during the new onboarding flow as well.

### Steps to reproducce:

1. Use the branch `feature/1610-streamlined-onboarding`
2. Remove the option `gla_mc_setup_completed_at`, `_transient_timeout_gla_mc_statuses`, and `_transient_gla_mc_statuses` from the table `wp_options`.
3. Call the API `GET mc/product-feed?per_page=1&orderby=total_sales&order=desc`
4. It should return `400` error with the message `Merchant Center account is not set up.`.

### Detailed test instructions:

1. Use the branch of this PR: `update/1610-return-null-statistics-when-onboarding-not-finish`.
2. Do the steps 2 and 3 from the above.
3. It should return the correct product data.