### PR TITLE
Use AppButton with extracted Button component

### DIFF
--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button } from 'extracted/@wordpress/components';
 import { Spinner } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import classnames from 'classnames';

--- a/js/src/components/app-button/index.scss
+++ b/js/src/components/app-button/index.scss
@@ -1,32 +1,4 @@
 .app-button {
-	// Hack to show correct font color for disabled primary destructive button.
-	// The color style is copied from https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L67-L72
-	&.is-primary.is-destructive:disabled {
-		color: rgba($white, 0.4);
-	}
-
-	// hack to fix tertiary destructive button.
-	&.is-tertiary.is-destructive {
-		box-shadow: none;
-
-		&:hover:not(:disabled) {
-			box-shadow: none;
-		}
-	}
-
-	&.is-link {
-		text-decoration: none;
-
-		&.is-destructive:focus {
-			box-shadow: none;
-			color: $alert-red;
-
-			&:not(:disabled) {
-				color: $alert-red;
-			}
-		}
-	}
-
 	white-space: nowrap;
 
 	svg {

--- a/js/src/components/app-button/index.scss
+++ b/js/src/components/app-button/index.scss
@@ -1,4 +1,32 @@
 .app-button {
+	// Hack to show correct font color for disabled primary destructive button.
+	// The color style is copied from https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L67-L72
+	&.is-primary.is-destructive:disabled {
+		color: rgba($white, 0.4);
+	}
+
+	// hack to fix tertiary destructive button.
+	&.is-tertiary.is-destructive {
+		box-shadow: none;
+
+		&:hover:not(:disabled) {
+			box-shadow: none;
+		}
+	}
+
+	&.is-link.is-destructive:focus {
+		box-shadow: none;
+		color: $alert-red;
+
+		&:not(:disabled) {
+			color: $alert-red;
+		}
+	}
+
+	&.is-link {
+		text-decoration: none;
+	}
+
 	white-space: nowrap;
 
 	svg {

--- a/js/src/components/app-button/index.scss
+++ b/js/src/components/app-button/index.scss
@@ -14,17 +14,17 @@
 		}
 	}
 
-	&.is-link.is-destructive:focus {
-		box-shadow: none;
-		color: $alert-red;
-
-		&:not(:disabled) {
-			color: $alert-red;
-		}
-	}
-
 	&.is-link {
 		text-decoration: none;
+
+		&.is-destructive:focus {
+			box-shadow: none;
+			color: $alert-red;
+
+			&:not(:disabled) {
+				color: $alert-red;
+			}
+		}
 	}
 
 	white-space: nowrap;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import AppModal from '.~/components/app-modal';
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
@@ -53,7 +53,7 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 							'google-listings-and-ads'
 						) }
 						buttons={ [
-							<Button
+							<AppButton
 								key="save"
 								isPrimary
 								disabled={ ! isValidForm }
@@ -63,7 +63,7 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 									'Add shipping time',
 									'google-listings-and-ads'
 								) }
-							</Button>,
+							</AppButton>,
 						] }
 						onRequestClose={ onRequestClose }
 					>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import GridiconPlusSmall from 'gridicons/dist/plus-small';
@@ -9,6 +8,7 @@ import GridiconPlusSmall from 'gridicons/dist/plus-small';
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import AddTimeModal from './add-time-modal';
 
 /**
@@ -30,13 +30,13 @@ const AddTimeButton = ( props ) => {
 
 	return (
 		<>
-			<Button
+			<AppButton
 				isSecondary
 				icon={ <GridiconPlusSmall /> }
 				onClick={ handleClick }
 			>
 				{ __( 'Add another time', 'google-listings-and-ads' ) }
-			</Button>
+			</AppButton>
 			{ isOpen && (
 				<AddTimeModal
 					onRequestClose={ handleModalRequestClose }

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Form } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import AppModal from '.~/components/app-modal';
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
@@ -74,15 +74,15 @@ const EditTimeModal = ( {
 							'google-listings-and-ads'
 						) }
 						buttons={ [
-							<Button
+							<AppButton
 								key="delete"
 								isTertiary
 								isDestructive
 								onClick={ handleDeleteClick }
 							>
 								{ __( 'Delete', 'google-listings-and-ads' ) }
-							</Button>,
-							<Button
+							</AppButton>,
+							<AppButton
 								key="save"
 								isPrimary
 								disabled={ ! isValidForm }
@@ -92,7 +92,7 @@ const EditTimeModal = ( {
 									'Update shipping time',
 									'google-listings-and-ads'
 								) }
-							</Button>,
+							</AppButton>,
 						] }
 						onRequestClose={ onRequestClose }
 					>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import EditTimeModal from './edit-time-modal';
 import './index.scss';
 
@@ -43,13 +43,13 @@ const EditTimeButton = ( { audienceCountries, time, onChange, onDelete } ) => {
 
 	return (
 		<>
-			<Button
+			<AppButton
 				className="gla-edit-time-button"
 				isTertiary
 				onClick={ handleClick }
 			>
 				{ __( 'Edit', 'google-listings-and-ads' ) }
-			</Button>
+			</AppButton>
 			{ isOpen && (
 				<EditTimeModal
 					audienceCountries={ audienceCountries }

--- a/js/src/components/google-ads-account-card/create-account.js
+++ b/js/src/components/google-ads-account-card/create-account.js
@@ -3,12 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import Section from '.~/wcdl/section';
+import AppButton from '.~/components/app-button';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import CreateAccountButton from './create-account-button';
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
@@ -70,12 +70,12 @@ const CreateAccount = ( props ) => {
 		>
 			{ allowShowExisting && (
 				<Section.Card.Footer>
-					<Button isLink onClick={ onShowExisting }>
+					<AppButton isLink onClick={ onShowExisting }>
 						{ __(
 							'Or, use your existing Google Ads account',
 							'google-listings-and-ads'
 						) }
-					</Button>
+					</AppButton>
 				</Section.Card.Footer>
 			) }
 		</AccountCard>

--- a/js/src/components/google-mc-account-card/create-account-button.js
+++ b/js/src/components/google-mc-account-card/create-account-button.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import WarningModal from './warning-modal';
 import TermsModal from './terms-modal';
 import useExistingGoogleMCAccounts from '.~/hooks/useExistingGoogleMCAccounts';
@@ -41,7 +41,7 @@ const CreateAccountButton = ( props ) => {
 
 	return (
 		<>
-			<Button onClick={ handleCreateAccountClick } { ...rest } />
+			<AppButton onClick={ handleCreateAccountClick } { ...rest } />
 			{ activeModal === MODALS.WARNING && (
 				<WarningModal
 					existingAccount={ matchingDomainAccount }

--- a/js/src/components/google-mc-account-card/disabled-card.js
+++ b/js/src/components/google-mc-account-card/disabled-card.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 
 const DisabledCard = () => {
@@ -15,9 +15,9 @@ const DisabledCard = () => {
 			disabled
 			appearance={ APPEARANCE.GOOGLE_MERCHANT_CENTER }
 			indicator={
-				<Button isSecondary disabled>
+				<AppButton isSecondary disabled>
 					{ __( 'Create account', 'google-listings-and-ads' ) }
-				</Button>
+				</AppButton>
 			}
 		/>
 	);

--- a/js/src/components/pre-launch-check-item/index.js
+++ b/js/src/components/pre-launch-check-item/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	Button,
 	CheckboxControl,
 	Panel,
 	PanelBody,
@@ -15,6 +14,7 @@ import { useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import './index.scss';
 
 const getPanelToggleHandler = ( id ) => ( isOpened ) => {
@@ -60,12 +60,12 @@ export default function PreLaunchCheckItem( {
 				>
 					<PanelRow>
 						{ children }
-						<Button
+						<AppButton
 							isPrimary
 							onClick={ () => setValue( fieldName, true ) }
 						>
 							{ __( 'Confirm', 'google-listings-and-ads' ) }
-						</Button>
+						</AppButton>
 					</PanelRow>
 				</PanelBody>
 			</Panel>

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import GridiconPlusSmall from 'gridicons/dist/plus-small';
 
@@ -9,6 +8,7 @@ import GridiconPlusSmall from 'gridicons/dist/plus-small';
  * Internal dependencies
  */
 import Section from '.~/wcdl/section';
+import AppButton from '.~/components/app-button';
 import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import useStoreCurrency from '.~/hooks/useStoreCurrency';
@@ -101,7 +101,7 @@ export default function EstimatedShippingRatesCard( {
 					<div>
 						<AppButtonModalTrigger
 							button={
-								<Button
+								<AppButton
 									isSecondary
 									icon={ <GridiconPlusSmall /> }
 								>
@@ -109,7 +109,7 @@ export default function EstimatedShippingRatesCard( {
 										'Add another rate',
 										'google-listings-and-ads'
 									) }
-								</Button>
+								</AppButton>
 							}
 							modal={
 								<AddRateFormModal

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/add-rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/add-rate-form-modal.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import RateFormModal from './rate-form-modal.js';
 
 /**
@@ -43,14 +43,14 @@ const AddRateFormModal = ( {
 				};
 
 				return [
-					<Button
+					<AppButton
 						key="submit"
 						isPrimary
 						disabled={ ! isValidForm }
 						onClick={ handleAddClick }
 					>
 						{ __( 'Add shipping rate', 'google-listings-and-ads' ) }
-					</Button>,
+					</AppButton>,
 				];
 			} }
 			onSubmit={ onSubmit }

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/edit-rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/edit-rate-form-modal.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import RateFormModal from './rate-form-modal.js';
 
 /**
@@ -50,15 +50,15 @@ const EditRateFormModal = ( {
 				};
 
 				return [
-					<Button
+					<AppButton
 						key="delete"
 						isTertiary
 						isDestructive
 						onClick={ handleDeleteClick }
 					>
 						{ __( 'Delete', 'google-listings-and-ads' ) }
-					</Button>,
-					<Button
+					</AppButton>,
+					<AppButton
 						key="submit"
 						isPrimary
 						disabled={ ! isValidForm }
@@ -68,7 +68,7 @@ const EditRateFormModal = ( {
 							'Update shipping rate',
 							'google-listings-and-ads'
 						) }
-					</Button>,
+					</AppButton>,
 				];
 			} }
 			onSubmit={ onSubmit }

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
@@ -16,7 +16,7 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import SupportedCountrySelect from '.~/components/supported-country-select';
 
 /**
- * @typedef { import("@wordpress/components").Button } Button
+ * @typedef { import(".~/components/app-button").default } AppButton
  * @typedef { import(".~/data/actions").CountryCode } CountryCode
  * @typedef { import("../typedefs.js").ShippingRateGroup } ShippingRateGroup
  */
@@ -29,7 +29,7 @@ import SupportedCountrySelect from '.~/components/supported-country-select';
  * @param {Object} props
  * @param {Array<CountryCode>} props.countryOptions Array of country codes, to be used as options in SupportedCountrySelect.
  * @param {ShippingRateGroup} props.initialValues Initial values for the form.
- * @param {(formProps: Object) => Array<Button>} props.renderButtons Function to render buttons for the modal. `formProps` will be passed into this render function.
+ * @param {(formProps: Object) => Array<AppButton>} props.renderButtons Function to render buttons for the modal. `formProps` will be passed into this render function.
  * @param {(values: ShippingRateGroup) => void} props.onSubmit Called with submitted value.
  * @param {() => void} props.onRequestClose Callback to close the modal.
  */

--- a/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-form-modals/add-minimum-order-form-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-form-modals/add-minimum-order-form-modal.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import MinimumOrderFormModal from './minimum-order-form-modal';
 
 /**
@@ -46,14 +46,14 @@ const AddMinimumOrderFormModal = ( {
 				};
 
 				return [
-					<Button
+					<AppButton
 						key="save"
 						isPrimary
 						disabled={ ! isValidForm }
 						onClick={ handleAddClick }
 					>
 						{ __( 'Add minimum order', 'google-listings-and-ads' ) }
-					</Button>,
+					</AppButton>,
 				];
 			} }
 			onSubmit={ onSubmit }

--- a/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-form-modals/edit-minimum-order-form-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-form-modals/edit-minimum-order-form-modal.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import MinimumOrderFormModal from './minimum-order-form-modal';
 
 /**
@@ -53,15 +53,15 @@ const EditMinimumOrderFormModal = ( {
 				};
 
 				return [
-					<Button
+					<AppButton
 						key="delete"
 						isTertiary
 						isDestructive
 						onClick={ handleDeleteClick }
 					>
 						{ __( 'Delete', 'google-listings-and-ads' ) }
-					</Button>,
-					<Button
+					</AppButton>,
+					<AppButton
 						key="save"
 						isPrimary
 						disabled={ ! isValidForm }
@@ -71,7 +71,7 @@ const EditMinimumOrderFormModal = ( {
 							'Update minimum order',
 							'google-listings-and-ads'
 						) }
-					</Button>,
+					</AppButton>,
 				];
 			} }
 			onSubmit={ onSubmit }

--- a/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-form-modals/minimum-order-form-modal.js
+++ b/js/src/components/shipping-rate-section/minimum-order-card/minimum-order-form-modals/minimum-order-form-modal.js
@@ -15,7 +15,7 @@ import SupportedCountrySelect from '.~/components/supported-country-select';
 import validateMinimumOrder from './validateMinimumOrder';
 
 /**
- * @typedef { import("@wordpress/components").Button } Button
+ * @typedef { import(".~/components/app-button").default } AppButton
  * @typedef { import(".~/data/actions").CountryCode } CountryCode
  * @typedef { import("../typedefs.js").MinimumOrderGroup } MinimumOrderGroup
  */
@@ -29,7 +29,7 @@ import validateMinimumOrder from './validateMinimumOrder';
  *
  * @param {Object} props Props.
  * @param {Array<CountryCode>} props.countryOptions Array of country codes options, to be used as options in SupportedCountrySelect.
- * @param {(formProps: Object) => Array<Button>} props.renderButtons Function to render buttons for the modal. `formProps` will be passed into this render function.
+ * @param {(formProps: Object) => Array<AppButton>} props.renderButtons Function to render buttons for the modal. `formProps` will be passed into this render function.
  * @param {MinimumOrderGroup} props.initialValues Initial values for the form.
  * @param {(values: MinimumOrderGroup) => void} props.onSubmit Callback when the form is submitted, with the form value.
  * @param {() => void} props.onRequestClose Callback to close the modal.

--- a/js/src/components/tree-select-control/tags.js
+++ b/js/src/components/tree-select-control/tags.js
@@ -4,7 +4,11 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Tag } from '@woocommerce/components';
 import { useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
 
 /**
  * A list of tags to display selected items.
@@ -72,7 +76,7 @@ const Tags = ( {
 			} ) }
 
 			{ maxTags > 0 && tags.length > maxTags && (
-				<Button
+				<AppButton
 					isTertiary
 					className="woocommerce-tree-select-control__show-more"
 					onClick={ () => {
@@ -86,7 +90,7 @@ const Tags = ( {
 								__( '+ %d more', 'google-listing-and-ads' ),
 								tags.length - maxTags
 						  ) }
-				</Button>
+				</AppButton>
 			) }
 		</div>
 	);

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -12,34 +12,6 @@
 }
 
 .components-button {
-	// Hack to show correct font color for disabled primary destructive button.
-	// The color style is copied from https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L67-L72
-	&.is-primary.is-destructive:disabled {
-		color: rgba($white, 0.4);
-	}
-
-	// hack to fix tertiary destructive button.
-	&.is-tertiary.is-destructive {
-		box-shadow: none;
-
-		&:hover:not(:disabled) {
-			box-shadow: none;
-		}
-	}
-
-	&.is-link.is-destructive:focus {
-		box-shadow: none;
-		color: $alert-red;
-
-		&:not(:disabled) {
-			color: $alert-red;
-		}
-	}
-
-	&.is-link {
-		text-decoration: none;
-	}
-
 	// Fix that the panel title is rendered under the button with dropdown arrow.
 	&.components-panel__body-toggle {
 		padding-right: $grid-unit-60;

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -9,6 +9,36 @@
 	// - It's fixed from @woocommerce/components
 	// - or @wordpress/components is changed to be imported via (WC)DEWP
 	@import "node_modules/@wordpress/components/src/date-time/date/datepicker"; /* stylelint-disable-line no-invalid-position-at-import-rule */
+
+	.components-button {
+		// Hack to show correct font color for disabled primary destructive button.
+		// The color style is copied from https://github.com/WordPress/gutenberg/blob/%40wordpress/components%4012.0.8/packages/components/src/button/style.scss#L67-L72
+		&.is-primary.is-destructive:disabled {
+			color: rgba($white, 0.4);
+		}
+
+		// hack to fix tertiary destructive button.
+		&.is-tertiary.is-destructive {
+			box-shadow: none;
+
+			&:hover:not(:disabled) {
+				box-shadow: none;
+			}
+		}
+
+		&.is-link {
+			text-decoration: none;
+
+			&.is-destructive:focus {
+				box-shadow: none;
+				color: $alert-red;
+
+				&:not(:disabled) {
+					color: $alert-red;
+				}
+			}
+		}
+	}
 }
 
 // hack to fix radio button selected style bug caused by woocommerce-admin.

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -11,13 +11,6 @@
 	@import "node_modules/@wordpress/components/src/date-time/date/datepicker"; /* stylelint-disable-line no-invalid-position-at-import-rule */
 }
 
-.components-button {
-	// Fix that the panel title is rendered under the button with dropdown arrow.
-	&.components-panel__body-toggle {
-		padding-right: $grid-unit-60;
-	}
-}
-
 // hack to fix radio button selected style bug caused by woocommerce-admin.
 .components-radio-control__input[type="radio"]:checked::before {
 	border: none;

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -1,5 +1,4 @@
 // Import Gutenberg components that aren't already imported in the lowest WC Admin version we support
-@import "node_modules/@wordpress/components/src/button/style"; // required for tab-panel
 @import "node_modules/@wordpress/components/src/panel/style";
 
 // Scope the old styles of core components to GLA pages to avoid styling conflicts with other non-GLA pages.

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getHistory } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
@@ -10,6 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
+import AppButton from '.~/components/app-button';
 import AppModal from '.~/components/app-modal';
 import './index.scss';
 import { getEditFreeListingsUrl, getEditCampaignUrl } from '.~/utils/urls';
@@ -53,12 +53,16 @@ const EditProgramPromptModal = ( { programId, onRequestClose } ) => {
 			className="gla-edit-program-prompt-modal"
 			title={ __( 'Before you edit…', 'google-listings-and-ads' ) }
 			buttons={ [
-				<Button key="no" isSecondary onClick={ handleDontEditClick }>
+				<AppButton key="no" isSecondary onClick={ handleDontEditClick }>
 					{ __( `Don't edit`, 'google-listings-and-ads' ) }
-				</Button>,
-				<Button key="yes" isPrimary onClick={ handleContinueEditClick }>
+				</AppButton>,
+				<AppButton
+					key="yes"
+					isPrimary
+					onClick={ handleContinueEditClick }
+				>
 					{ __( 'Continue to edit', 'google-listings-and-ads' ) }
-				</Button>,
+				</AppButton>,
 			] }
 			onRequestClose={ onRequestClose }
 		>

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import EditProgramPromptModal from './edit-program-prompt-modal';
 import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
 
@@ -16,9 +16,9 @@ const EditProgramButton = ( props ) => {
 	return (
 		<AppButtonModalTrigger
 			button={
-				<Button isLink>
+				<AppButton isLink>
 					{ __( 'Edit', 'google-listings-and-ads' ) }
-				</Button>
+				</AppButton>
 			}
 			modal={ <EditProgramPromptModal programId={ programId } /> }
 		/>

--- a/js/src/dashboard/all-programs-table-card/program-toggle/pause-program-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/program-toggle/pause-program-modal/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import AppModal from '.~/components/app-modal';
 import './index.scss';
 
@@ -34,12 +34,20 @@ const PauseProgramModal = ( props ) => {
 			className="gla-pause-program-modal"
 			title={ __( 'Before you pause…', 'google-listings-and-ads' ) }
 			buttons={ [
-				<Button key="1" isSecondary onClick={ handleKeepActiveClick }>
+				<AppButton
+					key="1"
+					isSecondary
+					onClick={ handleKeepActiveClick }
+				>
 					{ __( 'Keep Active', 'google-listings-and-ads' ) }
-				</Button>,
-				<Button key="2" isPrimary onClick={ handlePauseCampaignClick }>
+				</AppButton>,
+				<AppButton
+					key="2"
+					isPrimary
+					onClick={ handlePauseCampaignClick }
+				>
 					{ __( 'Pause Campaign', 'google-listings-and-ads' ) }
-				</Button>,
+				</AppButton>,
 			] }
 			onRequestClose={ onRequestClose }
 		>

--- a/js/src/dashboard/all-programs-table-card/remove-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/remove-program-button/index.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import RemoveProgramModal from './remove-program-modal';
 
 const RemoveProgramButton = ( props ) => {
@@ -24,9 +24,9 @@ const RemoveProgramButton = ( props ) => {
 
 	return (
 		<>
-			<Button isDestructive isLink onClick={ handleClick }>
+			<AppButton isDestructive isLink onClick={ handleClick }>
 				{ __( 'Remove', 'google-listings-and-ads' ) }
-			</Button>
+			</AppButton>
 			{ isOpen && (
 				<RemoveProgramModal
 					programId={ programId }

--- a/js/src/dashboard/all-programs-table-card/remove-program-button/remove-program-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/remove-program-button/remove-program-modal/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -47,14 +46,14 @@ const RemoveProgramModal = ( props ) => {
 			title={ __( 'Permanently Remove?', 'google-listings-and-ads' ) }
 			isDismissible={ ! isDeleting }
 			buttons={ [
-				<Button
+				<AppButton
 					key="keep"
 					isSecondary
 					disabled={ isDeleting }
 					onClick={ handleRequestClose }
 				>
 					{ __( 'Keep Campaign', 'google-listings-and-ads' ) }
-				</Button>,
+				</AppButton>,
 				<AppButton
 					key="remove"
 					isPrimary

--- a/js/src/dashboard/campaign-creation-success-guide/index.js
+++ b/js/src/dashboard/campaign-creation-success-guide/index.js
@@ -7,12 +7,12 @@ import {
 	useCallback,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import AppModal from '.~/components/app-modal';
 import GuidePageContent, {
 	ContentLink,
@@ -54,7 +54,7 @@ export default function CampaignCreationSuccessGuide( {
 			className="gla-campaign-creation-success-guide"
 			onRequestClose={ handleRequestClose }
 			buttons={ [
-				<Button
+				<AppButton
 					key="0"
 					isTertiary
 					data-action={ CTA_CREATE_ANOTHER_CAMPAIGN }
@@ -64,15 +64,15 @@ export default function CampaignCreationSuccessGuide( {
 						'Create another campaign',
 						'google-listings-and-ads'
 					) }
-				</Button>,
-				<Button
+				</AppButton>,
+				<AppButton
 					key="1"
 					isPrimary
 					data-action={ CTA_CONFIRM }
 					onClick={ onGuideRequestClose }
 				>
 					{ __( 'Got it', 'google-listings-and-ads' ) }
-				</Button>,
+				</AppButton>,
 			] }
 		>
 			<div className="gla-campaign-creation-success-guide__header-image">

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
@@ -11,6 +10,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import DifferentCurrencyNotice from '.~/components/different-currency-notice';
 import CampaignConversionDashboardNotice from '.~/components/campaign-conversion-notice';
 import NavigationClassic from '.~/components/navigation-classic';
@@ -73,7 +73,7 @@ const Dashboard = () => {
 	const ReportsLink = () => {
 		return (
 			<Link href={ getNewPath( null, '/google/reports' ) }>
-				<Button isPrimary>View Reports</Button>
+				<AppButton isPrimary>View Reports</AppButton>
 			</Link>
 		);
 	};

--- a/js/src/external-components/woocommerce/compare-filter/index.js
+++ b/js/src/external-components/woocommerce/compare-filter/index.js
@@ -9,13 +9,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardFooter,
-	CardHeader,
-} from '@wordpress/components';
+import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
+import { Button } from 'extracted/@wordpress/components';
 import { isEqual, isFunction } from 'lodash';
 import PropTypes from 'prop-types';
 import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';

--- a/js/src/external-components/woocommerce/compare-filter/index.js
+++ b/js/src/external-components/woocommerce/compare-filter/index.js
@@ -9,13 +9,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardFooter,
-	CardHeader,
-} from '@wordpress/components';
+import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
 import { isEqual, isFunction } from 'lodash';
 import PropTypes from 'prop-types';
 import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';
@@ -24,6 +18,7 @@ import { CompareButton, Search } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import Text from '.~/components/app-text';
 
 export { CompareButton };
@@ -123,9 +118,9 @@ class CompareFilter extends Component {
 						{ labels.update }
 					</CompareButton>
 					{ selected.length > 0 && (
-						<Button isLink={ true } onClick={ this.clearQuery }>
+						<AppButton isLink={ true } onClick={ this.clearQuery }>
 							{ __( 'Clear all', 'woocommerce-admin' ) }
-						</Button>
+						</AppButton>
 					) }
 				</CardFooter>
 			</Card>

--- a/js/src/external-components/woocommerce/compare-filter/index.js
+++ b/js/src/external-components/woocommerce/compare-filter/index.js
@@ -9,7 +9,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CardHeader,
+} from '@wordpress/components';
 import { isEqual, isFunction } from 'lodash';
 import PropTypes from 'prop-types';
 import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';
@@ -18,7 +24,6 @@ import { CompareButton, Search } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
 import Text from '.~/components/app-text';
 
 export { CompareButton };
@@ -118,9 +123,9 @@ class CompareFilter extends Component {
 						{ labels.update }
 					</CompareButton>
 					{ selected.length > 0 && (
-						<AppButton isLink={ true } onClick={ this.clearQuery }>
+						<Button isLink={ true } onClick={ this.clearQuery }>
 							{ __( 'Clear all', 'woocommerce-admin' ) }
-						</AppButton>
+						</Button>
 					) }
 				</CardFooter>
 			</Card>

--- a/js/src/external-components/woocommerce/filter-picker/index.js
+++ b/js/src/external-components/woocommerce/filter-picker/index.js
@@ -8,7 +8,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown } from '@wordpress/components';
+import { Button, Dropdown } from '@wordpress/components';
 import { focus } from '@wordpress/dom';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
@@ -36,11 +36,6 @@ import {
 	DropdownButton,
 	Search,
 } from '@woocommerce/components';
-
-/**
- * Internal dependencies
- */
-import AppButton from '.~/components/app-button';
 
 export const DEFAULT_FILTER = 'all';
 
@@ -236,12 +231,12 @@ class FilterPicker extends Component {
 		};
 
 		return (
-			<AppButton
+			<Button
 				className="woocommerce-filters-filter__button"
 				onClick={ onClick }
 			>
 				{ filter.label }
-			</AppButton>
+			</Button>
 		);
 	}
 
@@ -297,13 +292,13 @@ class FilterPicker extends Component {
 								<ul className="woocommerce-filters-filter__content-list">
 									{ parentFilter && (
 										<li className="woocommerce-filters-filter__content-list-item">
-											<AppButton
+											<Button
 												className="woocommerce-filters-filter__button"
 												onClick={ this.goBack }
 											>
 												<Icon icon={ chevronLeft } />
 												{ parentFilter.label }
-											</AppButton>
+											</Button>
 										</li>
 									) }
 									{ visibleFilters.map( ( filter ) => (

--- a/js/src/external-components/woocommerce/filter-picker/index.js
+++ b/js/src/external-components/woocommerce/filter-picker/index.js
@@ -8,7 +8,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Dropdown } from '@wordpress/components';
+import { Dropdown } from '@wordpress/components';
+import { Button } from 'extracted/@wordpress/components';
 import { focus } from '@wordpress/dom';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';

--- a/js/src/external-components/woocommerce/filter-picker/index.js
+++ b/js/src/external-components/woocommerce/filter-picker/index.js
@@ -8,7 +8,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Dropdown } from '@wordpress/components';
+import { Dropdown } from '@wordpress/components';
 import { focus } from '@wordpress/dom';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
@@ -36,6 +36,11 @@ import {
 	DropdownButton,
 	Search,
 } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
 
 export const DEFAULT_FILTER = 'all';
 
@@ -231,12 +236,12 @@ class FilterPicker extends Component {
 		};
 
 		return (
-			<Button
+			<AppButton
 				className="woocommerce-filters-filter__button"
 				onClick={ onClick }
 			>
 				{ filter.label }
-			</Button>
+			</AppButton>
 		);
 	}
 
@@ -292,13 +297,13 @@ class FilterPicker extends Component {
 								<ul className="woocommerce-filters-filter__content-list">
 									{ parentFilter && (
 										<li className="woocommerce-filters-filter__content-list-item">
-											<Button
+											<AppButton
 												className="woocommerce-filters-filter__button"
 												onClick={ this.goBack }
 											>
 												<Icon icon={ chevronLeft } />
 												{ parentFilter.label }
-											</Button>
+											</AppButton>
 										</li>
 									) }
 									{ visibleFilters.map( ( filter ) => (

--- a/js/src/external-components/wordpress/guide/finish-button.js
+++ b/js/src/external-components/wordpress/guide/finish-button.js
@@ -9,11 +9,7 @@
  * External dependencies
  */
 import { useRef, useLayoutEffect } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import AppButton from '.~/components/app-button';
+import { Button } from '@wordpress/components';
 
 export default function FinishButton( props ) {
 	const ref = useRef();
@@ -29,5 +25,5 @@ export default function FinishButton( props ) {
 		}
 	}, [] );
 
-	return <AppButton { ...props } ref={ ref } />;
+	return <Button { ...props } ref={ ref } />;
 }

--- a/js/src/external-components/wordpress/guide/finish-button.js
+++ b/js/src/external-components/wordpress/guide/finish-button.js
@@ -9,7 +9,11 @@
  * External dependencies
  */
 import { useRef, useLayoutEffect } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
 
 export default function FinishButton( props ) {
 	const ref = useRef();
@@ -25,5 +29,5 @@ export default function FinishButton( props ) {
 		}
 	}, [] );
 
-	return <Button { ...props } ref={ ref } />;
+	return <AppButton { ...props } ref={ ref } />;
 }

--- a/js/src/external-components/wordpress/guide/finish-button.js
+++ b/js/src/external-components/wordpress/guide/finish-button.js
@@ -9,7 +9,7 @@
  * External dependencies
  */
 import { useRef, useLayoutEffect } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Button } from 'extracted/@wordpress/components';
 
 export default function FinishButton( props ) {
 	const ref = useRef();

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -11,12 +11,11 @@
 import classnames from 'classnames';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Modal, KeyboardShortcuts } from '@wordpress/components';
+import { Modal, KeyboardShortcuts, Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
 import PageControl from './page-control';
 import FinishButton from './finish-button';
 
@@ -120,20 +119,20 @@ export default function Guide( {
 
 				<div className="components-guide__footer">
 					{ canGoBack && (
-						<AppButton
+						<Button
 							className="components-guide__back-button"
 							onClick={ goBack }
 						>
 							{ backButtonText || __( 'Previous' ) }
-						</AppButton>
+						</Button>
 					) }
 					{ canGoForward && (
-						<AppButton
+						<Button
 							className="components-guide__forward-button"
 							onClick={ goForward }
 						>
 							{ __( 'Next' ) }
-						</AppButton>
+						</Button>
 					) }
 					{ finishBlock }
 				</div>

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -11,11 +11,12 @@
 import classnames from 'classnames';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Modal, KeyboardShortcuts, Button } from '@wordpress/components';
+import { Modal, KeyboardShortcuts } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import PageControl from './page-control';
 import FinishButton from './finish-button';
 
@@ -119,20 +120,20 @@ export default function Guide( {
 
 				<div className="components-guide__footer">
 					{ canGoBack && (
-						<Button
+						<AppButton
 							className="components-guide__back-button"
 							onClick={ goBack }
 						>
 							{ backButtonText || __( 'Previous' ) }
-						</Button>
+						</AppButton>
 					) }
 					{ canGoForward && (
-						<Button
+						<AppButton
 							className="components-guide__forward-button"
 							onClick={ goForward }
 						>
 							{ __( 'Next' ) }
-						</Button>
+						</AppButton>
 					) }
 					{ finishBlock }
 				</div>

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -11,7 +11,8 @@
 import classnames from 'classnames';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Modal, KeyboardShortcuts, Button } from '@wordpress/components';
+import { Modal, KeyboardShortcuts } from '@wordpress/components';
+import { Button } from 'extracted/@wordpress/components';
 
 /**
  * Internal dependencies

--- a/js/src/external-components/wordpress/guide/page-control.js
+++ b/js/src/external-components/wordpress/guide/page-control.js
@@ -10,11 +10,11 @@
  */
 import { times } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
 import { PageControlIcon } from './icons';
 
 export default function PageControl( {
@@ -33,7 +33,7 @@ export default function PageControl( {
 					// Set aria-current="step" on the active page, see https://www.w3.org/TR/wai-aria-1.1/#aria-current
 					aria-current={ page === currentPage ? 'step' : undefined }
 				>
-					<AppButton
+					<Button
 						key={ page }
 						icon={
 							<PageControlIcon

--- a/js/src/external-components/wordpress/guide/page-control.js
+++ b/js/src/external-components/wordpress/guide/page-control.js
@@ -10,11 +10,11 @@
  */
 import { times } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import { PageControlIcon } from './icons';
 
 export default function PageControl( {
@@ -33,7 +33,7 @@ export default function PageControl( {
 					// Set aria-current="step" on the active page, see https://www.w3.org/TR/wai-aria-1.1/#aria-current
 					aria-current={ page === currentPage ? 'step' : undefined }
 				>
-					<Button
+					<AppButton
 						key={ page }
 						icon={
 							<PageControlIcon

--- a/js/src/external-components/wordpress/guide/page-control.js
+++ b/js/src/external-components/wordpress/guide/page-control.js
@@ -10,7 +10,7 @@
  */
 import { times } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'extracted/@wordpress/components';
 
 /**
  * Internal dependencies

--- a/js/src/product-feed/product-feed-table-card/edit-visibility-action.js
+++ b/js/src/product-feed/product-feed-table-card/edit-visibility-action.js
@@ -3,13 +3,14 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { Button, Icon } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { SelectControl } from '@woocommerce/components';
 import { edit as editIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import AppTooltip from '.~/components/app-tooltip';
 
 const tipText = __( 'Select channel visibility', 'google-listings-and-ads' );
@@ -90,7 +91,7 @@ export default function EditVisibilityAction( {
 				position="top center"
 				text={ tipText }
 			>
-				<Button
+				<AppButton
 					isSecondary
 					disabled={ selectedVisible === null }
 					onClick={ handleClick }
@@ -100,7 +101,7 @@ export default function EditVisibilityAction( {
 						__( 'Apply to %d selected', 'google-listings-and-ads' ),
 						selectedSize
 					) }
-				</Button>
+				</AppButton>
 			</ConditionalTooltip>
 		</>
 	);

--- a/js/src/product-feed/review-request/review-request-issues.js
+++ b/js/src/product-feed/review-request/review-request-issues.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
@@ -9,6 +8,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import Text from '.~/components/app-text';
 
 const COLLAPSED_ISSUES_SIZE = 5;
@@ -42,7 +42,7 @@ const ReviewRequestIssues = ( { issues = [] } ) => {
 				) ) }
 			</ul>
 			{ issues.length > COLLAPSED_ISSUES_SIZE && (
-				<Button isTertiary onClick={ toggleExpanded }>
+				<AppButton isTertiary onClick={ toggleExpanded }>
 					{ expanded
 						? __( 'Show less', 'google-listing-and-ads' )
 						: sprintf(
@@ -53,7 +53,7 @@ const ReviewRequestIssues = ( { issues = [] } ) => {
 								),
 								issues.length - COLLAPSED_ISSUES_SIZE
 						  ) }
-				</Button>
+				</AppButton>
 			) }
 		</>
 	);

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -8,7 +8,6 @@ import {
 	useCallback,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -18,6 +17,7 @@ import Guide from '.~/external-components/wordpress/guide';
 import GuidePageContent, {
 	ContentLink,
 } from '.~/components/guide-page-content';
+import AppButton from '.~/components/app-button';
 import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
 import { glaData, GUIDE_NAMES, LOCAL_STORAGE_KEYS } from '.~/constants';
 import localStorage from '.~/utils/localStorage';
@@ -169,26 +169,26 @@ const SubmissionSuccessGuide = () => {
 	const renderFinish = useCallback( () => {
 		if ( glaData.adsSetupComplete ) {
 			return (
-				<Button
+				<AppButton
 					isPrimary
 					data-action="view-product-feed"
 					onClick={ handleGuideFinish }
 				>
 					{ __( 'View product feed', 'google-listings-and-ads' ) }
-				</Button>
+				</AppButton>
 			);
 		}
 
 		return (
 			<>
 				<div className="gla-submission-success-guide__space_holder" />
-				<Button
+				<AppButton
 					isSecondary
 					data-action="maybe-later"
 					onClick={ handleGuideFinish }
 				>
 					{ __( 'Maybe later', 'google-listings-and-ads' ) }
-				</Button>
+				</AppButton>
 				<AddPaidCampaignButton
 					isPrimary
 					isSecondary={ false }

--- a/js/src/reports/compare-table-card.js
+++ b/js/src/reports/compare-table-card.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
-import { CheckboxControl, Button } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { onQueryChange } from '@woocommerce/navigation';
 
 /**
@@ -11,6 +11,7 @@ import { onQueryChange } from '@woocommerce/navigation';
  */
 import { getIdsFromQuery } from './utils';
 import useUrlQuery from '.~/hooks/useUrlQuery';
+import AppButton from '.~/components/app-button';
 import AppTableCard from '.~/components/app-table-card';
 
 /**
@@ -176,14 +177,14 @@ const CompareTableCard = ( {
 	return (
 		<AppTableCard
 			actions={
-				<Button
+				<AppButton
 					isSecondary
 					disabled={ isLoading || selectedRows.size <= 1 }
 					title={ compareButonTitle }
 					onClick={ compareSelected }
 				>
 					{ __( 'Compare', 'google-listings-and-ads' ) }
-				</Button>
+				</AppButton>
 			}
 			isLoading={ isLoading }
 			headers={ getHeaders( data ) }

--- a/js/src/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/settings/disconnect-modal/confirm-modal.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, CheckboxControl } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 /**
@@ -116,14 +116,14 @@ export default function ConfirmModal( {
 			}
 			isDismissible={ ! isDisconnecting }
 			buttons={ [
-				<Button
+				<AppButton
 					key="1"
 					isSecondary
 					disabled={ isDisconnecting }
 					onClick={ handleRequestClose }
 				>
 					{ __( 'Never mind', 'google-listings-and-ads' ) }
-				</Button>,
+				</AppButton>,
 				<AppButton
 					key="2"
 					isPrimary

--- a/js/src/settings/linked-accounts.js
+++ b/js/src/settings/linked-accounts.js
@@ -3,7 +3,7 @@
  */
 import { queueRecordEvent } from '@woocommerce/tracks';
 import { __ } from '@wordpress/i18n';
-import { Flex, Button } from '@wordpress/components';
+import { Flex } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 /**
@@ -15,6 +15,7 @@ import useJetpackAccount from '.~/hooks/useJetpackAccount';
 import useGoogleAccount from '.~/hooks/useGoogleAccount';
 import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
+import AppButton from '.~/components/app-button';
 import SpinnerCard from '.~/components/spinner-card';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import { ConnectedWPComAccountCard } from '.~/components/wpcom-account-card';
@@ -102,7 +103,7 @@ export default function LinkedAccounts() {
 							hideAccountSwitch
 						>
 							<Section.Card.Footer>
-								<Button
+								<AppButton
 									isDestructive
 									isLink
 									onClick={ openDisconnectAdsAccountModal }
@@ -111,12 +112,12 @@ export default function LinkedAccounts() {
 										'Disconnect Google Ads account only',
 										'google-listings-and-ads'
 									) }
-								</Button>
+								</AppButton>
 							</Section.Card.Footer>
 						</ConnectedGoogleAdsAccountCard>
 					) }
 					<Flex justify="flex-end">
-						<Button
+						<AppButton
 							isPrimary
 							isDestructive
 							onClick={ openDisconnectAllAccountsModal }
@@ -125,7 +126,7 @@ export default function LinkedAccounts() {
 								'Disconnect from all accounts',
 								'google-listings-and-ads'
 							) }
-						</Button>
+						</AppButton>
 					</Flex>
 				</VerticalGapLayout>
 			) }

--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import AppButton from '.~/components/app-button';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
@@ -65,13 +65,13 @@ const SetupAccounts = ( props ) => {
 				</VerticalGapLayout>
 			</Section>
 			<StepContentFooter>
-				<Button
+				<AppButton
 					isPrimary
 					disabled={ isContinueButtonDisabled }
 					onClick={ onContinue }
 				>
 					{ __( 'Continue', 'google-listings-and-ads' ) }
-				</Button>
+				</AppButton>
 			</StepContentFooter>
 		</StepContent>
 	);

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 
@@ -11,6 +10,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import useJetpackAccount from '.~/hooks/useJetpackAccount';
 import useGoogleAccount from '.~/hooks/useGoogleAccount';
 import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
+import AppButton from '.~/components/app-button';
 import AppSpinner from '.~/components/app-spinner';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
@@ -142,13 +142,13 @@ const SetupAccounts = ( props ) => {
 				<Faqs />
 			</Section>
 			<StepContentFooter>
-				<Button
+				<AppButton
 					isPrimary
 					disabled={ isContinueButtonDisabled }
 					onClick={ onContinue }
 				>
 					{ __( 'Continue', 'google-listings-and-ads' ) }
-				</Button>
+				</AppButton>
 			</StepContentFooter>
 		</StepContent>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/google-listings-and-ads/issues/1765, and partly addresses https://github.com/woocommerce/google-listings-and-ads/issues/1391.

In this PR, we move from using bundled Button component to using extracted Button component from the `@wordpress/components` package, and remove the usage of `@import "node_modules/@wordpress/components/src/button/style";` in `_gutenberg-components.scss`.

All `<Button>` usages are now changed to `<AppButton>`, including the usages in the `external-components` directory. AppButton is essentially a wrapper around Button. In the future, if there are breaking changes in Button, we just need to apply the fix in AppButton and it should work throughout the whole plugin.

In `_gutenberg-components.scss` file, there were some hacks or fixes under `.components-button` rule. I tested them and they are different from the default `@wordpress/components` button style. The video recording below shows the difference of the button styles in WooCommerce Marketing page and in GLA page:

<details>
	<summary>Sample code for testing button styles used in the video below</summary>

```jsx
<AppButton variant="primary" isDestructive disabled>
	primary destructive disabled
</AppButton>
<AppButton variant="tertiary" isDestructive>
	tertiary destructive
</AppButton>
<AppButton variant="tertiary" isDestructive>
	tertiary destructive hover not disabled
</AppButton>
<AppButton
	variant="link"
	href="https://www.example.com"
	isDestructive
>
	link destructive focus
</AppButton>
<AppButton
	variant="link"
	href="https://www.example.com"
	isDestructive
>
	link destructive focus not disabled
</AppButton>
<AppButton variant="link" href="https://www.example.com">
	link
</AppButton>
```
</details>

https://user-images.githubusercontent.com/417342/210098694-5210c7de-77e4-4c9b-a80e-44984e357b05.mov

To maintain UI appearance in GLA, I have moved the above button styles to AppButton CSS. 

For the `components-panel__body-toggle`'s `padding-right` fix, it seems like it is not needed, so I have removed it. It was introduced in [`2228fa5` (#1708)](https://github.com/woocommerce/google-listings-and-ads/pull/1708/commits/2228fa50828c8ebc0ba235b604385e96e954ddc1) (heads up to the PR author @eason9487). Screenshot below shows the panel without the `padding-right` fix, and it appears to be working as expected without UI issue:

![image](https://user-images.githubusercontent.com/417342/210096240-f855d670-474e-42ec-854f-78e25d647cf5.png)

With the button style no longer bundled and needed, this fixes the CSS issue in non-GLA pages mentioned in https://github.com/woocommerce/google-listings-and-ads/issues/1765.

### Screenshots:

Screenshot of WooCommerce Marketing page, without button style conflict from GLA:

![image](https://user-images.githubusercontent.com/417342/210094900-115a6abd-45cb-4d95-b28c-49c53a179d01.png)

### Detailed test instructions:

1. Buttons in GLA should continue to appear the same as before, and work as expected.
2. Enable WooCommerce Multichannel Marketing experience in WooCommerce Settings > Advanced > Features page: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
3. Go to WooCommerce Marketing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`
4. The expand/collapse button in "Discover more marketing tools" card should appear as normal size, not in tiny size.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Use extracted Button component from @wordpress/components package.
