### PR TITLE
Tweak Copy for Attribute Mapping

### DIFF
--- a/js/src/attribute-mapping/attribute-mapping-category-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-category-control.js
@@ -35,21 +35,21 @@ const AttributeMappingCategoryControl = ( {
 					{
 						value: CATEGORY_CONDITION_SELECT_TYPES.ALL,
 						label: __(
-							'Apply to All categories',
+							'Apply to all categories',
 							'google-listings-and-ads'
 						),
 					},
 					{
 						value: CATEGORY_CONDITION_SELECT_TYPES.EXCEPT,
 						label: __(
-							'Apply to All categories EXCEPT',
+							'Apply to all categories EXCEPT',
 							'google-listings-and-ads'
 						),
 					},
 					{
 						value: CATEGORY_CONDITION_SELECT_TYPES.ONLY,
 						label: __(
-							'Apply ONLY to this categories',
+							'Apply ONLY to these categories',
 							'google-listings-and-ads'
 						),
 					},

--- a/js/src/attribute-mapping/attribute-mapping-field-sources-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-field-sources-control.js
@@ -27,7 +27,7 @@ const AttributeMappingFieldSourcesControl = ( {
 					{
 						value: '',
 						label: __(
-							'Select one option',
+							'Select an option',
 							'google-listings-and-ads'
 						),
 					},

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -118,7 +118,7 @@ const AttributeMappingRuleModal = ( { rule, onRequestClose = noop } ) => {
 	const attributesOptions = [
 		{
 			value: '',
-			label: __( 'Select one attribute', 'google-listings-and-ads' ),
+			label: __( 'Select an attribute', 'google-listings-and-ads' ),
 		},
 		...mapOptions( attributes ),
 	];

--- a/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
+++ b/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
@@ -21,12 +21,12 @@ const SOURCE_TYPES = {
 };
 
 const fixedValueControlLabel = __(
-	'Set a fixed value.',
+	'Set a fixed value',
 	'google-listings-and-ads'
 );
 
 const selectFieldControlLabel = __(
-	'Use value from existing product field.',
+	'Use value from existing product field',
 	'google-listings-and-ads'
 );
 
@@ -93,7 +93,7 @@ const AttributeMappingSourceTypeSelector = ( {
 						<Subsection.HelperText className="gla-attribute-mapping__help-text">
 							{ createInterpolateElement(
 								__(
-									'Can’t find an appropriate field?. <link>Create a new attribute</link>',
+									'Can’t find an appropriate field? <link>Create a new attribute</link>',
 									'google-listings-and-ads'
 								),
 								{

--- a/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
+++ b/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
@@ -72,7 +72,7 @@ const AttributeMappingSourceTypeSelector = ( {
 						>
 							<div>
 								{ __(
-									'Create a connection between the target attribute and an existing product field to auto-populate the target attribute with with the value of the field it is linked to.',
+									'Auto-populate the target attribute with the value of the field you link it to.',
 									'google-listings-and-ads'
 								) }
 							</div>
@@ -119,9 +119,14 @@ const AttributeMappingSourceTypeSelector = ( {
 							id={ `${ SOURCE_TYPES.FIXED }-helper-popover` }
 						>
 							<div>
-								{ __(
-									'Use fixed values to populate the target attribute with a value you specify. For example, you can enter a fixed value of White to specify a single color for all your products.',
-									'google-listings-and-ads'
+								{ createInterpolateElement(
+									__(
+										"Use fixed values to populate the target attribute with a value you specify. For example, you can enter a fixed value of <em>'White'</em> to specify a single color for all your products.",
+										'google-listings-and-ads'
+									),
+									{
+										em: <em />,
+									}
 								) }
 							</div>
 						</HelpPopover>

--- a/js/src/attribute-mapping/index.scss
+++ b/js/src/attribute-mapping/index.scss
@@ -26,6 +26,10 @@
 			// hack for positioning the popover correctly in the modal radio control
 			.components-popover {
 				position: absolute;
+
+				&__content {
+					max-width: 350px;
+				}
 			}
 		}
 	}

--- a/js/src/attribute-mapping/index.test.js
+++ b/js/src/attribute-mapping/index.test.js
@@ -225,18 +225,18 @@ describe( 'Attribute Mapping', () => {
 
 		// Show fixed value when we check "Set a fixed value" radio
 		const setFixedRadio = await findByRole( 'radio', {
-			name: 'Set a fixed value.',
+			name: 'Set a fixed value',
 		} );
 		userEvent.click( setFixedRadio );
 		await findByRole( 'textbox' );
 
 		// Show selector value when we check "Use value from existing product field" radio
 		const setFieldRadio = await findByRole( 'radio', {
-			name: 'Use value from existing product field.',
+			name: 'Use value from existing product field',
 		} );
 		userEvent.click( setFieldRadio );
 		await findByRole( 'combobox', {
-			name: 'Use value from existing product field.',
+			name: 'Use value from existing product field',
 		} );
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1813 .

This PR implements suggested changes from 2 to 6.

### Screenshots

<img width="586" alt="Screenshot 2022-12-19 at 16 42 00" src="https://user-images.githubusercontent.com/5908855/208396386-7c82d12f-4f23-4c64-857a-458f3755939e.png">

<img width="733" alt="Screenshot 2022-12-19 at 16 41 53" src="https://user-images.githubusercontent.com/5908855/208396413-9b2b1d13-af06-40e7-9c02-948fd1f93b8f.png">

<img width="717" alt="Screenshot 2022-12-19 at 16 41 48" src="https://user-images.githubusercontent.com/5908855/208396449-e2119c9b-afc5-48d8-be1f-0a003fb6de86.png">

<img width="607" alt="Screenshot 2022-12-19 at 16 41 43" src="https://user-images.githubusercontent.com/5908855/208396476-db66d6b9-ea08-4a02-b315-a337b1a96eb6.png">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Attribute Mapping and click on Create new rule
2. See the selector appears as "Select an attribute"
3. Select Brands
4. See the new field selector appears as  "Select an option"
5. Check the tooltips are max 350px
6. Check there is no period after the copy sentences
7. Check that tooltip content in "Use value from existing product field" matches the specifications in #1813  point 6
8. Check that tooltip content in "Set a fixed value" matches the specifications in  #1813  point 6 especially the <em> markup in the word "White" 


### Additional details:

Notice point 1 was not implemented: Change text from No data to display to You have no attribute rules in the table when no rules

This is because `<Table>` component doesn't support changing that text. So we can use `<EmptyTable>` component but it will remove the table headers. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Adjust copy in Attribute Mapping section
