### PR TITLE
Update Assets Groups

### DIFF
--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -83,7 +83,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 * @return MutateOperation The text asset mutation.
 	 * @throws Exception If the asset type is not supported.
 	 */
-	public function create_operation_asset( array $data, int $temporary_id = self::TEMPORARY_ID ): MutateOperation {
+	public function create_operation( array $data, int $temporary_id = self::TEMPORARY_ID ): MutateOperation {
 		$asset = new Asset(
 			[
 				'resource_name' => $this->temporary_resource_name( $temporary_id ),

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -119,33 +119,39 @@ class AdsAsset implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Convert Asset data to an array.
+	 * Returns the asset content for the given row.
 	 *
 	 * @param GoogleAdsRow $row Data row returned from a query request.
 	 *
-	 * @return array
+	 * @return string The asset content.
 	 */
-	public function convert_asset( GoogleAdsRow $row ): array {
+	public function get_asset_content( GoogleAdsRow $row ): string {
 		/** @var Asset $asset */
 		$asset = $row->getAsset();
 
 		switch ( $asset->getType() ) {
 			case AssetType::IMAGE:
-				$data = $asset->getImageAsset()->getFullSize()->getUrl();
-				break;
+				return $asset->getImageAsset()->getFullSize()->getUrl();
 			case AssetType::TEXT:
-				$data = $asset->getTextAsset()->getText();
-				break;
+				return $asset->getTextAsset()->getText();
 			case AssetType::CALL_TO_ACTION:
-				$data = CallToActionType::label( $asset->getCallToActionAsset()->getCallToAction() );
-				break;
+				return CallToActionType::label( $asset->getCallToActionAsset()->getCallToAction() );
 			default:
-				$data = '';
+				return '';
 		}
+	}
 
+	/**
+	 * Convert Asset data to an array.
+	 *
+	 * @param GoogleAdsRow $row Data row returned from a query request.
+	 *
+	 * @return array The asset data converted.
+	 */
+	public function convert_asset( GoogleAdsRow $row ): array {
 		return [
-			'id'      => $asset->getId(),
-			'content' => $data,
+			'id'      => $row->getAsset()->getId(),
+			'content' => $this->get_asset_content( $row ),
 		];
 	}
 }

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -14,6 +14,7 @@ use Google\Ads\GoogleAds\Util\V11\ResourceNames;
 use Google\Ads\GoogleAds\V11\Common\TextAsset;
 use Google\Ads\GoogleAds\V11\Common\ImageAsset;
 use Google\Ads\GoogleAds\V11\Common\CallToActionAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Exception;
 
 /**
@@ -29,6 +30,22 @@ use Exception;
 class AdsAsset implements OptionsAwareInterface {
 
 	use OptionsAwareTrait;
+
+	/**
+	 * WP Proxy
+	 *
+	 * @var WP
+	 */
+	protected WP $wp;
+
+	/**
+	 * AdsAsset constructor.
+	 *
+	 * @param WP $wp The WordPress proxy.
+	 */
+	public function __construct( WP $wp ) {
+		$this->wp = $wp;
+	}
 
 	/**
 	 * Temporary ID to use within a batch job.
@@ -97,7 +114,7 @@ class AdsAsset implements OptionsAwareInterface {
 				$asset->setCallToActionAsset( new CallToActionAsset( [ 'call_to_action' => CallToActionType::number( $data['content'] ) ] ) );
 				break;
 			case AssetType::IMAGE:
-				$image_data = wp_remote_get( $data['content'] );
+				$image_data = $this->wp->wp_remote_get( $data['content'] );
 
 				if ( is_wp_error( $image_data ) || empty( $image_data['body'] ) ) {
 					throw new Exception( 'Incorrect image asset url.' );

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -3,10 +3,18 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Google\Ads\GoogleAds\V11\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V11\Enums\AssetTypeEnum\AssetType;
 use Google\Ads\GoogleAds\V11\Enums\CallToActionTypeEnum\CallToActionType;
 use Google\Ads\GoogleAds\V11\Resources\Asset;
+use Google\Ads\GoogleAds\V11\Services\AssetOperation;
+use Google\Ads\GoogleAds\V11\Services\MutateOperation;
+use Google\Ads\GoogleAds\Util\V11\ResourceNames;
+use Google\Ads\GoogleAds\V11\Common\TextAsset;
+use Google\Ads\GoogleAds\V11\Common\ImageAsset;
+use Google\Ads\GoogleAds\V11\Common\CallToActionAsset;
 
 /**
  * Class AdsAsset
@@ -18,7 +26,52 @@ use Google\Ads\GoogleAds\V11\Resources\Asset;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
-class AdsAsset {
+class AdsAsset implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/**
+	 * Temporary ID to use within a batch job.
+	 * A negative number which is unique for all the created resources.
+	 *
+	 * @var int
+	 */
+	protected const TEMPORARY_ID = -5;
+
+	/**
+	 * Return a temporary resource name for the asset.
+	 *
+	 * @param int $temporary_id The temporary ID to use for the asset.
+	 * @return string
+	 */
+	protected function temporary_resource_name( $temporary_id = self::TEMPORARY_ID ) {
+		return ResourceNames::forAsset( $this->options->get_ads_id(), $temporary_id );
+	}
+
+	/**
+	 * Returns a set of operations to create multiple text assets.
+	 *
+	 * @param array $asset The assets to use the text asset.
+	 * @param int   $temporary_id The temporary ID to use for the asset.
+	 * @return MutateOperation The text asset mutation.
+	 */
+	public function create_operation_text_asset( array $asset, int $temporary_id = self::TEMPORARY_ID ): MutateOperation {
+		return new MutateOperation(
+			[
+				'asset_operation' => new AssetOperation(
+					[
+						'create' => new Asset(
+							[
+								'resource_name' => $this->temporary_resource_name( $temporary_id ),
+								'text_asset'    => new TextAsset( [ 'text' => $asset['content'] ] ),
+							]
+						),
+					]
+				),
+			]
+		);
+
+	}
 
 	/**
 	 * Convert Asset data to an array.

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -125,7 +125,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 *
 	 * @return string The asset content.
 	 */
-	public function get_asset_content( GoogleAdsRow $row ): string {
+	protected function get_asset_content( GoogleAdsRow $row ): string {
 		/** @var Asset $asset */
 		$asset = $row->getAsset();
 

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -45,7 +45,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 *
 	 * @return string The Asset resource name.
 	 */
-	protected function temporary_resource_name( $temporary_id = self::TEMPORARY_ID ): string {
+	protected function temporary_resource_name( int $temporary_id = self::TEMPORARY_ID ): string {
 		return ResourceNames::forAsset( $this->options->get_ads_id(), $temporary_id );
 	}
 

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -42,9 +42,10 @@ class AdsAsset implements OptionsAwareInterface {
 	 * Return a temporary resource name for the asset.
 	 *
 	 * @param int $temporary_id The temporary ID to use for the asset.
-	 * @return string
+	 *
+	 * @return string The Asset resource name.
 	 */
-	protected function temporary_resource_name( $temporary_id = self::TEMPORARY_ID ) {
+	protected function temporary_resource_name( $temporary_id = self::TEMPORARY_ID ): string {
 		return ResourceNames::forAsset( $this->options->get_ads_id(), $temporary_id );
 	}
 
@@ -76,10 +77,11 @@ class AdsAsset implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Returns an operations to create a text asset.
+	 * Returns an operation to create a text asset.
 	 *
 	 * @param array $data The assets to use the text asset.
 	 * @param int   $temporary_id The temporary ID to use for the asset.
+	 *
 	 * @return MutateOperation The create asset operation.
 	 * @throws Exception If the asset type is not supported or if the image url is not a valid url.
 	 */

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -137,6 +137,11 @@ class AdsAsset implements OptionsAwareInterface {
 				$data = $asset->getTextAsset()->getText();
 				break;
 			case AssetType::CALL_TO_ACTION:
+				// When CallToActionType::UNSPECIFIED is returned, does not have a CallToActionAsset.
+				if ( ! $asset->getCallToActionAsset() ) {
+					$data = CallToActionType::UNSPECIFIED;
+					break;
+				}
 				$data = CallToActionType::label( $asset->getCallToActionAsset()->getCallToAction() );
 				break;
 			default:

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -80,7 +80,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 *
 	 * @param array $data The assets to use the text asset.
 	 * @param int   $temporary_id The temporary ID to use for the asset.
-	 * @return MutateOperation The text asset mutation.
+	 * @return MutateOperation The create asset operation.
 	 * @throws Exception If the asset type is not supported or if the image url is not a valid url.
 	 */
 	public function create_operation( array $data, int $temporary_id = self::TEMPORARY_ID ): MutateOperation {
@@ -95,13 +95,13 @@ class AdsAsset implements OptionsAwareInterface {
 				$asset->setCallToActionAsset( new CallToActionAsset( [ 'call_to_action' => CallToActionType::number( $data['content'] ) ] ) );
 				break;
 			case AssetType::IMAGE:
-				$data = wp_remote_get( $data['content'] );
+				$image_data = wp_remote_get( $data['content'] );
 
-				if ( is_wp_error( $data ) ) {
+				if ( is_wp_error( $image_data ) || empty( $image_data['body'] ) ) {
 					throw new Exception( 'Incorrect image asset url.' );
 				}
 
-				$asset->setImageAsset( new ImageAsset( [ 'data' => wp_remote_get( $data['content'] )['body'] ] ) );
+				$asset->setImageAsset( new ImageAsset( [ 'data' => $image_data['body'] ] ) );
 				$asset->setName( basename( $data['content'] ) );
 				break;
 			case AssetType::TEXT:

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Google\Ads\GoogleAds\V11\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V11\Enums\AssetTypeEnum\AssetType;
-use Google\Ads\GoogleAds\V11\Enums\CallToActionTypeEnum\CallToActionType;
 use Google\Ads\GoogleAds\V11\Resources\Asset;
 use Google\Ads\GoogleAds\V11\Services\AssetOperation;
 use Google\Ads\GoogleAds\V11\Services\MutateOperation;
@@ -93,7 +92,7 @@ class AdsAsset implements OptionsAwareInterface {
 
 		switch ( $this->get_asset_type_by_field_type( $data['field_type'] ) ) {
 			case AssetType::CALL_TO_ACTION:
-				$asset->setCallToActionAsset( new CallToActionAsset( [ 'call_to_action' => $data['content'] ] ) );
+				$asset->setCallToActionAsset( new CallToActionAsset( [ 'call_to_action' => CallToActionType::number( $data['content'] ) ] ) );
 				break;
 			case AssetType::IMAGE:
 				$asset->setImageAsset( new ImageAsset( [ 'data' => wp_remote_get( $data['content'] )['body'] ] ) );
@@ -130,7 +129,7 @@ class AdsAsset implements OptionsAwareInterface {
 				$data = $asset->getTextAsset()->getText();
 				break;
 			case AssetType::CALL_TO_ACTION:
-				$data = CallToActionType::name( $asset->getCallToActionAsset()->getCallToAction() );
+				$data = CallToActionType::label( $asset->getCallToActionAsset()->getCallToAction() );
 				break;
 			default:
 				$data = '';

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -57,7 +57,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 * @return int The asset type.
 	 * @throws Exception If the field type is not supported.
 	 */
-	protected function get_asset_type_by_field_type( $field_type ): int {
+	protected function get_asset_type_by_field_type( string $field_type ): int {
 		switch ( $field_type ) {
 			case AssetFieldType::LOGO:
 			case AssetFieldType::MARKETING_IMAGE:
@@ -79,7 +79,7 @@ class AdsAsset implements OptionsAwareInterface {
 	/**
 	 * Returns an operation to create a text asset.
 	 *
-	 * @param array $data The assets to use the text asset.
+	 * @param array $data The asset data.
 	 * @param int   $temporary_id The temporary ID to use for the asset.
 	 *
 	 * @return MutateOperation The create asset operation.

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -81,7 +81,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 * @param array $data The assets to use the text asset.
 	 * @param int   $temporary_id The temporary ID to use for the asset.
 	 * @return MutateOperation The text asset mutation.
-	 * @throws Exception If the asset type is not supported.
+	 * @throws Exception If the asset type is not supported or if the image url is not a valid url.
 	 */
 	public function create_operation( array $data, int $temporary_id = self::TEMPORARY_ID ): MutateOperation {
 		$asset = new Asset(
@@ -95,6 +95,12 @@ class AdsAsset implements OptionsAwareInterface {
 				$asset->setCallToActionAsset( new CallToActionAsset( [ 'call_to_action' => CallToActionType::number( $data['content'] ) ] ) );
 				break;
 			case AssetType::IMAGE:
+				$data = wp_remote_get( $data['content'] );
+
+				if ( is_wp_error( $data ) ) {
+					throw new Exception( 'Incorrect image asset url.' );
+				}
+
 				$asset->setImageAsset( new ImageAsset( [ 'data' => wp_remote_get( $data['content'] )['body'] ] ) );
 				$asset->setName( basename( $data['content'] ) );
 				break;

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -289,27 +289,23 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	 *
 	 * @param int   $asset_group_id The asset group ID.
 	 * @param array $data The asset group data.
+	 * @param array $assets A list of assets data.
 	 *
 	 * @return int The asset group ID.
 	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
-	public function edit_asset_group( int $asset_group_id, array $data ): int {
+	public function edit_asset_group( int $asset_group_id, array $data, array $assets = [] ): int {
 		try {
-			$asset_group_fields = [];
-			$operations         = $this->asset_group_asset->edit_operations_assets_group_assets( $asset_group_id, $data['assets'] ?? [] );
+			$operations = $this->asset_group_asset->edit_operations_assets_group_assets( $asset_group_id, $assets );
 
-			if ( ! empty( $data['path1'] ) ) {
-				$asset_group_fields['path1'] = $data['path1'];
-			}
-			if ( ! empty( $data['path2'] ) ) {
-				$asset_group_fields['path2'] = $data['path2'];
-			}
+			// PMax only supports one final URL but it is required to be an array.
 			if ( ! empty( $data['final_url'] ) ) {
-				$asset_group_fields['final_urls'] = [ $data['final_url'] ];
+				$data['final_urls'] = [ $data['final_url'] ];
+				unset( $data['final_url'] );
 			}
 
-			if ( ! empty( $asset_group_fields ) ) {
-				$operations[] = $this->edit_operation( $asset_group_id, $asset_group_fields );
+			if ( ! empty( $data ) ) {
+				$operations[] = $this->edit_operation( $asset_group_id, $data );
 			}
 
 			if ( ! empty( $operations ) ) {

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -296,7 +296,7 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	 */
 	public function edit_asset_group( int $asset_group_id, array $data, array $assets = [] ): int {
 		try {
-			$operations = $this->asset_group_asset->edit_operations_assets_group_assets( $asset_group_id, $assets );
+			$operations = $this->asset_group_asset->edit_operations( $asset_group_id, $assets );
 
 			// PMax only supports one final URL but it is required to be an array.
 			if ( ! empty( $data['final_url'] ) ) {

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -288,24 +288,24 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	 * Edit an asset group.
 	 *
 	 * @param int   $asset_group_id The asset group ID.
-	 * @param array $params The request parameters.
+	 * @param array $data The asset group data.
 	 *
 	 * @return int The asset group ID.
 	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
-	public function edit_asset_group( int $asset_group_id, array $params ): int {
+	public function edit_asset_group( int $asset_group_id, array $data ): int {
 		try {
 			$asset_group_fields = [];
-			$operations         = $this->asset_group_asset->edit_operations_assets_group_assets( $asset_group_id, $params['assets'] ?? [] );
+			$operations         = $this->asset_group_asset->edit_operations_assets_group_assets( $asset_group_id, $data['assets'] ?? [] );
 
-			if ( ! empty( $params['path1'] ) ) {
-				$asset_group_fields['path1'] = $params['path1'];
+			if ( ! empty( $data['path1'] ) ) {
+				$asset_group_fields['path1'] = $data['path1'];
 			}
-			if ( ! empty( $params['path2'] ) ) {
-				$asset_group_fields['path2'] = $params['path2'];
+			if ( ! empty( $data['path2'] ) ) {
+				$asset_group_fields['path2'] = $data['path2'];
 			}
-			if ( ! empty( $params['final_url'] ) ) {
-				$asset_group_fields['final_urls'] = [ $params['final_url'] ];
+			if ( ! empty( $data['final_url'] ) ) {
+				$asset_group_fields['final_urls'] = [ $data['final_url'] ];
 			}
 
 			if ( ! empty( $asset_group_fields ) ) {

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -304,6 +304,9 @@ class AdsAssetGroup implements OptionsAwareInterface {
 			if ( ! empty( $params['path2'] ) ) {
 				$asset_group_fields['path2'] = $params['path2'];
 			}
+			if ( ! empty( $params['final_url'] ) ) {
+				$asset_group_fields['final_urls'] = [ $params['final_url'] ];
+			}
 
 			if ( ! empty( $asset_group_fields ) ) {
 				$operations[] = $this->edit_operation( $asset_group_id, $asset_group_fields );

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -285,7 +285,7 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Get an asset group by ID.
+	 * Edit an asset group.
 	 *
 	 * @param int   $asset_group_id The asset group ID.
 	 * @param array $params The request parameters.
@@ -332,10 +332,10 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Returns a asset group edit operation.
+	 * Returns an asset group edit operation.
 	 *
-	 * @param integer $asset_group_id
-	 * @param array   $fields
+	 * @param integer $asset_group_id The Asset Group ID
+	 * @param array   $fields The fields to update.
 	 *
 	 * @return MutateOperation
 	 */

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAssetGroupQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsListingGroupFilterQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroupAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -296,12 +296,12 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	public function edit_asset_group( int $asset_group_id, array $params ): int {
 		try {
 			$asset_group_fields = [];
-			$operations         = $this->asset_group_asset->edit_operations_assets_group_assets( $asset_group_id, $params['assets'] );
+			$operations         = $this->asset_group_asset->edit_operations_assets_group_assets( $asset_group_id, $params['assets'] ?? [] );
 
-			if ( $params['path1'] ) {
+			if ( ! empty( $params['path1'] ) ) {
 				$asset_group_fields['path1'] = $params['path1'];
 			}
-			if ( $params['path2'] ) {
+			if ( ! empty( $params['path2'] ) ) {
 				$asset_group_fields['path2'] = $params['path2'];
 			}
 
@@ -341,9 +341,8 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	 */
 	protected function edit_operation( int $asset_group_id, array $fields ): MutateOperation {
 		$fields['resource_name'] = ResourceNames::forAssetGroup( $this->options->get_ads_id(), $asset_group_id );
-
-		$asset_group = new AssetGroup( $fields );
-		$operation   = new AssetGroupOperation();
+		$asset_group             = new AssetGroup( $fields );
+		$operation               = new AssetGroupOperation();
 		$operation->setUpdate( $asset_group );
 		$operation->setUpdateMask( FieldMasks::allSetFieldsOf( $asset_group ) );
 		return ( new MutateOperation() )->setAssetGroupOperation( $operation );

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -284,6 +284,19 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Get an asset group by ID.
+	 *
+	 * @param int   $asset_group_id The asset group ID.
+	 * @param array $params The request parameters.
+	 *
+	 * @return int The asset group ID.
+	 * @throws ExceptionWithResponseData When an ApiException is caught.
+	 */
+	public function edit_asset_group( int $asset_group_id, array $params ): int {
+		return $asset_group_id;
+	}
+
+	/**
 	 * Convert Asset Group data to an array.
 	 *
 	 * @since x.x.x

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -293,6 +293,7 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
 	public function edit_asset_group( int $asset_group_id, array $params ): int {
+		$this->asset_group_asset->edit_assets_group_assets( $asset_group_id, $params['assets'] );
 		return $asset_group_id;
 	}
 

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -142,7 +142,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 *
 	 * @return array The asset group asset operations.
 	 */
-	public function edit_operations_assets_group_assets( int $asset_group_id, array $assets ): array {
+	public function edit_operations( int $asset_group_id, array $assets ): array {
 		if ( empty( $assets ) ) {
 			return [];
 		}

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -146,9 +146,11 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		try {
 
 			$asset_group_assets = [];
-			$asset_results      = ( new AdsAssetGroupAssetQuery() )
+
+			// Search urls with and without trailing slash.
+			$asset_results = ( new AdsAssetGroupAssetQuery() )
 				->set_client( $this->client, $this->options->get_ads_id() )
-				->where( 'asset_group.final_urls', [ $url ], 'CONTAINS ANY' )
+				->where( 'asset_group.final_urls', [ rtrim( $url, '/' ), rtrim( $url, '/' ) . '/' ], 'CONTAINS ANY' )
 				->where( 'asset_group_asset.field_type', $this->get_asset_field_types_query(), 'IN' )
 				->where( 'asset_group_asset.status', 'REMOVED', '!=' )
 				->get_results();

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -15,7 +15,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
 use Google\Ads\GoogleAds\V11\Services\MutateOperation;
 use Google\Ads\GoogleAds\V11\Services\AssetGroupAssetOperation;
 use Google\Ads\GoogleAds\Util\V11\ResourceNames;
-use Google\Ads\GoogleAds\V11\Enums\AssetTypeEnum\AssetType;
 
 
 
@@ -156,7 +155,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 
 			// If content exists, create asset and asset group asset.
 			if ( ! empty( $asset['content'] ) ) {
-				$assets_operations[]             = $this->asset->create_operation_asset( $asset, self::$temporary_id );
+				$assets_operations[]             = $this->asset->create_operation( $asset, self::$temporary_id );
 				$asset_group_assets_operations[] = $this->create_operation( $asset_group_id, $asset['field_type'], self::$temporary_id-- );
 			}
 

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -142,7 +142,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * @return array The assets for the asset groups with a specific final url.
 	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
-	public function get_assets_by_url( string $url ): array {
+	public function get_assets_by_final_url( string $url ): array {
 		try {
 
 			$asset_group_assets = [];
@@ -170,7 +170,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			$errors = $this->get_api_exception_errors( $e );
 			throw new ExceptionWithResponseData(
 				/* translators: %s Error message */
-				sprintf( __( 'Error retrieving asset groups assets: %s', 'google-listings-and-ads' ), reset( $errors ) ),
+				sprintf( __( 'Error retrieving asset groups assets by final url: %s', 'google-listings-and-ads' ), reset( $errors ) ),
 				$this->map_grpc_code_to_http_status_code( $e ),
 				null,
 				[ 'errors' => $errors ]

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -154,14 +154,14 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 
 		foreach ( $assets as $asset ) {
 
-			// If content exists create asset and asset group asset.
-			if ( $asset['content'] ) {
+			// If content exists, create asset and asset group asset.
+			if ( ! empty( $asset['content'] ) ) {
 				$assets_operations[]             = $this->asset->create_operation_asset( $asset, self::$temporary_id );
 				$asset_group_assets_operations[] = $this->create_operation( $asset_group_id, $asset['field_type'], self::$temporary_id-- );
 			}
 
-			// As Assets are inmmutable, we delete the link between the asset and the asset group.
-			if ( $asset['id'] ) {
+			// As Assets are inmmutable, we delete the old link between the asset and the asset group if exists.
+			if ( ! empty( $asset['id'] ) ) {
 				$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
 			}
 		}

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -12,6 +12,10 @@ use Google\Ads\GoogleAds\V11\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V11\Resources\AssetGroupAsset;
 use Google\ApiCore\ApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Google\Ads\GoogleAds\V11\Services\MutateOperation;
+use Google\Ads\GoogleAds\V11\Services\AssetGroupAssetOperation;
+use Google\Ads\GoogleAds\Util\V11\ResourceNames;
+
 
 
 
@@ -43,6 +47,14 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * @var AdsAsset
 	 */
 	protected $asset;
+
+	/**
+	 * Temporary ID to use within a batch job.
+	 * A negative number which is unique for all the created resources.
+	 *
+	 * @var int
+	 */
+	protected static $temporary_id = -4;
 
 	/**
 	 * AdsAssetGroup constructor.

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -141,4 +141,23 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 
 		return ( new MutateOperation() )->setAssetGroupAssetOperation( $operation->setCreate( $new_asset_group_asset ) );
 	}
+
+	/**
+	 * Returns a campaign delete operation.
+	 *
+	 * @param int    $asset_group_id The ID of the asset group.
+	 * @param string $asset_field_type The field type of the asset.
+	 * @param int    $asset_id The ID of the asset.
+	 *
+	 * @return MutateOperation The remove operation for the asset group asset.
+	 */
+	protected function delete_operation( int $asset_group_id, string $asset_field_type, int $asset_id ): MutateOperation {
+		$asset_group_asset_resource_name = ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), $asset_group_id, $asset_id, AssetFieldType::name( $asset_field_type ) );
+		$operation                       = ( new AssetGroupAssetOperation() )->setRemove( $asset_group_asset_resource_name );
+		return ( new MutateOperation() )->setAssetGroupAssetOperation( $operation );
+	}
+
+
+
+
 }

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -151,7 +151,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			$asset_results = ( new AdsAssetGroupAssetQuery() )
 				->set_client( $this->client, $this->options->get_ads_id() )
 				->add_columns( [ 'asset_group.id', 'asset_group.path1', 'asset_group.path2' ] )
-				->where( 'asset_group.final_urls', [ rtrim( $url, '/' ), rtrim( $url, '/' ) . '/' ], 'CONTAINS ANY' )
+				->where( 'asset_group.final_urls', [ trailingslashit( $url ), untrailingslashit( $url ) ], 'CONTAINS ANY' )
 				->where( 'asset_group_asset.field_type', $this->get_asset_field_types_query(), 'IN' )
 				->where( 'asset_group_asset.status', 'REMOVED', '!=' )
 				->get_results();

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAssetGroupAssetQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -166,9 +165,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		}
 
 		// Delete asset group assets operations must be executed last so we are never under the minimum quantity.
-		$operations = array_merge( $assets_operations, $asset_group_assets_operations, $delete_asset_group_assets_operations );
-
-		return $operations;
+		return array_merge( $assets_operations, $asset_group_assets_operations, $delete_asset_group_assets_operations );
 
 	}
 
@@ -180,7 +177,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * @param string $asset_field_type The field type of the asset.
 	 * @param int    $asset_id The ID of the asset.
 	 *
-	 * @return AssetGroupAssetOperation The create operation for the asset group asset.
+	 * @return MutateOperation The mutate create operation for the asset group asset.
 	 */
 	protected function create_operation( int $asset_group_id, string $asset_field_type, int $asset_id ): MutateOperation {
 		$operation             = new AssetGroupAssetOperation();

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -121,4 +121,24 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		}
 
 	}
+	/**
+	 * Creates an operation for an asset group asset.
+	 *
+	 * @param int    $asset_group_id The ID of the asset group.
+	 * @param string $asset_field_type The field type of the asset.
+	 * @param int    $asset_id The ID of the asset.
+	 * @return AssetGroupAssetOperation The operation for the asset group asset.
+	 */
+	protected function create_operation( int $asset_group_id, string $asset_field_type, int $asset_id ): MutateOperation {
+		$operation             = new AssetGroupAssetOperation();
+		$new_asset_group_asset = new AssetGroupAsset(
+			[
+				'asset'       => ResourceNames::forAsset( $this->options->get_ads_id(), $asset_id ),
+				'asset_group' => ResourceNames::forAssetGroup( $this->options->get_ads_id(), $asset_group_id ),
+				'field_type'  => AssetFieldType::number( $asset_field_type ),
+			]
+		);
+
+		return ( new MutateOperation() )->setAssetGroupAssetOperation( $operation->setCreate( $new_asset_group_asset ) );
+	}
 }

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -138,11 +138,12 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * Get Assets for specific final URL.
 	 *
 	 * @param string $url The final url.
+	 * @param bool   $only_first_asset_group Whether to return only the first asset group found.
 	 *
 	 * @return array The assets for the asset groups with a specific final url.
 	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
-	public function get_assets_by_final_url( string $url ): array {
+	public function get_assets_by_final_url( string $url, bool $only_first_asset_group = false ): array {
 		try {
 
 			$asset_group_assets = [];
@@ -176,6 +177,10 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 					$row->getAssetGroup()->getPath1(),
 					$row->getAssetGroup()->getPath2(),
 				];
+			}
+
+			if ( $only_first_asset_group ) {
+				return reset( $asset_group_assets ) ?: [];
 			}
 
 			return $asset_group_assets;

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -142,32 +142,49 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * @param array $assets The assets to create.
 	 *
 	 * @return int The asset group id.
+	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
 	public function edit_assets_group_assets( int $asset_group_id, array $assets ): int {
-		$assets_operations                    = [];
-		$asset_group_assets_operations        = [];
-		$delete_asset_group_assets_operations = [];
+		try {
 
-		foreach ( $assets as $asset ) {
+			$assets_operations                    = [];
+			$asset_group_assets_operations        = [];
+			$delete_asset_group_assets_operations = [];
 
-			// If content exists create asset and asset group asset.
-			if ( $asset['content'] ) {
+			foreach ( $assets as $asset ) {
+
+				// If content exists create asset and asset group asset.
+				if ( $asset['content'] ) {
 					$assets_operations[]             = $this->asset->create_operation_asset( $asset, self::$temporary_id );
 					$asset_group_assets_operations[] = $this->create_operation( $asset_group_id, $asset['field_type'], self::$temporary_id-- );
+				}
+
+				// As Assets are inmmutable, we need to delete the link between the asset and the asset group.
+				if ( $asset['id'] ) {
+					$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
+				}
 			}
 
-			// As Assets are inmmutable, we need to delete the link between the asset and the asset group.
-			if ( $asset['id'] ) {
-				$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
-			}
+			// Delete asset group assets operations must be executed last so we are never under the minimum quantity.
+			$operations = array_merge( $assets_operations, $asset_group_assets_operations, $delete_asset_group_assets_operations );
+
+			$this->mutate( $operations );
+
+			return $asset_group_id;
+		} catch ( ApiException $e ) {
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
+
+			$errors = $this->get_api_exception_errors( $e );
+			/* translators: %s Error message */
+			$message = sprintf( __( 'Error updating asset group: %s', 'google-listings-and-ads' ), reset( $errors ) );
+
+			throw new ExceptionWithResponseData(
+				$message,
+				$this->map_grpc_code_to_http_status_code( $e ),
+				null,
+				[ 'errors' => $errors ]
+			);
 		}
-
-		// Delete asset group assets operations must be executed last so we are never under the minimum quantity.
-		$operations = array_merge( $assets_operations, $asset_group_assets_operations, $delete_asset_group_assets_operations );
-
-		$this->mutate( $operations );
-
-		return $asset_group_id;
 
 	}
 

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -162,7 +162,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				$asset_group_asset = $row->getAssetGroupAsset();
 
 				$field_type                          = AssetFieldType::label( $asset_group_asset->getFieldType() );
-				$asset_group_assets[ $field_type ][] = $this->asset->get_asset_content( $row );
+				$asset_group_assets[ $field_type ][] = $this->asset->convert_asset( $row );
 			}
 
 			return $asset_group_assets;

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -122,6 +122,29 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 
 	}
 	/**
+	 * Send a batch of operations to mutate a asset group.
+	 *
+	 * @param MutateOperation[] $operations
+	 *
+	 * @return int Campaign ID from the MutateOperationResponse.
+	 * @throws ApiException If any of the operations fail.
+	 */
+	protected function mutate( array $operations ): int {
+		$responses = $this->client->getGoogleAdsServiceClient()->mutate(
+			$this->options->get_ads_id(),
+			$operations
+		);
+
+		foreach ( $responses->getMutateOperationResponses() as $response ) {
+			$p = $response->getResponse();
+		}
+
+		// When editing only the budget there is no campaign mutate result.
+		return 0;
+	}
+
+
+	/**
 	 * Creates an operation for an asset group asset.
 	 *
 	 * @param int    $asset_group_id The ID of the asset group.

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -150,6 +150,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			// Search urls with and without trailing slash.
 			$asset_results = ( new AdsAssetGroupAssetQuery() )
 				->set_client( $this->client, $this->options->get_ads_id() )
+				->add_columns( [ 'asset_group.path1', 'asset_group.path2' ] )
 				->where( 'asset_group.final_urls', [ rtrim( $url, '/' ), rtrim( $url, '/' ) . '/' ], 'CONTAINS ANY' )
 				->where( 'asset_group_asset.field_type', $this->get_asset_field_types_query(), 'IN' )
 				->where( 'asset_group_asset.status', 'REMOVED', '!=' )
@@ -161,8 +162,19 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				/** @var AssetGroupAsset $asset_group_asset */
 				$asset_group_asset = $row->getAssetGroupAsset();
 
-				$field_type                          = AssetFieldType::label( $asset_group_asset->getFieldType() );
-				$asset_group_assets[ $field_type ][] = $this->asset->convert_asset( $row );
+				$field_type = AssetFieldType::label( $asset_group_asset->getFieldType() );
+				switch ( $field_type ) {
+					case AssetFieldType::BUSINESS_NAME:
+					case AssetFieldType::CALL_TO_ACTION_SELECTION:
+						$asset_group_assets[ $field_type ] = $this->asset->convert_asset( $row )['content'];
+						break;
+					default:
+						$asset_group_assets[ $field_type ][] = $this->asset->convert_asset( $row )['content'];
+				}
+
+				$asset_group_assets = $this->add_url_paths( $row->getAssetGroup()->getPath1(), $asset_group_assets );
+				$asset_group_assets = $this->add_url_paths( $row->getAssetGroup()->getPath2(), $asset_group_assets );
+
 			}
 
 			return $asset_group_assets;
@@ -178,6 +190,25 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				[ 'errors' => $errors ]
 			);
 		}
+
+	}
+
+	/**
+	 * Add url path to asset group assets.
+	 *
+	 * @param string $path The url path.
+	 * @param array  $asset_group_assets The asset group assets.
+	 * @param int    $max_number The max number of url paths to add.
+	 *
+	 * @return array The asset group assets.
+	 */
+	protected function add_url_paths( string $path, array $asset_group_assets, int $max_number = 2 ): array {
+		if ( count( $asset_group_assets['display_url_path'] ?? [] ) >= $max_number || in_array( $path, $asset_group_assets['display_url_path'] ?? [], true ) ) {
+			return $asset_group_assets;
+		}
+
+		$asset_group_assets['display_url_path'][] = $path;
+		return $asset_group_assets;
 
 	}
 

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -196,7 +196,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Returns a campaign delete operation.
+	 * Returns a delete operation for asset group asset.
 	 *
 	 * @param int    $asset_group_id The ID of the asset group.
 	 * @param string $asset_field_type The field type of the asset.

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -140,6 +140,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * @param array $assets The assets to create.
 	 *
 	 * @return array The asset group asset operations.
+	 * @throws Exception If the asset type is not supported.
 	 */
 	public function edit_operations( int $asset_group_id, array $assets ): array {
 		if ( empty( $assets ) ) {

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -179,7 +179,8 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * @param int    $asset_group_id The ID of the asset group.
 	 * @param string $asset_field_type The field type of the asset.
 	 * @param int    $asset_id The ID of the asset.
-	 * @return AssetGroupAssetOperation The operation for the asset group asset.
+	 *
+	 * @return AssetGroupAssetOperation The create operation for the asset group asset.
 	 */
 	protected function create_operation( int $asset_group_id, string $asset_field_type, int $asset_id ): MutateOperation {
 		$operation             = new AssetGroupAssetOperation();

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -121,6 +121,53 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		}
 
 	}
+
+	/**
+	 * Edit assets group assets.
+	 *
+	 * @param int   $asset_group_id The asset group id.
+	 * @param array $assets The assets to create.
+	 *
+	 * @return int The asset group id.
+	 */
+	public function edit_assets_group_assets( int $asset_group_id, array $assets ): int {
+		$assets_operations                   = [];
+		$asset_group_operations              = [];
+		$delete_asset_group_asset_operations = [];
+
+		foreach ( $assets as $asset ) {
+			switch ( $asset['field_type'] ) {
+				case AssetFieldType::LOGO:
+				case AssetFieldType::MARKETING_IMAGE:
+				case AssetFieldType::SQUARE_MARKETING_IMAGE:
+					break;
+
+				case AssetFieldType::HEADLINE:
+				case AssetFieldType::LONG_HEADLINE:
+				case AssetFieldType::DESCRIPTION:
+				case AssetFieldType::BUSINESS_NAME:
+					$assets_operations[]      = $this->asset->create_operation_text_asset( $asset, self::$temporary_id );
+					$asset_group_operations[] = $this->create_operation( $asset_group_id, $asset['field_type'], self::$temporary_id-- );
+					break;
+				case AssetFieldType::CALL_TO_ACTION_SELECTION:
+					break;
+				default:
+					break;
+			}
+
+			if ( $asset['id'] ) {
+				$delete_asset_group_asset_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
+			}
+		}
+
+		$operations = array_merge( $assets_operations, $asset_group_operations, $delete_asset_group_asset_operations );
+
+		$this->mutate( $operations );
+
+		return $asset_group_id;
+
+	}
+
 	/**
 	 * Send a batch of operations to mutate a asset group.
 	 *

--- a/src/API/Google/CallToActionType.php
+++ b/src/API/Google/CallToActionType.php
@@ -1,0 +1,116 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Google\Ads\GoogleAds\V11\Enums\CallToActionTypeEnum\CallToActionType as AdsCallToActionType;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\StatusMapping;
+
+
+/**
+ * Mapping between Google and internal CallToActionType
+ * https://developers.google.com/google-ads/api/reference/rpc/v11/CallToActionTypeEnum.CallToActionType
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class CallToActionType extends StatusMapping {
+
+	/**
+	 * Not specified.
+	 *
+	 * @var string
+	 */
+	public const UNSPECIFIED = 'unspecified';
+
+	/**
+	 * Used for return value only. Represents value unknown in this version.
+	 *
+	 * @var string
+	 */
+	public const UNKNOWN = 'unknown';
+
+	/**
+	 * The call to action type is learn more.
+	 *
+	 * @var string
+	 */
+	public const LEARN_MORE = 'learn_more';
+
+	/**
+	 * The call to action type is get quote.
+	 *
+	 * @var string
+	 */
+	public const GET_QUOTE = 'get_quote';
+
+	/**
+	 * The call to action type is apply now.
+	 *
+	 * @var string
+	 */
+	public const APPLY_NOW = 'apply_now';
+
+	/**
+	 * The call to action type is sign up.
+	 *
+	 * @var string
+	 */
+	public const SIGN_UP = 'sign_up';
+
+	/**
+	 * The call to action type is contact us.
+	 *
+	 * @var string
+	 */
+	public const CONTACT_US = 'contact_us';
+
+	/**
+	 * The call to action type is subscribe.
+	 *
+	 * @var string
+	 */
+	public const SUBSCRIBE = 'subscribe';
+
+	/**
+	 * The call to action type is download.
+	 *
+	 * @var string
+	 */
+	public const DOWNLOAD = 'download';
+
+	/**
+	 * The call to action type is book now.
+	 *
+	 * @var string
+	 */
+	public const BOOK_NOW = 'book_now';
+
+	/**
+	 * The call to action type is shop now.
+	 *
+	 * @var string
+	 */
+	public const SHOP_NOW = 'shop_now';
+
+	/**
+	 * Mapping between status number and it's label.
+	 *
+	 * @var string
+	 */
+	protected const MAPPING = [
+		AdsCallToActionType::UNSPECIFIED => self::UNSPECIFIED,
+		AdsCallToActionType::UNKNOWN     => self::UNKNOWN,
+		AdsCallToActionType::LEARN_MORE  => self::LEARN_MORE,
+		AdsCallToActionType::GET_QUOTE   => self::GET_QUOTE,
+		AdsCallToActionType::APPLY_NOW   => self::APPLY_NOW,
+		AdsCallToActionType::SIGN_UP     => self::SIGN_UP,
+		AdsCallToActionType::CONTACT_US  => self::CONTACT_US,
+		AdsCallToActionType::SUBSCRIBE   => self::SUBSCRIBE,
+		AdsCallToActionType::DOWNLOAD    => self::DOWNLOAD,
+		AdsCallToActionType::BOOK_NOW    => self::BOOK_NOW,
+		AdsCallToActionType::SHOP_NOW    => self::SHOP_NOW,
+
+	];
+}

--- a/src/API/Google/CallToActionType.php
+++ b/src/API/Google/CallToActionType.php
@@ -25,7 +25,7 @@ class CallToActionType extends StatusMapping {
 	public const UNSPECIFIED = 'unspecified';
 
 	/**
-	 * Used for return value only. Represents value unknown in this version.
+	 * Represents value unknown in this version.
 	 *
 	 * @var string
 	 */

--- a/src/API/Google/Query/Query.php
+++ b/src/API/Google/Query/Query.php
@@ -238,6 +238,7 @@ abstract class Query implements QueryInterface {
 			case 'NOT IN':
 			case 'BETWEEN':
 			case 'IS NOT NULL':
+			case 'CONTAINS ANY':
 				// These are all valid.
 				return;
 
@@ -319,7 +320,7 @@ abstract class Query implements QueryInterface {
 			$column  = $where['column'];
 			$compare = $where['compare'];
 
-			if ( 'IN' === $compare || 'NOT_IN' === $compare ) {
+			if ( 'IN' === $compare || 'NOT_IN' === $compare || 'CONTAINS ANY' === $compare ) {
 				$value = sprintf(
 					"('%s')",
 					join(

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -50,7 +50,7 @@ class AssetGroupController extends BaseController {
 					'methods'             => TransportMethods::EDITABLE,
 					'callback'            => $this->edit_asset_group_callback(),
 					'permission_callback' => $this->get_permission_callback(),
-					'args'                => $this->get_edit_params(),
+					'args'                => $this->edit_asset_group_params(),
 				],
 			]
 		);
@@ -71,8 +71,9 @@ class AssetGroupController extends BaseController {
 	/**
 	 * Get the schema for the asset group.
 	 *
-	 * @return array
-	 */
+	 * @return array The asset group schema.
+	 *
+	 * /
 	public function get_asset_group_fields(): array {
 		return [
 			'final_url' => [
@@ -91,9 +92,11 @@ class AssetGroupController extends BaseController {
 	}
 
 	/**
-	 * Get the edit params to update an asset group.
+	 * Get the edit asset group params params to update an asset group.
+	 *
+	 * @return array The edit asset group params.
 	 */
-	public function get_edit_params() {
+	public function edit_asset_group_params(): array {
 		return array_merge(
 			[
 				'id'     => [

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -49,7 +49,7 @@ class AssetGroupController extends BaseController {
 					'methods'             => TransportMethods::EDITABLE,
 					'callback'            => $this->edit_asset_group_callback(),
 					'permission_callback' => $this->get_permission_callback(),
-					'args'                => $this->get_schema_properties(),
+					'args'                => $this->get_edit_params(),
 				],
 			]
 		);
@@ -68,6 +68,35 @@ class AssetGroupController extends BaseController {
 	}
 
 	/**
+	 * Get the edit params to update an asset group.
+	 */
+	public function get_edit_params() {
+		return [
+			'id'     => [
+				'description' => __( 'Asset Group ID.', 'google-listings-and-ads' ),
+				'type'        => 'integer',
+				'required'    => true,
+
+			],
+			'path1'  => [
+				'description'       => __( 'Asset Group path 1.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'path2'  => [
+				'description'       => __( 'Asset Group path 2.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'assets' => [
+				'type'        => 'array',
+				'description' => __( 'List of asset to be edited.', 'google-listings-and-ads' ),
+				'items'       => $this->get_schema_asset(),
+			],
+		];
+	}
+
+	/**
 	 * Get the assets groups params.
 	 *
 	 * @return array
@@ -76,8 +105,7 @@ class AssetGroupController extends BaseController {
 		return [
 			'id' => [
 				'description'       => __( 'Campaign ID.', 'google-listings-and-ads' ),
-				'type'              => 'number',
-				'sanitize_callback' => 'absint',
+				'type'              => 'integer',
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];
@@ -116,7 +144,7 @@ class AssetGroupController extends BaseController {
 	public function edit_asset_group_callback(): callable {
 		return function( Request $request ) {
 			try {
-				$asset_group_id = $this->ads_asset_group->edit_asset_group( (int) $request->get_param( 'id' ), $request->get_params() );
+				$asset_group_id = $this->ads_asset_group->edit_asset_group( $request->get_param( 'id' ), $request->get_params() );
 				return [
 					'status'  => 'success',
 					'message' => __( 'Successfully edited asset group.', 'google-listings-and-ads' ),
@@ -194,13 +222,18 @@ class AssetGroupController extends BaseController {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'id'      => [
-					'type'        => 'number',
+				'id'         => [
+					'type'        => [ 'integer', 'null' ],
 					'description' => __( 'Asset ID', 'google-listings-and-ads' ),
 				],
-				'content' => [
+				'content'    => [
+					'type'              => [ 'string', 'null' ],
+					'description'       => __( 'Asset content', 'google-listings-and-ads' ),
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+				'field_type' => [
 					'type'        => 'string',
-					'description' => __( 'Asset content', 'google-listings-and-ads' ),
+					'description' => __( 'Asset field type', 'google-listings-and-ads' ),
 				],
 			],
 		];

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseControl
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use WP_REST_Request as Request;
 use Exception;
 
@@ -232,6 +233,16 @@ class AssetGroupController extends BaseController {
 				'field_type' => [
 					'type'        => 'string',
 					'description' => __( 'Asset field type', 'google-listings-and-ads' ),
+					'enum'        => [
+						AssetFieldType::HEADLINE,
+						AssetFieldType::LONG_HEADLINE,
+						AssetFieldType::DESCRIPTION,
+						AssetFieldType::BUSINESS_NAME,
+						AssetFieldType::MARKETING_IMAGE,
+						AssetFieldType::SQUARE_MARKETING_IMAGE,
+						AssetFieldType::LOGO,
+						AssetFieldType::CALL_TO_ACTION_SELECTION,
+					],
 				],
 			],
 		];

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -117,8 +117,12 @@ class AssetGroupController extends BaseController {
 	public function edit_asset_group_callback(): callable {
 		return function( Request $request ) {
 			try {
-				$asset_group = $this->ads_asset_group->edit_asset_group( $request->get_param( 'id' ), $request->get_params() );
-				return $this->prepare_item_for_response( $asset_group, $request );
+				$asset_group_id = $this->ads_asset_group->edit_asset_group( (int) $request->get_param( 'id' ), $request->get_params() );
+				return [
+					'status'  => 'success',
+					'message' => __( 'Successfully edited asset group.', 'google-listings-and-ads' ),
+					'id'      => $asset_group_id,
+				];
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -43,6 +43,18 @@ class AssetGroupController extends BaseController {
 	 */
 	public function register_routes(): void {
 		$this->register_route(
+			'ads/asset-groups/(?P<id>[\d]+)',
+			[
+				[
+					'methods'             => TransportMethods::EDITABLE,
+					'callback'            => $this->edit_asset_group_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_schema_properties(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
+		$this->register_route(
 			'ads/campaigns/(?P<id>[\d]+)/asset-groups',
 			[
 				[
@@ -74,6 +86,8 @@ class AssetGroupController extends BaseController {
 
 
 	/**
+	 * Get Asset Groups by Campaign ID.
+	 *
 	 * @return callable
 	 */
 	protected function get_asset_groups_by_campaign_id_callback(): callable {
@@ -92,6 +106,22 @@ class AssetGroupController extends BaseController {
 				return $this->response_from_exception( $e );
 			}
 
+		};
+	}
+
+	/**
+	 * Edit asset group.
+	 *
+	 * @return callable
+	 */
+	public function edit_asset_group_callback(): callable {
+		return function( Request $request ) {
+			try {
+				$asset_group = $this->ads_asset_group->edit_asset_group( $request->get_param( 'id' ), $request->get_params() );
+				return $this->prepare_item_for_response( $asset_group, $request );
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
 		};
 	}
 

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -43,7 +43,7 @@ class AssetGroupController extends BaseController {
 	 */
 	public function register_routes(): void {
 		$this->register_route(
-			'ads/asset-groups/(?P<id>[\d]+)',
+			'ads/campaigns/asset-groups/(?P<id>[\d]+)',
 			[
 				[
 					'methods'             => TransportMethods::EDITABLE,
@@ -51,7 +51,6 @@ class AssetGroupController extends BaseController {
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_schema_properties(),
 				],
-				'schema' => $this->get_api_response_schema_callback(),
 			]
 		);
 		$this->register_route(

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -69,39 +69,47 @@ class AssetGroupController extends BaseController {
 	}
 
 	/**
+	 * Get the schema for the asset group.
+	 *
+	 * @return array
+	 */
+	public function get_asset_group_fields(): array {
+		return [
+			'final_url' => [
+				'type'        => 'string',
+				'description' => __( 'Final URL.', 'google-listings-and-ads' ),
+			],
+			'path1'     => [
+				'type'        => 'string',
+				'description' => __( 'Asset Group path 1.', 'google-listings-and-ads' ),
+			],
+			'path2'     => [
+				'type'        => 'string',
+				'description' => __( 'Asset Group path 2.', 'google-listings-and-ads' ),
+			],
+		];
+	}
+
+	/**
 	 * Get the edit params to update an asset group.
 	 */
 	public function get_edit_params() {
-		return [
-			'id'        => [
-				'description' => __( 'Asset Group ID.', 'google-listings-and-ads' ),
-				'type'        => 'integer',
-				'required'    => true,
+		return array_merge(
+			[
+				'id'     => [
+					'description' => __( 'Asset Group ID.', 'google-listings-and-ads' ),
+					'type'        => 'integer',
+					'required'    => true,
+				],
+				'assets' => [
+					'type'        => 'array',
+					'description' => __( 'List of asset to be edited.', 'google-listings-and-ads' ),
+					'items'       => $this->get_schema_asset(),
+					'default'     => [],
+				],
 			],
-			'final_url' => [
-				'description'       => __( 'Final URL.', 'google-listings-and-ads' ),
-				'type'              => 'string',
-				'sanitize_callback' => 'esc_url_raw',
-				'validate_callback' => function( $url ) {
-					return filter_var( $url, FILTER_VALIDATE_URL );
-				},
-			],
-			'path1'     => [
-				'description'       => __( 'Asset Group path 1.', 'google-listings-and-ads' ),
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			],
-			'path2'     => [
-				'description'       => __( 'Asset Group path 2.', 'google-listings-and-ads' ),
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			],
-			'assets'    => [
-				'type'        => 'array',
-				'description' => __( 'List of asset to be edited.', 'google-listings-and-ads' ),
-				'items'       => $this->get_schema_asset(),
-			],
-		];
+			$this->get_asset_group_fields()
+		);
 	}
 
 	/**
@@ -152,7 +160,11 @@ class AssetGroupController extends BaseController {
 	public function edit_asset_group_callback(): callable {
 		return function( Request $request ) {
 			try {
-				$asset_group_id = $this->ads_asset_group->edit_asset_group( $request->get_param( 'id' ), $request->get_params() );
+				$asset_group_fields = array_intersect_key(
+					$request->get_params(),
+					$this->get_asset_group_fields()
+				);
+				$asset_group_id     = $this->ads_asset_group->edit_asset_group( $request->get_param( 'id' ), $asset_group_fields, $request->get_param( 'assets' ) );
 				return [
 					'status'  => 'success',
 					'message' => __( 'Successfully edited asset group.', 'google-listings-and-ads' ),

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -72,8 +72,7 @@ class AssetGroupController extends BaseController {
 	 * Get the schema for the asset group.
 	 *
 	 * @return array The asset group schema.
-	 *
-	 * /
+	 */
 	public function get_asset_group_fields(): array {
 		return [
 			'final_url' => [

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -73,22 +73,30 @@ class AssetGroupController extends BaseController {
 	 */
 	public function get_edit_params() {
 		return [
-			'id'     => [
+			'id'        => [
 				'description' => __( 'Asset Group ID.', 'google-listings-and-ads' ),
 				'type'        => 'integer',
 				'required'    => true,
 			],
-			'path1'  => [
+			'final_url' => [
+				'description'       => __( 'Final URL.', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'sanitize_callback' => 'esc_url_raw',
+				'validate_callback' => function( $url ) {
+					return filter_var( $url, FILTER_VALIDATE_URL );
+				},
+			],
+			'path1'     => [
 				'description'       => __( 'Asset Group path 1.', 'google-listings-and-ads' ),
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
 			],
-			'path2'  => [
+			'path2'     => [
 				'description'       => __( 'Asset Group path 2.', 'google-listings-and-ads' ),
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
 			],
-			'assets' => [
+			'assets'    => [
 				'type'        => 'array',
 				'description' => __( 'List of asset to be edited.', 'google-listings-and-ads' ),
 				'items'       => $this->get_schema_asset(),

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -76,7 +76,6 @@ class AssetGroupController extends BaseController {
 				'description' => __( 'Asset Group ID.', 'google-listings-and-ads' ),
 				'type'        => 'integer',
 				'required'    => true,
-
 			],
 			'path1'  => [
 				'description'       => __( 'Asset Group path 1.', 'google-listings-and-ads' ),
@@ -227,9 +226,8 @@ class AssetGroupController extends BaseController {
 					'description' => __( 'Asset ID', 'google-listings-and-ads' ),
 				],
 				'content'    => [
-					'type'              => [ 'string', 'null' ],
-					'description'       => __( 'Asset content', 'google-listings-and-ads' ),
-					'sanitize_callback' => 'sanitize_text_field',
+					'type'        => [ 'string', 'null' ],
+					'description' => __( 'Asset content', 'google-listings-and-ads' ),
 				],
 				'field_type' => [
 					'type'        => 'string',

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -253,6 +253,8 @@ class AssetGroupController extends BaseController {
 				'field_type' => [
 					'type'        => 'string',
 					'description' => __( 'Asset field type', 'google-listings-and-ads' ),
+					'required'    => true,
+					'context'     => [ 'edit' ],
 					'enum'        => [
 						AssetFieldType::HEADLINE,
 						AssetFieldType::LONG_HEADLINE,

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -169,12 +169,10 @@ class AssetSuggestionsService implements Service {
 	protected function get_asset_group_asset_suggestions( int $id, string $type ): array {
 		$final_url = $this->get_url( $id, $type );
 
-		$assets = array_values( $this->asset_group_asset->get_assets_by_final_url( $final_url ) );
-
 		// Suggest the assets from the first asset group if exists.
-		$asset_group_assets = array_shift( $assets );
+		$asset_group_assets = $this->asset_group_asset->get_assets_by_final_url( $final_url, true );
 
-		if ( $asset_group_assets === null ) {
+		if ( empty( $asset_group_assets ) ) {
 			return [];
 		}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -174,21 +174,27 @@ class AssetSuggestionsService implements Service {
 	 */
 	protected function combine_results_wp_assets_groups( array $asset_group_assets, array $wp_assets ): array {
 		foreach ( $asset_group_assets as $key => $value ) {
+			$contents = array_column( $value, 'content' );
 			switch ( $key ) {
 				case AssetFieldType::HEADLINE:
 				case AssetFieldType::LONG_HEADLINE:
 				case AssetFieldType::DESCRIPTION:
 				case AssetFieldType::SQUARE_MARKETING_IMAGE:
 				case AssetFieldType::MARKETING_IMAGE:
-					// Add the assets if we have less than the maximum allowed.
-					if ( count( $asset_group_assets[ $key ] ) < self::FIELD_TYPE_REQUIREMENTS[ $key ]['max'] ) {
-						$wp_assets[ $key ] = array_merge( $value, $wp_assets[ $key ] ?? [] );
+				case AssetFieldType::LOGO:
+					// if we have less than the maximum allowed, add more assets from the WP assets.
+					if ( count( $contents ) < self::FIELD_TYPE_REQUIREMENTS[ $key ]['max'] ) {
+						$wp_assets[ $key ] = array_merge( $contents, $wp_assets[ $key ] ?? [] );
 						break;
 					}
-					$wp_assets[ $key ] = $value;
+					$wp_assets[ $key ] = $contents;
+					break;
+				case AssetFieldType::BUSINESS_NAME:
+				case AssetFieldType::CALL_TO_ACTION_SELECTION:
+					$wp_assets[ $key ] = $contents[0] ?? $wp_assets[ $key ] ?? '';
 					break;
 				default:
-					$wp_assets[ $key ] = $value;
+					$wp_assets[ $key ] = $contents;
 			}
 		}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -144,6 +144,10 @@ class AssetSuggestionsService implements Service {
 			$final_url = get_term_link( $id );
 		}
 
+		if ( $final_url === false || is_wp_error( $final_url ) ) {
+			return [];
+		}
+
 		$assets = $this->asset_group_asset->get_assets_by_final_url( $final_url );
 
 		if ( empty( $assets ) ) {

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -120,13 +120,37 @@ class AssetSuggestionsService implements Service {
 	 * @param int    $id Post or Term ID.
 	 * @param string $type Only possible values are post or term.
 	 */
-	public function get_assets_suggestions( int $id, string $type ): array {
+	public function get_assets_suggestions( $id, string $type ): array {
 		$wp_assets = $this->get_wp_assets( $id, $type );
-		$url       = $wp_assets['final_url'];
 
-		$assets_from_other_campaings = $this->asset_group_asset->get_assets_by_url( $url );
+		return $this->combine_results_wp_assets_groups( $wp_assets, $this->asset_group_asset->get_assets_by_url( $wp_assets['final_url'] ) );
+	}
 
-		return array_merge( $wp_assets, $assets_from_other_campaings );
+	/**
+	 * Combine the results from the WP assets and the assets from other campaigns.
+	 *
+	 * @param array $wp_assets The WordPress Assets .
+	 * @param array $asset_group_assets The Asset Group Assets.
+	 *
+	 * @return array The combined results.
+	 */
+	protected function combine_results_wp_assets_groups( array $wp_assets, array $asset_group_assets ): array {
+		foreach ( $wp_assets as $key => $value ) {
+			switch ( $key ) {
+
+				case AssetFieldType::HEADLINE:
+				case AssetFieldType::LONG_HEADLINE:
+				case AssetFieldType::DESCRIPTION:
+				case AssetFieldType::SQUARE_MARKETING_IMAGE:
+				case AssetFieldType::MARKETING_IMAGE:
+					$wp_assets[ $key ] = array_merge( $value, $asset_group_assets[ $key ] ?? [] );
+					break;
+				default:
+					$wp_assets[ $key ] = $value;
+			}
+		}
+
+		return $wp_assets;
 	}
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -121,7 +121,7 @@ class AssetSuggestionsService implements Service {
 	 * @param int    $id Post or Term ID.
 	 * @param string $type Only possible values are post or term.
 	 */
-	public function get_assets_suggestions( $id, string $type ): array {
+	public function get_assets_suggestions( int $id, string $type ): array {
 		$asset_group_assets = $this->get_asset_group_asset_suggestions( $id, $type );
 
 		if ( ! empty( $asset_group_assets ) ) {

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -216,7 +216,7 @@ class AssetSuggestionsService implements Service {
 
 		if ( ! $post || $post->post_status === 'trash' ) {
 			throw new Exception(
-			/* translators: 1: is an integer representing an unknown Post ID */
+				/* translators: 1: is an integer representing an unknown Post ID */
 				sprintf( __( 'Invalid Post ID %1$d', 'google-listings-and-ads' ), $id )
 			);
 		}
@@ -267,7 +267,7 @@ class AssetSuggestionsService implements Service {
 
 		if ( ! $term ) {
 			throw new Exception(
-			/* translators: 1: is an integer representing an unknown Term ID */
+				/* translators: 1: is an integer representing an unknown Term ID */
 				sprintf( __( 'Invalid Term ID %1$d', 'google-listings-and-ads' ), $id )
 			);
 		}

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -150,6 +150,10 @@ class AssetSuggestionsService implements Service {
 			return [];
 		}
 
+		if ( ! isset( $assets[ AssetFieldType::CALL_TO_ACTION_SELECTION ] ) ) {
+			$assets[ AssetFieldType::CALL_TO_ACTION_SELECTION ] = null;
+		}
+
 		return array_merge( [ 'final_url' => $final_url ], $assets );
 
 	}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection as GoogleC
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroupAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\RESTControllers;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
@@ -250,7 +251,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getLeagueContainer()
 			 ->inflector( AdsAwareInterface::class )
 			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
-		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class );
+		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class, AdsAssetGroupAsset::class );
 
 		// Set up the installer.
 		$installer_definition = $this->share_with_tags(

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -111,7 +111,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class, AdsCampaignCriterion::class, GoogleHelper::class );
 		$this->share( AdsCampaignBudget::class, GoogleAdsClient::class );
 		$this->share( AdsAssetGroupAsset::class, GoogleAdsClient::class, AdsAsset::class );
-		$this->share( AdsAsset::class );
+		$this->share( AdsAsset::class, WP::class );
 		$this->share( AdsCampaignCriterion::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );

--- a/src/Internal/StatusMapping.php
+++ b/src/Internal/StatusMapping.php
@@ -32,7 +32,7 @@ abstract class StatusMapping {
 	 */
 	public static function number( string $label ): int {
 		$key = array_search( $label, static::MAPPING, true );
-		return $key ?? 0;
+		return $key === false ? 0 : $key;
 	}
 
 	/**

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -308,4 +308,20 @@ class WP {
 		return wp_update_image_subsizes( $attachment_id );
 
 	}
+
+	/**
+	 * Performs an HTTP request using the GET method and returns its response.
+	 *
+	 * @since x.x.x
+	 *
+	 * @see wp_remote_request() For more information on the response array format.
+	 * @see WP_Http::request() For default arguments information.
+	 *
+	 * @param string $url  URL to retrieve.
+	 * @param array  $args Optional. Request arguments. Default empty array.
+	 * @return array|WP_Error The response or WP_Error on failure.
+	 */
+	public function wp_remote_get( string $url, array $args = [] ) {
+		return wp_remote_get( $url, $args );
+	}
 }

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -669,6 +669,8 @@ trait GoogleAdsClientTrait {
 
 		$asset_group = $this->createMock( AssetGroup::class );
 		$asset_group->method( 'getId' )->willReturn( $data['asset_group_id'] );
+		$asset_group->method( 'getPath1' )->willReturn( $data['path1'] ?? '' );
+		$asset_group->method( 'getPath2' )->willReturn( $data['path2'] ?? '' );
 
 		return ( new GoogleAdsRow() )
 			->setAssetGroupAsset( $asset_group_asset )

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -107,7 +107,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 	}
 
 	public function test_edit_asset_group_assets_with_empty_assets() {
-		$this->assertEquals( [], $this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, [] ) );
+		$this->assertEquals( [], $this->asset_group_asset->edit_operations( self::TEST_ASSET_GROUP_ID, [] ) );
 	}
 
 	public function test_edit_asset_group_assets_with_update_assets() {
@@ -129,7 +129,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		->willReturnOnConsecutiveCalls( ...$this->generate_crate_asset_operations( $assets ) );
 
 		$grouped_operations = $this->group_operations(
-			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
+			$this->asset_group_asset->edit_operations( self::TEST_ASSET_GROUP_ID, $assets )
 		);
 
 		// We should have two type of operations: asset_operation and asset_group_asset_operation
@@ -172,7 +172,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		->willReturnOnConsecutiveCalls( ...$this->generate_crate_asset_operations( $assets ) );
 
 		$grouped_operations = $this->group_operations(
-			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
+			$this->asset_group_asset->edit_operations( self::TEST_ASSET_GROUP_ID, $assets )
 		);
 
 		// We should have two type of operations: asset_operation and asset_group_asset_operation
@@ -210,7 +210,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		->method( 'create_operation' );
 
 		$grouped_operations = $this->group_operations(
-			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
+			$this->asset_group_asset->edit_operations( self::TEST_ASSET_GROUP_ID, $assets )
 		);
 
 		// We should have one type of operations: asset_operation.

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -126,21 +126,26 @@ class AdsAssetGroupAssetTest extends UnitTest {
 				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
 				'field_type'     => AssetFieldType::number( AssetFieldType::DESCRIPTION ),
 				'asset'          => array_merge( $asset_1, [ 'type' => AssetType::TEXT ] ),
+				'path1'          => 'path1',
+				'path2'          => 'path2',
 			],
 			[
 				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
 				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
 				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
+				'path1'          => 'path11',
+				'path2'          => 'path22',
 			],
 		];
 
 		$expected = [
 			AssetFieldType::DESCRIPTION     => [
-				$asset_1,
+				$asset_1['content'],
 			],
 			AssetFieldType::MARKETING_IMAGE => [
-				$asset_2,
+				$asset_2['content'],
 			],
+			'display_url_path'              => [ 'path1', 'path2' ],
 		];
 
 		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -130,7 +130,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 				'path2'          => 'path2',
 			],
 			[
-				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID_2,
 				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
 				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
 				'path1'          => 'path11',
@@ -139,13 +139,19 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		];
 
 		$expected = [
-			AssetFieldType::DESCRIPTION     => [
-				$asset_1['content'],
+			self::TEST_ASSET_GROUP_ID   => [
+				AssetFieldType::DESCRIPTION => [
+					$asset_1['content'],
+				],
+				'display_url_path'          => [ 'path1', 'path2' ],
 			],
-			AssetFieldType::MARKETING_IMAGE => [
-				$asset_2['content'],
+			self::TEST_ASSET_GROUP_ID_2 => [
+				AssetFieldType::MARKETING_IMAGE => [
+					$asset_2['content'],
+				],
+				'display_url_path'              => [ 'path11', 'path22' ],
 			],
-			'display_url_path'              => [ 'path1', 'path2' ],
+
 		];
 
 		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -159,6 +159,50 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 	}
 
+	public function test_get_asset_groups_assets_by_final_url_firt_result() {
+		$asset_1 = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => 'Test Asset',
+		];
+
+		$asset_2 = [
+			'id'      => self::TEST_ASSET_ID_2,
+			'content' => 'https://example.com/image.jpg',
+		];
+
+		$this->asset->expects( $this->exactly( 2 ) )
+		->method( 'convert_asset' )
+		->willReturnOnConsecutiveCalls( $asset_1, $asset_2 );
+
+		$asset_group_asset_data = [
+			[
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
+				'field_type'     => AssetFieldType::number( AssetFieldType::DESCRIPTION ),
+				'asset'          => array_merge( $asset_1, [ 'type' => AssetType::TEXT ] ),
+				'path1'          => 'path1',
+				'path2'          => 'path2',
+			],
+			[
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID_2,
+				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
+				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
+				'path1'          => 'path11',
+				'path2'          => 'path22',
+			],
+		];
+
+		$expected = [
+			AssetFieldType::DESCRIPTION => [
+				$asset_1['content'],
+			],
+			'display_url_path'          => [ 'path1', 'path2' ],
+		];
+
+		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );
+		$this->assertEquals( $expected, $this->asset_group_asset->get_assets_by_final_url( 'https://example.com', true ) );
+
+	}
+
 
 
 	public function test_edit_asset_group_assets_with_empty_assets() {

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
  *
  * @property MockObject|OptionsInterface $options
- * @property AdsAssetGroup               $asset_group
+ * @property AdsAssetGroupAsset          $asset_group_asset
  */
 class AdsAssetGroupAssetTest extends UnitTest {
 
@@ -126,7 +126,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		$this->asset->expects( $this->exactly( 2 ) )
 		->method( 'create_operation' )
-		->willReturnOnConsecutiveCalls( ...$this->generate_asset_operations( $assets ) );
+		->willReturnOnConsecutiveCalls( ...$this->generate_crate_asset_operations( $assets ) );
 
 		$grouped_operations = $this->group_operations(
 			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
@@ -169,7 +169,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		$this->asset->expects( $this->exactly( 2 ) )
 		->method( 'create_operation' )
-		->willReturnOnConsecutiveCalls( ...$this->generate_asset_operations( $assets ) );
+		->willReturnOnConsecutiveCalls( ...$this->generate_crate_asset_operations( $assets ) );
 
 		$grouped_operations = $this->group_operations(
 			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
@@ -184,6 +184,8 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		$this->assertEquals( $assets[1]['content'], ( $grouped_operations['asset_operation']['create'][1] )->getCreate()->getTextAsset()->getText() );
 
 		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['create'] ) );
+		$this->assertEquals( AssetFieldType::number( AssetFieldType::DESCRIPTION ), ( $grouped_operations['asset_group_asset_operation']['create'][0] )->getCreate()->getFieldType() );
+		$this->assertEquals( AssetFieldType::number( AssetFieldType::HEADLINE ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getFieldType() );
 
 		// We should not remove old assets.
 		$this->assertArrayNotHasKey( 'remove', $grouped_operations['asset_group_asset_operation'] );
@@ -216,7 +218,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		$this->assertArrayNotHasKey( 'asset_operation', $grouped_operations );
 
-		// We should have two delete assets asset_group_asset_operation.
+		// We should have two delete  asset_group_asset_operation.
 		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['remove'] ) );
 		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[0]['id'], AssetFieldType::name( $assets[0]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][0] )->getRemove() );
 		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[1]['id'], AssetFieldType::name( $assets[1]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][1] )->getRemove() );

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -1,5 +1,5 @@
 <?php
-declare( strict_types=1 );
+declare( strict_types=0 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
@@ -9,8 +9,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
 use PHPUnit\Framework\MockObject\MockObject;
-use Google\Ads\GoogleAds\V11\Enums\AssetFieldTypeEnum\AssetFieldType;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Google\Ads\GoogleAds\V11\Enums\AssetTypeEnum\AssetType;
+use Google\Ads\GoogleAds\Util\V11\ResourceNames;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -40,7 +41,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		$this->ads_client_setup();
 
-		$this->asset   = new AdsAsset();
+		$this->asset   = $this->createMock( AdsAsset::class );
 		$this->options = $this->createMock( OptionsInterface::class );
 		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
 
@@ -51,36 +52,42 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 
 	public function test_get_asset_groups_assets() {
+		$asset_1 = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => 'Test Asset',
+		];
+
+		$asset_2 = [
+			'id'      => self::TEST_ASSET_ID_2,
+			'content' => 'https://example.com/image.jpg',
+		];
+
+		$this->asset->expects( $this->exactly( 2 ) )
+		->method( 'convert_asset' )
+		->willReturnOnConsecutiveCalls( $asset_1, $asset_2 );
+
 		$asset_group_asset_data = [
 			[
 				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
-				'field_type'     => AssetFieldType::DESCRIPTION,
-				'asset'          => [
-					'id'   => self::TEST_ASSET_ID,
-					'type' => AssetType::TEXT,
-					'text' => 'Test Asset',
-				],
+				'field_type'     => AssetFieldType::number( AssetFieldType::DESCRIPTION ),
+				'asset'          => array_merge( $asset_1, [ 'type' => AssetType::TEXT ] ),
 			],
 			[
 				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
-				'field_type'     => AssetFieldType::MARKETING_IMAGE,
-				'asset'          => [
-					'id'        => self::TEST_ASSET_ID_2,
-					'type'      => AssetType::IMAGE,
-					'image_url' => 'https://example.com/image.jpg',
-				],
+				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
+				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
 			],
 		];
 
 		$expected = [
 			self::TEST_ASSET_GROUP_ID => [
-				strtolower( AssetFieldType::name( AssetFieldType::DESCRIPTION ) ) => [
+				AssetFieldType::DESCRIPTION     => [
 					[
 						'id'      => self::TEST_ASSET_ID,
 						'content' => 'Test Asset',
 					],
 				],
-				strtolower( AssetFieldType::name( AssetFieldType::MARKETING_IMAGE ) ) => [
+				AssetFieldType::MARKETING_IMAGE => [
 					[
 						'id'      => self::TEST_ASSET_ID_2,
 						'content' => 'https://example.com/image.jpg',
@@ -99,6 +106,147 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		$this->assertEquals( [], $this->asset_group_asset->get_assets_by_asset_group_ids( [] ) );
 	}
 
+	public function test_edit_asset_group_assets_with_empty_assets() {
+		$this->assertEquals( [], $this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, [] ) );
+	}
+
+	public function test_edit_asset_group_assets_with_update_assets() {
+		$assets = [
+			[
+				'id'         => self::TEST_ASSET_ID,
+				'field_type' => AssetFieldType::DESCRIPTION,
+				'content'    => 'Test Asset',
+			],
+			[
+				'id'         => self::TEST_ASSET_ID_2,
+				'field_type' => AssetFieldType::HEADLINE,
+				'content'    => 'https://example.com/image.jpg',
+			],
+		];
+
+		$this->asset->expects( $this->exactly( 2 ) )
+		->method( 'create_operation' )
+		->willReturnOnConsecutiveCalls( ...$this->generate_asset_operations( $assets ) );
+
+		$grouped_operations = $this->group_operations(
+			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
+		);
+
+		// We should have two type of operations: asset_operation and asset_group_asset_operation
+		$this->assertEquals( 2, count( $grouped_operations ) );
+
+		// We should have two assets creation.
+		$this->assertEquals( 2, count( $grouped_operations['asset_operation']['create'] ) );
+		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['create'] ) );
+
+		$this->assertEquals( $assets[0]['content'], ( $grouped_operations['asset_operation']['create'][0] )->getCreate()->getTextAsset()->getText() );
+		$this->assertEquals( $assets[1]['content'], ( $grouped_operations['asset_operation']['create'][1] )->getCreate()->getTextAsset()->getText() );
+
+		$this->assertEquals( AssetFieldType::number( AssetFieldType::DESCRIPTION ), ( $grouped_operations['asset_group_asset_operation']['create'][0] )->getCreate()->getFieldType() );
+		$this->assertEquals( AssetFieldType::number( AssetFieldType::HEADLINE ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getFieldType() );
+
+		// We should remove the two old assets.
+		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['remove'] ) );
+
+		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[0]['id'], AssetFieldType::name( $assets[0]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][0] )->getRemove() );
+		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[1]['id'], AssetFieldType::name( $assets[1]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][1] )->getRemove() );
+
+	}
+
+	public function test_edit_asset_group_assets_create_assets() {
+		$assets = [
+			[
+				'id'         => null,
+				'field_type' => AssetFieldType::DESCRIPTION,
+				'content'    => 'Test Asset',
+			],
+			[
+				'id'         => null,
+				'field_type' => AssetFieldType::HEADLINE,
+				'content'    => 'https://example.com/image.jpg',
+			],
+		];
+
+		$this->asset->expects( $this->exactly( 2 ) )
+		->method( 'create_operation' )
+		->willReturnOnConsecutiveCalls( ...$this->generate_asset_operations( $assets ) );
+
+		$grouped_operations = $this->group_operations(
+			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
+		);
+
+		// We should have two type of operations: asset_operation and asset_group_asset_operation
+		$this->assertEquals( 2, count( $grouped_operations ) );
+
+		// We should have two assets creation.
+		$this->assertEquals( 2, count( $grouped_operations['asset_operation']['create'] ) );
+		$this->assertEquals( $assets[0]['content'], ( $grouped_operations['asset_operation']['create'][0] )->getCreate()->getTextAsset()->getText() );
+		$this->assertEquals( $assets[1]['content'], ( $grouped_operations['asset_operation']['create'][1] )->getCreate()->getTextAsset()->getText() );
+
+		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['create'] ) );
+
+		// We should not remove old assets.
+		$this->assertArrayNotHasKey( 'remove', $grouped_operations['asset_group_asset_operation'] );
+
+	}
+
+	public function test_edit_asset_group_assets_delete_assets() {
+		$assets = [
+			[
+				'id'         => self::TEST_ASSET_ID,
+				'field_type' => AssetFieldType::DESCRIPTION,
+				'content'    => null,
+			],
+			[
+				'id'         => self::TEST_ASSET_ID_2,
+				'field_type' => AssetFieldType::HEADLINE,
+				'content'    => null,
+			],
+		];
+
+		$this->asset->expects( $this->exactly( 0 ) )
+		->method( 'create_operation' );
+
+		$grouped_operations = $this->group_operations(
+			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
+		);
+
+		// We should have two type of operations: asset_operation and asset_group_asset_operation
+		$this->assertEquals( 1, count( $grouped_operations ) );
+
+		$this->assertArrayNotHasKey( 'asset_operation', $grouped_operations );
+
+		// We should have two delete assets asset_group_asset_operation.
+		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['remove'] ) );
+		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[0]['id'], AssetFieldType::name( $assets[0]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][0] )->getRemove() );
+		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[1]['id'], AssetFieldType::name( $assets[1]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][1] )->getRemove() );
+
+		// We should not create assets.
+		$this->assertArrayNotHasKey( 'create', $grouped_operations['asset_group_asset_operation'] );
+
+	}
+
+	private function group_operations( $operations ) {
+		$grouped_operations = [];
+
+		foreach ( $operations as $operation ) {
+
+			$operation_name = $operation->getOperation();
+
+			if ( $operation_name === 'asset_operation' ) {
+				$operation = $operation->getAssetOperation();
+			} elseif ( $operation_name === 'asset_group_asset_operation' ) {
+				$operation = $operation->getAssetGroupAssetOperation();
+			} else {
+				$operation = null;
+			}
+
+			$grouped_operations[ $operation_name ][ $operation->getOperation() ][] = $operation;
+
+		}
+
+		return $grouped_operations;
+	}
 
 
 }

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -106,6 +106,50 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		$this->assertEquals( [], $this->asset_group_asset->get_assets_by_asset_group_ids( [] ) );
 	}
 
+	public function test_get_asset_groups_assets_by_final_url() {
+		$asset_1 = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => 'Test Asset',
+		];
+
+		$asset_2 = [
+			'id'      => self::TEST_ASSET_ID_2,
+			'content' => 'https://example.com/image.jpg',
+		];
+
+		$this->asset->expects( $this->exactly( 2 ) )
+		->method( 'convert_asset' )
+		->willReturnOnConsecutiveCalls( $asset_1, $asset_2 );
+
+		$asset_group_asset_data = [
+			[
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
+				'field_type'     => AssetFieldType::number( AssetFieldType::DESCRIPTION ),
+				'asset'          => array_merge( $asset_1, [ 'type' => AssetType::TEXT ] ),
+			],
+			[
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
+				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
+				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
+			],
+		];
+
+		$expected = [
+			AssetFieldType::DESCRIPTION     => [
+				$asset_1,
+			],
+			AssetFieldType::MARKETING_IMAGE => [
+				$asset_2,
+			],
+		];
+
+		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );
+		$this->assertEquals( $expected, $this->asset_group_asset->get_assets_by_final_url( 'https://example.com' ) );
+
+	}
+
+
+
 	public function test_edit_asset_group_assets_with_empty_assets() {
 		$this->assertEquals( [], $this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, [] ) );
 	}

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -1,5 +1,5 @@
 <?php
-declare( strict_types=0 );
+declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
@@ -213,12 +213,12 @@ class AdsAssetGroupAssetTest extends UnitTest {
 			$this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, $assets )
 		);
 
-		// We should have two type of operations: asset_operation and asset_group_asset_operation
+		// We should have one type of operations: asset_operation.
 		$this->assertEquals( 1, count( $grouped_operations ) );
 
 		$this->assertArrayNotHasKey( 'asset_operation', $grouped_operations );
 
-		// We should have two delete  asset_group_asset_operation.
+		// We should have two delete asset_group_asset_operation.
 		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['remove'] ) );
 		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[0]['id'], AssetFieldType::name( $assets[0]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][0] )->getRemove() );
 		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[1]['id'], AssetFieldType::name( $assets[1]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][1] )->getRemove() );

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -1,0 +1,142 @@
+<?php
+declare( strict_types=0 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CallToActionType;
+use Google\Ads\GoogleAds\V11\Enums\AssetTypeEnum\AssetType;
+use Google\Ads\GoogleAds\Util\V11\ResourceNames;
+use Exception;
+
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsAssetTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ *
+ * @property MockObject|OptionsInterface $options
+ * @property AdsAsset                    $asset
+ */
+class AdsAssetTest extends UnitTest {
+
+	use GoogleAdsClientTrait;
+
+	protected const TEMPORARY_ID  = -6;
+	protected const TEST_ASSET_ID = 6677889911;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->ads_client_setup();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+
+		$this->asset = new AdsAsset();
+		$this->asset->set_options_object( $this->options );
+	}
+
+	public function test_convert_asset_text() {
+		$data = [
+			'field_type' => AssetFieldType::HEADLINE,
+			'content'    => 'Test headline',
+			'id'         => self::TEST_ASSET_ID,
+		];
+		$row  = $this->generate_asset_row_mock( $data );
+
+		$expected = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => $data['content'],
+		];
+
+		$this->assertEquals( $expected, $this->asset->convert_asset( $row ) );
+	}
+
+	public function test_convert_asset_image() {
+		$data = [
+			'field_type' => AssetFieldType::SQUARE_MARKETING_IMAGE,
+			'content'    => 'https://example.com/image.jpg',
+			'id'         => self::TEST_ASSET_ID,
+		];
+		$row  = $this->generate_asset_row_mock( $data );
+
+		$expected = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => $data['content'],
+		];
+
+		$this->assertEquals( $expected, $this->asset->convert_asset( $row ) );
+	}
+
+	public function test_convert_asset_call_action() {
+		$data = [
+			'field_type' => AssetFieldType::CALL_TO_ACTION_SELECTION,
+			'content'    => CallToActionType::SHOP_NOW,
+			'id'         => self::TEST_ASSET_ID,
+		];
+		$row  = $this->generate_asset_row_mock( $data );
+
+		$expected = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => $data['content'],
+		];
+
+		$this->assertEquals( $expected, $this->asset->convert_asset( $row ) );
+	}
+
+	public function test_create_operation_text_asset() {
+		$data = [
+			'field_type' => AssetFieldType::HEADLINE,
+			'content'    => 'Test headline',
+		];
+
+		$operation       = $this->asset->create_operation( $data, self::TEMPORARY_ID );
+		$asset_operation = $operation->getAssetOperation();
+
+		$this->assertTrue( $asset_operation->hasCreate() );
+		$this->assertEquals( ResourceNames::forAsset( $this->options->get_ads_id(), self::TEMPORARY_ID ), $asset_operation->getCreate()->getResourceName() );
+		$this->assertEquals( $data['content'], $asset_operation->getCreate()->getTextAsset()->getText() );
+
+	}
+
+	public function test_create_operation_call_to_action_asset() {
+		$data = [
+			'field_type' => AssetFieldType::CALL_TO_ACTION_SELECTION,
+			'content'    => CallToActionType::SHOP_NOW,
+		];
+
+		$operation       = $this->asset->create_operation( $data, self::TEMPORARY_ID );
+		$asset_operation = $operation->getAssetOperation();
+
+		$this->assertTrue( $asset_operation->hasCreate() );
+		$this->assertEquals( ResourceNames::forAsset( $this->options->get_ads_id(), self::TEMPORARY_ID ), $asset_operation->getCreate()->getResourceName() );
+		$this->assertEquals( CallToActionType::number( $data['content'] ), $asset_operation->getCreate()->getCallToActionAsset()->getCallToAction() );
+
+	}
+
+	public function test_create_operation_invalid_asset_field_type() {
+		$data = [
+			'field_type' => 'invalid',
+			'content'    => CallToActionType::SHOP_NOW,
+		];
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Asset Field type not supported' );
+
+		$this->asset->create_operation( $data, self::TEMPORARY_ID );
+
+	}
+
+
+}

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -1,5 +1,5 @@
 <?php
-declare( strict_types=0 );
+declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -46,20 +46,22 @@ class AdsAssetTest extends UnitTest {
 		$this->asset->set_options_object( $this->options );
 	}
 
+	protected function assertAssetTypeConversion( $data ) {
+		$row      = $this->generate_asset_row_mock( $data );
+		$expected = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => $data['content'],
+		];
+		$this->assertEquals( $expected, $this->asset->convert_asset( $row ) );
+	}
+
 	public function test_convert_asset_text() {
 		$data = [
 			'field_type' => AssetFieldType::HEADLINE,
 			'content'    => 'Test headline',
 			'id'         => self::TEST_ASSET_ID,
 		];
-		$row  = $this->generate_asset_row_mock( $data );
-
-		$expected = [
-			'id'      => self::TEST_ASSET_ID,
-			'content' => $data['content'],
-		];
-
-		$this->assertEquals( $expected, $this->asset->convert_asset( $row ) );
+		$this->assertAssetTypeConversion( $data );
 	}
 
 	public function test_convert_asset_image() {
@@ -68,14 +70,8 @@ class AdsAssetTest extends UnitTest {
 			'content'    => 'https://example.com/image.jpg',
 			'id'         => self::TEST_ASSET_ID,
 		];
-		$row  = $this->generate_asset_row_mock( $data );
 
-		$expected = [
-			'id'      => self::TEST_ASSET_ID,
-			'content' => $data['content'],
-		];
-
-		$this->assertEquals( $expected, $this->asset->convert_asset( $row ) );
+		$this->assertAssetTypeConversion( $data );
 	}
 
 	public function test_convert_asset_call_action() {
@@ -84,14 +80,8 @@ class AdsAssetTest extends UnitTest {
 			'content'    => CallToActionType::SHOP_NOW,
 			'id'         => self::TEST_ASSET_ID,
 		];
-		$row  = $this->generate_asset_row_mock( $data );
 
-		$expected = [
-			'id'      => self::TEST_ASSET_ID,
-			'content' => $data['content'],
-		];
-
-		$this->assertEquals( $expected, $this->asset->convert_asset( $row ) );
+		$this->assertAssetTypeConversion( $data );
 	}
 
 	public function test_create_operation_text_asset() {

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -10,7 +10,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAd
 use PHPUnit\Framework\MockObject\MockObject;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CallToActionType;
-use Google\Ads\GoogleAds\V11\Enums\AssetTypeEnum\AssetType;
 use Google\Ads\GoogleAds\Util\V11\ResourceNames;
 use Exception;
 

--- a/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
@@ -19,11 +19,12 @@ use Exception;
  */
 class AssetGroupControllerTest extends RESTControllerUnitTest {
 
-	protected const TEST_CAMPAIGN_ID       = 1234567890;
-	protected const TEST_ASSET_GROUP_ID    = 9876543210;
-	protected const ROUTE_ASSET_GROUPS     = '/wc/gla/ads/campaigns/' . self::TEST_CAMPAIGN_ID . '/asset-groups';
-	protected const TEST_NO_ASSET_GROUPS   = [];
-	protected const TEST_ASSET_GROUPS_DATA = [
+	protected const TEST_CAMPAIGN_ID            = 1234567890;
+	protected const TEST_ASSET_GROUP_ID         = 9876543210;
+	protected const ROUTE_ASSET_GROUPS          = '/wc/gla/ads/campaigns/asset-groups/' . self::TEST_ASSET_GROUP_ID;
+	protected const ROUTE_CAMPAIGN_ASSET_GROUPS = '/wc/gla/ads/campaigns/' . self::TEST_CAMPAIGN_ID . '/asset-groups';
+	protected const TEST_NO_ASSET_GROUPS        = [];
+	protected const TEST_ASSET_GROUPS_DATA      = [
 		[
 			'id'               => self::TEST_ASSET_GROUP_ID,
 			'final_url'        => 'https://test.com/shop',
@@ -52,7 +53,7 @@ class AssetGroupControllerTest extends RESTControllerUnitTest {
 			->with( self::TEST_CAMPAIGN_ID )
 			->willReturn( self::TEST_ASSET_GROUPS_DATA );
 
-		$response = $this->do_request( self::ROUTE_ASSET_GROUPS, 'GET' );
+		$response = $this->do_request( self::ROUTE_CAMPAIGN_ASSET_GROUPS, 'GET' );
 
 		$this->assertEquals( self::TEST_ASSET_GROUPS_DATA, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
@@ -64,7 +65,7 @@ class AssetGroupControllerTest extends RESTControllerUnitTest {
 			->with( self::TEST_CAMPAIGN_ID )
 			->willReturn( self::TEST_NO_ASSET_GROUPS );
 
-		$response = $this->do_request( self::ROUTE_ASSET_GROUPS, 'GET' );
+		$response = $this->do_request( self::ROUTE_CAMPAIGN_ASSET_GROUPS, 'GET' );
 
 		$this->assertEquals( self::TEST_NO_ASSET_GROUPS, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
@@ -75,9 +76,43 @@ class AssetGroupControllerTest extends RESTControllerUnitTest {
 			->method( 'get_asset_groups_by_campaign_id' )
 			->willThrowException( new Exception( 'Account not connected' ) );
 
-		$response = $this->do_request( self::ROUTE_ASSET_GROUPS, 'GET' );
+		$response = $this->do_request( self::ROUTE_CAMPAIGN_ASSET_GROUPS, 'GET' );
 
 		$this->assertEquals( 'Account not connected', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_edit_asset_group() {
+		$this->asset_group
+			->method( 'edit_asset_group' )
+			->willReturn( self::TEST_ASSET_GROUP_ID );
+
+		$response = $this->do_request( self::ROUTE_ASSET_GROUPS, 'PUT' );
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully edited asset group.',
+				'id'      => self::TEST_ASSET_GROUP_ID,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_asset_group_with_api_exception() {
+		$asset_group_data = [
+			'id'    => self::TEST_ASSET_GROUP_ID,
+			'path1' => 'test path1',
+		];
+
+		$this->asset_group->expects( $this->once() )
+			->method( 'edit_asset_group' )
+			->with( self::TEST_ASSET_GROUP_ID, $asset_group_data )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_ASSET_GROUPS, 'POST', $asset_group_data );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
 		$this->assertEquals( 400, $response->get_status() );
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
@@ -101,13 +101,16 @@ class AssetGroupControllerTest extends RESTControllerUnitTest {
 
 	public function test_edit_asset_group_with_api_exception() {
 		$asset_group_data = [
-			'id'    => self::TEST_ASSET_GROUP_ID,
-			'path1' => 'test path1',
+			'id'          => self::TEST_ASSET_GROUP_ID,
+			'path1'       => 'test path1',
+			'wrong_field' => 'should not be here',
 		];
+
+		$expected_asset_group_data = [ 'path1' => 'test path1' ];
 
 		$this->asset_group->expects( $this->once() )
 			->method( 'edit_asset_group' )
-			->with( self::TEST_ASSET_GROUP_ID, $asset_group_data )
+			->with( self::TEST_ASSET_GROUP_ID, $expected_asset_group_data, [] )
 			->willThrowException( new Exception( 'error', 400 ) );
 
 		$response = $this->do_request( self::ROUTE_ASSET_GROUPS, 'POST', $asset_group_data );

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -523,39 +523,51 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$this->asset_suggestions->get_assets_suggestions( self::INVALID_ID, 'term' );
 	}
 
+
+
 	public function test_combine_asset_results() {
+		$asset_1 = $this->generate_random_converted_asset();
+		$asset_2 = $this->generate_random_converted_asset();
+
 		$this->asset_group_asset->expects( $this->once() )
 			->method( 'get_assets_by_final_url' )
 			->with( get_permalink( $this->post->ID ) )
 			->willReturn(
 				[
-					AssetFieldType::DESCRIPTION => [ 'desc1', 'desc2' ],
-					AssetFieldType::HEADLINE    => [ 'headline1' ],
+					AssetFieldType::DESCRIPTION => [ $asset_1 ],
+					AssetFieldType::HEADLINE    => [ $asset_2 ],
 				]
 			);
 
 		$wp_asset                                = $this->format_post_asset_response( $this->post );
-		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ 'desc1', 'desc2', ...$wp_asset[ AssetFieldType::DESCRIPTION ] ];
-		$wp_asset[ AssetFieldType::HEADLINE ]    = [ 'headline1', ...$wp_asset[ AssetFieldType::HEADLINE ] ];
+		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ $asset_1['content'], ...$wp_asset[ AssetFieldType::DESCRIPTION ] ];
+		$wp_asset[ AssetFieldType::HEADLINE ]    = [ $asset_2['content'], ...$wp_asset[ AssetFieldType::HEADLINE ] ];
 
 		$this->assertEquals( $wp_asset, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 
 	}
 
 	public function test_combine_asset_max_results() {
+		$asset_1 = $this->generate_random_converted_asset();
+		$asset_2 = $this->generate_random_converted_asset();
+		$asset_3 = $this->generate_random_converted_asset();
+		$asset_4 = $this->generate_random_converted_asset();
+		$asset_5 = $this->generate_random_converted_asset();
+		$asset_6 = $this->generate_random_converted_asset();
+
 		$this->asset_group_asset->expects( $this->once() )
 			->method( 'get_assets_by_final_url' )
 			->with( get_permalink( $this->post->ID ) )
 			->willReturn(
 				[
-					AssetFieldType::DESCRIPTION => [ 'desc1', 'desc2', 'desc3', 'desc4', 'desc5' ],
-					AssetFieldType::HEADLINE    => [ 'headline1' ],
+					AssetFieldType::DESCRIPTION => [ $asset_1, $asset_2, $asset_3, $asset_4, $asset_5 ],
+					AssetFieldType::HEADLINE    => [ $asset_6 ],
 				]
 			);
 
 		$wp_asset                                = $this->format_post_asset_response( $this->post );
-		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ 'desc1', 'desc2', 'desc3', 'desc4', 'desc5' ];
-		$wp_asset[ AssetFieldType::HEADLINE ]    = [ 'headline1', ...$wp_asset[ AssetFieldType::HEADLINE ] ];
+		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ $asset_1['content'], $asset_2['content'], $asset_3['content'], $asset_4['content'], $asset_5['content'] ];
+		$wp_asset[ AssetFieldType::HEADLINE ]    = [ $asset_6['content'], ...$wp_asset[ AssetFieldType::HEADLINE ] ];
 
 		$this->assertEquals( $wp_asset, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 
@@ -633,6 +645,18 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 
+	}
+
+	/**
+	 * Generates a random converted asset.
+	 *
+	 * @return array The random converted asset.
+	 */
+	private function generate_random_converted_asset(): array {
+		return [
+			'id'      => rand(),
+			'content' => 'random content' . rand(),
+		];
 	}
 
 }

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -624,15 +624,13 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	public function test_get_asset_suggestions_with_assets_from_asset_group() {
 		$this->asset_group_asset->expects( $this->exactly( 1 ) )
 			->method( 'get_assets_by_final_url' )
-			->with( get_permalink( $this->post->ID ) )
+			->with( get_permalink( $this->post->ID ), true )
 			->willReturn(
 				[
-					[
-						AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
-						AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
-						AssetFieldType::CALL_TO_ACTION_SELECTION => 'learn_more',
-					],
-				]
+					AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
+					AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
+					AssetFieldType::CALL_TO_ACTION_SELECTION => 'learn_more',
+				],
 			);
 
 			$expected = [
@@ -649,14 +647,12 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	public function test_get_asset_suggestions_with_assets_from_asset_group_empty_call_to_action() {
 		$this->asset_group_asset->expects( $this->exactly( 1 ) )
 			->method( 'get_assets_by_final_url' )
-			->with( get_permalink( $this->post->ID ) )
+			->with( get_permalink( $this->post->ID ), true )
 			->willReturn(
 				[
-					[
-						AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
-						AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
-					],
-				]
+					AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
+					AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
+				],
 			);
 
 			$expected = [

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -26,6 +26,19 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads
  *
  * @property MockObject|WP  $wp
+ * @property MockObject|WC  $wc
+ * @property MockObject|wpdb $wpdb
+ * @property MockObject|ImageUtility $image_utility
+ * @property MockObject|\WP_Post $post
+ * @property MockObject|\WP_Term $term
+ * @property MockObject|AssetSuggestionsService $asset_suggestions
+ * @property MockObject|array $suggested_post
+ * @property MockObject|array $suggested_term
+ * @property MockObject|DimensionUtility $big_image
+ * @property MockObject|DimensionUtility $small_image
+ * @property MockObject|DimensionUtility $normal_image
+ * @property MockObject|DimensionUtility $suggested_image_square
+ * @property MockObject|DimensionUtility $suggested_image_landscape
  */
 class AssetSuggestionsServiceTest extends UnitTest {
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -27,6 +27,20 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads
  *
  * @property MockObject|WP  $wp
+ * @property MockObject|WC  $wc
+ * @property MockObject|ImageUtility  $image_utility
+ * @property MockObject|wpdb  $wpdb
+ * @property MockObject|AdsAssetGroupAsset  $asset_group_asset
+ * @property AssetSuggestionsService  $asset_suggestions
+ * @property \WP_Post  $post
+ * @property \WP_Term  $term
+ * @property array  $suggested_post
+ * @property array  $suggested_term
+ * @property DimensionUtility  $big_image
+ * @property DimensionUtility  $small_image
+ * @property DimensionUtility  $normal_image
+ * @property DimensionUtility  $suggested_image_square
+ * @property DimensionUtility  $suggested_image_landscape
  */
 class AssetSuggestionsServiceTest extends UnitTest {
 
@@ -597,16 +611,63 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 	}
 
-	/**
-	 * Generates a random converted asset.
-	 *
-	 * @return array The random converted asset.
-	 */
-	private function generate_random_converted_asset(): array {
-		return [
-			'id'      => rand(),
-			'content' => 'random content' . rand(),
-		];
+	public function test_get_asset_suggestions_with_empty_asset_group() {
+		$this->asset_group_asset->expects( $this->exactly( 1 ) )
+			->method( 'get_assets_by_final_url' )
+			->with( get_permalink( $this->post->ID ) )
+			->willReturn( [] );
+
+			$this->assertEquals( $this->format_post_asset_response( $this->post ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+
+	}
+
+	public function test_get_asset_suggestions_with_assets_from_asset_group() {
+		$this->asset_group_asset->expects( $this->exactly( 1 ) )
+			->method( 'get_assets_by_final_url' )
+			->with( get_permalink( $this->post->ID ) )
+			->willReturn(
+				[
+					[
+						AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
+						AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
+						AssetFieldType::CALL_TO_ACTION_SELECTION => 'learn_more',
+					],
+				]
+			);
+
+			$expected = [
+				AssetFieldType::HEADLINE                 => [ 'headline1', 'headline2' ],
+				AssetFieldType::DESCRIPTION              => [ 'description1', 'description2' ],
+				AssetFieldType::CALL_TO_ACTION_SELECTION => 'learn_more',
+				'final_url'                              => get_permalink( $this->post->ID ),
+			];
+
+			$this->assertEquals( $expected, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+
+	}
+
+	public function test_get_asset_suggestions_with_assets_from_asset_group_empty_call_to_action() {
+		$this->asset_group_asset->expects( $this->exactly( 1 ) )
+			->method( 'get_assets_by_final_url' )
+			->with( get_permalink( $this->post->ID ) )
+			->willReturn(
+				[
+					[
+						AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
+						AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
+					],
+				]
+			);
+
+			$expected = [
+				AssetFieldType::HEADLINE                 => [ 'headline1', 'headline2' ],
+				AssetFieldType::DESCRIPTION              => [ 'description1', 'description2' ],
+				AssetFieldType::CALL_TO_ACTION_SELECTION => null,
+				'final_url'                              => get_permalink( $this->post->ID ),
+			];
+
+			$this->assertEquals( $expected, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+
 	}
 
 }

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -523,56 +523,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$this->asset_suggestions->get_assets_suggestions( self::INVALID_ID, 'term' );
 	}
 
-
-
-	public function test_combine_asset_results() {
-		$asset_1 = $this->generate_random_converted_asset();
-		$asset_2 = $this->generate_random_converted_asset();
-
-		$this->asset_group_asset->expects( $this->once() )
-			->method( 'get_assets_by_final_url' )
-			->with( get_permalink( $this->post->ID ) )
-			->willReturn(
-				[
-					AssetFieldType::DESCRIPTION => [ $asset_1 ],
-					AssetFieldType::HEADLINE    => [ $asset_2 ],
-				]
-			);
-
-		$wp_asset                                = $this->format_post_asset_response( $this->post );
-		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ $asset_1['content'], ...$wp_asset[ AssetFieldType::DESCRIPTION ] ];
-		$wp_asset[ AssetFieldType::HEADLINE ]    = [ $asset_2['content'], ...$wp_asset[ AssetFieldType::HEADLINE ] ];
-
-		$this->assertEquals( $wp_asset, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
-	}
-
-	public function test_combine_asset_max_results() {
-		$asset_1 = $this->generate_random_converted_asset();
-		$asset_2 = $this->generate_random_converted_asset();
-		$asset_3 = $this->generate_random_converted_asset();
-		$asset_4 = $this->generate_random_converted_asset();
-		$asset_5 = $this->generate_random_converted_asset();
-		$asset_6 = $this->generate_random_converted_asset();
-
-		$this->asset_group_asset->expects( $this->once() )
-			->method( 'get_assets_by_final_url' )
-			->with( get_permalink( $this->post->ID ) )
-			->willReturn(
-				[
-					AssetFieldType::DESCRIPTION => [ $asset_1, $asset_2, $asset_3, $asset_4, $asset_5 ],
-					AssetFieldType::HEADLINE    => [ $asset_6 ],
-				]
-			);
-
-		$wp_asset                                = $this->format_post_asset_response( $this->post );
-		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ $asset_1['content'], $asset_2['content'], $asset_3['content'], $asset_4['content'], $asset_5['content'] ];
-		$wp_asset[ AssetFieldType::HEADLINE ]    = [ $asset_6['content'], ...$wp_asset[ AssetFieldType::HEADLINE ] ];
-
-		$this->assertEquals( $wp_asset, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
-	}
-
 	public function test_assets_with_logo() {
 		$image_id = $this->get_test_image();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

This PR allows updating the Asset Groups and their assets. The fields that are allowed to be updated in the asset group are:

- The Final URL - The Asset Group final URL.
- Path 1 - The first part of the text that may appear appended to the URL displayed in the ad.
- Path 2 - Second part of the text that may appear appended to the URL displayed in the ad. This field can only be set when path1 is set.
- And their assets.

Assets are [immutable](https://github.com/googleads/google-ads-php/blob/main/src/Google/Ads/GoogleAds/V11/Resources/Asset.php#L22-L25) and are linked to the Asset Group through the `AssetGroupAsset`, this means that in the case of updating an asset it is required to create a new `Asset` and its link in the `AssetGroupAsset`. 

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

### Get an Asset Group ID

1. As the branch `feature/pmax-assets` is using some new imports from the GoogleAds Library, you may need to remove your vendor folder `rm -Rf vendor/*` and install again the dependencies using `composer install`.
2. You can get an asset group id for a specific campaign by making a request to  `/gla/ads/campaigns/YOUR_CAMPAIGN_ID/asset-groups` and get the `id` from the response.


### Update Asset Group

1.  Make a request: `PUT gla/ads/campaigns/asset-groups/Your_AssetGroupID` with a JSON body.  The JSON body can be formed with the following fields:
```
{
"final_url": string, // The final URL and shopping merchant URL needs to have the same domain.
"path1": string,
"path2": string,
"assets": [
   {
      "id": string|null,
      "field_type":  string. // See enums values: https://github.com/woocommerce/google-listings-and-ads/pull/1832/files#diff-387aaa2a15a475b5e67f27d02bb3c638ca8c574f914a880bb4e95b54ce0a751cR236-R245
      "content": string|null. // If the field type is logo|square_marketing_image|marketing_images should be the url.
   }, 
   .... More assets
]
```
- If the `id` is null, it is considered as a new asset.
- If the `content` is null, it is considered as a deleted asset.
- If `id` and `content` are present, the asset will be updated.

4. Check that the Asset Group has been updated. You can check it in the Google Ads interface or call the endpoint: `/gla/ads/campaigns/YOUR_CAMPAIGN_ID/asset-groups`.


### Additional details:
- If there is an image with similar content loaded in the asset group previously, the Ads API will skip it.
- I realize that WCS has a maximum of 1 MB for POST requests, so when we are uploading multiple images, it will fail. The solution is increasing the maximum payload by adding the param `maxBytes` in the following line: https://github.com/Automattic/woocommerce-connect-server/blob/3f51d1ba3b90145137de5390366619621cfcd989/lib/google-proxy/index.js#L56-L58 . I will create a PR to increase this payload size.
- If you are updating images such as `logo`, `square_marketing_image` or `marketing_image` you need to use the right size image. You can use the endpoint `gla/assets/suggestions?id=POST_ID|TERM_ID&type=post|term` and it will suggest images with the right size if the post or the category has images.
- The image URL needs to be accessible. Localhost links may not work.
- See Assets requirements here: https://developers.google.com/google-ads/api/docs/performance-max/assets
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

