### PR TITLE
Bump WC/WP Components: Component Text fix

### DIFF
--- a/js/src/components/app-text/index.js
+++ b/js/src/components/app-text/index.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
+
+/**
+ * Renders a paragraph with some predefined styles based on the variant
+ *
+ *
+ * ```jsx
+ * <AppText variant="title-small">
+ * 		My text
+ * </AppText>
+ * ```
+ *
+ * @param {Object} props Component props
+ * @param {string} props.variant The variant to use for the text
+ * @param {string} props.className Custom classname for this component
+ * @param {JSX.Element} props.children The content for this component
+ * @return {JSX.Element} The component
+ */
+const AppText = ( { variant, className, children } ) => {
+	return (
+		<p
+			className={ classnames(
+				'gla-app-text',
+				`gla-app-text--${ variant }`,
+				className
+			) }
+		>
+			{ children }
+		</p>
+	);
+};
+
+export default AppText;

--- a/js/src/components/app-text/index.js
+++ b/js/src/components/app-text/index.js
@@ -21,20 +21,28 @@ import './index.scss';
  * @param {Object} props Component props
  * @param {string} [props.variant] The variant to use for the text
  * @param {string} [props.className] Custom classname for this component
+ * @param {keyof JSX.IntrinsicElements} [props.as] as Custom HTML tag for the component (by default <p>)
  * @param {JSX.Element} props.children The content for this component
  * @param {Object} [props.rest] Params to be forworded to the component
  * @return {JSX.Element} The component
  */
-const AppText = ( { variant, className = '', children, ...rest } ) => {
+const AppText = ( {
+	variant,
+	className = '',
+	children,
+	as = 'p',
+	...rest
+} ) => {
+	const AsTag = as;
 	return (
-		<p
+		<AsTag
 			{ ...rest }
 			className={ classnames( 'gla-app-text', className, {
 				[ `gla-app-text--${ variant }` ]: variant,
 			} ) }
 		>
 			{ children }
-		</p>
+		</AsTag>
 	);
 };
 

--- a/js/src/components/app-text/index.js
+++ b/js/src/components/app-text/index.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
+
+/**
+ * Renders a paragraph with some predefined styles based on the variant
+ *
+ *
+ * ```jsx
+ * <AppText variant="title-small">
+ * 		My text
+ * </AppText>
+ * ```
+ *
+ * @param {Object} props Component props
+ * @param {string} [props.variant] The variant to use for the text
+ * @param {string} [props.className] Custom classname for this component
+ * @param {JSX.Element} props.children The content for this component
+ * @param {Object} [props.rest] Params to be forworded to the component
+ * @return {JSX.Element} The component
+ */
+const AppText = ( { variant, className = '', children, ...rest } ) => {
+	return (
+		<p
+			{ ...rest }
+			className={ classnames( 'gla-app-text', className, {
+				[ `gla-app-text--${ variant }` ]: variant,
+			} ) }
+		>
+			{ children }
+		</p>
+	);
+};
+
+export default AppText;

--- a/js/src/components/app-text/index.js
+++ b/js/src/components/app-text/index.js
@@ -21,7 +21,7 @@ import './index.scss';
  * @param {Object} props Component props
  * @param {string} [props.variant] The variant to use for the text
  * @param {string} [props.className] Custom classname for this component
- * @param {keyof JSX.IntrinsicElements} [props.as] as Custom HTML tag for the component (by default <p>)
+ * @param {string} [props.as] as Custom HTML tag for the component. For example: p, h1, h2, h3, span... (by default <p>)
  * @param {JSX.Element} props.children The content for this component
  * @param {Object} [props.rest] Params to be forworded to the component
  * @return {JSX.Element} The component

--- a/js/src/components/app-text/index.scss
+++ b/js/src/components/app-text/index.scss
@@ -1,0 +1,41 @@
+.gla-app-text {
+	font-weight: 400;
+	margin: 0;
+	&--body {
+		font-size: $gla-font-base;
+		line-height: $gla-line-height-medium;
+	}
+
+	&--caption {
+		font-size: $gla-font-smaller;
+		line-height: $gla-line-height-smaller;
+	}
+
+	&--label {
+		font-weight: 600;
+		font-size: $gla-font-smaller;
+		line-height: $gla-line-height-smaller;
+	}
+
+	&--title-small {
+		font-size: $gla-font-small-medium;
+		line-height: $gla-line-height-medium-large;
+	}
+
+
+	&--title-medium {
+		font-size: $gla-font-medium;
+		line-height: $gla-line-height-large;
+	}
+
+	&--subtitle {
+		font-weight: 600;
+		font-size: 16px;
+		line-height: 24px;
+	}
+
+	&--subtitle-small {
+		font-size: $gla-font-small;
+		line-height: $gla-line-height-medium;
+	}
+}

--- a/js/src/components/campaign-conversion-notice/index.js
+++ b/js/src/components/campaign-conversion-notice/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Icon, __experimentalText as Text } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { external as externalIcon } from '@wordpress/icons';
 
 /**
@@ -12,6 +12,7 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import CONVERSION_STATUSES from './conversion-statuses';
 import getConversionCampaignStatusNotice from '.~/utils/getConversionCampaignStatusNotice';
 import DismissibleNotice from '.~/components/dismissible-notice';
+import Text from '.~/components/app-text';
 import './index.scss';
 
 const ExternalIcon = () => (
@@ -49,7 +50,7 @@ const CampaignConversionDashboardNotice = ( { context } ) => {
 			localStorageKey={ status.localStorageKey }
 		>
 			<Text
-				variant="subtitle.small"
+				variant="subtitle-small"
 				className="gla-campaign-conversion-status-notice__title"
 				data-testid="gla-campaign-conversion-dashboard-notice"
 			>

--- a/js/src/components/campaign-conversion-notice/reports-notice.js
+++ b/js/src/components/campaign-conversion-notice/reports-notice.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { __experimentalText as Text } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
 import { glaData } from '.~/constants';
 import CONVERSION_STATUSES from './conversion-statuses';
 import getConversionCampaignStatusNotice from '.~/utils/getConversionCampaignStatusNotice';
 import DismissibleNotice from '.~/components/dismissible-notice';
+import Text from '.~/components/app-text';
 import './reports-notice.scss';
 
 /**

--- a/js/src/css/abstracts/_variables.scss
+++ b/js/src/css/abstracts/_variables.scss
@@ -7,6 +7,7 @@
 
 $gla-font-smallest: 11px;
 $gla-font-smaller: 12px;
+$gla-font-base: 13px;
 $gla-font-small: 14px;
 $gla-font-small-medium: 20px;
 $gla-font-medium: 24px;

--- a/js/src/dashboard/summary-section/summary-card.js
+++ b/js/src/dashboard/summary-section/summary-card.js
@@ -1,15 +1,12 @@
 /**
  * External dependencies
  */
-import {
-	Card,
-	CardHeader,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardHeader } from '@wordpress/components';
 /**
  * Internal dependencies
  */
 import './summary-card.scss';
+import Text from '.~/components/app-text';
 
 /**
  * Returns a Card with the given content.
@@ -24,7 +21,7 @@ const SummaryCard = ( { title, children } ) => {
 	return (
 		<Card className="gla-summary-card">
 			<CardHeader size="medium">
-				<Text variant="title.small">{ title }</Text>
+				<Text variant="title-small">{ title }</Text>
 			</CardHeader>
 			{ children }
 		</Card>

--- a/js/src/external-components/woocommerce/compare-filter/index.js
+++ b/js/src/external-components/woocommerce/compare-filter/index.js
@@ -15,24 +15,16 @@ import {
 	CardBody,
 	CardFooter,
 	CardHeader,
-	__experimentalText as Text,
 } from '@wordpress/components';
 import { isEqual, isFunction } from 'lodash';
 import PropTypes from 'prop-types';
 import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';
-
-// /**
-//  * Internal dependencies
-//  */
-// import CompareButton from './button';
-// import Search from '../search';
-
-// export { default as CompareButton } from './button';
+import { CompareButton, Search } from '@woocommerce/components';
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { CompareButton, Search } from '@woocommerce/components';
+import Text from '.~/components/app-text';
 
 export { CompareButton };
 
@@ -109,7 +101,7 @@ class CompareFilter extends Component {
 		return (
 			<Card className="woocommerce-filters__compare">
 				<CardHeader>
-					<Text variant="subtitle.small">{ labels.title }</Text>
+					<Text variant="subtitle-small">{ labels.title }</Text>
 				</CardHeader>
 				<CardBody>
 					<Search

--- a/js/src/get-started-page/benefits-card/index.js
+++ b/js/src/get-started-page/benefits-card/index.js
@@ -2,18 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	CardBody,
-	FlexItem,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardBody, FlexItem } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import benefitsImageURL from './image.png';
+import Text from '.~/components/app-text';
 import './index.scss';
 
 const BenefitsCard = () => {
@@ -33,7 +29,7 @@ const BenefitsCard = () => {
 				</div>
 				<FlexItem>
 					<Text
-						variant="title.medium"
+						variant="title-medium"
 						className="gla-get-started-benefits-card__title"
 					>
 						{ createInterpolateElement(

--- a/js/src/get-started-page/customer-quotes-card/index.js
+++ b/js/src/get-started-page/customer-quotes-card/index.js
@@ -2,19 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	CardHeader,
-	Flex,
-	FlexBlock,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardHeader, Flex, FlexBlock } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './index.scss';
 import quoteImageURL from './img-quote.svg';
+import Text from '.~/components/app-text';
 
 const Quote = ( { quote, name } ) => {
 	return (
@@ -44,7 +39,7 @@ const CustomerQuotesCard = () => {
 			<CardHeader>
 				<Text
 					className="gla-get-started-customer-quotes-card__title"
-					variant="title.medium"
+					variant="title-medium"
 				>
 					{ __(
 						'21,000+ WooCommerce store owners like you already list products with Google',

--- a/js/src/get-started-page/features-card/index.js
+++ b/js/src/get-started-page/features-card/index.js
@@ -2,13 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	CardHeader,
-	Flex,
-	FlexBlock,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardHeader, Flex, FlexBlock } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 
 /**
@@ -18,6 +12,7 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import freeListingsImageURL from './img-free-listings.svg';
 import productPromotionImageURL from './img-product-promotion.svg';
 import dashboardImageURL from './img-dashboard.svg';
+import Text from '.~/components/app-text';
 import './index.scss';
 
 const LearnMoreLink = ( { linkId, href } ) => {
@@ -53,7 +48,7 @@ const FeaturesCard = () => {
 			<CardHeader>
 				<Text
 					className="gla-get-started-features-card__title"
-					variant="title.medium"
+					variant="title-medium"
 				>
 					{ __(
 						'49% of shoppers surveyed say they use Google to discover or find a new item or product',

--- a/js/src/get-started-page/get-started-card/index.js
+++ b/js/src/get-started-page/get-started-card/index.js
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	Card,
-	CardBody,
-	FlexItem,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardBody, FlexItem } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -17,6 +12,7 @@ import { glaData } from '.~/constants';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import motivationImageURL from './image.svg';
 import './index.scss';
+import Text from '.~/components/app-text';
 import AppButton from '.~/components/app-button';
 import { getSetupMCUrl } from '.~/utils/urls';
 
@@ -42,7 +38,7 @@ const GetStartedCard = () => {
 			</FlexItem>
 			<CardBody>
 				<Text
-					variant="title.medium"
+					variant="title-medium"
 					className="gla-get-started-card__title"
 				>
 					{ __(

--- a/js/src/get-started-page/get-started-with-video-card/index.js
+++ b/js/src/get-started-page/get-started-with-video-card/index.js
@@ -1,13 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	Card,
-	CardBody,
-	FlexBlock,
-	Tip,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardBody, FlexBlock, Tip } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -16,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { glaData } from '.~/constants';
 import AppButton from '.~/components/app-button';
+import Text from '.~/components/app-text';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import WistiaVideo from '.~/components/wistia-video';
 import { getSetupMCUrl } from '.~/utils/urls';
@@ -48,7 +43,7 @@ const GetStartedWithVideoCard = () => {
 					) }
 				</Text>
 				<Text
-					variant="title.medium"
+					variant="title-medium"
 					className="gla-get-started-with-video-card__title"
 				>
 					{ __(

--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -3,11 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
-import {
-	Card,
-	CardHeader,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardHeader } from '@wordpress/components';
 import classnames from 'classnames';
 
 /**
@@ -21,6 +17,7 @@ import IssuesTypeNavigation from '.~/product-feed/issues-table-card/issues-type-
 import ReviewRequest from '.~/product-feed/review-request';
 import useMCIssuesTotals from '.~/hooks/useMCIssuesTotals';
 import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import Text from '.~/components/app-text';
 import './index.scss';
 
 const actions = (
@@ -83,7 +80,7 @@ const IssuesTableCard = () => {
 			>
 				<CardHeader>
 					{ /* We use this Text component to make it similar to TableCard component. */ }
-					<Text variant="title.small" as="h2">
+					<Text variant="title-small" as="h2">
 						{ __( 'Issues to resolve', 'google-listings-and-ads' ) }
 					</Text>
 					{ /* This is also similar to TableCard component implementation. */ }

--- a/js/src/product-feed/issues-table-card/issues-solved.js
+++ b/js/src/product-feed/issues-table-card/issues-solved.js
@@ -3,13 +3,14 @@
  */
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { __experimentalText as Text, Dashicon } from '@wordpress/components';
+import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import useActiveIssueType from '.~/hooks/useActiveIssueType';
 import { ISSUE_TYPE_PRODUCT, ISSUE_TYPE_ACCOUNT } from '.~/constants';
+import Text from '.~/components/app-text';
 
 /**
  * This component renders a message when no issues of the

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -9,7 +9,6 @@ import {
 	CardHeader,
 	CardBody,
 	CardFooter,
-	__experimentalText as Text,
 } from '@wordpress/components';
 import {
 	EmptyTable,
@@ -32,6 +31,7 @@ import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import EditVisibilityAction from './edit-visibility-action';
 import statusLabelMap from './statusLabelMap';
+import Text from '.~/components/app-text';
 
 const PER_PAGE = 10;
 const EVENT_CONTEXT = 'product-feed';
@@ -194,7 +194,7 @@ const ProductFeedTableCard = () => {
 			>
 				<CardHeader>
 					{ /* We use this Text component to make it similar to TableCard component. */ }
-					<Text variant="title.small" as="h2">
+					<Text variant="title-small" as="h2">
 						{ __( 'Product Feed', 'google-listings-and-ads' ) }
 					</Text>
 					{ /* This is also similar to TableCard component implementation. */ }

--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -1,9 +1,4 @@
 /**
- * We use the __experimentalText component to make the card header
- * looks the same as other card headers on the Product Feed page.
- */
-
-/**
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -12,7 +7,6 @@ import {
 	CardHeader,
 	CardBody,
 	CardFooter,
-	__experimentalText as Text,
 	FlexItem,
 } from '@wordpress/components';
 
@@ -30,6 +24,7 @@ import ProductStatusHelpPopover from './product-status-help-popover';
 import SyncStatus from '.~/product-feed/product-statistics/status-box/sync-status';
 import FeedStatus from '.~/product-feed/product-statistics/status-box/feed-status';
 import AccountStatus from '.~/product-feed/product-statistics/status-box/account-status';
+import Text from '.~/components/app-text';
 import './index.scss';
 
 const ProductStatistics = () => {
@@ -39,7 +34,7 @@ const ProductStatistics = () => {
 		<Card className="gla-product-statistics">
 			<CardHeader justify="normal">
 				<FlexItem>
-					<Text variant="title.small" as="h2">
+					<Text variant="title-small" as="h2">
 						{ __( 'Overview', 'google-listings-and-ads' ) }
 					</Text>
 				</FlexItem>

--- a/js/src/product-feed/review-request/review-request-issues.js
+++ b/js/src/product-feed/review-request/review-request-issues.js
@@ -1,10 +1,15 @@
 /**
  * External dependencies
  */
-import { __experimentalText as Text, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import Text from '.~/components/app-text';
 
 const COLLAPSED_ISSUES_SIZE = 5;
 

--- a/js/src/product-feed/review-request/review-request-notice.js
+++ b/js/src/product-feed/review-request/review-request-notice.js
@@ -3,12 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { format as formatDate } from '@wordpress/date';
-import {
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalText as Text,
-	Flex,
-	FlexItem,
-} from '@wordpress/components';
+import { Flex, FlexItem } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,6 +11,7 @@ import {
 import AppButton from '.~/components/app-button';
 import REVIEW_STATUSES from './review-request-statuses';
 import { glaData } from '.~/constants';
+import Text from '.~/components/app-text';
 
 const ReviewRequestNotice = ( {
 	account,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is part of the tweaks needed in #1779 

This PR implements our own version of `<Text>` component instead of using `__experimentalText` from `wordpress/components`

The idea is:

A- Fix the UX issues in regards <Text> components after upgrading the dependencies. 
B- Avoid warnings in `js:lint` tasks
C- Avoid future problems regarding further changes in `__experimentalText` component 
D- Simplify our version of <Text> components since we are not using any of the enhancements provided by `__experimentalText`
E- Avoid massive replacement of previous <Text> implementations over all the codebase.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check the components affected by this change are rendering the text component properly.
2. As a reference you can use the Getting Started page in `develop` branch that include most of the <Text> variants.

ℹ️  Notice this PR doesn't fix other UX issues, like spacing in Flex items.

