### PR TITLE
Improve PHP 8.1 compatibility

### DIFF
--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -427,7 +427,7 @@ class AccountService implements OptionsAwareInterface, Service {
 
 		/** @var Account $account */
 		$account     = $merchant->get_account( $merchant_id );
-		$account_url = $account->getWebsiteUrl();
+		$account_url = $account->getWebsiteUrl() ?: '';
 
 		if ( untrailingslashit( $site_url ) !== untrailingslashit( $account_url ) ) {
 

--- a/src/Shipping/LocationRate.php
+++ b/src/Shipping/LocationRate.php
@@ -53,7 +53,7 @@ class LocationRate implements JsonSerializable {
 	/**
 	 * Specify data which should be serialized to JSON
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		$rate_serialized = $this->shipping_rate->jsonSerialize();
 
 		return array_merge(

--- a/src/Shipping/ShippingRate.php
+++ b/src/Shipping/ShippingRate.php
@@ -111,7 +111,7 @@ class ShippingRate implements JsonSerializable {
 	/**
 	 * Specify data which should be serialized to JSON
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'rate' => $this->get_rate(),
 		];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR consists of a couple small fixes to improve the compatibility with PHP 8.1.

1. Add a return type for jsonSerialize functions to prevent a deprecation warning.
2. Ensure URL is always a string before passing it to untrailinslashit (which passes it to rtrim).

However there are still two main blockers to fully run unit testing on PHP 8.1 as outlined here:
- https://github.com/woocommerce/google-listings-and-ads/issues/1758#issuecomment-1310294493
- https://github.com/woocommerce/google-listings-and-ads/issues/1758#issuecomment-1415897005

### Detailed test instructions:
1. Check out this PR and remove an older copy of the vendor folder and rerun composer install
2. Run bin/install-unit-tests.sh <db-name> <db-user> <db-pass> to install the unit tests
3. Run unit tests on php 8.1 vendor/bin/phpunit

> **Note**
It's expected that [two tests will fail](https://github.com/woocommerce/google-listings-and-ads/issues/1758#issuecomment-1415897005) with the following output:
```
1) Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\WCProductAdapterTest::test_maps_rules_attributes
class_exists(): Passing null to parameter #1 ($class) of type string is deprecated

google-listings-and-ads/vendor/google/apiclient/src/Model.php:296
google-listings-and-ads/vendor/google/apiclient/src/Model.php:106
google-listings-and-ads/src/Product/WCProductAdapter.php:942
google-listings-and-ads/src/Product/WCProductAdapter.php:110
google-listings-and-ads/vendor/google/apiclient/src/Model.php:51
google-listings-and-ads/tests/Unit/Product/WCProductAdapterTest.php:97

2) Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\WCProductAdapterTest::test_gla_attribute_has_priority_over_rules
class_exists(): Passing null to parameter #1 ($class) of type string is deprecated

google-listings-and-ads/vendor/google/apiclient/src/Model.php:296
google-listings-and-ads/vendor/google/apiclient/src/Model.php:106
google-listings-and-ads/src/Product/WCProductAdapter.php:942
google-listings-and-ads/src/Product/WCProductAdapter.php:110
google-listings-and-ads/vendor/google/apiclient/src/Model.php:51
google-listings-and-ads/tests/Unit/Product/WCProductAdapterTest.php:155
```
> We also expect several deprecation notices to show up at the beginning of the test which are related to packages used by WP and WP-CLI

We can also confirm that the automated checks in this PR passed to ensure that none of the changes affect testing on older versions of PHP.

### Changelog entry
* Tweak - Improve PHP 8.1 compatibility.
>
