### PR TITLE
Release 2.2.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,26 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
+= 2.2.0 - 2022-10-18 =
+* Add - Ad previews in the post-onboarding ads setup flow.
+* Add - Combine the audience and shipping steps for the onboarding flow and the editing free listings page.
+* Add - Streamlined Free Listings + Paid Ads for the onboarding flow.
+* Add - The disclaimer of Comparison Shopping Service of the accounts setup of onboarding flow.
+* Add - The submission success modal on the Product Feed page after the onboarding is completed along with paid ads setup.
+* Fix - A validateDOMNesting warning in the accounts setup step of the onboarding flow.
+* Fix - Free Listings + Paid Ads: Add the paid ads previews to the boost product listings section.
+* Fix - Remove - Support for WC < 6.8.
+* Fix - Shipping time values flash during the onboarding setup.
+* Fix - Steppers on the onboarding flow allow switching to later steps when the current step is not yet finished.
+* Fix - The "Or, create a new Google Ads account" button at the footer of the Google Ads account setup is clickable when connecting an existing account.
+* Fix - The incorrect active status style for a disabled button.
+* Tweak - Use different titles for the free listings setup of the onboarding and editing pages.
+* Update - Change the steppers in the onboarding flow to only allow going back to the previous steps.
+* Update - Detect the verification status of the phone number in the contact information settings.
+* Update - Layouts and copywriting of the Get Started page and the onboarding flow.
+* Update - Logos of Google Merchant Center and Google Ads.
+* Update - Open the billing setup page of Google Ads via a popup window and add an alternative hyperlink to open the same setup page.
+* Update - The FAQs in the paid ads setup and the campaign setup page.
+
 = 2.1.4 - 2022-10-04 =
 * Add - Policy Compliance Checks in the onboarding flow.
 * Tweak - WC 7.0 compatibility.

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google Listings and Ads
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 2.1.4
+ * Version: 2.2.0
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -28,7 +28,7 @@ use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '2.1.4' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '2.2.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
 define( 'WC_GLA_MIN_WC_VER', '6.8' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "2.1.4",
+	"version": "2.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "google-listings-and-ads",
 	"title": "Google Listings and Ads",
 	"license": "GPL-3.0-or-later",
-	"version": "2.1.4",
+	"version": "2.2.0",
 	"description": "google-listings-and-ads",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -118,8 +118,4 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 * Fix - Update Size Type Attribute available values.
 * Tweak - Update Website not Claimed issue information.
 
-= 2.1.2 - 2022-09-15 =
-* Fix - WooCommerce 6.7 compatibility issues.
-* Tweak - WC 6.9 compatibility.
-
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,27 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 
 == Changelog ==
 
+= 2.2.0 - 2022-10-18 =
+* Add - Ad previews in the post-onboarding ads setup flow.
+* Add - Combine the audience and shipping steps for the onboarding flow and the editing free listings page.
+* Add - Streamlined Free Listings + Paid Ads for the onboarding flow.
+* Add - The disclaimer of Comparison Shopping Service of the accounts setup of onboarding flow.
+* Add - The submission success modal on the Product Feed page after the onboarding is completed along with paid ads setup.
+* Fix - A validateDOMNesting warning in the accounts setup step of the onboarding flow.
+* Fix - Free Listings + Paid Ads: Add the paid ads previews to the boost product listings section.
+* Fix - Remove - Support for WC < 6.8.
+* Fix - Shipping time values flash during the onboarding setup.
+* Fix - Steppers on the onboarding flow allow switching to later steps when the current step is not yet finished.
+* Fix - The "Or, create a new Google Ads account" button at the footer of the Google Ads account setup is clickable when connecting an existing account.
+* Fix - The incorrect active status style for a disabled button.
+* Tweak - Use different titles for the free listings setup of the onboarding and editing pages.
+* Update - Change the steppers in the onboarding flow to only allow going back to the previous steps.
+* Update - Detect the verification status of the phone number in the contact information settings.
+* Update - Layouts and copywriting of the Get Started page and the onboarding flow.
+* Update - Logos of Google Merchant Center and Google Ads.
+* Update - Open the billing setup page of Google Ads via a popup window and add an alternative hyperlink to open the same setup page.
+* Update - The FAQs in the paid ads setup and the campaign setup page.
+
 = 2.1.4 - 2022-10-04 =
 * Add - Policy Compliance Checks in the onboarding flow.
 * Tweak - WC 7.0 compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, google, listings, ads
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.4
-Stable tag: 2.1.4
+Stable tag: 2.2.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Jobs/SyncableProductsBatchedActionSchedulerJobTrait.php
+++ b/src/Jobs/SyncableProductsBatchedActionSchedulerJobTrait.php
@@ -11,7 +11,7 @@ use WC_Product;
 /*
  * Contains AbstractBatchedActionSchedulerJob methods.
  *
- * @since x.x.x
+ * @since 2.2.0
  */
 trait SyncableProductsBatchedActionSchedulerJobTrait {
 

--- a/src/Jobs/UpdateSyncableProductsCount.php
+++ b/src/Jobs/UpdateSyncableProductsCount.php
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
  * Get the number of syncable products (i.e. product ready to be synced to Google Merchant Center) and update it in the DB.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
- * @since x.x.x
+ * @since 2.2.0
  */
 class UpdateSyncableProductsCount extends AbstractBatchedActionSchedulerJob implements OptionsAwareInterface {
 	use OptionsAwareTrait;

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -335,7 +335,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 *
 	 * @return bool If all required items in the pre-launch checklist have been checked.
 	 *
-	 * @since x.x.x
+	 * @since 2.2.0
 	 */
 	protected function checked_pre_launch_checklist(): bool {
 		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -477,7 +477,7 @@ class ProductHelper implements Service {
 	 * @throws InvalidValue If the given param ignore_product_on_error is false and any of a given ID doesn't reference a valid product.
 	 *                      Or if a variation product does not have a valid parent ID (i.e. it's an orphan).
 	 *
-	 * @since x.x.x
+	 * @since 2.2.0
 	 */
 	public function maybe_swap_for_parent_ids( array $product_ids, bool $check_product_status = true, bool $ignore_product_on_error = true ) {
 		$new_product_ids = [];


### PR DESCRIPTION
Release 2.2.0

Changelog: 

* Add - Ad previews in the post-onboarding ads setup flow.
* Add - Combine the audience and shipping steps for the onboarding flow and the editing free listings page.
* Add - Streamlined Free Listings + Paid Ads for the onboarding flow.
* Add - The disclaimer of Comparison Shopping Service of the accounts setup of onboarding flow.
* Add - The submission success modal on the Product Feed page after the onboarding is completed along with paid ads setup.
* Fix - A validateDOMNesting warning in the accounts setup step of the onboarding flow.
* Fix - Free Listings + Paid Ads: Add the paid ads previews to the boost product listings section.
* Fix - Remove - Support for WC < 6.8.
* Fix - Shipping time values flash during the onboarding setup.
* Fix - Steppers on the onboarding flow allow switching to later steps when the current step is not yet finished.
* Fix - The "Or, create a new Google Ads account" button at the footer of the Google Ads account setup is clickable when connecting an existing account.
* Fix - The incorrect active status style for a disabled button.
* Tweak - Use different titles for the free listings setup of the onboarding and editing pages.
* Update - Change the steppers in the onboarding flow to only allow going back to the previous steps.
* Update - Detect the verification status of the phone number in the contact information settings.
* Update - Layouts and copywriting of the Get Started page and the onboarding flow.
* Update - Logos of Google Merchant Center and Google Ads.
* Update - Open the billing setup page of Google Ads via a popup window and add an alternative hyperlink to open the same setup page.
* Update - The FAQs in the paid ads setup and the campaign setup page.
