### PR TITLE
Change the Stepper in the onboarding flow to only allow going back to the previous steps

### DIFF
--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -13,11 +13,7 @@ import useMCSetup from '.~/hooks/useMCSetup';
 import stepNameKeyMap from './stepNameKeyMap';
 
 const SetupStepper = () => {
-	const {
-		hasFinishedResolution,
-		data: mcSetup,
-		invalidateResolution: mcSetupInvalidateResolution,
-	} = useMCSetup();
+	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
 
 	if ( ! hasFinishedResolution && ! mcSetup ) {
 		return <AppSpinner />;
@@ -36,16 +32,7 @@ const SetupStepper = () => {
 		return null;
 	}
 
-	const handleRefetchSavedStep = () => {
-		mcSetupInvalidateResolution();
-	};
-
-	return (
-		<SavedSetupStepper
-			savedStep={ stepNameKeyMap[ step ] }
-			onRefetchSavedStep={ handleRefetchSavedStep }
-		/>
-	);
+	return <SavedSetupStepper savedStep={ stepNameKeyMap[ step ] } />;
 };
 
 export default SetupStepper;

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -28,10 +28,9 @@ import stepNameKeyMap from './stepNameKeyMap';
 /**
  * @param {Object} props React props
  * @param {string} [props.savedStep] A saved step overriding the current step
- * @param {Function} [props.onRefetchSavedStep] Callback when Saved Step is updated
  * @fires gla_setup_mc with `{ target: 'step1_continue' | 'step2_continue' | 'step3_continue', trigger: 'click' }`.
  */
-const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
+const SavedSetupStepper = ( { savedStep } ) => {
 	const [ step, setStep ] = useState( savedStep );
 
 	const { settings } = useSettings();
@@ -83,7 +82,6 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 			trigger: 'click',
 		} );
 		setStep( stepNameKeyMap.product_listings );
-		onRefetchSavedStep();
 	};
 
 	const handleSetupListingsContinue = () => {
@@ -92,7 +90,6 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 			trigger: 'click',
 		} );
 		setStep( stepNameKeyMap.store_requirements );
-		onRefetchSavedStep();
 	};
 
 	const handleStoreRequirementsContinue = () => {
@@ -101,11 +98,11 @@ const SavedSetupStepper = ( { savedStep, onRefetchSavedStep = () => {} } ) => {
 			trigger: 'click',
 		} );
 		setStep( stepNameKeyMap.paid_ads );
-		onRefetchSavedStep();
 	};
 
 	const handleStepClick = ( stepKey ) => {
-		if ( Number( stepKey ) <= Number( savedStep ) ) {
+		// Only allow going back to the previous steps.
+		if ( Number( stepKey ) < Number( step ) ) {
 			setStep( stepKey );
 		}
 	};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1684 

Initially, I tried to fix this issue by following the same interactivity provided by the original Stepper UI, but since there is necessary processing triggered by clicking on the Continue button, allowing switching steps back and forth via `Stepper` may cause this kind of processing to be skipped.

https://github.com/woocommerce/google-listings-and-ads/blob/be91f85fe67e3f20a3049bc1713c54298a1b5582/js/src/setup-mc/setup-stepper/store-requirements/index.js#L67-L72

In the following video, we can find that `updateGoogleMCContactInformation()` is not called when switching to step 4 by Stepper. Therefore, this PR changes the Stepper in the onboarding flow to only allow going back to the previous steps, which is also consistent with the post-onboarding ads setup flow. (`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads`)

https://user-images.githubusercontent.com/17420811/194486644-0b5c9f9b-380e-47fa-a459-f65173449671.mp4

#### 📌 About the checked items of the Pre-Launch Checklist becoming unchecked when every time switch to step 3

At about the 10th second of the above video, we can see some of the already manually checked items were changed to unchecked. According to [the comment](https://github.com/woocommerce/google-listings-and-ads/pull/1612#issuecomment-1244895578) in #1612, it's an expected results.

> > 2\. Does the auto-checked mechanism include the direction of changing the state from checked to unchecked? Because the current implementation will also auto-uncheck items when refreshing the page.
> 
> I think this is as expected. Auto-check will overwrite the previous state when refreshing the page.

However, changing this auto-checked/unchecked mechanism to one-way might make the experience better. 📜 

### Detailed test instructions:

1. Go to the onboarding flow.
2. Proceed with the setup steps and check if the Stepper only allows going back to the previous steps.

### Changelog entry

> Update - Change the steppers in the onboarding flow to only allow going back to the previous steps.
> Fix - Steppers on the onboarding flow allow switching to later steps when the current step is not yet finished.
