### PR TITLE
Detect the verification status of the phone number to the contact information settings

### DIFF
--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -82,24 +82,13 @@ export function ContactInformationPreview() {
  * Renders a contact information section with specified initial state and texts.
  *
  * @param {Object} props React props.
- * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified.
+ * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified or has been verified.
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
  * @fires gla_documentation_link_click with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
  * @fires gla_documentation_link_click with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
  */
 const ContactInformation = ( { onPhoneNumberVerified } ) => {
 	const phone = useGoogleMCPhoneNumber();
-
-	/**
-	 * Since it is still lacking the phone verification state,
-	 * all onboarding accounts are considered unverified phone numbers.
-	 *
-	 * TODO: replace the code at next line back to the original logic with
-	 * `const initEditing = null;`
-	 * after the phone verification state can be detected.
-	 */
-	const initEditing = true;
-
 	const title = mcTitle;
 	const trackContext = 'setup-mc-contact-information';
 
@@ -127,7 +116,7 @@ const ContactInformation = ( { onPhoneNumberVerified } ) => {
 				<PhoneNumberCard
 					view="setup-mc"
 					phoneNumber={ phone }
-					initEditing={ initEditing }
+					initEditing={ null }
 					onPhoneNumberVerified={ onPhoneNumberVerified }
 				/>
 				<StoreAddressCard />

--- a/js/src/components/contact-information/phone-number-card/phone-number-card-preview.js
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card-preview.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { APPEARANCE } from '.~/components/account-card';
 import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import ContactInformationPreviewCard from '../contact-information-preview-card';
+import './phone-number-card-preview.scss';
 
 /**
  * Triggered when phone number edit button is clicked.
@@ -35,7 +36,21 @@ export function PhoneNumberCardPreview( { editHref, learnMore } ) {
 
 	if ( loaded ) {
 		if ( data.isValid ) {
-			content = data.display;
+			const verificationStatus = data.isVerified ? (
+				<div className="gla-phone-number-card-preview__verified-status">
+					{ __( 'Verified', 'google-listings-and-ads' ) }
+				</div>
+			) : (
+				<div className="gla-phone-number-card-preview__unverified-status">
+					{ __( 'Unverified', 'google-listings-and-ads' ) }
+				</div>
+			);
+			content = (
+				<>
+					{ data.display }
+					{ verificationStatus }
+				</>
+			);
 		} else {
 			warning = __(
 				'Please add your phone number',

--- a/js/src/components/contact-information/phone-number-card/phone-number-card-preview.scss
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card-preview.scss
@@ -1,0 +1,15 @@
+.gla-contact-info-preview-card {
+	.gla-account-card__description {
+		gap: $grid-unit-05;
+	}
+}
+
+.gla-phone-number-card-preview {
+	&__verified-status {
+		color: $alert-green;
+	}
+
+	&__unverified-status {
+		color: $alert-red;
+	}
+}

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -10,6 +10,10 @@ import createSelector from 'rememo';
 import { STORE_KEY } from './constants';
 import { getReportQuery, getReportKey, getPerformanceQuery } from './utils';
 
+/**
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ */
+
 export const getShippingRates = ( state ) => {
 	return state.mc.shipping.rates;
 };
@@ -74,11 +78,42 @@ export const getExistingGoogleAdsAccounts = ( state ) => {
 	return state.mc.accounts.existing_ads;
 };
 
+/**
+ * @typedef {Object} Address
+ * @property {string|null} street_address Street-level part of the address. `null` when empty.
+ * @property {string|null} locality City, town or commune. `null` when empty.
+ * @property {string|null} region Top-level administrative subdivision of the country. `null` when empty.
+ * @property {string|null} postal_code Postal code or ZIP. `null` when empty.
+ * @property {CountryCode} country Two-letter country code in ISO 3166-1 alpha-2 format. Example: 'US'.
+ *
+ * @typedef {Object} ContactInformation
+ * @property {number} id The Google Merchant Center account ID.
+ * @property {string|null} phone_number The phone number in international format associated with the Google Merchant Center account. Example: '+12133734253'. `null` if the phone number is not yet set.
+ * @property {'verified'|'unverified'|null} phone_verification_status The verification status of the phone number associated with the Google Merchant Center account. `null` if the phone number is not yet set.
+ * @property {Address|null} mc_address The address associated with the Google Merchant Center account. `null` if the address is not yet set.
+ * @property {Address|null} wc_address The WooCommerce store address. `null` if the address is not yet set.
+ * @property {boolean} is_mc_address_different Whether the Google Merchant Center account address is different than the WooCommerce store address.
+ * @property {string[]} wc_address_errors The errors associated with the WooCommerce store address.
+ */
+
+/**
+ * Select the state of contact information associated with the Google Merchant Center account.
+ *
+ * @param {Object} state The current store state will be injected by `wp.data`.
+ * @return {ContactInformation|null} The contact information associated with the Google Merchant Center account. It would return `null` before the data is fetched.
+ */
 export const getGoogleMCContactInformation = ( state ) => {
 	return state.mc.contact;
 };
 
-// Create another selector to separate the `hasFinishedResolution` state with `getGoogleMCContactInformation`.
+/**
+ * Select the state of phone number associated with the Google Merchant Center account.
+ *
+ * Create another selector to separate the `hasFinishedResolution` state with `getGoogleMCContactInformation`.
+ *
+ * @param {Object} state The current store state will be injected by `wp.data`.
+ * @return {{ data: ContactInformation|null, loaded: boolean }} The payload of contact information associated with the Google Merchant Center account and its loaded state.
+ */
 export const getGoogleMCPhoneNumber = createRegistrySelector(
 	( select ) => ( state ) => {
 		const selector = select( STORE_KEY );

--- a/js/src/hooks/useGoogleMCPhoneNumber.js
+++ b/js/src/hooks/useGoogleMCPhoneNumber.js
@@ -14,6 +14,7 @@ const emptyData = {
 	countryCallingCode: '',
 	nationalNumber: '',
 	isValid: false,
+	isVerified: false,
 	display: '',
 };
 
@@ -29,13 +30,14 @@ const emptyData = {
  * @property {string} countryCallingCode The country calling code. Example: '1'.
  * @property {string} nationalNumber The national (significant) number. Example: '2133734253'.
  * @property {boolean} isValid Whether the phone number is valid.
+ * @property {boolean} isVerified Whether the phone number is verified.
  * @property {string} display The phone number string in international format. Example: '+1 213 373 4253'.
  */
 
 /**
  * A hook to load user's phone number data from Google Merchant Center.
  *
- * @return {PhoneNumber} [description]
+ * @return {PhoneNumber} The payload of parsed phone number associated with the Google Merchant Center account and its loaded state.
  */
 export default function useGoogleMCPhoneNumber() {
 	return useSelect( ( select ) => {
@@ -50,6 +52,8 @@ export default function useGoogleMCPhoneNumber() {
 				data = {
 					...parsed,
 					isValid: parsed.isValid(),
+					isVerified:
+						contact.phone_verification_status === 'verified',
 					display: parsed.formatInternational(),
 				};
 				delete data.metadata;

--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -13,11 +13,7 @@ import useMCSetup from '.~/hooks/useMCSetup';
 import stepNameKeyMap from './stepNameKeyMap';
 
 const SetupStepper = () => {
-	const {
-		hasFinishedResolution,
-		data: mcSetup,
-		invalidateResolution: mcSetupInvalidateResolution,
-	} = useMCSetup();
+	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
 
 	if ( ! hasFinishedResolution && ! mcSetup ) {
 		return <AppSpinner />;
@@ -36,16 +32,7 @@ const SetupStepper = () => {
 		return null;
 	}
 
-	const handleRefetchSavedStep = () => {
-		mcSetupInvalidateResolution();
-	};
-
-	return (
-		<SavedSetupStepper
-			savedStep={ stepNameKeyMap[ step ] }
-			onRefetchSavedStep={ handleRefetchSavedStep }
-		/>
-	);
+	return <SavedSetupStepper savedStep={ stepNameKeyMap[ step ] } />;
 };
 
 export default SetupStepper;

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -28,10 +28,9 @@ import stepNameKeyMap from './stepNameKeyMap';
 /**
  * @param {Object} props React props
  * @param {string} [props.savedStep] A saved step overriding the current step
- * @param {Function} [props.onRefetchSavedStep] Callback when Saved Step is updated
  * @fires gla_setup_mc with `{ target: 'step1_continue' | 'step2_continue' | 'step3_continue', trigger: 'click' }`.
  */
-const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
+const SavedSetupStepper = ( { savedStep } ) => {
 	const [ step, setStep ] = useState( savedStep );
 
 	const { settings } = useSettings();
@@ -83,7 +82,6 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 			trigger: 'click',
 		} );
 		setStep( stepNameKeyMap.product_listings );
-		onRefetchSavedStep();
 	};
 
 	const handleSetupListingsContinue = () => {
@@ -92,7 +90,6 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 			trigger: 'click',
 		} );
 		setStep( stepNameKeyMap.store_requirements );
-		onRefetchSavedStep();
 	};
 
 	const handleStoreRequirementsContinue = () => {
@@ -101,11 +98,11 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 			trigger: 'click',
 		} );
 		setStep( stepNameKeyMap.paid_ads );
-		onRefetchSavedStep();
 	};
 
 	const handleStepClick = ( stepKey ) => {
-		if ( Number( stepKey ) <= Number( savedStep ) ) {
+		// Only allow going back to the previous steps.
+		if ( Number( stepKey ) < Number( step ) ) {
 			setStep( stepKey );
 		}
 	};

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -293,8 +293,9 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 */
 	protected function is_mc_contact_information_setup(): bool {
 		$is_setup = [
-			'phone_number' => false,
-			'address'      => false,
+			'phone_number'              => false,
+			'phone_verification_status' => false,
+			'address'                   => false,
 		];
 
 		try {
@@ -310,7 +311,8 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		}
 
 		if ( $contact_info instanceof AccountBusinessInformation ) {
-			$is_setup['phone_number'] = ! empty( $contact_info->getPhoneNumber() );
+			$is_setup['phone_number']              = ! empty( $contact_info->getPhoneNumber() );
+			$is_setup['phone_verification_status'] = 'VERIFIED' === $contact_info->getPhoneVerificationStatus();
 
 			/** @var Settings $settings */
 			$settings = $this->container->get( Settings::class );
@@ -323,7 +325,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			}
 		}
 
-		return $is_setup['phone_number'] && $is_setup['address'];
+		return $is_setup['phone_number'] && $is_setup['phone_verification_status'] && $is_setup['address'];
 	}
 
 	/**

--- a/tests/Tools/HelperTrait/MerchantTrait.php
+++ b/tests/Tools/HelperTrait/MerchantTrait.php
@@ -48,6 +48,7 @@ trait MerchantTrait {
 	public function get_valid_business_info(): AccountBusinessInformation {
 		$business_info = new AccountBusinessInformation();
 		$business_info->setPhoneNumber( $this->valid_account_phone_number );
+		$business_info->setPhoneVerificationStatus( 'VERIFIED' );
 		$business_info->setAddress( $this->get_sample_address() );
 
 		return $business_info;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1033

- Add the verification status of the phone number to the API **GET** `mc/contact-information`.
- Add a phone verification status check to the API **GET** `mc/setup`.
- Detect the verification status of the phone number in the onboarding flow.
- Add the verification status of the phone number to `PhoneNumberCardPreview` component.

### Screenshots:

💡 The phone numbers shown in the following videos were temporarily changed to mocks in my local env. It still uses a real phone number when communicating with APIs.

#### 📹 Onboarding flow

https://user-images.githubusercontent.com/17420811/194003024-82aab6d8-3d35-4550-af30-2928df725f42.mp4

#### 📹 Settings page

https://user-images.githubusercontent.com/17420811/194003035-f17dbcf2-10a9-4011-ad6b-8748506bbb44.mp4

### Detailed test instructions:

1. Go to the admin page of Google Merchant Center and save an *Unverified* phone number. https://merchants.google.com/mc/merchantprofile/businessinfo
2. Go to the onboarding flow of GLA.
3. When entering step 3, the phone number card in the contact info settings should be in editing mode.
4. Verify a phone number and complete step 3.
5. After refreshing page, it should start with step 4 since the `mc/setup` API should consider step 3 was completed.
6. Back to step 3, the phone number card in the contact info settings should not be in editing mode.
7. Finish the onboarding flow and go to GLA settings page.
8. Check if there is a "Verified" status shown under the phone number.
9. Revisit the admin page of Google Merchant Center and save an *Unverified* phone number again.
10. Refresh GLA settings page to see if the verification status is changed to "Unverified".

### Changelog entry

> Update - Detect the verification status of the phone number in the contact information settings.
