### PR TITLE
Tweak Asset Suggestions format response.

### DIFF
--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Exception;
 use WP_Query;
 use wpdb;
@@ -169,16 +170,16 @@ class AssetSuggestionsService implements Service {
 		$long_headline    = get_bloginfo( 'name' ) . ': ' . $post->post_title;
 
 		return [
-			'headline'                => [ $post->post_title ],
-			'long_headline'           => [ $long_headline ],
-			'description'             => ArrayUtil::remove_empty_values( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ),
-			'logo'                    => $this->get_logo_images(),
-			'final_url'               => get_permalink( $id ),
-			'business_name'           => get_bloginfo( 'name' ),
-			'display_url_path'        => [ $post->post_name ],
-			'square_marketing_images' => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
-			'marketing_images'        => $marketing_images [ self::MARKETING_IMAGE_KEY ] ?? [],
-			'call_to_action'          => null,
+			AssetFieldType::HEADLINE                 => [ $post->post_title ],
+			AssetFieldType::LONG_HEADLINE            => [ $long_headline ],
+			AssetFieldType::DESCRIPTION              => ArrayUtil::remove_empty_values( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ),
+			AssetFieldType::LOGO                     => $this->get_logo_images(),
+			AssetFieldType::BUSINESS_NAME            => get_bloginfo( 'name' ),
+			AssetFieldType::SQUARE_MARKETING_IMAGE   => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
+			AssetFieldType::MARKETING_IMAGE          => $marketing_images [ self::MARKETING_IMAGE_KEY ] ?? [],
+			AssetFieldType::CALL_TO_ACTION_SELECTION => null,
+			'display_url_path'                       => [ $post->post_name ],
+			'final_url'                              => get_permalink( $id ),
 		];
 	}
 
@@ -216,16 +217,16 @@ class AssetSuggestionsService implements Service {
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
 
 		return [
-			'headline'                => [ $term->name ],
-			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $term->name ],
-			'description'             => ArrayUtil::remove_empty_values( [ wp_strip_all_tags( $term->description ), get_bloginfo( 'description' ) ] ),
-			'logo'                    => $this->get_logo_images(),
-			'final_url'               => get_term_link( $term->term_id ),
-			'business_name'           => get_bloginfo( 'name' ),
-			'display_url_path'        => [ $term->slug ],
-			'square_marketing_images' => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
-			'marketing_images'        => $marketing_images [ self::MARKETING_IMAGE_KEY ] ?? [],
-			'call_to_action'          => null,
+			AssetFieldType::HEADLINE                 => [ $term->name ],
+			AssetFieldType::LONG_HEADLINE            => [ get_bloginfo( 'name' ) . ': ' . $term->name ],
+			AssetFieldType::DESCRIPTION              => ArrayUtil::remove_empty_values( [ wp_strip_all_tags( $term->description ), get_bloginfo( 'description' ) ] ),
+			AssetFieldType::LOGO                     => $this->get_logo_images(),
+			AssetFieldType::BUSINESS_NAME            => get_bloginfo( 'name' ),
+			AssetFieldType::SQUARE_MARKETING_IMAGE   => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
+			AssetFieldType::MARKETING_IMAGE          => $marketing_images [ self::MARKETING_IMAGE_KEY ] ?? [],
+			AssetFieldType::CALL_TO_ACTION_SELECTION => null,
+			'display_url_path'                       => [ $term->slug ],
+			'final_url'                              => get_term_link( $term->term_id ),
 		];
 	}
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\DataTrai
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ArrayUtil;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DimensionUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
 use WC_Helper_Product;
@@ -109,32 +110,32 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 	protected function format_post_asset_response( $post, array $marketing_images = [] ): array {
 		return [
-			'final_url'               => get_permalink( $post->ID ),
-			'headline'                => [ $post->post_title ],
-			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $post->post_title ],
-			'description'             => ArrayUtil::remove_empty_values( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ),
-			'business_name'           => get_bloginfo( 'name' ),
-			'display_url_path'        => [ $post->post_name ],
-			'logo'                    => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
-			'square_marketing_images' => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
-			'marketing_images'        => $marketing_images[ self::MARKETING_IMAGE_KEY ] ?? [],
-			'call_to_action'          => null,
+			AssetFieldType::HEADLINE                 => [ $post->post_title ],
+			AssetFieldType::LONG_HEADLINE            => [ get_bloginfo( 'name' ) . ': ' . $post->post_title ],
+			AssetFieldType::DESCRIPTION              => ArrayUtil::remove_empty_values( [ $post->post_excerpt, get_bloginfo( 'description' ) ] ),
+			AssetFieldType::BUSINESS_NAME            => get_bloginfo( 'name' ),
+			AssetFieldType::LOGO                     => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
+			AssetFieldType::SQUARE_MARKETING_IMAGE   => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
+			AssetFieldType::MARKETING_IMAGE          => $marketing_images[ self::MARKETING_IMAGE_KEY ] ?? [],
+			AssetFieldType::CALL_TO_ACTION_SELECTION => null,
+			'display_url_path'                       => [ $post->post_name ],
+			'final_url'                              => get_permalink( $post->ID ),
 		];
 
 	}
 
 	protected function format_term_asset_response( $term, array $marketing_images = [] ): array {
 		return [
-			'final_url'               => get_term_link( $term->term_id ),
-			'headline'                => [ $term->name ],
-			'long_headline'           => [ get_bloginfo( 'name' ) . ': ' . $term->name ],
-			'description'             => ArrayUtil::remove_empty_values( [ wp_strip_all_tags( $term->description ), get_bloginfo( 'description' ) ] ),
-			'logo'                    => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
-			'business_name'           => get_bloginfo( 'name' ),
-			'display_url_path'        => [ $term->slug ],
-			'square_marketing_images' => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
-			'marketing_images'        => $marketing_images[ self::MARKETING_IMAGE_KEY ] ?? [],
-			'call_to_action'          => null,
+			AssetFieldType::HEADLINE                 => [ $term->name ],
+			AssetFieldType::LONG_HEADLINE            => [ get_bloginfo( 'name' ) . ': ' . $term->name ],
+			AssetFieldType::DESCRIPTION              => ArrayUtil::remove_empty_values( [ wp_strip_all_tags( $term->description ), get_bloginfo( 'description' ) ] ),
+			AssetFieldType::LOGO                     => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
+			AssetFieldType::BUSINESS_NAME            => get_bloginfo( 'name' ),
+			AssetFieldType::SQUARE_MARKETING_IMAGE   => $marketing_images[ self::SQUARE_MARKETING_IMAGE_KEY ] ?? [],
+			AssetFieldType::MARKETING_IMAGE          => $marketing_images[ self::MARKETING_IMAGE_KEY ] ?? [],
+			AssetFieldType::CALL_TO_ACTION_SELECTION => null,
+			'display_url_path'                       => [ $term->slug ],
+			'final_url'                              => get_term_link( $term->term_id ),
 		];
 
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

The response of the asset suggestions for posts and terms are formed using the asset field type, such as headline, long_headline, description, etc.

https://github.com/woocommerce/google-listings-and-ads/blob/34ed21c19fff707c058a8e8a895d437ef66a49c8/src/Ads/AssetSuggestionsService.php#L171-L181


This PR updates these fields using the the`AssetFieldType` mapping class that was introduced in the PR https://github.com/woocommerce/google-listings-and-ads/pull/1820. In this way, we standardise the asset field type across different parts of the code.

There are some differences, for example, the `square_marketing_images` and `marketing_images` fields were in plural and have been updated to singular  `square_marketing_image` and `marketing_images` or `call_to_action` has been updated to `call_to_action_selection` so it matches with the Ads API.  Those differences are OK and the front-end will be adjusted accordingly. 

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  As the branch `feature/pmax-assets` is using some new imports from the GoogleAds Library, you may need to remove your vendor folder `rm -rf vendor/*` and install again the dependencies using `composer install`
2. Make a request to `assets/suggestions?id=YOUR_POST_ID&type=post` and check that the fields correspond with the AssetFieldType used.
3. Make a request to `assets/suggestions?id=YOUR_TERM_ID&type=term` and check that the fields correspond with the AssetFieldType used.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

