### PR TITLE
Bump WC/WP Components:  Fix AppRadioContentControl

### DIFF
--- a/js/src/components/app-radio-content-control/index.js
+++ b/js/src/components/app-radio-content-control/index.js
@@ -20,20 +20,23 @@ const AppRadioContentControl = ( props ) => {
 		...rest
 	} = props;
 
+	const isSelected = selected === value;
+
 	return (
 		<div className={ classnames( 'app-radio-content-control', className ) }>
 			<RadioControl
+				{ ...rest }
 				selected={ selected }
+				checked={ isSelected }
 				options={ [
 					{
 						label,
 						value,
 					},
 				] }
-				{ ...rest }
 				help=""
 			/>
-			{ ( ! collapsible || selected === value ) && (
+			{ ( ! collapsible || isSelected ) && (
 				<div className="app-radio-content-control__content">
 					{ children }
 				</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is part of the tweaks needed in #1779 

It fixes the AppRadioContentControl component by fixing the check prop. In my investigations, it's returning always checked `true`, overriding the checked prop in RadioControl component

### Detailed test instructions:

1. Go to Onboarding Setup
2. In step 2 "Configure product listings" check that the form radio controls works as expected
3. Use develop branch as reference