### PR TITLE
PMax - Suggest HTML inserted images 

### DIFF
--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -312,7 +312,7 @@ class AssetSuggestionsService implements Service {
 		$dom->loadHTML( $html );
 		$images     = $dom->getElementsByTagName( 'img' );
 		$images_ids = [];
-		$pattern    = '/-\d+x\d+\.(jpg|jpeg|gif|png|svg|tiff|webp|heif|heic)$/i';
+		$pattern    = '/-\d+x\d+\.(jpg|jpeg|png)$/i';
 		foreach ( $images as $image ) {
 			$url_unscaled = preg_replace(
 				$pattern,

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -491,7 +491,7 @@ class AssetSuggestionsService implements Service {
 	protected function get_post_image_attachments( array $args = [] ): array {
 		$defaults = [
 			'post_type'      => 'attachment',
-			'post_mime_type' => 'image',
+			'post_mime_type' => [ 'image/jpeg', 'image/png', 'image/jpg' ],
 			'fields'         => 'ids',
 			'numberposts'    => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
 		];

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Exception;
 use WP_Query;
 use wpdb;
+use DOMDocument;
 
 /**
  * Class AssetSuggestionsService
@@ -234,7 +235,7 @@ class AssetSuggestionsService implements Service {
 			$attachments_ids = [ ...$attachments_ids, ...$product->get_gallery_image_ids() ];
 		}
 
-		$attachments_ids  = [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ), get_post_thumbnail_id( $id ) ];
+		$attachments_ids  = [ ...$attachments_ids, ...$this->get_gallery_images_ids( $id ), ...$this->get_html_inserted_images( $post->post_content ), get_post_thumbnail_id( $id ) ];
 		$marketing_images = $this->get_url_attachments_by_ids( $attachments_ids );
 		$long_headline    = get_bloginfo( 'name' ) . ': ' . $post->post_title;
 
@@ -297,6 +298,47 @@ class AssetSuggestionsService implements Service {
 			'display_url_path'                       => [ $term->slug ],
 			'final_url'                              => get_term_link( $term->term_id ),
 		];
+	}
+
+	/**
+	 * Get inserted images from HTML.
+	 *
+	 * @param string $html HTML string.
+	 *
+	 * @return array Array of image IDs.
+	 */
+	protected function get_html_inserted_images( string $html ): array {
+		$dom = new DOMDocument();
+		$dom->loadHTML( $html );
+		$images     = $dom->getElementsByTagName( 'img' );
+		$images_ids = [];
+		$pattern    = '/-\d+x\d+\.(jpg|jpeg|gif|png|svg|tiff|webp|heif|heic)$/i';
+		foreach ( $images as $image ) {
+			$url_unscaled = preg_replace(
+				$pattern,
+				'.${1}',
+				$image->getAttribute( 'src' ),
+			);
+
+			$image_id = attachment_url_to_postid( $url_unscaled );
+
+			// Look for scaled image if the original image is not found.
+			if ( $image_id === 0 ) {
+				$url_scaled = preg_replace(
+					$pattern,
+					'-scaled.${1}',
+					$image->getAttribute( 'src' ),
+				);
+				$image_id   = attachment_url_to_postid( $url_scaled );
+			}
+
+			if ( $image_id > 0 ) {
+				$images_ids[] = $image_id;
+			}
+		}
+
+		return $images_ids;
+
 	}
 
 	/**

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -361,7 +361,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->with(
 				[
 					'post_type'      => 'attachment',
-					'post_mime_type' => 'image',
+					'post_mime_type' => [ 'image/jpeg', 'image/png', 'image/jpg' ],
 					'numberposts'    => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
 					'fields'         => 'ids',
 					'post_parent'    => $this->post->ID,
@@ -451,7 +451,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->with(
 				[
 					'post_type'      => 'attachment',
-					'post_mime_type' => 'image',
+					'post_mime_type' => [ 'image/jpeg', 'image/png', 'image/jpg' ],
 					'numberposts'    => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
 					'fields'         => 'ids',
 					'post_parent'    => $post_html_image->ID,
@@ -513,7 +513,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		$args_post_image_attachments = [
 			'post_type'       => 'attachment',
-			'post_mime_type'  => 'image',
+			'post_mime_type'  => [ 'image/jpeg', 'image/png', 'image/jpg' ],
 			'fields'          => 'ids',
 			'numberposts'     => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
 			'post_parent__in' => [ $this->post->ID, $product->get_id() ],

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -433,6 +433,37 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 	}
 
+	public function test_get_post_assets_html_inserted_image() {
+		$image_id = $this->get_test_image();
+
+		$post_html_image = $this->factory()->post->create_and_get( [ 'post_content' => '<img src="' . wp_get_attachment_image_url( $image_id ) . '" />' ] );
+
+		$this->image_utility->expects( $this->exactly( 2 ) )
+		->method( 'recommend_size' )
+		->willReturnOnConsecutiveCalls( $this->suggested_image_square, $this->suggested_image_landscape );
+
+		$this->image_utility->expects( $this->exactly( 2 ) )
+		->method( 'maybe_add_subsize_image' )
+		->willReturn( true );
+
+		$this->wp->expects( $this->once() )
+			->method( 'get_posts' )
+			->with(
+				[
+					'post_type'      => 'attachment',
+					'post_mime_type' => 'image',
+					'numberposts'    => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
+					'fields'         => 'ids',
+					'post_parent'    => $post_html_image->ID,
+				]
+			)->willReturn( [] );
+
+		$images[ self::SQUARE_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_id ) ];
+		$images[ self::MARKETING_IMAGE_KEY ]        = [ wp_get_attachment_image_url( $image_id ) ];
+
+		$this->assertEquals( $this->format_post_asset_response( $post_html_image, $images ), $this->asset_suggestions->get_assets_suggestions( $post_html_image->ID, 'post' ) );
+	}	
+
 	public function test_get_invalid_post_id() {
 		$this->expectException( Exception::class );
 		$this->asset_suggestions->get_assets_suggestions( self::INVALID_ID, 'post' );

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -462,7 +462,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$images[ self::MARKETING_IMAGE_KEY ]        = [ wp_get_attachment_image_url( $image_id ) ];
 
 		$this->assertEquals( $this->format_post_asset_response( $post_html_image, $images ), $this->asset_suggestions->get_assets_suggestions( $post_html_image->ID, 'post' ) );
-	}	
+	}
 
 	public function test_get_invalid_post_id() {
 		$this->expectException( Exception::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

This PR adds the functionality to suggest image assets that are inserted as HTML tag in the post content. Until now the images that were suggested were attached to the post however it is also possible to add images to a specific post without attaching the image.

The image is inserted as HTML when we select an image that has been previously uploaded to the media library.

![image](https://user-images.githubusercontent.com/2488994/213175975-8034a7f2-0724-407e-b496-4194bb9039ac.png)

Also, this PR is limiting the type of attachments to `image/jpeg, image/png, image/jpg, as other types of images are not allowed. See: https://support.google.com/google-ads/answer/10724492?hl=en#zippy=%2Cimage-specifications

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Choose a page, post or product. Get the ID.
2. Add an image that is already in the media library.
3. Make a request to `GET gla/assets/suggestions?id=POST_ID&type=post`
4. Check that the image is showing in the response. 


### Additional details:

If the image size is less than the minimum requirement, it will not be suggested. For a square marketing image, the minimum is `300x300px` and for marketing_image is `600x314px.`

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
