### PR TITLE
Fix Size types ENUM options

### DIFF
--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -48,8 +48,8 @@ class SizeType extends AbstractAttribute implements WithValueOptionsInterface {
 			'regular'      => __( 'Regular', 'google-listings-and-ads' ),
 			'petite'       => __( 'Petite', 'google-listings-and-ads' ),
 			'plus'         => __( 'Plus', 'google-listings-and-ads' ),
-			'oversize'     => __( 'Oversize', 'google-listings-and-ads' ),
-			'big and tall' => __( 'Big and tall', 'google-listings-and-ads' ),
+			'tall'         => __( 'Tall', 'google-listings-and-ads' ),
+			'big'          => __( 'Big', 'google-listings-and-ads' ),
 			'maternity'    => __( 'Maternity', 'google-listings-and-ads' ),
 		];
 	}

--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -46,12 +46,12 @@ class SizeType extends AbstractAttribute implements WithValueOptionsInterface {
 	 */
 	public static function get_value_options(): array {
 		return [
-			'regular'      => __( 'Regular', 'google-listings-and-ads' ),
-			'petite'       => __( 'Petite', 'google-listings-and-ads' ),
-			'plus'         => __( 'Plus', 'google-listings-and-ads' ),
-			'tall'         => __( 'Tall', 'google-listings-and-ads' ),
-			'big'          => __( 'Big', 'google-listings-and-ads' ),
-			'maternity'    => __( 'Maternity', 'google-listings-and-ads' ),
+			'regular'   => __( 'Regular', 'google-listings-and-ads' ),
+			'petite'    => __( 'Petite', 'google-listings-and-ads' ),
+			'plus'      => __( 'Plus', 'google-listings-and-ads' ),
+			'tall'      => __( 'Tall', 'google-listings-and-ads' ),
+			'big'       => __( 'Big', 'google-listings-and-ads' ),
+			'maternity' => __( 'Maternity', 'google-listings-and-ads' ),
 		];
 	}
 

--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class SizeType
  *
+ * @see https://support.google.com/merchants/answer/6324497
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes
  */
 class SizeType extends AbstractAttribute implements WithValueOptionsInterface {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the options available for Size type attribute.

Based on this  docs https://support.google.com/merchants/answer/6324497 seems that these values were updated. Looks like the Google product data feed-spec was updated in 2021 to support the new fields for the `size_type` product attribute. The announcement article on the Merchant Center Help Center for the 2021 Feed-spec update is [here](https://support.google.com/merchants/answer/10451760).

⚠️  Notice the current values are "working" still and Google seems like converting `Oversize` to `Plus`

Google confirmed that 

### Screenshots:

<img width="728" alt="Screenshot 2022-09-23 at 14 02 25" src="https://user-images.githubusercontent.com/5908855/191937651-952127e3-cca1-46b3-b806-eac1bf612869.png">

<img width="406" alt="Screenshot 2022-09-23 at 14 05 40" src="https://user-images.githubusercontent.com/5908855/191938212-a53bb20a-b7bd-49bf-876e-02443ae1abbf.png">

<img width="1371" alt="Screenshot 2022-09-23 at 14 06 42" src="https://user-images.githubusercontent.com/5908855/191938404-2122fe7d-93de-4457-83df-a4d5319ab2cb.png">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to a Product  and check that the new values are added to the GLA Attributes tab Size Type selector.
2. Select one of the new values, for example "Tall"
3. Sync the product and see how the data correctly appears in Merchant center


### Changelog entry

> Fix - Update Size Type Attribute available values
