### PR TITLE
Pmax Assets - Override landscape logo

### DIFF
--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -19,9 +19,9 @@ use Google\Ads\GoogleAds\V11\Services\AssetGroupOperation;
 use Google\Ads\GoogleAds\V11\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V11\Services\MutateOperation;
 use Google\Ads\GoogleAds\V11\Services\AssetGroupServiceClient;
-use Google\Ads\GoogleAds\Util\FieldMasks;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;
+use Google\Protobuf\FieldMask;
 use Exception;
 use DateTime;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
@@ -401,7 +401,7 @@ class AdsAssetGroup implements OptionsAwareInterface {
 		$asset_group             = new AssetGroup( $fields );
 		$operation               = new AssetGroupOperation();
 		$operation->setUpdate( $asset_group );
-		$operation->setUpdateMask( FieldMasks::allSetFieldsOf( $asset_group ) );
+		$operation->setUpdateMask( ( new FieldMask() )->setPaths( [ 'resource_name', ...array_keys( $fields ) ] ) );
 		return ( new MutateOperation() )->setAssetGroupOperation( $operation );
 	}
 

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -401,6 +401,8 @@ class AdsAssetGroup implements OptionsAwareInterface {
 		$asset_group             = new AssetGroup( $fields );
 		$operation               = new AssetGroupOperation();
 		$operation->setUpdate( $asset_group );
+		// We create the FieldMask manually because empty paths (path1 and path2) are not processed by the library.
+		// See similar issue here: https://github.com/googleads/google-ads-php/issues/487
 		$operation->setUpdateMask( ( new FieldMask() )->setPaths( [ 'resource_name', ...array_keys( $fields ) ] ) );
 		return ( new MutateOperation() )->setAssetGroupOperation( $operation );
 	}

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -332,6 +332,8 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
 		}
 
+		// The delete operations must be executed first otherwise will cause a conflict with existing assets with identical content.
+		// See here: https://github.com/woocommerce/google-listings-and-ads/pull/1870
 		return array_merge( $delete_asset_group_assets_operations, $asset_group_assets_operations );
 
 	}

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -247,7 +247,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Get assets ids for specific asset types
+	 * Get specific assets by asset types.
 	 *
 	 * @param int   $asset_group_id The asset group id.
 	 * @param array $asset_types The asset types.

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -332,8 +332,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
 		}
 
-		// Delete asset group assets operations must be executed last so we are never under the minimum quantity.
-		return array_merge( $asset_group_assets_operations, $delete_asset_group_assets_operations );
+		return array_merge( $delete_asset_group_assets_operations, $asset_group_assets_operations );
 
 	}
 

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -250,22 +250,22 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * Get specific assets by asset types.
 	 *
 	 * @param int   $asset_group_id The asset group id.
-	 * @param array $asset_types The asset types.
+	 * @param array $asset_field_types The asset field types types.
 	 *
 	 * @return array The assets.
 	 */
-	protected function get_specific_assets( int $asset_group_id, array $asset_types ): array {
-		$result             = $this->get_assets_by_asset_group_ids( [ $asset_group_id ], $asset_types );
+	protected function get_specific_assets( int $asset_group_id, array $asset_field_types ): array {
+		$result             = $this->get_assets_by_asset_group_ids( [ $asset_group_id ], $asset_field_types );
 		$asset_group_assets = $result[ $asset_group_id ] ?? [];
-		$assets             = [];
+		$specific_assets    = [];
 
-		foreach ( $asset_group_assets as $field_type => $asset_type ) {
-			foreach ( $asset_type as $asset ) {
-				$assets[] = array_merge( $asset, [ 'field_type' => $field_type ] );
+		foreach ( $asset_group_assets as $field_type => $assets ) {
+			foreach ( $assets as $asset ) {
+				$specific_assets[] = array_merge( $asset, [ 'field_type' => $field_type ] );
 			}
 		}
 
-		return $assets;
+		return $specific_assets;
 	}
 
 	/**

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -252,7 +252,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 * @param int   $asset_group_id The asset group id.
 	 * @param array $asset_types The asset types.
 	 *
-	 * @return array The assets ids.
+	 * @return array The assets.
 	 */
 	protected function get_specific_assets( int $asset_group_id, array $asset_types ): array {
 		$result             = $this->get_assets_by_asset_group_ids( [ $asset_group_id ], $asset_types );

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -282,12 +282,18 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			return [];
 		}
 
-		$asset_group_assets_operations        = [];
-		$delete_asset_group_assets_operations = [];
-		$assets_for_creation                  = $this->get_assets_to_be_created( $assets );
+		$asset_group_assets_operations = [];
+		$assets_for_creation           = $this->get_assets_to_be_created( $assets );
+		$asset_arns                    = $this->asset->create_assets( $assets_for_creation );
+		$total_assets                  = count( $assets_for_creation );
 
-		$asset_arns   = $this->asset->create_assets( $assets_for_creation );
-		$total_assets = count( $assets_for_creation );
+		// As we are not working with the LANDSCAPE_LOGO, we delete it so it does not interfere with the maximum quantities of logos.
+		$delete_asset_group_assets_operations = array_map(
+			function( $asset ) use ( $asset_group_id ) {
+				return $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
+			},
+			$this->get_specific_assets( $asset_group_id, [ AssetFieldType::name( AssetFieldType::LANDSCAPE_LOGO ) ] )
+		);
 
 		// The asset mutation operation results (ARNs) are returned in the same order as the operations are specified.
 		// See: https://youtu.be/9KaVjqW5tVM?t=103

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -218,7 +218,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 			],
 			[
 				'id'         => self::TEST_ASSET_ID_2,
-				'field_type' => AssetFieldType::HEADLINE,
+				'field_type' => AssetFieldType::LOGO,
 				'content'    => 'https://example.com/image.jpg',
 			],
 		];
@@ -241,7 +241,7 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		$this->assertEquals( AssetFieldType::number( AssetFieldType::DESCRIPTION ), ( $grouped_operations['asset_group_asset_operation']['create'][0] )->getCreate()->getFieldType() );
 		$this->assertEquals( $this->generate_asset_resource_name( self::TEST_ASSET_ID ), ( $grouped_operations['asset_group_asset_operation']['create'][0] )->getCreate()->getAsset() );
 
-		$this->assertEquals( AssetFieldType::number( AssetFieldType::HEADLINE ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getFieldType() );
+		$this->assertEquals( AssetFieldType::number( AssetFieldType::LOGO ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getFieldType() );
 		$this->assertEquals( $this->generate_asset_resource_name( self::TEST_ASSET_ID_2 ), ( $grouped_operations['asset_group_asset_operation']['create'][1] )->getCreate()->getAsset() );
 
 		// We should remove the two old assets + the landscape logo.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

The total quantity of logos (square + landscape) is 5, however,  the landscape logo is not used in the MVP and it could interfere with the maximum of square logos allowed. For instance, if the customer has an existing asset group that contains 2 landscape logos, the user can add a maximum of 3 square logos.

This PRs adds a workaround for this issue, it deletes any landscape logo asset so it does not interfere with the maximum quantity of square logos.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

0. As the branch `feature/pmax-assets` is using some new imports from the GoogleAds Library, you may need to remove your vendor folder `rm -Rf vendor/*` and install again the dependencies using composer install.
1.  Go to the [Google Ads](https://ads.google.com/)
2.  Choose a campaign
3.  Edit an asset group 

![image](https://user-images.githubusercontent.com/2488994/216443656-a521adc6-ab43-490e-a0bc-aca42ad20052.png)

4. If the asset group is empty, fill in the mandatory fields (including a square logo). See here the [list of asset requirements](https://developers.google.com/google-ads/api/docs/performance-max/assets).
5. Download the following image. [Click here.](https://user-images.githubusercontent.com/2488994/216442582-c0ef4f65-773f-4fa8-9703-290887c8f92f.png) and add the image in the logo section.
5. Get your asset group ID and save the asset group. The asset group id is visible in the URL. 
![image](https://user-images.githubusercontent.com/2488994/216443454-8fcf2d2d-fb30-4eca-aef0-f0c39bc6db86.png)

6. Make a request `PUT /gla/ads/campaigns/asset-groups/YOUR_ASSET_GROUP_ID`, 

And use the following body:

```
{
   "assets": [
       {
        "id" : null,
        "field_type": "logo",
        "content": "https://profound-silverfish.jurassic.ninja/wp-content/uploads/2023/02/Image_created_with_a_mobile_phone-1-960x960-1.png"
        } 
   ]
}
```
7. Go to [Google Ads](https://ads.google.com/) and check the asset group, the image that you add in step 5 should be deleted. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry