### PR TITLE
Declare compatibility for High Performance Order Storage

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Autoloader;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\PluginValidator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\VersionValidator;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginFactory;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -48,6 +49,16 @@ register_activation_hook(
 	__FILE__,
 	function () {
 		PluginFactory::instance()->activate();
+	}
+);
+
+// HPOS compatibility declaration.
+add_action(
+	'before_woocommerce_init',
+	function () {
+		if ( class_exists( FeaturesUtil::class ) ) {
+			FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__ );
+		}
 	}
 );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Declares the extension as compatible with High Performance Order Storage. Which means the feature can be enabled while the plugin is activated.

Compatibility snippet: https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#declaring-extension-incompatibility

### Detailed test instructions:
1. Install WC 7.1 (beta or release candidate)
2. Go to WooCommerce > Settings > Advanced > Features
3. Confirm Google Listings & Ads is not on the list of incompatible plugins preventing HPOS from being enabled.


### Changelog entry
* Add - Declare compatibility for High Performance Order Storage.
