### PR TITLE
Override Website Claim Lost issue info

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -814,12 +814,20 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		 *
 		 * TODO: Remove the condition of matching the $issue['issue']
 		 *       if its issue code is the same as 'merchant_quality_low'
-		 *       after Free and Enhanced Listings merge.
+		 *       after Google replaces the issue title on their side.
 		 */
 		if ( 'merchant_quality_low' === $issue['code'] || "Account isn't eligible for free listings" === $issue['issue'] ) {
 			$issue['issue']      = 'Show products on additional surfaces across Google through free listings';
 			$issue['severity']   = self::SEVERITY_WARNING;
 			$issue['action_url'] = 'https://support.google.com/merchants/answer/9199328?hl=en';
+		}
+
+		/**
+		 * Reference: https://github.com/woocommerce/google-listings-and-ads/issues/1688
+		 */
+		if ( 'home_page_issue' === $issue['code'] ) {
+			$issue['issue']      = 'Website claim is lost, need to re verify and claim your website. Please reference the support link';
+			$issue['action_url'] = 'https://woocommerce.com/document/google-listings-and-ads-faqs/#reverify-website';
 		}
 
 		return $issue;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1688.

This PR overrides the Issue data for `home_page_issue` with

Title: Website claim is lost, need to re verify and claim your website. Please reference the support link
Support Link: https://woocommerce.com/document/google-listings-and-ads-faqs/#reverify-website

### Screenshots:

<img width="938" alt="Screenshot 2022-09-23 at 12 50 47" src="https://user-images.githubusercontent.com/5908855/191925774-2461c4cb-c9e7-4338-825f-b384138040ff.png">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make the site website claim to be lost
2. Refresh the issues and go to Product feed
3. See the Website not claimed issue with the new info.

### Changelog entry

> Tweak - Update Website not Claimed issue information. 
