### PR TITLE
WC 6.9 compatibility: Fix the incorrect form states of shipping settings

### DIFF
--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -123,6 +123,24 @@ const SetupFreeListings = ( {
 					formProps.setValue( 'offer_free_shipping', undefined );
 				} );
 			}
+		} else if ( change.name === 'offer_free_shipping' ) {
+			// After selecting the 'No' option of the free shipping threshold,
+			// Reset all shipping_country_rates.options.free_shipping_threshold.
+			if ( ! change.value ) {
+				const nextValue = values.shipping_country_rates.map(
+					( rate ) => ( {
+						...rate,
+						options: {
+							...rate.options,
+							free_shipping_threshold: undefined,
+						},
+					} )
+				);
+
+				formPropsDelegateeRef.current.push( ( formProps ) => {
+					formProps.setValue( 'shipping_country_rates', nextValue );
+				} );
+			}
 		} else if ( change.name === 'shipping_country_times' ) {
 			onShippingTimesChange( values.shipping_country_times );
 		} else if ( settingsFieldNames.includes( change.name ) ) {

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -12,6 +12,7 @@ import AppSpinner from '.~/components/app-spinner';
 import Hero from '.~/components/free-listings/configure-product-listings/hero';
 import checkErrors from '.~/components/free-listings/configure-product-listings/checkErrors';
 import getOfferFreeShippingInitialValue from '.~/utils/getOfferFreeShippingInitialValue';
+import isNonFreeShippingRate from '.~/utils/isNonFreeShippingRate';
 import FormContent from './form-content';
 
 /**
@@ -112,6 +113,16 @@ const SetupFreeListings = ( {
 	const handleChange = ( change, values ) => {
 		if ( change.name === 'shipping_country_rates' ) {
 			onShippingRatesChange( values.shipping_country_rates );
+
+			// If all the shipping rates are free shipping,
+			// we set the offer_free_shipping to undefined,
+			// so that when users add a non-free shipping rate,
+			// they would need to choose "yes" / "no" for offer_free_shipping.
+			if ( ! change.value.some( isNonFreeShippingRate ) ) {
+				formPropsDelegateeRef.current.push( ( formProps ) => {
+					formProps.setValue( 'offer_free_shipping', undefined );
+				} );
+			}
 		} else if ( change.name === 'shipping_country_times' ) {
 			onShippingTimesChange( values.shipping_country_times );
 		} else if ( settingsFieldNames.includes( change.name ) ) {

--- a/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
+++ b/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
@@ -8,34 +8,10 @@ import MinimumOrderCard from './minimum-order-card';
 
 const FlatShippingRatesInputCards = ( props ) => {
 	const { audienceCountries, formProps } = props;
-	const { getInputProps, values, setValue } = formProps;
+	const { getInputProps, values } = formProps;
 	const displayFreeShippingCards = values.shipping_country_rates.some(
 		isNonFreeShippingRate
 	);
-
-	const getOfferFreeShippingChangeHandler = ( onChange ) => (
-		newOfferFreeShippingValue
-	) => {
-		/**
-		 * When users select 'No', we remove all the
-		 * shippingRate.options.free_shipping_threshold.
-		 */
-		if ( ! newOfferFreeShippingValue ) {
-			const newValue = values.shipping_country_rates.map( ( el ) => {
-				return {
-					...el,
-					options: {
-						...el.options,
-						free_shipping_threshold: undefined,
-					},
-				};
-			} );
-
-			setValue( 'shipping_country_rates', newValue );
-		}
-
-		onChange( newOfferFreeShippingValue );
-	};
 
 	return (
 		<>
@@ -47,9 +23,6 @@ const FlatShippingRatesInputCards = ( props ) => {
 				<>
 					<OfferFreeShippingCard
 						{ ...getInputProps( 'offer_free_shipping' ) }
-						onChange={ getOfferFreeShippingChangeHandler(
-							getInputProps( 'offer_free_shipping' ).onChange
-						) }
 					/>
 					{ values.offer_free_shipping && (
 						<MinimumOrderCard

--- a/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
+++ b/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
@@ -13,22 +13,6 @@ const FlatShippingRatesInputCards = ( props ) => {
 		isNonFreeShippingRate
 	);
 
-	const getShippingRatesChangeHandler = ( onChange ) => (
-		newShippingRates
-	) => {
-		/**
-		 * If all the shipping rates are free shipping,
-		 * we set the offer_free_shipping to undefined,
-		 * so that when users add a non-free shipping rate,
-		 * they would need to choose "yes" / "no" for offer_free_shipping.
-		 */
-		if ( ! newShippingRates.some( isNonFreeShippingRate ) ) {
-			setValue( 'offer_free_shipping', undefined );
-		}
-
-		onChange( newShippingRates );
-	};
-
 	const getOfferFreeShippingChangeHandler = ( onChange ) => (
 		newOfferFreeShippingValue
 	) => {
@@ -58,9 +42,6 @@ const FlatShippingRatesInputCards = ( props ) => {
 			<EstimatedShippingRatesCard
 				audienceCountries={ audienceCountries }
 				{ ...getInputProps( 'shipping_country_rates' ) }
-				onChange={ getShippingRatesChangeHandler(
-					getInputProps( 'shipping_country_rates' ).onChange
-				) }
 			/>
 			{ displayFreeShippingCards && (
 				<>

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -20,23 +20,8 @@ import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
  */
 
 const ShippingRateSection = ( { formProps, audienceCountries } ) => {
-	const { getInputProps, values, setValue } = formProps;
+	const { getInputProps, values } = formProps;
 	const inputProps = getInputProps( 'shipping_rate' );
-
-	const getShippingRateOptionChangeHandler = ( onChange ) => ( value ) => {
-		switch ( value ) {
-			case 'automatic':
-			case 'flat':
-				setValue( 'shipping_time', 'flat' );
-				break;
-
-			case 'manual':
-				setValue( 'shipping_time', 'manual' );
-				break;
-		}
-
-		onChange( value );
-	};
 
 	return (
 		<Section
@@ -78,9 +63,6 @@ const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 								) }
 								value="automatic"
 								collapsible
-								onChange={ getShippingRateOptionChangeHandler(
-									inputProps.onChange
-								) }
 							>
 								<RadioHelperText>
 									{ __(
@@ -97,9 +79,6 @@ const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 								) }
 								value="flat"
 								collapsible
-								onChange={ getShippingRateOptionChangeHandler(
-									inputProps.onChange
-								) }
 							/>
 							<AppRadioContentControl
 								{ ...inputProps }
@@ -109,9 +88,6 @@ const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 								) }
 								value="manual"
 								collapsible
-								onChange={ getShippingRateOptionChangeHandler(
-									inputProps.onChange
-								) }
 							>
 								<RadioHelperText>
 									{ createInterpolateElement(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1747

- Fix the WC 6.9 compatibility problem that the `shipping_time` of the form state will be incorrect when the selection of shipping rate is 'complex'.

### Detailed test instructions:

1. Use a WooCommerce version >= 6.9.0
2. Go to the Edit free listings page
3. Change the shipping options:
   - When the recommended or simple shipping rate is selected, shipping time settings should be displayed.
   - When the complex shipping rate is selected, shipping time settings should be hidden.
4. Save changes and then inspect the `gla/mc/settings` API request to see if the saved data are correct.
   https://github.com/woocommerce/google-listings-and-ads/blob/e464c76de235de9fd1bcb22d1917d66e48d396e8/js/src/components/free-listings/setup-free-listings/index.js#L126-L127

### Additional details:

- This fix is **NOT** compatible with WC < 6.9 but I think it should be fine since we are going to bump the minimum support WC version to 6.9.
- There is a warning as the following as it did request state updates while rendering. Given the continued use of WC `Form` component and the need to satisfy business logic, this warning might not be avoided, even though the final form state will still be synchronized.
   ![image](https://user-images.githubusercontent.com/17420811/200304537-3445f42d-31cc-4e2e-b425-98d1a451d3f8.png)

### Changelog entry

> Fix - WC 6.9 compatibility: Shipping time settings should not appear after selecting the "complex" shipping option.
> Fix - WC 6.9 compatibility: The free shipping threshold should be cleared after selecting the "No" free shipping option.
> Fix - WC 6.9 compatibility: The selected free shipping option should be reset after setting all shipping rates to 0.