### PR TITLE
Tweak response asset group

### DIFF
--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -101,9 +101,16 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 
 				/** @var AssetGroupAsset $asset_group_asset */
 				$asset_group_asset = $row->getAssetGroupAsset();
+				$field_type        = AssetFieldType::label( $asset_group_asset->getFieldType() );
 
-				$field_type = AssetFieldType::label( $asset_group_asset->getFieldType() );
-				$asset_group_assets[ $row->getAssetGroup()->getId() ][ $field_type ][] = $this->asset->convert_asset( $row );
+				switch ( $field_type ) {
+					case AssetFieldType::BUSINESS_NAME:
+					case AssetFieldType::CALL_TO_ACTION_SELECTION:
+						$asset_group_assets[ $row->getAssetGroup()->getId() ][ $field_type ] = $this->asset->convert_asset( $row );
+						break;
+					default:
+						$asset_group_assets[ $row->getAssetGroup()->getId() ][ $field_type ][] = $this->asset->convert_asset( $row );
+				}
 			}
 
 			return $asset_group_assets;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

This PR changes the response format for the asset types: `BUSINESS_NAME` and `CALL_TO_ACTION_SELECTION` when making a request to `GET ads/campaigns/CAMPAIGN_ID/assetgroups`  , currently, it was returning an array of objects but I realized that is not needed to send an array as the maximum number of these assets is `1`.

I will add the test for these cases when the PR https://github.com/woocommerce/google-listings-and-ads/pull/1832 is merged, I created there a function that allows me to create the mocks easily. See https://github.com/woocommerce/google-listings-and-ads/pull/1832/files#diff-ce3988e96ebfe4e08831d1a3498e17570451c07f0b87b8b22460b2db0e638919R745

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow the steps mentioned in https://github.com/woocommerce/google-listings-and-ads/pull/1820
3. Check that the fields `BUSINESS_NAME` and `CALL_TO_ACTION_SELECTION` are objects and not an array of objects.
4. The Ads API does not return the `CALL_TO_ACTION_SELECTION` field if it is set as `Automated`, otherwise it will be included in the response.




<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

