### PR TITLE
Fetch WP Assets from specific post.

### DIFF
--- a/src/API/Site/Controllers/Assets/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Assets/AssetSuggestionsController.php
@@ -110,7 +110,7 @@ class AssetSuggestionsController extends BaseController {
 		return [
 			'id'   => [
 				'description'       => __( 'Post ID or Term ID.', 'google-listings-and-ads' ),
-				'type'              => 'string',
+				'type'              => 'number',
 				'default'           => '',
 				'sanitize_callback' => 'absint',
 				'validate_callback' => 'rest_validate_request_arg',

--- a/src/API/Site/Controllers/Assets/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Assets/AssetSuggestionsController.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseControl
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use WP_REST_Request as Request;
+use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -131,9 +132,13 @@ class AssetSuggestionsController extends BaseController {
 	 */
 	protected function get_assets_suggestions_callback(): callable {
 		return function( Request $request ) {
-			$id   = $request->get_param( 'id' );
-			$type = $request->get_param( 'type' );
-			return $this->asset_suggestions_service->get_assets_suggestions( $id, $type );
+			try {
+				$id   = $request->get_param( 'id' );
+				$type = $request->get_param( 'type' );
+				return $this->asset_suggestions_service->get_assets_suggestions( $id, $type );
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
 		};
 	}
 

--- a/src/API/Site/Controllers/Assets/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Assets/AssetSuggestionsController.php
@@ -102,7 +102,7 @@ class AssetSuggestionsController extends BaseController {
 	}
 
 	/**
-	 * Get the assets suggestions params for collections.
+	 * Get the assets suggestions params.
 	 *
 	 * @return array
 	 */
@@ -111,7 +111,6 @@ class AssetSuggestionsController extends BaseController {
 			'id'   => [
 				'description'       => __( 'Post ID or Term ID.', 'google-listings-and-ads' ),
 				'type'              => 'number',
-				'default'           => '',
 				'sanitize_callback' => 'absint',
 				'validate_callback' => 'rest_validate_request_arg',
 			],
@@ -126,7 +125,7 @@ class AssetSuggestionsController extends BaseController {
 	}
 
 	/**
-	 * Get the callback function for the list of final-url suggestions request.
+	 * Get the callback function for the assets suggestions request.
 	 *
 	 * @return callable
 	 */

--- a/src/API/Site/Controllers/Assets/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Assets/AssetSuggestionsController.php
@@ -43,6 +43,17 @@ class AssetSuggestionsController extends BaseController {
 	 */
 	public function register_routes(): void {
 		$this->register_route(
+			'assets/suggestions',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_assets_suggestions_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_assets_suggestions_params(),
+				],
+			]
+		);
+		$this->register_route(
 			'assets/final-url/suggestions',
 			[
 				[
@@ -87,6 +98,43 @@ class AssetSuggestionsController extends BaseController {
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];
+	}
+
+	/**
+	 * Get the assets suggestions params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_assets_suggestions_params(): array {
+		return [
+			'id'   => [
+				'description'       => __( 'Post ID or Term ID.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'type' => [
+				'description'       => __( 'Type linked to the id.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+				'enum'              => [ 'post', 'term' ],
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+		];
+	}
+
+	/**
+	 * Get the callback function for the list of final-url suggestions request.
+	 *
+	 * @return callable
+	 */
+	protected function get_assets_suggestions_callback(): callable {
+		return function( Request $request ) {
+			$id   = $request->get_param( 'id' );
+			$type = $request->get_param( 'type' );
+			return $this->asset_suggestions_service->get_assets_suggestions( $id, $type );
+		};
 	}
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -27,6 +27,45 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
+	 * Get assets from specific post or term or final urls in other Ads campaigns.
+	 *
+	 * @param int    $id Post or Term ID.
+	 * @param string $type Only possible values are post or term.
+	 */
+	public function get_assets_suggestions( int $id, string $type ): array {
+		return array_merge( $this->get_wp_assets( $id, $type ), $this->get_assets_from_others_campaigns() );
+	}
+
+	/**
+	 * Get assets from specific post or term.
+	 *
+	 * @param int    $id Post or Term ID.
+	 * @param string $type Only possible values are post or term.
+	 *
+	 * @return array All assets available for specific term or post.
+	 */
+	public function get_wp_assets( int $id, string $type ) {
+		if ( $type === 'post' ) {
+			return [];
+		}
+
+		return [];
+
+	}
+
+	/**
+	 * Get Assets from others campaigns using a specific final url.
+	 *
+	 * @param string $final_url URL used to search for other assets in other campaigns.
+	 *
+	 * @return array Assets fetch from other campaigns
+	 */
+	public function get_assets_from_others_campaigns( string $final_url = '' ): array {
+		// TO BE IMPLEMENTED IN THE FOLLOWING PR
+		return [];
+	}
+
+	/**
 	 * Get posts that can be used to suggest assets
 	 *
 	 * @param string $search The search query.

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -81,9 +81,6 @@ class AssetSuggestionsService implements Service {
 			);
 		}
 
-		$title   = $post->post_title;
-		$excerpt = $post->post_excerpt;
-
 		$attachments_ids = $this->get_post_attachments(
 			[
 				'post_parent' => $id,
@@ -99,16 +96,20 @@ class AssetSuggestionsService implements Service {
 			$attachments_ids = array_merge( $attachments_ids, $product->get_gallery_image_ids() );
 		}
 
-		$gallery_images_urls     = get_post_gallery_images( $id );
-		$square_marketing_images = array_merge( $this->get_url_attachments_by_ids( $attachments_ids ), $gallery_images_urls );
+		$gallery_images_urls = get_post_gallery_images( $id );
+		$marketing_images    = array_merge( $this->get_url_attachments_by_ids( $attachments_ids ), $gallery_images_urls );
+		$long_headline       = get_bloginfo( 'name' ) . ': ' . $post->post_title;
 
 		return [
-			'headline'                => [ $title ],
-			'long_headline'           => [ $title ],
-			'description'             => $this->remove_empty_strings( [ $excerpt, get_bloginfo( 'description' ) ] ),
-			'square_marketing_images' => $square_marketing_images,
+			'headline'                => [ $post->post_title ],
+			'long_headline'           => [ $long_headline ],
+			'description'             => $this->remove_empty_values( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ),
+			'logo'                    => $this->remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
 			'final_url'               => get_permalink( $id ),
 			'business_name'           => get_bloginfo( 'name' ),
+			'display_url'             => [ $post->post_name ],
+			'square_marketing_images' => $marketing_images,
+			'marketing_images'        => $marketing_images,
 		];
 	}
 
@@ -151,7 +152,7 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @return array A list of strings without empty strings.
 	 */
-	protected function remove_empty_strings( array $array ) {
+	protected function remove_empty_values( array $array ) {
 		return array_values( array_filter( $array ) );
 	}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -111,6 +111,7 @@ class AssetSuggestionsService implements Service {
 			'display_url_path'        => [ $post->post_name ],
 			'square_marketing_images' => $marketing_images,
 			'marketing_images'        => $marketing_images,
+			'call_to_action'          => null,
 		];
 	}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -36,7 +36,7 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
-	 * Get assets from specific post or term or final urls in other Ads campaigns.
+	 * Get assets from specific post or term.
 	 *
 	 * @param int    $id Post or Term ID.
 	 * @param string $type Only possible values are post or term.
@@ -114,7 +114,7 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
-	 * Get attachments related to the products.
+	 * Get attachments related to the shop page.
 	 *
 	 * @return array Shop attachments.
 	 */
@@ -157,7 +157,7 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
-	 * Remove empty values from array.
+	 * Get URL for each attachment using an array of attachment ids.
 	 *
 	 * @param array $ids A list of attachments ids.
 	 *

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -98,6 +98,7 @@ class AssetSuggestionsService implements Service {
 
 		$gallery_images_urls = get_post_gallery_images( $id );
 		$marketing_images    = array_merge( $this->get_url_attachments_by_ids( $attachments_ids ), $gallery_images_urls );
+		$marketing_images    = array_slice( $marketing_images, 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
 		$long_headline       = get_bloginfo( 'name' ) . ': ' . $post->post_title;
 
 		return [

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -91,9 +91,9 @@ class AssetSuggestionsService implements Service {
 			$attachments_ids = array_merge( $attachments_ids, $this->get_shop_attachments() );
 		}
 
-		if ( $post->post_type === 'product' ) {
+		if ( $post->post_type === 'product' || $post->post_type === 'product_variation' ) {
 			$product         = $this->wc->maybe_get_product( $id );
-			$attachments_ids = array_merge( $attachments_ids, $product->get_gallery_image_ids() );
+			$attachments_ids = array_merge( $attachments_ids, $product->get_gallery_image_ids(), [ $product->get_image_id() ] );
 		}
 
 		$gallery_images_urls = get_post_gallery_images( $id );
@@ -107,7 +107,7 @@ class AssetSuggestionsService implements Service {
 			'logo'                    => $this->remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
 			'final_url'               => get_permalink( $id ),
 			'business_name'           => get_bloginfo( 'name' ),
-			'display_url'             => [ $post->post_name ],
+			'display_url_path'        => [ $post->post_name ],
 			'square_marketing_images' => $marketing_images,
 			'marketing_images'        => $marketing_images,
 		];
@@ -164,6 +164,8 @@ class AssetSuggestionsService implements Service {
 	 * @return array A list of attachments urls.
 	 */
 	protected function get_url_attachments_by_ids( array $ids ) {
+		$ids = array_unique( $this->remove_empty_values( $ids ) );
+
 		$square_marketing_images = [];
 		foreach ( $ids as $id ) {
 			$square_marketing_images[] = wp_get_attachment_image_url( $id );

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -54,7 +54,7 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @return array All assets available for specific term or post.
 	 */
-	protected function get_wp_assets( int $id, string $type ) {
+	protected function get_wp_assets( int $id, string $type ): array {
 		if ( $type === 'post' ) {
 			return $this->get_post_assets( $id );
 		}
@@ -71,7 +71,7 @@ class AssetSuggestionsService implements Service {
 	 * @return array All assets for specific post.
 	 * @throws Exception If the Post ID is invalid.
 	 */
-	protected function get_post_assets( int $id ) {
+	protected function get_post_assets( int $id ): array {
 		$post = $this->wp->get_post( $id );
 
 		if ( ! $post ) {
@@ -118,7 +118,7 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @return array Shop attachments.
 	 */
-	protected function get_shop_attachments() {
+	protected function get_shop_attachments(): array {
 		return $this->get_post_attachments(
 			[
 				'post_parent__in' => $this->get_shop_products(),
@@ -133,7 +133,7 @@ class AssetSuggestionsService implements Service {
 	 * @param array $args See WP_Query::parse_query() for all available arguments.
 	 * @return array Shop products.
 	 */
-	protected function get_shop_products( array $args = [] ) {
+	protected function get_shop_products( array $args = [] ): array {
 		$defaults = [
 			'post_type'   => 'product',
 			'numberposts' => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
@@ -152,7 +152,7 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @return array A list of strings without empty strings.
 	 */
-	protected function remove_empty_values( array $array ) {
+	protected function remove_empty_values( array $array ): array {
 		return array_values( array_filter( $array ) );
 	}
 
@@ -163,14 +163,14 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @return array A list of attachments urls.
 	 */
-	protected function get_url_attachments_by_ids( array $ids ) {
+	protected function get_url_attachments_by_ids( array $ids ): array {
 		$ids = array_unique( $this->remove_empty_values( $ids ) );
 
-		$square_marketing_images = [];
+		$marketing_images = [];
 		foreach ( $ids as $id ) {
-			$square_marketing_images[] = wp_get_attachment_image_url( $id );
+			$marketing_images[] = wp_get_attachment_image_url( $id );
 		}
-		return $square_marketing_images;
+		return $marketing_images;
 	}
 
 
@@ -181,7 +181,7 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @return array List of attachments
 	 */
-	protected function get_post_attachments( array $args = [] ) {
+	protected function get_post_attachments( array $args = [] ): array {
 		$defaults = [
 			'post_type'      => 'attachment',
 			'post_mime_type' => 'image',

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -252,7 +252,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getLeagueContainer()
 			 ->inflector( AdsAwareInterface::class )
 			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
-		$this->share_with_tags( AssetSuggestionsService::class, WP::class );
+		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class );
 
 		// Set up the installer.
 		$installer_definition = $this->share_with_tags(

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -197,6 +197,26 @@ class WP {
 	}
 
 	/**
+	 * Retrieves post data given a post ID or post object.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int|WP_Post|null $post   Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
+	 *                                 return the current global post inside the loop. A numerically valid post ID that
+	 *                                 points to a non-existent post returns `null`. Defaults to global $post.
+	 * @param string           $output Optional. The required return type. One of OBJECT, ARRAY_A, or ARRAY_N, which
+	 *                                 correspond to a WP_Post object, an associative array, or a numeric array,
+	 *                                 respectively. Default OBJECT.
+	 * @param string           $filter Optional. Type of filter to apply. Accepts 'raw', 'edit', 'db',
+	 *                                 or 'display'. Default 'raw'.
+	 * @return WP_Post|array|null Type corresponding to $output on success or null on failure.
+	 *                            When $output is OBJECT, a `WP_Post` instance is returned.
+	 */
+	public function get_post( $post = null, string $output = OBJECT, string $filter = 'raw' ) {
+		return get_post( $post, $output, $filter );
+	}
+
+	/**
 	 * Gets a list of all registered post type objects.
 	 *
 	 * @since x.x.x

--- a/src/Utility/ArrayUtil.php
+++ b/src/Utility/ArrayUtil.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
+
+/**
+ * A class of utilities for dealing with arrays.
+ *
+ * @since x.x.x
+ */
+class ArrayUtil {
+
+	/**
+	 * Remove empty values from array.
+	 *
+	 * @param array $array A list of strings.
+	 *
+	 * @return array A list of strings without empty strings.
+	 */
+	public static function remove_empty_values( array $array ): array {
+		return array_values( array_filter( $array ) );
+	}
+
+}
+
+

--- a/tests/Unit/API/Site/Controllers/Assets/AssetSuggestionsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Assets/AssetSuggestionsControllerTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Assets\Asse
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
+use Exception;
 
 /**
  * Class AssetSuggestionsControllerTest
@@ -14,11 +15,12 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
  *
  * @property RESTServer                         $rest_server
- * @property AssetSuggestionsService|MockObject $asset_suggestions
+ * @property AssetSuggestionsService|MockObject $assets_suggestions
  */
 class AssetSuggestionsControllerTest extends RESTControllerUnitTest {
 
 	protected const ROUTE_FINAL_URL_SUGGESTIONS = '/wc/gla/assets/final-url/suggestions';
+	protected const ROUTE_ASSETS_SUGGESTIONS    = '/wc/gla/assets/suggestions';
 	protected const TEST_FINAL_URL_SUGGESTIONS  = [
 		[
 			'id'    => 1,
@@ -35,17 +37,25 @@ class AssetSuggestionsControllerTest extends RESTControllerUnitTest {
 
 	];
 	protected const TEST_NO_FINAL_URL_SUGGESTIONS = [];
+	protected const TEST_ASSETS_SUGGESTIONS       = [
+		'headline'                => [ 'Headline 1' ],
+		'long_headline'           => [ 'Long Headline 1' ],
+		'description'             => [ 'Description 1' ],
+		'square_marketing_images' => [ 'https://test.com/image.png' ],
+		'final_url'               => 'https://test.com/shop',
+		'business_name'           => 'Test Blog',
+	];
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->asset_suggestions = $this->createMock( AssetSuggestionsService::class );
-		$this->controller        = new AssetSuggestionsController( $this->server, $this->asset_suggestions );
+		$this->assets_suggestions = $this->createMock( AssetSuggestionsService::class );
+		$this->controller         = new AssetSuggestionsController( $this->server, $this->assets_suggestions );
 		$this->controller->register();
 	}
 
 	public function test_get_final_url_suggestions() {
-		$this->asset_suggestions->expects( $this->once() )
+		$this->assets_suggestions->expects( $this->once() )
 			->method( 'get_final_url_suggestions' )
 			->willReturn( self::TEST_FINAL_URL_SUGGESTIONS );
 
@@ -56,7 +66,7 @@ class AssetSuggestionsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_final_url_suggestions_empty_set() {
-		$this->asset_suggestions->expects( $this->once() )
+		$this->assets_suggestions->expects( $this->once() )
 			->method( 'get_final_url_suggestions' )
 			->willReturn( self::TEST_NO_FINAL_URL_SUGGESTIONS );
 
@@ -65,4 +75,41 @@ class AssetSuggestionsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( self::TEST_NO_FINAL_URL_SUGGESTIONS, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
 	}
+
+	public function test_assets_suggestions() {
+		$params = [
+			'id'   => 12345,
+			'type' => 'post',
+		];
+		$this->assets_suggestions->expects( $this->once() )
+			->method( 'get_assets_suggestions' )
+			->willReturn( self::TEST_ASSETS_SUGGESTIONS );
+
+		$response = $this->do_request(
+			self::ROUTE_ASSETS_SUGGESTIONS,
+			'GET',
+			$params
+		);
+
+		$this->assertEquals( self::TEST_ASSETS_SUGGESTIONS, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_assets_suggestions_with_invalid_id() {
+		$params = [
+			'id'   => 12345,
+			'type' => 'post',
+		];
+
+		$this->assets_suggestions
+			->method( 'get_assets_suggestions' )
+			->willThrowException( new Exception( 'Invalid ID' ) );
+
+		$response = $this->do_request( self::ROUTE_ASSETS_SUGGESTIONS, 'GET', $params );
+
+		$this->assertEquals( 'Invalid ID', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+
 }

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -90,7 +90,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'final_url'               => get_permalink( $post->ID ),
 			'headline'                => [ $post->post_title ],
 			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $post->post_title ],
-			'description'             => [ $post->post_excerpt ],
+			'description'             =>  array_values( array_filter( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ) ) ,
 			'business_name'           => get_bloginfo( 'name' ),
 			'display_url_path'        => [ $post->post_name ],
 			'logo'                    => [],

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -90,7 +90,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'final_url'               => get_permalink( $post->ID ),
 			'headline'                => [ $post->post_title ],
 			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $post->post_title ],
-			'description'             =>  array_values( array_filter( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ) ) ,
+			'description'             => array_values( array_filter( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ) ),
 			'business_name'           => get_bloginfo( 'name' ),
 			'display_url_path'        => [ $post->post_name ],
 			'logo'                    => [],

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -92,7 +92,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $post->post_title ],
 			'description'             => [ $post->post_excerpt ],
 			'business_name'           => get_bloginfo( 'name' ),
-			'display_url'             => [ $post->post_name ],
+			'display_url_path'        => [ $post->post_name ],
 			'logo'                    => [],
 			'square_marketing_images' => $marketing_images,
 			'marketing_images'        => $marketing_images,
@@ -306,11 +306,12 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	}
 
 	public function test_get_shop_assets() {
-		$image_id       = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$image_post     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$image_product  = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
 		$this->post->ID = wc_get_page_id( 'shop' );
 
 		$product = WC_Helper_Product::create_simple_product();
-		$product->set_gallery_image_ids( [ $image_id ] );
+		$product->set_gallery_image_ids( [ $image_product ] );
 
 		$this->wp->expects( $this->once() )
 			->method( 'get_post' )
@@ -318,9 +319,9 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		$this->wp->expects( $this->exactly( 3 ) )
 			->method( 'get_posts' )
-			->willReturnOnConsecutiveCalls( [ $image_id ], [ $product->get_id() ], [ $image_id ] );
+			->willReturnOnConsecutiveCalls( [ $image_post ], [ $product->get_id() ], [ $image_product ] );
 
-		$this->assertEquals( $this->format_post_asset_response( $this->post, [ wp_get_attachment_image_url( $image_id ), wp_get_attachment_image_url( $image_id ) ] ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+		$this->assertEquals( $this->format_post_asset_response( $this->post, [ wp_get_attachment_image_url( $image_post ), wp_get_attachment_image_url( $image_product ) ] ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 	}
 
 	public function test_get_invalid_post_id() {

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -329,8 +329,8 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->method( 'get_post' )
 			->willReturn( null );
 
-			$this->expectException( Exception::class );
-			$this->asset_suggestions->get_assets_suggestions( 123456, 'post' );
+		$this->expectException( Exception::class );
+		$this->asset_suggestions->get_assets_suggestions( 123456, 'post' );
 
 	}
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -96,6 +96,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'logo'                    => [],
 			'square_marketing_images' => $marketing_images,
 			'marketing_images'        => $marketing_images,
+			'call_to_action'          => null,
 		];
 
 	}

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -85,14 +85,17 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		];
 	}
 
-	protected function format_post_asset_response( $post, $square_marketing_images = [] ) {
+	protected function format_post_asset_response( $post, $marketing_images = [] ) {
 		return [
-			'headline'                => [ $post->post_title ],
-			'long_headline'           => [ $post->post_title ],
-			'description'             => [ $post->post_excerpt ],
-			'square_marketing_images' => $square_marketing_images,
 			'final_url'               => get_permalink( $post->ID ),
+			'headline'                => [ $post->post_title ],
+			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $post->post_title ],
+			'description'             => [ $post->post_excerpt ],
 			'business_name'           => get_bloginfo( 'name' ),
+			'display_url'             => [ $post->post_name ],
+			'logo'                    => [],
+			'square_marketing_images' => $marketing_images,
+			'marketing_images'        => $marketing_images,
 		];
 
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

This PR adds a new endpoint `assets/suggestions` that returns a list of assets for a specific post (page/product/post/etc),  with the below mapping:

Google text asset | Existing post/taxonomy meta
-- | --
Final URL | Permalink
(1) Headline Var1 Max. 15 chars | Post/taxonomy title
(2) Headline Var2 Max. 30 chars | Post/taxonomy title
(3) Long headline Max. 90 chars | Site title: Post/taxonomy title
(4) Short description Max. 60 chars | Post excerpt/taxonomy description
(5) Description Max. 90 chars | Post excerpt/taxonomy description, tagline
(5) Business name Max. 25 chars | Site title
(7) Call-to-action | –
(8) Display URL path | Slug


See original table: pcTzPl-12o-p2#comment-1849

- The Headlines (1 & 2) are grouped as one headline, as the Ads API only use one type which is [HEADLINE](https://github.com/googleads/google-ads-php/blob/151bab9bd37d46543bbeb2c3b0caedf91cb91b6b/src/Google/Ads/GoogleAds/V11/Enums/AssetFieldTypeEnum/AssetFieldType.php#L177).
- The Descriptions (4 & 5) are grouped as one description, as the Ads API only use one type which is [DESCRIPTION](https://github.com/googleads/google-ads-php/blob/151bab9bd37d46543bbeb2c3b0caedf91cb91b6b/src/Google/Ads/GoogleAds/V11/Enums/AssetFieldTypeEnum/AssetFieldType.php#L178).
- When fetching suggestions from WP/WC the field `call_to_action` will be `null` as it is not possible to offer a suggestion, however when we suggest assets used in other campaigns using the Ads API, the field will be filled. 

In addition to the mapping table, the endpoint returns the image assets linked to the post and the website logo.

At the moment we have three types of images:
- Square Marketing images.
- Marketing Images (landscape).
- Logo

The endpoint will return the same images for Square and Landascape images until we decide how to to resize/format the images. See comment: pcTzPl-12o-p2#comment-2090

The images that will return for a post are a combination of:
- Images attached to the post.
- Gallery images
- In case that is a product, images from the product gallery.
- If the page is the Shop page, it will return images of published products. 

### API Response:

```
{
    "headline": [
        "Sample Page"
    ],
    "long_headline": [
        "Wordpress: Sample Page"
    ],
    "description": [
        "I sell clothing!"
    ],
    "logo": [
        "http://localhost:8082/wp-content/uploads/2022/11/cropped-cropped-ocean-3605547_960_720-150x150.jpeg"
    ],
    "final_url": "http://localhost:8082/sample-page/",
    "business_name": "Wordpress",
    "display_url_path": [
        "sample-page"
    ],
    "square_marketing_images": [
        "http://localhost:8082/wp-content/uploads/2022/11/ocean-3605547_960_720-150x150.jpeg",
        ........
    ],
    "marketing_images": [
        "http://localhost:8082/wp-content/uploads/2022/11/Terminator-2-judgement-day-v3.jpeg",
        ..........
    ],
    call_to_action: null
}
```

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Chose any post created in your website. A post can be a product,page,post or any other custom post_type.
2. Get the ID of that post.
3. Make a request to: `assets/suggestions?id=YOUR_ID&type=post`
4. Check that the response matches the mapping table.


### Additional details:
New PRs will include fetching assets for a specific term/category and assets from other campaigns.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
