### PR TITLE
Delete products in GMC when force delete a product or change catalog visibility to hidden

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -343,7 +343,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			BatchProductHelper::class,
 			ProductHelper::class,
 			MerchantCenterService::class,
-			WC::class
+			WC::class,
+			ProductRepository::class
 		);
 
 		// Coupon management classes

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -37,12 +37,6 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
 	public function process_items( array $product_id_map ) {
-		$product_ids = array_values( $product_id_map );
-		$ready_ids   = $this->product_repository->find_delete_product_ids( $product_ids );
-
-		// Exclude any ID's which are not ready to delete.
-		$product_id_map = array_intersect( $product_id_map, $ready_ids );
-
 		$product_entries = BatchProductIDRequestEntry::create_from_id_map( new ProductIDMap( $product_id_map ) );
 		$this->product_syncer->delete_by_batch_requests( $product_entries );
 	}

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -114,7 +114,11 @@ class BatchProductHelper implements Service {
 	 * @param BatchProductEntry $product_entry
 	 */
 	public function mark_as_unsynced( BatchProductEntry $product_entry ) {
-		$wc_product = $this->product_helper->get_wc_product( $product_entry->get_wc_product_id() );
+		try {
+			$wc_product = $this->product_helper->get_wc_product( $product_entry->get_wc_product_id() );
+		} catch ( InvalidValue $exception ) {
+			return;
+		}
 
 		$this->product_helper->mark_as_unsynced( $wc_product );
 	}

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -164,7 +164,8 @@ class ProductRepository implements Service {
 	 * @return array
 	 */
 	public function find_delete_product_ids( array $ids, int $limit = - 1, int $offset = 0 ): array {
-		$args    = [ 'status' => 'trash' ];
+		// Default status query args in WC_Product_Query plus status trash.
+		$args    = [ 'status' => [ 'draft', 'pending', 'private', 'publish', 'trash' ] ];
 		$results = $this->find_by_ids( $ids, $args, $limit, $offset );
 		return $this->product_filter->filter_products_for_delete( $results )->get_product_ids();
 	}

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -308,6 +308,7 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 	}
 	public function test_find_delete_product_ids() {
+		// A simple synced product.
 		$product_1 = WC_Helper_Product::create_simple_product();
 		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
 
@@ -320,10 +321,16 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		$product_3 = WC_Helper_Product::create_simple_product( true, [ 'status' => 'trash' ] );
 		$this->product_helper->mark_as_unsynced( $product_3 );
 
-		$ids = [ $product_1->get_id(), $product_2->get_id(), $product_3->get_id() ];
+		// A simple product with status publish which its catalog visibility is hidden.
+		$product_4 = WC_Helper_Product::create_simple_product( true, [ 'status' => 'publish' ] );
+		$product_4->set_catalog_visibility( 'hidden' );
+		$product_4->save();
+		$this->product_helper->mark_as_unsynced( $product_4 );
+
+		$ids = [ $product_1->get_id(), $product_2->get_id(), $product_3->get_id(), $product_4->get_id() ];
 
 		$this->assertEquals(
-			[ $product_3->get_id() ],
+			[ $product_1->get_id(), $product_3->get_id(), $product_4->get_id() ],
 			$this->product_repository->find_delete_product_ids( $ids )
 		);
 	}

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -392,7 +392,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	/**
 	 * Function to return an instance of ProductSyncer.
 	 *
-	 * @param object[] $arg
+	 * @param object[] $args
 	 */
 	private function get_product_syncer( $args = [] ): ProductSyncer {
 		$args['google_service']     = $args['google_service'] ?? $this->google_service;


### PR DESCRIPTION
## Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1785.

This PR fixes the problem which in some cases the deleted products are not actually deleted in GMC.

### When we force delete a product by WP-CLI

The problem is when we force delete a product it no longer exist in the database, so the filter in `process_items()` of `DeleteProducts` job would exclude this product before calling `delete_by_batch_request()`.

This is solved by moving the filtering logic from the method `process_items()` in `DeleteProducts` job to the code block where the retries are scheduled. So we will do the initial `delete_by_batch_request()` anyway, then when any internal errors occur returned by GMC we will be excluding any no longer existing products and ones that retried too many times.

However, there is still a case when we got internal error returned by GMC for the force deleted product. The force deleted product will be excluded before retrying so the data is still in GMC. I'm not sure if we need to take care of this case as it seems a bit of an edge case. For a complete data cleaning maybe we could have a daily or weekly job to remove the products that are not available in the local DB but still exists in GMC.

### When we change the product's catalog visibility to `hidden`.

In PR #1728 we added a condition that [only get products with status `trash` for deleting](https://github.com/woocommerce/google-listings-and-ads/pull/1728/files#diff-6934ab807d1707ca88f670c6059b54ae86ae9d22bf3e8151db14fe542c268ba9R167). However for the product that is changed to catalog visibility `hidden` its status is still `publish` so we are excluding this product to be deleted in GMC. This is solved by changing the condition to get all the default status plus status `trash`.

## Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow the steps to reproduce in #1785 for both **force delete a product** and **set a product's catalog visibility to hidded**
2. The product should also be deleted in GMC.
3. The infinite retry when deleting products problem that was solved in #1238 should still behave correctly.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
## Changelog entry

> Fix - Products are not deleted in GMC when force delete a product or change catalog visibility to hidden.
