### PR TITLE
Free Listings + Paid Ads: Add ad previews to the post-onboarding ads setup flow

### DIFF
--- a/js/src/components/paid-ads/create-campaign-form-content.js
+++ b/js/src/components/paid-ads/create-campaign-form-content.js
@@ -6,8 +6,14 @@ import BudgetSection from '.~/components/paid-ads/budget-section';
 import FaqsSection from '.~/components/paid-ads/faqs-section';
 import './campaign-form-content.scss';
 
-const CreateCampaignFormContent = ( props ) => {
-	const { formProps } = props;
+/**
+ * Renders the audience and budget sections for creating a new campaign.
+ *
+ * @param {Object} props React props.
+ * @param {Object} props.formProps Form props forwarded from `Form` component.
+ * @param {JSX.Element} [props.budgetSectionChildren] The children to be rendered in the budget section.
+ */
+const CreateCampaignFormContent = ( { formProps, budgetSectionChildren } ) => {
 	const disabledBudgetSection = ! formProps.values.countryCodes.length;
 
 	return (
@@ -16,7 +22,9 @@ const CreateCampaignFormContent = ( props ) => {
 			<BudgetSection
 				formProps={ formProps }
 				disabled={ disabledBudgetSection }
-			/>
+			>
+				{ budgetSectionChildren }
+			</BudgetSection>
 			<FaqsSection />
 		</div>
 	);

--- a/js/src/setup-ads/ads-stepper/create-campaign/campaign-preview-card.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/campaign-preview-card.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useRef } from '@wordpress/element';
+import { Flex, FlexItem, FlexBlock } from '@wordpress/components';
+import GridiconChevronLeft from 'gridicons/dist/chevron-left';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
+
+/**
+ * Internal dependencies
+ */
+import Section from '.~/wcdl/section';
+import AppButton from '.~/components/app-button';
+import CampaignPreview from '.~/components/paid-ads/campaign-preview';
+import './campaign-preview-card.scss';
+
+/**
+ * @typedef { import(".~/components/paid-ads/campaign-preview/campaign-preview.js").CampaignPreviewHandler } CampaignPreviewHandler
+ */
+
+/**
+ * Renders a Card that includes a CampaignPreview with previous and next buttons.
+ */
+export default function CampaignPreviewCard() {
+	/**
+	 * @type {import('react').MutableRefObject<CampaignPreviewHandler>}
+	 */
+	const previewRef = useRef();
+
+	const handleClick = ( e ) => {
+		const step = Number( e.currentTarget.dataset.step );
+		previewRef.current.moveBy( step );
+	};
+
+	return (
+		<Section.Card className="gla-campaign-preview-card">
+			<Section.Card.Body>
+				<Flex align="start" gap={ 9 }>
+					<FlexBlock>
+						<Section.Card.Title>
+							{ __(
+								'Preview product ad',
+								'google-listings-and-ads'
+							) }
+						</Section.Card.Title>
+						<div>
+							{ __(
+								`Each of your product variants will have its own ad. Previews shown here are examples and don't include all possible formats.`,
+								'google-listings-and-ads'
+							) }
+						</div>
+					</FlexBlock>
+					<FlexItem>
+						<Flex align="center" gap={ 5 }>
+							<AppButton
+								className="gla-campaign-preview-card__moving-button"
+								icon={ <GridiconChevronLeft /> }
+								iconSize={ 16 }
+								onClick={ handleClick }
+								data-step="-1"
+							/>
+							<CampaignPreview
+								ref={ previewRef }
+								autoplay={ false }
+							/>
+							<AppButton
+								className="gla-campaign-preview-card__moving-button"
+								icon={ <GridiconChevronRight /> }
+								iconSize={ 16 }
+								onClick={ handleClick }
+								data-step="1"
+							/>
+						</Flex>
+					</FlexItem>
+				</Flex>
+			</Section.Card.Body>
+		</Section.Card>
+	);
+}

--- a/js/src/setup-ads/ads-stepper/create-campaign/campaign-preview-card.scss
+++ b/js/src/setup-ads/ads-stepper/create-campaign/campaign-preview-card.scss
@@ -1,0 +1,13 @@
+.gla-campaign-preview-card {
+	.wcdl-section-card-title {
+		margin-bottom: $grid-unit-10;
+	}
+
+	&__moving-button.components-button.has-icon {
+		height: auto;
+		min-width: 0;
+		padding: $grid-unit-05;
+		border-radius: 50%;
+		background-color: $gray-100;
+	}
+}

--- a/js/src/setup-ads/ads-stepper/create-campaign/index.js
+++ b/js/src/setup-ads/ads-stepper/create-campaign/index.js
@@ -13,6 +13,7 @@ import StepContentFooter from '.~/components/stepper/step-content-footer';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import CreateCampaignFormContent from '.~/components/paid-ads/create-campaign-form-content';
 import AppButton from '.~/components/app-button';
+import CampaignPreviewCard from './campaign-preview-card';
 
 /**
  * @fires gla_documentation_link_click with `{ context: 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
@@ -45,7 +46,10 @@ const CreateCampaign = ( props ) => {
 					}
 				) }
 			/>
-			<CreateCampaignFormContent formProps={ formProps } />
+			<CreateCampaignFormContent
+				formProps={ formProps }
+				budgetSectionChildren={ <CampaignPreviewCard /> }
+			/>
 			<StepContentFooter>
 				<AppButton
 					isPrimary


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements an item of the **📌 Post-onboarding setup flow** in #1610.

- Add ad previews to the post-onboarding ads setup flow.

### Screenshots:

https://user-images.githubusercontent.com/17420811/194531820-ee509277-6dbf-4c5a-9934-ce752032b5ca.mp4

### Detailed test instructions:

1. Go to step 2 of the post-onboarding ads setup flow. `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-ads`
2. Click on the next and previous buttons to see if the ad previews work as expected.

### Changelog entry

> Add - Ad previews in the post-onboarding ads setup flow.
