### PR TITLE
Remove a semicolon that should not be rendered from `withAdminPageShell`

### DIFF
--- a/js/src/components/withAdminPageShell.js
+++ b/js/src/components/withAdminPageShell.js
@@ -14,7 +14,7 @@ const withAdminPageShell = createHigherOrderComponent(
 		return (
 			// gla-admin-page is for scoping particular styles to a GLA admin page.
 			<div className="gla-admin-page">
-				<Page { ...props } />;
+				<Page { ...props } />
 			</div>
 		);
 	},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove a semicolon that should not be rendered from `withAdminPageShell`

![2022-11-14 10 40 55](https://user-images.githubusercontent.com/17420811/201563981-56388e1e-ad86-4f97-964f-520c3917f544.png)

### Detailed test instructions:

1. Go to any of GLA admin pages.
2. There should be no semicolon at the bottom of page.

### Changelog entry
