### PR TITLE
Prevent the "import/no-duplicates" warning for the externalization process

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,5 +40,14 @@ module.exports = {
 				additionalHooks: 'useSelect',
 			},
 		],
+		// When a file imports from both `@wordpress/components` and `extracted/@wordpress/components`
+		// at the same time, it would get the "no-duplicates" warning. It should be considered a
+		// false positive when working on the externalization process. So here we temporarily change
+		// to use "no-duplicate-imports" instead.
+		//
+		// TODO: After the externalizations of `@wordpress/*` and `@woocommerce/*` are complete,
+		//       remove the following two lines of rule settings.
+		'import/no-duplicates': 'off',
+		'no-duplicate-imports': 'warn',
 	},
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Quotes from @ecgan's https://github.com/woocommerce/google-listings-and-ads/pull/1834#issuecomment-1373854933:

> Three of the external-components files have eslint warnings that say "node_modules/@wordpress/components/build-module/index.js' imported multiple times. eslint [import/no-duplicates](https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/docs/rules/no-duplicates.md)", because we have imports from both `@wordpress/components` and `extracted/@wordpress/components`. See screenshot below:
> 
> ![image](https://user-images.githubusercontent.com/417342/211046547-182b87c4-5690-42aa-8a2d-bababc5eb26d.png)

This PR changes to use the "no-duplicate-imports" rule to prevent the warnings.

### Screenshots:

It can still find the basic duplicated imports:

<img width="886" alt="image" src="https://user-images.githubusercontent.com/17420811/211234388-20ee56bd-45e6-4623-a6d9-323fb7bfcc98.png">

### Detailed test instructions:

1. `npm run lint:js`
2. Check if there are no "import/no-duplicates" warnings.

### Additional details:

"no-duplicate-imports" doesn't do the actual file path resolving, so something like `import Foo from '. /foo'` and `import Foo from '. /foo.js'` are not recognized as duplicates.

However, such rules are for code clearer purposes only, and these undetected duplicates should not cause errors.

### Changelog entry
