### PR TITLE
PMax - Assets for non static homepage

### DIFF
--- a/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
@@ -110,8 +110,10 @@ class AssetSuggestionsController extends BaseController {
 		return [
 			'id'   => [
 				'description'       => __( 'Post ID or Term ID.', 'google-listings-and-ads' ),
-				'type'              => [ 'integer', 'null' ],
+				'type'              => 'number',
+				'sanitize_callback' => 'absint',
 				'validate_callback' => 'rest_validate_request_arg',
+				'required'          => true,
 			],
 			'type' => [
 				'description'       => __( 'Type linked to the id.', 'google-listings-and-ads' ),
@@ -119,6 +121,7 @@ class AssetSuggestionsController extends BaseController {
 				'sanitize_callback' => 'sanitize_text_field',
 				'enum'              => [ 'post', 'term', 'homepage' ],
 				'validate_callback' => 'rest_validate_request_arg',
+				'required'          => true,
 			],
 		];
 	}

--- a/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
@@ -179,7 +179,7 @@ class AssetSuggestionsController extends BaseController {
 			],
 			'type'  => [
 				'type'        => 'string',
-				'description' => __( 'Post or term', 'google-listings-and-ads' ),
+				'description' => __( 'Post, term or homepage', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'enum'        => [ 'post', 'term', 'homepage' ],
 				'readonly'    => true,

--- a/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
@@ -110,15 +110,14 @@ class AssetSuggestionsController extends BaseController {
 		return [
 			'id'   => [
 				'description'       => __( 'Post ID or Term ID.', 'google-listings-and-ads' ),
-				'type'              => 'number',
-				'sanitize_callback' => 'absint',
+				'type'              => [ 'integer', 'null' ],
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 			'type' => [
 				'description'       => __( 'Type linked to the id.', 'google-listings-and-ads' ),
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
-				'enum'              => [ 'post', 'term' ],
+				'enum'              => [ 'post', 'term', 'homepage' ],
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];

--- a/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
@@ -178,7 +178,7 @@ class AssetSuggestionsController extends BaseController {
 				'type'        => 'string',
 				'description' => __( 'Post or term', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
-				'enum'        => [ 'post', 'term' ],
+				'enum'        => [ 'post', 'term', 'homepage' ],
 				'readonly'    => true,
 			],
 			'title' => [

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -620,14 +620,15 @@ class AssetSuggestionsService implements Service {
 			 return $this->get_defaults_final_url_suggestions();
 		}
 
-		// Split possible results between posts and terms.
-		$per_page_posts = (int) ceil( $per_page / 2 );
-		$homepage       = [];
+		$homepage = [];
 
 		if ( strpos( 'homepage', $search ) !== false ) {
 			$homepage[] = $this->get_homepage_final_url();
-			$per_page_posts--;
+			$per_page--;
 		}
+
+		// Split possible results between posts and terms.
+		$per_page_posts = (int) ceil( $per_page / 2 );
 
 		$posts = $this->get_post_suggestions( $search, $per_page_posts );
 

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -154,10 +154,10 @@ class AssetSuggestionsService implements Service {
 			$url = get_bloginfo( 'url' );
 		}
 
-		if ( $url === false || is_wp_error( $url ) || empty( $url ) ) {
+		if ( is_wp_error( $url ) || empty( $url ) ) {
 			throw new Exception(
 				/* translators: 1: is an integer representing an unknown Term ID */
-				sprintf( __( 'Invalid Term ID or Post ID %1$d', 'google-listings-and-ads' ), $id )
+				sprintf( __( 'Invalid Term ID or Post ID or site url %1$d', 'google-listings-and-ads' ), $id )
 			);
 		}
 
@@ -198,6 +198,7 @@ class AssetSuggestionsService implements Service {
 	 * @param string $type Only possible values are post or term.
 	 *
 	 * @return array All assets available for specific term, post or homepage.
+	 * @throws Exception If the ID is invalid.
 	 */
 	protected function get_wp_assets( int $id, string $type ): array {
 		if ( $type === 'post' ) {

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -99,9 +99,9 @@ class AssetSuggestionsService implements Service {
 	protected const LOGO_IMAGE_KEY = 'gla_logo_asset';
 
 	/**
-	 * The homepage ID if it is not a static page.
+	 * The homepage key ID.
 	 */
-	protected const HOMEPAGE_NON_STATIC_ID = 0;
+	protected const HOMEPAGE_KEY_ID = 0;
 
 	/**
 	 * AssetSuggestionsService constructor.
@@ -123,7 +123,7 @@ class AssetSuggestionsService implements Service {
 	/**
 	 * Get WP and other campaigns' assets from the specific post or term.
 	 *
-	 * @param int    $id Post ID, Term ID or null if it's the homepage.
+	 * @param int    $id Post ID, Term ID or self::HOMEPAGE_KEY_ID if it's the homepage.
 	 * @param string $type Only possible values are post, term and homepage.
 	 */
 	public function get_assets_suggestions( int $id, string $type ): array {
@@ -139,7 +139,7 @@ class AssetSuggestionsService implements Service {
 	/**
 	 * Get URL for a specific post or term.
 	 *
-	 * @param int    $id Post or Term ID.
+	 * @param int    $id Post ID, Term ID or self::HOMEPAGE_KEY_ID
 	 * @param string $type Only possible values are post, term and homepage.
 	 *
 	 * @return string The URL.
@@ -194,10 +194,10 @@ class AssetSuggestionsService implements Service {
 	/**
 	 * Get assets from specific post or term.
 	 *
-	 * @param int    $id Post or Term ID, or self::HOMEPAGE_NON_STATIC_ID.
+	 * @param int    $id Post or Term ID, or self::HOMEPAGE_KEY_ID.
 	 * @param string $type Only possible values are post or term.
 	 *
-	 * @return array All assets available for specific term or post.
+	 * @return array All assets available for specific term, post or homepage.
 	 */
 	protected function get_wp_assets( int $id, string $type ): array {
 		if ( $type === 'post' ) {
@@ -211,17 +211,18 @@ class AssetSuggestionsService implements Service {
 	}
 
 	/**
-	 * Get assets from the homepage without static page.
+	 * Get assets from the homepage.
 	 *
 	 * @return array Assets available for the homepage.
 	 */
 	protected function get_homepage_assets() {
 		$home_page = $this->wp->get_static_homepage();
 
+		// Static homepage.
 		if ( $home_page ) {
 			return $this->get_post_assets( $home_page->ID );
 		}
-
+		// Non static homepage.
 		return [
 			AssetFieldType::HEADLINE                 => [ __( 'Homepage', 'google-listings-and-ads' ) ],
 			AssetFieldType::LONG_HEADLINE            => [],
@@ -655,13 +656,7 @@ class AssetSuggestionsService implements Service {
 	 * @return array final url for the homepage.
 	 */
 	protected function get_homepage_final_url(): array {
-		$home_page = $this->wp->get_static_homepage();
-
-		if ( $home_page ) {
-			return $this->format_final_url_response( $home_page->ID, 'post', __( 'Homepage', 'google-listings-and-ads' ), get_permalink( $home_page->ID ) );
-		} else {
-			return $this->format_final_url_response( self::HOMEPAGE_NON_STATIC_ID, 'homepage', __( 'Homepage', 'google-listings-and-ads' ), get_bloginfo( 'url' ) );
-		}
+		return $this->format_final_url_response( self::HOMEPAGE_KEY_ID, 'homepage', __( 'Homepage', 'google-listings-and-ads' ), get_bloginfo( 'url' ) );
 	}
 
 	/**
@@ -670,8 +665,8 @@ class AssetSuggestionsService implements Service {
 	 * @return array default final urls.
 	 */
 	protected function get_defaults_final_url_suggestions(): array {
-		$shop_page = $this->wp->get_shop_page();
 		$defaults  = [ $this->get_homepage_final_url() ];
+		$shop_page = $this->wp->get_shop_page();
 
 		if ( $shop_page ) {
 			$defaults[] = $this->format_final_url_response( $shop_page->ID, 'post', $shop_page->post_title, get_permalink( $shop_page->ID ) );
@@ -703,7 +698,7 @@ class AssetSuggestionsService implements Service {
 	/**
 	 * Return an assotiave array with the page suggestion response format.
 	 *
-	 * @param int    $id post id, term id or self::HOMEPAGE_NON_STATIC_ID.
+	 * @param int    $id post id, term id or self::HOMEPAGE_KEY_ID.
 	 * @param string $type post|term
 	 * @param string $title page|term title
 	 * @param string $url page|term url

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -156,7 +156,7 @@ class AssetSuggestionsService implements Service {
 	/**
 	 * Get assets from specific post or term.
 	 *
-	 * @param int|null $id Post or Term ID or null f it's the homepage.
+	 * @param int|null $id Post or Term ID or null if it's not a static homepage.
 	 * @param string   $type Only possible values are post or term.
 	 *
 	 * @return array All assets available for specific term or post.

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -214,8 +214,9 @@ class AssetSuggestionsService implements Service {
 	 * Get assets from the homepage.
 	 *
 	 * @return array Assets available for the homepage.
+	 * @throws Exception If the homepage id is invalid.
 	 */
-	protected function get_homepage_assets() {
+	protected function get_homepage_assets(): array {
 		$home_page = $this->wp->get_static_homepage();
 
 		// Static homepage.
@@ -622,6 +623,7 @@ class AssetSuggestionsService implements Service {
 
 		$homepage = [];
 
+		// If the search query contains the word "homepage" add the homepage to the results.
 		if ( strpos( 'homepage', $search ) !== false ) {
 			$homepage[] = $this->get_homepage_final_url();
 			$per_page--;

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -624,7 +624,7 @@ class AssetSuggestionsService implements Service {
 		$homepage = [];
 
 		// If the search query contains the word "homepage" add the homepage to the results.
-		if ( strpos( 'homepage', $search ) !== false ) {
+		if ( strpos( 'homepage', strtolower( $search ) ) !== false ) {
 			$homepage[] = $this->get_homepage_final_url();
 			$per_page--;
 		}

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -55,7 +55,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	protected const SQUARE_MARKETING_IMAGE_KEY       = 'gla_square_marketing_asset';
 	protected const MARKETING_IMAGE_KEY              = 'gla_marketing_asset';
 	protected const LOGO_IMAGE_KEY                   = 'gla_logo_asset';
-	protected const HOMEPAGE_NON_STATIC_ID           = 0;
+	protected const HOMEPAGE_KEY_ID                  = 0;
 
 
 	protected const TEST_POST_TYPES               = [
@@ -306,14 +306,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	}
 
 	public function test_get_default_urls() {
-		$homepage = $this->factory()->post->create_and_get( [ 'post_title' => 'Homepage' ] );
-		$shop     = $this->factory()->post->create_and_get( [ 'post_title' => 'Shop' ] );
-
-		$this->wp->expects( $this->once() )
-		->method( 'get_static_homepage' )
-		->willReturn(
-			$homepage
-		);
+		$shop = $this->factory()->post->create_and_get( [ 'post_title' => 'Shop' ] );
 
 		$this->wp->expects( $this->once() )
 		->method( 'get_shop_page' )
@@ -321,7 +314,18 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			$shop
 		);
 
-		$this->assertEquals( [ $this->format_url_post_item( $homepage ), $this->format_url_post_item( $shop ) ], $this->asset_suggestions->get_final_url_suggestions() );
+		$this->assertEquals(
+			[
+				[
+					'id'    => self::HOMEPAGE_KEY_ID,
+					'type'  => 'homepage',
+					'title' => 'Homepage',
+					'url'   => get_bloginfo( 'url' ),
+				],
+				$this->format_url_post_item( $shop ),
+			],
+			$this->asset_suggestions->get_final_url_suggestions()
+		);
 	}
 
 
@@ -365,7 +369,17 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			null
 		);
 
-		$this->assertEquals( $this->format_homepage_asset_response( $this->post ), $this->asset_suggestions->get_assets_suggestions( self::HOMEPAGE_NON_STATIC_ID, 'homepage' ) );
+		$this->assertEquals( $this->format_homepage_asset_response(), $this->asset_suggestions->get_assets_suggestions( self::HOMEPAGE_KEY_ID, 'homepage' ) );
+	}
+
+	public function test_get_static_homepage() {
+		$this->wp->expects( $this->once() )
+		->method( 'get_static_homepage' )
+		->willReturn(
+			$this->post
+		);
+
+		$this->assertEquals( $this->format_post_asset_response( $this->post ), $this->asset_suggestions->get_assets_suggestions( self::HOMEPAGE_KEY_ID, 'homepage' ) );
 	}
 
 	public function test_get_post_assets() {

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -55,6 +55,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	protected const SQUARE_MARKETING_IMAGE_KEY       = 'gla_square_marketing_asset';
 	protected const MARKETING_IMAGE_KEY              = 'gla_marketing_asset';
 	protected const LOGO_IMAGE_KEY                   = 'gla_logo_asset';
+	protected const HOMEPAGE_NON_STATIC_ID           = 0;
 
 
 	protected const TEST_POST_TYPES               = [
@@ -121,6 +122,21 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			'type'  => 'term',
 			'title' => $term->name,
 			'url'   => get_term_link( $term->term_id, $term->taxonomy ),
+		];
+	}
+
+	protected function format_homepage_asset_response() {
+		return [
+			AssetFieldType::HEADLINE                 => [ 'Homepage' ],
+			AssetFieldType::LONG_HEADLINE            => [],
+			AssetFieldType::DESCRIPTION              => ArrayUtil::remove_empty_values( [ get_bloginfo( 'description' ) ] ),
+			AssetFieldType::LOGO                     => ArrayUtil::remove_empty_values( [ wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ) ) ] ),
+			AssetFieldType::BUSINESS_NAME            => get_bloginfo( 'name' ),
+			AssetFieldType::SQUARE_MARKETING_IMAGE   => [],
+			AssetFieldType::MARKETING_IMAGE          => [],
+			AssetFieldType::CALL_TO_ACTION_SELECTION => null,
+			'display_url_path'                       => [],
+			'final_url'                              => get_bloginfo( 'url' ),
 		];
 	}
 
@@ -340,6 +356,16 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		}
 
 		$this->assertEquals( $expected, $this->asset_suggestions->get_final_url_suggestions( self::TEST_SEARCH, $per_page ) );
+	}
+
+	public function test_get_non_static_homepage() {
+		$this->wp->expects( $this->once() )
+		->method( 'get_static_homepage' )
+		->willReturn(
+			null
+		);
+
+		$this->assertEquals( $this->format_homepage_asset_response( $this->post ), $this->asset_suggestions->get_assets_suggestions( self::HOMEPAGE_NON_STATIC_ID, 'homepage' ) );
 	}
 
 	public function test_get_post_assets() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

Until now it was only possible to fetch assets from the homepage if it was linked to a static page (post, page, etc). This PR adds the functionality of getting assets from a non-static homepage by adding a new asset suggestion type: `homepage`.

In case that is a non-static homepage, the assets will be populated using one of the below options:

- Get assets from other asset groups  (see https://github.com/woocommerce/google-listings-and-ads/pull/1837), 
- A list of default assets.

<!--- ### Screenshots: --->

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to WP Settings -> Reading -> Select "Your latest posts" which means that you are not selecting a static homepage.
2. Make a GET request: `wc/gla/assets/final-url/suggestions` or search for `homepage` (`wc/gla/assets/final-url/suggestions?search=homepage`),  it should return the homepage with the new `homepage type`: 

```
    {
        "id": 0,
        "type": "homepage", 
        "title": "Homepage",
        "url": "https://example.io"
    },
```

3. Make a GET request  `gla/assets/suggestions?id=0&type=homepage`
4. If you have an asset group with the same homepage URL, it should return the assets from that asset group.
5. If you do not have an asset group it should return a list of default assets.
6. If you change it to a static homepage and there are no asset groups with the homepage URL, it should return the assets from the static page.


### Additional details:
- In the case there are more than one asset group with the same URL, it will show the assets from only one asset group. See https://github.com/woocommerce/google-listings-and-ads/pull/1837
- If you are using a local URL and you would like to change it temporarily so it can match with the URL in the asset group you can use the following filter:
```
add_filter('home_url', function ($url) {
   return  str_replace('http://localhost', 'https://test.ngrok.io', $url);
}, 10, 1);
```
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
