### PR TITLE
Free Listings + Paid Ads: Do not refresh MC status when user is not onboarded for product feed API

### DIFF
--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
@@ -24,6 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * Class ProductFeedQueryHelper
  *
  * ContainerAware used to access:
+ * - MerchantCenterService
  * - MerchantStatuses
  * - ProductHelper
  *
@@ -81,7 +83,10 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 		$args                   = $this->prepare_query_args();
 		list( $limit, $offset ) = $this->prepare_query_pagination();
 
-		$this->container->get( MerchantStatuses::class )->maybe_refresh_status_data();
+		$mc_service = $this->container->get( MerchantCenterService::class );
+		if ( $mc_service->is_connected() ) {
+			$this->container->get( MerchantStatuses::class )->maybe_refresh_status_data();
+		}
 
 		/** @var ProductHelper $product_helper */
 		$product_helper = $this->container->get( ProductHelper::class );

--- a/tests/Unit/DB/ProductFeedQueryHelperTest.php
+++ b/tests/Unit/DB/ProductFeedQueryHelperTest.php
@@ -1,0 +1,66 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use WP_REST_Request;
+use wpdb;
+
+/**
+ * Class ProductFeedQueryHelperTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB
+ */
+class ProductFeedQueryHelperTest extends UnitTest {
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->wpdb               = $this->createMock( wpdb::class );
+		$this->product_repository = $this->createMock( ProductRepository::class );
+		$this->mc_service         = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses  = $this->createMock( MerchantStatuses::class );
+		$this->product_helper     = $this->createMock( ProductHelper::class );
+		$this->request            = $this->createMock( WP_REST_Request::class );
+
+		$container = new Container();
+		$container->share( MerchantCenterService::class, $this->mc_service );
+		$container->share( MerchantStatuses::class, $this->merchant_statuses );
+		$container->share( ProductHelper::class, $this->product_helper );
+
+		$this->product_feed_query_helper = new ProductFeedQueryHelper( $this->wpdb, $this->product_repository );
+		$this->product_feed_query_helper->set_container( $container );
+	}
+
+	public function test_get_product_feed_merchant_center_is_connected() {
+		$this->mc_service->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->merchant_statuses->expects( $this->exactly( 1 ) )
+			->method( 'maybe_refresh_status_data' );
+
+		$this->product_feed_query_helper->get( $this->request );
+	}
+
+	public function test_get_product_feed_merchant_center_is_not_connected() {
+		$this->mc_service->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( false );
+
+		$this->merchant_statuses->expects( $this->exactly( 0 ) )
+			->method( 'maybe_refresh_status_data' );
+
+		$this->product_feed_query_helper->get( $this->request );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a follow-up for #1681 and #1690. The `mc/product-feed` API is expected to be called when the user is not onboarded for GLA in the new onboarding flow so we need to bypass calling the method `maybe_refresh_status_data()` from `MerchantStatuses's` when the user is not onboarded otherwise it will return `400` error.

### Steps to reproducce:

1. Use the branch `feature/1610-streamlined-onboarding`
2. Remove the option `gla_mc_setup_completed_at`, `_transient_timeout_gla_mc_statuses`, and `_transient_gla_mc_statuses` from the table `wp_options`.
3. Call the API `GET mc/product-feed?per_page=1&orderby=total_sales&order=desc`
4. It should return `400` error with the message `Merchant Center account is not set up.`.

### Detailed test instructions:

1. Use the branch of this PR: `update/1610-do-not-refresh-mc-status-when-not-onboarded-for-product-feed-api`.
2. Do the steps 2 and 3 from the above.
3. It should return the correct product data.