### PR TITLE
Composer `install-scripts` are now OS-indifferent, path safe, and mention modified files

### DIFF
--- a/bin/GoogleAdsCleanupServices.php
+++ b/bin/GoogleAdsCleanupServices.php
@@ -193,15 +193,17 @@ class GoogleAdsCleanupServices {
 		try {
 			$rdi = new RecursiveDirectoryIterator( $path );
 		} catch ( UnexpectedValueException $e ) {
-			$this->output_text( sprintf(
-				'Expected directory "%s" was not found',
-				$path
-			) );
+			$this->output_text(
+				sprintf(
+					'Expected directory "%s" was not found',
+					$path
+				)
+			);
 			exit( 1 );
 		}
 
-		$rii = new RecursiveIteratorIterator( $rdi );
-		$rri = new RegexIterator( $rii, $match );
+		$rii   = new RecursiveIteratorIterator( $rdi );
+		$rri   = new RegexIterator( $rii, $match );
 		$files = [];
 		foreach ( $rri as $file ) {
 			$files[] = $file->getPathname();
@@ -219,12 +221,12 @@ class GoogleAdsCleanupServices {
 	 * @return array List of names that match.
 	 */
 	protected function find_used_pattern( string $pattern ): array {
-		$files  = $this->get_dir_contents( $this->code_path,  '/\.php$/i');
+		$files  = $this->get_dir_contents( $this->code_path, '/\.php$/i' );
 		$output = [];
-		foreach ( $files as $file) {
-			preg_match_all( '/' . $pattern . '/', file_get_contents( $file ), $matches); // phpcs:ignore WordPress.WP.AlternativeFunctions
+		foreach ( $files as $file ) {
+			preg_match_all( "/{$pattern}/", file_get_contents( $file ), $matches ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 			if ( isset( $matches[1] ) ) {
-				foreach ($matches[1] AS $match) {
+				foreach ( $matches[1] as $match ) {
 					$output[] = $match;
 				}
 			}
@@ -234,7 +236,7 @@ class GoogleAdsCleanupServices {
 			return [];
 		}
 
-		return array_unique($output);
+		return array_unique( $output );
 	}
 
 	/**

--- a/bin/GoogleAdsCleanupServices.php
+++ b/bin/GoogleAdsCleanupServices.php
@@ -4,6 +4,10 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Util;
 
 use Composer\Script\Event;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use UnexpectedValueException;
 
 /**
  * Utilities to remove Google Ads API services in the library.
@@ -179,27 +183,27 @@ class GoogleAdsCleanupServices {
 	}
 
 	/**
-	 * Find a list of files in a path matching a pattern.
+	 * Find a list of files in a path, including subdirectories, matching a pattern.
 	 *
 	 * @param string $path Package path
 	 * @param string $match Regex pattern to match
 	 * @return array Matching files
 	 */
-	protected function get_dir_contents($path, $match) {
+	protected function get_dir_contents( $path, $match ) {
 		try {
-			$rdi = new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS);
-		} catch ( Exception  $e ) {
-			printf(
-				'Expected directory "%s" was not found' . PHP_EOL,
+			$rdi = new RecursiveDirectoryIterator( $path );
+		} catch ( UnexpectedValueException $e ) {
+			$this->output_text( sprintf(
+				'Expected directory "%s" was not found',
 				$path
-			);
+			) );
 			exit( 1 );
 		}
 
-		$rii = new \RecursiveIteratorIterator($rdi);
-		$rri = new \RegexIterator($rii, $match);
+		$rii = new RecursiveIteratorIterator( $rdi );
+		$rri = new RegexIterator( $rii, $match );
 		$files = [];
-		foreach ($rri as $file) {
+		foreach ( $rri as $file ) {
 			$files[] = $file->getPathname();
 		}
 
@@ -217,8 +221,8 @@ class GoogleAdsCleanupServices {
 	protected function find_used_pattern( string $pattern ): array {
 		$files  = $this->get_dir_contents( $this->code_path,  '/\.php$/i');
 		$output = [];
-		foreach ( $files AS $file) {
-			preg_match_all( '/' . $pattern . '/', file_get_contents( $file ), $matches);
+		foreach ( $files as $file) {
+			preg_match_all( '/' . $pattern . '/', file_get_contents( $file ), $matches); // phpcs:ignore WordPress.WP.AlternativeFunctions
 			if ( isset( $matches[1] ) ) {
 				foreach ($matches[1] AS $match) {
 					$output[] = $match;

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -154,14 +154,14 @@ function get_dir_contents( $path, $match ) {
 		exit( 1 );
 	}
 
-	$rii = new RecursiveIteratorIterator($rdi);
-    $rri = new RegexIterator($rii, $match);
-    $files = [];
-    foreach ($rri as $file) {
+	$rii = new RecursiveIteratorIterator( $rdi );
+	$rri = new RegexIterator( $rii, $match );
+	$files = [];
+	foreach ( $rri as $file ) {
 		$files[] = $file->getPathname();
 	}
 
-    return $files;
+	return $files;
 }
 
 /**
@@ -176,11 +176,11 @@ function get_dir_contents( $path, $match ) {
 function find_files( string $path ): array {
 	global $vendor_dir, $dependencies;
 
-	$files = get_dir_contents($vendor_dir . '/' . $path, '/\.php$/i');
+	$files = get_dir_contents( "{$vendor_dir}/{$path}", '/\.php$/i' );
 
 	if ( ! empty( $dependencies[ $path ] ) ) {
 		foreach ( $dependencies[ $path ] as $dependency ) {
-			$dependent_files = get_dir_contents($vendor_dir . '/' . $dependency, '/\.php$/i');
+			$dependent_files = get_dir_contents( "{$vendor_dir}/{$dependency}", '/\.php$/i' );
 			$files = array_merge( $files, $dependent_files );
 		}
 	}

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -103,7 +103,10 @@ foreach ( $replacements as $namespace => $path ) {
 	}
 
 	// Update the namespace in the composer.json files, recursively finding all files named explicitly "composer.json".
-	$composer_files = get_dir_contents($vendor_dir . '/' . $path, '/' . preg_quote(DIRECTORY_SEPARATOR . 'composer.json') . '$/');
+	$composer_files = get_dir_contents(
+		"{$vendor_dir}/{$path}",
+		'/' . preg_quote( DIRECTORY_SEPARATOR, '/') . 'composer.json$/'
+	);
 
 	array_map(
 		function( $file ) use ( $namespace, $new_namespace ) {
@@ -234,7 +237,7 @@ function remove_file_autoloads( string $file, array $composer_autoload, string $
 
 	$modified = false;
 	foreach ( $json['packages'] as $key => $package ) {
-		if ( strpos( $package['name'], $package_name ) ) {
+		if ( 0 !== strpos( $package['name'], $package_name ) ) {
 			continue;
 		}
 

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -45,6 +45,9 @@ $direct_replacements = [
 // Read our composer.json file into an array.
 $composer_json = json_decode( file_get_contents( dirname( __DIR__ ) . '/composer.json' ), true );
 
+// Flag modified files that maybe should have been modified more.
+$file_notices = [];
+
 foreach ( $replacements as $namespace => $path ) {
 	$files = find_files( $path );
 
@@ -57,39 +60,51 @@ foreach ( $replacements as $namespace => $path ) {
 			continue 2;
 		}
 
+		$namespace_change = 0;
+		$uses_change      = 0;
+
 		$contents =	preg_replace(
 			"#^(\s*)(namespace)\s*({$quoted}[\\\\|;])#m",
 			"\$1\$2 {$new_namespace}\\\\\$3",
-			$contents
+			$contents,
+			-1,
+			$namespace_change
 		);
 
 		$contents =	preg_replace(
 			"#^(\s*)(use)\s*({$quoted}\\\\)#m",
 			"\$1\$2 {$new_namespace}\\\\\$3",
-			$contents
+			$contents,
+			-1,
+			$uses_change
 		);
 
 		if ( ! empty( $direct_replacements[ $path ] ) ) {
 			foreach ( $direct_replacements[ $path ] as $replace ) {
-				$replace  = preg_quote( $replace, '#' );
-				$contents =	preg_replace(
+				$direct_change = 0;
+				$replace       = preg_quote( $replace, '#' );
+				$contents      = preg_replace(
 					"#({$replace})#m",
 					"{$new_namespace}\\\\\$1",
-					$contents
+					$contents,
+					-1,
+					$direct_change
 				);
+				if ( 0 < $direct_change ) {
+					$uses_change += $direct_change;
+				}
 			}
+		}
+		if ( 0 === $namespace_change && 0 < $uses_change ) {
+			$file_notices[] = $file;
 		}
 
 		file_put_contents( $file, $contents );
 	}
 
 	// Update the namespace in the composer.json files.
-	$composer_files = array_filter(
-		explode(
-			"\n",
-			`find "{$vendor_dir}/{$path}" -iname 'composer.json'`
-		)
-	);
+
+	$composer_files = get_dir_contents($vendor_dir . DIRECTORY_SEPARATOR . $path, '/composer.json/');
 
 	array_map(
 		function( $file ) use ( $namespace, $new_namespace ) {
@@ -110,6 +125,43 @@ foreach ( $replacements as $namespace => $path ) {
 	);
 }
 
+if ( 0 < count( $file_notices ) ) {
+	printf(
+		'Several files were modified without changes to namespace: %s' . PHP_EOL,
+		implode('; ', $file_notices)
+	);
+}
+
+/**
+ * Find a list of files in a path matching a pattern.
+ *
+ * @since 2.2.2
+ *
+ * @param string $path Package path
+ * @param string $match Regex pattern to match
+ * @return array Matching files
+ */
+function get_dir_contents($path, $match) {
+	try {
+		$rdi = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS);
+	} catch ( Exception  $e ) {
+		printf(
+			'Expected directory "%s" was not found' . PHP_EOL,
+			$path
+		);
+		exit( 1 );
+	}
+
+	$rii = new RecursiveIteratorIterator($rdi);
+    $rri = new RegexIterator($rii, $match);
+    $files = [];
+    foreach ($rri as $file) {
+		$files[] = $file->getPathname();
+	}
+
+    return $files;
+}
+
 /**
  * Find a list of PHP files for this package, and append a list of dependent
  * files that use the package.
@@ -122,21 +174,11 @@ foreach ( $replacements as $namespace => $path ) {
 function find_files( string $path ): array {
 	global $vendor_dir, $dependencies;
 
-	$files = array_filter(
-		explode(
-			"\n",
-			`find "{$vendor_dir}/{$path}" -iname '*.php'`
-		)
-	);
+	$files = get_dir_contents($vendor_dir . DIRECTORY_SEPARATOR . $path, '/\.php$/i');
 
 	if ( ! empty( $dependencies[ $path ] ) ) {
 		foreach ( $dependencies[ $path ] as $dependency ) {
-			$dependent_files = array_filter(
-				explode(
-					"\n",
-					`find "{$vendor_dir}/{$dependency}" -iname '*.php'`
-				)
-			);
+			$dependent_files = get_dir_contents($vendor_dir . DIRECTORY_SEPARATOR . $dependency, '/\.php$/i');
 			$files = array_merge( $files, $dependent_files );
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

For occasions where `composer install` is run on a non-*NIX operating system, or in a path that included a " ", the install had been failing. This modifies the calls to happen entirely within PHP, so it works on any OS and within any path.

The script also tweaks `prefix-vendor-namespace.php` to mention files that have their class dependencies altered, but retain their original namespace (with intent of ensuring future package changes to introduce new namespace conflicts similar to #1760)



### Changelog entry

> Dev - Adjusted parts of the post-install process to work on machines without `grep` and `find`. 
> Dev - Adjusted post-install process to mention when files have their class-expectations modified but retain their original namespace.
