### PR TITLE
WP 6.1 Compatibility: Fix styles of `Popover`, `Tooltip` and `DatePicker` components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-const webpackConfig = require( './webpack.config' );
+const { webpackConfig } = require( './webpack.config' );
 
 const webpackResolver = {
 	config: {
@@ -29,6 +29,8 @@ module.exports = {
 			'@wordpress/stylelint-config',
 			'@pmmmwh/react-refresh-webpack-plugin',
 			'react-transition-group',
+			'mini-css-extract-plugin',
+			'clean-webpack-plugin',
 		],
 		'import/resolver': { webpack: webpackResolver },
 	},

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,4 +1,5 @@
 build
+build-dev
 build-module
 coverage
 languages

--- a/js/src/css/index.scss
+++ b/js/src/css/index.scss
@@ -7,3 +7,9 @@
 
 // Import GLA-wise styling that based on woocommerce-admin styles.
 @import "./shared/woocommerce-admin";
+
+// Scope the old styles of core components to GLA pages to avoid styling conflicts with other non-GLA pages.
+.gla-admin-page {
+	/* stylelint-disable-next-line no-invalid-position-at-import-rule */
+	@import "../../build-dev/prebuild";
+}

--- a/js/src/css/prebuild.scss
+++ b/js/src/css/prebuild.scss
@@ -1,0 +1,39 @@
+// Import SCSS variables and functions used by the SCSS files in @wordpress/components.
+@import "node_modules/@wordpress/base-styles/variables";
+@import "node_modules/@wordpress/base-styles/z-index";
+
+// WP 5.9 Compatibility (@wordpress/components 19.2.2)
+// The style of `VisuallyHidden` component was changed to apply `style` prop directly.
+// This import could be removed after:
+// - GLA relies on @wordpress/components >= 19.2.2
+// - or @wordpress/components is changed to be imported via (WC)DEWP
+@import "node_modules/@wordpress/components/src/visually-hidden/style";
+
+// WP 6.1 Compatibility (@wordpress/components 21.0.6)
+// The styles of `Popover`, `Tooltip` and `DatePicker` components were significantly changed as per the new implementations.
+// These imports could be removed after:
+// - GLA relies on @wordpress/components >= 21.0.6
+// - or @wordpress/components is changed to be imported via (WC)DEWP
+@import "node_modules/@wordpress/components/src/popover/style";
+@import "node_modules/@wordpress/components/src/tooltip/style";
+@import "node_modules/@wordpress/components/src/date-time/datepicker";
+
+.components-popover {
+	// Remove the extra outline showing with the border.
+	&__content {
+		outline: none;
+	}
+
+	// Fix the incompatible arrow pseudo-elements.
+	&:not(.is-without-arrow) {
+		&::before,
+		&::after {
+			display: none;
+		}
+	}
+
+	// Fix the incorrect positioning.
+	.components-popover__content {
+		position: static;
+	}
+}

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -2,16 +2,6 @@
 @import "node_modules/@wordpress/components/src/button/style"; // required for tab-panel
 @import "node_modules/@wordpress/components/src/panel/style";
 
-// Scope the old styles of core components to GLA pages to avoid styling conflicts with other non-GLA pages.
-.gla-admin-page {
-	// WP 5.9 Compatibility (@wordpress/components 19.2.2)
-	// The style of `VisuallyHidden` component was changed to apply `style` prop directly.
-	// This import could be removed after:
-	// - GLA relies on @wordpress/components >= 19.2.2
-	// - or @wordpress/components is changed to be imported via (WC)DEWP
-	@import "node_modules/@wordpress/components/src/visually-hidden/style"; /* stylelint-disable-line no-invalid-position-at-import-rule */
-}
-
 .components-button {
 	// Hack to show correct font color for disabled primary destructive button.
 	// The color style is copied from https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L67-L72

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
 			},
 			{
 				"path": "./js/build/index.css",
-				"maxSize": "12 kB"
+				"maxSize": "16.5 kB"
 			},
 			{
 				"path": "./google-listings-and-ads.zip",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1748 

Fix WP 6.1 compatibility:

- Add a prebuild processing for importing the needed old styles.
   - Import popover style in the following way won't work since [some parent selectors were placed in the middle](https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/popover/style.scss#L174-L215). Therefore, the workaround is to build those scss files first and then import the built css file directly under the `.gla-admin-page` CSS class.
      ```scss
      .gla-admin-page {
        @import "node_modules/@wordpress/components/src/popover/style";
      }
      ```
   - Please refer to the "Heads up!" block in the Nesting section: https://sass-lang.com/documentation/at-rules/import#nesting
- The styles of `Popover` and `Tooltip` components.
- Extra: The `DatePicker` components.
   ![image](https://user-images.githubusercontent.com/17420811/200817938-211d7120-146d-4abe-9afe-9e65d0143fb9.png)

### Screenshots:

https://user-images.githubusercontent.com/17420811/200822442-ad0f776b-ba4f-44e8-8974-7f9271e426b1.mp4

### Detailed test instructions:

1. Install WP 6.1.
2. Check if the build scripts can run successfully and if the development scripts can rebuild changes.
   - `npm start`. Make some changes to JS files and the prebuild.scss. Refresh page to view the changed parts.
   - `npm run start:hot`. Make some changes to JS files and the prebuild.scss. Check if the page is updated accordingly without refreshing the page on the browser level.
   - `npm run dev`
   - `npm run build`
3. Go to the Dashboard page.
   - Click the ellipsis menu in the Programs table to check if the position and styles of the popover content are correct.
   - Click the date range option to open datepicker. Switch to custom tab to verify if the icon size of navigation buttons is appropriate.
4. Go to the Product Feed page.
   - Click the question mark icon in the Overview header. Check if the popover is displayed as floating.
   - Hover on the edit icon in the Product Feed table. Check if the tooltip is displayed.
5. Install a WP version >=5.9 and < 6.1
6. Repeat steps 2-4 to verify if this fix also works for other support WP versions.

### Additional details:

Looks like, after importing old styles, they also break some newer `@wordpress/components` imported via `@woocommerce/components`, so it needs [extra style patches](https://github.com/woocommerce/google-listings-and-ads/blob/6747c6cabc8c9366fc2d02af8c2bb3e634912152/js/src/css/prebuild.scss#L21-L39) to adjust the old styles to be compatible with the newer ones. 😅 

1. Double thick border
3. Invalid pseudo-elements
4. Incorrect positioning cut off by viewport
   ![2022-11-09 16 56 15](https://user-images.githubusercontent.com/17420811/200812141-10414701-8f65-4d78-8321-d8721cba135f.png)

Ref:

- [WP 6.0.0](https://github.com/WordPress/wordpress-develop/blob/6.0.0/package.json#L89) use `@wordpress/components` 19.8.4
   - [Popover](https://github.com/WordPress/gutenberg/tree/@wordpress/components@19.8.4/packages/components/src/popover)
   - [Tooltip](https://github.com/WordPress/gutenberg/tree/@wordpress/components@19.8.4/packages/components/src/tooltip)
   - [DateTimePicker](https://github.com/WordPress/gutenberg/tree/@wordpress/components@19.8.4/packages/components/src/date-time)
- [WP 6.1.0](https://github.com/WordPress/wordpress-develop/blob/6.1.0/package.json#L89) use `@wordpress/components` 21.0.6
   - [Popover](https://github.com/WordPress/gutenberg/tree/@wordpress/components@21.0.6/packages/components/src/popover)
   - [Tooltip](https://github.com/WordPress/gutenberg/tree/@wordpress/components@21.0.6/packages/components/src/tooltip)
   - [DateTimePicker](https://github.com/WordPress/gutenberg/tree/@wordpress/components@21.0.6/packages/components/src/date-time)

### Changelog entry

> Fix - WordPress 6.1 Compatibility: Popover and Tooltip components should be displayed as floating.
> Fix - WordPress 6.1 Compatibility: The size of navigation icons in Datepicker component should not be a giant size.