### PR TITLE
Attribute Mapping - Add tracking

### DIFF
--- a/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
 import { useState } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -12,6 +13,34 @@ import AppModal from '.~/components/app-modal';
 import AppButton from '.~/components/app-button';
 import { useAppDispatch } from '.~/data';
 
+/**
+ * Deletes the rule successfully
+ *
+ * @event gla_attribute_mapping_delete_rule
+ * @property {string} context Indicates where this event happened
+ * @property {string} id Rule id
+ * @property {string} attribute Rule attribute
+ * @property {string} source Rule source
+ * @property {string} category_condition_type Rule category condition type
+ * @property {string} categories Rule categories
+ */
+
+/**
+ * Clicks on delete rule button
+ *
+ * @event gla_attribute_mapping_delete_rule_click
+ * @property {string} context Indicates where this event happened
+ */
+
+/**
+ * Renders a Modal to confirm Attribute Mapping Rule deletion
+ *
+ * @param {Object} props Component props
+ * @param {Function} props.onRequestClose Callback function when the modal is closed
+ * @param {Object} props.rule The rule to be deleted
+ * @fires gla_attribute_mapping_delete_rule When the rule is successfully deleted
+ * @fires gla_attribute_mapping_delete_rule_click When user clicks on delete rule button
+ */
 const AttributeMappingDeleteRuleModal = ( { onRequestClose = noop, rule } ) => {
 	const [ deleting, setDeleting ] = useState( false );
 	const { deleteMappingRule } = useAppDispatch();
@@ -21,7 +50,11 @@ const AttributeMappingDeleteRuleModal = ( { onRequestClose = noop, rule } ) => {
 
 		try {
 			await deleteMappingRule( rule );
-			onRequestClose();
+			recordEvent( 'gla_attribute_mapping_delete_rule', {
+				context: 'attribute-mapping-delete-rule-modal',
+				...rule,
+			} );
+			onRequestClose( 'confirm' );
 		} catch ( error ) {
 			setDeleting( false );
 		}
@@ -29,7 +62,7 @@ const AttributeMappingDeleteRuleModal = ( { onRequestClose = noop, rule } ) => {
 
 	const handleClose = () => {
 		if ( deleting ) return;
-		onRequestClose();
+		onRequestClose( 'dismiss' );
 	};
 
 	return (
@@ -57,9 +90,9 @@ const AttributeMappingDeleteRuleModal = ( { onRequestClose = noop, rule } ) => {
 									'google-listings-and-ads'
 							  )
 					}
-					eventName="gla_attribute_mapping_delete_rule"
+					eventName="gla_attribute_mapping_delete_rule_click"
 					eventProps={ {
-						context: 'attribute-mapping-rule-modal',
+						context: 'attribute-mapping-delete-rule-modal',
 					} }
 					onClick={ onDelete }
 				/>,

--- a/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
@@ -18,11 +18,6 @@ import { useAppDispatch } from '.~/data';
  *
  * @event gla_attribute_mapping_delete_rule
  * @property {string} context Indicates where this event happened
- * @property {string} id Rule id
- * @property {string} attribute Rule attribute
- * @property {string} source Rule source
- * @property {string} category_condition_type Rule category condition type
- * @property {string} categories Rule categories
  */
 
 /**
@@ -52,7 +47,6 @@ const AttributeMappingDeleteRuleModal = ( { onRequestClose = noop, rule } ) => {
 			await deleteMappingRule( rule );
 			recordEvent( 'gla_attribute_mapping_delete_rule', {
 				context: 'attribute-mapping-delete-rule-modal',
-				...rule,
 			} );
 			onRequestClose( 'confirm' );
 		} catch ( error ) {

--- a/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
@@ -38,8 +38,8 @@ import { useAppDispatch } from '.~/data';
  * @param {Object} props Component props
  * @param {Function} props.onRequestClose Callback function when the modal is closed
  * @param {Object} props.rule The rule to be deleted
- * @fires gla_attribute_mapping_delete_rule When the rule is successfully deleted
- * @fires gla_attribute_mapping_delete_rule_click When user clicks on delete rule button
+ * @fires gla_attribute_mapping_delete_rule When the rule is successfully deleted with `context: attribute-mapping-delete-rule-modal`
+ * @fires gla_attribute_mapping_delete_rule_click When user clicks on delete rule button with `context: attribute-mapping-delete-rule-modal`
  */
 const AttributeMappingDeleteRuleModal = ( { onRequestClose = noop, rule } ) => {
 	const [ deleting, setDeleting ] = useState( false );

--- a/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
@@ -33,8 +33,8 @@ import { useAppDispatch } from '.~/data';
  * @param {Object} props Component props
  * @param {Function} props.onRequestClose Callback function when the modal is closed
  * @param {Object} props.rule The rule to be deleted
- * @fires gla_attribute_mapping_delete_rule When the rule is successfully deleted with `context: attribute-mapping-delete-rule-modal`
- * @fires gla_attribute_mapping_delete_rule_click When user clicks on delete rule button with `context: attribute-mapping-delete-rule-modal`
+ * @fires gla_attribute_mapping_delete_rule When the rule is successfully deleted with `{ context: 'attribute-mapping-delete-rule-modal'}`
+ * @fires gla_attribute_mapping_delete_rule_click When user clicks on delete rule button with `{ context: 'attribute-mapping-delete-rule-modal' }`
  */
 const AttributeMappingDeleteRuleModal = ( { onRequestClose = noop, rule } ) => {
 	const [ deleting, setDeleting ] = useState( false );

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -96,9 +96,9 @@ const prepareRule = ( newRule ) => {
  * @param {Object} props React props
  * @param {Object} [props.rule] Optional rule to manage
  * @param {Function} [props.onRequestClose] Callback on closing the modal
- * @fires gla_attribute_mapping_update_rule When the rule is successfully updated
- * @fires gla_attribute_mapping_create_rule When the rule is successfully created
- * @fires gla_attribute_mapping_save_rule_click When user clicks on save rule button
+ * @fires gla_attribute_mapping_update_rule When the rule is successfully updated  with `context: attribute-mapping-manage-rule-modal`
+ * @fires gla_attribute_mapping_create_rule When the rule is successfully created  with `context: attribute-mapping-create-rule-modal`
+ * @fires gla_attribute_mapping_save_rule_click When user clicks on save rule button  with `context: attribute-mapping-manage-rule-modal|attribute-mapping-create-rule-modal`
  */
 const AttributeMappingRuleModal = ( { rule, onRequestClose = noop } ) => {
 	const [ newRule, setNewRule ] = useState(

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -27,11 +27,6 @@ import { CATEGORY_CONDITION_SELECT_TYPES } from '.~/constants';
  *
  * @event gla_attribute_mapping_update_rule
  * @property {string} context Indicates where this event happened
- * @property {string} id Rule id
- * @property {string} attribute Rule attribute
- * @property {string} source Rule source
- * @property {string} category_condition_type Rule category condition type
- * @property {string} categories Rule categories
  */
 
 /**
@@ -39,10 +34,6 @@ import { CATEGORY_CONDITION_SELECT_TYPES } from '.~/constants';
  *
  * @event gla_attribute_mapping_create_rule
  * @property {string} context Indicates where this event happened
- * @property {string} attribute Rule attribute
- * @property {string} source Rule source
- * @property {string} category_condition_type Rule category condition type
- * @property {string} categories Rule categories
  */
 
 /**
@@ -65,9 +56,10 @@ const attributeSelectorLabel = __(
 /**
  * Map the format received from the backend into the format needed in the SelectControl
  *
- * @param {Array} data The array with the values from the backend
- * @return {Array} The data formatted
+ * @param {Array<{id: string, label: string}>} data The array with the values from the backend
+ * @return {Array<{label: string, value: string}>} The data formatted
  */
+
 const mapOptions = ( data = [] ) => {
 	return [
 		...data.map( ( attribute ) => {
@@ -147,13 +139,11 @@ const AttributeMappingRuleModal = ( { rule, onRequestClose = noop } ) => {
 				await updateMappingRule( newRule );
 				recordEvent( 'gla_attribute_mapping_update_rule', {
 					context: 'attribute-mapping-manage-rule-modal',
-					...newRule,
 				} );
 			} else {
 				await createMappingRule( newRule );
 				recordEvent( 'gla_attribute_mapping_create_rule', {
 					context: 'attribute-mapping-create-rule-modal',
-					...newRule,
 				} );
 			}
 			onRequestClose( 'confirm' );

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -88,9 +88,9 @@ const prepareRule = ( newRule ) => {
  * @param {Object} props React props
  * @param {Object} [props.rule] Optional rule to manage
  * @param {Function} [props.onRequestClose] Callback on closing the modal
- * @fires gla_attribute_mapping_update_rule When the rule is successfully updated  with `context: attribute-mapping-manage-rule-modal`
- * @fires gla_attribute_mapping_create_rule When the rule is successfully created  with `context: attribute-mapping-create-rule-modal`
- * @fires gla_attribute_mapping_save_rule_click When user clicks on save rule button  with `context: attribute-mapping-manage-rule-modal|attribute-mapping-create-rule-modal`
+ * @fires gla_attribute_mapping_update_rule When the rule is successfully updated  with `{ context: 'attribute-mapping-manage-rule-modal' }`
+ * @fires gla_attribute_mapping_create_rule When the rule is successfully created  with `{ context: 'attribute-mapping-create-rule-modal' }`
+ * @fires gla_attribute_mapping_save_rule_click When user clicks on save rule button  with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
  */
 const AttributeMappingRuleModal = ( { rule, onRequestClose = noop } ) => {
 	const [ newRule, setNewRule ] = useState(

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -65,8 +65,8 @@ const attributeSelectorLabel = __(
 /**
  * Map the format received from the backend into the format needed in the SelectControl
  *
- * @param {{id: string, label: string}[]} data The array with the values from the backend
- * @return {{label: string, value: string}[]} The data formatted
+ * @param {Array} data The array with the values from the backend
+ * @return {Array} The data formatted
  */
 const mapOptions = ( data = [] ) => {
 	return [

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -23,21 +23,6 @@ import useMappingRules from '.~/hooks/useMappingRules';
 import usePagination from '.~/hooks/usePagination';
 import { recordTablePageEvent } from '.~/utils/recordEvent';
 
-/**
- * Modal is closed
- *
- * @event gla_modal_closed
- * @property {string} context Indicates which modal is closed
- * @property {'confirm'|'dismiss'} action Indicates how the modal was closed. If closed after confirmation, then action is 'confirm', otherwise, action is 'dismiss'
- */
-
-/**
- * Modal is open
- *
- * @event gla_modal_open
- * @property {string} context Indicates which modal is open
- */
-
 const PER_PAGE = 10;
 const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
 	{

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -32,10 +32,10 @@ import { recordTablePageEvent } from '.~/utils/recordEvent';
  */
 
 /**
- * Modal is opened
+ * Modal is open
  *
  * @event gla_modal_open
- * @property {string} context Indicates which modal is opened
+ * @property {string} context Indicates which modal is open
  */
 
 const PER_PAGE = 10;

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -54,7 +54,7 @@ const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
  * Renders the Attribute Mapping table component
  *
  * @fires gla_modal_closed When any of the modals is closed
- * @fires gla_modal_open When any of the modals is open with `context: attribute-mapping-manage-rule-modal` | attribute-mapping-create-rule-modal`
+ * @fires gla_modal_open When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
  * @return {JSX.Element} The component
  */
 const AttributeMappingTable = () => {

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -54,7 +54,7 @@ const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
  * Renders the Attribute Mapping table component
  *
  * @fires gla_modal_closed When any of the modals is closed
- * @fires gla_modal_open When any of the modals is open
+ * @fires gla_modal_open When any of the modals is open with `context: attribute-mapping-manage-rule-modal`
  * @return {JSX.Element} The component
  */
 const AttributeMappingTable = () => {

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Pagination, Table, TablePlaceholder } from '@woocommerce/components';
 import { CardBody, CardFooter, Flex, FlexItem } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -21,6 +22,21 @@ import useMappingAttributes from '.~/hooks/useMappingAttributes';
 import useMappingRules from '.~/hooks/useMappingRules';
 import usePagination from '.~/hooks/usePagination';
 import { recordTablePageEvent } from '.~/utils/recordEvent';
+
+/**
+ * Modal is closed
+ *
+ * @event gla_modal_closed
+ * @property {string} context Indicates which modal is closed
+ * @property {'confirm'|'dismiss'} action Indicates how the modal was closed. If closed after confirmation, then action is 'confirm', otherwise, action is 'dismiss'
+ */
+
+/**
+ * Modal is opened
+ *
+ * @event gla_modal_open
+ * @property {string} context Indicates which modal is opened
+ */
 
 const PER_PAGE = 10;
 const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
@@ -52,6 +68,8 @@ const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
 /**
  * Renders the Attribute Mapping table component
  *
+ * @fires gla_modal_closed When any of the modals is closed
+ * @fires gla_modal_open When any of the modals is open
  * @return {JSX.Element} The component
  */
 const AttributeMappingTable = () => {
@@ -146,16 +164,28 @@ const AttributeMappingTable = () => {
 																'Manage',
 																'google-listings-and-ads'
 															) }
-															eventName="gla_attribute_mapping_manage_rule_click"
+															eventName="gla_modal_open"
 															eventProps={ {
 																context:
-																	'attribute-mapping-table',
+																	'attribute-mapping-manage-rule-modal',
 															} }
 														/>
 													}
 													modal={
 														<AttributeMappingRuleModal
 															rule={ rule }
+															onRequestClose={ (
+																action
+															) => {
+																recordEvent(
+																	'gla_modal_closed',
+																	{
+																		context:
+																			'attribute-mapping-manage-rule-modal',
+																		action,
+																	}
+																);
+															} }
 														/>
 													}
 												/>
@@ -169,16 +199,28 @@ const AttributeMappingTable = () => {
 																'Delete',
 																'google-listings-and-ads'
 															) }
-															eventName="gla_attribute_mapping_delete_rule_click"
+															eventName="gla_modal_open"
 															eventProps={ {
 																context:
-																	'attribute-mapping-table',
+																	'attribute-mapping-delete-rule-modal',
 															} }
 														/>
 													}
 													modal={
 														<AttributeMappingDeleteRuleModal
 															rule={ rule }
+															onRequestClose={ (
+																action
+															) => {
+																recordEvent(
+																	'gla_modal_closed',
+																	{
+																		context:
+																			'attribute-mapping-delete-rule-modal',
+																		action,
+																	}
+																);
+															} }
 														/>
 													}
 												/>
@@ -202,13 +244,24 @@ const AttributeMappingTable = () => {
 									'Create attribute rule',
 									'google-listings-and-ads'
 								) }
-								eventName="gla_attribute_mapping_create_rule_click"
+								eventName="gla_modal_open"
 								eventProps={ {
-									context: 'attribute-mapping-table',
+									context:
+										'attribute-mapping-create-rule-modal',
 								} }
 							/>
 						}
-						modal={ <AttributeMappingRuleModal /> }
+						modal={
+							<AttributeMappingRuleModal
+								onRequestClose={ ( action ) => {
+									recordEvent( 'gla_modal_closed', {
+										context:
+											'attribute-mapping-create-rule-modal',
+										action,
+									} );
+								} }
+							/>
+						}
 					/>
 					<Pagination
 						className="gla-attribute-mapping__pagination"

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -54,7 +54,7 @@ const ATTRIBUTE_MAPPING_TABLE_HEADERS = [
  * Renders the Attribute Mapping table component
  *
  * @fires gla_modal_closed When any of the modals is closed
- * @fires gla_modal_open When any of the modals is open with `context: attribute-mapping-manage-rule-modal`
+ * @fires gla_modal_open When any of the modals is open with `context: attribute-mapping-manage-rule-modal` | attribute-mapping-create-rule-modal`
  * @return {JSX.Element} The component
  */
 const AttributeMappingTable = () => {

--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -27,7 +27,7 @@ function isEvent( value ) {
  * several workarounds in order to be compatible with WC 6.9 to 7.1.
  *
  * @param {Object} props React props.
- * @param {JSX.Element | Function} props.children Children to be rendered. Could be a render prop function.
+ * @param {(formProps: Object) => JSX.Element | JSX.Element} props.children Children to be rendered. Could be a render prop function.
  * @param {import('react').MutableRefObject<AdaptiveFormHandler>} ref React ref to be attached to the handler of this component.
  */
 function AdaptiveForm( { children, ...props }, ref ) {

--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -27,7 +27,7 @@ function isEvent( value ) {
  * several workarounds in order to be compatible with WC 6.9 to 7.1.
  *
  * @param {Object} props React props.
- * @param {JSX.Element | (formProps: Object) => JSX.Element} props.children Children to be rendered. Could be a render prop function.
+ * @param {JSX.Element | Function} props.children Children to be rendered. Could be a render prop function.
  * @param {import('react').MutableRefObject<AdaptiveFormHandler>} ref React ref to be attached to the handler of this component.
  */
 function AdaptiveForm( { children, ...props }, ref ) {

--- a/js/src/hooks/useCategories.js
+++ b/js/src/hooks/useCategories.js
@@ -111,7 +111,7 @@ const getSelected = ( selected, allCategories ) => {
  * Return a category in SelectControl format
  *
  * @param {Object} category The category to be formatted
- * @return {{label, value, key}} The category formatted in SelectControl format
+ * @return {{label: string, value: number, key: number}} The category formatted in SelectControl format
  */
 const getSelectControlFormat = ( category ) => {
 	return {

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -144,13 +144,6 @@ const handleGuideFinish = ( e ) => {
 };
 
 /**
- * A modal is opend
- *
- * @event gla_modal_open
- * @property {string} context Indicates which modal is opened
- */
-
-/**
  * Modal window to greet the user at Product Feed, after successful completion of onboarding.
  *
  * Show this guide modal by visiting the path with a specific query `guide=submission-success`.

--- a/js/src/utils/recordEvent.js
+++ b/js/src/utils/recordEvent.js
@@ -114,7 +114,15 @@ export const recordTablePageEvent = ( context, page, direction ) => {
  * @property {string} context Indicates which modal is closed
  * @property {string} action Indicates the modal is closed by what action (e.g. `maybe-later`|`dismiss` | `create-another-campaign`)
  *   - `maybe-later` is used when the "Maybe later" button on the modal is clicked
- *   - `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, or pressing ESC
+ *   - `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, generic "Cancel" button, or pressing ESC
  *   - `create-another-campaign` is used when the button "Create another campaign" is clicked
  *   - `create-paid-campaign` is used when the button "Create paid campaign" is clicked
+ *   - `confirm` is used when the button "Confirm", "Save"  or similar generic "Accept" button is clicked
+ */
+
+/**
+ * A modal is open
+ *
+ * @event gla_modal_open
+ * @property {string} context Indicates which modal is open
  */

--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingCategoriesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingCategoriesController.php
@@ -78,13 +78,13 @@ class AttributeMappingCategoriesController extends BaseController {
 		return [
 			'id'     => [
 				'description'       => __( 'The Category ID.', 'google-listings-and-ads' ),
-				'type'              => 'string',
+				'type'              => 'integer',
 				'validate_callback' => 'rest_validate_request_arg',
 				'readonly'          => true,
 			],
 			'name'   => [
 				'description'       => __( 'The category name.', 'google-listings-and-ads' ),
-				'type'              => 'integer',
+				'type'              => 'string',
 				'validate_callback' => 'rest_validate_request_arg',
 				'readonly'          => true,
 			],

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -120,7 +120,7 @@ Creates the rule successfully
 `category_condition_type` | `string` | Rule category condition type
 `categories` | `string` | Rule categories
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When the rule is successfully created
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When the rule is successfully created  with `context: attribute-mapping-create-rule-modal`
 
 ### [`gla_attribute_mapping_delete_rule`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L16)
 Deletes the rule successfully
@@ -134,7 +134,7 @@ Deletes the rule successfully
 `category_condition_type` | `string` | Rule category condition type
 `categories` | `string` | Rule categories
 #### Emitters
-- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L44) When the rule is successfully deleted
+- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L44) When the rule is successfully deleted with `context: attribute-mapping-delete-rule-modal`
 
 ### [`gla_attribute_mapping_delete_rule_click`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L28)
 Clicks on delete rule button
@@ -143,7 +143,7 @@ Clicks on delete rule button
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L44) When user clicks on delete rule button
+- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L44) When user clicks on delete rule button with `context: attribute-mapping-delete-rule-modal`
 
 ### [`gla_attribute_mapping_save_rule_click`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L48)
 Clicks on save rule button
@@ -152,7 +152,7 @@ Clicks on save rule button
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When user clicks on save rule button
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When user clicks on save rule button  with `context: attribute-mapping-manage-rule-modal|attribute-mapping-create-rule-modal`
 
 ### [`gla_attribute_mapping_update_rule`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L25)
 Updates the rule successfully
@@ -166,7 +166,7 @@ Updates the rule successfully
 `category_condition_type` | `string` | Rule category condition type
 `categories` | `string` | Rule categories
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When the rule is successfully updated
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When the rule is successfully updated  with `context: attribute-mapping-manage-rule-modal`
 
 ### [`gla_bulk_edit_click`](../../js/src/product-feed/product-feed-table-card/index.js#L41)
 Triggered when the product feed "bulk edit" functionality is being used
@@ -571,7 +571,7 @@ A modal is open
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates which modal is open
 #### Emitters
-- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open
+- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open with `context: attribute-mapping-manage-rule-modal`
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -116,7 +116,7 @@ Creates the rule successfully
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When the rule is successfully created  with `context: attribute-mapping-create-rule-modal`
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When the rule is successfully created  with `{ context: 'attribute-mapping-create-rule-modal' }`
 
 ### [`gla_attribute_mapping_delete_rule`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L16)
 Deletes the rule successfully
@@ -125,7 +125,7 @@ Deletes the rule successfully
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L39) When the rule is successfully deleted with `context: attribute-mapping-delete-rule-modal`
+- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L39) When the rule is successfully deleted with `{ context: 'attribute-mapping-delete-rule-modal'}`
 
 ### [`gla_attribute_mapping_delete_rule_click`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L23)
 Clicks on delete rule button
@@ -134,7 +134,7 @@ Clicks on delete rule button
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L39) When user clicks on delete rule button with `context: attribute-mapping-delete-rule-modal`
+- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L39) When user clicks on delete rule button with `{ context: 'attribute-mapping-delete-rule-modal' }`
 
 ### [`gla_attribute_mapping_save_rule_click`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L39)
 Clicks on save rule button
@@ -143,7 +143,7 @@ Clicks on save rule button
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When user clicks on save rule button  with `context: attribute-mapping-manage-rule-modal|attribute-mapping-create-rule-modal`
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When user clicks on save rule button  with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal'`
 
 ### [`gla_attribute_mapping_update_rule`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L25)
 Updates the rule successfully
@@ -152,7 +152,7 @@ Updates the rule successfully
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When the rule is successfully updated  with `context: attribute-mapping-manage-rule-modal`
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When the rule is successfully updated  with `{ context: 'attribute-mapping-manage-rule-modal' }`
 
 ### [`gla_bulk_edit_click`](../../js/src/product-feed/product-feed-table-card/index.js#L41)
 Triggered when the product feed "bulk edit" functionality is being used
@@ -557,7 +557,7 @@ A modal is open
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates which modal is open
 #### Emitters
-- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open with `context: attribute-mapping-manage-rule-modal` | attribute-mapping-create-rule-modal`
+- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal'}`
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -109,6 +109,65 @@ Clicking on the button to create a new Google Ads account, after agreeing to the
 #### Emitters
 - [`BillingSetupCard`](../../js/src/components/paid-ads/billing-card/billing-setup-card.js#L52) with `{ context: 'setup-ads', link_id: 'set-up-billing',	href: billingUrl }`
 
+### [`gla_attribute_mapping_create_rule`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L37)
+Creates the rule successfully
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Indicates where this event happened
+`attribute` | `string` | Rule attribute
+`source` | `string` | Rule source
+`category_condition_type` | `string` | Rule category condition type
+`categories` | `string` | Rule categories
+#### Emitters
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When the rule is successfully created
+
+### [`gla_attribute_mapping_delete_rule`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L16)
+Deletes the rule successfully
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Indicates where this event happened
+`id` | `string` | Rule id
+`attribute` | `string` | Rule attribute
+`source` | `string` | Rule source
+`category_condition_type` | `string` | Rule category condition type
+`categories` | `string` | Rule categories
+#### Emitters
+- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L44) When the rule is successfully deleted
+
+### [`gla_attribute_mapping_delete_rule_click`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L28)
+Clicks on delete rule button
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Indicates where this event happened
+#### Emitters
+- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L44) When user clicks on delete rule button
+
+### [`gla_attribute_mapping_save_rule_click`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L48)
+Clicks on save rule button
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Indicates where this event happened
+#### Emitters
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When user clicks on save rule button
+
+### [`gla_attribute_mapping_update_rule`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L25)
+Updates the rule successfully
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Indicates where this event happened
+`id` | `string` | Rule id
+`attribute` | `string` | Rule attribute
+`source` | `string` | Rule source
+`category_condition_type` | `string` | Rule category condition type
+`categories` | `string` | Rule categories
+#### Emitters
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When the rule is successfully updated
+
 ### [`gla_bulk_edit_click`](../../js/src/product-feed/product-feed-table-card/index.js#L41)
 Triggered when the product feed "bulk edit" functionality is being used
 #### Properties
@@ -120,25 +179,25 @@ Triggered when the product feed "bulk edit" functionality is being used
 #### Emitters
 - [`ProductFeedTableCard`](../../js/src/product-feed/product-feed-table-card/index.js#L66) with `context: 'product-feed'`
 
-### [`gla_ces_feedback`](../../js/src/components/customer-effort-score-prompt/index.js#L38)
+### [`gla_ces_feedback`](../../js/src/components/customer-effort-score-prompt/index.js#L30)
 CES feedback recorded
 #### Emitters
-- [`CustomerEffortScorePrompt`](../../js/src/components/customer-effort-score-prompt/index.js#L58) whenever the CES feedback is recorded
+- [`CustomerEffortScorePrompt`](../../js/src/components/customer-effort-score-prompt/index.js#L50) whenever the CES feedback is recorded
 
-### [`gla_ces_modal_open`](../../js/src/components/customer-effort-score-prompt/index.js#L33)
+### [`gla_ces_modal_open`](../../js/src/components/customer-effort-score-prompt/index.js#L25)
 CES modal open
 #### Emitters
-- [`CustomerEffortScorePrompt`](../../js/src/components/customer-effort-score-prompt/index.js#L58) whenever the CES modal is open
+- [`CustomerEffortScorePrompt`](../../js/src/components/customer-effort-score-prompt/index.js#L50) whenever the CES modal is open
 
-### [`gla_ces_snackbar_closed`](../../js/src/components/customer-effort-score-prompt/index.js#L28)
+### [`gla_ces_snackbar_closed`](../../js/src/components/customer-effort-score-prompt/index.js#L20)
 CES prompt snackbar closed
 #### Emitters
-- [`CustomerEffortScorePrompt`](../../js/src/components/customer-effort-score-prompt/index.js#L58) whenever the CES snackbar (notice) is closed
+- [`CustomerEffortScorePrompt`](../../js/src/components/customer-effort-score-prompt/index.js#L50) whenever the CES snackbar (notice) is closed
 
-### [`gla_ces_snackbar_open`](../../js/src/components/customer-effort-score-prompt/index.js#L23)
+### [`gla_ces_snackbar_open`](../../js/src/components/customer-effort-score-prompt/index.js#L15)
 CES prompt snackbar open
 #### Emitters
-- [`CustomerEffortScorePrompt`](../../js/src/components/customer-effort-score-prompt/index.js#L58) whenever the CES snackbar (notice) is open
+- [`CustomerEffortScorePrompt`](../../js/src/components/customer-effort-score-prompt/index.js#L50) whenever the CES snackbar (notice) is open
 
 ### [`gla_chart_tab_click`](../../js/src/reports/summary-section.js#L20)
 Triggered when a chart tab is clicked
@@ -240,11 +299,14 @@ When a documentation link is clicked.
 - [`ProductStatusHelpPopover`](../../js/src/product-feed/product-statistics/product-status-help-popover/index.js#L16) with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`
 - [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
 - [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
-- [`CreateCampaign`](../../js/src/setup-ads/ads-stepper/create-campaign/index.js#L21) with `{ context: 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
+- [`CreateCampaign`](../../js/src/setup-ads/ads-stepper/create-campaign/index.js#L22) with `{ context: 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
 - [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27) with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
-- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L69) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
+- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L68) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
+- [`GoogleMCDisclaimer`](../../js/src/setup-mc/setup-stepper/setup-accounts/index.js#L33)
+	- with `{ context: 'setup-mc-accounts', link_id: 'comparison-shopping-services', href: 'https://support.google.com/merchants/topic/9080307' }`
+	- with `{ context: 'setup-mc-accounts', link_id: 'comparison-shopping-partners-find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
 
-### [`gla_edit_mc_phone_number`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L13)
+### [`gla_edit_mc_phone_number`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L14)
 Triggered when phone number edit button is clicked.
 #### Properties
 | name | type | description |
@@ -252,7 +314,7 @@ Triggered when phone number edit button is clicked.
 `path` | `string` | The path used in the page, e.g. `"/google/settings"`.
 `subpath` | `string` | The subpath used in the page, or `undefined` when there is no subpath.
 #### Emitters
-- [`PhoneNumberCardPreview`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L32) Whenever "Edit" is clicked.
+- [`PhoneNumberCardPreview`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L33) Whenever "Edit" is clicked.
 
 ### [`gla_edit_mc_store_address`](../../js/src/components/contact-information/store-address-card.js#L126)
 Trigger when store address edit button is clicked.
@@ -322,7 +384,7 @@ Clicking on faq item to collapse or expand it.
 	- with `{ context: 'get-started', id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'collapse' }`.
 	- with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'expand' }`.
 	- with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'collapse' }`.
-- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L69)
+- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L68)
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-wp-account', action: 'expand' }`.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-wp-account', action: 'collapse' }`.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'expand' }`.
@@ -485,11 +547,12 @@ A modal is closed.
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates which modal is closed
-`action` | `string` | Indicates the modal is closed by what action (e.g. `maybe-later`\|`dismiss` \| `create-another-campaign`)    - `maybe-later` is used when the "Maybe later" button on the modal is clicked    - `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, or pressing ESC    - `create-another-campaign` is used when the button "Create another campaign" is clicked    - `create-paid-campaign` is used when the button "Create paid campaign" is clicked
+`action` | `string` | Indicates the modal is closed by what action (e.g. `maybe-later`\|`dismiss` \| `create-another-campaign`)    - `maybe-later` is used when the "Maybe later" button on the modal is clicked    - `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, generic "Cancel" button, or pressing ESC    - `create-another-campaign` is used when the button "Create another campaign" is clicked    - `create-paid-campaign` is used when the button "Create paid campaign" is clicked    - `confirm` is used when the button "Confirm", "Save"  or similar generic "Accept" button is clicked
 #### Emitters
+- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is closed
 - [`Dashboard`](../../js/src/dashboard/index.js#L34) when CES modal is closed.
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
-- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L160) with `action: 'create-paid-campaign' | 'maybe-later' | 'dismiss'`
+- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
 
 ### [`gla_modal_content_link_click`](../../js/src/components/guide-page-content/index.js#L28)
 Clicking on a text link within the modal content
@@ -501,15 +564,16 @@ Clicking on a text link within the modal content
 #### Emitters
 - [`ContentLink`](../../js/src/components/guide-page-content/index.js#L46) with given `context, href`
 
-### [`gla_modal_open`](../../js/src/product-feed/submission-success-guide/index.js#L144)
-A modal is opend
+### [`gla_modal_open`](../../js/src/utils/recordEvent.js#L123)
+A modal is open
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
-`context` | `string` | Indicates which modal is opened
+`context` | `string` | Indicates which modal is open
 #### Emitters
+- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
-- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L160) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
+- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
 ### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L45)
 Clicking on the skip paid ads button to complete the onboarding flow.
@@ -571,15 +635,15 @@ Triggered on events during ads setup and editing
 #### Emitters
 - [`SetupAdsTopBar`](../../js/src/setup-ads/top-bar/index.js#L25) with given `{ target: 'back', trigger: 'click' }` when back button is clicked.
 
-### [`gla_setup_ads_faq`](../../js/src/components/paid-ads/faqs-section.js#L13)
-Clicking on faq items to collapse or expand it in the Setup Ads page
+### [`gla_setup_ads_faq`](../../js/src/components/paid-ads/faqs-section.js#L76)
+Clicking on faq items to collapse or expand it in the Onboarding Flow or creating/editing a campaign
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `id` | `string` | FAQ identifier
 `action` | `string` | (`expand`\|`collapse`)
 #### Emitters
-- [`FaqsSection`](../../js/src/components/paid-ads/faqs-section.js#L24)
+- [`FaqsSection`](../../js/src/components/paid-ads/faqs-section.js#L89)
 
 ### [`gla_setup_mc`](../../js/src/utils/recordEvent.js#L75)
 Setup Merchant Center
@@ -592,7 +656,7 @@ Setup Merchant Center
 #### Emitters
 - [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L27) with `{ target: 'set_up_free_listings', trigger: 'click', context: 'get-started' }`.
 - [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L28) with `{ target: 'set_up_free_listings', trigger: 'click', context: 'get-started-with-video' }`.
-- [`SavedSetupStepper`](../../js/src/setup-mc/setup-stepper/saved-setup-stepper.js#L34) with `{ target: 'step1_continue' | 'step2_continue' | 'step3_continue', trigger: 'click' }`.
+- [`SavedSetupStepper`](../../js/src/setup-mc/setup-stepper/saved-setup-stepper.js#L33) with `{ target: 'step1_continue' | 'step2_continue' | 'step3_continue', trigger: 'click' }`.
 - [`SetupMCTopBar`](../../js/src/setup-mc/top-bar/index.js#L17) with `{ target: 'back', trigger: 'click' }`.
 
 ### [`gla_table_go_to_page`](../../js/src/utils/recordEvent.js#L10)

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -109,18 +109,14 @@ Clicking on the button to create a new Google Ads account, after agreeing to the
 #### Emitters
 - [`BillingSetupCard`](../../js/src/components/paid-ads/billing-card/billing-setup-card.js#L52) with `{ context: 'setup-ads', link_id: 'set-up-billing',	href: billingUrl }`
 
-### [`gla_attribute_mapping_create_rule`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L37)
+### [`gla_attribute_mapping_create_rule`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L32)
 Creates the rule successfully
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
-`attribute` | `string` | Rule attribute
-`source` | `string` | Rule source
-`category_condition_type` | `string` | Rule category condition type
-`categories` | `string` | Rule categories
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When the rule is successfully created  with `context: attribute-mapping-create-rule-modal`
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When the rule is successfully created  with `context: attribute-mapping-create-rule-modal`
 
 ### [`gla_attribute_mapping_delete_rule`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L16)
 Deletes the rule successfully
@@ -128,31 +124,26 @@ Deletes the rule successfully
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
-`id` | `string` | Rule id
-`attribute` | `string` | Rule attribute
-`source` | `string` | Rule source
-`category_condition_type` | `string` | Rule category condition type
-`categories` | `string` | Rule categories
 #### Emitters
-- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L44) When the rule is successfully deleted with `context: attribute-mapping-delete-rule-modal`
+- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L39) When the rule is successfully deleted with `context: attribute-mapping-delete-rule-modal`
 
-### [`gla_attribute_mapping_delete_rule_click`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L28)
+### [`gla_attribute_mapping_delete_rule_click`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L23)
 Clicks on delete rule button
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L44) When user clicks on delete rule button with `context: attribute-mapping-delete-rule-modal`
+- [`AttributeMappingDeleteRuleModal`](../../js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js#L39) When user clicks on delete rule button with `context: attribute-mapping-delete-rule-modal`
 
-### [`gla_attribute_mapping_save_rule_click`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L48)
+### [`gla_attribute_mapping_save_rule_click`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L39)
 Clicks on save rule button
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When user clicks on save rule button  with `context: attribute-mapping-manage-rule-modal|attribute-mapping-create-rule-modal`
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When user clicks on save rule button  with `context: attribute-mapping-manage-rule-modal|attribute-mapping-create-rule-modal`
 
 ### [`gla_attribute_mapping_update_rule`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L25)
 Updates the rule successfully
@@ -160,13 +151,8 @@ Updates the rule successfully
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
-`id` | `string` | Rule id
-`attribute` | `string` | Rule attribute
-`source` | `string` | Rule source
-`category_condition_type` | `string` | Rule category condition type
-`categories` | `string` | Rule categories
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L103) When the rule is successfully updated  with `context: attribute-mapping-manage-rule-modal`
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When the rule is successfully updated  with `context: attribute-mapping-manage-rule-modal`
 
 ### [`gla_bulk_edit_click`](../../js/src/product-feed/product-feed-table-card/index.js#L41)
 Triggered when the product feed "bulk edit" functionality is being used
@@ -571,7 +557,7 @@ A modal is open
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates which modal is open
 #### Emitters
-- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open with `context: attribute-mapping-manage-rule-modal`
+- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open with `context: attribute-mapping-manage-rule-modal` | attribute-mapping-create-rule-modal`
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -143,7 +143,7 @@ Clicks on save rule button
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates where this event happened
 #### Emitters
-- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When user clicks on save rule button  with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal'`
+- [`AttributeMappingRuleModal`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L95) When user clicks on save rule button  with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
 
 ### [`gla_attribute_mapping_update_rule`](../../js/src/attribute-mapping/attribute-mapping-rule-modal.js#L25)
 Updates the rule successfully
@@ -557,7 +557,7 @@ A modal is open
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates which modal is open
 #### Emitters
-- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal'}`
+- [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L60) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #1648 .

This PR adds the tracking for the feature:

`gla_modal_closed`
`gla_modal_open`
`gla_attribute_mapping_save_rule_click`
`gla_attribute_mapping_delete_rule_click`
`gla_attribute_mapping_create_rule`
`gla_attribute_mapping_update_rule`
`gla_attribute_mapping_delete_rule`

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Enable event tracking logging by running `localStorage.setItem( 'debug', 'wc-admin:*' )` in the Console tab of DevTool, and refresh page to make it effective.
2. Go to Attribute Mapping page and click on Create rule button. It should trigger `gla_modal_open` with the context `attribute-mapping-create-rule-modal`.
3. Close the modal using cancel button, X button and clicking outside. It should trigger the event `gla_modal_closed` with the context `attribute-mapping-create-rule-modal` and the action `dismiss`
4.  Click again on Create rule button and click on save rule (after filling the form). It should trigger  `gla_attribute_mapping_save_rule_click` with context  `attribute-mapping-create-rule-modal` and also `gla_attribute_mapping_create_rule` with the same context and the rule props.
5. Click on Manage on the rule you just created. It should trigger  `gla_modal_open` with context  `attribute-mapping-manage-rule-modal`
6. Close the modal using cancel button, X button and clicking outside. It should trigger the event `gla_modal_closed` with the context `attribute-mapping-manage-rule-modal` and the action `dismiss`
7. Click again on Manage on the rule you just created and click on Save rule (after modifying the rule). It should trigger  `gla_attribute_mapping_save_rule_click` with context  `attribute-mapping-manage-rule-modal` and also `gla_attribute_mapping_update_rule` with the same context and the rule props.
8. Click on Delete on the rule you just created. It should trigger  `gla_modal_open` with context  `attribute-mapping-delete-rule-modal`
9. Close the modal using cancel button, X button and clicking outside. It should trigger the event `gla_modal_closed` with the context `attribute-mapping-delete-rule-modal` and the action `dismiss`
10. 8. Click again on Delete on the rule you just created. Confirm deletion. It should trigger  `gla_attribute_mapping_delete_rule_click` with context  `attribute-mapping-delete-rule-modal` and also `gla_attribute_mapping_delete_rule` with the same context and the rule props.


### Additional details:

Some  errors happened when I run `npm run doc:tracking`. Most of them are fixable by changing JSDOC definition but the one at the end:

```
google-listings-and-ads/node_modules/jsdoc-advanced-types-plugin/index.js:105
				throw "infinite loop!"
```

Requires more investigation and might be solved in future PRs