### PR TITLE
Compatibility between CES and WC7.3

### DIFF
--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -37,7 +37,8 @@ import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
  * A CustomerEffortScore wrapper that uses tracks to track the selected
  * customer effort score.
  *
- * TODO: Remove Temoorary fix for WC 7.3 in which adding secondQuestion is required.
+ * compatibility-code "WC >= 7.3"
+ * TODO: Remove temporary fix for WC 7.3 in which adding `secondQuestion` is required.
  * See: https://github.com/woocommerce/google-listings-and-ads/issues/1836
  *
  * @fires gla_ces_snackbar_open whenever the CES snackbar (notice) is open

--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -37,6 +37,9 @@ import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
  * A CustomerEffortScore wrapper that uses tracks to track the selected
  * customer effort score.
  *
+ * TODO: Remove Temoorary fix for WC 7.3 in which adding secondQuestion is required.
+ * See: https://github.com/woocommerce/google-listings-and-ads/issues/1836
+ *
  * @fires gla_ces_snackbar_open whenever the CES snackbar (notice) is open
  * @fires gla_ces_snackbar_closed whenever the CES snackbar (notice) is closed
  * @fires gla_ces_modal_open whenever the CES modal is open
@@ -45,9 +48,10 @@ import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
  * @param {Object} props React component props.
  * @param {string} props.eventContext Context to be used in the CES wrapper events.
  * @param {string} props.label Text to be displayed in the CES notice and modal.
+ * @param {string} props.secondLabel Only WC >= 7.3. Text to be displayed for the second question in the modal.
  * @return {JSX.Element} Rendered element.
  */
-const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
+const CustomerEffortScorePrompt = ( { eventContext, label, secondLabel } ) => {
 	// NOTE: Currently CES Prompts uses core/notices2 as a store key, this seems something temporal
 	// and probably will be needed to change back to core/notices.
 	// See: https://github.com/woocommerce/woocommerce/blob/6.6.0/packages/js/notices/src/store/index.js
@@ -78,7 +82,7 @@ const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
 		} );
 	};
 
-	const recordScore = ( score, comments ) => {
+	const recordScore = ( score, score2, comments ) => {
 		recordEvent( 'gla_ces_feedback', {
 			context: eventContext,
 			score,
@@ -89,6 +93,9 @@ const CustomerEffortScorePrompt = ( { eventContext, label } ) => {
 	return (
 		<CustomerEffortScore
 			label={ label }
+			title={ label }
+			firstQuestion={ label }
+			secondQuestion={ secondLabel }
 			recordScoreCallback={ recordScore }
 			onNoticeShownCallback={ onNoticeShown }
 			onNoticeDismissedCallback={ onNoticeDismissed }

--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -77,7 +77,7 @@
 	}
 }
 
-// FIX in WC 7.3 for adding margin in the first question label
+// compatibility-code "WC >= 7.3" -- adding margin in the first question label.
 .wp-admin .woocommerce-customer-effort-score__intro {
 	margin-bottom: 1em;
 }

--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -76,3 +76,8 @@
 		}
 	}
 }
+
+// FIX in WC 7.3 for adding margin in the first question label
+.wp-admin .woocommerce-customer-effort-score__intro {
+	margin-bottom: 1em;
+}

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -118,6 +118,10 @@ const Dashboard = () => {
 						'How easy was it to create a Google Ad campaign?',
 						'google-listings-and-ads'
 					) }
+					secondLabel={ __(
+						'How easy was it to understand the requirements for the Google Ad campaign creation?',
+						'google-listings-and-ads'
+					) }
 					eventContext={ GUIDE_NAMES.CAMPAIGN_CREATION_SUCCESS }
 				/>
 			) }

--- a/js/src/product-feed/index.js
+++ b/js/src/product-feed/index.js
@@ -57,6 +57,10 @@ const ProductFeed = () => {
 						'How easy was it to set up Google Listings & Ads?',
 						'google-listings-and-ads'
 					) }
+					secondLabel={ __(
+						'How easy was it to understand the requirements for the Google Listings & Ads setup?',
+						'google-listings-and-ads'
+					) }
 					eventContext={ GUIDE_NAMES.SUBMISSION_SUCCESS }
 				/>
 			) }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1836 

This PR implements some new properties required in CES prompt under WC 7.3 to render properly. At the same time, it maintains compatibility with WC < 7.3

### Screenshots:


WC 7.3

https://user-images.githubusercontent.com/5908855/210545755-330d70af-5a5b-4eb5-83f0-43b90180e2a5.mov



WC 7.2

https://user-images.githubusercontent.com/5908855/210545265-6aa75fdb-db36-4185-a924-0a9b49abf151.mov


 
### Detailed test instructions:

1. Install WC 7.3beta 1 - https://github.com/woocommerce/woocommerce/releases/tag/7.3.0-beta.1
2. See the CES prompt renders with two questions and you can send the score and comment. (Only 1 question is being sent)
3. Install WC < 7.3 (for example 7.2) 
4. See the CES prompt renders with one question and you can send the score and comment.


### Additional details:

To test this issue easily, you can modify the following line:

[google-listings-and-ads/js/src/product-feed/index.js](https://github.com/woocommerce/google-listings-and-ads/blob/161f254dc243b6967fbbe78be030d9ba500947a7/js/src/product-feed/index.js#L54)

Line 54 in [161f254](https://github.com/woocommerce/google-listings-and-ads/commit/161f254dc243b6967fbbe78be030d9ba500947a7)

 { canCESPromptOpen && ( 
with:

			{ ( true || canCESPromptOpen ) && (
to force the Customer Effort Score prompt to show up when you navigate to the Product Feed tab.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - WooCommerce 7.3 Compatibility with Customer Effort Score prompt
