### PR TITLE
Fix Yoast global identifiers for variable products

### DIFF
--- a/src/Integration/YoastWooCommerceSeo.php
+++ b/src/Integration/YoastWooCommerceSeo.php
@@ -151,7 +151,7 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 		if ( $product instanceof WC_Product_Variation ) {
 			$identifiers = $product->get_meta( 'wpseo_variation_global_identifiers_values', true );
 
-			if ( empty( $identifiers ) ) {
+			if ( ! is_array( $identifiers ) || empty( array_filter( $identifiers ) ) ) {
 				$parent_product = wc_get_product( $product->get_parent_id() );
 				$identifiers    = $this->get_identifier_meta( $parent_product );
 			}

--- a/src/Integration/YoastWooCommerceSeo.php
+++ b/src/Integration/YoastWooCommerceSeo.php
@@ -116,6 +116,8 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 	}
 
 	/**
+	 * Get the identifier value from cache or product meta.
+	 *
 	 * @param string     $key
 	 * @param WC_Product $product
 	 *
@@ -125,11 +127,38 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 		$product_id = $product->get_id();
 
 		if ( ! isset( $this->yoast_global_identifiers[ $product_id ] ) ) {
-			$product = $product instanceof WC_Product_Variation ? wc_get_product( $product->get_parent_id() ) : $product;
-
-			$this->yoast_global_identifiers[ $product_id ] = $product->get_meta( 'wpseo_global_identifier_values', true );
+			$this->yoast_global_identifiers[ $product_id ] = $this->get_identifier_meta( $product );
 		}
 
 		return ! empty( $this->yoast_global_identifiers[ $product_id ][ $key ] ) ? $this->yoast_global_identifiers[ $product_id ][ $key ] : null;
+	}
+
+	/**
+	 * Get identifier meta from product.
+	 * For variations fallback to parent product if meta is empty.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param WC_Product $product
+	 *
+	 * @return mixed|null
+	 */
+	protected function get_identifier_meta( WC_Product $product ) {
+		if ( ! $product ) {
+			return null;
+		}
+
+		if ( $product instanceof WC_Product_Variation ) {
+			$identifiers = $product->get_meta( 'wpseo_variation_global_identifiers_values', true );
+
+			if ( empty( $identifiers ) ) {
+				$parent_product = wc_get_product( $product->get_parent_id() );
+				$identifiers    = $this->get_identifier_meta( $parent_product );
+			}
+
+			return $identifiers;
+		}
+
+		return $product->get_meta( 'wpseo_global_identifier_values', true );
 	}
 }

--- a/tests/Unit/Integration/YoastWooCommerceSeoTest.php
+++ b/tests/Unit/Integration/YoastWooCommerceSeoTest.php
@@ -99,6 +99,52 @@ class YoastWooCommerceSeoTest extends UnitTest {
 		$this->assertNull( $adapted_product->getGtin() );
 	}
 
+	public function test_get_gtin_variation_product() {
+		$variable  = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product( $variable->get_children()[0] );
+
+		// Set identifier in variation meta.
+		$variation->update_meta_data(
+			'wpseo_variation_global_identifiers_values',
+			[ 'gtin8' => self::TEST_GTIN ]
+		);
+		$variation->save();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $variation,
+				'parent_wc_product' => $variable,
+				'gla_attributes'    => [ 'gtin' => 'yoast_seo' ],
+				'targetCountry'     => 'US',
+			]
+		);
+
+		$this->assertEquals( self::TEST_GTIN, $adapted_product->getGtin() );
+	}
+
+	public function test_get_gtin_variation_product_parent_fallback() {
+		$variable  = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product( $variable->get_children()[0] );
+
+		// Set identifier meta in parent product.
+		$variable->update_meta_data(
+			'wpseo_global_identifier_values',
+			[ 'gtin8' => self::TEST_GTIN ]
+		);
+		$variable->save();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $variation,
+				'parent_wc_product' => $variable,
+				'gla_attributes'    => [ 'gtin' => 'yoast_seo' ],
+				'targetCountry'     => 'US',
+			]
+		);
+
+		$this->assertEquals( self::TEST_GTIN, $adapted_product->getGtin() );
+	}
+
 	public function test_get_gtin_multiple_products() {
 		$product_one = WC_Helper_Product::create_simple_product( false );
 		$product_one->update_meta_data(

--- a/tests/Unit/Integration/YoastWooCommerceSeoTest.php
+++ b/tests/Unit/Integration/YoastWooCommerceSeoTest.php
@@ -145,6 +145,39 @@ class YoastWooCommerceSeoTest extends UnitTest {
 		$this->assertEquals( self::TEST_GTIN, $adapted_product->getGtin() );
 	}
 
+	public function test_get_gtin_variation_product_parent_fallback_empty_array() {
+		$variable  = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product( $variable->get_children()[0] );
+
+		// Set empty set of identifiers in variation meta.
+		$variation->update_meta_data(
+			'wpseo_variation_global_identifiers_values',
+			[
+				'gtin8'  => '',
+				'gtin13' => '',
+			]
+		);
+		$variation->save();
+
+		// Set identifier meta in parent product.
+		$variable->update_meta_data(
+			'wpseo_global_identifier_values',
+			[ 'gtin8' => self::TEST_GTIN ]
+		);
+		$variable->save();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $variation,
+				'parent_wc_product' => $variable,
+				'gla_attributes'    => [ 'gtin' => 'yoast_seo' ],
+				'targetCountry'     => 'US',
+			]
+		);
+
+		$this->assertEquals( self::TEST_GTIN, $adapted_product->getGtin() );
+	}
+
 	public function test_get_gtin_multiple_products() {
 		$product_one = WC_Helper_Product::create_simple_product( false );
 		$product_one->update_meta_data(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the global identifiers for variable products. While it's possible they are stored in the parent product, it's also possible to set the identifiers per variation. This PR takes the latter part into consideration and will fallback to the identifiers stored in the variable product if they are not set.

Closes #1763

### Detailed test instructions:
1. Install the Yoast SEO plugin: https://wordpress.org/plugins/wordpress-seo/
2. Install the Yoast SEO: WooCommerce plugin: https://github.com/Yoast/wpseo-woocommerce/releases/tag/15.3
3. Edit a variable product and under the variation data set both the Yoast identifier values and the GLA attributes to be loaded from Yoast.
![image](https://user-images.githubusercontent.com/11388669/201708028-08ba4ad8-0d9b-4513-9e66-2d55f7910d2d.png)
4. Save the product (will trigger a scheduled sync).
5. Wait till the sync completes (and some time for the product to update in Google).
6. Confirm the identifier values have been synced.
![image](https://user-images.githubusercontent.com/11388669/201709174-9a155544-e61e-4d92-819b-e4f199ea8d64.png)

### Changelog entry
* Fix - Yoast global identifiers for variable products.

