### PR TITLE
PMax Assets - Tweak asset suggestions for the latests posts

### DIFF
--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -167,6 +167,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				->where( 'asset_group.final_urls', [ trailingslashit( $url ), untrailingslashit( $url ) ], 'CONTAINS ANY' )
 				->where( 'asset_group_asset.field_type', $this->get_asset_field_types_query(), 'IN' )
 				->where( 'asset_group_asset.status', 'REMOVED', '!=' )
+				->where( 'asset_group.status', 'REMOVED', '!=' )
 				->get_results();
 
 			/** @var GoogleAdsRow $row */

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -196,11 +196,7 @@ class AssetSuggestionsService implements Service {
 			return [];
 		}
 
-		if ( ! isset( $asset_group_assets[ AssetFieldType::CALL_TO_ACTION_SELECTION ] ) ) {
-			$asset_group_assets[ AssetFieldType::CALL_TO_ACTION_SELECTION ] = null;
-		}
-
-		return array_merge( [ 'final_url' => $final_url ], $asset_group_assets );
+		return array_merge( $this->get_suggestions_common_fields( [] ), [ 'final_url' => $final_url ], $asset_group_assets );
 
 	}
 
@@ -238,6 +234,7 @@ class AssetSuggestionsService implements Service {
 			return $this->get_post_assets( $home_page->ID );
 		}
 
+		// Get images from the last posts.
 		$marketing_images = $this->get_url_attachments_by_ids( $this->get_post_image_attachments() );
 
 		// Non static homepage.

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -237,6 +237,9 @@ class AssetSuggestionsService implements Service {
 		if ( $home_page ) {
 			return $this->get_post_assets( $home_page->ID );
 		}
+
+		$marketing_images = $this->get_url_attachments_by_ids( $this->get_post_image_attachments() );
+
 		// Non static homepage.
 		return array_merge(
 			[
@@ -246,7 +249,7 @@ class AssetSuggestionsService implements Service {
 				'display_url_path'            => [],
 				'final_url'                   => get_bloginfo( 'url' ),
 			],
-			$this->get_suggestions_common_fields( [] )
+			$this->get_suggestions_common_fields( $marketing_images )
 		);
 
 	}

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -69,17 +69,17 @@ class AssetSuggestionsService implements Service {
 		self::MARKETING_IMAGE_KEY          => [
 			'minimum'     => [ 600, 314 ],
 			'recommended' => [ 1200, 628 ],
-			'max_qty'     => 10,
+			'max_qty'     => 8,
 		],
 		self::SQUARE_MARKETING_IMAGE_KEY   => [
 			'minimum'     => [ 300, 300 ],
 			'recommended' => [ 1200, 1200 ],
-			'max_qty'     => 5,
+			'max_qty'     => 8,
 		],
 		self::PORTRAIT_MARKETING_IMAGE_KEY => [
 			'minimum'     => [ 480, 600 ],
 			'recommended' => [ 960, 1200 ],
-			'max_qty'     => 5,
+			'max_qty'     => 4,
 		],
 		self::LOGO_IMAGE_KEY               => [
 			'minimum'     => [ 128, 128 ],

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -241,8 +241,8 @@ class AssetSuggestionsService implements Service {
 		return array_merge(
 			[
 				AssetFieldType::HEADLINE      => [ __( 'Homepage', 'google-listings-and-ads' ) ],
-				AssetFieldType::LONG_HEADLINE => [],
-				AssetFieldType::DESCRIPTION   => ArrayUtil::remove_empty_values( [ get_bloginfo( 'description' ) ] ),
+				AssetFieldType::LONG_HEADLINE => [ get_bloginfo( 'name' ) . ': ' . __( 'Homepage', 'google-listings-and-ads' ) ],
+				AssetFieldType::DESCRIPTION   => ArrayUtil::remove_empty_values( [ __( 'Homepage', 'google-listings-and-ads' ), get_bloginfo( 'description' ) ] ),
 				'display_url_path'            => [],
 				'final_url'                   => get_bloginfo( 'url' ),
 			],

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -132,8 +132,8 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		return array_merge(
 			[
 				AssetFieldType::HEADLINE      => [ 'Homepage' ],
-				AssetFieldType::LONG_HEADLINE => [],
-				AssetFieldType::DESCRIPTION   => ArrayUtil::remove_empty_values( [ get_bloginfo( 'description' ) ] ),
+				AssetFieldType::LONG_HEADLINE => [ get_bloginfo( 'name' ) . ': Homepage' ],
+				AssetFieldType::DESCRIPTION   => ArrayUtil::remove_empty_values( [ 'Homepage', get_bloginfo( 'description' ) ] ),
 				'display_url_path'            => [],
 				'final_url'                   => get_bloginfo( 'url' ),
 			],

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -733,7 +733,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 				'final_url'                              => get_permalink( $this->post->ID ),
 			];
 
-			$this->assertEquals( $expected, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+			$this->assertEquals( array_merge( $this->get_suggestions_common_fields( [] ), $expected ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 
 	}
 
@@ -755,7 +755,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 				'final_url'                              => get_permalink( $this->post->ID ),
 			];
 
-			$this->assertEquals( $expected, $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
+			$this->assertEquals( array_merge( $this->get_suggestions_common_fields( [] ), $expected ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
 
 	}
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -378,6 +378,12 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			null
 		);
 
+		$this->wp->expects( $this->once( 1 ) )
+		->method( 'get_posts' )
+		->willReturn(
+			[]
+		);
+
 		$this->assertEquals( $this->format_homepage_asset_response(), $this->asset_suggestions->get_assets_suggestions( self::HOMEPAGE_KEY_ID, 'homepage' ) );
 	}
 

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -378,10 +378,25 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			null
 		);
 
-		$this->wp->expects( $this->once( 1 ) )
+		$this->wp->expects( $this->exactly( 2 ) )
 		->method( 'get_posts' )
-		->willReturn(
-			[]
+		->withConsecutive(
+			[
+				[],
+			],
+			[
+				[
+					'post_type'       => 'attachment',
+					'post_mime_type'  => [ 'image/jpeg', 'image/png', 'image/jpg' ],
+					'fields'          => 'ids',
+					'numberposts'     => self::DEFAULT_MAXIMUM_MARKETING_IMAGES,
+					'post_parent__in' => [ $this->post->ID ],
+				],
+			]
+		)
+		->willReturnOnConsecutiveCalls(
+			[ $this->post ],
+			[],
 		);
 
 		$this->assertEquals( $this->format_homepage_asset_response(), $this->asset_suggestions->get_assets_suggestions( self::HOMEPAGE_KEY_ID, 'homepage' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

This PR adds the following tweaks:

1. Suggest the latest post images when the homepage is a non-static page.
2. Adjust the suggested number of asset images to 8 `MARKETING_IMAGE_KEY`, 8 `SQUARE_MARKETING_IMAGE_KEY` and 4 `PORTRAIT_MARKETING_IMAGE_KEY` to make a total of 20 Marketing images. With this adjustment, we are aligned with the following comment: pcTzPl-12o-p2#comment-2247
3. Adjust the response of Asset Suggestions to include the optional field type: `PORTRAIT_MARKETING_IMAGE` when it is empty.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Testing images for latest posts.

1. Go to WP Settings -> Reading -> Select "Your latest posts".
2. Make a GET request `gla/assets/suggestions?id=0&type=homepage`
3. If you have some images in your latest posts,  they should be included in the response. See here the minimum sizes allowed: https://developers.google.com/google-ads/api/docs/performance-max/assets


#### Testing optional fields for Ads API asset suggestions.

4. Go to the [Google Ads](https://ads.google.com/)
5. Choose a campaign
6. Edit an asset group
7. Get the final URL.

![image](https://user-images.githubusercontent.com/2488994/217832953-a7cc7b74-e805-420a-8644-7e45daecb420.png)

8. Force you localhost homepage URL to be the same as the previous URL. You can use the following filter:

```
add_filter('home_url', function ($url) {
   return  str_replace('http://localhost', 'https://test.ngrok.io', $url);
}, 10, 1);
```

8. Make a GET request `gla/assets/suggestions?id=0&type=homepage`
9. If you homepage URL matches with the Asset Group final URL, the assets suggested should be the ones that are in the asset group. See this PR for more context: https://github.com/woocommerce/google-listings-and-ads/pull/1837
10. Check that the fields `portrait_marketing_image` and `call_to_action_selection` are present.


### Additional details:

As the branch `feature/pmax-assets` is using some new imports from the GoogleAds Library, you may need to remove your vendor folder `rm -Rf vendor/*` and install again the dependencies using `composer install`.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>