### PR TITLE
Fetch assets from other Asset Groups using the final url

### DIFF
--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -119,33 +119,39 @@ class AdsAsset implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Convert Asset data to an array.
+	 * Returns the asset content for the given row.
 	 *
 	 * @param GoogleAdsRow $row Data row returned from a query request.
 	 *
-	 * @return array
+	 * @return string The asset content.
 	 */
-	public function convert_asset( GoogleAdsRow $row ): array {
+	public function get_asset_content( GoogleAdsRow $row ): string {
 		/** @var Asset $asset */
 		$asset = $row->getAsset();
 
 		switch ( $asset->getType() ) {
 			case AssetType::IMAGE:
-				$data = $asset->getImageAsset()->getFullSize()->getUrl();
-				break;
+				return $asset->getImageAsset()->getFullSize()->getUrl();
 			case AssetType::TEXT:
-				$data = $asset->getTextAsset()->getText();
-				break;
+				return $asset->getTextAsset()->getText();
 			case AssetType::CALL_TO_ACTION:
-				$data = CallToActionType::label( $asset->getCallToActionAsset()->getCallToAction() );
-				break;
+				return CallToActionType::label( $asset->getCallToActionAsset()->getCallToAction() );
 			default:
-				$data = '';
+				return '';
 		}
+	}
 
+	/**
+	 * Convert Asset data to an array.
+	 *
+	 * @param GoogleAdsRow $row Data row returned from a query request.
+	 *
+	 * @return array The asset data converted.
+	 */
+	public function convert_asset( GoogleAdsRow $row ): array {
 		return [
-			'id'      => $asset->getId(),
-			'content' => $data,
+			'id'      => $row->getAsset()->getId(),
+			'content' => $this->get_asset_content( $row ),
 		];
 	}
 }

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -125,7 +125,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 *
 	 * @return string The asset content.
 	 */
-	public function get_asset_content( GoogleAdsRow $row ): string {
+	protected function get_asset_content( GoogleAdsRow $row ): string {
 		/** @var Asset $asset */
 		$asset = $row->getAsset();
 

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -146,9 +146,11 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		try {
 
 			$asset_group_assets = [];
-			$asset_results      = ( new AdsAssetGroupAssetQuery() )
+
+			// Search urls with and without trailing slash.
+			$asset_results = ( new AdsAssetGroupAssetQuery() )
 				->set_client( $this->client, $this->options->get_ads_id() )
-				->where( 'asset_group.final_urls', [ $url ], 'CONTAINS ANY' )
+				->where( 'asset_group.final_urls', [ rtrim( $url, '/' ), rtrim( $url, '/' ) . '/' ], 'CONTAINS ANY' )
 				->where( 'asset_group_asset.field_type', $this->get_asset_field_types_query(), 'IN' )
 				->where( 'asset_group_asset.status', 'REMOVED', '!=' )
 				->get_results();

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -142,7 +142,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * @return array The assets for the asset groups with a specific final url.
 	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
-	public function get_assets_by_url( string $url ): array {
+	public function get_assets_by_final_url( string $url ): array {
 		try {
 
 			$asset_group_assets = [];
@@ -170,7 +170,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			$errors = $this->get_api_exception_errors( $e );
 			throw new ExceptionWithResponseData(
 				/* translators: %s Error message */
-				sprintf( __( 'Error retrieving asset groups assets: %s', 'google-listings-and-ads' ), reset( $errors ) ),
+				sprintf( __( 'Error retrieving asset groups assets by final url: %s', 'google-listings-and-ads' ), reset( $errors ) ),
 				$this->map_grpc_code_to_http_status_code( $e ),
 				null,
 				[ 'errors' => $errors ]

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -151,7 +151,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			$asset_results = ( new AdsAssetGroupAssetQuery() )
 				->set_client( $this->client, $this->options->get_ads_id() )
 				->add_columns( [ 'asset_group.id', 'asset_group.path1', 'asset_group.path2' ] )
-				->where( 'asset_group.final_urls', [ rtrim( $url, '/' ), rtrim( $url, '/' ) . '/' ], 'CONTAINS ANY' )
+				->where( 'asset_group.final_urls', [ trailingslashit( $url ), untrailingslashit( $url ) ], 'CONTAINS ANY' )
 				->where( 'asset_group_asset.field_type', $this->get_asset_field_types_query(), 'IN' )
 				->where( 'asset_group_asset.status', 'REMOVED', '!=' )
 				->get_results();

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -138,11 +138,12 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * Get Assets for specific final URL.
 	 *
 	 * @param string $url The final url.
+	 * @param bool   $only_first_asset_group Whether to return only the first asset group found.
 	 *
 	 * @return array The assets for the asset groups with a specific final url.
 	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
-	public function get_assets_by_final_url( string $url ): array {
+	public function get_assets_by_final_url( string $url, bool $only_first_asset_group = false ): array {
 		try {
 
 			$asset_group_assets = [];
@@ -176,6 +177,10 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 					$row->getAssetGroup()->getPath1(),
 					$row->getAssetGroup()->getPath2(),
 				];
+			}
+
+			if ( $only_first_asset_group ) {
+				return reset( $asset_group_assets ) ?: [];
 			}
 
 			return $asset_group_assets;

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -162,7 +162,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				$asset_group_asset = $row->getAssetGroupAsset();
 
 				$field_type                          = AssetFieldType::label( $asset_group_asset->getFieldType() );
-				$asset_group_assets[ $field_type ][] = $this->asset->get_asset_content( $row );
+				$asset_group_assets[ $field_type ][] = $this->asset->convert_asset( $row );
 			}
 
 			return $asset_group_assets;

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -150,6 +150,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			// Search urls with and without trailing slash.
 			$asset_results = ( new AdsAssetGroupAssetQuery() )
 				->set_client( $this->client, $this->options->get_ads_id() )
+				->add_columns( [ 'asset_group.path1', 'asset_group.path2' ] )
 				->where( 'asset_group.final_urls', [ rtrim( $url, '/' ), rtrim( $url, '/' ) . '/' ], 'CONTAINS ANY' )
 				->where( 'asset_group_asset.field_type', $this->get_asset_field_types_query(), 'IN' )
 				->where( 'asset_group_asset.status', 'REMOVED', '!=' )
@@ -161,8 +162,19 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				/** @var AssetGroupAsset $asset_group_asset */
 				$asset_group_asset = $row->getAssetGroupAsset();
 
-				$field_type                          = AssetFieldType::label( $asset_group_asset->getFieldType() );
-				$asset_group_assets[ $field_type ][] = $this->asset->convert_asset( $row );
+				$field_type = AssetFieldType::label( $asset_group_asset->getFieldType() );
+				switch ( $field_type ) {
+					case AssetFieldType::BUSINESS_NAME:
+					case AssetFieldType::CALL_TO_ACTION_SELECTION:
+						$asset_group_assets[ $field_type ] = $this->asset->convert_asset( $row )['content'];
+						break;
+					default:
+						$asset_group_assets[ $field_type ][] = $this->asset->convert_asset( $row )['content'];
+				}
+
+				$asset_group_assets = $this->add_url_paths( $row->getAssetGroup()->getPath1(), $asset_group_assets );
+				$asset_group_assets = $this->add_url_paths( $row->getAssetGroup()->getPath2(), $asset_group_assets );
+
 			}
 
 			return $asset_group_assets;
@@ -178,6 +190,25 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				[ 'errors' => $errors ]
 			);
 		}
+
+	}
+
+	/**
+	 * Add url path to asset group assets.
+	 *
+	 * @param string $path The url path.
+	 * @param array  $asset_group_assets The asset group assets.
+	 * @param int    $max_number The max number of url paths to add.
+	 *
+	 * @return array The asset group assets.
+	 */
+	protected function add_url_paths( string $path, array $asset_group_assets, int $max_number = 2 ): array {
+		if ( count( $asset_group_assets['display_url_path'] ?? [] ) >= $max_number || in_array( $path, $asset_group_assets['display_url_path'] ?? [], true ) ) {
+			return $asset_group_assets;
+		}
+
+		$asset_group_assets['display_url_path'][] = $path;
+		return $asset_group_assets;
 
 	}
 

--- a/src/API/Google/Query/Query.php
+++ b/src/API/Google/Query/Query.php
@@ -238,6 +238,7 @@ abstract class Query implements QueryInterface {
 			case 'NOT IN':
 			case 'BETWEEN':
 			case 'IS NOT NULL':
+			case 'CONTAINS ANY':
 				// These are all valid.
 				return;
 
@@ -319,7 +320,7 @@ abstract class Query implements QueryInterface {
 			$column  = $where['column'];
 			$compare = $where['compare'];
 
-			if ( 'IN' === $compare || 'NOT_IN' === $compare ) {
+			if ( 'IN' === $compare || 'NOT_IN' === $compare || 'CONTAINS ANY' === $compare ) {
 				$value = sprintf(
 					"('%s')",
 					join(

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -169,12 +169,10 @@ class AssetSuggestionsService implements Service {
 	protected function get_asset_group_asset_suggestions( int $id, string $type ): array {
 		$final_url = $this->get_url( $id, $type );
 
-		$assets = array_values( $this->asset_group_asset->get_assets_by_final_url( $final_url ) );
-
 		// Suggest the assets from the first asset group if exists.
-		$asset_group_assets = array_shift( $assets );
+		$asset_group_assets = $this->asset_group_asset->get_assets_by_final_url( $final_url, true );
 
-		if ( $asset_group_assets === null ) {
+		if ( empty( $asset_group_assets ) ) {
 			return [];
 		}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -174,21 +174,27 @@ class AssetSuggestionsService implements Service {
 	 */
 	protected function combine_results_wp_assets_groups( array $asset_group_assets, array $wp_assets ): array {
 		foreach ( $asset_group_assets as $key => $value ) {
+			$contents = array_column( $value, 'content' );
 			switch ( $key ) {
 				case AssetFieldType::HEADLINE:
 				case AssetFieldType::LONG_HEADLINE:
 				case AssetFieldType::DESCRIPTION:
 				case AssetFieldType::SQUARE_MARKETING_IMAGE:
 				case AssetFieldType::MARKETING_IMAGE:
-					// Add the assets if we have less than the maximum allowed.
-					if ( count( $asset_group_assets[ $key ] ) < self::FIELD_TYPE_REQUIREMENTS[ $key ]['max'] ) {
-						$wp_assets[ $key ] = array_merge( $value, $wp_assets[ $key ] ?? [] );
+				case AssetFieldType::LOGO:
+					// if we have less than the maximum allowed, add more assets from the WP assets.
+					if ( count( $contents ) < self::FIELD_TYPE_REQUIREMENTS[ $key ]['max'] ) {
+						$wp_assets[ $key ] = array_merge( $contents, $wp_assets[ $key ] ?? [] );
 						break;
 					}
-					$wp_assets[ $key ] = $value;
+					$wp_assets[ $key ] = $contents;
+					break;
+				case AssetFieldType::BUSINESS_NAME:
+				case AssetFieldType::CALL_TO_ACTION_SELECTION:
+					$wp_assets[ $key ] = $contents[0] ?? $wp_assets[ $key ] ?? '';
 					break;
 				default:
-					$wp_assets[ $key ] = $value;
+					$wp_assets[ $key ] = $contents;
 			}
 		}
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -144,6 +144,10 @@ class AssetSuggestionsService implements Service {
 			$final_url = get_term_link( $id );
 		}
 
+		if ( $final_url === false || is_wp_error( $final_url ) ) {
+			return [];
+		}
+
 		$assets = $this->asset_group_asset->get_assets_by_final_url( $final_url );
 
 		if ( empty( $assets ) ) {

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -120,13 +120,37 @@ class AssetSuggestionsService implements Service {
 	 * @param int    $id Post or Term ID.
 	 * @param string $type Only possible values are post or term.
 	 */
-	public function get_assets_suggestions( int $id, string $type ): array {
+	public function get_assets_suggestions( $id, string $type ): array {
 		$wp_assets = $this->get_wp_assets( $id, $type );
-		$url       = $wp_assets['final_url'];
 
-		$assets_from_other_campaings = $this->asset_group_asset->get_assets_by_url( $url );
+		return $this->combine_results_wp_assets_groups( $wp_assets, $this->asset_group_asset->get_assets_by_url( $wp_assets['final_url'] ) );
+	}
 
-		return array_merge( $wp_assets, $assets_from_other_campaings );
+	/**
+	 * Combine the results from the WP assets and the assets from other campaigns.
+	 *
+	 * @param array $wp_assets The WordPress Assets .
+	 * @param array $asset_group_assets The Asset Group Assets.
+	 *
+	 * @return array The combined results.
+	 */
+	protected function combine_results_wp_assets_groups( array $wp_assets, array $asset_group_assets ): array {
+		foreach ( $wp_assets as $key => $value ) {
+			switch ( $key ) {
+
+				case AssetFieldType::HEADLINE:
+				case AssetFieldType::LONG_HEADLINE:
+				case AssetFieldType::DESCRIPTION:
+				case AssetFieldType::SQUARE_MARKETING_IMAGE:
+				case AssetFieldType::MARKETING_IMAGE:
+					$wp_assets[ $key ] = array_merge( $value, $asset_group_assets[ $key ] ?? [] );
+					break;
+				default:
+					$wp_assets[ $key ] = $value;
+			}
+		}
+
+		return $wp_assets;
 	}
 
 	/**

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -121,7 +121,7 @@ class AssetSuggestionsService implements Service {
 	 * @param int    $id Post or Term ID.
 	 * @param string $type Only possible values are post or term.
 	 */
-	public function get_assets_suggestions( $id, string $type ): array {
+	public function get_assets_suggestions( int $id, string $type ): array {
 		$asset_group_assets = $this->get_asset_group_asset_suggestions( $id, $type );
 
 		if ( ! empty( $asset_group_assets ) ) {

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -216,7 +216,7 @@ class AssetSuggestionsService implements Service {
 
 		if ( ! $post || $post->post_status === 'trash' ) {
 			throw new Exception(
-			/* translators: 1: is an integer representing an unknown Post ID */
+				/* translators: 1: is an integer representing an unknown Post ID */
 				sprintf( __( 'Invalid Post ID %1$d', 'google-listings-and-ads' ), $id )
 			);
 		}
@@ -267,7 +267,7 @@ class AssetSuggestionsService implements Service {
 
 		if ( ! $term ) {
 			throw new Exception(
-			/* translators: 1: is an integer representing an unknown Term ID */
+				/* translators: 1: is an integer representing an unknown Term ID */
 				sprintf( __( 'Invalid Term ID %1$d', 'google-listings-and-ads' ), $id )
 			);
 		}

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -150,6 +150,10 @@ class AssetSuggestionsService implements Service {
 			return [];
 		}
 
+		if ( ! isset( $assets[ AssetFieldType::CALL_TO_ACTION_SELECTION ] ) ) {
+			$assets[ AssetFieldType::CALL_TO_ACTION_SELECTION ] = null;
+		}
+
 		return array_merge( [ 'final_url' => $final_url ], $assets );
 
 	}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection as GoogleC
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroupAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\RESTControllers;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
@@ -250,7 +251,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getLeagueContainer()
 			 ->inflector( AdsAwareInterface::class )
 			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
-		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class );
+		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class, AdsAssetGroupAsset::class );
 
 		// Set up the installer.
 		$installer_definition = $this->share_with_tags(

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -669,6 +669,8 @@ trait GoogleAdsClientTrait {
 
 		$asset_group = $this->createMock( AssetGroup::class );
 		$asset_group->method( 'getId' )->willReturn( $data['asset_group_id'] );
+		$asset_group->method( 'getPath1' )->willReturn( $data['path1'] ?? '' );
+		$asset_group->method( 'getPath2' )->willReturn( $data['path2'] ?? '' );
 
 		return ( new GoogleAdsRow() )
 			->setAssetGroupAsset( $asset_group_asset )

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -126,21 +126,26 @@ class AdsAssetGroupAssetTest extends UnitTest {
 				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
 				'field_type'     => AssetFieldType::number( AssetFieldType::DESCRIPTION ),
 				'asset'          => array_merge( $asset_1, [ 'type' => AssetType::TEXT ] ),
+				'path1'          => 'path1',
+				'path2'          => 'path2',
 			],
 			[
 				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
 				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
 				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
+				'path1'          => 'path11',
+				'path2'          => 'path22',
 			],
 		];
 
 		$expected = [
 			AssetFieldType::DESCRIPTION     => [
-				$asset_1,
+				$asset_1['content'],
 			],
 			AssetFieldType::MARKETING_IMAGE => [
-				$asset_2,
+				$asset_2['content'],
 			],
+			'display_url_path'              => [ 'path1', 'path2' ],
 		];
 
 		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -130,7 +130,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 				'path2'          => 'path2',
 			],
 			[
-				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID_2,
 				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
 				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
 				'path1'          => 'path11',
@@ -139,13 +139,19 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		];
 
 		$expected = [
-			AssetFieldType::DESCRIPTION     => [
-				$asset_1['content'],
+			self::TEST_ASSET_GROUP_ID   => [
+				AssetFieldType::DESCRIPTION => [
+					$asset_1['content'],
+				],
+				'display_url_path'          => [ 'path1', 'path2' ],
 			],
-			AssetFieldType::MARKETING_IMAGE => [
-				$asset_2['content'],
+			self::TEST_ASSET_GROUP_ID_2 => [
+				AssetFieldType::MARKETING_IMAGE => [
+					$asset_2['content'],
+				],
+				'display_url_path'              => [ 'path11', 'path22' ],
 			],
-			'display_url_path'              => [ 'path1', 'path2' ],
+
 		];
 
 		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -159,6 +159,50 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 	}
 
+	public function test_get_asset_groups_assets_by_final_url_firt_result() {
+		$asset_1 = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => 'Test Asset',
+		];
+
+		$asset_2 = [
+			'id'      => self::TEST_ASSET_ID_2,
+			'content' => 'https://example.com/image.jpg',
+		];
+
+		$this->asset->expects( $this->exactly( 2 ) )
+		->method( 'convert_asset' )
+		->willReturnOnConsecutiveCalls( $asset_1, $asset_2 );
+
+		$asset_group_asset_data = [
+			[
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
+				'field_type'     => AssetFieldType::number( AssetFieldType::DESCRIPTION ),
+				'asset'          => array_merge( $asset_1, [ 'type' => AssetType::TEXT ] ),
+				'path1'          => 'path1',
+				'path2'          => 'path2',
+			],
+			[
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID_2,
+				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
+				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
+				'path1'          => 'path11',
+				'path2'          => 'path22',
+			],
+		];
+
+		$expected = [
+			AssetFieldType::DESCRIPTION => [
+				$asset_1['content'],
+			],
+			'display_url_path'          => [ 'path1', 'path2' ],
+		];
+
+		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );
+		$this->assertEquals( $expected, $this->asset_group_asset->get_assets_by_final_url( 'https://example.com', true ) );
+
+	}
+
 
 
 	public function test_edit_asset_group_assets_with_empty_assets() {

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -106,6 +106,50 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		$this->assertEquals( [], $this->asset_group_asset->get_assets_by_asset_group_ids( [] ) );
 	}
 
+	public function test_get_asset_groups_assets_by_final_url() {
+		$asset_1 = [
+			'id'      => self::TEST_ASSET_ID,
+			'content' => 'Test Asset',
+		];
+
+		$asset_2 = [
+			'id'      => self::TEST_ASSET_ID_2,
+			'content' => 'https://example.com/image.jpg',
+		];
+
+		$this->asset->expects( $this->exactly( 2 ) )
+		->method( 'convert_asset' )
+		->willReturnOnConsecutiveCalls( $asset_1, $asset_2 );
+
+		$asset_group_asset_data = [
+			[
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
+				'field_type'     => AssetFieldType::number( AssetFieldType::DESCRIPTION ),
+				'asset'          => array_merge( $asset_1, [ 'type' => AssetType::TEXT ] ),
+			],
+			[
+				'asset_group_id' => self::TEST_ASSET_GROUP_ID,
+				'field_type'     => AssetFieldType::number( AssetFieldType::MARKETING_IMAGE ),
+				'asset'          => array_merge( $asset_2, [ 'type' => AssetType::IMAGE ] ),
+			],
+		];
+
+		$expected = [
+			AssetFieldType::DESCRIPTION     => [
+				$asset_1,
+			],
+			AssetFieldType::MARKETING_IMAGE => [
+				$asset_2,
+			],
+		];
+
+		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );
+		$this->assertEquals( $expected, $this->asset_group_asset->get_assets_by_final_url( 'https://example.com' ) );
+
+	}
+
+
+
 	public function test_edit_asset_group_assets_with_empty_assets() {
 		$this->assertEquals( [], $this->asset_group_asset->edit_operations_assets_group_assets( self::TEST_ASSET_GROUP_ID, [] ) );
 	}

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -523,39 +523,51 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$this->asset_suggestions->get_assets_suggestions( self::INVALID_ID, 'term' );
 	}
 
+
+
 	public function test_combine_asset_results() {
+		$asset_1 = $this->generate_random_converted_asset();
+		$asset_2 = $this->generate_random_converted_asset();
+
 		$this->asset_group_asset->expects( $this->once() )
 			->method( 'get_assets_by_final_url' )
 			->with( get_permalink( $this->post->ID ) )
 			->willReturn(
 				[
-					AssetFieldType::DESCRIPTION => [ 'desc1', 'desc2' ],
-					AssetFieldType::HEADLINE    => [ 'headline1' ],
+					AssetFieldType::DESCRIPTION => [ $asset_1 ],
+					AssetFieldType::HEADLINE    => [ $asset_2 ],
 				]
 			);
 
 		$wp_asset                                = $this->format_post_asset_response( $this->post );
-		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ 'desc1', 'desc2', ...$wp_asset[ AssetFieldType::DESCRIPTION ] ];
-		$wp_asset[ AssetFieldType::HEADLINE ]    = [ 'headline1', ...$wp_asset[ AssetFieldType::HEADLINE ] ];
+		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ $asset_1['content'], ...$wp_asset[ AssetFieldType::DESCRIPTION ] ];
+		$wp_asset[ AssetFieldType::HEADLINE ]    = [ $asset_2['content'], ...$wp_asset[ AssetFieldType::HEADLINE ] ];
 
 		$this->assertEquals( $wp_asset, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 
 	}
 
 	public function test_combine_asset_max_results() {
+		$asset_1 = $this->generate_random_converted_asset();
+		$asset_2 = $this->generate_random_converted_asset();
+		$asset_3 = $this->generate_random_converted_asset();
+		$asset_4 = $this->generate_random_converted_asset();
+		$asset_5 = $this->generate_random_converted_asset();
+		$asset_6 = $this->generate_random_converted_asset();
+
 		$this->asset_group_asset->expects( $this->once() )
 			->method( 'get_assets_by_final_url' )
 			->with( get_permalink( $this->post->ID ) )
 			->willReturn(
 				[
-					AssetFieldType::DESCRIPTION => [ 'desc1', 'desc2', 'desc3', 'desc4', 'desc5' ],
-					AssetFieldType::HEADLINE    => [ 'headline1' ],
+					AssetFieldType::DESCRIPTION => [ $asset_1, $asset_2, $asset_3, $asset_4, $asset_5 ],
+					AssetFieldType::HEADLINE    => [ $asset_6 ],
 				]
 			);
 
 		$wp_asset                                = $this->format_post_asset_response( $this->post );
-		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ 'desc1', 'desc2', 'desc3', 'desc4', 'desc5' ];
-		$wp_asset[ AssetFieldType::HEADLINE ]    = [ 'headline1', ...$wp_asset[ AssetFieldType::HEADLINE ] ];
+		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ $asset_1['content'], $asset_2['content'], $asset_3['content'], $asset_4['content'], $asset_5['content'] ];
+		$wp_asset[ AssetFieldType::HEADLINE ]    = [ $asset_6['content'], ...$wp_asset[ AssetFieldType::HEADLINE ] ];
 
 		$this->assertEquals( $wp_asset, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 
@@ -633,6 +645,18 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 
+	}
+
+	/**
+	 * Generates a random converted asset.
+	 *
+	 * @return array The random converted asset.
+	 */
+	private function generate_random_converted_asset(): array {
+		return [
+			'id'      => rand(),
+			'content' => 'random content' . rand(),
+		];
 	}
 
 }

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -624,15 +624,13 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	public function test_get_asset_suggestions_with_assets_from_asset_group() {
 		$this->asset_group_asset->expects( $this->exactly( 1 ) )
 			->method( 'get_assets_by_final_url' )
-			->with( get_permalink( $this->post->ID ) )
+			->with( get_permalink( $this->post->ID ), true )
 			->willReturn(
 				[
-					[
-						AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
-						AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
-						AssetFieldType::CALL_TO_ACTION_SELECTION => 'learn_more',
-					],
-				]
+					AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
+					AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
+					AssetFieldType::CALL_TO_ACTION_SELECTION => 'learn_more',
+				],
 			);
 
 			$expected = [
@@ -649,14 +647,12 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	public function test_get_asset_suggestions_with_assets_from_asset_group_empty_call_to_action() {
 		$this->asset_group_asset->expects( $this->exactly( 1 ) )
 			->method( 'get_assets_by_final_url' )
-			->with( get_permalink( $this->post->ID ) )
+			->with( get_permalink( $this->post->ID ), true )
 			->willReturn(
 				[
-					[
-						AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
-						AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
-					],
-				]
+					AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
+					AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
+				],
 			);
 
 			$expected = [

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -27,6 +27,20 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads
  *
  * @property MockObject|WP  $wp
+ * @property MockObject|WC  $wc
+ * @property MockObject|ImageUtility  $image_utility
+ * @property MockObject|wpdb  $wpdb
+ * @property MockObject|AdsAssetGroupAsset  $asset_group_asset
+ * @property AssetSuggestionsService  $asset_suggestions
+ * @property \WP_Post  $post
+ * @property \WP_Term  $term
+ * @property array  $suggested_post
+ * @property array  $suggested_term
+ * @property DimensionUtility  $big_image
+ * @property DimensionUtility  $small_image
+ * @property DimensionUtility  $normal_image
+ * @property DimensionUtility  $suggested_image_square
+ * @property DimensionUtility  $suggested_image_landscape
  */
 class AssetSuggestionsServiceTest extends UnitTest {
 
@@ -597,16 +611,63 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 	}
 
-	/**
-	 * Generates a random converted asset.
-	 *
-	 * @return array The random converted asset.
-	 */
-	private function generate_random_converted_asset(): array {
-		return [
-			'id'      => rand(),
-			'content' => 'random content' . rand(),
-		];
+	public function test_get_asset_suggestions_with_empty_asset_group() {
+		$this->asset_group_asset->expects( $this->exactly( 1 ) )
+			->method( 'get_assets_by_final_url' )
+			->with( get_permalink( $this->post->ID ) )
+			->willReturn( [] );
+
+			$this->assertEquals( $this->format_post_asset_response( $this->post ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+
+	}
+
+	public function test_get_asset_suggestions_with_assets_from_asset_group() {
+		$this->asset_group_asset->expects( $this->exactly( 1 ) )
+			->method( 'get_assets_by_final_url' )
+			->with( get_permalink( $this->post->ID ) )
+			->willReturn(
+				[
+					[
+						AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
+						AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
+						AssetFieldType::CALL_TO_ACTION_SELECTION => 'learn_more',
+					],
+				]
+			);
+
+			$expected = [
+				AssetFieldType::HEADLINE                 => [ 'headline1', 'headline2' ],
+				AssetFieldType::DESCRIPTION              => [ 'description1', 'description2' ],
+				AssetFieldType::CALL_TO_ACTION_SELECTION => 'learn_more',
+				'final_url'                              => get_permalink( $this->post->ID ),
+			];
+
+			$this->assertEquals( $expected, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+
+	}
+
+	public function test_get_asset_suggestions_with_assets_from_asset_group_empty_call_to_action() {
+		$this->asset_group_asset->expects( $this->exactly( 1 ) )
+			->method( 'get_assets_by_final_url' )
+			->with( get_permalink( $this->post->ID ) )
+			->willReturn(
+				[
+					[
+						AssetFieldType::HEADLINE    => [ 'headline1', 'headline2' ],
+						AssetFieldType::DESCRIPTION => [ 'description1', 'description2' ],
+					],
+				]
+			);
+
+			$expected = [
+				AssetFieldType::HEADLINE                 => [ 'headline1', 'headline2' ],
+				AssetFieldType::DESCRIPTION              => [ 'description1', 'description2' ],
+				AssetFieldType::CALL_TO_ACTION_SELECTION => null,
+				'final_url'                              => get_permalink( $this->post->ID ),
+			];
+
+			$this->assertEquals( $expected, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+
 	}
 
 }

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -523,56 +523,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$this->asset_suggestions->get_assets_suggestions( self::INVALID_ID, 'term' );
 	}
 
-
-
-	public function test_combine_asset_results() {
-		$asset_1 = $this->generate_random_converted_asset();
-		$asset_2 = $this->generate_random_converted_asset();
-
-		$this->asset_group_asset->expects( $this->once() )
-			->method( 'get_assets_by_final_url' )
-			->with( get_permalink( $this->post->ID ) )
-			->willReturn(
-				[
-					AssetFieldType::DESCRIPTION => [ $asset_1 ],
-					AssetFieldType::HEADLINE    => [ $asset_2 ],
-				]
-			);
-
-		$wp_asset                                = $this->format_post_asset_response( $this->post );
-		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ $asset_1['content'], ...$wp_asset[ AssetFieldType::DESCRIPTION ] ];
-		$wp_asset[ AssetFieldType::HEADLINE ]    = [ $asset_2['content'], ...$wp_asset[ AssetFieldType::HEADLINE ] ];
-
-		$this->assertEquals( $wp_asset, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
-	}
-
-	public function test_combine_asset_max_results() {
-		$asset_1 = $this->generate_random_converted_asset();
-		$asset_2 = $this->generate_random_converted_asset();
-		$asset_3 = $this->generate_random_converted_asset();
-		$asset_4 = $this->generate_random_converted_asset();
-		$asset_5 = $this->generate_random_converted_asset();
-		$asset_6 = $this->generate_random_converted_asset();
-
-		$this->asset_group_asset->expects( $this->once() )
-			->method( 'get_assets_by_final_url' )
-			->with( get_permalink( $this->post->ID ) )
-			->willReturn(
-				[
-					AssetFieldType::DESCRIPTION => [ $asset_1, $asset_2, $asset_3, $asset_4, $asset_5 ],
-					AssetFieldType::HEADLINE    => [ $asset_6 ],
-				]
-			);
-
-		$wp_asset                                = $this->format_post_asset_response( $this->post );
-		$wp_asset[ AssetFieldType::DESCRIPTION ] = [ $asset_1['content'], $asset_2['content'], $asset_3['content'], $asset_4['content'], $asset_5['content'] ];
-		$wp_asset[ AssetFieldType::HEADLINE ]    = [ $asset_6['content'], ...$wp_asset[ AssetFieldType::HEADLINE ] ];
-
-		$this->assertEquals( $wp_asset, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
-	}
-
 	public function test_assets_with_logo() {
 		$image_id = $this->get_test_image();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

This PR allows populating assets (images, descriptions, headlines..) from other asset groups using the same final URL than the URL from a specific product, page, post or category. In case there are no assets available in other asset groups it will fetch the WP Assets.

See the following PRs for more context: 

- https://github.com/woocommerce/google-listings-and-ads/pull/1795
- https://github.com/woocommerce/google-listings-and-ads/pull/1797

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Look for a post, page, product or category and get the ID. 
3. Make a request to `gla/assets/suggestions?type=post|term&id=POST_ID|TERM_ID`. If it is category or taxonomy the `type` is `term` otherwise it will be `post`
4. If there are not asset groups with the post/term URL, the response should include the assets included in the WP post or term.
5. If there was an asset group with the same `final_url` (see `final_url` from the previous response) it should show the assets from that asset group.
6. If you do not have any asset group using that `final_url`, you can go to [Google Ads ](https://ads.google.com/intl/en_EN/home/), choose a Campaign -> Asset Groups -> Edit Asset Group -> Update the final URL with the post or term URL that you got earlier.

![image](https://user-images.githubusercontent.com/2488994/210385047-544d373c-82b1-4e93-8a98-4d90ccec4c10.png)

7. Repeat the steps and you should get the Assets from the Asset group.



### Additional details:
- If there is more than one asset group using the same final URL, we would suggest the assets found in the first asset group returned from the Ads API, the reason for this is that we do not want to exceed the maximum allowed assets and to avoid repeated assets. See here all the assets requirements: https://developers.google.com/google-ads/api/docs/performance-max/assets.
- If you are using a local URL and you would like to change it temporarily so it can match with the URL in the asset group you can use the following filter:

```
add_filter('home_url', function ($url) {
   return  str_replace('http://localhost', 'https://test.ngrok.io', $url);
}, 10, 1);
```


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

