### PR TITLE
PMax Assets: TextsEditor for managing the asset texts

### DIFF
--- a/js/src/components/app-input-control/index.js
+++ b/js/src/components/app-input-control/index.js
@@ -2,37 +2,74 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { __, sprintf } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
 import { __experimentalInputControl as InputControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import getCharacterCounter from '.~/utils/getCharacterCounter';
 import './index.scss';
 
 const baseClassName = 'app-input-control';
 
 /**
  * Renders <InputControl> with a wrapper to be applicable extend additional class names.
- * noPointerEvents
  *
  * @param {Object} props React props to be forwarded to {@link InputControl}.
  * @param {string} [props.className] Additional CSS class name to be appended.
- * @param {boolean} [props.noPointerEvents] Whether disabled all pointer events. It will attach `pointer-events: none;` onto wrapper if true.
+ * @param {boolean} [props.noPointerEvents=false] Whether disabled all pointer events. It will attach `pointer-events: none;` onto wrapper if true.
+ * @param {number} [props.maxCharacterCount=0] The maximum number of character counter for showing a label below the input element to inform whether the input has exceeded the limit. 0 by default and it means no limit and no label is shown. When using this prop, it must also set the `kindCharacterCount`.
+ * @param {'google-ads'} [props.kindCharacterCount] Kind of character counter to be used.
+ * @param {import('react').MutableRefObject<HTMLInputElement>} ref React ref to be forwarded to the input element within this component.
  */
-const AppInputControl = forwardRef( ( props, ref ) => {
-	const { className, noPointerEvents, ...rest } = props;
-	const wrapperClassName = classnames(
-		baseClassName,
-		noPointerEvents && `${ baseClassName }--no-pointer-events`,
-		className
-	);
+const AppInputControl = (
+	{
+		className,
+		noPointerEvents = false,
+		maxCharacterCount = 0,
+		kindCharacterCount,
+		...rest
+	},
+	ref
+) => {
+	const wrapperClassNames = [ baseClassName, className ];
+
+	if ( noPointerEvents ) {
+		wrapperClassNames.push( `${ baseClassName }--no-pointer-events` );
+	}
+
+	let countText;
+
+	if ( maxCharacterCount > 0 && kindCharacterCount ) {
+		const count = getCharacterCounter( kindCharacterCount );
+		const characterCount = count( rest.value?.trim() || '' );
+
+		countText = sprintf(
+			// translators: 1: number of character count. 2: the maximum number of character count.
+			__( '%1$d/%2$d characters', 'google-listings-and-ads' ),
+			characterCount,
+			maxCharacterCount
+		);
+
+		if ( characterCount > maxCharacterCount ) {
+			wrapperClassNames.push(
+				`${ baseClassName }--error-character-count`
+			);
+		}
+	}
 
 	return (
-		<div className={ wrapperClassName }>
+		<div className={ classnames( wrapperClassNames ) }>
 			<InputControl ref={ ref } { ...rest } />
+			{ countText && (
+				<div className="app-input-control__character-count">
+					{ countText }
+				</div>
+			) }
 		</div>
 	);
-} );
+};
 
-export default AppInputControl;
+export default forwardRef( AppInputControl );

--- a/js/src/components/app-input-control/index.scss
+++ b/js/src/components/app-input-control/index.scss
@@ -20,4 +20,21 @@
 	&--no-pointer-events {
 		pointer-events: none;
 	}
+
+	&__character-count {
+		margin-top: calc($grid-unit-05 / 2);
+		text-align: right;
+		line-height: $gla-line-height-smaller;
+		font-size: $gla-font-smaller;
+		color: $gray-700;
+	}
+
+	&--error-character-count .components-input-control .components-input-control__container .components-input-control__backdrop {
+		border-color: $alert-red;
+		box-shadow: none;
+	}
+
+	&--error-character-count &__character-count {
+		color: $alert-red;
+	}
 }

--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -12,6 +12,7 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import FinalUrlCard from './final-url-card';
 import ImagesSelector from './images-selector';
+import TextsEditor from './texts-editor';
 import AssetField from './asset-field';
 import './asset-group-section.scss';
 
@@ -58,7 +59,7 @@ export default function AssetGroupSection() {
 			<VerticalGapLayout size="medium">
 				<FinalUrlCard onAssetsChange={ setAssetGroup } />
 				<div>Assets card will be added here</div>
-				<h3>Temporary demo for AssetField:</h3>
+				<h3>Temporary demo for AssetField and TextsEditor:</h3>
 				<div>
 					<AssetField
 						heading={ __(
@@ -135,7 +136,70 @@ export default function AssetGroupSection() {
 						numOfIssues={ 0 }
 						initialExpanded
 					>
-						Initially expanded asset field
+						<TextsEditor
+							minNumberOfTexts={ 3 }
+							maxNumberOfTexts={ 5 }
+							maxCharacterCounts={ [ 15, 30, 30, 30, 30 ] }
+							placeholder={ __(
+								'Headline',
+								'google-listings-and-ads'
+							) }
+							addButtonText={ __(
+								'Add headline',
+								'google-listings-and-ads'
+							) }
+							initialTexts={ [ 'Hello', 'World' ] }
+							onChange={ ( v ) =>
+								// eslint-disable-next-line no-console
+								console.log( 'Headline:onChange', v )
+							}
+						/>
+					</AssetField>
+					<AssetField
+						heading={ __(
+							'Long headlines',
+							'google-listings-and-ads'
+						) }
+						subheading={ __(
+							'At least 1 required. Add up to 5.',
+							'google-listings-and-ads'
+						) }
+						help={
+							<>
+								<p>
+									{ __(
+										'The long headline is the first line of your ad, and appears instead of your short headline in larger ads. Long headlines can be up to 90 characters, and may appear with or without your description.',
+										'google-listings-and-ads'
+									) }
+								</p>
+								<p>
+									{ __(
+										'The length of the rendered headline will depend on the site it appears on. If shortened, it will end with an ellipsis(…).',
+										'google-listings-and-ads'
+									) }
+								</p>
+							</>
+						}
+						numOfIssues={ 0 }
+					>
+						<TextsEditor
+							minNumberOfTexts={ 1 }
+							maxNumberOfTexts={ 5 }
+							maxCharacterCounts={ 90 }
+							placeholder={ __(
+								'Long headlines',
+								'google-listings-and-ads'
+							) }
+							addButtonText={ __(
+								'Add long headline',
+								'google-listings-and-ads'
+							) }
+							initialTexts={ [] }
+							onChange={ ( v ) =>
+								// eslint-disable-next-line no-console
+								console.log( 'Long headlines:onChange', v )
+							}
+						/>
 					</AssetField>
 				</div>
 			</VerticalGapLayout>

--- a/js/src/components/paid-ads/asset-group/texts-editor.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.js
@@ -46,17 +46,7 @@ export default function TextsEditor( {
 	onChange = noop,
 } ) {
 	const updateTextsRef = useRef();
-	const [ texts, setTexts ] = useState( () => {
-		const nextTexts = normalizeNumberOfTexts(
-			initialTexts,
-			minNumberOfTexts,
-			maxNumberOfTexts
-		);
-		if ( nextTexts.length !== initialTexts.length ) {
-			onChange( nextTexts );
-		}
-		return nextTexts;
-	} );
+	const [ texts, setTexts ] = useState( initialTexts );
 
 	const updateTexts = ( nextTexts ) => {
 		setTexts( nextTexts );

--- a/js/src/components/paid-ads/asset-group/texts-editor.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.js
@@ -23,7 +23,7 @@ import './texts-editor.scss';
  * @param {number|number[]} props.maxCharacterCounts Maximum number of characters for each text. If the limits are the same, a single number can be used instead of an array.
  * @param {string} props.addButtonText Text for the button to add a new text input.
  * @param {string} [props.placeholder] Placeholder text.
- * @param {Function} props.onChange Callback function to be called when the texts are changed.
+ * @param {(texts: Array<string>) => void} props.onChange Callback function to be called when the texts are changed.
  */
 export default function TextsEditor( {
 	initialTexts = [],

--- a/js/src/components/paid-ads/asset-group/texts-editor.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
+import AppInputControl from '.~/components/app-input-control';
+import AddAssetItemButton from './add-asset-item-button';
+import './texts-editor.scss';
+
+/**
+ * Renders a list of text inputs for managing the single type of asset texts.
+ *
+ * @param {Object} props React props.
+ * @param {string[]} [props.initialTexts=[]] Initial texts.
+ * @param {number} [props.minNumberOfTexts=0] Minimum number of texts.
+ * @param {number} [props.maxNumberOfTexts=0] Maximum number of texts.
+ * @param {number|number[]} props.maxCharacterCounts Maximum number of characters for each text. If the limits are the same, a single number can be used instead of an array.
+ * @param {string} props.addButtonText Text for the button to add a new text input.
+ * @param {string} [props.placeholder] Placeholder text.
+ * @param {Function} props.onChange Callback function to be called when the texts are changed.
+ */
+export default function TextsEditor( {
+	initialTexts = [],
+	minNumberOfTexts = 0,
+	maxNumberOfTexts = 0,
+	maxCharacterCounts,
+	addButtonText,
+	placeholder,
+	onChange,
+} ) {
+	const [ texts, setTexts ] = useState( () => {
+		const shortage = minNumberOfTexts - initialTexts.length;
+		if ( shortage <= 0 ) {
+			return initialTexts;
+		}
+
+		const supplement = Array.from( { length: shortage }, () => '' );
+		return initialTexts.concat( supplement );
+	} );
+
+	const updateTexts = ( nextTexts ) => {
+		setTexts( nextTexts );
+		onChange( nextTexts );
+	};
+
+	const handleChange = ( text, { event } ) => {
+		const { index } = event.target.dataset;
+		const nextTexts = [ ...texts ];
+		nextTexts[ index ] = text.trim();
+		updateTexts( nextTexts );
+	};
+
+	const handleRemoveClick = ( event ) => {
+		const { index } = event.currentTarget.dataset;
+		const nextTexts = [ ...texts ];
+		nextTexts.splice( index, 1 );
+		updateTexts( nextTexts );
+	};
+
+	const handleAddClick = () => {
+		updateTexts( texts.concat( '' ) );
+	};
+
+	const normalizedMaxCharacterCounts = [ maxCharacterCounts ].flat();
+
+	return (
+		<div className="gla-texts-editor">
+			<div className="gla-texts-editor__text-list">
+				{ texts.map( ( text, index ) => {
+					const maxCharacterCount =
+						normalizedMaxCharacterCounts[ index ] ??
+						normalizedMaxCharacterCounts[ 0 ];
+
+					return (
+						<div
+							key={ index }
+							className="gla-texts-editor__text-item"
+						>
+							<AppInputControl
+								className="gla-texts-editor__text-input"
+								value={ text }
+								kindCharacterCount="google-ads"
+								maxCharacterCount={ maxCharacterCount }
+								placeholder={ placeholder }
+								data-index={ index }
+								onChange={ handleChange }
+							/>
+							<div className="gla-texts-editor__remove-text-button-anchor">
+								{ index + 1 > minNumberOfTexts && (
+									<AppButton
+										className="gla-texts-editor__remove-text-button"
+										aria-label={ __(
+											'Remove text',
+											'google-listings-and-ads'
+										) }
+										icon={ <GridiconCrossSmall /> }
+										iconSize={ 20 }
+										data-index={ index }
+										onClick={ handleRemoveClick }
+									/>
+								) }
+							</div>
+						</div>
+					);
+				} ) }
+			</div>
+			<AddAssetItemButton
+				aria-label={ __( 'Add text', 'google-listings-and-ads' ) }
+				disabled={
+					maxNumberOfTexts !== 0 && texts.length >= maxNumberOfTexts
+				}
+				text={ addButtonText }
+				onClick={ handleAddClick }
+			/>
+		</div>
+	);
+}

--- a/js/src/components/paid-ads/asset-group/texts-editor.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.js
@@ -113,7 +113,7 @@ export default function TextsEditor( {
 			<AddAssetItemButton
 				aria-label={ __( 'Add text', 'google-listings-and-ads' ) }
 				disabled={
-					maxNumberOfTexts !== 0 && texts.length >= maxNumberOfTexts
+					maxNumberOfTexts > 0 && texts.length >= maxNumberOfTexts
 				}
 				text={ addButtonText }
 				onClick={ handleAddClick }

--- a/js/src/components/paid-ads/asset-group/texts-editor.scss
+++ b/js/src/components/paid-ads/asset-group/texts-editor.scss
@@ -1,0 +1,40 @@
+.gla-texts-editor {
+	.components-input-control .components-input-control__container .components-input-control__input {
+		height: $gla-size-control-height;
+		padding-left: $grid-unit-20;
+		padding-right: $grid-unit-20;
+	}
+
+	&__text-list {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-20;
+
+		&:not(:empty) {
+			margin-bottom: $grid-unit-20;
+		}
+	}
+
+	&__text-item {
+		display: flex;
+		align-items: flex-start;
+		gap: $grid-unit-05 * 7;
+	}
+
+	&__text-input {
+		flex: 1 1;
+	}
+
+	&__remove-text-button-anchor {
+		position: relative;
+		width: 24px;
+		height: $gla-size-control-height;
+	}
+
+	&__remove-text-button {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+	}
+}

--- a/js/src/components/paid-ads/asset-group/texts-editor.test.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.test.js
@@ -1,0 +1,186 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import TextsEditor from './texts-editor';
+
+describe( 'TextsEditor', () => {
+	it( 'Should render addButtonText to the add button', () => {
+		render( <TextsEditor addButtonText="Add headline" /> );
+		const addButton = screen.getByRole( 'button', { name: 'Add text' } );
+
+		expect( addButton ).toHaveTextContent( 'Add headline' );
+	} );
+
+	it( 'Should set placeholder to inputs', () => {
+		render(
+			<TextsEditor minNumberOfTexts={ 2 } placeholder="Enter headline" />
+		);
+		const inputs = screen.getAllByRole( 'textbox' );
+
+		expect( inputs[ 0 ] ).toHaveAttribute(
+			'placeholder',
+			'Enter headline'
+		);
+		expect( inputs[ 1 ] ).toHaveAttribute(
+			'placeholder',
+			'Enter headline'
+		);
+	} );
+
+	it( 'Should use `initialTexts` as the initial texts', () => {
+		const initialTexts = [ 'Text 1', 'Text 2' ];
+		render( <TextsEditor initialTexts={ initialTexts } /> );
+		const inputs = screen.getAllByRole( 'textbox' );
+
+		expect( inputs ).toHaveLength( 2 );
+		expect( inputs[ 0 ] ).toHaveValue( initialTexts[ 0 ] );
+		expect( inputs[ 1 ] ).toHaveValue( initialTexts[ 1 ] );
+	} );
+
+	it( 'When `minNumberOfTexts` is specified, it should prefill empty strings as initial texts to supplement the shortage parts of `initialTexts`', () => {
+		const initialTexts = [ 'Text 1' ];
+		render(
+			<TextsEditor initialTexts={ initialTexts } minNumberOfTexts={ 3 } />
+		);
+		const inputs = screen.getAllByRole( 'textbox' );
+
+		expect( inputs ).toHaveLength( 3 );
+		expect( inputs[ 0 ] ).toHaveValue( initialTexts[ 0 ] );
+		expect( inputs[ 1 ] ).toHaveValue( '' );
+		expect( inputs[ 2 ] ).toHaveValue( '' );
+	} );
+
+	it( 'Inputs with sequence numbers larger than `minNumberOfTexts` should be accompanied by a delete button', () => {
+		const initialTexts = [ 'Text 1', 'Text 2', 'Text 3', 'Text 4' ];
+		render(
+			<TextsEditor initialTexts={ initialTexts } minNumberOfTexts={ 2 } />
+		);
+		const inputs = screen.getAllByRole( 'textbox' );
+		const deleteButtons = screen.getAllByRole( 'button', {
+			name: 'Remove text',
+		} );
+
+		expect( inputs ).toHaveLength( 4 );
+		expect( deleteButtons ).toHaveLength( 2 );
+		expect(
+			inputs[ 2 ]
+				.closest( '.gla-texts-editor__text-item' )
+				.querySelector( 'button' )
+		).toBe( deleteButtons[ 0 ] );
+		expect(
+			inputs[ 3 ]
+				.closest( '.gla-texts-editor__text-item' )
+				.querySelector( 'button' )
+		).toBe( deleteButtons[ 1 ] );
+	} );
+
+	it( 'When the number of texts reaches `maxNumberOfTexts`, it should disable the add button and vice versa', async () => {
+		const initialTexts = [ 'Text 1', 'Text 2' ];
+		render(
+			<TextsEditor
+				initialTexts={ initialTexts }
+				maxNumberOfTexts={ 3 }
+				onChange={ () => {} }
+			/>
+		);
+		const addButton = screen.getByRole( 'button', { name: 'Add text' } );
+
+		expect( addButton ).toBeEnabled();
+
+		await userEvent.click( addButton );
+
+		expect( addButton ).toBeDisabled();
+
+		await userEvent.click(
+			screen.getAllByRole( 'button', { name: 'Remove text' } ).at( -1 )
+		);
+
+		expect( addButton ).toBeEnabled();
+	} );
+
+	it( 'When `maxCharacterCounts` is an array, it should be applied to each input fields in order of index', () => {
+		render(
+			<TextsEditor
+				minNumberOfTexts={ 2 }
+				maxCharacterCounts={ [ 10, 20 ] }
+			/>
+		);
+		const labels = screen.getAllByText( /0\/\d+ characters/ );
+
+		expect( labels ).toHaveLength( 2 );
+		expect( labels[ 0 ] ).toHaveTextContent( '0/10 characters' );
+		expect( labels[ 1 ] ).toHaveTextContent( '0/20 characters' );
+	} );
+
+	it( 'When `maxCharacterCounts` is a number, it should be applied to each input fields', () => {
+		render(
+			<TextsEditor minNumberOfTexts={ 2 } maxCharacterCounts={ 10 } />
+		);
+		const labels = screen.getAllByText( /0\/\d+ characters/ );
+
+		expect( labels ).toHaveLength( 2 );
+		expect( labels[ 0 ] ).toHaveTextContent( '0/10 characters' );
+		expect( labels[ 1 ] ).toHaveTextContent( '0/10 characters' );
+	} );
+
+	it( 'When typing on the input field, the count of characters should be updated accordingly', async () => {
+		render(
+			<TextsEditor
+				minNumberOfTexts={ 1 }
+				maxCharacterCounts={ 10 }
+				onChange={ () => {} }
+			/>
+		);
+		const input = screen.getByRole( 'textbox' );
+		const label = screen.getByText( /\d+\/10 characters/ );
+
+		await userEvent.type( input, 'Hello' );
+
+		expect( label ).toHaveTextContent( '5/10 characters' );
+
+		await userEvent.type( input, ' World!' );
+
+		expect( label ).toHaveTextContent( '12/10 characters' );
+	} );
+
+	it( 'When the texts are changed, should trigger `onChange` callback function with the updated texts', async () => {
+		const onChange = jest.fn();
+		render( <TextsEditor minNumberOfTexts={ 1 } onChange={ onChange } /> );
+
+		await userEvent.type( screen.getByRole( 'textbox' ), 'Hello' );
+
+		expect( onChange ).toHaveBeenCalledWith( [ 'Hello' ] );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Add text' } )
+		);
+
+		expect( onChange ).toHaveBeenCalledWith( [ 'Hello', '' ] );
+
+		await userEvent.type( screen.getAllByRole( 'textbox' )[ 1 ], 'World' );
+
+		expect( onChange ).toHaveBeenCalledWith( [ 'Hello', 'World' ] );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Remove text' } )
+		);
+
+		expect( onChange ).toHaveBeenCalledWith( [ 'Hello' ] );
+	} );
+
+	it( 'Should trim the texts for the `onChange` callback function', async () => {
+		const onChange = jest.fn();
+		render( <TextsEditor minNumberOfTexts={ 1 } onChange={ onChange } /> );
+
+		await userEvent.type( screen.getByRole( 'textbox' ), ' Hello ' );
+
+		expect( onChange ).toHaveBeenCalledWith( [ 'Hello' ] );
+	} );
+} );

--- a/js/src/components/paid-ads/asset-group/texts-editor.test.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.test.js
@@ -44,17 +44,39 @@ describe( 'TextsEditor', () => {
 		expect( inputs[ 1 ] ).toHaveValue( initialTexts[ 1 ] );
 	} );
 
-	it( 'When `minNumberOfTexts` is specified, it should prefill empty strings as initial texts to supplement the shortage parts of `initialTexts`', () => {
+	it( 'When `minNumberOfTexts` is specified, it should prefill empty strings as initial texts to supplement the shortage parts of `initialTexts` or `texts`', () => {
 		const initialTexts = [ 'Text 1' ];
-		render(
-			<TextsEditor initialTexts={ initialTexts } minNumberOfTexts={ 3 } />
+		const onChange = jest.fn();
+		const { rerender } = render(
+			<TextsEditor
+				initialTexts={ initialTexts }
+				minNumberOfTexts={ 2 }
+				onChange={ onChange }
+			/>
 		);
-		const inputs = screen.getAllByRole( 'textbox' );
+		let inputs = screen.getAllByRole( 'textbox' );
+
+		expect( inputs ).toHaveLength( 2 );
+		expect( inputs[ 0 ] ).toHaveValue( initialTexts[ 0 ] );
+		expect( inputs[ 1 ] ).toHaveValue( '' );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( [ ...initialTexts, '' ] );
+
+		rerender(
+			<TextsEditor
+				initialTexts={ initialTexts }
+				minNumberOfTexts={ 3 }
+				onChange={ onChange }
+			/>
+		);
+		inputs = screen.getAllByRole( 'textbox' );
 
 		expect( inputs ).toHaveLength( 3 );
 		expect( inputs[ 0 ] ).toHaveValue( initialTexts[ 0 ] );
 		expect( inputs[ 1 ] ).toHaveValue( '' );
 		expect( inputs[ 2 ] ).toHaveValue( '' );
+		expect( onChange ).toHaveBeenCalledTimes( 2 );
+		expect( onChange ).toHaveBeenCalledWith( [ ...initialTexts, '', '' ] );
 	} );
 
 	it( 'Inputs with sequence numbers larger than `minNumberOfTexts` should be accompanied by a delete button', () => {
@@ -103,6 +125,34 @@ describe( 'TextsEditor', () => {
 		);
 
 		expect( addButton ).toBeEnabled();
+	} );
+
+	it( 'When the length of `initialTexts` or `texts` is greater than `maxNumberOfTexts`, it should truncate the excess', () => {
+		const initialTexts = [ 'Text 1', 'Text 2', 'Text 3' ];
+		const onChange = jest.fn();
+		const { rerender } = render(
+			<TextsEditor
+				initialTexts={ initialTexts }
+				maxNumberOfTexts={ 2 }
+				onChange={ onChange }
+			/>
+		);
+
+		expect( screen.getAllByRole( 'textbox' ) ).toHaveLength( 2 );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( initialTexts.slice( 0, 2 ) );
+
+		rerender(
+			<TextsEditor
+				texts={ initialTexts }
+				maxNumberOfTexts={ 1 }
+				onChange={ onChange }
+			/>
+		);
+
+		expect( screen.getAllByRole( 'textbox' ) ).toHaveLength( 1 );
+		expect( onChange ).toHaveBeenCalledTimes( 2 );
+		expect( onChange ).toHaveBeenCalledWith( initialTexts.slice( 0, 1 ) );
 	} );
 
 	it( 'When `maxCharacterCounts` is an array, it should be applied to each input fields in order of index', () => {

--- a/js/src/utils/getCharacterCounter.js
+++ b/js/src/utils/getCharacterCounter.js
@@ -1,0 +1,141 @@
+const counterMap = new Map();
+
+/**
+ * @function
+ * @name CharacterCounter
+ * @param {string} string The string to be counted characters.
+ */
+
+/**
+ * Returns a function that uses the same character counting rule as the Google Ads admin pages.
+ *
+ * @return {CharacterCounter} Character counter function using the same character counting rule as the Google Ads admin pages
+ */
+export function getCharacterCounterOfGoogleAds() {
+	const oneCountRules = [
+		// Unicode blocks:
+		// - Basic Latin
+		// - Latin-1 Supplement
+		// - Latin Extended-A
+		// - Latin Extended-B
+		// - IPA Extensions
+		// - Spacing Modifier Letters
+		// - Combining Diacritical Marks
+		// - Greek and Coptic
+		// - Cyrillic (Part of. The full range is \u0400 - \u04FF)
+		/[\u0000-\u04F9]/,
+
+		// Unicode blocks:
+		// - Latin Extended Additional
+		// - Greek Extended
+		// - General Punctuation
+		// - Superscripts and Subscripts
+		// - Currency Symbols
+		/[\u1E00-\u20BF]/,
+
+		// Unicode block: Halfwidth and Fullwidth Forms (Part of halfwidth ranges. The full range is \uFF00 - \uFFEF)
+		// This check includes the halfwidth character ranges except for the "Halfwidth symbol variants".
+		// - Halfwidth CJK punctuation
+		// - Halfwidth Katakana variants
+		// - Halfwidth Hangul variants
+		// Ref: https://unicode.org/charts/PDF/UFF00.pdf
+		/[\uFF61-\uFFDC]/,
+
+		// Unicode block: Thai
+		/[\u0E00-\u0E7F]/,
+
+		// Unicode block: Letterlike Symbols (Part of. The full range is \u2100 - \u214F)
+		/[\u2100-\u213A]/,
+
+		// Unicode block: Arabic
+		/[\u0600-\u06FF]/,
+
+		// Unicode block: Arabic Supplement
+		/[\u0750-\u077F]/,
+
+		// Unicode block: Arabic Presentation Forms-A
+		/[\uFB50-\uFDFF]/,
+
+		// Unicode block: Arabic Presentation Forms-B
+		/[\uFE70-\uFEFF]/,
+
+		// Unicode block: Hebrew (Part of. The full range is \u0590 - \u05FF)
+		/[\u05D0-\u05EA]/,
+
+		// Unicode block: Hebrew Punctuation: Maqaf, Geresh, and Gershayim
+		/\u05BE|\u05F3|\u05F4/,
+	];
+
+	// Some of the vowel diacritics, virama and accent marks in Devanagari letters
+	// are considered 0 char count as they don't affect the visual width of a char.
+	// - Various signs
+	// - Dependent vowel signs
+	// - Virama
+	// - Vedic tone marks
+	// - Accent marks
+	// - Dependent vowel sign
+	// - Dependent vowel signs for Kashmiri
+	// - Additional vowels for Sanskrit
+	//
+	// Ref: https://unicode.org/charts/nameslist/n_0900.html
+	//
+	// The readability is better than applying the formatting here.
+	/* eslint-disable prettier/prettier */
+	// prettier-ignore
+	const zeroWidthSet = new Set( [
+		'\u0900', '\u0901', '\u0902', '\u093A', '\u093C',
+		'\u0941', '\u0942', '\u0943', '\u0944', '\u0945',
+		'\u0946', '\u0947', '\u0948', '\u094D', '\u0951',
+		'\u0952', '\u0953', '\u0954', '\u0955', '\u0956',
+		'\u0957', '\u0962', '\u0963',
+	] );
+	/* eslint-enable prettier/prettier */
+
+	function countChar( char ) {
+		if ( oneCountRules.some( ( rule ) => rule.test( char ) ) ) {
+			return 1;
+		}
+
+		// Unicode blocks:
+		// - Devanagari
+		// - Bengali
+		// - Gurmukhi
+		// - Gujarati
+		// - Oriya
+		// - Tamil
+		// - Telugu
+		// - Kannada
+		// - Malayalam
+		if ( /[\u0900-\u0D7F]/.test( char ) ) {
+			return zeroWidthSet.has( char ) ? 0 : 1;
+		}
+
+		return 2;
+	}
+
+	return function ( string ) {
+		return string
+			.split( '' )
+			.reduce( ( sum, char ) => sum + countChar( char ), 0 );
+	};
+}
+
+counterMap.set( 'google-ads', getCharacterCounterOfGoogleAds() );
+
+/**
+ * Gets the specified kind of character counter function.
+ *
+ * @param {'google-ads'} kind Kind of character counter.
+ *
+ * @return {CharacterCounter} The specified kind of character counter function.
+ * @throws Will throw an error if the given `kind` is unknown.
+ */
+export default function getCharacterCounter( kind ) {
+	if ( counterMap.has( kind ) ) {
+		return counterMap.get( kind );
+	}
+
+	throw new Error(
+		`The given \`kind\` of character counter is an unknown kind: ${ kind }`
+	);
+}

--- a/js/src/utils/getCharacterCounter.test.js
+++ b/js/src/utils/getCharacterCounter.test.js
@@ -1,0 +1,241 @@
+/**
+ * Internal dependencies
+ */
+import getCharacterCounter, {
+	getCharacterCounterOfGoogleAds,
+} from './getCharacterCounter';
+
+describe( 'getCharacterCounter', () => {
+	it( 'Should return the specified character counter function by the given kind.', () => {
+		expect( getCharacterCounter( 'google-ads' ) ).toEqual(
+			expect.any( Function )
+		);
+	} );
+
+	it( 'Should throw error if the given `kind` is unknown.', () => {
+		expect( () => getCharacterCounter( 'foobar' ) ).toThrow();
+	} );
+} );
+
+describe( 'getCharacterCounterOfGoogleAds', () => {
+	function prevChar( char ) {
+		return String.fromCharCode( char.charCodeAt( 0 ) - 1 );
+	}
+
+	function nextChar( char ) {
+		return String.fromCharCode( char.charCodeAt( 0 ) + 1 );
+	}
+
+	const count = getCharacterCounterOfGoogleAds();
+
+	describe( 'Boundary tests', () => {
+		test( 'Boundary between Basic Latin and Cyrillic', () => {
+			expect( count( '\u0000' ) ).toBe( 1 );
+			expect( count( '\u04F9' ) ).toBe( 1 );
+			expect( count( nextChar( '\u04F9' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary between Latin Extended Additional and Currency Symbols', () => {
+			expect( count( '\u1E00' ) ).toBe( 1 );
+			expect( count( '\u20BF' ) ).toBe( 1 );
+			expect( count( prevChar( '\u1E00' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\u20BF' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary of Halfwidth and Fullwidth Forms', () => {
+			expect( count( '\uFF61' ) ).toBe( 1 );
+			expect( count( '\uFFDC' ) ).toBe( 1 );
+			expect( count( prevChar( '\uFF61' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\uFFDC' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary of Thai', () => {
+			expect( count( '\u0E00' ) ).toBe( 1 );
+			expect( count( '\u0E7F' ) ).toBe( 1 );
+			expect( count( prevChar( '\u0E00' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\u0E7F' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary of Letterlike Symbols', () => {
+			expect( count( '\u2100' ) ).toBe( 1 );
+			expect( count( '\u213A' ) ).toBe( 1 );
+			expect( count( prevChar( '\u2100' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\u213A' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary of Arabic', () => {
+			expect( count( '\u0600' ) ).toBe( 1 );
+			expect( count( '\u06FF' ) ).toBe( 1 );
+			expect( count( prevChar( '\u0600' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\u06FF' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary of Arabic Supplement', () => {
+			expect( count( '\u0750' ) ).toBe( 1 );
+			expect( count( '\u077F' ) ).toBe( 1 );
+			expect( count( prevChar( '\u0750' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\u077F' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary of Arabic Presentation Forms-A', () => {
+			expect( count( '\uFB50' ) ).toBe( 1 );
+			expect( count( '\uFDFF' ) ).toBe( 1 );
+			expect( count( prevChar( '\uFB50' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\uFDFF' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary of Arabic Presentation Forms-B', () => {
+			expect( count( '\uFE70' ) ).toBe( 1 );
+			expect( count( '\uFEFF' ) ).toBe( 1 );
+			expect( count( prevChar( '\uFE70' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\uFEFF' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary of Hebrew', () => {
+			expect( count( '\u05D0' ) ).toBe( 1 );
+			expect( count( '\u05EA' ) ).toBe( 1 );
+			expect( count( prevChar( '\u05D0' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\u05EA' ) ) ).toBe( 2 );
+		} );
+
+		test( 'Boundary between Devanagari and Malayalam', () => {
+			expect( count( '\u0900' ) ).toBe( 0 );
+			expect( count( '\u0D7F' ) ).toBe( 1 );
+			expect( count( prevChar( '\u0900' ) ) ).toBe( 2 );
+			expect( count( nextChar( '\u0D7F' ) ) ).toBe( 2 );
+		} );
+	} );
+
+	describe( 'Special cases', () => {
+		it( 'Should count some Hebrew punctuation chars as 1', () => {
+			expect( count( '\u05BE' ) ).toBe( 1 );
+			expect( count( '\u05F3' ) ).toBe( 1 );
+			expect( count( '\u05F4' ) ).toBe( 1 );
+		} );
+
+		it( 'Should count some specific chars in Devanagari as 0', () => {
+			expect( count( '\u0900\u0901\u0902\u093A\u093C' ) ).toBe( 0 );
+			expect( count( '\u0941\u0942\u0943\u0944\u0945' ) ).toBe( 0 );
+			expect( count( '\u0946\u0947\u0948\u094D\u0951' ) ).toBe( 0 );
+			expect( count( '\u0952\u0953\u0954\u0955\u0956' ) ).toBe( 0 );
+			expect( count( '\u0957\u0962\u0963' ) ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'Writing systems', () => {
+		test( 'English', () => {
+			const greeting = 'Hello from the children of planet Earth';
+			expect( count( greeting ) ).toBe( 39 );
+		} );
+
+		test( 'Chinese', () => {
+			const greeting = '太空朋友，恁好！恁食飽未？有閒著來阮遮坐喔。';
+			expect( count( greeting ) ).toBe( 44 );
+		} );
+
+		test( 'Japanese', () => {
+			expect( count( 'こんにちは。お元気ですか？' ) ).toBe( 26 );
+			// Halfwidth kana (半角カナ)
+			expect( count( 'ｺﾝﾆﾁﾊ｡ｵ元気ﾃﾞｽｶ?' ) ).toBe( 16 );
+		} );
+
+		test( 'Korean', () => {
+			expect( count( '안녕하세요' ) ).toBe( 10 );
+		} );
+
+		test( 'Hindi', () => {
+			expect( count( 'धरती के वासियों की ओर से नमस्कार' ) ).toBe( 28 );
+		} );
+
+		test( 'Greek', () => {
+			const greeting = `Οἵτινές ποτ'ἔστε χαίρετε! Εἰρηνικῶς πρὸς φίλους ἐληλύθαμεν φίλοι.`;
+			expect( count( greeting ) ).toBe( 65 );
+		} );
+
+		test( 'Thai', () => {
+			const greeting =
+				'สวัสดีค่ะ สหายในธรณีโพ้น พวกเราในธรณีนี้ขอส่งมิตรจิตมาถึงท่านทุกคน';
+			expect( count( greeting ) ).toBe( 66 );
+		} );
+
+		test( 'Polish', () => {
+			expect( count( 'Witajcie, istoty z zaświatów.' ) ).toBe( 29 );
+		} );
+
+		test( 'Arabic', () => {
+			const greeting =
+				'.تحياتنا للأصدقاء في النجوم. يا ليت يجمعنا الزمان';
+			expect( count( greeting ) ).toBe( 49 );
+		} );
+
+		test( 'Hebrew', () => {
+			expect( count( 'שלום' ) ).toBe( 4 );
+		} );
+
+		test( 'Devanagari', () => {
+			expect( count( 'देवनागरी' ) ).toBe( 7 );
+			expect( count( 'संस्कृता' ) ).toBe( 5 );
+		} );
+
+		test( 'Burmese', () => {
+			expect( count( 'နေကောင်းပါသလား' ) ).toBe( 28 );
+		} );
+	} );
+
+	describe( 'Symbols and miscellaneous cases that have no consistency', () => {
+		test( 'Emoji', () => {
+			expect( count( '✌' ) ).toBe( 2 );
+			expect( count( '✌🏿' ) ).toBe( 6 );
+			expect( count( '👍' ) ).toBe( 4 );
+			expect( count( '👍🏻' ) ).toBe( 8 );
+			expect( count( '😮‍💨' ) ).toBe( 9 );
+			expect( count( '👨‍👩‍👧‍👦' ) ).toBe( 19 );
+			expect( count( '🧑🏻‍❤️‍💋‍🧑🏼' ) ).toBe( 27 );
+		} );
+
+		test( 'Enumeration of symbols without consistency rules', () => {
+			// The diaeresis of Latin letters could be a combining diaeresis.
+			expect( count( 'ä' ) ).toBe( 1 );
+			expect( count( 'ä' ) ).toBe( 2 );
+
+			// Most Cyrillic chars are counted as 1 but a few as 2.
+			expect( count( 'ҳ' ) ).toBe( 1 );
+			expect( count( 'ӽ' ) ).toBe( 2 );
+			expect( count( 'Ӻ' ) ).toBe( 2 );
+			expect( count( 'ӿ' ) ).toBe( 2 );
+
+			// Inconsistencies in Hebrew punctuations.
+			expect( count( '״' ) ).toBe( 1 );
+			expect( count( '׃' ) ).toBe( 2 );
+
+			// Inconsistencies in Letterlike Symbols.
+			expect( count( '℡' ) ).toBe( 1 );
+			expect( count( '℻' ) ).toBe( 2 );
+			expect( count( '℁' ) ).toBe( 1 );
+			expect( count( '⅍' ) ).toBe( 2 );
+
+			// Inconsistencies in Halfwidth and Fullwidth Forms.
+			// - Halfwidth CJK punctuation
+			expect( count( '｢' ) ).toBe( 1 );
+			// - Halfwidth symbol variants
+			expect( count( '￪' ) ).toBe( 2 );
+			expect( count( '￮' ) ).toBe( 2 );
+
+			// CJK-related blocks are not fully included such as the CJK compatibility letters and Hangul syllables.
+			expect( count( '城' ) ).toBe( 2 );
+			expect( count( '城' ) ).toBe( 4 );
+			expect( count( '각' ) ).toBe( 2 );
+			expect( count( '각' ) ).toBe( 6 );
+
+			// Special symbols or ligatures.
+			expect( count( '﷽' ) ).toBe( 1 );
+			expect( count( '꧅' ) ).toBe( 2 );
+			expect( count( '𒐫' ) ).toBe( 4 );
+			expect( count( 'Æ' ) ).toBe( 1 );
+			expect( count( 'Ꜳ' ) ).toBe( 2 );
+			expect( count( '🜇' ) ).toBe( 4 );
+			expect( count( 'æ' ) ).toBe( 1 );
+			expect( count( 'ꜽ' ) ).toBe( 2 );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a part of 📌 [Assets form and related components](https://github.com/woocommerce/google-listings-and-ads/issues/1787#fe-misc) in #1787.

- Multiple texts editor
   - Set the min/max number of texts
   - Set the max of character counting for each input
   - Add/remove text input
   - Get updated texts via callback
- Characters length calculation
   - The results should be the same with the text input fields of assets management on Google Ads admin page.
   - 💡 Please note that currently there are no detailed rules for this section, and the ported code retains all unintended inconsistent results. (See its tests)

### Screenshots:

https://user-images.githubusercontent.com/17420811/212669335-378b8691-ba92-41f4-a357-0b674fbbbd0a.mp4

### Detailed test instructions:

1. Go to the assets step of the campaign creation page.
2. Use the TextsEditor demo to test.
3. Go to an assets management on Google Ads admin page
   1. Open Google Ads admin page
   1. Go to **Campaigns** list via the main menu on left side
   1. Click an active campaign to view the details
   1. View the **Asset groups** via the menu on left side
   1. Click **Edit assets** button to enter the assets management. The page should look like the following:
      <img width="1035" alt="image" src="https://user-images.githubusercontent.com/17420811/212671699-8bfb2a83-fc4f-420b-8c54-e829370adea4.png">
4. Enter the same strings on both sides to see if the results of character counting are the same.

### Additional details:

The logic of character counting was ported from the actual implementation found on Google Ads admin page. As a record, the code can be partially found by the following steps.

1. Go to an assets management on Google Ads admin page.
2. Find a JS file ends with `/aw_cm/editing/main.dart.js`.
3. Format the minified JS.
4. The first part is the main logic and it can be found by searching the keyword `65023`.
5. The second part is listing the zero-width char codes and it can be found by searching the keyword `2304, null`.

#### The first part:
```js
{
    aUt(a) {
      var s, r
      if (a == null)
        return 0
      for (s = new A.aLc(a),
      s = new A.eK(s,s.gav(s),t.iY.p("eK<br.E>")),
      r = 0; s.am(); )
        r += A.DIV(s.d)
      return r
    },
    DIV(a) {
      var s
      if (a >= 2304 && a <= 3455)
        return J.ii(B.mgJ.a, a) ? 0 : 1
      if (!(a <= 1273))
        if (a !== 1470)
          if (!(a >= 1488 && a <= 1514))
            if (a !== 1523)
              if (a !== 1524)
                if (!(a >= 1536 && a <= 1791))
                  if (!(a >= 1872 && a <= 1919))
                    if (!(a >= 64336 && a <= 65023))
                      if (!(a >= 65136 && a <= 65279))
                        if (!(a >= 7680 && a <= 8383))
                          if (!(a >= 8448 && a <= 8506))
                            if (!(a >= 3584 && a <= 3711))
                              s = a >= 65377 && a <= 65500
                            else
                              s = !0
                          else
                            s = !0
                        else
                          s = !0
                      else
                        s = !0
                    else
                      s = !0
                  else
                    s = !0
                else
                  s = !0
              else
                s = !0
            else
              s = !0
          else
            s = !0
        else
          s = !0
      else
        s = !0
      if (s)
        return 1
      return 2
    },
}
```

#### The second part:

```js
B.kl3 = new A.bk([2304, null, 2305, null, 2306, null, 2362, null, 2364, null, 2369, null, 2370, null, 2371, null, 2372, null, 2373, null, 2374, null, 2375, null, 2376, null, 2381, null, 2385, null, 2386, null, 2387, null, 2388, null, 2389, null, 2390, null, 2391, null, 2402, null, 2403, null],A.c("bk<x*,an>"))
```

### Changelog entry

>
