### PR TITLE
Specify WP_VERSION for Docker Container

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"dev": "NODE_ENV=development wp-scripts build",
 		"dewps:woo": "node bin/list-woo-dewped.mjs",
 		"doc:tracking": "woocommerce-grow-jsdoc ./js/src",
-		"docker:up": "npx wc-e2e docker:up",
+		"docker:up": "WP_VERSION=5.9 npx wc-e2e docker:up",
 		"docker:down": "npx wc-e2e docker:down",
 		"format": "wp-scripts format",
 		"i18n": "WP_CLI_PHP_ARGS='-d memory_limit=2048M' ./vendor/bin/wp i18n make-pot ./ languages/$npm_package_name.pot --slug=$npm_package_name --domain=$npm_package_name --exclude=bin,data,js/src,node_modules,tests,vendor",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"dev": "NODE_ENV=development wp-scripts build",
 		"dewps:woo": "node bin/list-woo-dewped.mjs",
 		"doc:tracking": "woocommerce-grow-jsdoc ./js/src",
-		"docker:up": "WP_VERSION=5.9 npx wc-e2e docker:up",
+		"docker:up": "WP_VERSION=6.1 npx wc-e2e docker:up",
 		"docker:down": "npx wc-e2e docker:down",
 		"format": "wp-scripts format",
 		"i18n": "WP_CLI_PHP_ARGS='-d memory_limit=2048M' ./vendor/bin/wp i18n make-pot ./ languages/$npm_package_name.pot --slug=$npm_package_name --domain=$npm_package_name --exclude=bin,data,js/src,node_modules,tests,vendor",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR sets the `WP_VERSION` variable for the `@woocommerce/e2e-environment` Docker Container to `6.1` to make sure the extension can be activated in the test environment so the e2e tests can run.

Closes #1817

### Detailed test instructions:
1. Checkout branch
2. `npm install && composer install`
3. `npm run build`
4. `npm run docker:up`
5. `npm run test:e2e`
6. Confirm the tests run successfully
