### PR TITLE
Update ISO3166 package to 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"google/apiclient-services": "~0.258",
 		"googleads/google-ads-php": "^16.0",
 		"league/container": "^3.3",
-		"league/iso3166": "^3.0",
+		"league/iso3166": "^4.1",
 		"phpseclib/bcmath_compat": "^2.0",
 		"psr/container": "^1.0",
 		"symfony/validator": "^5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccc7ae9442d35f84d42e3169074cf653",
+    "content-hash": "c870e5441a3f1fbae10f20fc5abc35c6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1371,23 +1371,23 @@
         },
         {
             "name": "league/iso3166",
-            "version": "3.0.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/iso3166.git",
-                "reference": "9976d382f270ad3f3df8a68719beb7a7179ffa1e"
+                "reference": "a0dd2a1d956f85811f9c667a1744d822fb2c63d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/iso3166/zipball/9976d382f270ad3f3df8a68719beb7a7179ffa1e",
-                "reference": "9976d382f270ad3f3df8a68719beb7a7179ffa1e",
+                "url": "https://api.github.com/repos/thephpleague/iso3166/zipball/a0dd2a1d956f85811f9c667a1744d822fb2c63d8",
+                "reference": "a0dd2a1d956f85811f9c667a1744d822fb2c63d8",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3|^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
@@ -1424,7 +1424,7 @@
                 "issues": "https://github.com/thephpleague/iso3166/issues",
                 "source": "https://github.com/thephpleague/iso3166"
             },
-            "time": "2020-12-05T06:50:42+00:00"
+            "time": "2022-09-07T09:14:19+00:00"
         },
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the ISO3166 package to version 4.1, which removes any deprecation notices for PHP 8.1. The usage of the package remains the same so we don't need to adjust our code.

> **Note**
Even though we are removing some deprecation notices, WP itself might still give other Deprecated notices for the Requests library, which are unrelated and need to be resolved in WP and/or WPCLI.
Unit test are also not ready to be run for PHP 8.1 (see further details [here](https://github.com/woocommerce/google-listings-and-ads/issues/1758#issuecomment-1310294493))

Closes #1745

### Detailed test instructions:
1. Setup the plugin on a site with PHP 8.1
2. Send a request GET request to `https://domain.test/wp-json/wc/gla/mc/target_audience` (note onboarding must be completed)
3. Ensure we receive a response with a list of countries
4. If you are logging DEPRECATED notices to debug.log then check there before and after applying this PR, for the deprecated return type of `ISO3166::count()` or `ISO3166::getIterator`.

### Changelog entry
* Update - ISO3166 package version 4.1
