### PR TITLE
Detect the verification status of the phone number: Follow-up adjustments for PR 1717 code reviews

### DIFF
--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -116,7 +116,6 @@ const ContactInformation = ( { onPhoneNumberVerified } ) => {
 				<PhoneNumberCard
 					view="setup-mc"
 					phoneNumber={ phone }
-					initEditing={ null }
 					onPhoneNumberVerified={ onPhoneNumberVerified }
 				/>
 				<StoreAddressCard />

--- a/js/src/components/contact-information/phone-number-card/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card.js
@@ -134,10 +134,10 @@ const PhoneNumberCard = ( {
 	// after the phone number is verified. If `initEditing` is false or null, this useEffect handles
 	// the call of `onPhoneNumberVerified` when the loaded phone number has already been verified.
 	useEffect( () => {
-		if ( loaded && initEditing !== true && isVerified ) {
+		if ( initEditing !== true && isVerified ) {
 			onPhoneNumberVerifiedRef.current();
 		}
-	}, [ loaded, isVerified, initEditing ] );
+	}, [ initEditing, isVerified ] );
 
 	// Return a simple loading AccountCard since the initial edit state is unknown before loaded.
 	if ( isEditing === null ) {

--- a/js/src/components/contact-information/phone-number-card/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card.js
@@ -99,8 +99,8 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberVerified } ) {
  * @param {string} props.view The view the card is in.
  * @param {PhoneNumber} props.phoneNumber Phone number data.
  * @param {boolean|null} [props.initEditing=null] Specify the inital UI state.
- *     `true`: initialize with the editing UI.
- *     `false`: initialize with the viewing UI.
+ *     `true`: initialize with the editing UI for entering the phone number and proceeding with verification.
+ *     `false`: initialize with the non-editing UI viewing the phone number and a button for switching to the editing UI.
  *     `null`: determine the initial UI state according to the `data.isVerified` after the `phoneNumber` loaded.
  * @param {Function} [props.onEditClick] Called when clicking on "Edit" button.
  *     If this callback is omitted, it will enter edit mode when clicking on "Edit" button.
@@ -122,8 +122,8 @@ const PhoneNumberCard = ( {
 
 	const { isVerified } = data;
 
-	// Handle the initial UI state of `initEditing = null`.
-	// The `isEditing` state is on hold. Determine it after the `phoneNumber` loaded.
+	// If the initial value of `isEditing` got from `initEditing` is null, then the `isEditing` state
+	// is determined after the `phoneNumber` is loaded.
 	useEffect( () => {
 		if ( loaded && isEditing === null ) {
 			setEditing( ! isVerified );

--- a/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php
@@ -139,6 +139,7 @@ class ContactInformationController extends BaseOptionsController {
 				'type'        => 'string',
 				'description' => __( 'The verification status of the phone number associated with the Merchant Center account.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
+				'enum'        => [ 'verified', 'unverified' ],
 			],
 			'mc_address'                => [
 				'type'        => 'object',

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -293,9 +293,9 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 */
 	protected function is_mc_contact_information_setup(): bool {
 		$is_setup = [
-			'phone_number'              => false,
-			'phone_verification_status' => false,
-			'address'                   => false,
+			'phone_number'          => false,
+			'phone_number_verified' => false,
+			'address'               => false,
 		];
 
 		try {
@@ -311,8 +311,8 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		}
 
 		if ( $contact_info instanceof AccountBusinessInformation ) {
-			$is_setup['phone_number']              = ! empty( $contact_info->getPhoneNumber() );
-			$is_setup['phone_verification_status'] = 'VERIFIED' === $contact_info->getPhoneVerificationStatus();
+			$is_setup['phone_number']          = ! empty( $contact_info->getPhoneNumber() );
+			$is_setup['phone_number_verified'] = 'VERIFIED' === $contact_info->getPhoneVerificationStatus();
 
 			/** @var Settings $settings */
 			$settings = $this->container->get( Settings::class );
@@ -325,7 +325,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 			}
 		}
 
-		return $is_setup['phone_number'] && $is_setup['phone_verification_status'] && $is_setup['address'];
+		return $is_setup['phone_number'] && $is_setup['phone_number_verified'] && $is_setup['address'];
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1724 

This PR includes some minor changes according to the code reviews of PR #1717:

- Remove specifying of PhoneNumberCard's `initEditing` prop from `ContactInformation` component since it's the same as the default value.
- Rephrase the JSDoc descriptions and code comments for `PhoneNumberCard`'s `initEditing` prop and related processing.
- Omit the `loaded` checking in the useEffect that handles the call of `onPhoneNumberVerified` in `PhoneNumberCard`.
- Add enum to the `phone_verification_status` schema property in `ContactInformationController`.
- Rename an array key from `phone_verification_status` to `phone_number_verified` in `MerchantCenterService`.


### Detailed test instructions:

Follow the same test instructions in #1717 

### Changelog entry
