### PR TITLE
Improve landing page URL for policy compliance checks 

### DIFF
--- a/src/MerchantCenter/PolicyComplianceCheck.php
+++ b/src/MerchantCenter/PolicyComplianceCheck.php
@@ -105,7 +105,12 @@ class PolicyComplianceCheck implements Service {
 	 * @return string Landing page URL.
 	 */
 	private function get_landing_page_url(): string {
-		$products = wc_get_products( [ 'limit' => 1, 'status' => 'publish' ] );
+		$products = wc_get_products(
+			[
+				'limit'  => 1,
+				'status' => 'publish',
+			]
+		);
 		if ( ! empty( $products ) ) {
 			return $products[0]->get_permalink();
 		}

--- a/src/MerchantCenter/PolicyComplianceCheck.php
+++ b/src/MerchantCenter/PolicyComplianceCheck.php
@@ -105,7 +105,7 @@ class PolicyComplianceCheck implements Service {
 	 * @return string Landing page URL.
 	 */
 	private function get_landing_page_url(): string {
-		$products = wc_get_products( [ 'limit' => 1 ] );
+		$products = wc_get_products( [ 'limit' => 1, 'status' => 'publish' ] );
 		if ( ! empty( $products ) ) {
 			return $products[0]->get_permalink();
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

We should only consider the url for the products with publish status

Reference from this [issue](https://github.com/woocommerce/google-listings-and-ads/issues/1822)

We add this fix to help query only products with publish status.



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create only one product and set it to a publish product.
2. Go through the onboarding steps and confirm that the check "Confirm your store is live and accessible to all users" is passed.

### Changelog entry
* Tweak - Retrieve a published product as a landing page URL.
>
