### PR TITLE
PMax Assets: AssetField for constructing the layout for editing images and texts

### DIFF
--- a/js/src/components/help-popover/index.js
+++ b/js/src/components/help-popover/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { __ } from '@wordpress/i18n';
 import { Popover } from 'extracted/@wordpress/components';
 import { useState } from '@wordpress/element';
 import GridiconHelpOutline from 'gridicons/dist/help-outline';
@@ -23,6 +24,7 @@ import './index.scss';
  * @param {Object} props React props
  * @param {string} [props.className] Additional CSS class name to be appended.
  * @param {string} [props.id] The Popover’s ID for event tracking.
+ * @param {boolean} [props.disabled=false] Whether to disable the help icon button and also hide the popover.
  * @param {number} [props.iconSize=16] Size of the help icon.
  * @param {Array<JSX.Element>} props.children The Popover’s content
  * @fires gla_tooltip_viewed with the given `id`.
@@ -30,6 +32,7 @@ import './index.scss';
 const HelpPopover = ( {
 	className,
 	id,
+	disabled = false,
 	iconSize = 16,
 	children,
 	...props
@@ -50,10 +53,14 @@ const HelpPopover = ( {
 
 	return (
 		<span className={ classnames( 'help-popover', className ) }>
-			<button onClick={ handleButtonClick }>
+			<button
+				aria-label={ __( 'Open popover', 'google-listings-and-ads' ) }
+				disabled={ disabled }
+				onClick={ handleButtonClick }
+			>
 				<GridiconHelpOutline size={ iconSize }></GridiconHelpOutline>
 			</button>
-			{ showPopover && (
+			{ showPopover && ! disabled && (
 				<Popover
 					focusOnMount="container"
 					onClose={ handlePopoverClose }

--- a/js/src/components/help-popover/index.js
+++ b/js/src/components/help-popover/index.js
@@ -20,7 +20,7 @@ import './index.scss';
 
 /**
  * @param {Object} props React props
- * @param {string} props.id The Popover’s ID
+ * @param {string} [props.id] The Popover’s ID for event tracking.
  * @param {Array<JSX.Element>} props.children The Popover’s content
  * @fires gla_tooltip_viewed with the given `id`.
  */
@@ -29,9 +29,10 @@ const HelpPopover = ( { id, children, ...props } ) => {
 
 	const handleButtonClick = () => {
 		setShowPopover( true );
-		recordEvent( 'gla_tooltip_viewed', {
-			id,
-		} );
+
+		if ( id ) {
+			recordEvent( 'gla_tooltip_viewed', { id } );
+		}
 	};
 
 	const handlePopoverClose = () => {

--- a/js/src/components/help-popover/index.js
+++ b/js/src/components/help-popover/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { Popover } from 'extracted/@wordpress/components';
 import { useState } from '@wordpress/element';
 import GridiconHelpOutline from 'gridicons/dist/help-outline';
@@ -20,11 +21,19 @@ import './index.scss';
 
 /**
  * @param {Object} props React props
+ * @param {string} [props.className] Additional CSS class name to be appended.
  * @param {string} [props.id] The Popover’s ID for event tracking.
+ * @param {number} [props.iconSize=16] Size of the help icon.
  * @param {Array<JSX.Element>} props.children The Popover’s content
  * @fires gla_tooltip_viewed with the given `id`.
  */
-const HelpPopover = ( { id, children, ...props } ) => {
+const HelpPopover = ( {
+	className,
+	id,
+	iconSize = 16,
+	children,
+	...props
+} ) => {
 	const [ showPopover, setShowPopover ] = useState( false );
 
 	const handleButtonClick = () => {
@@ -40,9 +49,9 @@ const HelpPopover = ( { id, children, ...props } ) => {
 	};
 
 	return (
-		<span className="help-popover">
+		<span className={ classnames( 'help-popover', className ) }>
 			<button onClick={ handleButtonClick }>
-				<GridiconHelpOutline size={ 16 }></GridiconHelpOutline>
+				<GridiconHelpOutline size={ iconSize }></GridiconHelpOutline>
 			</button>
 			{ showPopover && (
 				<Popover

--- a/js/src/components/help-popover/index.scss
+++ b/js/src/components/help-popover/index.scss
@@ -13,9 +13,12 @@ $button-color: $gray-600;
 		background: none;
 		padding: 1px;
 		fill: $button-color;
-		cursor: pointer;
 
-		&:hover {
+		&:not(:disabled) {
+			cursor: pointer;
+		}
+
+		&:hover:not(:disabled) {
 			fill: color.adjust($button-color, $lightness: -20%);
 		}
 	}

--- a/js/src/components/help-popover/index.scss
+++ b/js/src/components/help-popover/index.scss
@@ -22,6 +22,7 @@ $button-color: $gray-600;
 
 	.components-popover__content {
 		width: $gla-width-medium;
+		padding: $grid-unit-20;
 
 		@include break-large {
 			width: $gla-width-medium-large;
@@ -29,11 +30,6 @@ $button-color: $gray-600;
 
 		@include break-xlarge {
 			width: $gla-width-mobile;
-		}
-
-		> div {
-			text-align: left;
-			margin: $grid-unit-20;
 		}
 	}
 }

--- a/js/src/components/paid-ads/asset-group/add-asset-item-button.js
+++ b/js/src/components/paid-ads/asset-group/add-asset-item-button.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
+import './add-asset-item-button.scss';
+
+export default function AddAssetItemButton( props ) {
+	return (
+		<AppButton
+			className="gla-add-asset-item-button"
+			isLink
+			icon={ <GridiconPlusSmall /> }
+			iconSize={ 16 }
+			{ ...props }
+		/>
+	);
+}

--- a/js/src/components/paid-ads/asset-group/add-asset-item-button.scss
+++ b/js/src/components/paid-ads/asset-group/add-asset-item-button.scss
@@ -1,0 +1,5 @@
+.gla-add-asset-item-button {
+	&.has-icon {
+		padding: $grid-unit-05;
+	}
+}

--- a/js/src/components/paid-ads/asset-group/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.js
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useReducedMotion } from '@wordpress/compose';
+import {
+	useState,
+	useRef,
+	useImperativeHandle,
+	forwardRef,
+} from '@wordpress/element';
+import { chevronUp, chevronDown } from '@wordpress/icons';
+import { Pill } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
+import HelpPopover from '.~/components/help-popover';
+import './asset-field.scss';
+
+/**
+ * @typedef {Object} AssetFieldHandler
+ * @property {() => void} scrollIntoComponent Scroll to the nearest alignable position to show this component in the visible area.
+ */
+
+/**
+ * Renders an expandable wrapper for editing asset fields.
+ *
+ * @param {Object} props React props.
+ * @param {JSX.Element} props.heading Heading.
+ * @param {JSX.Element} props.subheading Subheading.
+ * @param {JSX.Element} props.help Help content to be shown after clicking on the help icon.
+ * @param {number} props.numOfIssues The number of issues used to label on UI. It only labels when the number is greater than 0.
+ * @param {boolean} [props.initialExpanded=false] Whether the UI to initial with expanded content.
+ * @param {boolean} [props.disabled=false] Whether display the UI in disabled style. It will collapse the content when disabled.
+ * @param {JSX.Element} [props.children] Content to be rendered.
+ * @param {import('react').MutableRefObject<AssetFieldHandler>} ref React ref to be attached to the handler of this component.
+ */
+function AssetField(
+	{
+		heading,
+		subheading,
+		help,
+		numOfIssues,
+		initialExpanded = false,
+		disabled = false,
+		children,
+	},
+	ref
+) {
+	const containerRef = useRef();
+	const [ isExpanded, setExpanded ] = useState( initialExpanded );
+
+	const isReducedMotion = useReducedMotion();
+
+	useImperativeHandle( ref, () => ( {
+		scrollIntoComponent() {
+			containerRef.current.scrollIntoView( {
+				behavior: isReducedMotion ? 'auto' : 'smooth',
+				inline: 'nearest',
+				block: 'nearest',
+			} );
+		},
+	} ) );
+
+	const handleToggle = () => {
+		setExpanded( ! isExpanded );
+	};
+
+	const issuePillText = sprintf(
+		// translators: %d: number of issues in a asset field.
+		_n( '%d issue', '%d issues', numOfIssues, 'google-listings-and-ads' ),
+		numOfIssues
+	);
+
+	const className = classnames(
+		'gla-asset-field',
+		disabled ? 'gla-asset-field--is-disabled' : false
+	);
+
+	const shouldExpanded = isExpanded && ! disabled;
+
+	return (
+		<div className={ className } ref={ containerRef }>
+			<header className="gla-asset-field__header">
+				<div className="gla-asset-field__heading-part">
+					<h2 className="gla-asset-field__heading">
+						{ heading }
+						<HelpPopover
+							className="gla-asset-field__help-popover"
+							position="top"
+							iconSize={ 20 }
+							disabled={ disabled }
+						>
+							{ help }
+						</HelpPopover>
+					</h2>
+					<h3 className="gla-asset-field__subheading">
+						{ subheading }
+					</h3>
+				</div>
+				{ numOfIssues > 0 && (
+					<Pill className="gla-asset-field__issue-pill">
+						{ issuePillText }
+					</Pill>
+				) }
+				<div className="gla-asset-field__toggle-button-anchor">
+					<AppButton
+						className="gla-asset-field__toggle-button"
+						icon={ shouldExpanded ? chevronUp : chevronDown }
+						aria-expanded={ shouldExpanded }
+						aria-label={ __(
+							'Toggle asset',
+							'google-listings-and-ads'
+						) }
+						disabled={ disabled }
+						onClick={ handleToggle }
+					/>
+				</div>
+			</header>
+			<div className="gla-asset-field__content">
+				{ shouldExpanded && children }
+			</div>
+		</div>
+	);
+}
+
+export default forwardRef( AssetField );

--- a/js/src/components/paid-ads/asset-group/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.js
@@ -32,8 +32,8 @@ import './asset-field.scss';
  * @param {JSX.Element} props.heading Heading.
  * @param {JSX.Element} props.subheading Subheading.
  * @param {JSX.Element} props.help Help content to be shown after clicking on the help icon.
- * @param {number} props.numOfIssues The number of issues used to label on UI. It only labels when the number is greater than 0.
- * @param {boolean} [props.initialExpanded=false] Whether the UI to initial with expanded content.
+ * @param {number} props.numOfIssues The number of issues to be marked as a label on UI. It only shows the label when the number is greater than 0.
+ * @param {boolean} [props.initialExpanded=false] Whether the UI is initialized expanded.
  * @param {boolean} [props.disabled=false] Whether display the UI in disabled style. It will collapse the content when disabled.
  * @param {JSX.Element} [props.children] Content to be rendered.
  * @param {import('react').MutableRefObject<AssetFieldHandler>} ref React ref to be attached to the handler of this component.
@@ -70,7 +70,7 @@ function AssetField(
 	};
 
 	const issuePillText = sprintf(
-		// translators: %d: number of issues in a asset field.
+		// translators: %d: number of issues in an asset field.
 		_n( '%d issue', '%d issues', numOfIssues, 'google-listings-and-ads' ),
 		numOfIssues
 	);

--- a/js/src/components/paid-ads/asset-group/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.js
@@ -80,7 +80,7 @@ function AssetField(
 		disabled ? 'gla-asset-field--is-disabled' : false
 	);
 
-	const shouldExpanded = isExpanded && ! disabled;
+	const shouldExpand = isExpanded && ! disabled;
 
 	return (
 		<div className={ className } ref={ containerRef }>
@@ -109,8 +109,8 @@ function AssetField(
 				<div className="gla-asset-field__toggle-button-anchor">
 					<AppButton
 						className="gla-asset-field__toggle-button"
-						icon={ shouldExpanded ? chevronUp : chevronDown }
-						aria-expanded={ shouldExpanded }
+						icon={ shouldExpand ? chevronUp : chevronDown }
+						aria-expanded={ shouldExpand }
 						aria-label={ __(
 							'Toggle asset',
 							'google-listings-and-ads'
@@ -121,7 +121,7 @@ function AssetField(
 				</div>
 			</header>
 			<div className="gla-asset-field__content">
-				{ shouldExpanded && children }
+				{ shouldExpand && children }
 			</div>
 		</div>
 	);

--- a/js/src/components/paid-ads/asset-group/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.js
@@ -51,7 +51,7 @@ function AssetField(
 	ref
 ) {
 	const containerRef = useRef();
-	const [ isExpanded, setExpanded ] = useState( initialExpanded );
+	const [ expanded, setExpanded ] = useState( initialExpanded );
 
 	const isReducedMotion = useReducedMotion();
 
@@ -66,7 +66,7 @@ function AssetField(
 	} ) );
 
 	const handleToggle = () => {
-		setExpanded( ! isExpanded );
+		setExpanded( ! expanded );
 	};
 
 	const issuePillText = sprintf(
@@ -80,7 +80,7 @@ function AssetField(
 		disabled ? 'gla-asset-field--is-disabled' : false
 	);
 
-	const shouldExpand = isExpanded && ! disabled;
+	const shouldExpand = expanded && ! disabled;
 
 	return (
 		<div className={ className } ref={ containerRef }>

--- a/js/src/components/paid-ads/asset-group/asset-field.scss
+++ b/js/src/components/paid-ads/asset-group/asset-field.scss
@@ -1,0 +1,87 @@
+.gla-asset-field {
+	padding: $grid-unit-30;
+	box-shadow: 0 0 0 1px rgb(0 0 0 / 10%);
+	border-radius: 2px;
+	background-color: $white;
+
+	&--is-disabled {
+		opacity: 0.5;
+	}
+
+	&__heading-part {
+		flex: 1 1;
+	}
+
+	&__header {
+		display: flex;
+		align-items: flex-start;
+	}
+
+	&__heading {
+		display: flex;
+		align-items: center;
+		margin: 0;
+		line-height: $gla-line-height-smaller;
+		font-size: $gla-font-base;
+		color: $gray-900;
+	}
+
+	&__subheading {
+		margin: $grid-unit-05 0 0;
+		line-height: $gla-line-height-smaller;
+		font-weight: normal;
+		font-size: $gla-font-base;
+		color: $gray-700;
+	}
+
+	&__help-popover {
+		margin-left: $grid-unit-05;
+
+		button {
+			padding: 0;
+		}
+
+		.components-popover__content {
+			width: 400px;
+			padding: $grid-unit-05 * 7.5;
+			line-height: $gla-line-height-smaller;
+			color: $gray-800;
+
+			p {
+				margin: 0;
+				line-height: $gla-line-height-smaller;
+
+				& + p {
+					margin-top: 1.5em;
+				}
+			}
+		}
+	}
+
+	& &__issue-pill {
+		margin-right: $grid-unit-10;
+		border: none;
+		background-color: #fcf0f1;
+		color: $alert-red;
+	}
+
+	&__toggle-button-anchor {
+		position: relative;
+		width: 24px;
+		height: 24px;
+	}
+
+	& &__toggle-button {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		color: $gray-900;
+	}
+
+	&__content {
+		&:not(:empty) {
+			padding-top: $grid-unit-20;
+		}
+	}
+}

--- a/js/src/components/paid-ads/asset-group/asset-field.test.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.test.js
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import AssetField from './asset-field';
+
+describe( 'AssetField', () => {
+	function getToggleButton() {
+		return screen.getByRole( 'button', { name: /toggle/i } );
+	}
+
+	function getHelpButton() {
+		return screen.getByRole( 'button', { name: /open popover/i } );
+	}
+
+	it( 'Should render the heading', () => {
+		render( <AssetField heading="Heading" numOfIssues={ 0 } /> );
+
+		expect( screen.getByText( 'Heading' ) ).toBeInTheDocument();
+	} );
+
+	it( 'Should render the subheading', () => {
+		render( <AssetField subheading="Subheading" numOfIssues={ 0 } /> );
+
+		expect( screen.getByText( 'Subheading' ) ).toBeInTheDocument();
+	} );
+
+	it( 'When `numOfIssues` > 0, it should render the number of issues', () => {
+		const { rerender } = render( <AssetField numOfIssues={ 1 } /> );
+
+		expect( screen.getByText( '1 issue' ) ).toBeInTheDocument();
+
+		rerender( <AssetField numOfIssues={ 2 } /> );
+
+		expect( screen.getByText( '2 issues' ) ).toBeInTheDocument();
+	} );
+
+	it( 'When `numOfIssues` = 0, it should not render the number of issues', () => {
+		render( <AssetField numOfIssues={ 0 } /> );
+
+		expect( screen.queryByText( '0 issues' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'When not setting `initialExpanded`, it should collapse to hide the children', () => {
+		render( <AssetField numOfIssues={ 0 }>Children</AssetField> );
+
+		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'When setting `initialExpanded`, it should expand to render the children', () => {
+		render(
+			<AssetField numOfIssues={ 0 } initialExpanded>
+				Children
+			</AssetField>
+		);
+
+		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
+	} );
+
+	it( 'When disabling, it should also collapse to hide the children', () => {
+		const { rerender } = render(
+			<AssetField numOfIssues={ 0 } initialExpanded>
+				Children
+			</AssetField>
+		);
+
+		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
+
+		rerender(
+			<AssetField numOfIssues={ 0 } initialExpanded disabled>
+				Children
+			</AssetField>
+		);
+
+		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'When disabled, it should also disable the toggle button and help button', async () => {
+		const { rerender } = render( <AssetField numOfIssues={ 0 } /> );
+
+		expect( getToggleButton() ).toBeEnabled();
+		expect( getHelpButton() ).toBeEnabled();
+
+		rerender( <AssetField numOfIssues={ 0 } disabled /> );
+
+		expect( getToggleButton() ).toBeDisabled();
+		expect( getHelpButton() ).toBeDisabled();
+	} );
+
+	it( 'When clicking on the toggle button, it should toggle to show or hide the children', async () => {
+		render( <AssetField numOfIssues={ 0 }>Children</AssetField> );
+
+		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+
+		await userEvent.click( getToggleButton() );
+
+		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
+
+		await userEvent.click( getToggleButton() );
+
+		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useRef, createInterpolateElement } from '@wordpress/element';
+import { useState, createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,7 +20,6 @@ import './asset-group-section.scss';
  */
 export default function AssetGroupSection() {
 	const [ assetGroup, setAssetGroup ] = useState( null );
-	const fieldRef = useRef();
 
 	return (
 		<Section
@@ -142,27 +141,6 @@ export default function AssetGroupSection() {
 			</VerticalGapLayout>
 			<h3>Temporary demo for showing the current assets data:</h3>
 			<pre>{ JSON.stringify( assetGroup, null, 2 ) }</pre>
-			<div
-				style={ {
-					height: '3000px',
-					paddingTop: '1500px',
-				} }
-			>
-				<AssetField
-					ref={ fieldRef }
-					heading={ __(
-						'For testing scrollIntoComponent',
-						'google-listings-and-ads'
-					) }
-					numOfIssues={ 2 }
-				/>
-				<button
-					style={ { position: 'fixed', top: '50%', left: '200px' } }
-					onClick={ () => fieldRef.current.scrollIntoComponent() }
-				>
-					Call scrollIntoComponent()
-				</button>
-			</div>
 		</Section>
 	);
 }

--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -12,6 +12,7 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import FinalUrlCard from './final-url-card';
 import ImagesSelector from './images-selector';
+import AssetField from './asset-field';
 import './asset-group-section.scss';
 
 /**
@@ -57,9 +58,48 @@ export default function AssetGroupSection() {
 			<VerticalGapLayout size="medium">
 				<FinalUrlCard onAssetsChange={ setAssetGroup } />
 				<div>Assets card will be added here</div>
-				<Section.Card>
-					<Section.Card.Body>
-						<h3>Temporary demo of rectangular images selector</h3>
+				<h3>Temporary demo for AssetField:</h3>
+				<div>
+					<AssetField
+						heading={ __(
+							'Rectangular images',
+							'google-listings-and-ads'
+						) }
+						subheading={ __(
+							'At least 1 required. Add up to 20.',
+							'google-listings-and-ads'
+						) }
+						help={
+							<>
+								<p>
+									{ __(
+										'Add images that meet or can be cropped to the recommended sizes. Note: The maximum file size for any image is 5120 KB.',
+										'google-listings-and-ads'
+									) }
+								</p>
+								<p>
+									<strong>
+										{ __(
+											'Landscape image (1.91:1)',
+											'google-listings-and-ads'
+										) }
+									</strong>
+								</p>
+								<p>
+									{ __(
+										'Recommended size: 1200 x 628',
+										'google-listings-and-ads'
+									) }
+									<br />
+									{ __(
+										'Min. size: 600 x 314',
+										'google-listings-and-ads'
+									) }
+								</p>
+							</>
+						}
+						numOfIssues={ 2 }
+					>
 						<ImagesSelector
 							maxNumberOfImages={ 3 }
 							imageConfig={ {
@@ -69,22 +109,35 @@ export default function AssetGroupSection() {
 								suggestedHeight: 628,
 							} }
 						/>
-					</Section.Card.Body>
-				</Section.Card>
-				<Section.Card>
-					<Section.Card.Body>
-						<h3>Temporary demo of square image selector</h3>
-						<ImagesSelector
-							maxNumberOfImages={ 20 }
-							imageConfig={ {
-								minWidth: 300,
-								minHeight: 300,
-								suggestedWidth: 1200,
-								suggestedHeight: 1200,
-							} }
-						/>
-					</Section.Card.Body>
-				</Section.Card>
+					</AssetField>
+					<AssetField
+						heading={ __(
+							'Square images',
+							'google-listings-and-ads'
+						) }
+						subheading={ __(
+							'At least 1 required. Add up to 20.',
+							'google-listings-and-ads'
+						) }
+						numOfIssues={ 1 }
+						disabled
+					/>
+					<AssetField
+						heading={ __( 'Headline', 'google-listings-and-ads' ) }
+						subheading={ __(
+							'At least 3 required. Add up to 5.',
+							'google-listings-and-ads'
+						) }
+						help={ __(
+							'The headline is the first line of your ad and is most likely the first thing people notice, so consider including words that people may have entered in their Google search.',
+							'google-listings-and-ads'
+						) }
+						numOfIssues={ 0 }
+						initialExpanded
+					>
+						Initially expanded asset field
+					</AssetField>
+				</div>
 			</VerticalGapLayout>
 			<h3>Temporary demo for showing the current assets data:</h3>
 			<pre>{ JSON.stringify( assetGroup, null, 2 ) }</pre>

--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, createInterpolateElement } from '@wordpress/element';
+import { useState, useRef, createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,6 +20,7 @@ import './asset-group-section.scss';
  */
 export default function AssetGroupSection() {
 	const [ assetGroup, setAssetGroup ] = useState( null );
+	const fieldRef = useRef();
 
 	return (
 		<Section
@@ -141,6 +142,27 @@ export default function AssetGroupSection() {
 			</VerticalGapLayout>
 			<h3>Temporary demo for showing the current assets data:</h3>
 			<pre>{ JSON.stringify( assetGroup, null, 2 ) }</pre>
+			<div
+				style={ {
+					height: '3000px',
+					paddingTop: '1500px',
+				} }
+			>
+				<AssetField
+					ref={ fieldRef }
+					heading={ __(
+						'For testing scrollIntoComponent',
+						'google-listings-and-ads'
+					) }
+					numOfIssues={ 2 }
+				/>
+				<button
+					style={ { position: 'fixed', top: '50%', left: '200px' } }
+					onClick={ () => fieldRef.current.scrollIntoComponent() }
+				>
+					Call scrollIntoComponent()
+				</button>
+			</div>
 		</Section>
 	);
 }

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import GridiconPlusSmall from 'gridicons/dist/plus-small';
 import GridiconCrossCircle from 'gridicons/dist/cross-circle';
 
 /**
@@ -11,6 +10,7 @@ import GridiconCrossCircle from 'gridicons/dist/cross-circle';
  */
 import AppButton from '.~/components/app-button';
 import useCroppedImageSelector from '.~/hooks/useCroppedImageSelector';
+import AddAssetItemButton from './add-asset-item-button';
 import './images-selector.scss';
 
 /**
@@ -112,15 +112,11 @@ export default function ImagesSelector( {
 					);
 				} ) }
 			</div>
-			<AppButton
-				className="gla-images-selector__add-image-button"
-				isLink
+			<AddAssetItemButton
 				disabled={
 					maxNumberOfImages !== 0 &&
 					images.length >= maxNumberOfImages
 				}
-				icon={ <GridiconPlusSmall /> }
-				iconSize={ 16 }
 				text={ __( 'Add image', 'google-listings-and-ads' ) }
 				onClick={ handleUpsertImageClick }
 			/>

--- a/js/src/components/paid-ads/asset-group/images-selector.scss
+++ b/js/src/components/paid-ads/asset-group/images-selector.scss
@@ -3,6 +3,10 @@
 		display: flex;
 		flex-wrap: wrap;
 		gap: $grid-unit-15;
+
+		&:not(:empty) {
+			margin-bottom: $grid-unit-20;
+		}
 	}
 
 	&__image-item {
@@ -23,11 +27,6 @@
 	&__image {
 		max-width: 100%;
 		max-height: 100%;
-	}
-
-	&__add-image-button.has-icon {
-		margin-top: $grid-unit-20;
-		padding: $grid-unit-05;
 	}
 
 	&__remove-image-button {

--- a/js/src/wcdl/section/index.js
+++ b/js/src/wcdl/section/index.js
@@ -39,7 +39,7 @@ const Section = ( {
 
 	return (
 		<section className={ sectionClassName }>
-			<header>
+			<header className="wcdl-section__header">
 				{ topContent && <p>{ topContent }</p> }
 				{ title && <h1>{ title }</h1> }
 				{ description }

--- a/js/src/wcdl/section/index.scss
+++ b/js/src/wcdl/section/index.scss
@@ -4,7 +4,7 @@
 	margin-bottom: var(--large-gap);
 
 	&--is-disabled,
-	&--is-disabled-left header {
+	&--is-disabled-left &__header {
 		opacity: 0.5;
 	}
 
@@ -13,7 +13,7 @@
 		gap: var(--main-gap);
 	}
 
-	header {
+	&__header {
 		@include break-small {
 			width: 33%;
 			padding-top: var(--main-gap);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a part of 📌 [Assets form and related components](https://github.com/woocommerce/google-listings-and-ads/issues/1787#fe-misc) in #1787.

AssetField component includes:

- Construct the basic layout like heading, subheading, help content, etc.
- Toggle the content
- Composite the help popover
- Display the number of issues with a Pill
- Disableable

### Screenshots:

<img width="632" alt="2023-01-16 17 18 26" src="https://user-images.githubusercontent.com/17420811/212666895-d3e10031-6957-48c0-9d2d-0ea4d54616b5.png">

### Detailed test instructions:

1. Go to the assets step of the campaign creation page.
2. Use the AssetField demo to test.

### 📌 Dev notes

- [x] Revert fc5c54c46d4eb096ba0e396147ffdb78633530fc before merging.

### Changelog entry
