### PR TITLE
WP 6.1 Compatibility: Fix the giant icons in the `DatePicker` component

### DIFF
--- a/js/src/components/app-modal/index.js
+++ b/js/src/components/app-modal/index.js
@@ -42,6 +42,9 @@ const AppModal = ( {
 	...rest
 } ) => {
 	const modalClassName = classnames(
+		// gla-admin-page is for scoping particular styles to components that are used by
+		// a GLA admin page and are rendered via ReactDOM.createPortal.
+		'gla-admin-page',
 		'app-modal',
 		overflowStyleName[ overflow ],
 		className

--- a/js/src/components/withAdminPageShell.js
+++ b/js/src/components/withAdminPageShell.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import useLayout from '.~/hooks/useLayout';
+
+/**
+ * A higher-order component for wrapping the app shell on top of the GLA admin page.
+ * Cross-page shared things could be handled here.
+ *
+ * @param {JSX.Element} Page Top-level admin page component to be wrapped by app shell.
+ */
+const withAdminPageShell = createHigherOrderComponent(
+	( Page ) => ( props ) => {
+		useLayout( 'admin-page' );
+		return <Page { ...props } />;
+	},
+	'withAdminPageShell'
+);
+
+export default withAdminPageShell;

--- a/js/src/components/withAdminPageShell.js
+++ b/js/src/components/withAdminPageShell.js
@@ -4,11 +4,6 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
- * Internal dependencies
- */
-import useLayout from '.~/hooks/useLayout';
-
-/**
  * A higher-order component for wrapping the app shell on top of the GLA admin page.
  * Cross-page shared things could be handled here.
  *
@@ -16,8 +11,12 @@ import useLayout from '.~/hooks/useLayout';
  */
 const withAdminPageShell = createHigherOrderComponent(
 	( Page ) => ( props ) => {
-		useLayout( 'admin-page' );
-		return <Page { ...props } />;
+		return (
+			// gla-admin-page is for scoping particular styles to a GLA admin page.
+			<div className="gla-admin-page">
+				<Page { ...props } />;
+			</div>
+		);
 	},
 	'withAdminPageShell'
 );

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -2,12 +2,15 @@
 @import "node_modules/@wordpress/components/src/button/style"; // required for tab-panel
 @import "node_modules/@wordpress/components/src/panel/style";
 
-// WP 5.9 Compatibility (@wordpress/components 19.2.2):
-// The style of `VisuallyHidden` component changed to apply `style` prop directly.
-// This could be removed after
-// - GLA relies on @wordpress/components >= 19.2.2
-// - or @wordpress/components is changed to be imported via (WC)DEWP.
-@import "node_modules/@wordpress/components/src/visually-hidden/style";
+// Scope the old styles of core components to GLA pages to avoid styling conflicts with other non-GLA pages.
+.gla-admin-page {
+	// WP 5.9 Compatibility (@wordpress/components 19.2.2)
+	// The style of `VisuallyHidden` component was changed to apply `style` prop directly.
+	// This import could be removed after:
+	// - GLA relies on @wordpress/components >= 19.2.2
+	// - or @wordpress/components is changed to be imported via (WC)DEWP
+	@import "node_modules/@wordpress/components/src/visually-hidden/style"; /* stylelint-disable-line no-invalid-position-at-import-rule */
+}
 
 .components-button {
 	// Hack to show correct font color for disabled primary destructive button.

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -2,6 +2,13 @@
 @import "node_modules/@wordpress/components/src/button/style"; // required for tab-panel
 @import "node_modules/@wordpress/components/src/panel/style";
 
+// WP 5.9 Compatibility (@wordpress/components 19.2.2):
+// The style of `VisuallyHidden` component changed to apply `style` prop directly.
+// This could be removed after
+// - GLA relies on @wordpress/components >= 19.2.2
+// - or @wordpress/components is changed to be imported via (WC)DEWP.
+@import "node_modules/@wordpress/components/src/visually-hidden/style";
+
 .components-button {
 	// Hack to show correct font color for disabled primary destructive button.
 	// The color style is copied from https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L67-L72

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -4,12 +4,12 @@
 
 // Scope the old styles of core components to GLA pages to avoid styling conflicts with other non-GLA pages.
 .gla-admin-page {
-	// WP 5.9 Compatibility (@wordpress/components 19.2.2)
-	// The style of `VisuallyHidden` component was changed to apply `style` prop directly.
+	// WP 6.1 Compatibility (@wordpress/components 21.0.6 imported by @woocommerce/components)
+	// The style of `DatePicker` component was significantly changed as per the new implementations.
 	// This import could be removed after:
-	// - GLA relies on @wordpress/components >= 19.2.2
+	// - It's fixed from @woocommerce/components
 	// - or @wordpress/components is changed to be imported via (WC)DEWP
-	@import "node_modules/@wordpress/components/src/visually-hidden/style"; /* stylelint-disable-line no-invalid-position-at-import-rule */
+	@import "node_modules/@wordpress/components/src/date-time/datepicker"; /* stylelint-disable-line no-invalid-position-at-import-rule */
 }
 
 .components-button {

--- a/js/src/hooks/useLayout.js
+++ b/js/src/hooks/useLayout.js
@@ -3,9 +3,8 @@
  */
 import { useEffect } from '@wordpress/element';
 
-// Styles of .gla-full-page and .gla-full-content are defined in .~/css/shared/_woocommerce-admin.scss
+// gla-* styles are defined in .~/css/shared/_woocommerce-admin.scss
 const classNameDict = {
-	'admin-page': [ 'gla-admin-page' ],
 	'full-page': [
 		'woocommerce-admin-full-screen',
 		'is-wp-toolbar-disabled',
@@ -19,8 +18,7 @@ const classNameDict = {
  * A hook to attach specified layout styles onto topper DOM nodes when mounting,
  * and unattach when unmounting.
  *
- * @param {'admin-page'|'full-page'|'full-content'} layoutName Indicates which layout to be applied.
- *   - admin-page: Add a specific CSS class to the top of DOM tree for scoping particular styles to a GLA admin page.
+ * @param {'full-page'|'full-content'} layoutName Indicates which layout to be applied.
  *   - full-page: Display full page layout by hiding top bar, left sidebar and header.
  *   - full-content: Display full content layout by hiding header and StoreAlerts.
  */

--- a/js/src/hooks/useLayout.js
+++ b/js/src/hooks/useLayout.js
@@ -3,8 +3,9 @@
  */
 import { useEffect } from '@wordpress/element';
 
-// gla-* styles are defined in .~/css/shared/_woocommerce-admin.scss
+// Styles of .gla-full-page and .gla-full-content are defined in .~/css/shared/_woocommerce-admin.scss
 const classNameDict = {
+	'admin-page': [ 'gla-admin-page' ],
 	'full-page': [
 		'woocommerce-admin-full-screen',
 		'is-wp-toolbar-disabled',
@@ -18,7 +19,8 @@ const classNameDict = {
  * A hook to attach specified layout styles onto topper DOM nodes when mounting,
  * and unattach when unmounting.
  *
- * @param {'full-page'|'full-content'} layoutName Indicates which layout to be applied.
+ * @param {'admin-page'|'full-page'|'full-content'} layoutName Indicates which layout to be applied.
+ *   - admin-page: Add a specific CSS class to the top of DOM tree for scoping particular styles to a GLA admin page.
  *   - full-page: Display full page layout by hiding top bar, left sidebar and header.
  *   - full-content: Display full content layout by hiding header and StoreAlerts.
  */

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -11,6 +11,7 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
  * Internal dependencies
  */
 import './css/index.scss';
+import withAdminPageShell from '.~/components/withAdminPageShell';
 import GetStartedPage from './get-started-page';
 import SetupMC from './setup-mc';
 import SetupAds from './setup-ads';
@@ -48,8 +49,7 @@ addFilter(
 			__( 'Google Listings & Ads', 'google-listings-and-ads' )
 		);
 
-		return [
-			...pages,
+		const pluginAdminPages = [
 			{
 				breadcrumbs: [ ...initialBreadcrumbs ],
 				container: GetStartedPage,
@@ -124,5 +124,11 @@ addFilter(
 				},
 			},
 		];
+
+		pluginAdminPages.forEach( ( page ) => {
+			page.container = withAdminPageShell( page.container );
+		} );
+
+		return pages.concat( pluginAdminPages );
 	}
 );

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
 			},
 			{
 				"path": "./js/build/index.css",
-				"maxSize": "12 kB"
+				"maxSize": "15.4 kB"
 			},
 			{
 				"path": "./google-listings-and-ads.zip",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1736 

- ~Fix that the style of `VisuallyHidden` component is not working since WP 5.9.~
- Fix the giant icons in the `DatePicker` component
   ![image](https://user-images.githubusercontent.com/17420811/200817938-211d7120-146d-4abe-9afe-9e65d0143fb9.png)

This PR also implements the base of the app shell (#1548):

- ~Add a new value of `layoutName` to `useLayout` hook for isolating GLA's style fixes.~
- Wrap all top-level admin pages with an app shell and CSS class `gla-admin-page`.
- Add CSS class `gla-admin-page` to the root of `Modal` as well.

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/201340263-2afb0fb9-f767-4b68-a2dd-36cef2a7ca6e.png)

### Detailed test instructions:

~1. Install a WP version >= 5.9~
~2. Set up paid ads or go to GLA Settings page to view the external link on the card UI of the connected Google Ads account.~
~3. The text "(opens in a new tab)" within the external link should be invisible.~

1. Install WP 6.1.
2. Go to the Dashboard page.
3. Click the date range option to open datepicker. Switch to custom tab to verify if the icon size of navigation buttons is appropriate.

### Changelog entry

> Fix - WordPress 6.1 Compatibility: The size of navigation icons in Datepicker component should not be a giant size.
