### PR TITLE
Resizing Images Assets Pmax assets

### DIFF
--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -164,10 +164,10 @@ class AssetSuggestionsService implements Service {
 
 		if ( $post->post_type === 'product' || $post->post_type === 'product_variation' ) {
 			$product         = $this->wc->maybe_get_product( $id );
-			$attachments_ids = [ ...$attachments_ids, ...$product->get_gallery_image_ids(), $product->get_image_id() ];
+			$attachments_ids = [ ...$attachments_ids, ...$product->get_gallery_image_ids() ];
 		}
 
-		$attachments_ids  = array_slice( [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ) ], 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
+		$attachments_ids  = array_slice( [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ), get_post_thumbnail_id( $id ) ], 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
 		$long_headline    = get_bloginfo( 'name' ) . ': ' . $post->post_title;
 
@@ -208,12 +208,7 @@ class AssetSuggestionsService implements Service {
 		$attachments_ids            = [];
 
 		foreach ( $posts_assigned_to_term as $post ) {
-
-			if ( $post->post_type === 'product' ) {
-				$product           = $this->wc->maybe_get_product( $post->ID );
-				$attachments_ids[] = $product->get_image_id();
-			}
-
+			$attachments_ids[]            = get_post_thumbnail_id( $post->ID );
 			$posts_ids_assigned_to_term[] = $post->ID;
 		}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -439,6 +439,24 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
+	 * Filter for the posts_where hook, adds WHERE clause to search
+	 * for the 'search_title' parameter in the post titles (when present).
+	 *
+	 * @param string   $where The WHERE clause of the query.
+	 * @param WP_Query $wp_query The WP_Query instance (passed by reference).
+	 *
+	 * @return string The updated WHERE clause.
+	 */
+	public function title_filter( string $where, WP_Query $wp_query ): string {
+		$search_title = $wp_query->get( 'search_title' );
+		if ( $search_title ) {
+			$title_search = '%' . $this->wpdb->esc_like( $search_title ) . '%';
+			$where       .= $this->wpdb->prepare( " AND `{$this->wpdb->posts}`.`post_title` LIKE %s", $title_search ); // phpcs:ignore WordPress.DB.PreparedSQL
+		}
+		return $where;
+	}
+
+	/**
 	 * Get terms that can be used to suggest assets
 	 *
 	 * @param string $search The search query

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -133,10 +133,7 @@ class AssetSuggestionsService implements Service {
 			$attachments_ids = [ ...$attachments_ids, ...$product->get_gallery_image_ids(), $product->get_image_id() ];
 		}
 
-		$gallery_images_urls = get_post_gallery_images( $id );
-		$marketing_images    = [ ...$this->get_url_attachments_by_ids( $attachments_ids ), ...$gallery_images_urls ];
-		$marketing_images    = array_slice( $marketing_images, 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
-		$long_headline       = get_bloginfo( 'name' ) . ': ' . $post->post_title;
+		$attachments_ids  = [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ) ];
 
 		return [
 			'headline'                => [ $post->post_title ],
@@ -260,6 +257,23 @@ class AssetSuggestionsService implements Service {
 		$args = wp_parse_args( $args, $defaults );
 
 		return $this->wp->get_posts( $args );
+	}
+
+	/**
+	 * Get gallery images ids.
+	 *
+	 * @param int $post_id Post ID that contains the gallery.
+	 *
+	 * @return array List of gallery images ids.
+	 */
+	protected function get_gallery_images_ids( int $post_id ): array {
+		$gallery = get_post_gallery( $post_id, false );
+
+		if ( ! $gallery || ! isset( $gallery['ids'] ) ) {
+			return [];
+		}
+
+		return explode( ',', $gallery['ids'] );
 	}
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -328,7 +328,7 @@ class AssetSuggestionsService implements Service {
 
 				// If the original size matches the suggested size with a precision of +-1px.
 				if ( $suggested_size && wp_fuzzy_number_match( $suggested_size->x, $image_size->x ) && wp_fuzzy_number_match( $suggested_size->y, $image_size->y ) ) {
-					$marketing_images[ $size_key ][] = wp_get_attachment_url( $id, $size_key );
+					$marketing_images[ $size_key ][] = wp_get_attachment_url( $id );
 				} elseif ( isset( $metadata['sizes'][ $size_key ] ) ) {
 					// use the sub size.
 					$marketing_images[ $size_key ][] = wp_get_attachment_image_url( $id, $size_key );

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -332,7 +332,7 @@ class AssetSuggestionsService implements Service {
 				} elseif ( isset( $metadata['sizes'][ $size_key ] ) ) {
 					// use the sub size.
 					$marketing_images[ $size_key ][] = wp_get_attachment_image_url( $id, $size_key );
-				} elseif ( $suggested_size && $this->image_utility->try_add_subsize_image( $id, $size_key, $suggested_size ) ) {
+				} elseif ( $suggested_size && $this->image_utility->maybe_add_subsize_image( $id, $size_key, $suggested_size ) ) {
 					// use the resized image.
 					$marketing_images[ $size_key ][] = wp_get_attachment_image_url( $id, $size_key );
 				} else {

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -433,14 +433,19 @@ class AssetSuggestionsService implements Service {
 		$filtered_post_types = array_diff( $post_types, $excluded_post_types );
 
 		$args = [
-			'post_type'      => $filtered_post_types,
-			'posts_per_page' => $per_page,
-			'post_status'    => 'publish',
-			's'              => $search,
-			'offset'         => $offset,
+			'post_type'        => $filtered_post_types,
+			'posts_per_page'   => $per_page,
+			'post_status'      => 'publish',
+			'search_title'     => $search,
+			'offset'           => $offset,
+			'suppress_filters' => false,
 		];
 
+		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );
+
 		$posts = $this->wp->get_posts( $args );
+
+		remove_filter( 'posts_where', [ $this, 'title_filter' ] );
 
 		foreach ( $posts as $post ) {
 			$post_suggestions[] = $this->format_final_url_response( $post->ID, 'post', $post->post_title, get_permalink( $post->ID ) );

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -45,10 +45,8 @@ class AssetSuggestionsService implements Service {
 
 	/**
 	 * Image requirements.
-	 *
-	 * @var array
 	 */
-	protected array $image_requirements = [
+	protected const IMAGE_REQUIREMENTS = [
 		self::MARKETING_IMAGE_KEY        => [
 			'minimum'     => [ 600, 314 ],
 			'recommended' => [ 1200, 628 ],
@@ -337,8 +335,8 @@ class AssetSuggestionsService implements Service {
 
 			foreach ( $size_keys as $size_key ) {
 
-				$minimum_size     = new DimensionUtility( ...$this->image_requirements[ $size_key ]['minimum'] );
-				$recommended_size = new DimensionUtility( ...$this->image_requirements[ $size_key ]['recommended'] );
+				$minimum_size     = new DimensionUtility( ...self::IMAGE_REQUIREMENTS[ $size_key ]['minimum'] );
+				$recommended_size = new DimensionUtility( ...self::IMAGE_REQUIREMENTS[ $size_key ]['recommended'] );
 				$image_size       = new DimensionUtility( $metadata['width'], $metadata['height'] );
 				$suggested_size   = $this->image_utility->recommend_size( $image_size, $recommended_size, $minimum_size );
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -65,7 +65,7 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @var array
 	 */
-	protected $image_requirements = [
+	protected array $image_requirements = [
 		self::MARKETING_IMAGE_KEY        => self::MARKETING_IMAGE_SIZES,
 		self::SQUARE_MARKETING_IMAGE_KEY => self::MARKETING_SQUARE_IMAGE_SIZES,
 		self::LOGO_IMAGE_KEY             => self::LOGO_IMAGE_SIZES,

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -133,7 +133,7 @@ class AssetSuggestionsService implements Service {
 			$attachments_ids = [ ...$attachments_ids, ...$product->get_gallery_image_ids(), $product->get_image_id() ];
 		}
 
-		$attachments_ids  = [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ) ];
+		$attachments_ids  = array_slice( [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ) ], 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
 		$long_headline    = get_bloginfo( 'name' ) . ': ' . $post->post_title;
 
@@ -187,6 +187,7 @@ class AssetSuggestionsService implements Service {
 			$attachments_ids = [ ...$this->get_post_image_attachments( [ 'post_parent__in' => $posts_ids_assigned_to_term ] ), ...$attachments_ids ];
 		}
 
+		$attachments_ids  = array_slice( $attachments_ids, 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
 
 		return [

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -27,21 +27,33 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @var WP
 	 */
-	protected $wp;
+	protected WP $wp;
 
 	/**
 	 * WC Proxy
 	 *
 	 * @var WC
 	 */
-	protected $wc;
+	protected WC $wc;
 
 	/**
 	 * Image utilities.
 	 *
 	 * @var ImageUtility
 	 */
-	protected $image_utility;
+	protected ImageUtility $image_utility;
+
+	/**
+	 * Image requirements.
+	 *
+	 * @var array
+	 */
+	protected array $image_requirements = [
+		self::MARKETING_IMAGE_KEY        => self::MARKETING_IMAGE_SIZES,
+		self::SQUARE_MARKETING_IMAGE_KEY => self::MARKETING_SQUARE_IMAGE_SIZES,
+		self::LOGO_IMAGE_KEY             => self::LOGO_IMAGE_SIZES,
+
+	];
 
 	/**
 	 * Default maximum marketing images.
@@ -79,18 +91,6 @@ class AssetSuggestionsService implements Service {
 	protected const LOGO_IMAGE_SIZES = [
 		'minimum'     => [ 128, 128 ],
 		'recommended' => [ 1200, 1200 ],
-	];
-
-	/**
-	 * Image requirements.
-	 *
-	 * @var array
-	 */
-	protected array $image_requirements = [
-		self::MARKETING_IMAGE_KEY        => self::MARKETING_IMAGE_SIZES,
-		self::SQUARE_MARKETING_IMAGE_KEY => self::MARKETING_SQUARE_IMAGE_SIZES,
-		self::LOGO_IMAGE_KEY             => self::LOGO_IMAGE_SIZES,
-
 	];
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -65,7 +65,12 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @var array
 	 */
-	protected $image_requirements = [];
+	protected $image_requirements = [
+		self::MARKETING_IMAGE_KEY        => self::MARKETING_IMAGE_SIZES,
+		self::SQUARE_MARKETING_IMAGE_KEY => self::MARKETING_SQUARE_IMAGE_SIZES,
+		self::LOGO_IMAGE_KEY             => self::LOGO_IMAGE_SIZES,
+
+	];
 
 	/**
 	 * AssetSuggestionsService constructor.
@@ -78,11 +83,6 @@ class AssetSuggestionsService implements Service {
 		$this->wp            = $wp;
 		$this->wc            = $wc;
 		$this->image_utility = $image_utility;
-
-		$this->image_requirements[ self::MARKETING_IMAGE_KEY ]        = self::MARKETING_IMAGE_SIZES;
-		$this->image_requirements[ self::SQUARE_MARKETING_IMAGE_KEY ] = self::MARKETING_SQUARE_IMAGE_SIZES;
-		$this->image_requirements[ self::LOGO_IMAGE_KEY ]             = self::LOGO_IMAGE_SIZES;
-
 	}
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -49,12 +49,20 @@ class AssetSuggestionsService implements Service {
 	 * @var array
 	 */
 	protected array $image_requirements = [
-		self::MARKETING_IMAGE_KEY        => self::MARKETING_IMAGE_SIZES,
-		self::SQUARE_MARKETING_IMAGE_KEY => self::MARKETING_SQUARE_IMAGE_SIZES,
-		self::LOGO_IMAGE_KEY             => self::LOGO_IMAGE_SIZES,
+		self::MARKETING_IMAGE_KEY        => [
+			'minimum'     => [ 600, 314 ],
+			'recommended' => [ 1200, 628 ],
+		],
+		self::SQUARE_MARKETING_IMAGE_KEY => [
+			'minimum'     => [ 300, 300 ],
+			'recommended' => [ 1200, 1200 ],
+		],
+		self::LOGO_IMAGE_KEY             => [
+			'minimum'     => [ 128, 128 ],
+			'recommended' => [ 1200, 1200 ],
+		],
 
 	];
-
 	/**
 	 * Default maximum marketing images.
 	 */
@@ -71,27 +79,6 @@ class AssetSuggestionsService implements Service {
 	 * The subsize key for the logo image.
 	 */
 	protected const LOGO_IMAGE_KEY = 'gla_logo_asset';
-	/**
-	 * The minimum and recommended size for a square marketing image. The first value is the width and the second is the height.
-	 */
-	protected const MARKETING_SQUARE_IMAGE_SIZES = [
-		'minimum'     => [ 300, 300 ],
-		'recommended' => [ 1200, 1200 ],
-	];
-	/**
-	 * The minimum and recommended size for a marketing image. The first value is the width and the second is the height.
-	 */
-	protected const MARKETING_IMAGE_SIZES = [
-		'minimum'     => [ 600, 314 ],
-		'recommended' => [ 1200, 628 ],
-	];
-	/**
-	 * The minimum and recommended size for the logo image. The first value is the width and the second is the height.
-	 */
-	protected const LOGO_IMAGE_SIZES = [
-		'minimum'     => [ 128, 128 ],
-		'recommended' => [ 1200, 1200 ],
-	];
 
 	/**
 	 * AssetSuggestionsService constructor.
@@ -364,8 +351,6 @@ class AssetSuggestionsService implements Service {
 				} elseif ( $suggested_size && $this->image_utility->maybe_add_subsize_image( $id, $size_key, $suggested_size ) ) {
 					// use the resized image.
 					$marketing_images[ $size_key ][] = wp_get_attachment_image_url( $id, $size_key );
-				} else {
-					continue;
 				}
 			}
 		}

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -23,6 +23,27 @@ use Exception;
 class AssetSuggestionsService implements Service {
 
 	/**
+	 * WP Proxy
+	 *
+	 * @var WP
+	 */
+	protected $wp;
+
+	/**
+	 * WC Proxy
+	 *
+	 * @var WC
+	 */
+	protected $wc;
+
+	/**
+	 * Image utilities.
+	 *
+	 * @var ImageUtility
+	 */
+	protected $image_utility;
+
+	/**
 	 * Default maximum marketing images.
 	 */
 	protected const DEFAULT_MAXIMUM_MARKETING_IMAGES = 20;

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -321,10 +321,10 @@ class AssetSuggestionsService implements Service {
 
 			foreach ( $size_keys as $size_key ) {
 
-				$minimum_size    = new DimensionUtility( ...$this->image_requirements[ $size_key ]['minimum'] );
-				$recomended_size = new DimensionUtility( ...$this->image_requirements[ $size_key ]['recommended'] );
-				$image_size      = new DimensionUtility( $metadata['width'], $metadata['height'] );
-				$suggested_size  = $this->image_utility->recommend_size( $image_size, $recomended_size, $minimum_size );
+				$minimum_size     = new DimensionUtility( ...$this->image_requirements[ $size_key ]['minimum'] );
+				$recommended_size = new DimensionUtility( ...$this->image_requirements[ $size_key ]['recommended'] );
+				$image_size       = new DimensionUtility( $metadata['width'], $metadata['height'] );
+				$suggested_size   = $this->image_utility->recommend_size( $image_size, $recommended_size, $minimum_size );
 
 				// If the original size matches the suggested size with a precision of +-1px.
 				if ( $suggested_size && wp_fuzzy_number_match( $suggested_size->x, $image_size->x ) && wp_fuzzy_number_match( $suggested_size->y, $image_size->y ) ) {

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -72,7 +72,7 @@ class AssetSuggestionsService implements Service {
 	 *
 	 * @param WP           $wp WP Proxy.
 	 * @param WC           $wc WC Proxy.
-	 * @param ImageUtility $image_utility WC Proxy.
+	 * @param ImageUtility $image_utility Image utility.
 	 */
 	public function __construct( WP $wp, WC $wc, ImageUtility $image_utility ) {
 		$this->wp            = $wp;

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -167,7 +167,7 @@ class AssetSuggestionsService implements Service {
 			$attachments_ids = [ ...$attachments_ids, ...$product->get_gallery_image_ids() ];
 		}
 
-		$attachments_ids  = array_slice( [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ), get_post_thumbnail_id( $id ) ], 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
+		$attachments_ids  = [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ), get_post_thumbnail_id( $id ) ];
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
 		$long_headline    = get_bloginfo( 'name' ) . ': ' . $post->post_title;
 
@@ -216,7 +216,6 @@ class AssetSuggestionsService implements Service {
 			$attachments_ids = [ ...$this->get_post_image_attachments( [ 'post_parent__in' => $posts_ids_assigned_to_term ] ), ...$attachments_ids ];
 		}
 
-		$attachments_ids  = array_slice( $attachments_ids, 0, self::DEFAULT_MAXIMUM_MARKETING_IMAGES );
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
 
 		return [
@@ -318,16 +317,30 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
+	 * Get unique attachments ids converted to int values if needed.
+	 *
+	 * @param array $ids Attachments ids.
+	 * @param int   $maximum_images Maximum number of images to return.
+	 *
+	 * @return array List of unique attachments ids and converted to int values.
+	 */
+	protected function prepare_image_ids( array $ids, int $maximum_images = self::DEFAULT_MAXIMUM_MARKETING_IMAGES ): array {
+		$ids = array_unique( ArrayUtil::remove_empty_values( $ids ) );
+		$ids = array_map( 'intval', $ids );
+		return array_slice( $ids, 0, $maximum_images );
+	}
+
+	/**
 	 * Get URL for each attachment using an array of attachment ids and a list of subsizes.
 	 *
 	 * @param array $ids Attachments ids.
 	 * @param array $size_keys Image subsize keys.
+	 * @param int   $maximum_images Maximum number of images to return.
 	 *
 	 * @return array A list of attachments urls.
 	 */
-	protected function get_url_attachments_by_ids( array $ids, array $size_keys = [ self::SQUARE_MARKETING_IMAGE_KEY, self::MARKETING_IMAGE_KEY ] ): array {
-		$ids = array_unique( ArrayUtil::remove_empty_values( $ids ) );
-		$ids = array_map( 'intval', $ids );
+	protected function get_url_attachments_by_ids( array $ids, array $size_keys = [ self::SQUARE_MARKETING_IMAGE_KEY, self::MARKETING_IMAGE_KEY ], $maximum_images = self::DEFAULT_MAXIMUM_MARKETING_IMAGES ): array {
+		$ids = $this->prepare_image_ids( $ids, $maximum_images );
 
 		$marketing_images = [];
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Exception;
+use WP_Query;
+use wpdb;
 
 /**
  * Class AssetSuggestionsService
@@ -42,6 +44,13 @@ class AssetSuggestionsService implements Service {
 	 * @var ImageUtility
 	 */
 	protected $image_utility;
+
+	/**
+	 * WordPress database access abstraction class.
+	 *
+	 * @var wpdb
+	 */
+	protected $wpdb;
 
 	/**
 	 * Default maximum marketing images.
@@ -99,10 +108,12 @@ class AssetSuggestionsService implements Service {
 	 * @param WP           $wp WP Proxy.
 	 * @param WC           $wc WC Proxy.
 	 * @param ImageUtility $image_utility Image utility.
+	 * @param wpdb         $wpdb WordPress database access abstraction class.
 	 */
-	public function __construct( WP $wp, WC $wc, ImageUtility $image_utility ) {
+	public function __construct( WP $wp, WC $wc, ImageUtility $image_utility, wpdb $wpdb ) {
 		$this->wp            = $wp;
 		$this->wc            = $wc;
+		$this->wpdb          = $wpdb;
 		$this->image_utility = $image_utility;
 	}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -24,6 +24,37 @@ class AssetSuggestionsService implements Service {
 	 * Default maximum marketing images.
 	 */
 	protected const DEFAULT_MAXIMUM_MARKETING_IMAGES = 20;
+	/**
+	 * The subsize key for the square marketing image.
+	 */
+	protected const SQUARE_MARKETING_IMAGE_KEY = 'gla_square_marketing';
+	/**
+	 * The subsize key for the marketing image.
+	 */
+	protected const MARKETING_IMAGE_KEY = 'gla_marketing';
+	/**
+	 * The subsize key for the marketing image.
+	 */
+	protected const LOGO_IMAGE_KEY = 'gla_logo';
+	/**
+	 * The minimum size for a square marketing image. The first value is the width and the second is the height.
+	 */
+	protected const MARKETING_SQUARE_IMAGE_MINIMUM_SIZE = [ 300, 300 ];
+	/**
+	 * The minimum size for a marketing image. The first value is the width and the second is the height.
+	 */
+	protected const MARKETING_IMAGE_MINIMUM_SIZE = [ 600, 314 ];
+	/**
+	 * The minimum size for the logo image. The first value is the width and the second is the height.
+	 */
+	protected const LOGO_IMAGE_MINIMUM_SIZE = [ 128, 128 ];
+
+	/**
+	 * Minimum image requirements.
+	 *
+	 * @var array
+	 */
+	protected $minimum_image_requirements;
 
 	/**
 	 * AssetSuggestionsService constructor.

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -61,11 +61,11 @@ class AssetSuggestionsService implements Service {
 	];
 
 	/**
-	 * Minimum image requirements.
+	 * Image requirements.
 	 *
 	 * @var array
 	 */
-	protected $image_requirements;
+	protected $image_requirements = [];
 
 	/**
 	 * AssetSuggestionsService constructor.
@@ -220,7 +220,7 @@ class AssetSuggestionsService implements Service {
 	/**
 	 * Get logo images urls.
 	 *
-	 * @return array Logo images URLS.
+	 * @return array Logo images urls.
 	 */
 	protected function get_logo_images(): array {
 		$logo_images = $this->get_url_attachments_by_ids( [ get_theme_mod( 'custom_logo' ) ], [ self::LOGO_IMAGE_KEY ] );
@@ -326,8 +326,8 @@ class AssetSuggestionsService implements Service {
 				$image_size      = new DimensionUtility( $metadata['width'], $metadata['height'] );
 				$suggested_size  = $this->image_utility->recommend_size( $image_size, $recomended_size, $minimum_size );
 
-				// If the original size matches the recommendation with a precision of +-1px.
-				if ( wp_fuzzy_number_match( $suggested_size->x, $image_size->x ) && wp_fuzzy_number_match( $suggested_size->y, $image_size->y ) ) {
+				// If the original size matches the suggested size with a precision of +-1px.
+				if ( $suggested_size && wp_fuzzy_number_match( $suggested_size->x, $image_size->x ) && wp_fuzzy_number_match( $suggested_size->y, $image_size->y ) ) {
 					$marketing_images[ $size_key ][] = wp_get_attachment_url( $id, $size_key );
 				} elseif ( isset( $metadata['sizes'][ $size_key ] ) ) {
 					// use the sub size.

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -141,7 +141,7 @@ class AssetSuggestionsService implements Service {
 			'headline'                => [ $post->post_title ],
 			'long_headline'           => [ $long_headline ],
 			'description'             => ArrayUtil::remove_empty_values( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ),
-			'logo'                    => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
+			'logo'                    => $this->get_logo_images(),
 			'final_url'               => get_permalink( $id ),
 			'business_name'           => get_bloginfo( 'name' ),
 			'display_url_path'        => [ $post->post_name ],
@@ -188,13 +188,12 @@ class AssetSuggestionsService implements Service {
 		}
 
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
-		$logo_images      = $this->get_url_attachments_by_ids( [ get_theme_mod( 'custom_logo' ) ], [ self::LOGO_IMAGE_KEY ] );
 
 		return [
 			'headline'                => [ $term->name ],
 			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $term->name ],
 			'description'             => ArrayUtil::remove_empty_values( [ wp_strip_all_tags( $term->description ), get_bloginfo( 'description' ) ] ),
-			'logo'                    => $logo_images[ self::LOGO_IMAGE_KEY ] ?? [],
+			'logo'                    => $this->get_logo_images(),
 			'final_url'               => get_term_link( $term->term_id ),
 			'business_name'           => get_bloginfo( 'name' ),
 			'display_url_path'        => [ $term->slug ],
@@ -202,6 +201,16 @@ class AssetSuggestionsService implements Service {
 			'marketing_images'        => $marketing_images [ self::MARKETING_IMAGE_KEY ] ?? [],
 			'call_to_action'          => null,
 		];
+	}
+
+	/**
+	 * Get logo images urls.
+	 *
+	 * @return array Logo images URLS.
+	 */
+	protected function get_logo_images(): array {
+		$logo_images = $this->get_url_attachments_by_ids( [ get_theme_mod( 'custom_logo' ) ], [ self::LOGO_IMAGE_KEY ] );
+		return $logo_images[ self::LOGO_IMAGE_KEY ] ?? [];
 	}
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -65,6 +65,11 @@ class AssetSuggestionsService implements Service {
 	public function __construct( WP $wp, WC $wc ) {
 		$this->wp = $wp;
 		$this->wc = $wc;
+
+		$this->minimum_image_requirements[ self::MARKETING_IMAGE_KEY ]        = self::MARKETING_IMAGE_MINIMUM_SIZE;
+		$this->minimum_image_requirements[ self::SQUARE_MARKETING_IMAGE_KEY ] = self::MARKETING_SQUARE_IMAGE_MINIMUM_SIZE;
+		$this->minimum_image_requirements[ self::LOGO_IMAGE_KEY ]             = self::LOGO_IMAGE_MINIMUM_SIZE;
+
 	}
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -348,7 +348,7 @@ class AssetSuggestionsService implements Service {
 				$suggested_size   = $this->image_utility->recommend_size( $image_size, $recommended_size, $minimum_size );
 
 				// If the original size matches the suggested size with a precision of +-1px.
-				if ( $suggested_size && wp_fuzzy_number_match( $suggested_size->x, $image_size->x ) && wp_fuzzy_number_match( $suggested_size->y, $image_size->y ) ) {
+				if ( $suggested_size && $suggested_size->equals( $image_size ) ) {
 					$marketing_images[ $size_key ][] = wp_get_attachment_url( $id );
 				} elseif ( isset( $metadata['sizes'][ $size_key ] ) ) {
 					// use the sub size.

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -317,12 +317,12 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
-	 * Get unique attachments ids converted to int values if needed.
+	 * Get unique attachments ids converted to int values.
 	 *
 	 * @param array $ids Attachments ids.
 	 * @param int   $maximum_images Maximum number of images to return.
 	 *
-	 * @return array List of unique attachments ids and converted to int values.
+	 * @return array List of unique attachments ids converted to int values.
 	 */
 	protected function prepare_image_ids( array $ids, int $maximum_images = self::DEFAULT_MAXIMUM_MARKETING_IMAGES ): array {
 		$ids = array_unique( ArrayUtil::remove_empty_values( $ids ) );

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -33,7 +33,7 @@ class AssetSuggestionsService implements Service {
 	 */
 	protected const MARKETING_IMAGE_KEY = 'gla_marketing';
 	/**
-	 * The subsize key for the marketing image.
+	 * The subsize key for the logo image.
 	 */
 	protected const LOGO_IMAGE_KEY = 'gla_logo';
 	/**
@@ -289,10 +289,10 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
-	 * Get URL for each attachment using an array of attachment ids.
+	 * Get URL for each attachment using an array of attachment ids and a list of subsizes.
 	 *
 	 * @param array $ids Attachments ids.
-	 * @param array $size_keys Subsize keys that we would like to create.
+	 * @param array $size_keys Image subsize keys.
 	 *
 	 * @return array A list of attachments urls.
 	 */

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -52,7 +52,7 @@ class AssetSuggestionsService implements Service {
 	 */
 	protected $wpdb;
 
-  /**
+	/**
 	 * Image requirements.
 	 */
 	protected const IMAGE_REQUIREMENTS = [

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -115,6 +115,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\TracksAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\TracksInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\AddressUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ISOUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
@@ -252,7 +253,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getLeagueContainer()
 			 ->inflector( AdsAwareInterface::class )
 			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
-		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class );
+		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class );
 
 		// Set up the installer.
 		$installer_definition = $this->share_with_tags(
@@ -270,6 +271,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Share utility classes
 		$this->share_with_tags( AddressUtility::class );
 		$this->share_with_tags( DateTimeUtility::class );
+		$this->share_with_tags( ImageUtility::class );
 		$this->share_with_tags( ISOUtility::class, ISO3166DataProvider::class );
 
 		// Share our regular service classes.

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -271,7 +271,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Share utility classes
 		$this->share_with_tags( AddressUtility::class );
 		$this->share_with_tags( DateTimeUtility::class );
-		$this->share_with_tags( ImageUtility::class );
+		$this->share_with_tags( ImageUtility::class, WP::class );
 		$this->share_with_tags( ISOUtility::class, ISO3166DataProvider::class );
 
 		// Share our regular service classes.

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -121,6 +121,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166Dat
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use wpdb;
 
 /**
  * Class CoreServiceProvider
@@ -253,7 +254,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getLeagueContainer()
 			 ->inflector( AdsAwareInterface::class )
 			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
-		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class );
+		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class );
 
 		// Set up the installer.
 		$installer_definition = $this->share_with_tags(

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -288,4 +288,24 @@ class WP {
 		return null;
 
 	}
+
+	/**
+	 * If any of the currently registered image sub-sizes are missing,
+	 * create them and update the image meta data.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $attachment_id The image attachment post ID.
+	 * @return array|WP_Error The updated image meta data array or WP_Error object
+	 *                        if both the image meta and the attached file are missing.
+	 */
+	public function wp_update_image_subsizes( int $attachment_id ) {
+		// It is required as wp_update_image_subsizes is not loaded automatically.
+		if ( ! function_exists( 'wp_update_image_subsizes' ) ) {
+			include ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		return wp_update_image_subsizes( $attachment_id );
+
+	}
 }

--- a/src/Utility/DimensionUtility.php
+++ b/src/Utility/DimensionUtility.php
@@ -34,14 +34,14 @@ class DimensionUtility {
 	}
 
 	/**
-	 * Checks if the dimension is bigger or equal than the other one.
+	 * Checks if the dimension fulfils the minimum size.
 	 *
-	 * @param DimensionUtility $target The dimension to be compared.
+	 * @param DimensionUtility $minimum_size The minimum size.
 	 *
-	 * @return bool true if the dimension is bigger or equal than the other one otherwise false.
+	 * @return bool true if the dimension is bigger or equal than the the minimum size otherwise false.
 	 */
-	public function is_bigger( DimensionUtility $target ): bool {
-		return $this->x >= $target->x && $this->y >= $target->y;
+	public function is_minimum_size( DimensionUtility $minimum_size ): bool {
+		return $this->x >= $minimum_size->x && $this->y >= $minimum_size->y;
 	}
 
 	/**

--- a/src/Utility/DimensionUtility.php
+++ b/src/Utility/DimensionUtility.php
@@ -32,5 +32,30 @@ class DimensionUtility {
 		$this->x = $x;
 		$this->y = $y;
 	}
+
+	/**
+	 * Checks if the image is bigger than the other one.
+	 *
+	 * @param DimensionUtility $target The image to be compared.
+	 *
+	 * @return bool true if the image is bigger than the other one otherwise false.
+	 */
+	public function is_bigger( DimensionUtility $target ): bool {
+		return $this->x >= $target->x && $this->y >= $target->y;
+	}
+
+	/**
+	 * Checks if the image is equal to the other one with a specific precision.
+	 *
+	 * @param DimensionUtility $target The image to be compared.
+	 * @param int|float        $precision The precision to use when comparing the two numbers.
+	 *
+	 * @return bool true if the image is bigger than the other one otherwise false.
+	 */
+	public function equals( DimensionUtility $target, $precision = 1 ): bool {
+		return wp_fuzzy_number_match( $this->x, $target->x, $precision ) && wp_fuzzy_number_match( $this->y, $target->y, $precision );
+	}
+
+
 }
 

--- a/src/Utility/DimensionUtility.php
+++ b/src/Utility/DimensionUtility.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
+
+/**
+ * A class for dealing with Dimensions.
+ *
+ * @since x.x.x
+ */
+class DimensionUtility {
+
+	/**
+	 * Width.
+	 *
+	 * @var int
+	 */
+	public int $x;
+	/**
+	 * Height.
+	 *
+	 * @var int
+	 */
+	public int $y;
+
+	/**
+	 * DimensionUtility constructor.
+	 *
+	 * @param int $x Width.
+	 * @param int $y Height.
+	 */
+	public function __construct( int $x, int $y ) {
+		$this->x = $x;
+		$this->y = $y;
+	}
+}
+

--- a/src/Utility/DimensionUtility.php
+++ b/src/Utility/DimensionUtility.php
@@ -34,23 +34,23 @@ class DimensionUtility {
 	}
 
 	/**
-	 * Checks if the image is bigger than the other one.
+	 * Checks if the dimension is bigger or equal than the other one.
 	 *
-	 * @param DimensionUtility $target The image to be compared.
+	 * @param DimensionUtility $target The dimension to be compared.
 	 *
-	 * @return bool true if the image is bigger than the other one otherwise false.
+	 * @return bool true if the dimension is bigger or equal than the other one otherwise false.
 	 */
 	public function is_bigger( DimensionUtility $target ): bool {
 		return $this->x >= $target->x && $this->y >= $target->y;
 	}
 
 	/**
-	 * Checks if the image is equal to the other one with a specific precision.
+	 * Checks if the dimension is equal to the other one with a specific precision.
 	 *
-	 * @param DimensionUtility $target The image to be compared.
+	 * @param DimensionUtility $target The dimension to be compared.
 	 * @param int|float        $precision The precision to use when comparing the two numbers.
 	 *
-	 * @return bool true if the image is equal than the other one otherwise false.
+	 * @return bool true if the dimension is equal than the other one otherwise false.
 	 */
 	public function equals( DimensionUtility $target, $precision = 1 ): bool {
 		return wp_fuzzy_number_match( $this->x, $target->x, $precision ) && wp_fuzzy_number_match( $this->y, $target->y, $precision );

--- a/src/Utility/DimensionUtility.php
+++ b/src/Utility/DimensionUtility.php
@@ -50,7 +50,7 @@ class DimensionUtility {
 	 * @param DimensionUtility $target The image to be compared.
 	 * @param int|float        $precision The precision to use when comparing the two numbers.
 	 *
-	 * @return bool true if the image is bigger than the other one otherwise false.
+	 * @return bool true if the image is equal than the other one otherwise false.
 	 */
 	public function equals( DimensionUtility $target, $precision = 1 ): bool {
 		return wp_fuzzy_number_match( $this->x, $target->x, $precision ) && wp_fuzzy_number_match( $this->y, $target->y, $precision );

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 /**
  * A class of utilities for dealing with images.
@@ -11,6 +12,22 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
  * @since x.x.x
  */
 class ImageUtility implements Service {
+
+	/**
+	 * The WP Proxy.
+	 *
+	 * @var WP
+	 */
+	protected $wp;
+
+	/**
+	 * AssetSuggestionsService constructor.
+	 *
+	 * @param WP $wp WP Proxy.
+	 */
+	public function __construct( WP $wp ) {
+		$this->wp = $wp;
+	}
 
 	/**
 	 * Try to add a new subsize image.
@@ -23,14 +40,9 @@ class ImageUtility implements Service {
 	 * @return bool True if the subsize has been added to the attachment metadata otherwise false.
 	 */
 	public function maybe_add_subsize_image( int $attachment_id, string $subsize_key, DimensionUtility $size, bool $crop = true ): bool {
-		// It is required as wp_update_image_subsizes is not loaded automatically.
-		if ( ! function_exists( 'wp_update_image_subsizes' ) ) {
-			include ABSPATH . 'wp-admin/includes/image.php';
-		}
-
 		add_image_size( $subsize_key, $size->x, $size->y, $crop );
 
-		$metadata = wp_update_image_subsizes( $attachment_id );
+		$metadata = $this->wp->wp_update_image_subsizes( $attachment_id );
 
 		remove_image_size( $subsize_key );
 
@@ -51,7 +63,7 @@ class ImageUtility implements Service {
 	 * @return DimensionUtility|bool False if does not fulfil the minimum size otherwise returns the suggested size.
 	 */
 	public function recommend_size( DimensionUtility $size, DimensionUtility $recommended, DimensionUtility $minimum ) {
-		if ( ! $this->is_bigger( $size, $minimum ) ) {
+		if ( ! $size->is_bigger( $minimum ) ) {
 			return false;
 		}
 
@@ -69,17 +81,7 @@ class ImageUtility implements Service {
 		return new DimensionUtility( $x, $y );
 	}
 
-	/**
-	 * Checks if the first image is bigger than the other one.
-	 *
-	 * @param DimensionUtility $image First image.
-	 * @param DimensionUtility $target The image to be compared.
-	 *
-	 * @return bool true if the first image is bigger than the other one otherwise false.
-	 */
-	public function is_bigger( DimensionUtility $image, DimensionUtility $target ): bool {
-		return $image->x >= $target->x && $image->y >= $target->y;
-	}
+
 
 
 }

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -51,7 +51,7 @@ class ImageUtility implements Service {
 	 * @return DimensionUtility|bool False if does not fulfil the minimum size otherwise returns the suggested size.
 	 */
 	public function recommend_size( DimensionUtility $size, DimensionUtility $recommended, DimensionUtility $minimum ) {
-		if ( ! $this->check_minimum_image_size( $size, $minimum ) ) {
+		if ( ! $this->is_bigger( $size, $minimum ) ) {
 			return false;
 		}
 
@@ -70,15 +70,15 @@ class ImageUtility implements Service {
 	}
 
 	/**
-	 * Checks minimum image size
+	 * Checks if the first image is bigger than the other one.
 	 *
-	 * @param DimensionUtility $size Width and height values in pixels (in that order).
-	 * @param DimensionUtility $recommended Minimum width and height values in pixels (in that order).
+	 * @param DimensionUtility $image First image.
+	 * @param DimensionUtility $target The image to be compared.
 	 *
-	 * @return bool true if the image size fulfils the minimum requirements otherwise false.
+	 * @return bool true if the first image is bigger than the other one otherwise false.
 	 */
-	public function check_minimum_image_size( DimensionUtility $size, DimensionUtility $recommended ): bool {
-		return $size->x >= $recommended->x && $size->y >= $recommended->y;
+	public function is_bigger( DimensionUtility $image, DimensionUtility $target ): bool {
+		return $image->x >= $target->x && $image->y >= $target->y;
 	}
 
 

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -18,7 +18,7 @@ class ImageUtility implements Service {
 	 *
 	 * @var WP
 	 */
-	protected $wp;
+	protected WP $wp;
 
 	/**
 	 * AssetSuggestionsService constructor.

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -17,7 +17,7 @@ class ImageUtility implements Service {
 	 *
 	 * @param int              $attachment_id Attachment ID.
 	 * @param string           $subsize_key The subsize key that we are trying to generate.
-	 * @param DimensionUtility $size Image width in pixels.
+	 * @param DimensionUtility $size The new size for the subsize key.
 	 * @param bool             $crop Whether to crop the image.
 	 *
 	 * @return bool True if the subsize has been added to the attachment metadata otherwise false.
@@ -42,7 +42,7 @@ class ImageUtility implements Service {
 	}
 
 	/**
-	 * Try to add a new subsize image.
+	 * Try to recommend a size using the real size, the recommended and the minimum.
 	 *
 	 * @param DimensionUtility $size Image size.
 	 * @param DimensionUtility $recommended Recommended image size.

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -22,7 +22,7 @@ class ImageUtility implements Service {
 	 *
 	 * @return bool True if the subsize has been added to the attachment metadata otherwise false.
 	 */
-	public function try_add_subsize_image( int $attachment_id, string $subsize_key, DimensionUtility $size, bool $crop = true ): bool {
+	public function maybe_add_subsize_image( int $attachment_id, string $subsize_key, DimensionUtility $size, bool $crop = true ): bool {
 		// It is required as wp_update_image_subsizes is not loaded automatically.
 		if ( ! function_exists( 'wp_update_image_subsizes' ) ) {
 			include ABSPATH . 'wp-admin/includes/image.php';

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -30,7 +30,7 @@ class ImageUtility implements Service {
 	}
 
 	/**
-	 * Try to add a new subsize image.
+	 * Maybe add a new subsize image.
 	 *
 	 * @param int              $attachment_id Attachment ID.
 	 * @param string           $subsize_key The subsize key that we are trying to generate.

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+
+/**
+ * A class of utilities for dealing with images.
+ *
+ * @since x.x.x
+ */
+class ImageUtility implements Service {
+
+	/**
+	 * Try to add a new subsize image.
+	 *
+	 * @param int              $attachment_id Attachment ID.
+	 * @param string           $subsize_key The subsize key that we are trying to generate.
+	 * @param DimensionUtility $size Image width in pixels.
+	 * @param bool             $crop Whether to crop the image.
+	 *
+	 * @return bool True if the subsize has been added to the attachment metadata otherwise false.
+	 */
+	public function try_add_subsize_image( int $attachment_id, string $subsize_key, DimensionUtility $size, bool $crop = true ): bool {
+		// It is required as wp_update_image_subsizes is not loaded automatically.
+		if ( ! function_exists( 'wp_update_image_subsizes' ) ) {
+			include ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		add_image_size( $subsize_key, $size->x, $size->y, $crop );
+
+		$metadata = wp_update_image_subsizes( $attachment_id );
+
+		remove_image_size( $subsize_key );
+
+		if ( is_wp_error( $metadata ) ) {
+			return false;
+		}
+
+		return isset( $metadata['sizes'][ $subsize_key ] );
+	}
+
+	/**
+	 * Try to add a new subsize image.
+	 *
+	 * @param DimensionUtility $size Image size.
+	 * @param DimensionUtility $recommended Recommended image size.
+	 * @param DimensionUtility $minimum Minimum image size.
+	 *
+	 * @return DimensionUtility|bool False if does not fulfil the minimum size otherwise returns the suggested size.
+	 */
+	public function recommend_size( DimensionUtility $size, DimensionUtility $recommended, DimensionUtility $minimum ) {
+		if ( ! $this->check_minimum_image_size( $size, $minimum ) ) {
+			return false;
+		}
+
+		$image_ratio       = $size->x / $size->y;
+		$recommended_ratio = $recommended->x / $recommended->y;
+
+		if ( $recommended_ratio > $image_ratio ) {
+			$x = $size->x > $recommended->x ? $recommended->x : $size->x;
+			$y = (int) floor( $x / $recommended_ratio );
+		} else {
+			$y = $size->y > $recommended->y ? $recommended->y : $size->y;
+			$x = (int) floor( $y * $recommended_ratio );
+		}
+
+		return new DimensionUtility( $x, $y );
+	}
+
+	/**
+	 * Checks minimum image size
+	 *
+	 * @param DimensionUtility $size Width and height values in pixels (in that order).
+	 * @param DimensionUtility $recommended Minimum width and height values in pixels (in that order).
+	 *
+	 * @return bool true if the image size fulfils the minimum requirements otherwise false.
+	 */
+	public function check_minimum_image_size( DimensionUtility $size, DimensionUtility $recommended ): bool {
+		return $size->x >= $recommended->x && $size->y >= $recommended->y;
+	}
+
+
+}
+
+

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -63,7 +63,7 @@ class ImageUtility implements Service {
 	 * @return DimensionUtility|bool False if does not fulfil the minimum size otherwise returns the suggested size.
 	 */
 	public function recommend_size( DimensionUtility $size, DimensionUtility $recommended, DimensionUtility $minimum ) {
-		if ( ! $size->is_bigger( $minimum ) ) {
+		if ( ! $size->is_minimum_size( $minimum ) ) {
 			return false;
 		}
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -56,6 +56,13 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	];
 
 	/**
+	 * Minimum image requirements.
+	 *
+	 * @var array
+	 */
+	protected $minimum_image_requirements;	
+
+	/**
 	 * Runs before each test is executed.
 	 */
 	public function setUp(): void {
@@ -70,7 +77,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		$this->suggested_post = $this->format_url_post_item( $this->post );
 		$this->suggested_term = $this->format_url_term_item( $this->term );
-
+	
 		$this->minimum_image_requirements[ self::MARKETING_IMAGE_KEY ]        = self::MARKETING_IMAGE_MINIMUM_SIZE;
 		$this->minimum_image_requirements[ self::SQUARE_MARKETING_IMAGE_KEY ] = self::MARKETING_SQUARE_IMAGE_MINIMUM_SIZE;
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -437,11 +437,9 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	}
 
 	public function test_get_term_without_product() {
-		$post             = $this->factory()->post->create_and_get();
-		$image_post_1     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
-		$image_post_2     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
-		$marketing_images = [ wp_get_attachment_image_url( $image_post_1 ), wp_get_attachment_image_url( $image_post_2 ) ];
-
+		$post                       = $this->factory()->post->create_and_get();
+		$image_post_1               = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$image_post_2               = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
 		$posts_ids_assigned_to_term = [ $this->post, $post ];
 
 		$this->update_size_image( $image_post_1, [ 1200, 1200 ], self::SQUARE_MARKETING_IMAGE_KEY );

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -446,10 +446,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		$posts_ids_assigned_to_term = [ $this->post, $post ];
 
-		$this->wc->expects( $this->once() )
-			->method( 'maybe_get_product' )
-			->willReturn( $product );
-
 		$args_posts_assigned_to_term = [
 			'post_type'   => 'any',
 			'numberposts' => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -332,7 +332,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		// Both images should be resized
 		$this->image_utility->expects( $this->exactly( 2 ) )
-		->method( 'try_add_subsize_image' )
+		->method( 'maybe_add_subsize_image' )
 		->willReturn( true );
 
 		$this->wp->expects( $this->once() )
@@ -366,7 +366,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		// Should not create any subsize because already exists
 		$this->image_utility->expects( $this->exactly( 0 ) )->
-		method( 'try_add_subsize_image' );
+		method( 'maybe_add_subsize_image' );
 
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_gallery_image_ids( [ $image_id ] );
@@ -397,7 +397,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		// Should not create any subsize because already exists
 		$this->image_utility->expects( $this->exactly( 0 ) )->
-		method( 'try_add_subsize_image' );
+		method( 'maybe_add_subsize_image' );
 
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_gallery_image_ids( [ $image_product_id ] );
@@ -437,7 +437,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		// One image is too small and the other one is ok.
 		$this->image_utility->expects( $this->exactly( 4 ) )
-		->method( 'try_add_subsize_image' )
+		->method( 'maybe_add_subsize_image' )
 		->willReturnOnConsecutiveCalls( false, false, true, true );
 
 		$product = WC_Helper_Product::create_simple_product();
@@ -536,7 +536,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		->willReturn( $this->suggested_image_square );
 
 		$this->image_utility->expects( $this->exactly( 1 ) )
-		->method( 'try_add_subsize_image' )
+		->method( 'maybe_add_subsize_image' )
 		->willReturn( true );
 
 		$images[ self::LOGO_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_id ) ];
@@ -557,7 +557,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		// It should not create a subsize because the original image already has the suggested size.
 		$this->image_utility->expects( $this->exactly( 0 ) )
-		->method( 'try_add_subsize_image' );
+		->method( 'maybe_add_subsize_image' );
 
 		$this->wp->expects( $this->exactly( 1 ) )
 		->method( 'get_posts' )
@@ -581,7 +581,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		// It should not create a subsize because the original image already has the suggested size.
 		$this->image_utility->expects( $this->exactly( 0 ) )
-		->method( 'try_add_subsize_image' );
+		->method( 'maybe_add_subsize_image' );
 
 		$this->wp->expects( $this->exactly( 1 ) )
 		->method( 'get_posts' )

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -570,6 +570,30 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 	}
 
+	public function tests_assets_image_too_small_size() {
+		$image_id = $this->get_test_image();
+
+		$this->update_size_image( $image_id, $this->suggested_image_square );
+
+		$this->image_utility->expects( $this->exactly( 2 ) )
+		->method( 'recommend_size' )
+		->willReturn( false );
+
+		// It should not create a subsize because the original image already has the suggested size.
+		$this->image_utility->expects( $this->exactly( 0 ) )
+		->method( 'try_add_subsize_image' );
+
+		$this->wp->expects( $this->exactly( 1 ) )
+		->method( 'get_posts' )
+		->willReturn( [ $image_id ] );
+
+		$images[ self::SQUARE_MARKETING_IMAGE_KEY ] = [];
+		$images[ self::MARKETING_IMAGE_KEY ]        = [];
+
+		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+
+	}
+
 
 
 }

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -60,7 +60,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	 *
 	 * @var array
 	 */
-	protected $minimum_image_requirements;	
+	protected $minimum_image_requirements;
 
 	/**
 	 * Runs before each test is executed.
@@ -77,7 +77,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		$this->suggested_post = $this->format_url_post_item( $this->post );
 		$this->suggested_term = $this->format_url_term_item( $this->term );
-	
+
 		$this->minimum_image_requirements[ self::MARKETING_IMAGE_KEY ]        = self::MARKETING_IMAGE_MINIMUM_SIZE;
 		$this->minimum_image_requirements[ self::SQUARE_MARKETING_IMAGE_KEY ] = self::MARKETING_SQUARE_IMAGE_MINIMUM_SIZE;
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
 use WC_Helper_Product;
+use wpdb;
 
 
 defined( 'ABSPATH' ) || exit;
@@ -67,8 +68,9 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$this->wp            = $this->createMock( WP::class );
 		$this->wc            = $this->createMock( WC::class );
 		$this->image_utility = $this->createMock( ImageUtility::class );
+		$this->wpdb          = $this->createMock( wpdb::class );
 
-		$this->asset_suggestions = new AssetSuggestionsService( $this->wp, $this->wc, $this->image_utility );
+		$this->asset_suggestions = new AssetSuggestionsService( $this->wp, $this->wc, $this->image_utility, $this->wpdb );
 
 		$this->post = $this->factory()->post->create_and_get( [ 'post_title' => 'Abcd' ] );
 		$this->term = $this->factory()->term->create_and_get( [ 'name' => 'bcde' ] );
@@ -167,11 +169,13 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		->method( 'get_posts' )
 		->with(
 			[
-				'post_type'      => self::TEST_POST_TYPES_NO_ATTACHMENT,
-				'posts_per_page' => self::DEFAULT_PER_PAGE_POSTS,
-				'post_status'    => 'publish',
-				's'              => self::TEST_SEARCH,
-				'offset'         => 0,
+				'post_type'        => self::TEST_POST_TYPES_NO_ATTACHMENT,
+				'posts_per_page'   => self::DEFAULT_PER_PAGE_POSTS,
+				'post_status'      => 'publish',
+				'search_title'     => self::TEST_SEARCH,
+				'offset'           => 0,
+				'suppress_filters' => false,
+
 			]
 		)
 		->willReturn( [ $this->post ] );

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -26,12 +26,16 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 	use DataTrait;
 
-	protected const DEFAULT_PER_PAGE                 = 30;
-	protected const DEFAULT_PER_PAGE_POSTS           = 15;
-	protected const EMPTY_SEARCH                     = '';
-	protected const TEST_SEARCH                      = 'mySearch';
-	protected const DEFAULT_MAXIMUM_MARKETING_IMAGES = 20;
-	protected const INVALID_ID                       = 123456;
+	protected const DEFAULT_PER_PAGE                    = 30;
+	protected const DEFAULT_PER_PAGE_POSTS              = 15;
+	protected const EMPTY_SEARCH                        = '';
+	protected const TEST_SEARCH                         = 'mySearch';
+	protected const DEFAULT_MAXIMUM_MARKETING_IMAGES    = 20;
+	protected const INVALID_ID                          = 123456;
+	protected const SQUARE_MARKETING_IMAGE_KEY          = 'gla_square_marketing';
+	protected const MARKETING_IMAGE_KEY                 = 'gla_marketing';
+	protected const MARKETING_SQUARE_IMAGE_MINIMUM_SIZE = [ 300, 300 ];
+	protected const MARKETING_IMAGE_MINIMUM_SIZE        = [ 600, 314 ];
 
 	protected const TEST_POST_TYPES               = [
 		'post',
@@ -67,6 +71,9 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$this->suggested_post = $this->format_url_post_item( $this->post );
 		$this->suggested_term = $this->format_url_term_item( $this->term );
 
+		$this->minimum_image_requirements[ self::MARKETING_IMAGE_KEY ]        = self::MARKETING_IMAGE_MINIMUM_SIZE;
+		$this->minimum_image_requirements[ self::SQUARE_MARKETING_IMAGE_KEY ] = self::MARKETING_SQUARE_IMAGE_MINIMUM_SIZE;
+
 	}
 
 	protected function format_url_post_item( $post ) {
@@ -96,8 +103,8 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'business_name'           => get_bloginfo( 'name' ),
 			'display_url_path'        => [ $post->post_name ],
 			'logo'                    => [],
-			'square_marketing_images' => $marketing_images,
-			'marketing_images'        => $marketing_images,
+			'square_marketing_images' => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
+			'marketing_images'        => $marketing_images[ self::MARKETING_IMAGE_KEY ] ?? [],
 			'call_to_action'          => null,
 		];
 
@@ -112,95 +119,111 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'logo'                    => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
 			'business_name'           => get_bloginfo( 'name' ),
 			'display_url_path'        => [ $term->slug ],
-			'square_marketing_images' => $marketing_images,
-			'marketing_images'        => $marketing_images,
+			'square_marketing_images' => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
+			'marketing_images'        => $marketing_images[ self::MARKETING_IMAGE_KEY ] ?? [],
 			'call_to_action'          => null,
 		];
 
 	}
 
+	protected function update_size_image( $attachmend_id, $size, $size_type = null ) {
+		$metadata           = wp_get_attachment_metadata( $attachmend_id );
+		$metadata['width']  = $size[0];
+		$metadata['height'] = $size[1];
+
+		if ( $size_type ) {
+			$metadata['sizes'][ $size_type ] = [
+				'file'   => $metadata['file'],
+				'width'  => $this->minimum_image_requirements[ $size_type ][0],
+				'height' => $this->minimum_image_requirements[ $size_type ][1],
+			];
+		}
+
+		wp_update_attachment_metadata( $attachmend_id, $metadata );
+	}
+
 	public function test_get_post_suggestions() {
 		$this->wp->expects( $this->once() )
-			->method( 'get_post_types' )
-			->willReturn( self::TEST_POST_TYPES );
+		->method( 'get_post_types' )
+		->willReturn( self::TEST_POST_TYPES );
 
 		// Should be called without the attachment type
 		$this->wp->expects( $this->once() )
-			->method( 'get_posts' )
-			->with(
-				[
-					'post_type'      => self::TEST_POST_TYPES_NO_ATTACHMENT,
-					'posts_per_page' => self::DEFAULT_PER_PAGE_POSTS,
-					'post_status'    => 'publish',
-					's'              => self::TEST_SEARCH,
-					'offset'         => 0,
-				]
-			)
-			->willReturn( [ $this->post ] );
+		->method( 'get_posts' )
+		->with(
+			[
+				'post_type'      => self::TEST_POST_TYPES_NO_ATTACHMENT,
+				'posts_per_page' => self::DEFAULT_PER_PAGE_POSTS,
+				'post_status'    => 'publish',
+				's'              => self::TEST_SEARCH,
+				'offset'         => 0,
+			]
+		)
+		->willReturn( [ $this->post ] );
 
-			$this->wp->expects( $this->once() )
-			->method( 'get_taxonomies' );
+		$this->wp->expects( $this->once() )
+		->method( 'get_taxonomies' );
 
-			$this->wp->expects( $this->once() )
-			->method( 'get_terms' )
-			->willReturn( [] );
+		$this->wp->expects( $this->once() )
+		->method( 'get_terms' )
+		->willReturn( [] );
 
 		$this->assertEquals( [ $this->suggested_post ], $this->asset_suggestions->get_final_url_suggestions( self::TEST_SEARCH ) );
 	}
 
 	public function test_get_term_suggestions() {
 		$this->wp->expects( $this->once() )
-			->method( 'get_post_types' )
-			->willReturn( self::TEST_POST_TYPES );
+		->method( 'get_post_types' )
+		->willReturn( self::TEST_POST_TYPES );
 
 		$this->wp->expects( $this->once() )
-			->method( 'get_posts' )
-			->willReturn( [ $this->post ] );
+		->method( 'get_posts' )
+		->willReturn( [ $this->post ] );
 
 		$this->wp->expects( $this->once() )
-			->method( 'get_taxonomies' )
-			->willReturn( self::TEST_TAXONOMIES );
+		->method( 'get_taxonomies' )
+		->willReturn( self::TEST_TAXONOMIES );
 
 		$this->wp->expects( $this->once() )
-			->method( 'get_terms' )
-			->with(
-				[
-					'taxonomy'   => self::TEST_TAXONOMIES,
-					'hide_empty' => false,
-					'number'     => self::DEFAULT_PER_PAGE - 1,
-					'name__like' => self::TEST_SEARCH,
-				]
-			)
-			->willReturn( [ $this->term ] );
+		->method( 'get_terms' )
+		->with(
+			[
+				'taxonomy'   => self::TEST_TAXONOMIES,
+				'hide_empty' => false,
+				'number'     => self::DEFAULT_PER_PAGE - 1,
+				'name__like' => self::TEST_SEARCH,
+			]
+		)
+		->willReturn( [ $this->term ] );
 
 		$this->assertEquals( [ $this->suggested_post, $this->suggested_term ], $this->asset_suggestions->get_final_url_suggestions( self::TEST_SEARCH ) );
 	}
 
 	public function test_get_urls_suggestions_with_no_posts_results() {
 		$this->wp->expects( $this->once() )
-			->method( 'get_post_types' )
-			->willReturn( self::TEST_POST_TYPES );
+		->method( 'get_post_types' )
+		->willReturn( self::TEST_POST_TYPES );
 
 		$this->wp->expects( $this->once() )
-			->method( 'get_posts' )
-			->willReturn( [] );
+		->method( 'get_posts' )
+		->willReturn( [] );
 
 		$this->wp->expects( $this->once() )
-			->method( 'get_taxonomies' )
-			->willReturn( self::TEST_TAXONOMIES );
+		->method( 'get_taxonomies' )
+		->willReturn( self::TEST_TAXONOMIES );
 
 		// Should try to retrieve all results from the terms
 		$this->wp->expects( $this->once() )
-			->method( 'get_terms' )
-			->with(
-				[
-					'taxonomy'   => self::TEST_TAXONOMIES,
-					'hide_empty' => false,
-					'number'     => self::DEFAULT_PER_PAGE,
-					'name__like' => self::TEST_SEARCH,
-				]
-			)
-			->willReturn( [ $this->term ] );
+		->method( 'get_terms' )
+		->with(
+			[
+				'taxonomy'   => self::TEST_TAXONOMIES,
+				'hide_empty' => false,
+				'number'     => self::DEFAULT_PER_PAGE,
+				'name__like' => self::TEST_SEARCH,
+			]
+		)
+		->willReturn( [ $this->term ] );
 
 		$this->assertEquals( [ $this->suggested_term ], $this->asset_suggestions->get_final_url_suggestions( self::TEST_SEARCH ) );
 	}
@@ -210,21 +233,21 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$term = $this->factory()->term->create_and_get( [ 'name' => 'Abcde' ] );
 
 		$this->wp->expects( $this->once() )
-			->method( 'get_posts' )
-			->willReturn(
-				[
-					$post,
-				]
-			);
+		->method( 'get_posts' )
+		->willReturn(
+			[
+				$post,
+			]
+		);
 
 		// Should try to retrieve all results from the terms
 		$this->wp->expects( $this->once() )
-			->method( 'get_terms' )
-			->willReturn(
-				[
-					$term,
-				]
-			);
+		->method( 'get_terms' )
+		->willReturn(
+			[
+				$term,
+			]
+		);
 
 		// Term item should go first
 		$this->assertEquals( [ $this->format_url_term_item( $term ), $this->format_url_post_item( $post ) ], $this->asset_suggestions->get_final_url_suggestions( self::TEST_SEARCH ) );
@@ -235,16 +258,16 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$shop     = $this->factory()->post->create_and_get( [ 'post_title' => 'Shop' ] );
 
 		$this->wp->expects( $this->once() )
-			->method( 'get_static_homepage' )
-			->willReturn(
-				$homepage
-			);
+		->method( 'get_static_homepage' )
+		->willReturn(
+			$homepage
+		);
 
 		$this->wp->expects( $this->once() )
-			->method( 'get_shop_page' )
-			->willReturn(
-				$shop
-			);
+		->method( 'get_shop_page' )
+		->willReturn(
+			$shop
+		);
 
 		$this->assertEquals( [ $this->format_url_post_item( $homepage ), $this->format_url_post_item( $shop ) ], $this->asset_suggestions->get_final_url_suggestions() );
 	}
@@ -257,22 +280,22 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$posts_ids      = $this->factory()->post->create_many( $per_page_posts );
 
 		$this->wp->expects( $this->exactly( 2 ) )
-			->method( 'get_posts' )
-			->willReturnOnConsecutiveCalls(
-				get_posts(
-					[
-						'include' => $posts_ids,
-					]
-				),
-				[ $post ]
-			);
+		->method( 'get_posts' )
+		->willReturnOnConsecutiveCalls(
+			get_posts(
+				[
+					'include' => $posts_ids,
+				]
+			),
+			[ $post ]
+		);
 
 		// Should try to retrieve all results from the terms
 		$this->wp->expects( $this->once() )
-			->method( 'get_terms' )
-			->willReturn(
-				[]
-			);
+		->method( 'get_terms' )
+		->willReturn(
+			[]
+		);
 
 		$expected = [ $this->format_url_post_item( $post ) ];
 
@@ -286,6 +309,8 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	public function test_get_post_assets() {
 		$image_id = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ), $this->post->ID );
 
+		$this->update_size_image( $image_id, [ 300, 300 ], self::SQUARE_MARKETING_IMAGE_KEY );
+
 		$this->wp->expects( $this->once() )
 			->method( 'get_posts' )
 			->with(
@@ -298,12 +323,18 @@ class AssetSuggestionsServiceTest extends UnitTest {
 				]
 			)->willReturn( [ $image_id ] );
 
-		$this->assertEquals( $this->format_post_asset_response( $this->post, [ wp_get_attachment_image_url( $image_id ) ] ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+		$images[ self::SQUARE_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_id, self::SQUARE_MARKETING_IMAGE_KEY ) ];
+		$images[ self::MARKETING_IMAGE_KEY ]        = [];
+
+		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 	}
 
 	public function test_get_post_assets_for_products() {
 		$post     = $this->factory()->post->create_and_get( [ 'post_type' => 'product' ] );
 		$image_id = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+
+		$this->update_size_image( $image_id, [ 1200, 1200 ], self::SQUARE_MARKETING_IMAGE_KEY );
+		$this->update_size_image( $image_id, [ 1200, 1200 ], self::MARKETING_IMAGE_KEY );
 
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_gallery_image_ids( [ $image_id ] );
@@ -312,24 +343,32 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->method( 'maybe_get_product' )
 			->willReturn( $product );
 
-		$this->assertEquals( $this->format_post_asset_response( $post, [ wp_get_attachment_image_url( $image_id ) ] ), $this->asset_suggestions->get_assets_suggestions( $post->ID, 'post' ) );
+		$images[ self::SQUARE_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_id, self::SQUARE_MARKETING_IMAGE_KEY ) ];
+		$images[ self::MARKETING_IMAGE_KEY ]        = [ wp_get_attachment_image_url( $image_id, self::MARKETING_IMAGE_KEY ) ];
+
+		$this->assertEquals( $this->format_post_asset_response( $post, $images ), $this->asset_suggestions->get_assets_suggestions( $post->ID, 'post' ) );
 
 	}
-
 	public function test_get_shop_assets() {
-		$image_post    = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
-		$image_product = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$image_post_id    = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$image_product_id = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+
+		$this->update_size_image( $image_post_id, [ 1200, 1200 ], self::SQUARE_MARKETING_IMAGE_KEY );
+		$this->update_size_image( $image_product_id, [ 1200, 1200 ], self::MARKETING_IMAGE_KEY );
 
 		update_option( 'woocommerce_shop_page_id', $this->post->ID );
 
 		$product = WC_Helper_Product::create_simple_product();
-		$product->set_gallery_image_ids( [ $image_product ] );
+		$product->set_gallery_image_ids( [ $image_product_id ] );
 
 		$this->wp->expects( $this->exactly( 3 ) )
 			->method( 'get_posts' )
-			->willReturnOnConsecutiveCalls( [ $image_post ], [ $product->get_id() ], [ $image_product ] );
+			->willReturnOnConsecutiveCalls( [ $image_post_id ], [ $product->get_id() ], [ $image_product_id ] );
 
-		$this->assertEquals( $this->format_post_asset_response( $this->post, [ wp_get_attachment_image_url( $image_post ), wp_get_attachment_image_url( $image_product ) ] ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+		$images[ self::SQUARE_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_post_id, self::SQUARE_MARKETING_IMAGE_KEY ) ];
+		$images[ self::MARKETING_IMAGE_KEY ]        = [ wp_get_attachment_image_url( $image_product_id, self::MARKETING_IMAGE_KEY ) ];
+
+		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 	}
 
 	public function test_get_invalid_post_id() {
@@ -344,10 +383,12 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	}
 
 	public function test_get_term_with_product() {
-		$post             = $this->factory()->post->create_and_get( [ 'post_type' => 'product' ] );
-		$image_post_1     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
-		$image_post_2     = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
-		$marketing_images = [ wp_get_attachment_image_url( $image_post_1 ), wp_get_attachment_image_url( $image_post_2 ) ];
+		$post         = $this->factory()->post->create_and_get( [ 'post_type' => 'product' ] );
+		$image_post_1 = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+		$image_post_2 = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+
+		$this->update_size_image( $image_post_1, [ 1200, 1200 ], self::SQUARE_MARKETING_IMAGE_KEY );
+		$this->update_size_image( $image_post_2, [ 1200, 1200 ], self::SQUARE_MARKETING_IMAGE_KEY );
 
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_image_id( $image_post_2 );
@@ -388,7 +429,10 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			)
 			->willReturnOnConsecutiveCalls( $posts_ids_assigned_to_term, [ $image_post_1, $image_post_2 ] );
 
-		$this->assertEquals( $this->format_term_asset_response( $this->term, $marketing_images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
+		$images[ self::SQUARE_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_post_1, self::SQUARE_MARKETING_IMAGE_KEY ), wp_get_attachment_image_url( $image_post_2, self::SQUARE_MARKETING_IMAGE_KEY ) ];
+		$images[ self::MARKETING_IMAGE_KEY ]        = [];
+
+		$this->assertEquals( $this->format_term_asset_response( $this->term, $images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
 
 	}
 
@@ -400,6 +444,9 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		$posts_ids_assigned_to_term = [ $this->post, $post ];
 
+		$this->update_size_image( $image_post_1, [ 1200, 1200 ], self::SQUARE_MARKETING_IMAGE_KEY );
+		$this->update_size_image( $image_post_2, [ 1200, 1200 ], self::MARKETING_IMAGE_KEY );
+
 		$this->wc->expects( $this->never() )
 			->method( 'maybe_get_product' );
 
@@ -407,7 +454,10 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->method( 'get_posts' )
 			->willReturnOnConsecutiveCalls( $posts_ids_assigned_to_term, [ $image_post_1, $image_post_2 ] );
 
-		$this->assertEquals( $this->format_term_asset_response( $this->term, $marketing_images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
+		$images[ self::SQUARE_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_post_1, self::SQUARE_MARKETING_IMAGE_KEY ) ];
+		$images[ self::MARKETING_IMAGE_KEY ]        = [ wp_get_attachment_image_url( $image_post_2, self::MARKETING_IMAGE_KEY ) ];
+
+		$this->assertEquals( $this->format_term_asset_response( $this->term, $images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
 
 	}
 
@@ -428,6 +478,36 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	public function test_get_invalid_term_id() {
 		$this->expectException( Exception::class );
 		$this->asset_suggestions->get_assets_suggestions( self::INVALID_ID, 'term' );
+	}
+
+
+	public function test_resize_image() {
+		$image_id = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ), $this->post->ID );
+
+		$this->update_size_image( $image_id, [ 300, 300 ] );
+
+		$this->wp->expects( $this->once() )
+			->method( 'get_posts' )
+			->willReturn( [ $image_id ] );
+
+		// As the file test-image-1.png is only 64x64 we tweak the code, so it seems that the image has been resize to 300x300 px.
+		add_filter(
+			'wp_generate_attachment_metadata',
+			function ( $metadata ) use ( $image_id ) {
+				$metadata['sizes'][ self::SQUARE_MARKETING_IMAGE_KEY ] = [
+					'file'   => basename( get_attached_file( $image_id ) ),
+					'width'  => $this->minimum_image_requirements[ self::SQUARE_MARKETING_IMAGE_KEY ][0],
+					'height' => $this->minimum_image_requirements[ self::SQUARE_MARKETING_IMAGE_KEY ][1],
+				];
+
+				return $metadata;
+			}
+		);
+
+		$images[ self::SQUARE_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_id, self::SQUARE_MARKETING_IMAGE_KEY ) ];
+		$images[ self::MARKETING_IMAGE_KEY ]        = [];
+
+		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 	}
 
 }

--- a/tests/Unit/Utility/DimensionUtilityTest.php
+++ b/tests/Unit/Utility/DimensionUtilityTest.php
@@ -44,7 +44,7 @@ class DimensionUtilityTest extends UnitTest {
 
 		$this->assertTrue( $image_1->equals( $image_2 ) );
 
-	}	
+	}
 
 	public function test_image_is_equal_with_precision_of_2() {
 		$image_1 = new DimensionUtility( 300, 400 );
@@ -52,7 +52,7 @@ class DimensionUtilityTest extends UnitTest {
 
 		$this->assertTrue( $image_1->equals( $image_2, 2 ) );
 
-	}		
+	}
 
 	public function test_image_is_not_equal() {
 		$image_1 = new DimensionUtility( 300, 400 );
@@ -60,7 +60,7 @@ class DimensionUtilityTest extends UnitTest {
 
 		$this->assertFalse( $image_1->equals( $image_2 ) );
 
-	}	
+	}
 
 
 }

--- a/tests/Unit/Utility/DimensionUtilityTest.php
+++ b/tests/Unit/Utility/DimensionUtilityTest.php
@@ -4,12 +4,10 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\DataTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
 
 /**
- * Class ImageUtilityTest
+ * Class DimensionUtilityTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
  */

--- a/tests/Unit/Utility/DimensionUtilityTest.php
+++ b/tests/Unit/Utility/DimensionUtilityTest.php
@@ -1,0 +1,66 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\DataTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
+
+/**
+ * Class ImageUtilityTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
+ */
+class DimensionUtilityTest extends UnitTest {
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+	}
+
+	public function test_image_is_bigger() {
+		$image_1 = new DimensionUtility( 650, 400 );
+		$image_2 = new DimensionUtility( 600, 300 );
+
+		$this->assertTrue( $image_1->is_bigger( $image_2 ) );
+
+	}
+
+	public function test_image_is_smaller() {
+		$image_1 = new DimensionUtility( 300, 400 );
+		$image_2 = new DimensionUtility( 600, 300 );
+
+		$this->assertFalse( $image_1->is_bigger( $image_2 ) );
+
+	}
+
+	public function test_image_is_equal_with_default_precision() {
+		$image_1 = new DimensionUtility( 300, 400 );
+		$image_2 = new DimensionUtility( 300, 400 );
+
+		$this->assertTrue( $image_1->equals( $image_2 ) );
+
+	}	
+
+	public function test_image_is_equal_with_precision_of_2() {
+		$image_1 = new DimensionUtility( 300, 400 );
+		$image_2 = new DimensionUtility( 302, 398 );
+
+		$this->assertTrue( $image_1->equals( $image_2, 2 ) );
+
+	}		
+
+	public function test_image_is_not_equal() {
+		$image_1 = new DimensionUtility( 300, 400 );
+		$image_2 = new DimensionUtility( 600, 300 );
+
+		$this->assertFalse( $image_1->equals( $image_2 ) );
+
+	}	
+
+
+}

--- a/tests/Unit/Utility/DimensionUtilityTest.php
+++ b/tests/Unit/Utility/DimensionUtilityTest.php
@@ -20,19 +20,19 @@ class DimensionUtilityTest extends UnitTest {
 		parent::setUp();
 	}
 
-	public function test_image_is_bigger() {
+	public function test_image_is_minimum_size() {
 		$image_1 = new DimensionUtility( 650, 400 );
 		$image_2 = new DimensionUtility( 600, 300 );
 
-		$this->assertTrue( $image_1->is_bigger( $image_2 ) );
+		$this->assertTrue( $image_1->is_minimum_size( $image_2 ) );
 
 	}
 
-	public function test_image_is_smaller() {
+	public function test_image_is_smaller_than_the_minimum_size() {
 		$image_1 = new DimensionUtility( 300, 400 );
 		$image_2 = new DimensionUtility( 600, 300 );
 
-		$this->assertFalse( $image_1->is_bigger( $image_2 ) );
+		$this->assertFalse( $image_1->is_minimum_size( $image_2 ) );
 
 	}
 

--- a/tests/Unit/Utility/ImageUtilityTest.php
+++ b/tests/Unit/Utility/ImageUtilityTest.php
@@ -1,0 +1,121 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\DataTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
+
+/**
+ * Class ImageUtilityTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
+ */
+class ImageUtilityTest extends UnitTest {
+
+	use DataTrait;
+
+	protected const SUBSIZE_IMAGE_KEY = 'test_subisize_key';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->image_utility = new ImageUtility();
+	}
+
+	protected function assert_aspect_rate_tolerance( DimensionUtility $suggested, DimensionUtility $recommended, float $tolerance = 0.01 ) {
+		$precision = ( $suggested->x / $suggested->y ) * $tolerance;
+		$this->assertTrue( wp_fuzzy_number_match( $suggested->x / $suggested->y, $recommended->x / $recommended->y, $precision ) );
+	}
+
+	public function test_add_subsize_image() {
+		// Image size: 64x64px.
+		$image_id = $this->factory()->attachment->create_upload_object( $this->get_data_file_path( 'test-image-1.png' ) );
+
+		$metadata = wp_get_attachment_metadata( $image_id );
+
+		$this->assertArrayNotHasKey( self::SUBSIZE_IMAGE_KEY, $metadata['sizes'] );
+
+		// Add subsize of 20x20px
+		$new_subisze = new DimensionUtility( 20, 20 );
+		$this->image_utility->try_add_subsize_image( $image_id, self::SUBSIZE_IMAGE_KEY, $new_subisze );
+
+		$metadata_updated = wp_get_attachment_metadata( $image_id );
+
+		$this->assertArrayHasKey( self::SUBSIZE_IMAGE_KEY, $metadata_updated['sizes'] );
+
+	}
+
+	public function test_real_size_bigger_than_suggested_square() {
+		$real_size        = new DimensionUtility( 1350, 1550 );
+		$recommended_size = new DimensionUtility( 1200, 1200 );
+		$minimum_size     = new DimensionUtility( 300, 300 );
+
+		$suggested_size = $this->image_utility->recommend_size( $real_size, $recommended_size, $minimum_size );
+
+		$this->assertEquals( 1200, $suggested_size->x );
+		$this->assertEquals( 1200, $suggested_size->y );
+
+		$this->assert_aspect_rate_tolerance( $suggested_size, $recommended_size );
+
+	}
+
+	public function test_real_size_bigger_than_suggested_landscape() {
+		$real_size        = new DimensionUtility( 850, 600 );
+		$recommended_size = new DimensionUtility( 725, 525 );
+		$minimum_size     = new DimensionUtility( 300, 200 );
+
+		$suggested_size = $this->image_utility->recommend_size( $real_size, $recommended_size, $minimum_size );
+
+		$this->assertEquals( 725, $suggested_size->x );
+		$this->assertEquals( 525, $suggested_size->y );
+
+		$this->assert_aspect_rate_tolerance( $suggested_size, $recommended_size );
+
+	}
+
+	public function test_real_size_smaller_than_suggested_square() {
+		$real_size        = new DimensionUtility( 350, 350 );
+		$recommended_size = new DimensionUtility( 700, 700 );
+		$minimum_size     = new DimensionUtility( 300, 200 );
+
+		$suggested_size = $this->image_utility->recommend_size( $real_size, $recommended_size, $minimum_size );
+
+		$this->assertEquals( 350, $suggested_size->x );
+		$this->assertEquals( 350, $suggested_size->y );
+
+		$this->assert_aspect_rate_tolerance( $suggested_size, $recommended_size );
+
+	}
+
+	public function test_real_size_smaller_than_suggested_landscape() {
+		$real_size        = new DimensionUtility( 350, 225 );
+		$recommended_size = new DimensionUtility( 725, 525 );
+		$minimum_size     = new DimensionUtility( 300, 200 );
+
+		$suggested_size = $this->image_utility->recommend_size( $real_size, $recommended_size, $minimum_size );
+
+		$this->assertEquals( 310, $suggested_size->x );
+		$this->assertEquals( 225, $suggested_size->y );
+
+		$this->assert_aspect_rate_tolerance( $suggested_size, $recommended_size );
+
+	}
+
+	public function test_recommend_size_less_than_the_minimum() {
+		$real_size        = new DimensionUtility( 100, 400 );
+		$recommended_size = new DimensionUtility( 600, 300 );
+		$minimum_size     = new DimensionUtility( 300, 200 );
+
+		$suggested_size = $this->image_utility->recommend_size( $real_size, $recommended_size, $minimum_size );
+
+		$this->assertFalse( $suggested_size );
+
+	}
+
+
+}

--- a/tests/Unit/Utility/ImageUtilityTest.php
+++ b/tests/Unit/Utility/ImageUtilityTest.php
@@ -25,7 +25,7 @@ class ImageUtilityTest extends UnitTest {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->wp = new WP();
+		$this->wp            = new WP();
 		$this->image_utility = new ImageUtility( $this->wp );
 	}
 
@@ -115,7 +115,7 @@ class ImageUtilityTest extends UnitTest {
 
 		$suggested_size = $this->image_utility->recommend_size( $real_size, $recommended_size, $minimum_size );
 
-		$this->assertFalse( $suggested_size);
+		$this->assertFalse( $suggested_size );
 
 	}
 

--- a/tests/Unit/Utility/ImageUtilityTest.php
+++ b/tests/Unit/Utility/ImageUtilityTest.php
@@ -117,5 +117,21 @@ class ImageUtilityTest extends UnitTest {
 
 	}
 
+	public function test_image_is_bigger() {
+		$image_1 = new DimensionUtility( 650, 400 );
+		$image_2 = new DimensionUtility( 600, 300 );
+
+		$this->assertTrue( $this->image_utility->is_bigger( $image_1, $image_2 ) );
+
+	}
+
+	public function test_image_is_smaller() {
+		$image_1 = new DimensionUtility( 300, 400 );
+		$image_2 = new DimensionUtility( 600, 300 );
+
+		$this->assertFalse( $this->image_utility->is_bigger( $image_1, $image_2 ) );
+
+	}
+
 
 }

--- a/tests/Unit/Utility/ImageUtilityTest.php
+++ b/tests/Unit/Utility/ImageUtilityTest.php
@@ -42,7 +42,7 @@ class ImageUtilityTest extends UnitTest {
 
 		// Add subsize of 20x20px
 		$new_subisze = new DimensionUtility( 20, 20 );
-		$this->image_utility->try_add_subsize_image( $image_id, self::SUBSIZE_IMAGE_KEY, $new_subisze );
+		$this->image_utility->maybe_add_subsize_image( $image_id, self::SUBSIZE_IMAGE_KEY, $new_subisze );
 
 		$metadata_updated = wp_get_attachment_metadata( $image_id );
 

--- a/tests/Unit/Utility/ImageUtilityTest.php
+++ b/tests/Unit/Utility/ImageUtilityTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\DataTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 /**
  * Class ImageUtilityTest
@@ -24,7 +25,8 @@ class ImageUtilityTest extends UnitTest {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->image_utility = new ImageUtility();
+		$this->wp = new WP();
+		$this->image_utility = new ImageUtility( $this->wp );
 	}
 
 	protected function assert_aspect_rate_tolerance( DimensionUtility $suggested, DimensionUtility $recommended, float $tolerance = 0.01 ) {
@@ -113,23 +115,7 @@ class ImageUtilityTest extends UnitTest {
 
 		$suggested_size = $this->image_utility->recommend_size( $real_size, $recommended_size, $minimum_size );
 
-		$this->assertFalse( $suggested_size );
-
-	}
-
-	public function test_image_is_bigger() {
-		$image_1 = new DimensionUtility( 650, 400 );
-		$image_2 = new DimensionUtility( 600, 300 );
-
-		$this->assertTrue( $this->image_utility->is_bigger( $image_1, $image_2 ) );
-
-	}
-
-	public function test_image_is_smaller() {
-		$image_1 = new DimensionUtility( 300, 400 );
-		$image_2 = new DimensionUtility( 600, 300 );
-
-		$this->assertFalse( $this->image_utility->is_bigger( $image_1, $image_2 ) );
+		$this->assertFalse( $suggested_size);
 
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

This PR resizes the images to match the Ads API requirements. There are three types of images:

- MARKETING_IMAGE: Landscape (1.91:1) 1200 x 628 recommended; 600 x 314 min.
- SQUARE_MARKETING_IMAGE: (1:1) 1200 x 1200 recommended; 300 x 300 min.
- LOGO: (1:1) 1200 x 1200 recommended; 128 x 128 min; 

The PR will try to resize the image to the closest size to the recommended size. For instance, for MARKETING_IMAGE, the resize target will be 1200x628px. Furthermore, an image can be resized if the width **and** height are bigger than the minimum sizes, otherwise, it will be excluded.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

### Testings with posts (products/pages/posts/etc).

1. Make a request to GET `wc/gla/assets/suggestions?id=YOUR_POST_ID&type=post`
2. If the images are bigger than the minimum requirements mentioned above, the response should contain the images/galleries that are attached to the post with the closest size to the recommended size.
4. Open your uploads folder and verify that the images created have the correct sizes, if you make the same request the images should not be created again.

### Testings with terms.

1. Go to any taxonomy that is created on your website, for example, Product->Categories.
2. Go to edit one of the terms. For example Hoodies. Get the ID term, it can be found on the URL as the param `tag_id`
3. Make a request to GET `wc/gla/assets/suggestions?id=YOUR_TERM_ID&type=term`
4. Follow steps 3 & 4 from the section of "Testings with posts"

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
