### PR TITLE
Fetch WP Assets from specific term

### DIFF
--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -124,7 +124,7 @@ class AssetSuggestionsService implements Service {
 	 * @return array All assets for specific term.
 	 * @throws Exception If the Term ID is invalid.
 	 */
-	protected function get_term_assets( int $id ) {
+	protected function get_term_assets( int $id ): array {
 		$term = get_term( $id );
 
 		if ( ! $term ) {
@@ -172,9 +172,9 @@ class AssetSuggestionsService implements Service {
 	 * @param int    $term_id Term ID.
 	 * @param string $taxonomy_name Taxonomy name.
 	 *
-	 * @return array List of attachments
+	 * @return array List of posts assigned to the term.
 	 */
-	protected function get_posts_assigned_to_a_term( int $term_id, string $taxonomy_name ) {
+	protected function get_posts_assigned_to_a_term( int $term_id, string $taxonomy_name ): array {
 		$args = [
 			'post_type'   => 'any',
 			'numberposts' => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -140,7 +140,7 @@ class AssetSuggestionsService implements Service {
 
 		return [
 			'headline'                => [ $term->name ],
-			'long_headline'           => [ $term->name ],
+			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $term->name ],
 			'description'             => ArrayUtil::remove_empty_values( [ wp_strip_all_tags( $term->description ), get_bloginfo( 'description' ) ] ),
 			'logo'                    => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
 			'final_url'               => get_term_link( $term->term_id ),

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -73,7 +73,7 @@ class AssetSuggestionsService implements Service {
 	 * @throws Exception If the Post ID is invalid.
 	 */
 	protected function get_post_assets( int $id ): array {
-		$post = $this->wp->get_post( $id );
+		$post = get_post( $id );
 
 		if ( ! $post || $post->post_status === 'trash' ) {
 			throw new Exception(
@@ -89,7 +89,7 @@ class AssetSuggestionsService implements Service {
 		);
 
 		if ( $id === wc_get_page_id( 'shop' ) ) {
-			$attachments_ids = array_merge( $attachments_ids, $this->get_shop_attachments() );
+			$attachments_ids = [ ...$attachments_ids, ...$this->get_shop_attachments() ];
 		}
 
 		if ( $post->post_type === 'product' || $post->post_type === 'product_variation' ) {
@@ -98,7 +98,7 @@ class AssetSuggestionsService implements Service {
 		}
 
 		$gallery_images_urls = get_post_gallery_images( $id );
-		$marketing_images    = array_merge( $this->get_url_attachments_by_ids( $attachments_ids ), $gallery_images_urls );
+		$marketing_images    = [ ...$this->get_url_attachments_by_ids( $attachments_ids ), ...$gallery_images_urls ];
 		$marketing_images    = array_slice( $marketing_images, 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
 		$long_headline       = get_bloginfo( 'name' ) . ': ' . $post->post_title;
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -148,7 +148,10 @@ class AssetSuggestionsService implements Service {
 			$posts_ids_assigned_to_term[] = $post->ID;
 		}
 
-		$attachments_ids  = [ ...$this->get_post_image_attachments( [ 'post_parent__in' => $posts_ids_assigned_to_term ] ), ...$attachments_ids ];
+		if ( count( $posts_assigned_to_term ) ) {
+			$attachments_ids = [ ...$this->get_post_image_attachments( [ 'post_parent__in' => $posts_ids_assigned_to_term ] ), ...$attachments_ids ];
+		}
+
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
 		$marketing_images = array_slice( $marketing_images, 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -60,7 +60,7 @@ class AssetSuggestionsService implements Service {
 			return $this->get_post_assets( $id );
 		}
 
-		return [];
+		return $this->get_term_assets( $id );
 
 	}
 
@@ -114,6 +114,68 @@ class AssetSuggestionsService implements Service {
 			'marketing_images'        => $marketing_images,
 			'call_to_action'          => null,
 		];
+	}
+
+	/**
+	 * Get assets from specific term.
+	 *
+	 * @param int $id Term ID.
+	 *
+	 * @return array All assets for specific term.
+	 * @throws Exception If the Term ID is invalid.
+	 */
+	protected function get_term_assets( int $id ) {
+		$term = get_term( $id );
+
+		if ( ! $term ) {
+			throw new Exception(
+				/* translators: 1: is an integer representing an unknown Post ID */
+				sprintf( __( 'Invalid Term ID %1$d', 'google-listings-and-ads' ), $id )
+			);
+		}
+
+		$posts_ids_assigned_to_term = $this->get_posts_assigned_to_a_term( $term->term_id, $term->taxonomy );
+		$attachments_ids            = $this->get_post_image_attachments( [ 'post_parent__in' => $posts_ids_assigned_to_term ] );
+		$marketing_images           = $this->get_url_attachments_by_ids( $attachments_ids );
+
+		return [
+			'headline'                => [ $term->name ],
+			'long_headline'           => [ $term->name ],
+			'description'             => ArrayUtil::remove_empty_values( [ wp_strip_all_tags( $term->description ), get_bloginfo( 'description' ) ] ),
+			'logo'                    => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
+			'final_url'               => get_term_link( $term->term_id ),
+			'business_name'           => get_bloginfo( 'name' ),
+			'display_url_path'        => [ $term->slug ],
+			'square_marketing_images' => $marketing_images,
+			'marketing_images'        => $marketing_images,
+			'call_to_action'          => null,
+		];
+	}
+
+	/**
+	 * Get posts linked to a specific term.
+	 *
+	 * @param int    $term_id Term ID.
+	 * @param string $taxonomy_name Taxonomy name.
+	 *
+	 * @return array List of attachments
+	 */
+	protected function get_posts_assigned_to_a_term( int $term_id, string $taxonomy_name ) {
+		$args = [
+			'post_type'   => 'any',
+			'numberposts' => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
+			'fields'      => 'ids',
+			'tax_query'   => [
+				[
+					'taxonomy'         => $taxonomy_name,
+					'terms'            => $term_id,
+					'field'            => 'term_id',
+					'include_children' => false,
+				],
+			],
+		];
+
+		return $this->wp->get_posts( $args );
 	}
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -75,7 +75,7 @@ class AssetSuggestionsService implements Service {
 	protected function get_post_assets( int $id ): array {
 		$post = $this->wp->get_post( $id );
 
-		if ( ! $post ) {
+		if ( ! $post || $post->post_status === 'trash' ) {
 			throw new Exception(
 				/* translators: 1: is an integer representing an unknown Post ID */
 				sprintf( __( 'Invalid Post ID %1$d', 'google-listings-and-ads' ), $id )

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -197,26 +197,6 @@ class WP {
 	}
 
 	/**
-	 * Retrieves post data given a post ID or post object.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param int|WP_Post|null $post   Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
-	 *                                 return the current global post inside the loop. A numerically valid post ID that
-	 *                                 points to a non-existent post returns `null`. Defaults to global $post.
-	 * @param string           $output Optional. The required return type. One of OBJECT, ARRAY_A, or ARRAY_N, which
-	 *                                 correspond to a WP_Post object, an associative array, or a numeric array,
-	 *                                 respectively. Default OBJECT.
-	 * @param string           $filter Optional. Type of filter to apply. Accepts 'raw', 'edit', 'db',
-	 *                                 or 'display'. Default 'raw'.
-	 * @return WP_Post|array|null Type corresponding to $output on success or null on failure.
-	 *                            When $output is OBJECT, a `WP_Post` instance is returned.
-	 */
-	public function get_post( $post = null, string $output = OBJECT, string $filter = 'raw' ) {
-		return get_post( $post, $output, $filter );
-	}
-
-	/**
 	 * Gets a list of all registered post type objects.
 	 *
 	 * @since x.x.x

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -352,7 +352,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 	}
 
-	public function test_get_term() {
+	public function test_get_term_with_product() {
 		$post             = $this->factory()->post->create_and_get( [ 'post_type' => 'product' ] );
 		$image_post_1     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
 		$image_post_2     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
@@ -398,6 +398,39 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->willReturnOnConsecutiveCalls( $posts_ids_assigned_to_term, [ $image_post_1, $image_post_2 ] );
 
 		$this->assertEquals( $this->format_term_asset_response( $this->term, $marketing_images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
+
+	}
+
+	public function test_get_term_without_product() {
+		$post             = $this->factory()->post->create_and_get();
+		$image_post_1     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$image_post_2     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$marketing_images = [ wp_get_attachment_image_url( $image_post_1 ), wp_get_attachment_image_url( $image_post_2 ) ];
+
+		$posts_ids_assigned_to_term = [ $this->post, $post ];
+
+		$this->wc->expects( $this->never() )
+			->method( 'maybe_get_product' );
+
+		$this->wp->expects( $this->exactly( 2 ) )
+			->method( 'get_posts' )
+			->willReturnOnConsecutiveCalls( $posts_ids_assigned_to_term, [ $image_post_1, $image_post_2 ] );
+
+		$this->assertEquals( $this->format_term_asset_response( $this->term, $marketing_images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
+
+	}
+
+	public function test_get_term_without_assigned_posts() {
+		$posts_ids_assigned_to_term = [];
+
+		$this->wc->expects( $this->never() )
+			->method( 'maybe_get_product' );
+
+		$this->wp->expects( $this->exactly( 1 ) )
+			->method( 'get_posts' )
+			->willReturnOnConsecutiveCalls( $posts_ids_assigned_to_term );
+
+		$this->assertEquals( $this->format_term_asset_response( $this->term, [] ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
 
 	}
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -91,7 +91,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'final_url'               => get_permalink( $post->ID ),
 			'headline'                => [ $post->post_title ],
 			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $post->post_title ],
-			'description'             => ArrayUtil::remove_empty_values( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ) ,
+			'description'             => ArrayUtil::remove_empty_values( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ),
 			'business_name'           => get_bloginfo( 'name' ),
 			'display_url_path'        => [ $post->post_name ],
 			'logo'                    => [],
@@ -106,7 +106,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		return [
 			'final_url'               => get_term_link( $term->term_id ),
 			'headline'                => [ $term->name ],
-			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' .$term->name ],
+			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $term->name ],
 			'description'             => ArrayUtil::remove_empty_values( [ wp_strip_all_tags( $term->description ), get_bloginfo( 'description' ) ] ),
 			'logo'                    => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
 			'business_name'           => get_bloginfo( 'name' ),
@@ -116,7 +116,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'call_to_action'          => null,
 		];
 
-	}	
+	}
 
 	public function test_get_post_suggestions() {
 		$this->wp->expects( $this->once() )
@@ -353,13 +353,12 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	}
 
 	public function test_get_term() {
-
 		$image_post_1     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
 		$image_post_2     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
-		$image_post_3     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );		
-		$marketing_images = [  wp_get_attachment_image_url( $image_post_1 ),  wp_get_attachment_image_url( $image_post_2 ),  wp_get_attachment_image_url( $image_post_3 )   ];
+		$image_post_3     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$marketing_images = [ wp_get_attachment_image_url( $image_post_1 ), wp_get_attachment_image_url( $image_post_2 ), wp_get_attachment_image_url( $image_post_3 ) ];
 
-		$posts_ids_assigned_to_term = [1,2,3];
+		$posts_ids_assigned_to_term = [ 1, 2, 3 ];
 
 		$args_posts_assigned_to_term = [
 			'post_type'   => 'any',
@@ -374,13 +373,13 @@ class AssetSuggestionsServiceTest extends UnitTest {
 				],
 			],
 		];
-		
+
 		$args_post_image_attachments = [
-			'post_type'      => 'attachment',
-			'post_mime_type' => 'image',
-			'fields'         => 'ids',
-			'numberposts'    => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
-			'post_parent__in' => $posts_ids_assigned_to_term 		
+			'post_type'       => 'attachment',
+			'post_mime_type'  => 'image',
+			'fields'          => 'ids',
+			'numberposts'     => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
+			'post_parent__in' => $posts_ids_assigned_to_term,
 		];
 
 		$this->wp->expects( $this->exactly( 2 ) )
@@ -389,16 +388,15 @@ class AssetSuggestionsServiceTest extends UnitTest {
 				[ $args_posts_assigned_to_term ],
 				[ $args_post_image_attachments ],
 			)
-			->willReturnOnConsecutiveCalls( $posts_ids_assigned_to_term , [ $image_post_1, $image_post_2, $image_post_3] );
-		
-		$this->assertEquals($this->format_term_asset_response( $this->term, $marketing_images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ));
+			->willReturnOnConsecutiveCalls( $posts_ids_assigned_to_term, [ $image_post_1, $image_post_2, $image_post_3 ] );
+
+		$this->assertEquals( $this->format_term_asset_response( $this->term, $marketing_images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
 
 	}
 
 	public function test_get_invalid_term_id() {
 		$this->expectException( Exception::class );
 		$this->asset_suggestions->get_assets_suggestions( 123456, 'term' );
-
-	}	
+	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

This PR adds the functionality to return a list of Ads assets for a specific term/category.  The assets will be mapped using the below table:

Google text asset | Existing post/taxonomy meta
-- | --
Final URL | Permalink
(1) Headline Var1 Max. 15 chars |Term title
(2) Headline Var2 Max. 30 chars | Term title
(3) Long headline Max. 90 chars | Site title: Term title
(4) Short description Max. 60 chars | Term description
(5) Description Max. 90 chars | Term description, tagline
(5) Business name Max. 25 chars | Site title
(7) Call-to-action | –
(8) Display URL path | Slug


See original table: pcTzPl-12o-p2#comment-1849

- The Headlines (1 & 2) are grouped as one headline, as the Ads API only use one type which is [HEADLINE](https://github.com/googleads/google-ads-php/blob/151bab9bd37d46543bbeb2c3b0caedf91cb91b6b/src/Google/Ads/GoogleAds/V11/Enums/AssetFieldTypeEnum/AssetFieldType.php#L177).
- The Descriptions (4 & 5) are grouped as one description, as the Ads API only use one type which is [DESCRIPTION](https://github.com/googleads/google-ads-php/blob/151bab9bd37d46543bbeb2c3b0caedf91cb91b6b/src/Google/Ads/GoogleAds/V11/Enums/AssetFieldTypeEnum/AssetFieldType.php#L178).
- When fetching suggestions from WP/WC the field `call_to_action` will be `null` as it is not possible to offer a suggestion, however, when we suggest assets used in other campaigns using the Ads API, the field will be filled.


In addition to the mapping table, the endpoint returns the post's images linked to that term.

For instance, if the category Hoodies contains 5 products, it will show the images of those 5 products.

At the moment we have three types of images:

- Square Marketing images.
- Marketing Images (landscape).
- Logo

The endpoint will return the same images for Square and Landscape images until we decide how to resize/format the images. See comment: pcTzPl-12o-p2#comment-2090

### API Response:

```
{
    "headline": [
        "Hoodies"
    ],
    "long_headline": [
        "Wordpress: Hoodies"
    ],
    "description": [
        "Super Hoodies!",
        "I sell clothing!"
    ],
    "logo": [
        "http://localhost:8082/wp-content/uploads/2022/11/cropped-cropped-ocean-3605547_960_720-150x150.jpeg"
    ],
    "final_url": "http://localhost:8082/product-category/clothing/hoodies/",
    "business_name": "Wordpress",
    "display_url_path": [
        "hoodies"
    ],
    "square_marketing_images": [
        "http://localhost:8082/wp-content/uploads/2022/11/hoodie-with-zipper-2-150x150.jpg",
       .....
    ],
    "marketing_images": [
        "http://localhost:8082/wp-content/uploads/2022/11/hoodie-with-zipper-2-150x150.jpg",
       ....
    ],
    "call_to_action": null
}
```

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to any taxonomy that is created in your website, for example Product->Categories.
2. Go to edit one of the terms. For example: Hoodies. Get the ID term, it can be found on the URL as a the param `tag_id`

![image](https://user-images.githubusercontent.com/2488994/204772330-735acf8d-1067-44d7-bb98-f478521e6586.png)

3. Make a request to: GET assets/suggestions?id=YOUR_TERM_ID&type=term
4. Check that the response matches the mapping table with the term information.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
