### PR TITLE
PMax Assets: Integrate WP Media library to implement the asset images selector

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -11,6 +11,7 @@ import Section from '.~/wcdl/section';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import FinalUrlCard from './final-url-card';
+import ImagesSelector from './images-selector';
 import './asset-group-section.scss';
 
 /**
@@ -56,6 +57,34 @@ export default function AssetGroupSection() {
 			<VerticalGapLayout size="medium">
 				<FinalUrlCard onAssetsChange={ setAssetGroup } />
 				<div>Assets card will be added here</div>
+				<Section.Card>
+					<Section.Card.Body>
+						<h3>Temporary demo of rectangular images selector</h3>
+						<ImagesSelector
+							maxNumberOfImages={ 3 }
+							imageConfig={ {
+								minWidth: 600,
+								minHeight: 314,
+								suggestedWidth: 1200,
+								suggestedHeight: 628,
+							} }
+						/>
+					</Section.Card.Body>
+				</Section.Card>
+				<Section.Card>
+					<Section.Card.Body>
+						<h3>Temporary demo of square image selector</h3>
+						<ImagesSelector
+							maxNumberOfImages={ 20 }
+							imageConfig={ {
+								minWidth: 300,
+								minHeight: 300,
+								suggestedWidth: 1200,
+								suggestedHeight: 1200,
+							} }
+						/>
+					</Section.Card.Body>
+				</Section.Card>
 			</VerticalGapLayout>
 			<h3>Temporary demo for showing the current assets data:</h3>
 			<pre>{ JSON.stringify( assetGroup, null, 2 ) }</pre>

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -58,7 +58,7 @@ export default function ImagesSelector( {
 					// If the selected image already exists while replacing, it's considered a swap position.
 					nextImages.splice( index, 1, { ...replacingImage } );
 				}
-				// If index gets -1 here, it means the image to be replaced has been deleted.
+				// If index gets -1 here, it means the image to be replaced has been removed via the `onDelete` callback.
 				index = nextImages.indexOf( replacingImage );
 			}
 

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -36,7 +36,8 @@ export default function ImagesSelector( {
 } ) {
 	const [ replacingImage, setReplacingImage ] = useState( null );
 	const [ images, setImages ] = useState( () =>
-		initialImageUrls.map( ( url ) => ( { url, alt: '' } ) )
+		// The asset images fetched from Google Ads are only URLs.
+		initialImageUrls.map( ( url ) => ( { url, id: url, alt: '' } ) )
 	);
 
 	const removeImage = ( deletedImage ) => {

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -41,6 +41,9 @@ export default function ImagesSelector( {
 	);
 
 	const removeImage = ( deletedImage ) => {
+		if ( deletedImage.id === awaitingActionImage?.id ) {
+			setAwaitingActionImage( null );
+		}
 		setImages( images.filter( ( { id } ) => id !== deletedImage.id ) );
 	};
 

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -61,7 +61,7 @@ export default function ImagesSelector( {
 					// If the selected image already exists while replacing, it's considered a swap position.
 					nextImages.splice( index, 1, { ...awaitingActionImage } );
 				}
-				// If index gets -1 here, it means the image to be replaced has been removed via the `onDelete` callback.
+				// Find the index to be replaced with the selected image.
 				index = nextImages.indexOf( awaitingActionImage );
 			}
 

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
+import GridiconCrossCircle from 'gridicons/dist/cross-circle';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
+import useCroppedImageSelector from '.~/hooks/useCroppedImageSelector';
+import './images-selector.scss';
+
+/**
+ * @typedef {Object} AssetImageConfig
+ * @property {number} minWidth The minimum width.
+ * @property {number} minHeight The minimum height.
+ * @property {number} suggestedWidth The suggested width.
+ * @property {number} suggestedHeight The suggested height.
+ */
+
+/**
+ * Renders a selector for asset images.
+ *
+ * @param {Object} props React props.
+ * @param {AssetImageConfig} props.imageConfig The config of the asset image.
+ * @param {string[]} props.initialImageUrls The initial image URLs.
+ * @param {number} [props.maxNumberOfImages=0] The maximum number of images. 0 by default and it means unlimited number.
+ */
+export default function ImagesSelector( {
+	imageConfig,
+	initialImageUrls = [],
+	maxNumberOfImages = 0,
+} ) {
+	const [ replacingImage, setReplacingImage ] = useState( null );
+	const [ images, setImages ] = useState( () =>
+		initialImageUrls.map( ( url ) => ( { url, alt: '' } ) )
+	);
+
+	const removeImage = ( deletedImage ) => {
+		setImages( images.filter( ( { id } ) => id !== deletedImage.id ) );
+	};
+
+	const handle = useCroppedImageSelector( {
+		...imageConfig,
+		onDelete: removeImage,
+		onSelect( image ) {
+			const nextImages = [ ...images ];
+
+			// Find if there is a duplicate image first.
+			let index = nextImages.findIndex( ( { id } ) => id === image.id );
+
+			if ( replacingImage ) {
+				if ( index !== -1 && image.id !== replacingImage.id ) {
+					// If the selected image already exists while replacing, it's considered a swap position.
+					nextImages.splice( index, 1, { ...replacingImage } );
+				}
+				// If index gets -1 here, it means the image to be replaced has been deleted.
+				index = nextImages.indexOf( replacingImage );
+			}
+
+			if ( index === -1 ) {
+				nextImages.push( image );
+			} else {
+				nextImages.splice( index, 1, image );
+			}
+
+			setReplacingImage( null );
+			setImages( nextImages );
+		},
+	} );
+
+	const handleUpsertImageClick = ( event, image = null ) => {
+		setReplacingImage( image );
+		handle.openSelector( image?.id );
+	};
+
+	return (
+		<div className="gla-images-selector">
+			<div className="gla-images-selector__image-list">
+				{ images.map( ( image ) => {
+					return (
+						<div
+							key={ image.url }
+							className="gla-images-selector__image-item"
+						>
+							<AppButton
+								className="gla-images-selector__replace-image-button"
+								onClick={ () =>
+									handleUpsertImageClick( null, image )
+								}
+							>
+								<img
+									className="gla-images-selector__image"
+									alt={ image.alt }
+									src={ image.url }
+								/>
+							</AppButton>
+							<AppButton
+								className="gla-images-selector__remove-image-button"
+								icon={ <GridiconCrossCircle /> }
+								iconSize={ 20 }
+								onClick={ () => removeImage( image ) }
+							/>
+						</div>
+					);
+				} ) }
+			</div>
+			<AppButton
+				className="gla-images-selector__add-image-button"
+				isLink
+				disabled={
+					maxNumberOfImages !== 0 &&
+					images.length >= maxNumberOfImages
+				}
+				icon={ <GridiconPlusSmall /> }
+				iconSize={ 16 }
+				text={ __( 'Add image', 'google-listings-and-ads' ) }
+				onClick={ handleUpsertImageClick }
+			/>
+		</div>
+	);
+}

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -34,7 +34,7 @@ export default function ImagesSelector( {
 	initialImageUrls = [],
 	maxNumberOfImages = 0,
 } ) {
-	const [ replacingImage, setReplacingImage ] = useState( null );
+	const [ awaitingActionImage, setAwaitingActionImage ] = useState( null );
 	const [ images, setImages ] = useState( () =>
 		// The asset images fetched from Google Ads are only URLs.
 		initialImageUrls.map( ( url ) => ( { url, id: url, alt: '' } ) )
@@ -53,13 +53,13 @@ export default function ImagesSelector( {
 			// Find if there is a duplicate image first.
 			let index = nextImages.findIndex( ( { id } ) => id === image.id );
 
-			if ( replacingImage ) {
-				if ( index !== -1 && image.id !== replacingImage.id ) {
+			if ( awaitingActionImage ) {
+				if ( index !== -1 && image.id !== awaitingActionImage.id ) {
 					// If the selected image already exists while replacing, it's considered a swap position.
-					nextImages.splice( index, 1, { ...replacingImage } );
+					nextImages.splice( index, 1, { ...awaitingActionImage } );
 				}
 				// If index gets -1 here, it means the image to be replaced has been removed via the `onDelete` callback.
-				index = nextImages.indexOf( replacingImage );
+				index = nextImages.indexOf( awaitingActionImage );
 			}
 
 			if ( index === -1 ) {
@@ -68,13 +68,13 @@ export default function ImagesSelector( {
 				nextImages.splice( index, 1, image );
 			}
 
-			setReplacingImage( null );
+			setAwaitingActionImage( null );
 			setImages( nextImages );
 		},
 	} );
 
 	const handleUpsertImageClick = ( event, image = null ) => {
-		setReplacingImage( image );
+		setAwaitingActionImage( image );
 		handle.openSelector( image?.id );
 	};
 

--- a/js/src/components/paid-ads/asset-group/images-selector.scss
+++ b/js/src/components/paid-ads/asset-group/images-selector.scss
@@ -1,0 +1,56 @@
+.gla-images-selector {
+	&__image-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: $grid-unit-15;
+	}
+
+	&__image-item {
+		position: relative;
+		display: flex;
+	}
+
+	&__replace-image-button {
+		width: 100px;
+		height: 100px;
+		padding: 0;
+		border: 1px solid $gray-200;
+		border-radius: 2px;
+		overflow: hidden;
+		background-color: $white;
+	}
+
+	&__image {
+		max-width: 100%;
+		max-height: 100%;
+	}
+
+	&__add-image-button.has-icon {
+		margin-top: $grid-unit-20;
+		padding: $grid-unit-05;
+	}
+
+	&__remove-image-button {
+		display: none;
+		position: absolute;
+		top: 0;
+		right: 0;
+		transform: translate(50%, -50%);
+		color: $gray-500;
+
+		// Fill in the background color under the SVG icon.
+		&::after {
+			content: "";
+			position: absolute;
+			z-index: -1;
+			width: 30%;
+			height: 30%;
+			margin: auto;
+			background-color: $white;
+		}
+	}
+
+	&__image-item:hover &__remove-image-button {
+		display: flex;
+	}
+}

--- a/js/src/components/paid-ads/campaign-preview/campaign-preview.scss
+++ b/js/src/components/paid-ads/campaign-preview/campaign-preview.scss
@@ -83,8 +83,7 @@ $gla-campaign-preview-height: 270px;
 		}
 
 		&--gray-500 {
-			// $gray-400 is not declared Gutenberg style.
-			background-color: #bbb;
+			background-color: $gray-500;
 		}
 
 		&--blue {

--- a/js/src/css/abstracts/_variables.scss
+++ b/js/src/css/abstracts/_variables.scss
@@ -1,6 +1,10 @@
 // Import Gutenberg variables
 @import "node_modules/@wordpress/base-styles/variables";
 
+// Gutenberg Missing Styles
+// $gray-500 is not declared in Gutenberg.
+$gray-500: #bbb;
+
 // Add other variables or adjustments we want below
 
 // Typography

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -39,6 +39,11 @@
 
 	&.is-link {
 		text-decoration: none;
+
+		// Hack to show correct font color for disabled link button.
+		&:disabled {
+			color: initial;
+		}
 	}
 
 	// Fix that the panel title is rendered under the button with dropdown arrow.

--- a/js/src/hooks/types.js
+++ b/js/src/hooks/types.js
@@ -1,0 +1,12 @@
+/**
+ * @typedef {Object} ImageMedia
+ * @property {number} id The media ID of the image.
+ * @property {string} url URL.
+ * @property {number} width Width.
+ * @property {number} height Height.
+ * @property {number} filesizeInBytes File size in bytes.
+ * @property {string} alt Alternate text.
+ */
+
+// This export is required for JSDoc in other files to import the type definitions from this file.
+export default {};

--- a/js/src/hooks/useCroppedImageSelector/index.js
+++ b/js/src/hooks/useCroppedImageSelector/index.js
@@ -1,0 +1,1 @@
+export { default } from './useCroppedImageSelector';

--- a/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
+++ b/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
@@ -1,0 +1,284 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './useCroppedImageSelector.scss';
+
+/**
+ * @typedef {import('.~/hooks/types.js').ImageMedia} ImageMedia
+ */
+
+/**
+ * @typedef {Object} CroppedImageSelector
+ * @property {(preselectedId: number) => void} openSelector Function to open the selector modal.
+ */
+
+/**
+ * Calculates the maximum cropping size according to the fixed aspect ratio.
+ *
+ * @param {number} width The image width.
+ * @param {number} height The image height.
+ * @param {number} widthScale The scale of width.
+ * @param {number} heightScale The scale of height.
+ * @return {[number, number]} The tuple of cropped width and height.
+ */
+export function cropByFixedRatio( width, height, widthScale, heightScale ) {
+	const ratio = widthScale / heightScale;
+
+	if ( width / height > ratio ) {
+		width = Math.round( height * ratio );
+	} else {
+		height = Math.round( width / ratio );
+	}
+
+	return [ width, height ];
+}
+
+/**
+ * Returns the options to be used with the jQuery plugin `imgAreaSelect` to specify the
+ * initial selection.
+ *
+ * @param {number} width The image width.
+ * @param {number} height The image height.
+ * @param {number} minWidth The minimum width and also the width to be calculated as the aspect ratio.
+ * @param {number} minHeight The minimum height and also the height to be calculated as the aspect ratio.
+ * @return {Object} The options to be used with the jQuery plugin `imgAreaSelect`.
+ */
+export function getSelectionOptions( width, height, minWidth, minHeight ) {
+	const [ croppedWidth, croppedHeight ] = cropByFixedRatio( ...arguments );
+	const x1 = ( width - croppedWidth ) / 2;
+	const y1 = ( height - croppedHeight ) / 2;
+
+	return {
+		// Shows the resize handles.
+		handles: true,
+		// Returns the `imgAreaSelect` instance instead of jQuery object.
+		// Ref:
+		// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/media/views/cropper.js#L83
+		// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/media/views/cropper.js#L60
+		instance: true,
+		// Don't start a new selection when clicking outside the selection area.
+		persistent: true,
+		imageWidth: width,
+		imageHeight: height,
+		minWidth,
+		minHeight,
+		x1,
+		y1,
+		x2: x1 + croppedWidth,
+		y2: y1 + croppedHeight,
+		aspectRatio: `${ minWidth }:${ minHeight }`,
+	};
+}
+
+/**
+ * Calculates the percent error between the actual aspect ratio and the expected aspect ratio.
+ *
+ * @param {number} width The actual width.
+ * @param {number} height The actual height.
+ * @param {number} expectedWidth The expected width.
+ * @param {number} expectedHeight The expected height.
+ * @return {number} The percent error of aspect ratio.
+ */
+export function calcRatioPercentError(
+	width,
+	height,
+	expectedWidth,
+	expectedHeight
+) {
+	const imageRatio = width / height;
+	const expectedRatio = expectedWidth / expectedHeight;
+	return Math.abs( ( imageRatio - expectedRatio ) / expectedRatio ) * 100;
+}
+
+/**
+ * Hook for opening a modal to select images with fixed aspect ratio via
+ * WordPress Media library. It will request cropping when the size of the
+ * selected image doesn't match the given aspect ratio.
+ *
+ * @param {Object} options
+ * @param {number} options.minWidth The minimum width and also the width to be calculated as the aspect ratio.
+ * @param {number} options.minHeight The minimum height and also the height to be calculated as the aspect ratio.
+ * @param {number} options.suggestedWidth The suggested width showing on the modal.
+ * @param {number} options.suggestedHeight The suggested height showing on the modal.
+ * @param {(image: ImageMedia) => void} options.onSelect Callback when an image is selected.
+ * @param {(image: ImageMedia) => void} options.onDelete Callback when an image is deleted.
+ * @param {number} [options.allowedRatioPercentError=1] The percent error of the aspect ratio.
+ * @return {CroppedImageSelector} The handle of this hook.
+ */
+export default function useCroppedImageSelector( {
+	minWidth,
+	minHeight,
+	suggestedWidth,
+	suggestedHeight,
+	onSelect,
+	onDelete,
+	allowedRatioPercentError = 1,
+} ) {
+	const callbackRef = useRef( {} );
+	callbackRef.current.onSelect = onSelect;
+	callbackRef.current.onDelete = onDelete;
+
+	const openSelector = useCallback(
+		( preselectedId ) => {
+			const { media } = wp;
+			const sizeErrorMessage = sprintf(
+				// translators: 1: Minimum width, 2: Minimum height.
+				__(
+					'Image size needs to be at least %1$d x %2$d',
+					'google-listings-and-ads'
+				),
+				minWidth,
+				minHeight
+			);
+
+			// Will be called by the controller of the parent class of CustomizeImageCropper. Ref:
+			// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/media/controllers/customize-image-cropper.js#L14
+			// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/media/controllers/cropper.js#L65
+			// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/media/views/cropper.js#L48-L54
+			const imgSelectOptions = ( attachment, controller ) => {
+				const width = attachment.get( 'width' );
+				const height = attachment.get( 'height' );
+				const args = [ width, height, minWidth, minHeight ];
+				const ratioPercentError = calcRatioPercentError( ...args );
+
+				if ( ratioPercentError < allowedRatioPercentError ) {
+					controller.set( 'canSkipCrop', true );
+				}
+				return getSelectionOptions( ...args );
+			};
+
+			// Ref:
+			// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/_enqueues/wp/media/models.js#L36
+			// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/media/views/frame/select.js
+			const frame = media( {
+				button: {
+					text: __( 'Select', 'google-listings-and-ads' ),
+					close: false,
+				},
+				states: [
+					// Ref: https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/media/controllers/library.js
+					new media.controller.Library( {
+						title: __(
+							'Select or upload image',
+							'google-listings-and-ads'
+						),
+						library: media.query( { type: 'image' } ),
+						date: false,
+						suggestedWidth,
+						suggestedHeight,
+					} ),
+					new media.controller.CustomizeImageCropper( {
+						imgSelectOptions,
+						// Ignores the adjustment of the flexible sides.
+						// Ref: https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/js/media/controllers/customize-image-cropper.js#L39-L40
+						control: { params: {} },
+					} ),
+				],
+			} );
+
+			function handlePreselect( library ) {
+				if ( ! preselectedId ) {
+					return;
+				}
+				const attachment = library.get( preselectedId );
+				if ( attachment ) {
+					frame.state().get( 'selection' ).reset( [ attachment ] );
+				}
+			}
+
+			function handleImageDeleted( attachment ) {
+				callbackRef.current.onDelete( attachment );
+			}
+
+			function handleSelectionToggle() {
+				// Workaround to update the disabled state of button after uploading a new image
+				// since `toolbar` will be triggered the refresh event at the end, so this function
+				// must be called after that.
+				if ( this === frame ) {
+					setImmediate( handleSelectionToggle );
+					return;
+				}
+
+				const selection = frame.state().get( 'selection' );
+				const toolbar = frame.toolbar.get();
+
+				let invalidSize;
+
+				if ( selection.length ) {
+					const { width, height } = selection.first().toJSON();
+					invalidSize = width < minWidth || height < minHeight;
+				}
+
+				const primaryBlock = toolbar.primary.el;
+
+				if ( invalidSize ) {
+					primaryBlock.dataset.errorMessage = sizeErrorMessage;
+					primaryBlock.classList.add( 'gla-decorated-error-message' );
+					toolbar.get( 'select' ).model.set( 'disabled', true );
+				} else {
+					delete primaryBlock.dataset.errorMessage;
+				}
+			}
+
+			function handleSelectButtonClick() {
+				frame.setState( 'cropper' );
+			}
+
+			function handleCrop( image ) {
+				// 'skippedcrop' will pass an attachment model.
+				if ( image instanceof media.model.Attachment ) {
+					image = image.toJSON();
+				}
+				callbackRef.current.onSelect( image );
+			}
+
+			function handleClose() {
+				// Remove all callbacks bound with the same context.
+				// Ref: https://backbonejs.org/#Events-off
+				const libraryModel = frame.state( 'library' );
+				libraryModel.get( 'library' ).off( null, null, frame );
+				libraryModel.get( 'selection' ).off( null, null, frame );
+				frame.off( null, null, frame );
+				frame.remove();
+			}
+
+			frame
+				.on( 'select', handleSelectButtonClick, frame )
+				.on( 'cropped skippedcrop', handleCrop, frame )
+				.on( 'close', handleClose, frame );
+
+			frame
+				.state( 'library' )
+				.get( 'selection' )
+				.on(
+					'selection:single selection:unsingle',
+					handleSelectionToggle,
+					frame
+				);
+
+			frame
+				.state( 'library' )
+				.get( 'library' )
+				.once( 'attachments:received', handlePreselect, frame )
+				.on( 'reset', handleSelectionToggle, frame ) // Triggered after uploading a new image
+				.on( 'destroy', handleImageDeleted, frame ); // Triggered after deleting an image
+
+			frame.open();
+		},
+		[
+			minWidth,
+			minHeight,
+			suggestedWidth,
+			suggestedHeight,
+			allowedRatioPercentError,
+		]
+	);
+
+	return { openSelector };
+}

--- a/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
+++ b/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
@@ -93,7 +93,12 @@ export function calcRatioPercentError(
 ) {
 	const imageRatio = width / height;
 	const expectedRatio = expectedWidth / expectedHeight;
-	return Math.abs( ( imageRatio - expectedRatio ) / expectedRatio ) * 100;
+	const errorRatio =
+		imageRatio > expectedRatio
+			? imageRatio / expectedRatio
+			: expectedRatio / imageRatio;
+
+	return ( errorRatio - 1 ) * 100;
 }
 
 /**

--- a/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
+++ b/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
@@ -120,7 +120,7 @@ export function calcRatioPercentError(
  * @param {number} options.suggestedHeight The suggested height showing on the modal.
  * @param {(image: ImageMedia) => void} options.onSelect Callback when an image is selected.
  * @param {(image: ImageMedia) => void} options.onDelete Callback when an image is deleted.
- * @param {number} [options.allowedRatioPercentError=1] The percent error of the aspect ratio.
+ * @param {number} [options.ratioPercentError=1] The percent error of the aspect ratio.
  * @return {CroppedImageSelector} The handle of this hook.
  */
 export default function useCroppedImageSelector( {
@@ -130,7 +130,7 @@ export default function useCroppedImageSelector( {
 	suggestedHeight,
 	onSelect,
 	onDelete,
-	allowedRatioPercentError = 1,
+	ratioPercentError = 1,
 } ) {
 	const callbackRef = useRef( {} );
 	callbackRef.current.onSelect = onSelect;
@@ -159,7 +159,7 @@ export default function useCroppedImageSelector( {
 				const args = [ width, height, minWidth, minHeight ];
 				const ratioPercentError = calcRatioPercentError( ...args );
 
-				if ( ratioPercentError < allowedRatioPercentError ) {
+				if ( calcRatioPercentError( ...args ) < ratioPercentError ) {
 					controller.set( 'canSkipCrop', true );
 				}
 				return getSelectionOptions( ...args );
@@ -288,7 +288,7 @@ export default function useCroppedImageSelector( {
 			minHeight,
 			suggestedWidth,
 			suggestedHeight,
-			allowedRatioPercentError,
+			ratioPercentError,
 		]
 	);
 

--- a/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
+++ b/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
@@ -27,7 +27,12 @@ import './useCroppedImageSelector.scss';
  * @param {number} heightScale The scale of height.
  * @return {[number, number]} The tuple of cropped width and height.
  */
-export function cropByFixedRatio( width, height, widthScale, heightScale ) {
+export function calcMaxCroppingByFixedRatio(
+	width,
+	height,
+	widthScale,
+	heightScale
+) {
 	const ratio = widthScale / heightScale;
 
 	if ( width / height > ratio ) {
@@ -50,7 +55,9 @@ export function cropByFixedRatio( width, height, widthScale, heightScale ) {
  * @return {Object} The options to be used with the jQuery plugin `imgAreaSelect`.
  */
 export function getSelectionOptions( width, height, minWidth, minHeight ) {
-	const [ croppedWidth, croppedHeight ] = cropByFixedRatio( ...arguments );
+	const [ croppedWidth, croppedHeight ] = calcMaxCroppingByFixedRatio(
+		...arguments
+	);
 	const x1 = ( width - croppedWidth ) / 2;
 	const y1 = ( height - croppedHeight ) / 2;
 

--- a/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.scss
+++ b/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.scss
@@ -1,0 +1,14 @@
+// Pseudo-element for showing error message at the left side of the primary block
+// in the footer of Media Modal.
+// The values of float, height, and margin-top are referred from:
+// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/wp-includes/css/buttons.css#L74
+// - https://github.com/WordPress/wordpress-develop/blob/5.9.0/src/wp-includes/css/media-views.css#L330-L331
+.gla-decorated-error-message[data-error-message]::before {
+	content: attr(data-error-message);
+	float: left;
+	height: 32px;
+	margin-top: 15px;
+	line-height: 32px;
+	font-size: $gla-font-small;
+	color: $alert-red;
+}

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -77,6 +77,11 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 		add_action(
 			'admin_enqueue_scripts',
 			function() {
+				if ( wc_admin_is_registered_page() ) {
+					// Enqueue the required JavaScript scripts and CSS styles of the Media library.
+					wp_enqueue_media();
+				}
+
 				$this->assets_handler->enqueue_many( $this->get_assets() );
 			}
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a part of 📌 [Assets form and related components](https://github.com/woocommerce/google-listings-and-ads/issues/1787#fe-misc) in #1787.

- Multiple images selector

### Screenshots:

#### 📹 Crop, skip cropping, check image size, remove selected image, and replace selected image

https://user-images.githubusercontent.com/17420811/208123491-7a403bb0-17e8-41a5-8edf-62f01b39e9bd.mp4

#### 📹 Pre-select when replacing image and check the size of the newly uploaded image

https://user-images.githubusercontent.com/17420811/208124129-29c80288-314d-421e-a271-a42ea5d2ddb9.mp4

#### 📹 Remove the deleted image from the selected images

https://user-images.githubusercontent.com/17420811/208124578-711f1ef8-2772-4412-aa3e-66f4f167d29b.mp4

#### 📹 Swap images if the selected image already exists while replacing

https://user-images.githubusercontent.com/17420811/208124807-a5ca07cf-ccf8-447c-b4ed-a5efbd5a03c7.mp4

#### 📹 The image to be replaced has been deleted

https://user-images.githubusercontent.com/17420811/208124844-b7c72ac1-bedb-4e78-810f-163f7ad83438.mp4

#### 📷 Disable "Add image" button and multiline images

![image](https://user-images.githubusercontent.com/17420811/208123458-17c4fe4e-229b-4092-8f07-8353a4203fd1.png)

### Detailed test instructions:

1. Go to the assets step of the campaign creation page.
2. Use the asset image selector to see if most of the operations are working properly.

### Changelog entry
