### PR TITLE
Add a hint for troubleshooting E2E on Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ To remove the Docker container and images (this will **delete everything** in th
 
 `npm run docker:down`
 
+### Linux Troubleshooting
+
+If you encounter problems starting your `test:e2e`, like `No usable sandbox!` or `UnhandledPromiseRejectionWarning: Error: Page crashed!`, you may try disabling the Chromium sandbox by adding `--no-sandbox` to `launch.args` in [`/tests/e2e/config/jest-puppeteer.config.js#L7`](https://github.com/woocommerce/google-listings-and-ads/blob/develop/tests/e2e/config/jest-puppeteer.config.js#L7).
+
 ## Docs
 
 - [Usage Tracking](./src/Tracking/README.md)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a hint for troubleshooting E2E on Linux.

I was facing `UnhandledPromiseRejectionWarning: Error: Page crashed!` on my Ubuntu 22 setup. Most probably due to some Docker permission setup. Configuring sandbox as in https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#recommended-enable-user-namespace-cloning didn't help.

@mikkamp Was facing ``No usable sandbox!``.

In both cases adding `--no-sandbox` arg helped.

However, it's not recommended and safe to disable sandbox in general, so I'd not add it to the repo's configuration permanently.


Discovered in https://github.com/woocommerce/google-listings-and-ads/pull/1636#issuecomment-1300508325

```
npm run test:e2e-dev

> google-listings-and-ads@2.0.4 test:e2e-dev /home/tomalec/repos/google-listings-and-ads
> npx wc-e2e test:e2e-dev

Testing URL: http://localhost:8084

śro, 2 lis 2022, 14:45:36 CET - Waiting for testing environment
śro, 2 lis 2022, 14:45:47 CET - Waiting for testing environment
śro, 2 lis 2022, 14:45:57 CET - Testing environment is ready
(node:50745) UnhandledPromiseRejectionWarning: Error: Page crashed!
    at Page._onTargetCrashed (/home/tomalec/repos/google-listings-and-ads/node_modules/puppeteer/lib/Page.js:213:24)
    at CDPSession.<anonymous> (/home/tomalec/repos/google-listings-and-ads/node_modules/puppeteer/lib/Page.js:122:56)
    at CDPSession.emit (events.js:400:28)
    at CDPSession._onMessage (/home/tomalec/repos/google-listings-and-ads/node_modules/puppeteer/lib/Connection.js:200:12)
    at Connection._onMessage (/home/tomalec/repos/google-listings-and-ads/node_modules/puppeteer/lib/Connection.js:112:17)
    at runNextTicks (internal/process/task_queues.js:60:5)
    at listOnTimeout (internal/timers.js:526:9)
    at processTimers (internal/timers.js:500:7)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:50745) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:50745) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

### Screenshots:

![Crashed browser](https://user-images.githubusercontent.com/17435/199522896-a67b4cdf-6018-431b-83aa-50500c5ce50b.png)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Review instruction
2. Check that they help in Ubuntu 22 setups.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add hint for Linux E2E problems.
