### PR TITLE
PMax Assets: Stay on the same step after refreshing the campaign editing page

### DIFF
--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { getQuery, onQueryChange } from '@woocommerce/navigation';
-import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -17,11 +16,10 @@ import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
 import useAdsCurrency from '.~/hooks/useAdsCurrency';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import AppSpinner from '.~/components/app-spinner';
-import { FREE_LISTINGS_PROGRAM_ID, CAMPAIGN_STEP } from '.~/constants';
+import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
 import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
 import ProgramToggle from './program-toggle';
 import FreeListingsDisabledToggle from './free-listings-disabled-toggle';
-import { getEditCampaignUrl } from '.~/utils/urls';
 
 const headers = [
 	{
@@ -38,10 +36,6 @@ const headers = [
 	{
 		key: 'dailyBudget',
 		label: __( 'Daily budget', 'google-listings-and-ads' ),
-	},
-	{
-		key: 'assets',
-		label: __( 'Assets', 'google-listings-and-ads' ),
 	},
 	{
 		key: 'enabled',
@@ -127,12 +121,6 @@ const AllProgramsTableCard = ( props ) => {
 			}
 			headers={ headers }
 			rows={ data.map( ( el ) => {
-				const isPaidCampaign = el.id !== FREE_LISTINGS_PROGRAM_ID;
-				const editingAssetsPath = getEditCampaignUrl(
-					el.id,
-					CAMPAIGN_STEP.ASSET_GROUP
-				);
-
 				// Since the <Table> component uses array index as key to render rows,
 				// it might cause incorrect state control if a column has an internal state.
 				// So we have to specific `key` prop on some components of the `display` to work around it.
@@ -142,23 +130,18 @@ const AllProgramsTableCard = ( props ) => {
 					{ display: el.country },
 					{ display: el.dailyBudget },
 					{
-						display: isPaidCampaign && (
-							// TODO: Revisit this temporary demo since the spec of assets column is not yet decided.
-							<Link href={ editingAssetsPath }>Edit</Link>
-						),
-					},
-					{
-						display: isPaidCampaign ? (
-							<ProgramToggle key={ el.id } program={ el } />
-						) : (
-							<FreeListingsDisabledToggle />
-						),
+						display:
+							el.id === FREE_LISTINGS_PROGRAM_ID ? (
+								<FreeListingsDisabledToggle />
+							) : (
+								<ProgramToggle key={ el.id } program={ el } />
+							),
 					},
 					{
 						display: (
 							<div className="program-actions" key={ el.id }>
 								<EditProgramButton programId={ el.id } />
-								{ isPaidCampaign && (
+								{ el.id !== FREE_LISTINGS_PROGRAM_ID && (
 									<RemoveProgramButton programId={ el.id } />
 								) }
 							</div>

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -3,8 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Stepper } from '@woocommerce/components';
-import { useState } from '@wordpress/element';
-import { getQuery, getHistory } from '@woocommerce/navigation';
+import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -26,10 +25,10 @@ import { CAMPAIGN_STEP as STEP } from '.~/constants';
 const dashboardURL = getDashboardUrl();
 const helpButton = <HelpIconButton eventContext="edit-ads" />;
 
-function getInitialStep() {
-	const { initialStep } = getQuery();
-	if ( Object.values( STEP ).includes( initialStep ) ) {
-		return initialStep;
+function getCurrentStep() {
+	const { step } = getQuery();
+	if ( Object.values( STEP ).includes( step ) ) {
+		return step;
 	}
 	return STEP.CAMPAIGN;
 }
@@ -40,12 +39,16 @@ function getInitialStep() {
 const EditPaidAdsCampaign = () => {
 	useLayout( 'full-content' );
 
-	const [ step, setStep ] = useState( getInitialStep );
 	const { updateAdsCampaign } = useAppDispatch();
 
 	const id = Number( getQuery().programId );
 	const { loaded, data: campaigns } = useAdsCampaigns();
 	const campaign = campaigns?.find( ( el ) => el.id === id );
+
+	const setStep = ( step ) => {
+		const url = getNewPath( { ...getQuery(), step } );
+		getHistory().push( url );
+	};
 
 	if ( ! loaded ) {
 		return (
@@ -114,7 +117,7 @@ const EditPaidAdsCampaign = () => {
 				onSubmit={ handleSubmit }
 			>
 				<Stepper
-					currentStep={ step }
+					currentStep={ getCurrentStep() }
 					steps={ [
 						{
 							key: STEP.CAMPAIGN,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the code review of https://github.com/woocommerce/google-listings-and-ads/pull/1873#pullrequestreview-1288947337 and https://github.com/woocommerce/google-listings-and-ads/pull/1873#issuecomment-1423966440, @jorgemd24 found that it will back to the first step after refreshing the campaign editing page on the second step.

This PR fixes the bug, and also reverts d3dccb2dbf83af32b23535ff92d1a3bb68a24bbb because the dashboard page was changed to not add the new assets column and that commitment is only a demo.

### Detailed test instructions:

1. Go to the campaign editing step.
2. Refresh the page on each step and check if it stays on the same step.
3. Check if other relevant navigation functions on the page work correctly.

### Changelog entry
