### PR TITLE
Fix incorrect product statistics count

### DIFF
--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -37,11 +37,6 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
 	public function process_items( array $product_id_map ) {
-		$ready_ids = $this->product_repository->find_delete_product_ids( $product_id_map );
-
-		// Exclude any ID's which are not ready to delete.
-		$product_id_map = array_intersect( $product_id_map, $ready_ids );
-
 		$product_entries = BatchProductIDRequestEntry::create_from_id_map( new ProductIDMap( $product_id_map ) );
 		$this->product_syncer->delete_by_batch_requests( $product_entries );
 	}

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -37,6 +37,12 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
 	public function process_items( array $product_id_map ) {
+		$product_ids = array_values( $product_id_map );
+		$ready_ids   = $this->product_repository->find_delete_product_ids( $product_ids );
+
+		// Exclude any ID's which are not ready to delete.
+		$product_id_map = array_intersect( $product_id_map, $ready_ids );
+
 		$product_entries = BatchProductIDRequestEntry::create_from_id_map( new ProductIDMap( $product_id_map ) );
 		$this->product_syncer->delete_by_batch_requests( $product_entries );
 	}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -350,7 +350,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 				continue;
 			}
 
-			$wc_product = get_post( $wc_product_id );
+			$wc_product = $product_helper->get_wc_product_by_wp_post( $wc_product_id );
 			if ( ! $wc_product || 'product' !== substr( $wc_product->post_type, 0, 7 ) ) {
 				// Should never reach here since the products IDS are retrieved from postmeta.
 				do_action(

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -599,23 +599,66 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	}
 
 	/**
-	 * Calculate the product status statistics and update the transient.
+	 * Calculate the synced product status statistics. It will group
+	 * the variations for the same parent.
+	 *
+	 * For the case that one variation is approved and the other disapproved:
+	 * 1. Give each status a priority.
+	 * 2. Store the last highest priority status in `$parent_statuses`.
+	 * 3. Compare if a higher priority status is found for that variable product.
+	 * 4. Loop through the `$parent_statuses` array at the end to add the final status counts.
+	 *
+	 * @return array Product status statistics.
 	 */
-	protected function update_mc_statuses() {
+	protected function calculate_synced_product_statistics(): array {
 		$product_statistics = [
 			MCStatus::APPROVED           => 0,
 			MCStatus::PARTIALLY_APPROVED => 0,
 			MCStatus::EXPIRING           => 0,
 			MCStatus::PENDING            => 0,
 			MCStatus::DISAPPROVED        => 0,
-			MCSTATUS::NOT_SYNCED         => 0,
+			MCStatus::NOT_SYNCED         => 0,
 		];
 
-		foreach ( $this->product_statuses['products'] as $statuses ) {
+		$product_statistics_priority = [
+			MCStatus::APPROVED           => 6,
+			MCStatus::PARTIALLY_APPROVED => 5,
+			MCStatus::EXPIRING           => 4,
+			MCStatus::PENDING            => 3,
+			MCStatus::DISAPPROVED        => 2,
+			MCStatus::NOT_SYNCED         => 1,
+		];
+
+		$parent_statuses = [];
+
+		foreach ( $this->product_statuses['products'] as $product_id => $statuses ) {
 			foreach ( $statuses as $status => $num_products ) {
-				$product_statistics[ $status ] += $num_products;
+				$parent_id = $this->product_data_lookup[ $product_id ]['parent_id'];
+				if ( ! $parent_id ) {
+					$product_statistics[ $status ] += $num_products;
+				} elseif ( ! isset( $parent_statuses[ $parent_id ] ) ) {
+					$parent_statuses[ $parent_id ] = $status;
+				} else {
+					$current_parent_status = $parent_statuses[ $parent_id ];
+					if ( $product_statistics_priority[ $status ] < $product_statistics_priority[ $current_parent_status ] ) {
+						$parent_statuses[ $parent_id ] = $status;
+					}
+				}
 			}
 		}
+
+		foreach ( $parent_statuses as $parent_status ) {
+			$product_statistics[ $parent_status ] += 1;
+		}
+
+		return $product_statistics;
+	}
+
+	/**
+	 * Calculate the product status statistics and update the transient.
+	 */
+	protected function update_mc_statuses() {
+		$product_statistics = $this->calculate_synced_product_statistics();
 
 		/** @var ProductRepository $product_repository */
 		$product_repository                         = $this->container->get( ProductRepository::class );

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -295,9 +295,9 @@ class ProductHelper implements Service {
 	 *
 	 * @param int $product_id
 	 *
-	 * @return WP_Post
+	 * @return WP_Post|null
 	 */
-	public function get_wc_product_by_wp_post( int $product_id ): WP_Post {
+	public function get_wc_product_by_wp_post( int $product_id ): ?WP_Post {
 		return get_post( $product_id );
 	}
 

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use Google\Service\ShoppingContent\Product as GoogleProduct;
 use WC_Product;
 use WC_Product_Variation;
+use WP_Post;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -287,6 +288,17 @@ class ProductHelper implements Service {
 	 */
 	public function get_wc_product( int $product_id ): WC_Product {
 		return $this->wc->get_product( $product_id );
+	}
+
+	/**
+	 * Get WooCommerce product by WP get_post
+	 *
+	 * @param int $product_id
+	 *
+	 * @return WP_Post
+	 */
+	public function get_wc_product_by_wp_post( int $product_id ): WP_Post {
+		return get_post( $product_id );
 	}
 
 	/**

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -103,7 +103,11 @@ class ProductHelper implements Service {
 	 */
 	public function mark_as_unsynced( WC_Product $product ) {
 		$this->meta_handler->delete_synced_at( $product );
-		$this->meta_handler->update_sync_status( $product, SyncStatus::NOT_SYNCED );
+		if ( ! $this->is_sync_ready( $product ) ) {
+			$this->meta_handler->delete_sync_status( $product );
+		} else {
+			$this->meta_handler->update_sync_status( $product, SyncStatus::NOT_SYNCED );
+		}
 		$this->meta_handler->delete_google_ids( $product );
 		$this->meta_handler->delete_errors( $product );
 		$this->meta_handler->delete_failed_sync_attempts( $product );

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
@@ -264,9 +264,9 @@ class ProductRepository implements Service {
 			'type'       => $types,
 			'meta_query' => [
 				[
-					'key'     => ProductMetaHandler::KEY_MC_STATUS,
-					'compare' => '=',
-					'value'   => MCStatus::NOT_SYNCED,
+					'key'     => ProductMetaHandler::KEY_SYNC_STATUS,
+					'compare' => '!=',
+					'value'   => SyncStatus::SYNCED,
 				],
 			],
 		];

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -81,12 +81,13 @@ class ProductRepository implements Service {
 	 * Find and return an array of WooCommerce product objects based on the provided product IDs.
 	 *
 	 * @param int[] $ids    Array of WooCommerce product IDs
+	 * @param array $args   Array of WooCommerce args (except 'return'), and product metadata.
 	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
 	 * @param int   $offset Amount to offset product results.
 	 *
 	 * @return WC_Product[] Array of WooCommerce product objects
 	 */
-	public function find_by_ids( array $ids, int $limit = -1, int $offset = 0 ): array {
+	public function find_by_ids( array $ids, array $args = [], int $limit = -1, int $offset = 0 ): array {
 		$args['include'] = $ids;
 
 		return $this->find( $args, $limit, $offset );
@@ -163,7 +164,8 @@ class ProductRepository implements Service {
 	 * @return array
 	 */
 	public function find_delete_product_ids( array $ids, int $limit = - 1, int $offset = 0 ): array {
-		$results = $this->find_by_ids( $ids, $limit, $offset );
+		$args    = [ 'status' => 'trash' ];
+		$results = $this->find_by_ids( $ids, $args, $limit, $offset );
 		return $this->product_filter->filter_products_for_delete( $results )->get_product_ids();
 	}
 

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -270,6 +270,11 @@ class ProductRepository implements Service {
 					'compare' => '!=',
 					'value'   => SyncStatus::SYNCED,
 				],
+				[
+					'key'     => ProductMetaHandler::KEY_VISIBILITY,
+					'compare' => '=',
+					'value'   => ChannelVisibility::SYNC_AND_SHOW,
+				],
 			],
 		];
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -10,10 +10,12 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Google\Service\ShoppingContent;
+use WP_Post;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -24,6 +26,12 @@ defined( 'ABSPATH' ) || exit;
  * @property ShoppingContent\AccountStatus $account_status
  * @property ProductMetaQueryHelper $product_meta_query_helper
  * @property MerchantStatuses $merchant_statuses
+ * @property ProductRepository $product_repository
+ * @property ProductHelper $product_helper
+ * @property ShoppingContent\ProductStatus $product_status
+ * @property ShoppingContent\ProductStatusesCustomBatchResponse $product_statuses_custom_batch_response
+ * @property ShoppingContent\ProductStatusesCustomBatchResponseEntry $product_statuses_custom_batch_response_entry
+ * @property ShoppingContent\ProductStatusDestinationStatus $product_status_destination_status
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
  * @group MerchantCenterStatuses
  */
@@ -35,19 +43,30 @@ class MerchantStatusesTest extends UnitTest {
 	private $account_status;
 	private $product_meta_query_helper;
 	private $merchant_statuses;
+	private $product_repository;
+	private $product_helper;
+	private $product_status;
+	private $product_statuses_custom_batch_response;
+	private $product_statuses_custom_batch_response_entry;
+	private $product_status_destination_status;
 
 	/**
 	 * Runs before each test is executed.
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->merchant                  = $this->createMock( Merchant::class );
-		$this->merchant_issue_query      = $this->createMock( MerchantIssueQuery::class );
-		$this->merchant_center_service   = $this->createMock( MerchantCenterService::class );
-		$this->account_status            = $this->createMock( ShoppingContent\AccountStatus::class );
-		$this->product_meta_query_helper = $this->createMock( ProductMetaQueryHelper::class );
+		$this->merchant                                     = $this->createMock( Merchant::class );
+		$this->merchant_issue_query                         = $this->createMock( MerchantIssueQuery::class );
+		$this->merchant_center_service                      = $this->createMock( MerchantCenterService::class );
+		$this->account_status                               = $this->createMock( ShoppingContent\AccountStatus::class );
+		$this->product_meta_query_helper                    = $this->createMock( ProductMetaQueryHelper::class );
+		$this->product_repository                           = $this->createMock( ProductRepository::class );
+		$this->product_helper                               = $this->createMock( ProductHelper::class );
+		$this->product_status                               = $this->createMock( ShoppingContent\ProductStatus::class );
+		$this->product_statuses_custom_batch_response       = $this->createMock( ShoppingContent\ProductstatusesCustomBatchResponse::class );
+		$this->product_statuses_custom_batch_response_entry = $this->createMock( ShoppingContent\ProductstatusesCustomBatchResponseEntry::class );
+		$this->product_status_destination_status            = $this->createMock( ShoppingContent\ProductStatusDestinationStatus::class );
 
-		$product_repository   = $this->createMock( ProductRepository::class );
 		$transients           = $this->createMock( TransientsInterface::class );
 		$merchant_issue_table = $this->createMock( MerchantIssueTable::class );
 
@@ -56,8 +75,9 @@ class MerchantStatusesTest extends UnitTest {
 		$container->share( MerchantIssueQuery::class, $this->merchant_issue_query );
 		$container->share( MerchantCenterService::class, $this->merchant_center_service );
 		$container->share( TransientsInterface::class, $transients );
-		$container->share( ProductRepository::class, $product_repository );
+		$container->share( ProductRepository::class, $this->product_repository );
 		$container->share( ProductMetaQueryHelper::class, $this->product_meta_query_helper );
+		$container->share( ProductHelper::class, $this->product_helper );
 		$container->share( MerchantIssueTable::class, $merchant_issue_table );
 
 		$this->merchant_statuses = new MerchantStatuses();
@@ -148,5 +168,176 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'update_or_insert' )
 			->withConsecutive( [ $issues ], [] );
 		$this->merchant_statuses->maybe_refresh_status_data( true );
+	}
+
+	/*
+	 * Test get product statistics.
+	 *
+	 * Test data:
+	 * - Product ID: 100, Type: Variable,  Parent: 0,   MC Status: N/A
+	 * - Product ID: 101, Type: Simple,    Parent: 0,   MC Status: disapproved
+	 * - Product ID: 102, Type: Variation, Parent: 100, MC Status: approved
+	 * - Product ID: 103, Type: Variable,  Parent: 0,   MC Status: N/A
+	 * - Product ID: 104, Type: Variation, Parent: 103, MC Status: disapproved
+	 * - Product ID: 105, Type: Variation, Parent: 100, MC Status: disapproved
+	 *
+	 * Note that product 102 and 105 have the same parent so they will be grouped as one.
+	 * The MC status of 102 is approved while that of 105 is disapproved, Since "disapproved"
+	 * has higher priority it'd be marked as disapproved.
+	 */
+	public function test_get_product_statistics() {
+		$this->merchant_center_service->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->account_status->expects( $this->any() )
+			->method( 'getAccountLevelIssues' )
+			->willReturn( [] );
+
+		$this->merchant->expects( $this->any() )
+			->method( 'get_accountstatus' )
+			->willReturn( $this->account_status );
+
+		$this->product_repository->expects( $this->once() )
+			->method( 'find_synced_product_ids' )
+			->willReturn( [ 101, 102, 104, 105 ] );
+
+		$this->product_meta_query_helper->expects( $this->exactly( 3 ) )
+			->method( 'get_all_values' )
+			->willReturnOnConsecutiveCalls(
+				[
+					101 => [ 'TW' => 'online:en:TW:gla_101' ],
+					102 => [ 'TW' => 'online:en:TW:gla_102' ],
+					104 => [ 'TW' => 'online:en:TW:gla_104' ],
+					105 => [ 'TW' => 'online:en:TW:gla_105' ],
+				],
+				[],
+				[]
+			);
+
+		$this->product_helper->expects( $this->exactly( 12 ) )
+			->method( 'get_wc_product_id' )
+			->willReturnOnConsecutiveCalls(
+				101,
+				102,
+				104,
+				105,
+				101,
+				102,
+				104,
+				105,
+				101,
+				102,
+				104,
+				105,
+			);
+
+		$this->product_helper->expects( $this->exactly( 4 ) )
+			->method( 'get_wc_product_by_wp_post' )
+			->willReturnOnConsecutiveCalls(
+				new WP_Post(
+					(object) [
+						'ID'          => 101,
+						'post_type'   => 'product',
+						'post_parent' => 0,
+					]
+				),
+				new WP_Post(
+					(object) [
+						'ID'          => 102,
+						'post_type'   => 'product',
+						'post_parent' => 100,
+					]
+				),
+				new WP_Post(
+					(object) [
+						'ID'          => 104,
+						'post_type'   => 'product',
+						'post_parent' => 103,
+					]
+				),
+				new WP_Post(
+					(object) [
+						'ID'          => 105,
+						'post_type'   => 'product',
+						'post_parent' => 100,
+					]
+				),
+			);
+
+		$this->product_status_destination_status->expects( $this->exactly( 4 ) )
+			->method( 'getStatus' )
+			->willReturnOnConsecutiveCalls(
+				'disapproved', // 101
+				'approved',    // 102
+				'disapproved', // 104
+				'disapproved', // 105
+			);
+
+		$this->product_status_destination_status->expects( $this->exactly( 4 ) )
+			->method( 'getDestination' )
+			->willReturn( 'SurfacesAcrossGoogle' );
+
+		$this->product_status->expects( $this->exactly( 4 ) )
+			->method( 'getDestinationStatuses' )
+			->willReturnOnConsecutiveCalls(
+				[ $this->product_status_destination_status ],
+				[ $this->product_status_destination_status ],
+				[ $this->product_status_destination_status ],
+				[ $this->product_status_destination_status ],
+			);
+
+		$this->product_status->expects( $this->exactly( 12 ) )
+			->method( 'getProductId' )
+			->willReturnOnConsecutiveCalls(
+				'gla_101',
+				'gla_102',
+				'gla_104',
+				'gla_105',
+				'gla_101',
+				'gla_102',
+				'gla_104',
+				'gla_105',
+				'gla_101',
+				'gla_102',
+				'gla_104',
+				'gla_105',
+			);
+
+		$this->product_status->expects( $this->any() )
+			->method( 'getItemLevelIssues' )
+			->willReturn( [] );
+
+		$this->product_statuses_custom_batch_response_entry->expects( $this->any() )
+			->method( 'getProductStatus' )
+			->willReturn( $this->product_status );
+
+		$this->product_statuses_custom_batch_response->expects( $this->once() )
+			->method( 'getEntries' )
+			->willReturn(
+				[
+					$this->product_statuses_custom_batch_response_entry,
+					$this->product_statuses_custom_batch_response_entry,
+					$this->product_statuses_custom_batch_response_entry,
+					$this->product_statuses_custom_batch_response_entry,
+				]
+			);
+
+		$this->merchant->expects( $this->once() )
+			->method( 'get_productstatuses_batch' )
+			->willReturn( $this->product_statuses_custom_batch_response );
+
+		$product_statistics = $this->merchant_statuses->get_product_statistics( true );
+
+		$this->assertEquals(
+			[
+				'active'      => 0,
+				'expiring'    => 0,
+				'pending'     => 0,
+				'disapproved' => 3,
+				'not_synced'  => 0,
+			],
+			$product_statistics['statistics']
+		);
 	}
 }

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -259,13 +259,20 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 
 		$product_2 = WC_Helper_Product::create_simple_product();
 		$this->product_meta->update_sync_status( $product_2, SyncStatus::HAS_ERRORS );
+		$this->product_meta->update_visibility( $product_2, ChannelVisibility::SYNC_AND_SHOW );
+
+		$product_3 = WC_Helper_Product::create_simple_product();
+		$this->product_meta->update_sync_status( $product_3, SyncStatus::HAS_ERRORS );
+		$this->product_meta->update_visibility( $product_3, ChannelVisibility::DONT_SYNC_AND_SHOW );
 
 		WC_Helper_Product::create_simple_product();
 
 		$variable_product = WC_Helper_Product::create_variation_product();
 		$this->product_meta->update_sync_status( $variable_product, SyncStatus::NOT_SYNCED );
+		$this->product_meta->update_visibility( $variable_product, ChannelVisibility::SYNC_AND_SHOW );
 		foreach ( $variable_product->get_children() as $variation_id ) {
 			$this->product_meta->update_sync_status( wc_get_product( $variation_id ), SyncStatus::NOT_SYNCED );
+			$this->product_meta->update_visibility( wc_get_product( $variation_id ), ChannelVisibility::SYNC_AND_SHOW );
 		}
 
 		$this->assertEqualSets(

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -309,10 +309,14 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
 		$this->product_meta->update_failed_delete_attempts( $product_2, 5 );
 
-		$ids = [ $product_1->get_id(), $product_2->get_id() ];
+		// A trashed product that is marked as not_synced in SyncStatus.
+		$product_3 = WC_Helper_Product::create_simple_product( true, [ 'status' => 'trash' ] );
+		$this->product_helper->mark_as_unsynced( $product_3 );
+
+		$ids = [ $product_1->get_id(), $product_2->get_id(), $product_3->get_id() ];
 
 		$this->assertEquals(
-			[ $product_1->get_id() ],
+			[ $product_3->get_id() ],
 			$this->product_repository->find_delete_product_ids( $ids )
 		);
 	}

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use WC_Helper_Product;
 use WC_Product;
 
@@ -258,14 +258,14 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
 
 		$product_2 = WC_Helper_Product::create_simple_product();
-		$this->product_meta->update_mc_status( $product_2, MCStatus::NOT_SYNCED );
+		$this->product_meta->update_sync_status( $product_2, SyncStatus::HAS_ERRORS );
 
 		WC_Helper_Product::create_simple_product();
 
 		$variable_product = WC_Helper_Product::create_variation_product();
-		$this->product_meta->update_mc_status( $variable_product, MCStatus::NOT_SYNCED );
+		$this->product_meta->update_sync_status( $variable_product, SyncStatus::NOT_SYNCED );
 		foreach ( $variable_product->get_children() as $variation_id ) {
-			$this->product_meta->update_mc_status( wc_get_product( $variation_id ), MCStatus::NOT_SYNCED );
+			$this->product_meta->update_sync_status( wc_get_product( $variation_id ), SyncStatus::NOT_SYNCED );
 		}
 
 		$this->assertEqualSets(


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Project post: pcTzPl-1a9-p2

This is a follow up for #1713, which is part of the project #1610.

The number returned by product statistics API are not aligned with the syncable products count because it includes the variation products. There are two parts when getting product statistics: counting `synced` products and `not_synced` products, we need to group the variations as one for the same parent for both parts.

### 1. Group variation products when counting `synced` products.

The solution is inspired by @mikkamp's [comments in the PR 1713](https://href.li/?https://github.com/woocommerce/google-listings-and-ads/pull/1713#discussion_r987921062) by using two existing data `$this->product_data_lookup` and `$this->product_statuses` from `MerchantStatuses.php`, the format of both data are:

**product_statuses**

```json
{
  "products": {
    "602": {
      "disapproved": 1
    },
    "603": {
      "approved": 1
    }
    "604": {
      "disapproved": 1
    }
  },
  "parents": {
    "589": {
      "approved": 1,
      "disapproved": 1
    }
  }
}
```

**product_data_lookup**

```json
{
  "602": {
    "name": "Name A",
    "visibility": [],
    "parent_id": 589,
  },
  "603": {
    "name": "Name B",
    "visibility": [],
    "parent_id": 589,
  },
  "604": {
    "name": "Name C",
    "visibility": [],
    "parent_id": 0,
  },
}
```

The modified code loop through `product_statuses` and check `product_data_lookup` to see if a product has a parent. From the above data we can get two `synced` products: `589` and `604`, where `589` is a variable product that has two variations `602` and `603`.

@mikkamp also suggested in pcTzPl-I1-p2#comment-1839 that we should consider a case where one variation is `approved` and the other is `disapproved`. So we add a new data `product_statistics_priority` to assign each status a priority (in this case `disapproved` has higher priority) then we can get the correct status for each product. The new data's format looks like this:

```php
$product_statistics_priority = [
  MCStatus::APPROVED           => 6,
  MCStatus::PARTIALLY_APPROVED => 5,
  MCStatus::EXPIRING           => 4,
  MCStatus::PENDING            => 3,
  MCStatus::DISAPPROVED        => 2,
  MCStatus::NOT_SYNCED         => 1,
];
```

### 2. Get **syncable but not synced** products

- **GMC status**: product statuses fetched from GMC and stored in `wp_postmeta` with meta key `_wc_gla_mc_status` and has statues:
  - approved
  - partially_approved
  - expiring
  - pending
  - disapproved
  - not_synced
- **Sync status**: product sync statuses stored in `wp_postmeta` with meta key `_wc_gla_sync_status` and has statuses:
  - synced
  - not-synced
  - has-errors
  - pending

The original implementation to get the `not_synced` products is: finding all the `simple` and `variable` products where their GMC status is `not_synced`. While it already excludes the `variation` products but the result would contains **unsyncable** products. Our goal is to get the **syncable but not synced** products, to achieve this we could simply get all the `simple` and `variable` products where their `SyncStatus` is not `synced`. The reason why we can use `SyncStatus` is, only the **syncable** products would have a status recorded in `SyncStatus`.

### <a href="#trash-products" id="trash-products">3.</a> Fix a problem that "trashing" a product would never really trigger delete batch requests

In [DeleteProducts.php](https://github.com/woocommerce/google-listings-and-ads/blob/d1cb95b835a248f3035026f417aecd416facf28f/src/Jobs/DeleteProducts.php#L40), the format of `$product_id_map` is:

```php
[
  "online:en:TW:gla_1234" => 1234,
  "online:en:TW:gla_5678" => 5678,
]
```

However in `ProductRepository.php` the method `find_delete_product_ids()` accepts an array of WC product IDs. But even though we use `array_values` on `$product_id_map` to pass the array of IDs, the product is already in `trash` status so [WC_Product_Query](https://github.com/woocommerce/woocommerce/wiki/wc_get_products-and-WC_Product_Query#general) still couldn't get the product unless we set the args `'status' => 'trash'` in the query.

## Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

### Use an existing Merchant Centre account

1. Disconnect all accounts from GLA settings.
2. Clear `SyncStatus` and `MCStatus` from the DB.
    ```sql
    DELETE FROM wp_postmeta WHERE meta_key = '_wc_gla_sync_status';
    DELETE FROM wp_postmeta WHERE meta_key = '_wc_gla_mc_status';
    ```
3. Go through the onboarding process. In the step 1 `Set up your accounts`, choose an existing Merchant Centre account.
4. In the step 4 `Complete your campaign` you will see `Your product listings are ready to be uploaded
N products`.
5. Complete the onboarding by clicking `Skip this step for now`, as we don't need the Ads account for the test.
6. Check if the products sync jobs is completed from `/wp-admin/admin.php?page=wc-status&tab=action-scheduler&s=update_all_products&action=-1&action2=-1&orderby=schedule&order=desc&paged=1`
7. When the product sync job is done, call `GET /mc/product-statistics/refresh` or go to GLA product feed page, the total number should be identical to the `N` products in step 4.

### Create a new Merchant Centre account

Follow the above steps but in step 3 create a new Merchant Centre account.

### Add, update, or delete a product

- Adding, updating, or deleting a product, the number returned by `GET /mc/product-statistics/refresh` should be changed accordingly.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
## Changelog entry

> Update - Fix incorrect product statistics count