### PR TITLE
i18n for View Reports button

### DIFF
--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -73,7 +73,9 @@ const Dashboard = () => {
 	const ReportsLink = () => {
 		return (
 			<Link href={ getNewPath( null, '/google/reports' ) }>
-				<Button isPrimary>View Reports</Button>
+				<Button isPrimary>
+					{ __( 'View Reports', 'google-listings-and-ads' ) }
+				</Button>
 			</Link>
 		);
 	};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The "View Reports" button in the dashboard page was not wrapped in i18n function, so the text cannot be translated.

In this PR, we wrapped the text with i18n function `__()`, so that it can be translated.

### Screenshots:

![image](https://user-images.githubusercontent.com/417342/210100393-e66a7ea1-1b61-414f-bbb1-d6ae5be8e3b0.png)

### Detailed test instructions:

1. Run `npm run i18n`.
2. Look into the generated `languages/google-listings-and-ads.pot` file. There should be a line with "View Reports".

### Additional details:

I found this when I was working on PR https://github.com/woocommerce/google-listings-and-ads/pull/1834.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - i18n for "View Reports" button.
