### PR TITLE
Simplify report controller parameters

### DIFF
--- a/src/API/Site/Controllers/Ads/ReportsController.php
+++ b/src/API/Site/Controllers/Ads/ReportsController.php
@@ -87,13 +87,13 @@ class ReportsController extends BaseReportsController {
 	}
 
 	/**
-	 * Add collection parameters.
-	 *
-	 * @param array $params Initial set of collection parameters.
+	 * Get the query params for collections.
 	 *
 	 * @return array
 	 */
-	protected function add_collection_parameters( array $params ): array {
+	public function get_collection_params(): array {
+		$params = parent::get_collection_params();
+
 		$params['interval'] = [
 			'description'       => __( 'Time interval to use for segments in the returned data.', 'google-listings-and-ads' ),
 			'type'              => 'string',

--- a/src/API/Site/Controllers/BaseReportsController.php
+++ b/src/API/Site/Controllers/BaseReportsController.php
@@ -120,30 +120,16 @@ abstract class BaseReportsController extends BaseController {
 	 * @return array
 	 */
 	protected function prepare_query_arguments( Request $request ): array {
-		$params   = $this->get_collection_params();
-		$defaults = $this->get_defaults( $params );
-		$args     = wp_parse_args( array_intersect_key( $request->get_query_params(), $params ), $defaults );
+		$args = wp_parse_args(
+			array_intersect_key(
+				$request->get_query_params(),
+				$this->get_collection_params()
+			),
+			$request->get_default_params()
+		);
 
 		$this->normalize_timezones( $args );
 		return $args;
-	}
-
-	/**
-	 * Get parameter defaults.
-	 *
-	 * @param array $params List of parameters.
-	 *
-	 * @return array
-	 */
-	protected function get_defaults( array $params ): array {
-		$defaults = [];
-		foreach ( $params as $key => $param ) {
-			if ( isset( $param['default'] ) ) {
-				$defaults[ $key ] = $param['default'];
-			}
-		}
-
-		return $defaults;
 	}
 
 	/**

--- a/src/API/Site/Controllers/BaseReportsController.php
+++ b/src/API/Site/Controllers/BaseReportsController.php
@@ -39,7 +39,7 @@ abstract class BaseReportsController extends BaseController {
 	 * @return array
 	 */
 	public function get_collection_params(): array {
-		$params = [
+		return [
 			'context'   => $this->get_context_param( [ 'default' => 'view' ] ),
 			'after'     => [
 				'description'       => __( 'Limit response to data after a given ISO8601 compliant date.', 'google-listings-and-ads' ),
@@ -100,18 +100,7 @@ abstract class BaseReportsController extends BaseController {
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];
-
-		return $this->add_collection_parameters( $params );
 	}
-
-	/**
-	 * Add collection parameters.
-	 *
-	 * @param array $params Initial set of collection parameters.
-	 *
-	 * @return array
-	 */
-	abstract protected function add_collection_parameters( array $params ): array;
 
 	/**
 	 * Maps query arguments from the REST request.

--- a/src/API/Site/Controllers/MerchantCenter/ReportsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ReportsController.php
@@ -86,13 +86,13 @@ class ReportsController extends BaseReportsController {
 	}
 
 	/**
-	 * Add collection parameters.
-	 *
-	 * @param array $params Initial set of collection parameters.
+	 * Get the query params for collections.
 	 *
 	 * @return array
 	 */
-	protected function add_collection_parameters( array $params ): array {
+	public function get_collection_params(): array {
+		$params = parent::get_collection_params();
+
 		$params['interval'] = [
 			'description'       => __( 'Time interval to use for segments in the returned data.', 'google-listings-and-ads' ),
 			'type'              => 'string',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Based on the discussion [here](https://github.com/woocommerce/automatewoo/pull/1226#discussion_r1054443474), this PR cleans up the report controllers to make the code reusable and take advantage of the existing function [WP_REST_Request::get_default_params](https://developer.wordpress.org/reference/classes/wp_rest_request/get_default_params/)

### Detailed test instructions:
Unit testing is still not implemented for the Report Controllers (I started an attempt, but it's going to take a substantial effort to unit test these classes so I left it out for now).

The reports can be tested manually as outlined in PR #251, although this PR doesn't change the report data so we would only want to confirm that the parameter defaults still get mapped in the same way.

The easiest way to test that is to set a break point in `prepare_query_arguments` and confirm that the arguments are as expected:
![image](https://user-images.githubusercontent.com/11388669/208962008-defa410d-737e-455e-aa73-28d65ee0e8a3.png)

> **Note**
The DateTime's will vary but it should cover the time range from `-7 days` to `now`.

A GET request without query parameters can be sent to `https://domain.test/wp-json/wc/gla/ads/reports/programs`.

### Changelog entry
* Tweak - Simplify report controller parameters.