### PR TITLE
Fix table footer rendering a zero when no pagination is needed

### DIFF
--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -271,11 +271,11 @@ const ProductFeedTableCard = () => {
 					) }
 				</CardBody>
 				<CardFooter justify="center">
-					{ data?.total && (
+					{ data?.total > 0 && (
 						<Pagination
 							page={ query.page }
 							perPage={ query.per_page }
-							total={ data?.total }
+							total={ data.total }
 							showPagePicker={ true }
 							showPerPagePicker={ false }
 							onPageChange={ handlePageChange }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1856

PR fixing an issue of rendering  a zero in table footer when total product was zero and no pagination was needed. 

### Screenshots:

**Before**
<img width="992" alt="Screenshot 2023-01-17 at 14 16 47" src="https://user-images.githubusercontent.com/5908855/213191921-19b199a0-b4cb-4538-88aa-08e4139fc0ae.png">

**After**
<img width="1596" alt="Screenshot 2023-01-18 at 21 03 35" src="https://user-images.githubusercontent.com/5908855/213191966-51250d6d-634a-4e81-b0bd-e147b1581518.png">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this PR
2. Create a shop with zero products (or hardcode `data?.total=0` in `js/src/product-feed/product-feed-table-card/index.js`)
3. Go to product feed
4. See the footer is not rendered and no zero appears anymore

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Product feed table footer rendering a zero when there are no products.
