### PR TITLE
Release 2.3.8

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
+= 2.3.8 - 2023-01-24 =
+* Fix - Product feed table footer rendering a zero when there are no products.
+
 = 2.3.7 - 2023-01-17 =
 * Tweak - Pre-select a default MC account.
 

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google Listings and Ads
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 2.3.7
+ * Version: 2.3.8
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -29,7 +29,7 @@ use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '2.3.7' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '2.3.8' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
 define( 'WC_GLA_MIN_WC_VER', '6.9' );
 

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -271,11 +271,11 @@ const ProductFeedTableCard = () => {
 					) }
 				</CardBody>
 				<CardFooter justify="center">
-					{ data?.total && (
+					{ data?.total > 0 && (
 						<Pagination
 							page={ query.page }
 							perPage={ query.per_page }
-							total={ data?.total }
+							total={ data.total }
 							showPagePicker={ true }
 							showPerPagePicker={ false }
 							onPageChange={ handlePageChange }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "2.3.7",
+	"version": "2.3.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-listings-and-ads",
 	"title": "Google Listings and Ads",
-	"version": "2.3.7",
+	"version": "2.3.8",
 	"description": "google-listings-and-ads",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -117,12 +117,4 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 * Fix - i18n for "View Reports" button.
 * Tweak - WooCommerce 7.3 Compatibility with Customer Effort Score prompt.
 
-= 2.3.5 - 2022-12-28 =
-* Tweak - Adjust copy in Attribute Mapping section.
-* Tweak - Retrieve a published product as a landing page URL.
-* Tweak - Simplify report controller parameters.
-
-= 2.3.4 - 2022-12-20 =
-* Tweak - Improve image validation error messages.
-
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,9 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 
 == Changelog ==
 
+= 2.3.8 - 2023-01-24 =
+* Fix - Product feed table footer rendering a zero when there are no products.
+
 = 2.3.7 - 2023-01-17 =
 * Tweak - Pre-select a default MC account.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, google, listings, ads
 Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 7.4
-Stable tag: 2.3.7
+Stable tag: 2.3.8
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
## WPORG changelog

* Fix - Product feed table footer rendering a zero when there are no products.

<!-- Release notes generated using configuration in .github/release.yml at 2.3.8 -->

## What's Changed
### [Fix] Fixes 🛠
* Fix table footer rendering a zero when no pagination is needed by @puntope in https://github.com/woocommerce/google-listings-and-ads/pull/1861


**Full Changelog**: https://github.com/woocommerce/google-listings-and-ads/compare/2.3.7...2.3.8