### PR TITLE
PMax Assets - Posts URLs suggestions - Search by title

### DIFF
--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -439,6 +439,24 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
+	 * Filter for the posts_where hook, adds WHERE clause to search
+	 * for the 'search_title' parameter in the post titles (when present).
+	 *
+	 * @param string   $where The WHERE clause of the query.
+	 * @param WP_Query $wp_query The WP_Query instance (passed by reference).
+	 *
+	 * @return string The updated WHERE clause.
+	 */
+	public function title_filter( string $where, WP_Query $wp_query ): string {
+		$search_title = $wp_query->get( 'search_title' );
+		if ( $search_title ) {
+			$title_search = '%' . $this->wpdb->esc_like( $search_title ) . '%';
+			$where       .= $this->wpdb->prepare( " AND `{$this->wpdb->posts}`.`post_title` LIKE %s", $title_search ); // phpcs:ignore WordPress.DB.PreparedSQL
+		}
+		return $where;
+	}
+
+	/**
 	 * Get terms that can be used to suggest assets
 	 *
 	 * @param string $search The search query

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -433,14 +433,19 @@ class AssetSuggestionsService implements Service {
 		$filtered_post_types = array_diff( $post_types, $excluded_post_types );
 
 		$args = [
-			'post_type'      => $filtered_post_types,
-			'posts_per_page' => $per_page,
-			'post_status'    => 'publish',
-			's'              => $search,
-			'offset'         => $offset,
+			'post_type'        => $filtered_post_types,
+			'posts_per_page'   => $per_page,
+			'post_status'      => 'publish',
+			'search_title'     => $search,
+			'offset'           => $offset,
+			'suppress_filters' => false,
 		];
 
+		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );
+
 		$posts = $this->wp->get_posts( $args );
+
+		remove_filter( 'posts_where', [ $this, 'title_filter' ] );
 
 		foreach ( $posts as $post ) {
 			$post_suggestions[] = $this->format_final_url_response( $post->ID, 'post', $post->post_title, get_permalink( $post->ID ) );

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Exception;
+use WP_Query;
+use wpdb;
 
 /**
  * Class AssetSuggestionsService
@@ -42,6 +44,13 @@ class AssetSuggestionsService implements Service {
 	 * @var ImageUtility
 	 */
 	protected $image_utility;
+
+	/**
+	 * WordPress database access abstraction class.
+	 *
+	 * @var wpdb
+	 */
+	protected $wpdb;
 
 	/**
 	 * Default maximum marketing images.
@@ -99,10 +108,12 @@ class AssetSuggestionsService implements Service {
 	 * @param WP           $wp WP Proxy.
 	 * @param WC           $wc WC Proxy.
 	 * @param ImageUtility $image_utility Image utility.
+	 * @param wpdb         $wpdb WordPress database access abstraction class.
 	 */
-	public function __construct( WP $wp, WC $wc, ImageUtility $image_utility ) {
+	public function __construct( WP $wp, WC $wc, ImageUtility $image_utility, wpdb $wpdb ) {
 		$this->wp            = $wp;
 		$this->wc            = $wc;
+		$this->wpdb          = $wpdb;
 		$this->image_utility = $image_utility;
 	}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -52,7 +52,7 @@ class AssetSuggestionsService implements Service {
 	 */
 	protected $wpdb;
 
-  /**
+	/**
 	 * Image requirements.
 	 */
 	protected const IMAGE_REQUIREMENTS = [

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -121,6 +121,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166Dat
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use wpdb;
 
 /**
  * Class CoreServiceProvider
@@ -253,7 +254,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getLeagueContainer()
 			 ->inflector( AdsAwareInterface::class )
 			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
-		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class );
+		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class );
 
 		// Set up the installer.
 		$installer_definition = $this->share_with_tags(

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
 use WC_Helper_Product;
+use wpdb;
 
 
 defined( 'ABSPATH' ) || exit;
@@ -67,8 +68,9 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$this->wp            = $this->createMock( WP::class );
 		$this->wc            = $this->createMock( WC::class );
 		$this->image_utility = $this->createMock( ImageUtility::class );
+		$this->wpdb          = $this->createMock( wpdb::class );
 
-		$this->asset_suggestions = new AssetSuggestionsService( $this->wp, $this->wc, $this->image_utility );
+		$this->asset_suggestions = new AssetSuggestionsService( $this->wp, $this->wc, $this->image_utility, $this->wpdb );
 
 		$this->post = $this->factory()->post->create_and_get( [ 'post_title' => 'Abcd' ] );
 		$this->term = $this->factory()->term->create_and_get( [ 'name' => 'bcde' ] );
@@ -167,11 +169,13 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		->method( 'get_posts' )
 		->with(
 			[
-				'post_type'      => self::TEST_POST_TYPES_NO_ATTACHMENT,
-				'posts_per_page' => self::DEFAULT_PER_PAGE_POSTS,
-				'post_status'    => 'publish',
-				's'              => self::TEST_SEARCH,
-				'offset'         => 0,
+				'post_type'        => self::TEST_POST_TYPES_NO_ATTACHMENT,
+				'posts_per_page'   => self::DEFAULT_PER_PAGE_POSTS,
+				'post_status'      => 'publish',
+				'search_title'     => self::TEST_SEARCH,
+				'offset'           => 0,
+				'suppress_filters' => false,
+
 			]
 		)
 		->willReturn( [ $this->post ] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR updates the query that is suggesting the post's URLs depending on the search term.

The search was returning all posts that included the search term in the **title** or the **content**, this PR updates the query to return only posts that contain the search term in the **title**.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- Make a request to ` GET /wc/gla/assets/final-url/suggestions?search=YOUR_SEARCH`
- The response should display all your posts/pages/products/categories URLs that match the **title**.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
