### PR TITLE
Improve image validation error messages

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -793,6 +793,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * Parse the code and formatted issue text out of the presync validation error text.
 	 *
+	 * Converts the error strings:
+	 * "[attribute] Error message." > "Error message [attribute]"
+	 *
+	 * Note:
+	 * If attribute is an array the name can be "[attribute[0]]".
+	 * So we need to match the additional set of square brackets.
+	 *
 	 * @param string $text
 	 *
 	 * @return string[] With indexes `code` and `issue`
@@ -807,12 +814,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 			];
 		}
 
-		// Convert imageLink to image
+		// Convert attribute name "imageLink" to "image".
 		if ( 'imageLink' === $matches[1] ) {
 			$matches[1] = 'image';
 		}
 
-		// Convert additionalImageLinks[] to galleryImage.
+		// Convert attribute name "additionalImageLinks[]" to "galleryImage".
 		if ( str_starts_with( $matches[1], 'additionalImageLinks' ) ) {
 			$matches[1] = 'galleryImage';
 		}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -799,7 +799,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 */
 	protected function parse_presync_issue_text( string $text ): array {
 		$matches = [];
-		preg_match( '/^\[([^\]]+)\]\s*(.+)$/', $text, $matches );
+		preg_match( '/^\[([^\]]+\]?)\]\s*(.+)$/', $text, $matches );
 		if ( count( $matches ) !== 3 ) {
 			return [
 				'code'  => 'presync_error_attrib_' . md5( $text ),
@@ -811,6 +811,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		if ( 'imageLink' === $matches[1] ) {
 			$matches[1] = 'image';
 		}
+
+		// Convert additionalImageLinks[] to galleryImage.
+		if ( str_starts_with( $matches[1], 'additionalImageLinks' ) ) {
+			$matches[1] = 'galleryImage';
+		}
+
 		$matches[2] = trim( $matches[2], ' .' );
 		return [
 			'code'  => 'presync_error_' . $matches[1],

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\SizeSystem;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\SizeType;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AgeGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\Validator\GooglePriceConstraint;
+use Automattic\WooCommerce\GoogleListingsAndAds\Validator\ImageUrlConstraint;
 use Automattic\WooCommerce\GoogleListingsAndAds\Validator\Validatable;
 use DateInterval;
 use Google\Service\ShoppingContent\Price as GooglePrice;
@@ -761,14 +762,12 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$metadata->addPropertyConstraint( 'link', new Assert\Url() );
 
 		$metadata->addPropertyConstraint( 'imageLink', new Assert\NotBlank() );
-		$metadata->addPropertyConstraint( 'imageLink', new Assert\Url( [ 'normalizer' => 'Normalizer::normalize' ] ) );
+		$metadata->addPropertyConstraint( 'imageLink', new ImageUrlConstraint() );
 		$metadata->addPropertyConstraint(
 			'additionalImageLinks',
 			new Assert\All(
 				[
-					'constraints' => [
-						new Assert\Url( [ 'normalizer' => 'Normalizer::normalize' ] ),
-					],
+					'constraints' => [ new ImageUrlConstraint() ],
 				]
 			)
 		);

--- a/src/Validator/ImageUrlConstraint.php
+++ b/src/Validator/ImageUrlConstraint.php
@@ -1,0 +1,20 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Validator;
+
+use Symfony\Component\Validator\Constraints\Url as UrlConstraint;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ImageUrlConstraint
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Validator
+ */
+class ImageUrlConstraint extends UrlConstraint {
+	/**
+	 * @var string
+	 */
+	public $message = 'Product image "{{ name }}" is not a valid name.';
+}

--- a/src/Validator/ImageUrlConstraintValidator.php
+++ b/src/Validator/ImageUrlConstraintValidator.php
@@ -21,8 +21,8 @@ class ImageUrlConstraintValidator extends UrlConstraintValidator {
 	/**
 	 * Checks if the passed value is valid.
 	 *
-	 * @param GooglePrice $value The value that should be validated
-	 * @param Constraint  $constraint
+	 * @param string     $value The value that should be validated
+	 * @param Constraint $constraint
 	 *
 	 * @throws UnexpectedTypeException If invalid constraint provided.
 	 * @throws UnexpectedValueException If invalid value provided.

--- a/src/Validator/ImageUrlConstraintValidator.php
+++ b/src/Validator/ImageUrlConstraintValidator.php
@@ -1,0 +1,60 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Validator;
+
+use Normalizer;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\UrlValidator as UrlConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ImageUrlConstraintValidator
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Validator
+ */
+class ImageUrlConstraintValidator extends UrlConstraintValidator {
+
+	/**
+	 * Checks if the passed value is valid.
+	 *
+	 * @param GooglePrice $value The value that should be validated
+	 * @param Constraint  $constraint
+	 *
+	 * @throws UnexpectedTypeException If invalid constraint provided.
+	 * @throws UnexpectedValueException If invalid value provided.
+	 */
+	public function validate( $value, Constraint $constraint ) {
+		if ( ! $constraint instanceof ImageUrlConstraint ) {
+			throw new UnexpectedTypeException( $constraint, ImageUrlConstraint::class );
+		}
+
+		if ( null === $value || '' === $value ) {
+			return;
+		}
+
+		if ( ! is_scalar( $value ) && ! ( is_object( $value ) && method_exists( $value, '__toString' ) ) ) {
+			throw new UnexpectedValueException( $value, 'string' );
+		}
+
+		$value = (string) $value;
+		if ( '' === $value ) {
+			return;
+		}
+
+		$value   = Normalizer::normalize( $value );
+		$pattern = sprintf( static::PATTERN, implode( '|', $constraint->protocols ) );
+
+		if ( ! preg_match( $pattern, $value ) ) {
+			$this->context->buildViolation( $constraint->message )
+				->setParameter( '{{ name }}', wp_basename( $value ) )
+				->setCode( ImageUrlConstraint::INVALID_URL_ERROR )
+				->addViolation();
+
+			return;
+		}
+	}
+}

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -442,4 +442,34 @@ trait ProductTrait {
 		}
 		return $products;
 	}
+
+	/**
+	 * Helper function to create a mocked image attachment with a specific name.
+	 *
+	 * @param int    $product_id Parent product ID.
+	 * @param string $image_name Image name to mock.
+	 * @return int Attachment ID.
+	 */
+	protected function generate_mock_image_attachment( int $product_id, string $image_name ) {
+		$attachment_id = wp_insert_post(
+			[
+				'post_parent'    => $product_id,
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'import',
+			]
+		);
+
+		update_post_meta( $attachment_id, '_wp_attached_file', $image_name );
+		update_post_meta(
+			$attachment_id,
+			'_wp_attachment_metadata',
+			[
+				'width'  => 600,
+				'height' => 300,
+				'file'   => $image_name,
+			]
+		);
+
+		return $attachment_id;
+	}
 }

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -1577,6 +1577,35 @@ DESCRIPTION;
 		$this->assertNull( $violation );
 	}
 
+	public function test_invalid_image_names() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$main_image = $this->generate_mock_image_attachment( $product->get_id(), '600-×-300.png' );
+
+		$additional_images = [ $this->generate_mock_image_attachment( $product->get_id(), 'æą€.jpg' ) ];
+
+		$product->set_image_id( $main_image );
+		$product->set_gallery_image_ids( $additional_images );
+		$product->save();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		$violation = $this->validate_product_property( $adapted_product, 'imageLink' );
+		$this->assertEquals(
+			'Product image "600-×-300.png" is not a valid name.',
+			$this->validate_product_property( $adapted_product, 'imageLink' )->getMessage()
+		);
+		$this->assertEquals(
+			'Product image "æą€.jpg" is not a valid name.',
+			$this->validate_product_property( $adapted_product, 'additionalImageLinks' )->getMessage()
+		);
+	}
+
 	/**
 	 * Validate a product property and return the first violation.
 	 *
@@ -1590,7 +1619,7 @@ DESCRIPTION;
 			->getValidator();
 
 		foreach ( $validator->validate( $adapted_product ) as $violation ) {
-			if ( $violation->getPropertyPath() === $property ) {
+			if ( str_starts_with( $violation->getPropertyPath(), $property ) ) {
 				return $violation;
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As [outlined within the issue](https://github.com/woocommerce/google-listings-and-ads/issues/1582#issuecomment-1350674620), Google doesn't support images names with non standard characters. So the purpose of this PR is to improve the error messages that were returned to make it easier for users to identify which images need to be changed. This involves a custom validator to change the generic message `This value is not a valid URL` to specifically naming the image within the error message.

![image](https://user-images.githubusercontent.com/11388669/207610069-f42354d5-84da-47e5-bb80-f6abbf304862.png)

This PR added the following changes:
- A custom validator (based on the regular url validator) which by default enables normalization and customizes the error message.
- Improve error messages in the product issues table, previously errors were showing up with a leading bracket `] This value is not a valid URL [additionalImageLinks[0]`
- Add unit tests for custom image validation.

Closes #1582 


### Detailed test instructions:
1. Create a png image with the name `Untitled-1000-×-1000-px-7-2.png` and upload it to a publicly accessible folder on your site (I placed it in wp-content/uploads).
2. Create a csv file to update the image name using the importer (replace the product ID and the image URL in the following example):
```csv
ID,Type,Images
1234,simple,"https://domain.test/wp-content/uploads/Untitled-1000-×-1000-px-7-2.png,https://domain.test/wp-content/uploads/æą€×.jpg"
```
3. Go to Products > Import and use the created CSV file to update the product (make sure to check update product).
![image](https://user-images.githubusercontent.com/11388669/207548448-bc905948-1e4c-4197-b1c5-d91ce51563d2.png)
4. Go to the connection test page `wp-admin/admin.php?page=connection-test-admin-page` and sync the product ID (or wait till the scheduled sync completes.
5. Confirm that there is an error syncing the product because the images are not valid.
6. Go to Marketing > Google Listings & Ads > Product Feed and select the Product Issues table (clear the transients if it's not loading a fresh list of issues).
7. Step through the pages till you find the product we used during the test (helps to name it starting with A if you have a lot of product issues).
8. Confirm that the errors are not correctly formatted, showing the image name, to help identify which one should be changed.
![image](https://user-images.githubusercontent.com/11388669/207610069-f42354d5-84da-47e5-bb80-f6abbf304862.png)

### Additional details:
As a follow up to these improvements it would be nice to add a [FAQ in the docs](https://woocommerce.com/document/google-listings-and-ads-faqs/) to explain the steps users need to take to re-upload an image with a valid name. cc: @sukafia 

### Changelog entry
* Tweak - Improve image validation error messages.

