### PR TITLE
Proposal/RFC scoped styles with custom elements

### DIFF
--- a/js/src/components/connected-icon-label/index.js
+++ b/js/src/components/connected-icon-label/index.js
@@ -1,33 +1,39 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import { Flex, FlexItem } from '@wordpress/components';
 import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 
 /**
  * Internal dependencies
  */
-import './index.scss';
+import { css, defineShadowStylesHost } from '.~/utils/defineShadowStylesHost';
 
-const ConnectedIconLabel = ( props ) => {
-	const { className } = props;
+export const ConnectedIconLabelStyle = css`
+	:host {
+		display: inline-flex;
+		fill: currentcolor;
+		color: #23a713;
+		gap: var( --wp-grid-gap, 4px );
+		align-items: center;
 
-	return (
-		<Flex
-			className={ classnames( 'gla-connected-icon-label', className ) }
-			align="center"
-			gap={ 1 }
-		>
-			<FlexItem>
-				<GridiconCheckmarkCircle />
-			</FlexItem>
-			<FlexItem>
-				{ __( 'Connected', 'google-listings-and-ads' ) }
-			</FlexItem>
-		</Flex>
-	);
-};
+		direction: row;
+		justify-content: space-between;
+	}
+	::slotted( svg ) {
+		display: block;
+	}
+`;
+
+defineShadowStylesHost( 'gla-connected-icon-label', [
+	ConnectedIconLabelStyle,
+] );
+
+const ConnectedIconLabel = ( { className, ...props } ) => (
+	<gla-connected-icon-label class={ className } { ...props }>
+		<GridiconCheckmarkCircle />
+		{ __( 'Connected', 'google-listings-and-ads' ) }
+	</gla-connected-icon-label>
+);
 
 export default ConnectedIconLabel;

--- a/js/src/components/connected-icon-label/index.scss
+++ b/js/src/components/connected-icon-label/index.scss
@@ -1,8 +1,0 @@
-.gla-connected-icon-label {
-	fill: currentcolor;
-	color: #23a713;
-
-	svg {
-		display: block;
-	}
-}

--- a/js/src/utils/defineShadowStylesHost.js
+++ b/js/src/utils/defineShadowStylesHost.js
@@ -1,0 +1,50 @@
+/**
+ * Utility to define scoped styles using a custom element with a shadow root.
+ */
+/* global CSSStyleSheet, HTMLElement */
+/**
+ * A template literal tag to create stylesheet objects.
+ *
+ * It's overly simplify, in future we may introduce more features, like:
+ * - Safari support
+ * - lazy constructing - not to create object untill the first instance is used
+ * - safe rules nesting
+ * - etc.
+ *
+ * @param {TemplateStringsArray} strings
+ * @param  {Array} values
+ * @return {CSSStyleSheet} Constructed stylesheet.
+ */
+export const css = ( strings, ...values ) => {
+	const cssText =
+		strings.length === 1
+			? strings[ 0 ]
+			: values.reduce(
+					( accumulator, value, index ) =>
+						accumulator + value + strings[ index + 1 ],
+					strings[ 0 ]
+			  );
+	const sheet = new CSSStyleSheet();
+	sheet.replaceSync( cssText );
+	return sheet;
+};
+
+/**
+ * Creates a custom element that will act as the host for given styles.
+ *
+ * @param {string} name Valid custom element name.
+ * @param {Array<CSSStyleSheet>} styles Style sheets to be adoptes by the host.
+ */
+export const defineShadowStylesHost = ( name, styles ) => {
+	window.customElements.define(
+		name,
+		class extends HTMLElement {
+			constructor() {
+				super();
+				const shadowRoot = this.attachShadow( { mode: 'open' } );
+				shadowRoot.innerHTML = `<slot></slot>`;
+				shadowRoot.adoptedStyleSheets = styles;
+			}
+		}
+	);
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is another proposal to use Shadow DOM to encapsulate at least some of our styles.

This is an alternative to https://github.com/woocommerce/google-listings-and-ads/pull/539 that joins https://github.com/woocommerce/google-listings-and-ads/pull/538
And has all the pros and cons of both :) 

### Screenshots:
#### Declutters HTML
- We no longer need to autogenerate class names and Emotion dependency to do scoping
- Element is denoted by its name, so we do not mix the purpose of class attribute of selecting a group of elements of a kind.
- 
![image](https://user-images.githubusercontent.com/17435/201387659-b9b52d98-e784-4fff-a447-c8eaab46751b.png)
#### Declutters CSS
- We now know which rules comes from element definition, which are applied by the consumer of an element.
![image](https://user-images.githubusercontent.com/17435/201387670-ac8cc8b1-23f2-4c40-bb61-21996d3513c4.png)

![image](https://user-images.githubusercontent.com/17435/201387680-420d9aba-eaf4-4d54-8bc3-c2f4db1e3afc.png)
#### Coding flexibility
- We can use single file components
- We are CSS-in-JS ready
- But we can still use separate CSS files if we want to
- We can now explicitly import and export just styles for elements, to extend/re-use them
![image](https://user-images.githubusercontent.com/17435/201387689-2266844e-03b2-4667-90b6-4901020c9405.png)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. checkout, `npm run build`
2. go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`
3. Inspect the "Connected" element. 


### Additional details:
1. To make it work in Safari, we'd need either use a CSS polyfill, like https://www.npmjs.com/package/construct-style-sheets-polyfill - still lighter, and more bulletproof than emotion. Or we can stamp `<style>` tag to every root to play safe.
2.  Also, in long run we could enrich the `css` tagged template, or replace it with something from an external library, like lit.
3. To get <code>css`</code> highlighted in VSCode, you need a plugin like https://marketplace.visualstudio.com/items?itemName=bashmish.es6-string-css or `lit-html`
4. If we would like to avoid custom element name collisions. In case somebody else happen to register an element with `<gla-connected-icon-label>` or we want to use two different versions of the same component. **What we currently cannot with `@wordpress/` and `@woocommerce/components`** we can simply add generated suffix to `defineShadowStylesHost` and make it return the name. Styles will keep their isolation thanks to Shadow DOM.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - scope styles with shadow hosting custom element.
