### PR TITLE
PMax Assets - Fix issue when updating asset groups with empty paths

### DIFF
--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -19,9 +19,9 @@ use Google\Ads\GoogleAds\V11\Services\AssetGroupOperation;
 use Google\Ads\GoogleAds\V11\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V11\Services\MutateOperation;
 use Google\Ads\GoogleAds\V11\Services\AssetGroupServiceClient;
-use Google\Ads\GoogleAds\Util\FieldMasks;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;
+use Google\Protobuf\FieldMask;
 use Exception;
 use DateTime;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
@@ -401,7 +401,7 @@ class AdsAssetGroup implements OptionsAwareInterface {
 		$asset_group             = new AssetGroup( $fields );
 		$operation               = new AssetGroupOperation();
 		$operation->setUpdate( $asset_group );
-		$operation->setUpdateMask( FieldMasks::allSetFieldsOf( $asset_group ) );
+		$operation->setUpdateMask( ( new FieldMask() )->setPaths( [ 'resource_name', ...array_keys( $fields ) ] ) );
 		return ( new MutateOperation() )->setAssetGroupOperation( $operation );
 	}
 

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -401,6 +401,8 @@ class AdsAssetGroup implements OptionsAwareInterface {
 		$asset_group             = new AssetGroup( $fields );
 		$operation               = new AssetGroupOperation();
 		$operation->setUpdate( $asset_group );
+		// We create the FieldMask manually because empty paths (path1 and path2) are not processed by the library.
+		// See similar issue here: https://github.com/googleads/google-ads-php/issues/487
 		$operation->setUpdateMask( ( new FieldMask() )->setPaths( [ 'resource_name', ...array_keys( $fields ) ] ) );
 		return ( new MutateOperation() )->setAssetGroupOperation( $operation );
 	}

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -332,6 +332,8 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
 		}
 
+		// The delete operations must be executed first otherwise will cause a conflict with existing assets with identical content.
+		// See here: https://github.com/woocommerce/google-listings-and-ads/pull/1870
 		return array_merge( $delete_asset_group_assets_operations, $asset_group_assets_operations );
 
 	}

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -332,8 +332,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 			$delete_asset_group_assets_operations[] = $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
 		}
 
-		// Delete asset group assets operations must be executed last so we are never under the minimum quantity.
-		return array_merge( $asset_group_assets_operations, $delete_asset_group_assets_operations );
+		return array_merge( $delete_asset_group_assets_operations, $asset_group_assets_operations );
 
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

When we try to update an asset group with empty paths (path1 and path2), they do not get updated because the Google Ads library does not recognize that these values have been changed.

See a similar issue here: https://github.com/googleads/google-ads-php/issues/487

This PR adds a workaround, creating a `FieldMask` manually so the paths get updated correctly.

Besides that, this PR swaps the order of asset group asset operations, removing first the assets and later creating the assets, this is because of how assets are stored in Google. For example, if the asset group contains the following asset: 

```
// Descriptions contained in an asset group
[
  {
    "id": 67311903995,
    "content": "1"
  },
]

//Updating the asset group
[
  {
    "id": 67311903995,
    "content": null,
    "field_type": "description"
  },
  {
    "id": null,
    "content": "1",
    "field_type": "description"
  },
]

```
The following process would happen: 
1. It tries to create the asset with content "1", the Ads API does not create the new asset because already exists and returns the id: `67311903995`
2. After the "creation" it deletes the asset with id: `67311903995` from the asset group. 
3. The final result is that the asset 67311903995 has been unlink from the asset group.

After this PR:
1. It deletes the asset with id: `67311903995`
2. It adds again the asset `67311903995` to the asset group.
3. The asset stays in the asset group.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

### Updating AssetGroup path1 and path2

0. As we are using some new imports from the GoogleAds Library, you may need to remove your vendor folder `rm -rf vendor/*`  and install again the dependencies `composer install`.
1. Make a request to GET gla/ads/campaigns/asset-groups?campaign_id=YOUR_CAMPAIGN_ID, and get the asset group id returned in the response (the endpoint returns only one asset group).
2. Make a request: `PUT wc/gla/ads/campaigns/asset-groups/YOUR_ASSET_GROUP_ID` with the below body:

```
{
  "path1": "a",
  "path2": "b"
}
```

And then try:

```
{
  "path1": "",
  "path2": ""
}
```

3. Check the asset group, it should contain empty paths. Keep in mind that path1 can not be empty if path2 is not, otherwise the Ads API will give you an error.

### Updating an Asset with identical content.

1. Get a campaign Id which contains an asset group with some assets.
2. Make a request: `GET gla/ads/campaigns/asset-groups?campaign_id=YOUR_CAMPAIGN_ID`
3. Get one asset ID and the asset group id.
4. Make a request: `PUT gla/ads/campaigns/asset-groups/YOUR_ASSET_GROUP_ID`

```
{
	"assets" : [
		{
			"id": YOUR_ASSET_ID,
			"field_type": the asset field type linked to your asset, ie. headline, description, etc,
			"content": null
		},
		{
			"id": null,
			"field_type":  the asset field type linked to your asset, ie. headline, description, etc,
			"content": The exact content from the asset that you get on step 3.
		}		
	]
}
```
5. Repeat step 2, the asset should stay in the asset group. 
6. If you repeat the same steps using the branch `feature/pmax-assets`, the asset will be deleted.

### Additional details:
- I had a comment about executing the delete operations last, so we would not exceed the maximum, however after some testing with the maximum quantities I have not found this issue anymore. I guess when I put the comment I was not grouping all AssetGroupAsset asset operations. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

