### PR TITLE
WC 7.1 Compatibility: Fix Form's onChange is called unexpected times which leads to infinite requesting state updates

### DIFF
--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -23,7 +23,7 @@ function isEvent( value ) {
  */
 
 /**
- * Renders an adapted form component that wraps the `Form` of `@wordpress/element` with
+ * Renders an adapted form component that wraps the `Form` of `@woocommerce/components` with
  * several workarounds in order to be compatible with WC 6.9 to 7.1.
  *
  * @param {Object} props React props.

--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -125,8 +125,8 @@ function AdaptiveForm( { children, ...props }, ref ) {
 					// Use `setImmediate` to avoid the warning of request state updates while rendering.
 					// Mutating a React hook state is an anti-pattern in most cases. Here is done intentionally
 					// because it's necessary to ensure this component will be triggered re-rendering through
-					// `setBatchQueue`, but also to avoid calling `settingBatchQueue` here and triggering
-					// additional rendering again.
+					// `setBatchQueue`, but also to avoid calling `setBatchQueue` here and triggering additional
+					// rendering again.
 					setImmediate( () => setDelegation( batchQueue.shift() ) );
 				}
 

--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -121,9 +121,12 @@ function AdaptiveForm( { children, ...props }, ref ) {
 
 				// Related to WC 6.9. Only one delegate can be consumed at a time in this render prop to
 				// ensure the updating states will always be the latest when calling.
-				//const { batchQueue } = adapterRef.current;
 				if ( batchQueue.length ) {
 					// Use `setImmediate` to avoid the warning of request state updates while rendering.
+					// Mutating a React hook state is an anti-pattern in most cases. Here is done intentionally
+					// because it's necessary to ensure this component will be triggered re-rendering through
+					// `setBatchQueue`, but also to avoid calling `settingBatchQueue` here and triggering
+					// additional rendering again.
 					setImmediate( () => setDelegation( batchQueue.shift() ) );
 				}
 

--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import {
+	useRef,
+	useState,
+	useEffect,
+	useCallback,
+	useImperativeHandle,
+	forwardRef,
+} from '@wordpress/element';
+import { Form } from '@woocommerce/components';
+import { get } from 'lodash';
+
+function isEvent( value ) {
+	return ( value?.nativeEvent || value ) instanceof Event;
+}
+
+/**
+ * @typedef {Object} AdaptiveFormHandler
+ * @property {(initialValues: Object) => void} resetForm Reset form with given initial values.
+ * @property {(name: string, value: *) => void} setValue Set the `name` field of the form states to the given `value`.
+ */
+
+/**
+ * Renders an adapted form component that wraps the `Form` of `@wordpress/element` with
+ * several workarounds in order to be compatible with WC 6.9 to 7.1.
+ *
+ * @param {Object} props React props.
+ * @param {JSX.Element | (formProps: Object) => JSX.Element} props.children Children to be rendered. Could be a render prop function.
+ * @param {import('react').MutableRefObject<AdaptiveFormHandler>} ref React ref to be attached to the handler of this component.
+ */
+function AdaptiveForm( { children, ...props }, ref ) {
+	const formRef = useRef();
+	const adapterRef = useRef( {} );
+	const [ batchQueue, setBatchQueue ] = useState( [] );
+	const [ delegation, setDelegation ] = useState();
+
+	const queueSetValue = useCallback( ( ...args ) => {
+		setBatchQueue( ( items ) => [ ...items, args ] );
+	}, [] );
+
+	useEffect( () => {
+		if ( delegation ) {
+			adapterRef.current.setValueCompatibly( ...delegation );
+		}
+	}, [ delegation ] );
+
+	// Since WC 6.9, the exposed interfaces were completely changed. Given that
+	// there is no longer a regular interface for updating Form values externally,
+	// this is a workaround to add the access of `setValue` for external use.
+	// Ref: https://github.com/woocommerce/woocommerce/blob/6.9.0/packages/js/components/src/form/form.tsx#L125-L127
+	useImperativeHandle( ref, () => ( {
+		// Placing `setValue` before object spreading is for compatibility <= 6.8
+		setValue: queueSetValue,
+		...formRef.current,
+	} ) );
+
+	return (
+		<Form { ...props } ref={ formRef }>
+			{ ( { setValue, setValues, getInputProps, ...formProps } ) => {
+				// Since WC 6.9, the original Form is re-implemented as Functional component from
+				// Class component. But when `setValue` is called, the closure of `values` is
+				// referenced to the currently rendered snapshot states instead of a reference
+				// that is continuously kept up to date to handle batch updates.
+				//
+				// Therefore, if the `setValue` is called more than once synchronously, the later call
+				// will overwrite the previous update one by one, so that only the last call is updated
+				// in the end.
+				//
+				// Ref:
+				// - https://github.com/woocommerce/woocommerce/blob/6.8.2/packages/js/components/src/form/index.js#L42-L46
+				// - https://github.com/woocommerce/woocommerce/blob/6.9.0/packages/js/components/src/form/form.tsx#L134-L138
+				adapterRef.current.setValueCompatibly = ( name, value ) => {
+					// WC 7.1 workaround handles the issue that after calling `setValue` to update
+					// a single value, all form `values` will be triggered `onChange` individually,
+					// even if those values don't actually change.
+					//
+					// Ref:
+					// - https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L209-L211
+					// - https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L182-L197
+					if ( setValues ) {
+						setValues( { [ name ]: value } );
+					} else {
+						// WC < 7.1 goes here as `setValues` was introduced in 7.1.
+						setValue( name, value );
+					}
+				};
+
+				// WC 6.9 workaround makes the reference of `formProps.setValue` stable to prevent
+				// an infinite re-rendering loop when using `setValue` within `useEffect`.
+				// Ref: https://github.com/woocommerce/woocommerce/blob/6.9.0/packages/js/components/src/form/form.tsx#L177
+				formProps.setValue = queueSetValue;
+
+				// The same WC 7.1 workaround as `setValueCompatibly` above, avoiding the
+				// `getInputProps(name).onChange` calling the problematic `setValue`.
+				//
+				// Ref:
+				// - https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L291-L293
+				// - https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L215-L232
+				formProps.getInputProps = ( name ) => {
+					const inputProps = getInputProps( name );
+
+					function onChange( value ) {
+						// Get value from SyntheticEvent or native Event.
+						if ( isEvent( value ) ) {
+							if ( value.target.type === 'checkbox' ) {
+								value = ! get( inputProps.values, name );
+							} else {
+								value = value.target.value;
+							}
+						}
+
+						adapterRef.current.setValueCompatibly( name, value );
+					}
+					return {
+						...inputProps,
+						onChange,
+					};
+				};
+
+				// Related to WC 6.9. Only one delegate can be consumed at a time in this render prop to
+				// ensure the updating states will always be the latest when calling.
+				//const { batchQueue } = adapterRef.current;
+				if ( batchQueue.length ) {
+					// Use `setImmediate` to avoid the warning of request state updates while rendering.
+					setImmediate( () => setDelegation( batchQueue.shift() ) );
+				}
+
+				return children( formProps );
+			} }
+		</Form>
+	);
+}
+
+export default forwardRef( AdaptiveForm );

--- a/js/src/components/adaptive-form/index.js
+++ b/js/src/components/adaptive-form/index.js
@@ -1,0 +1,1 @@
+export { default } from './adaptive-form';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Create a new component `AdaptiveForm` for wrapping workarounds for the `Form` of `@woocommerce/components` in order to be compatible with WC 6.9 to 7.1.
- Fix the issue of unanticipated number of calls Form's `onChange`.
   - Ref: https://github.com/woocommerce/google-listings-and-ads/pull/1750#issuecomment-1309300428

### Detailed test instructions:

1. Install WooCommerce 7.1.0
2. Go to the Edit free listings page
3. Change the shipping options:
   - When the recommended or simple shipping rate is selected, shipping time settings should be displayed.
   - When the complex shipping rate is selected, shipping time settings should be hidden.
4. Free Shipping selection
   1. Add shipping rates > 0
   1. Select "Yes" option for the Free Shipping
   1. Add the Minimum order to qualify for free shipping with any value bigger than 0
   1. Edit the shipping rates to 0
   1. "Save Changes" button should be enabled
5. Minimum order settings
   1. Add shipping rates > 0
   1. Select "Yes" option for the Free Shipping
   1. Add the Minimum order to qualify for free shipping with any value bigger than 0
   1. Select "No" option for the Free Shipping and then back to "Yes"
   1. The value of Minimum order... should be cleared
6. Target audience and shipping
   1. Remove a target audience country that has set the relevant shipping rate and time.
   1. Check if the removed country is also removed from the shipping rate and time settings.
7. During the test, there should not be a blank page, and there should not be unexpected callbacks if inspect the  `onChange` calls of `<From>`.
8. Install WC [7.0, 6.9]. Repeat steps 2 - 7.

💡 With this solution, it should be also compatible with some WC versions < 6.9, such as 6.8.

### Additional details:

The codes below lead to trigger `onChange` for each item in the values regardless of whether a value change did happen, even if we only call `setValue` for updating a single value.
- https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L209-L211
- https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L182-L197

### Changelog entry

> Fix - WC 7.1 compatibility: Fixing the forms in the free listings setup may cause infinite requesting state updates which lead to a blank page or issue a lot of API requests.
