### PR TITLE
Attribute Mapping - Tweak Sources & Data Types in backend

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingDataController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingDataController.php
@@ -129,23 +129,6 @@ class AttributeMappingDataController extends BaseOptionsController {
 				'description' => __( 'The list of attributes or attribute sources.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
-				'items'       => [
-					'id' => [
-						'type'        => 'integer',
-						'description' => __( 'The id for the item.', 'google-listings-and-ads' ),
-						'context'     => [ 'view' ],
-					],
-					'label' => [
-						'type'        => 'string',
-						'description' => __( 'The user friendly name for the item.', 'google-listings-and-ads' ),
-						'context'     => [ 'view' ],
-					],
-					'enum' => [
-						'type'        => 'boolean',
-						'description' => __( 'Indicates if the item is enum type.', 'google-listings-and-ads' ),
-						'context'     => [ 'view' ],
-					],
-				]
 			],
 		];
 	}

--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingDataController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingDataController.php
@@ -125,10 +125,27 @@ class AttributeMappingDataController extends BaseOptionsController {
 	protected function get_schema_properties(): array {
 		return [
 			'data' => [
-				'type'        => 'object',
+				'type'        => 'array',
 				'description' => __( 'The list of attributes or attribute sources.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
+				'items'       => [
+					'id' => [
+						'type'        => 'integer',
+						'description' => __( 'The id for the item.', 'google-listings-and-ads' ),
+						'context'     => [ 'view' ],
+					],
+					'label' => [
+						'type'        => 'string',
+						'description' => __( 'The user friendly name for the item.', 'google-listings-and-ads' ),
+						'context'     => [ 'view' ],
+					],
+					'enum' => [
+						'type'        => 'boolean',
+						'description' => __( 'Indicates if the item is enum type.', 'google-listings-and-ads' ),
+						'context'     => [ 'view' ],
+					],
+				]
 			],
 		];
 	}

--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingRulesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingRulesController.php
@@ -229,6 +229,9 @@ class AttributeMappingRulesController extends BaseOptionsController {
 	 * @throw Exception when invalid categories are provided
 	 */
 	public function validate_categories_param( string $categories ) {
+
+		if ($categories === '') return true;
+
 		$categories_array = explode( ',', $categories );
 
 		foreach ( $categories_array as $category ) {

--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingRulesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingRulesController.php
@@ -229,8 +229,9 @@ class AttributeMappingRulesController extends BaseOptionsController {
 	 * @throw Exception when invalid categories are provided
 	 */
 	public function validate_categories_param( string $categories ) {
-
-		if ($categories === '') return true;
+		if ( $categories === '' ) {
+			return true;
+		}
 
 		$categories_array = explode( ',', $categories );
 

--- a/src/DB/Query/AttributeMappingRulesQuery.php
+++ b/src/DB/Query/AttributeMappingRulesQuery.php
@@ -39,8 +39,8 @@ class AttributeMappingRulesQuery extends Query {
 			return sanitize_text_field( $value );
 		}
 
-		if( $column === 'categories' && is_null( $value ) ) {
-			return "";
+		if ( $column === 'categories' && is_null( $value ) ) {
+			return '';
 		}
 
 		return $value;

--- a/src/DB/Query/AttributeMappingRulesQuery.php
+++ b/src/DB/Query/AttributeMappingRulesQuery.php
@@ -39,6 +39,10 @@ class AttributeMappingRulesQuery extends Query {
 			return sanitize_text_field( $value );
 		}
 
+		if( $column === 'categories' && is_null( $value ) ) {
+			return "";
+		}
+
 		return $value;
 	}
 

--- a/src/DB/Table/AttributeMappingRulesTable.php
+++ b/src/DB/Table/AttributeMappingRulesTable.php
@@ -26,9 +26,9 @@ class AttributeMappingRulesTable extends Table {
 CREATE TABLE `{$this->get_sql_safe_name()}` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT,
     `attribute` varchar(255) NOT NULL,
-    `source` varchar(255) NOT NULL,
+    `source` varchar(100) NOT NULL,
     `category_condition_type` varchar(10) NOT NULL,
-    `categories` text DEFAULT NULL,
+    `categories` text DEFAULT '',
     PRIMARY KEY `id` (`id`)
 ) {$this->get_collation()};
 SQL;

--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -90,7 +90,17 @@ class AttributeMappingHelper implements Service {
 		 * @var AttributeInterface $attribute
 		 */
 		foreach ( self::ATTRIBUTES_AVAILABLE_FOR_MAPPING as $attribute ) {
-			$sources[ $attribute::get_id() ] = $attribute::get_sources();
+
+			$attribute_sources = [];
+
+			foreach ( $attribute::get_sources() as $key => $value ) {
+				array_push($attribute_sources, [
+					'id' => $key,
+					'label' => $value
+				]);
+			}
+
+			$sources[ $attribute::get_id() ] = $attribute_sources;
 		}
 
 		return $sources;

--- a/src/Product/AttributeMappingHelper.php
+++ b/src/Product/AttributeMappingHelper.php
@@ -94,10 +94,13 @@ class AttributeMappingHelper implements Service {
 			$attribute_sources = [];
 
 			foreach ( $attribute::get_sources() as $key => $value ) {
-				array_push($attribute_sources, [
-					'id' => $key,
-					'label' => $value
-				]);
+				array_push(
+					$attribute_sources,
+					[
+						'id'    => $key,
+						'label' => $value,
+					]
+				);
 			}
 
 			$sources[ $attribute::get_id() ] = $attribute_sources;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of  #1648 

This PR implements minor tweaks in backend as follows:

- In sources API route we return now an array instead of object for consistency with attributes API route
- We set  '' as default value for categories column. Also we allow '' as  valid data for categories in the API route. 
- Limited sources size to 100 in DB 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Test source route, ie. `GET /wp-json/wc/gla/mc/mapping/sources?attribute=color` 
2. See that it returns an array with id & value params.
3. Do a POST request to `/wp-json/wc/gla/mc/mapping/rules` using this payload

`{ "attribute": "adult", "source": "No", "category_condition_type": "ALL", "categories" : "" }``

4. See how it works.
5. Do a POST request again to `/wp-json/wc/gla/mc/mapping/rules` using this payload

`{ "attribute": "adult", "source": "No", "category_condition_type": "ALL"  }``

6. See how it works
