### PR TITLE
Attribute Mapping - Table Data

### DIFF
--- a/js/src/attribute-mapping/attribute-mapping-table-categories.js
+++ b/js/src/attribute-mapping/attribute-mapping-table-categories.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AppTooltip from '.~/components/app-tooltip';
+
+const DUMMY_CATEGORIES = [
+	{ id: 1, name: 'Category 1' },
+	{ id: 2, name: 'Category 2' },
+	{ id: 3, name: 'Category 3' },
+];
+
+const AttributeMappingTableCategories = ( { categories } ) => {
+	const categoryNames = categories
+		.slice( 0, 5 )
+		.map( ( category ) => {
+			return DUMMY_CATEGORIES.find(
+				( e ) => e.id === parseInt( category, 10 )
+			).name;
+		} )
+		.join( ', ' );
+
+	const maybeDots = categories.length > 5 ? '...' : '';
+
+	return (
+		<AppTooltip text={ `${ categoryNames }${ maybeDots }` }>
+			<div className="gla-attribute-mapping__table-categories-help">
+				{ sprintf(
+					// translators: %d: number of categories.
+					_n(
+						'%d category',
+						'%d categories',
+						categories.length,
+						'google-listings-and-ads'
+					),
+					categories.length
+				) }
+			</div>
+		</AppTooltip>
+	);
+};
+
+export default AttributeMappingTableCategories;

--- a/js/src/attribute-mapping/attribute-mapping-table-categories.js
+++ b/js/src/attribute-mapping/attribute-mapping-table-categories.js
@@ -46,7 +46,7 @@ const AttributeMappingTableCategories = ( { categories, condition } ) => {
 		} )
 		.join( SEPARATOR );
 
-	const maybeDots =
+	const more =
 		categoryArray.length > CATEGORIES_TO_SHOW
 			? sprintf(
 					// translators: %d: The number of categories.
@@ -66,7 +66,7 @@ const AttributeMappingTableCategories = ( { categories, condition } ) => {
 				text={
 					<div className="gla-attribute-mapping__table-categories-tooltip">
 						{ categoryNames }
-						{ maybeDots && <span>{ maybeDots }</span> }
+						{ more && <span>{ more }</span> }
 					</div>
 				}
 			>

--- a/js/src/attribute-mapping/attribute-mapping-table-categories.js
+++ b/js/src/attribute-mapping/attribute-mapping-table-categories.js
@@ -20,7 +20,7 @@ const SEPARATOR = _x(
 	'google-listings-and-ads'
 );
 
-const CATEGORIES_TO_SHOW = 4;
+const CATEGORIES_TO_SHOW = 5;
 
 /**
  * Renders a text and maybe a tooltip showing the categories for an Attribute Mapping rule

--- a/js/src/attribute-mapping/attribute-mapping-table-categories.js
+++ b/js/src/attribute-mapping/attribute-mapping-table-categories.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { _n, sprintf } from '@wordpress/i18n';
+import { _n, sprintf, _x, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,33 +14,76 @@ const DUMMY_CATEGORIES = [
 	{ id: 3, name: 'Category 3' },
 ];
 
-const AttributeMappingTableCategories = ( { categories } ) => {
-	const categoryNames = categories
-		.slice( 0, 5 )
+const SEPARATOR = _x(
+	', ',
+	'the separator for concatenating the categories where the Attribute mapping rule is applied.',
+	'google-listings-and-ads'
+);
+
+const CATEGORIES_TO_SHOW = 4;
+
+/**
+ * Renders a text and maybe a tooltip showing the categories for an Attribute Mapping rule
+ *
+ * @param {Object} props Component props
+ * @param {string}  props.categories The categories to render
+ * @param {string} props.condition The condition to which this categories apply
+ *
+ * @return {JSX.Element|string} The component
+ */
+const AttributeMappingTableCategories = ( { categories, condition } ) => {
+	if ( condition === 'ALL' ) {
+		return __( 'All', 'google-listings-and-ads' );
+	}
+
+	const categoryArray = categories.split( ',' );
+	const categoryNames = categoryArray
+		.slice( 0, CATEGORIES_TO_SHOW )
 		.map( ( category ) => {
 			return DUMMY_CATEGORIES.find(
 				( e ) => e.id === parseInt( category, 10 )
 			).name;
 		} )
-		.join( ', ' );
+		.join( SEPARATOR );
 
-	const maybeDots = categories.length > 5 ? '...' : '';
+	const maybeDots =
+		categoryArray.length > CATEGORIES_TO_SHOW
+			? sprintf(
+					// translators: %d: The number of categories.
+					__( '+ %d more', 'google-listings-and-ads' ),
+					categoryArray.length - CATEGORIES_TO_SHOW
+			  )
+			: '';
 
 	return (
-		<AppTooltip text={ `${ categoryNames }${ maybeDots }` }>
-			<div className="gla-attribute-mapping__table-categories-help">
-				{ sprintf(
-					// translators: %d: number of categories.
-					_n(
-						'%d category',
-						'%d categories',
-						categories.length,
-						'google-listings-and-ads'
-					),
-					categories.length
-				) }
-			</div>
-		</AppTooltip>
+		<>
+			<span>
+				{ condition === 'ONLY'
+					? __( 'Only in', 'google-listings-and-ads' )
+					: __( 'All except', 'google-listings-and-ads' ) }
+			</span>
+			<AppTooltip
+				text={
+					<div className="gla-attribute-mapping__table-categories-tooltip">
+						{ categoryNames }
+						{ maybeDots && <span>{ maybeDots }</span> }
+					</div>
+				}
+			>
+				<div className="gla-attribute-mapping__table-categories-help">
+					{ sprintf(
+						// translators: %d: number of categories.
+						_n(
+							'%d category',
+							'%d categories',
+							categoryArray.length,
+							'google-listings-and-ads'
+						),
+						categoryArray.length
+					) }
+				</div>
+			</AppTooltip>
+		</>
 	);
 };
 

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -2,29 +2,29 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import { Table } from '@woocommerce/components';
-import { CardBody, CardFooter } from '@wordpress/components';
-
+import { CardBody, CardFooter, Flex } from '@wordpress/components';
+import GridIconTrash from 'gridicons/dist/trash';
 /**
  * Internal dependencies
  */
 import Card from '.~/wcdl/section/card';
 import AppButton from '.~/components/app-button';
 import AppTableCardDiv from '.~/components/app-table-card-div';
+import AppIconButton from '.~/components/app-icon-button';
+import AttributeMappingTableCategories from './attribute-mapping-table-categories';
 
 const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
 	{
-		key: 'destination',
+		key: 'attribute',
 		label: __( 'Target Attribute', 'google-listings-and-ads' ),
 		isLeftAligned: true,
 		required: true,
 	},
 	{
 		key: 'source',
-		label: __(
-			'Reference Field / Default Value',
-			'google-listings-and-ads'
-		),
+		label: __( 'Data Source / Default Value', 'google-listings-and-ads' ),
 		isLeftAligned: true,
 		required: true,
 	},
@@ -34,14 +34,56 @@ const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
 		isLeftAligned: true,
 		required: true,
 	},
+	{
+		key: 'controls',
+		label: '',
+		required: true,
+	},
 ];
+
+const DUMMY_DESTINATIONS = [
+	{ id: 'adult', name: 'Adult' },
+	{ id: 'brands', name: 'Brands' },
+	{ id: 'color', name: 'Color' },
+];
+
+const parseCategories = ( condition, categories ) => {
+	if ( condition === 'ALL' ) {
+		return __( 'All', 'google-listings-and-ads' );
+	}
+
+	const conversionMap = {
+		categories: (
+			<AttributeMappingTableCategories
+				categories={ categories.split( ',' ) }
+			/>
+		),
+	};
+
+	if ( condition === 'ONLY' ) {
+		return createInterpolateElement(
+			__( 'Only in <categories />', 'google-listings-and-ads' ),
+			conversionMap
+		);
+	}
+
+	return createInterpolateElement(
+		__( 'All except <categories />', 'google-listings-and-ads' ),
+		conversionMap
+	);
+};
+
+const parseDestinationName = ( destination ) =>
+	DUMMY_DESTINATIONS.find( ( e ) => e.id === destination ).name;
 
 /**
  * Renders the Attribute Mapping table component
  *
+ * @param {Object} props The component props
+ * @param {Object} props.rules The rules to show in the table
  * @return {JSX.Element} The component
  */
-const AttributeMappingTable = () => {
+const AttributeMappingTable = ( { rules } ) => {
 	return (
 		<AppTableCardDiv>
 			<Card>
@@ -52,8 +94,47 @@ const AttributeMappingTable = () => {
 							'google-listings-and-ads'
 						) }
 						headers={ ATTRIBUTE_MAPPING_TABLE_HEADERS }
-						numberOfRows={ 1 }
-						rows={ [] } // TODO: Implement data getter
+						rows={ rules.map( ( rule ) => [
+							{
+								display: parseDestinationName(
+									rule.destination
+								),
+							},
+							{
+								display: (
+									<span className="gla-attribute-mapping__table-label">
+										{ rule.source_name }
+									</span>
+								),
+							},
+							{
+								display: (
+									<span className="gla-attribute-mapping__table-categories">
+										{ parseCategories(
+											rule.category_conditional_type,
+											rule.categories
+										) }
+									</span>
+								),
+							},
+							{
+								display: (
+									<Flex justify="end">
+										<AppButton isLink>
+											{ __(
+												'Manage',
+												'google-listings-and-ads'
+											) }
+										</AppButton>
+										<AppIconButton
+											icon={
+												<GridIconTrash size={ 18 } />
+											}
+										/>
+									</Flex>
+								),
+							},
+						] ) }
 					/>
 				</CardBody>
 				<CardFooter

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -2,17 +2,15 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
 import { Table } from '@woocommerce/components';
 import { CardBody, CardFooter, Flex } from '@wordpress/components';
-import GridIconTrash from 'gridicons/dist/trash';
+import GridiconTrash from 'gridicons/dist/trash';
 /**
  * Internal dependencies
  */
 import Card from '.~/wcdl/section/card';
 import AppButton from '.~/components/app-button';
 import AppTableCardDiv from '.~/components/app-table-card-div';
-import AppIconButton from '.~/components/app-icon-button';
 import AttributeMappingTableCategories from './attribute-mapping-table-categories';
 
 const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
@@ -46,32 +44,6 @@ const DUMMY_DESTINATIONS = [
 	{ id: 'brands', name: 'Brands' },
 	{ id: 'color', name: 'Color' },
 ];
-
-const parseCategories = ( condition, categories ) => {
-	if ( condition === 'ALL' ) {
-		return __( 'All', 'google-listings-and-ads' );
-	}
-
-	const conversionMap = {
-		categories: (
-			<AttributeMappingTableCategories
-				categories={ categories.split( ',' ) }
-			/>
-		),
-	};
-
-	if ( condition === 'ONLY' ) {
-		return createInterpolateElement(
-			__( 'Only in <categories />', 'google-listings-and-ads' ),
-			conversionMap
-		);
-	}
-
-	return createInterpolateElement(
-		__( 'All except <categories />', 'google-listings-and-ads' ),
-		conversionMap
-	);
-};
 
 const parseDestinationName = ( destination ) =>
 	DUMMY_DESTINATIONS.find( ( e ) => e.id === destination ).name;
@@ -110,10 +82,12 @@ const AttributeMappingTable = ( { rules } ) => {
 							{
 								display: (
 									<span className="gla-attribute-mapping__table-categories">
-										{ parseCategories(
-											rule.category_conditional_type,
-											rule.categories
-										) }
+										<AttributeMappingTableCategories
+											categories={ rule.categories }
+											condition={
+												rule.category_conditional_type
+											}
+										/>
 									</span>
 								),
 							},
@@ -126,11 +100,7 @@ const AttributeMappingTable = ( { rules } ) => {
 												'google-listings-and-ads'
 											) }
 										</AppButton>
-										<AppIconButton
-											icon={
-												<GridIconTrash size={ 18 } />
-											}
-										/>
+										<AppButton icon={ <GridiconTrash /> } />
 									</Flex>
 								),
 							},

--- a/js/src/attribute-mapping/index.js
+++ b/js/src/attribute-mapping/index.js
@@ -12,6 +12,30 @@ import AttributeMappingTable from './attribute-mapping-table';
 import NavigationClassic from '.~/components/navigation-classic';
 import './index.scss';
 
+const DUMMY_TABLE_DATA = [
+	{
+		destination: 'adult',
+		source: 'yes',
+		source_name: 'Yes',
+		category_conditional_type: 'ALL',
+	},
+	{
+		destination: 'brands',
+		source: 'taxonomy:product_brands',
+		source_name: 'Taxonomy - Product Brands',
+		category_conditional_type: 'EXCEPT',
+		categories: '1,2',
+	},
+	{
+		destination: 'color',
+		source: 'attribute:color',
+		source_name: 'Attribute - Color',
+		category_conditional_type: 'ONLY',
+		categories:
+			'1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3',
+	},
+];
+
 /**
  * Renders the Attribute Mapping Page
  *
@@ -25,7 +49,7 @@ const AttributeMapping = () => {
 				title={ __( 'Attribute Mapping', 'google-listings-and-ads' ) }
 				description={ <AttributeMappingDescription /> }
 			>
-				<AttributeMappingTable />
+				<AttributeMappingTable rules={ DUMMY_TABLE_DATA } />
 			</Section>
 		</div>
 	);

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -3,4 +3,20 @@
 	&__table-footer {
 		padding: $grid-unit-20;
 	}
+
+	&__table-label {
+		background: $gray-100;
+		padding: $grid-unit-05 $grid-unit-10;
+		border-radius: 2px;
+		font-size: 12px;
+		line-height: 16px;
+	}
+
+	&__table-categories {
+		color: $gray-700;
+	}
+
+	&__table-categories-help {
+		border-bottom: 1px dashed;
+	}
 }

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -16,7 +16,21 @@
 		color: $gray-700;
 	}
 
+	&__table-categories-tooltip {
+		font-weight: 600;
+		width: 150px;
+		white-space: break-spaces;
+		display: block;
+
+		span {
+			font-weight: normal;
+			margin-left: $grid-unit-05;
+		}
+	}
+
 	&__table-categories-help {
 		border-bottom: 1px dashed;
+		margin-left: $grid-unit-05;
+		word-wrap: break-word;
 	}
 }

--- a/js/src/attribute-mapping/index.test.js
+++ b/js/src/attribute-mapping/index.test.js
@@ -1,21 +1,62 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 /**
  * Internal dependencies
  */
 import AttributeMapping from './index';
+import AttributeMappingTable from '.~/attribute-mapping/attribute-mapping-table';
+import AttributeMappingTableCategories from '.~/attribute-mapping/attribute-mapping-table-categories';
+
+const DUMMY_TABLE_DATA = [
+	{
+		destination: 'adult',
+		source: 'yes',
+		source_name: 'Yes',
+		category_conditional_type: 'ALL',
+	},
+	{
+		destination: 'brands',
+		source: 'taxonomy:product_brands',
+		source_name: 'Taxonomy - Product Brands',
+		category_conditional_type: 'EXCEPT',
+		categories: '1',
+	},
+	{
+		destination: 'color',
+		source: 'attribute:color',
+		source_name: 'Attribute - Color',
+		category_conditional_type: 'ONLY',
+		categories:
+			'1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2,3',
+	},
+];
 
 describe( 'Attribute Mapping', () => {
 	test( 'Renders table', () => {
 		const { queryByText, queryByRole } = render( <AttributeMapping /> );
 		expect( queryByRole( 'table' ) ).toBeTruthy();
 		expect( queryByText( 'Target Attribute' ) ).toBeTruthy();
-		expect( queryByText( 'Reference Field / Default Value' ) ).toBeTruthy();
+		expect( queryByText( 'Data Source / Default Value' ) ).toBeTruthy();
 		expect( queryByText( 'Categories' ) ).toBeTruthy();
+	} );
+
+	test( 'Renders table data', () => {
+		const { queryByText } = render(
+			<AttributeMappingTable rules={ DUMMY_TABLE_DATA } />
+		);
+
+		expect( queryByText( 'Adult' ) ).toBeTruthy();
+		expect( queryByText( 'Brands' ) ).toBeTruthy();
+		expect( queryByText( 'Color' ) ).toBeTruthy();
+		expect( queryByText( 'All' ) ).toBeTruthy();
+		expect( queryByText( 'All except' ) ).toBeTruthy();
+		expect( queryByText( '1 category' ) ).toBeTruthy();
+		expect( queryByText( 'Only in' ) ).toBeTruthy();
+		expect( queryByText( '54 categories' ) ).toBeTruthy();
 	} );
 
 	test( 'Renders Add new Attribute mapping button', () => {
@@ -44,5 +85,44 @@ describe( 'Attribute Mapping', () => {
 			'href',
 			'https://support.google.com/'
 		); // TODO: Update link
+	} );
+
+	test( 'Renders categories helper', async () => {
+		const { queryByText, findByText } = render(
+			<AttributeMappingTableCategories categories={ [ '1' ] } />
+		);
+
+		const category = queryByText( '1 category' );
+		expect( category ).toBeTruthy();
+		fireEvent.mouseOver( category );
+		await findByText( 'Category 1' );
+	} );
+
+	test( 'Renders categories helper with tons of categories', async () => {
+		const { queryByText, findByText } = render(
+			<AttributeMappingTableCategories
+				categories={ [
+					'1',
+					'2',
+					'3',
+					'1',
+					'2',
+					'3',
+					'1',
+					'2',
+					'3',
+					'1',
+					'2',
+					'3',
+				] }
+			/>
+		);
+
+		const categories = queryByText( '12 categories' );
+		expect( categories ).toBeTruthy();
+		fireEvent.mouseOver( categories );
+		await findByText(
+			'Category 1, Category 2, Category 3, Category 1, Category 2...'
+		);
 	} );
 } );

--- a/js/src/attribute-mapping/index.test.js
+++ b/js/src/attribute-mapping/index.test.js
@@ -89,9 +89,12 @@ describe( 'Attribute Mapping', () => {
 
 	test( 'Renders categories helper', async () => {
 		const { queryByText, findByText } = render(
-			<AttributeMappingTableCategories categories={ [ '1' ] } />
+			<AttributeMappingTableCategories
+				categories={ '1' }
+				condition="EXCEPT"
+			/>
 		);
-
+		expect( queryByText( 'All except' ) ).toBeTruthy();
 		const category = queryByText( '1 category' );
 		expect( category ).toBeTruthy();
 		fireEvent.mouseOver( category );
@@ -101,28 +104,18 @@ describe( 'Attribute Mapping', () => {
 	test( 'Renders categories helper with tons of categories', async () => {
 		const { queryByText, findByText } = render(
 			<AttributeMappingTableCategories
-				categories={ [
-					'1',
-					'2',
-					'3',
-					'1',
-					'2',
-					'3',
-					'1',
-					'2',
-					'3',
-					'1',
-					'2',
-					'3',
-				] }
+				categories={ '1,2,3,1,2,3,1,2,3,1,2,3' }
+				condition="ONLY"
 			/>
 		);
 
+		expect( queryByText( 'Only in' ) ).toBeTruthy();
 		const categories = queryByText( '12 categories' );
 		expect( categories ).toBeTruthy();
 		fireEvent.mouseOver( categories );
 		await findByText(
-			'Category 1, Category 2, Category 3, Category 1, Category 2...'
+			'Category 1, Category 2, Category 3, Category 1, Category 2'
 		);
+		await findByText( '+ 7 more' );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes  part of #1648 .

This PR renders the rows in the table data according to Figma Design.

⚠️  For now the data is Dummy until PR's regarding Data are fully approved. See #1687 
⚠️  Button for Adding new Rule is implemented here #1680 

### Screenshots:

<img width="1214" alt="Screenshot 2022-09-22 at 18 32 42" src="https://user-images.githubusercontent.com/5908855/191784204-81c3369c-7d22-41de-9b1f-9a08783e4331.png">

### Detailed test instructions:

1.  Enter into Attribute Mapping tab
2.  See the table looks like the desing in Figma
3.  Hover the mause in the categories column and see the tooltip appearing with the category names.
4. If there are more than 5 categories, only 5 categories are shown and `...` is added. 


### Additional details:

Project: https://googleforwooextension.wordpress.com/2022/07/06/project-thread-custom-attribute-mapping/
Figma: https://www.figma.com/file/fqR0EHi63lWahRcVTKCcba/Google-Listings-%26-Ads-v2.x?node-id=1573%3A141294

