### PR TITLE
Batch assets creation

### DIFF
--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -165,9 +165,8 @@ class AdsAsset implements OptionsAwareInterface {
 				$batch_size   += $image_data['size'];
 
 				if ( $batch_size > $max_size ) {
-					$index++;
-					$batches[ $index ][] = $asset;
-					$batch_size          = $image_data['size'];
+					$batches[ ++$index ][] = $asset;
+					$batch_size            = $image_data['size'];
 					continue;
 				}
 			}

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -140,7 +140,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 * @return array A list of batches of assets.
 	 * @throws Exception If the image url is not a valid url.
 	 */
-	protected function create_batches( array $assets, int $max_size = self::MAX_PAYLOAD_BYTES ): array {
+	public function create_batches( array $assets, int $max_size = self::MAX_PAYLOAD_BYTES ): array {
 		$batch_size = 0;
 		$index      = 0;
 		$batches    = [];
@@ -154,7 +154,7 @@ class AdsAsset implements OptionsAwareInterface {
 				if ( $batch_size > $max_size ) {
 					$index++;
 					$batches[ $index ][] = $asset;
-					$batch_size          = 0;
+					$batch_size          = $image_data['size'];
 					continue;
 				}
 			}

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -122,6 +122,18 @@ class AdsAsset implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Returns a list of batches of assets.
+	 *
+	 * @param array $assets A list of assets.
+	 *
+	 * @return array A list of batches of assets.
+	 */
+	protected function create_batches( array $assets ): array {
+		$batches = [];
+		return $batches;
+	}
+
+	/**
 	 * Creates the assets so they can be used in the asset groups.
 	 *
 	 * @param array $assets The assets to create.

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -135,6 +135,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 * Returns a list of batches of assets.
 	 *
 	 * @param array $assets A list of assets.
+	 * @param int   $max_size The maximum size of the payload in bytes.
 	 *
 	 * @return array A list of batches of assets.
 	 * @throws Exception If the image url is not a valid url.

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -201,6 +201,8 @@ class AdsAsset implements OptionsAwareInterface {
 			foreach ( $batch as $asset ) {
 				$operations[] = $this->create_operation( $asset, self::$temporary_id-- );
 			}
+
+			// If the mutate operation fails, it will throw an exception that will be caught by the caller.
 			$arns = [ ...$arns, ...$this->mutate( $operations ) ];
 		}
 

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -367,11 +367,18 @@ class AdsAssetGroup implements OptionsAwareInterface {
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
 
-			$errors = $this->get_api_exception_errors( $e );
+			if ( $e->getCode() === 413 ) {
+				$errors = [ 'Request entity too large' ];
+				$code   = $e->getCode();
+			} else {
+				$errors = $this->get_api_exception_errors( $e );
+				$code   = $this->map_grpc_code_to_http_status_code( $e );
+			}
+
 			throw new ExceptionWithResponseData(
 			/* translators: %s Error message */
 				sprintf( __( 'Error editing asset group: %s', 'google-listings-and-ads' ), reset( $errors ) ),
-				$this->map_grpc_code_to_http_status_code( $e ),
+				$code,
 				null,
 				[
 					'errors' => $errors,

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -251,26 +251,25 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			return [];
 		}
 
-		$assets_operations                    = [];
 		$asset_group_assets_operations        = [];
 		$delete_asset_group_assets_operations = [];
+		$assets_for_creation                  = $this->get_assets_to_be_created( $assets );
 
-		foreach ( $assets as $asset ) {
+		$asset_arns   = $this->asset->create_assets( $assets_for_creation );
+		$total_assets = count( $assets_for_creation );
 
-			// If content exists, create asset and asset group asset.
-			if ( ! empty( $asset['content'] ) ) {
-				$assets_operations[]             = $this->asset->create_operation( $asset, self::$temporary_id );
-				$asset_group_assets_operations[] = $this->create_operation( $asset_group_id, $asset['field_type'], self::$temporary_id-- );
-			}
+		// The asset mutation operation results (ARNs) are returned in the same order as the operations are specified.
+		// See: https://youtu.be/9KaVjqW5tVM?t=103
+		for ( $i = 0; $i < $total_assets; $i++ ) {
+			$asset_group_assets_operations[] = $this->create_operation( $asset_group_id, $assets_for_creation[ $i ]['field_type'], $asset_arns[ $i ] );
+		}
 
-			// As Assets are inmmutable, we delete the old link between the asset and the asset group if exists.
-			if ( ! empty( $asset['id'] ) ) {
-				$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
-			}
+		foreach ( $this->get_assets_to_be_deleted( $assets ) as $asset ) {
+			$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
 		}
 
 		// Delete asset group assets operations must be executed last so we are never under the minimum quantity.
-		return array_merge( $assets_operations, $asset_group_assets_operations, $delete_asset_group_assets_operations );
+		return array_merge( $asset_group_assets_operations, $delete_asset_group_assets_operations );
 
 	}
 
@@ -280,15 +279,15 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 *
 	 * @param int    $asset_group_id The ID of the asset group.
 	 * @param string $asset_field_type The field type of the asset.
-	 * @param int    $asset_id The ID of the asset.
+	 * @param string $asset_arn The the asset ARN.
 	 *
 	 * @return MutateOperation The mutate create operation for the asset group asset.
 	 */
-	protected function create_operation( int $asset_group_id, string $asset_field_type, int $asset_id ): MutateOperation {
+	protected function create_operation( int $asset_group_id, string $asset_field_type, string $asset_arn ): MutateOperation {
 		$operation             = new AssetGroupAssetOperation();
 		$new_asset_group_asset = new AssetGroupAsset(
 			[
-				'asset'       => ResourceNames::forAsset( $this->options->get_ads_id(), $asset_id ),
+				'asset'       => $asset_arn,
 				'asset_group' => ResourceNames::forAssetGroup( $this->options->get_ads_id(), $asset_group_id ),
 				'field_type'  => AssetFieldType::number( $asset_field_type ),
 			]

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -206,6 +206,38 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Get assets to be deleted.
+	 *
+	 * @param array $assets A list of assets.
+	 *
+	 * @return array The assets to be deleted.
+	 */
+	public function get_assets_to_be_deleted( array $assets ): array {
+		return array_filter(
+			$assets,
+			function( $asset ) {
+				return ! empty( $asset['id'] );
+			}
+		);
+	}
+
+	/**
+	 * Get assets to be created.
+	 *
+	 * @param array $assets A list of assets.
+	 *
+	 * @return array The assets to be created.
+	 */
+	public function get_assets_to_be_created( array $assets ): array {
+		return array_filter(
+			$assets,
+			function( $asset ) {
+				return ! empty( $asset['content'] );
+			}
+		);
+	}
+
+	/**
 	 * Edit assets group assets.
 	 *
 	 * @param int   $asset_group_id The asset group id.

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -111,7 +111,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class, AdsCampaignCriterion::class, GoogleHelper::class );
 		$this->share( AdsCampaignBudget::class, GoogleAdsClient::class );
 		$this->share( AdsAssetGroupAsset::class, GoogleAdsClient::class, AdsAsset::class );
-		$this->share( AdsAsset::class, WP::class );
+		$this->share( AdsAsset::class, GoogleAdsClient::class, WP::class );
 		$this->share( AdsCampaignCriterion::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -343,6 +343,15 @@ trait GoogleAdsClientTrait {
 	}
 
 	/**
+	 * Generates an asset resource name.
+	 *
+	 * @param int $asset_id
+	 */
+	protected function generate_asset_resource_name( int $asset_id ) {
+		return ResourceNames::forAsset( $this->ads_id, $asset_id );
+	}
+
+	/**
 	 * Generates a list of mocked AdsAccountQuery responses.
 	 *
 	 * @param array $customers List of customer data to mock.

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -880,6 +880,32 @@ trait GoogleAdsClientTrait {
 
 	}
 
+	protected function generate_asset_batch_mutate_mock( $matcher, $asset_batches_callback ) {
+		$this->service_client->expects( $matcher )
+		->method( 'mutate' )
+		->willReturnCallback(
+			function( int $ads_id, array $operations ) use ( $matcher, $asset_batches_callback ) {
+				$responses = [];
+
+				$asset_batches_callback( $matcher, $operations );
+
+				foreach ( $operations as $operation ) {
+					$asset_result = $this->createMock( MutateAssetResult::class );
+					$asset_result->method( 'getResourceName' )->willReturn(
+						$operation->getAssetOperation()->getCreate()->getResourceName()
+					);
+					$responses[] = ( new MutateOperationResponse() )->setAssetResult( $asset_result );
+				}
+
+				return ( new MutateGoogleAdsResponse() )->setMutateOperationResponses(
+					$responses
+				);
+
+			}
+		);
+
+	}
+
 	/**
 	 * Returns the asset content for the given row.
 	 *

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -223,26 +223,23 @@ class AdsAssetGroupAssetTest extends UnitTest {
 			],
 		];
 
-		$this->asset->expects( $this->exactly( 2 ) )
-		->method( 'create_operation' )
-		->willReturnOnConsecutiveCalls( ...$this->generate_crate_asset_operations( $assets ) );
+		$this->asset->expects( $this->exactly( 1 ) )
+		->method( 'create_assets' )
+		->with( $assets )
+		->willReturn( [ $this->generate_asset_resource_name( self::TEST_ASSET_ID ), $this->generate_asset_resource_name( self::TEST_ASSET_ID_2 ) ] );
 
 		$grouped_operations = $this->group_operations(
 			$this->asset_group_asset->edit_operations( self::TEST_ASSET_GROUP_ID, $assets )
 		);
 
-		// We should have two type of operations: asset_operation and asset_group_asset_operation
-		$this->assertEquals( 2, count( $grouped_operations ) );
-
-		// We should have two assets creation.
-		$this->assertEquals( 2, count( $grouped_operations['asset_operation']['create'] ) );
+		// We should have two asset links creation.
 		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['create'] ) );
 
-		$this->assertEquals( $assets[0]['content'], ( $grouped_operations['asset_operation']['create'][0] )->getCreate()->getTextAsset()->getText() );
-		$this->assertEquals( $assets[1]['content'], ( $grouped_operations['asset_operation']['create'][1] )->getCreate()->getTextAsset()->getText() );
-
 		$this->assertEquals( AssetFieldType::number( AssetFieldType::DESCRIPTION ), ( $grouped_operations['asset_group_asset_operation']['create'][0] )->getCreate()->getFieldType() );
+		$this->assertEquals( $this->generate_asset_resource_name( self::TEST_ASSET_ID ), ( $grouped_operations['asset_group_asset_operation']['create'][0] )->getCreate()->getAsset() );
+
 		$this->assertEquals( AssetFieldType::number( AssetFieldType::HEADLINE ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getFieldType() );
+		$this->assertEquals( $this->generate_asset_resource_name( self::TEST_ASSET_ID_2 ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getAsset() );
 
 		// We should remove the two old assets.
 		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['remove'] ) );
@@ -266,25 +263,21 @@ class AdsAssetGroupAssetTest extends UnitTest {
 			],
 		];
 
-		$this->asset->expects( $this->exactly( 2 ) )
-		->method( 'create_operation' )
-		->willReturnOnConsecutiveCalls( ...$this->generate_crate_asset_operations( $assets ) );
+		$this->asset->expects( $this->exactly( 1 ) )
+		->method( 'create_assets' )
+		->with( $assets )
+		->willReturn( [ $this->generate_asset_resource_name( self::TEST_ASSET_ID ), $this->generate_asset_resource_name( self::TEST_ASSET_ID_2 ) ] );
 
 		$grouped_operations = $this->group_operations(
 			$this->asset_group_asset->edit_operations( self::TEST_ASSET_GROUP_ID, $assets )
 		);
 
-		// We should have two type of operations: asset_operation and asset_group_asset_operation
-		$this->assertEquals( 2, count( $grouped_operations ) );
-
-		// We should have two assets creation.
-		$this->assertEquals( 2, count( $grouped_operations['asset_operation']['create'] ) );
-		$this->assertEquals( $assets[0]['content'], ( $grouped_operations['asset_operation']['create'][0] )->getCreate()->getTextAsset()->getText() );
-		$this->assertEquals( $assets[1]['content'], ( $grouped_operations['asset_operation']['create'][1] )->getCreate()->getTextAsset()->getText() );
-
-		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['create'] ) );
+		// We should have two asset links creation.
 		$this->assertEquals( AssetFieldType::number( AssetFieldType::DESCRIPTION ), ( $grouped_operations['asset_group_asset_operation']['create'][0] )->getCreate()->getFieldType() );
+		$this->assertEquals( $this->generate_asset_resource_name( self::TEST_ASSET_ID ), ( $grouped_operations['asset_group_asset_operation']['create'][0] )->getCreate()->getAsset() );
+
 		$this->assertEquals( AssetFieldType::number( AssetFieldType::HEADLINE ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getFieldType() );
+		$this->assertEquals( $this->generate_asset_resource_name( self::TEST_ASSET_ID_2 ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getAsset() );
 
 		// We should not remove old assets.
 		$this->assertArrayNotHasKey( 'remove', $grouped_operations['asset_group_asset_operation'] );
@@ -305,17 +298,14 @@ class AdsAssetGroupAssetTest extends UnitTest {
 			],
 		];
 
-		$this->asset->expects( $this->exactly( 0 ) )
-		->method( 'create_operation' );
+		$this->asset->expects( $this->exactly( 1 ) )
+		->method( 'create_assets' )
+		->with( [] )
+		->willReturn( [] );
 
 		$grouped_operations = $this->group_operations(
 			$this->asset_group_asset->edit_operations( self::TEST_ASSET_GROUP_ID, $assets )
 		);
-
-		// We should have one type of operations: asset_operation.
-		$this->assertEquals( 1, count( $grouped_operations ) );
-
-		$this->assertArrayNotHasKey( 'asset_operation', $grouped_operations );
 
 		// We should have two delete asset_group_asset_operation.
 		$this->assertEquals( 2, count( $grouped_operations['asset_group_asset_operation']['remove'] ) );
@@ -327,7 +317,14 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 	}
 
-	private function group_operations( $operations ) {
+	/**
+	 * Returns the test assets.
+	 *
+	 * @param array $operations Mutate operations.
+	 *
+	 * @return array Grouped operations by operation name and operation type.
+	 */
+	protected function group_operations( array $operations ): array {
 		$grouped_operations = [];
 
 		foreach ( $operations as $operation ) {

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -179,6 +179,28 @@ class AdsAssetGroupTest extends UnitTest {
 		}
 	}
 
+	public function test_edit_asset_group_request_too_long() {
+		$asset_group_data = [
+			'path2' => 123456,
+		];
+
+		$this->generate_mutate_mock_exception( new ApiException( 'Request entity too large', 413, 'UNRECOGNIZED_STATUS' ) );
+
+		try {
+			$this->asset_group->edit_asset_group( self::TEST_ASSET_GROUP_ID, $asset_group_data );
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertEquals(
+				[
+					'message' => 'Error editing asset group: Request entity too large',
+					'errors'  => [ 'Request entity too large' ],
+					'id'      => self::TEST_ASSET_GROUP_ID,
+				],
+				$e->get_response_data( true )
+			);
+			$this->assertEquals( 413, $e->getCode() );
+		}
+	}
+
 	public function test_create_asset_group() {
 		$this->generate_asset_group_mutate_mock( 'create', self::TEST_CAMPAIGN_ID );
 

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -154,7 +154,7 @@ class AdsAssetTest extends UnitTest {
 			);
 
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Incorrect image asset url.' );
+		$this->expectExceptionMessage( sprintf( 'There was a problem loading the url: %s', $data['content'] ) );
 		$this->asset->create_assets( [ $data ], self::TEMPORARY_ID );
 	}
 

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -215,14 +215,14 @@ class AdsAssetTest extends UnitTest {
 
 		$assert_batches = function ( $matcher, $operations ) use ( $assets ) {
 			$index = 0;
-			//First Batch
+			// First Batch
 			if ( $matcher->getInvocationCount() === 1 ) {
 				$this->assertEquals( 2, count( $operations ) );
-			//Second Batch	
+				// Second Batch
 			} elseif ( $matcher->getInvocationCount() === 2 ) {
 				$index = 2;
 				$this->assertEquals( 1, count( $operations ) );
-			//Third Batch
+				// Third Batch
 			} elseif ( $matcher->getInvocationCount() === 3 ) {
 				$index = 3;
 				$this->assertEquals( 1, count( $operations ) );

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -215,11 +215,14 @@ class AdsAssetTest extends UnitTest {
 
 		$assert_batches = function ( $matcher, $operations ) use ( $assets ) {
 			$index = 0;
+			//First Batch
 			if ( $matcher->getInvocationCount() === 1 ) {
 				$this->assertEquals( 2, count( $operations ) );
+			//Second Batch	
 			} elseif ( $matcher->getInvocationCount() === 2 ) {
 				$index = 2;
 				$this->assertEquals( 1, count( $operations ) );
+			//Third Batch
 			} elseif ( $matcher->getInvocationCount() === 3 ) {
 				$index = 3;
 				$this->assertEquals( 1, count( $operations ) );

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -32,8 +32,9 @@ class AdsAssetTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
 
-	protected const TEMPORARY_ID  = -5;
-	protected const TEST_ASSET_ID = 6677889911;
+	protected const MAX_PAYLOAD_BYTES = 30 * 1024 * 1024;
+	protected const TEMPORARY_ID      = -5;
+	protected const TEST_ASSET_ID     = 6677889911;
 
 	/**
 	 * Runs before each test is executed.
@@ -167,6 +168,67 @@ class AdsAssetTest extends UnitTest {
 		$this->expectExceptionMessage( 'Asset Field type not supported' );
 
 		$this->asset->create_assets( [ $data ], self::TEMPORARY_ID );
+
+	}
+
+	public function test_create_batches_multiple() {
+		$data = [
+			[
+				'field_type' => AssetFieldType::SQUARE_MARKETING_IMAGE,
+				'content'    => 'https://test.com/image1.jpg',
+			],
+			[
+				'field_type' => AssetFieldType::MARKETING_IMAGE,
+				'content'    => 'https://test.com/image2.jpg',
+			],
+			[
+				'field_type' => AssetFieldType::MARKETING_IMAGE,
+				'content'    => 'https://test.com/image3.jpg',
+			],
+			[
+				'field_type' => AssetFieldType::MARKETING_IMAGE,
+				'content'    => 'https://test.com/image4.jpg',
+			],
+		];
+
+		$this->wp->expects( $this->exactly( 4 ) )
+			->method( 'wp_remote_get' )
+			->withConsecutive( [ $data[0]['content'] ], [ $data[1]['content'] ] )
+			->willReturnOnConsecutiveCalls(
+				[
+					'body'    => $data[0]['content'],
+					'headers' => new ArrayObject( [ 'content-length' => 25 * 1024 * 1024 ] ),
+				],
+				[
+					'body'    => $data[1]['content'],
+					'headers' => new ArrayObject( [ 'content-length' => 3 * 1024 * 1024 ] ),
+				],
+				[
+					'body'    => $data[2]['content'],
+					'headers' => new ArrayObject( [ 'content-length' => 6 * 1024 * 1024 ] ),
+				],
+				[
+					'body'    => $data[3]['content'],
+					'headers' => new ArrayObject( [ 'content-length' => 28 * 1024 * 1024 ] ),
+				],
+			);
+
+		$batches = $this->asset->create_batches( $data, self::MAX_PAYLOAD_BYTES );
+
+		$this->assertEquals( 3, count( $batches ) );
+
+		// First Batch
+		$this->assertEquals( 2, count( $batches[0] ) );
+		$this->assertEquals( $data[0]['content'], $batches[0][0]['content'] );
+		$this->assertEquals( $data[1]['content'], $batches[0][1]['content'] );
+
+		// Second Batch
+		$this->assertEquals( 1, count( $batches[1] ) );
+		$this->assertEquals( $data[2]['content'], $batches[1][0]['content'] );
+
+		// Third Batch
+		$this->assertEquals( 1, count( $batches[1] ) );
+		$this->assertEquals( $data[3]['content'], $batches[2][0]['content'] );
 
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

While I was testing with different types of images and Google API limitations, I found that when uploading high-resolution images ( >3MB) the Ads API could return the following error:

``` The data written is too large. Split the request into smaller requests ```

Theoretically, the [Ads Library allows until 64MB payload](https://developers.google.com/google-ads/api/docs/best-practices/quotas#grpc_limitations) when using [gRPC](https://grpc.io/) protocol, in our case we use `rest` so we should not have this limitation however when I was testing this limitation I found that when the body is bigger than 30MB, the Ads API returns the error mention earlier. 

This PR allows uploading multiple images by creating asset batches, the challenge was to be able to maintain the atomicity for the asset group transaction. For that, I am creating first the assets and then I am mutating all operations related to the asset group assets (link and unlink assets with the asset group) so we keep the atomicity of the asset group operations.

If an asset with the same content is created multiple times, the Ads API will return the same ARN, which means, that the Ads API does not create duplicated assets. 

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. The WooCommerce Connect Server by [default](https://hapi.dev/api/?v=21.1.0), allows 1MB maximum as a payload so you will need to check this branch: `add/max-payload-size-google-proxy`  that allows bigger payloads and run WCS locally. 
2. Create an empty asset group `POST /gla/ads/campaigns/asset-groups` with the following body: ` { "campaign_id" : YOUR_CAMPAIGN_ID }`
2. Make a call to `PUT /gla/ads/campaigns/asset-groups/YOUR_ASSET_GROUP_ID` with the below body.
<details>
<summary> Click here. The body contains high-resolution images (>3MB , maximum is 5MB each image) and the maximum number of assets for each type. (worst case scenario) </summary>

```
{
   "assets": [
       {
           "id" : null,
           "field_type": "headline",
           "content": "headline 1"
       },
       {
           "id" : null,
           "field_type": "headline",
           "content": "headline 2"
       },
       {
           "id" : null,
           "field_type": "headline",
           "content": "headline 3"
       },
       {
           "id" : null,
           "field_type": "headline",
           "content": "headline 4"
       },
       {
           "id" : null,
           "field_type": "headline",
           "content": "headline 5"
       },
       {
           "id" : null,
           "field_type": "long_headline",
           "content": "long headline 1"
       },
       {
           "id" : null,
           "field_type": "long_headline",
           "content": "long headline 2"
       },
       {
           "id" : null,
           "field_type": "long_headline",
           "content": "long headline 3"
       },
       {
           "id" : null,
           "field_type": "long_headline",
           "content": "long headline 4"
       },
       {
           "id" : null,
           "field_type": "long_headline",
           "content": "long headline 5"
       },
       {
           "id" : null,
           "field_type": "description",
           "content": "description 1"
       },
       {
           "id" : null,
           "field_type": "description",
           "content": "description 2"
       },
       {
           "id" : null,
           "field_type": "description",
           "content": "description 3"
       },
       {
           "id" : null,
           "field_type": "description",
           "content": "description 4"
       },
       {
           "id" : null,
           "field_type": "description",
           "content": "description 5"
       },
       {
           "id" : null,
           "field_type": "business_name",
           "content": "business name test"
       },       
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_1.jpg"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_2.png"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_3.png"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_4.png"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_5.png"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_6.png"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_7.png"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_8.png"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_9.png"
       },
       {
           "id" : null,
           "field_type": "square_marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_square_10.png"
       },   
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_1.jpg"
       },
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_2.png"
       }, 
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_3.png"
       }, 
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_4.png"
       },
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_5.png"
       },
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_6.png"
       },
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_7.png"
       },
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_8.png"
       },
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_9.png"
       },
       {
           "id" : null,
           "field_type": "marketing_image",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_marketing_10.png"
       },
       {
           "id" : null,
           "field_type": "logo",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_logo_1.png"
       },
       {
           "id" : null,
           "field_type": "logo",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_logo_2.jpeg"
       },
       {
           "id" : null,
           "field_type": "logo",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_logo_3.jpeg"
       },
       {
           "id" : null,
           "field_type": "logo",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_logo_4.jpeg"
       },
       {
           "id" : null,
           "field_type": "logo",
           "content": "https://stormy-rabbit.jurassic.ninja/wp-content/uploads/2023/01/test_logo_5.jpg"
       }
   ]
}
```
</details>

4. You should see that the asset group has been edited successfully. It can take some time depending on your connection and device. The total body is about 100MB.

### Additional details:
- As we are using some new imports from the GoogleAds Library, you will need to remove your vendor folder `rm -rf vendor/* ` and install again the dependencies `composer install`.
- You may need to increase your memory limit so your device can process all images. You can add the following line in your `wp-config` file to increase the memory limit: `define( 'WP_MEMORY_LIMIT', '512M' );`
- The maximum number of marketing images is 20 and it is the sum of marketing images + square_images + portrait marketing images.
- The maximum is 5 logo images. 



<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

