### PR TITLE
Remove unused GRPC packages

### DIFF
--- a/bin/cleanup-vendor-files.sh
+++ b/bin/cleanup-vendor-files.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 echo Removing unused vendor files to reduce space
-rm vendor/google/grpc-gcp/cloudprober/bins/opt/grpc_php_plugin || true
 rm vendor/symfony/validator/Resources/translations/*.xlf || true

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,10 @@
 		"wp-coding-standards/wpcs": "^2.3",
 		"yoast/phpunit-polyfills": "^1.0"
 	},
+	"replace" : {
+		"google/grpc-gcp": "*",
+		"grpc/grpc": "*"
+	},
 	"license": "GPL-3.0",
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c870e5441a3f1fbae10f20fc5abc35c6",
+    "content-hash": "d3a8b2414bdede67a099175f82c3b62a",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -771,51 +771,6 @@
             "time": "2022-06-19T23:40:58+00:00"
         },
         {
-            "name": "google/grpc-gcp",
-            "version": "v0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/GoogleCloudPlatform/grpc-gcp-php.git",
-                "reference": "2465c2273e11ada1e95155aa1e209f3b8f03c314"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/2465c2273e11ada1e95155aa1e209f3b8f03c314",
-                "reference": "2465c2273e11ada1e95155aa1e209f3b8f03c314",
-                "shasum": ""
-            },
-            "require": {
-                "google/auth": "^1.3",
-                "google/protobuf": "^v3.3.0",
-                "grpc/grpc": "^v1.13.0",
-                "php": ">=5.5.0",
-                "psr/cache": "^1.0.1||^2.0.0||^3.0.0"
-            },
-            "require-dev": {
-                "google/cloud-spanner": "^1.7",
-                "phpunit/phpunit": "4.8.36"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Grpc\\Gcp\\": "src/"
-                },
-                "classmap": [
-                    "src/generated/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "gRPC GCP library for channel management",
-            "support": {
-                "issues": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/issues",
-                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.2.0"
-            },
-            "time": "2021-09-27T22:57:18+00:00"
-        },
-        {
             "name": "google/protobuf",
             "version": "v3.21.2",
             "source": {
@@ -922,50 +877,6 @@
                 "source": "https://github.com/googleads/google-ads-php/tree/v16.0.0"
             },
             "time": "2022-07-19T14:23:38+00:00"
-        },
-        {
-            "name": "grpc/grpc",
-            "version": "1.42.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/grpc/grpc-php.git",
-                "reference": "9fa44f104cb92e924d4da547323a97f3d8aca6d4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/9fa44f104cb92e924d4da547323a97f3d8aca6d4",
-                "reference": "9fa44f104cb92e924d4da547323a97f3d8aca6d4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0.0"
-            },
-            "require-dev": {
-                "google/auth": "^v1.3.0"
-            },
-            "suggest": {
-                "ext-protobuf": "For better performance, install the protobuf C extension.",
-                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Grpc\\": "src/lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "gRPC library for PHP",
-            "homepage": "https://grpc.io",
-            "keywords": [
-                "rpc"
-            ],
-            "support": {
-                "source": "https://github.com/grpc/grpc-php/tree/v1.42.0"
-            },
-            "time": "2021-11-19T08:13:51+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the unused GRPC composer packages. They are added as dependency of `googleads/google-ads-php`, however since we opted to use REST request we do not use this package. Removing the packages reduces the final plugin zip file.

Closes #1643 

### Detailed test instructions:
1. Remove and previous copy of the vendors folder and run `composer install`.
2. Confirm that the packages `grpc/grpc` and `google/grpc-gcp` are no longer found in the vendor folder.
3. Send some test requests to the Google Ads API such as load the GLA dashboard screen (make sure we have a MC and Ads account onboarded).
4. Run the unit tests locally and confirm we don't have any warnings/errors.
5. Check all the tests of this PR passed and the bundle size decreased.
![image](https://user-images.githubusercontent.com/11388669/201679608-7037b704-df56-4e61-9a02-3a40ded7562f.png)


### Changelog entry
* Tweak - Remove unused GRPC packages.
