### PR TITLE
Free Listings + Paid Ads: Use merchant's data to composite the ad previews

### DIFF
--- a/js/src/components/paid-ads/campaign-preview/campaign-preview.scss
+++ b/js/src/components/paid-ads/campaign-preview/campaign-preview.scss
@@ -94,6 +94,7 @@ $gla-campaign-preview-height: 270px;
 
 	// Display smaller font sizes than browsers' limitations.
 	&__scaled-text {
+		height: 1em;
 		transform: scale(0.5);
 		transform-origin: top left;
 		margin-right: -100%; // Inner shrinkage for offsetting the outer horizontal gap caused by 0.5 times scaling.
@@ -101,7 +102,7 @@ $gla-campaign-preview-height: 270px;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		line-height: 1;
+		line-height: 0.9; // With 1em height, it prevents the font descender from getting cropped out.
 		font-size: 20px;
 
 		&--smaller {
@@ -125,6 +126,10 @@ $gla-campaign-preview-height: 270px;
 		}
 
 		&--ad-badge {
+			// Reset height and line-height because ad badge holds enough height for font descender.
+			height: auto;
+			line-height: 1;
+
 			// The same vertical inner shrinkage as above.
 			// A: Height of badge                     = &--ad-badge font-size + vertical padding
 			// B: Height of text after badge          = &--smaller font-size

--- a/js/src/components/paid-ads/campaign-preview/campaign-preview.scss
+++ b/js/src/components/paid-ads/campaign-preview/campaign-preview.scss
@@ -44,6 +44,11 @@ $gla-campaign-preview-height: 270px;
 	overflow: hidden;
 	background-color: $white;
 
+	.app-spinner {
+		align-items: center;
+		height: 100%;
+	}
+
 	// === Shared components within ad previews ===
 	&__placeholder {
 		height: 3px;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements an item of the **📌 Client states management and API integration** in #1610.

- Fetch the product and site data from API and preload data for compositing the ad previews.
- Extra change: Tweak ScaledText style to prevent the font descender from getting cropped out.
   - Font descender was cropped out:
      ![2022-09-23 12 51 34](https://user-images.githubusercontent.com/17420811/191909928-7b8f6f4b-702a-4ccd-9240-05c31f8c34c1.png)
   - After tweak:
      ![2022-09-23 12 52 34](https://user-images.githubusercontent.com/17420811/191909948-c21afbaf-91ad-4306-b2e6-014db820470f.png)

### Screenshots:

https://user-images.githubusercontent.com/17420811/191910280-0f85ccd6-9645-4816-bf1f-77d85643bdd1.mp4

### Detailed test instructions:

💡 ~~There is an additional backend check that needs to be around, and it will be adjusted in a later PR. Basically, the API integration can be tested for now. To bypass that check, temporarily replace [this line](https://github.com/woocommerce/google-listings-and-ads/blob/b5f51d48373a8406cd0174021427e851bf3d12a0/src/MerchantCenter/MerchantCenterService.php#L85) with:~~
```php
return $this->is_google_connected();
```
**Updated**: I rebased this PR onto #1693, so it should not need the above local adjustment.

1. Set a logo and site title for your shop: **Appearance** -> **Customize** -> **Site Identity** -> edit **Logo** and **Site Title** settings -> click on **Publish** button.
1. Go to step 4 of onboarding flow.
2. Check if the product and shop data come from your shop's data.

### Changelog entry
