### PR TITLE
PMax Assets: Add a tour to the Dashboard page for introducing the campaign assets

### DIFF
--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -41,6 +41,16 @@
 			}
 		}
 	}
+
+	// Fix the obvious styles conflicts caused by WooCommerce Payments since approximately version 2.2.0.
+	// Ref: https://github.com/Automattic/woocommerce-payments/blob/2.2.0/client/payment-details/summary/style.scss#L3-L9
+	.components-card {
+		margin-bottom: 0;
+
+		&__header {
+			font-size: inherit;
+		}
+	}
 }
 
 // hack to fix radio button selected style bug caused by woocommerce-admin.

--- a/js/src/dashboard/all-programs-table-card/campaign-assets-tour.js
+++ b/js/src/dashboard/all-programs-table-card/campaign-assets-tour.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { TourKit, Pill } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import useTour from '.~/hooks/useTour';
+import './campaign-assets-tour.scss';
+
+const TOUR_ID = 'dashboard-feature--campaign-assets';
+
+/**
+ * Renders the tour for notifying the new feature of campaign assets
+ * if its flag is not yet set to hidden.
+ *
+ * @param {Object} props React props
+ * @param {string} props.referenceElementCssSelector The CSS selector to find the first DOM to render this tour nearby.
+ */
+export default function CampaignAssetsTour( { referenceElementCssSelector } ) {
+	const { showTour, setTourChecked } = useTour( TOUR_ID );
+
+	if ( ! showTour ) {
+		return null;
+	}
+
+	const config = {
+		steps: [
+			{
+				referenceElements: {
+					desktop: referenceElementCssSelector,
+				},
+				meta: {
+					heading: (
+						<>
+							{ __(
+								'🎉 Add creative assets',
+								'google-listings-and-ads'
+							) }
+							<Pill>
+								{ _x(
+									'New',
+									'A highlighting label behind the heading of the new feature',
+									'google-listings-and-ads'
+								) }
+							</Pill>
+						</>
+					),
+					descriptions: {
+						desktop: (
+							<>
+								{ __(
+									'Boost your ads performance by adding creative assets to your campaign.',
+									'google-listings-and-ads'
+								) }
+								<br />
+								<br />
+								{ __(
+									'Edit your campaign to explore this new feature.',
+									'google-listings-and-ads'
+								) }
+							</>
+						),
+					},
+				},
+			},
+		],
+		options: {
+			classNames: 'gla-campaign-assets-tour',
+			effects: { overlay: false },
+		},
+		placement: 'top',
+		closeHandler: () => setTourChecked( true ),
+	};
+
+	return <TourKit config={ config } />;
+}

--- a/js/src/dashboard/all-programs-table-card/campaign-assets-tour.js
+++ b/js/src/dashboard/all-programs-table-card/campaign-assets-tour.js
@@ -3,6 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { TourKit, Pill } from '@woocommerce/components';
+import GridiconTrending from 'gridicons/dist/trending';
 
 /**
  * Internal dependencies
@@ -34,9 +35,10 @@ export default function CampaignAssetsTour( { referenceElementCssSelector } ) {
 				},
 				meta: {
 					heading: (
-						<>
+						<div className="gla-campaign-assets-tour__heading">
+							<GridiconTrending />
 							{ __(
-								'🎉 Add creative assets',
+								'Boost your campaign',
 								'google-listings-and-ads'
 							) }
 							<Pill>
@@ -46,13 +48,13 @@ export default function CampaignAssetsTour( { referenceElementCssSelector } ) {
 									'google-listings-and-ads'
 								) }
 							</Pill>
-						</>
+						</div>
 					),
 					descriptions: {
 						desktop: (
 							<>
 								{ __(
-									'Boost your ads performance by adding creative assets to your campaign.',
+									'Create ads that boost visibility and maximize campaign performance using dynamic ad assets.',
 									'google-listings-and-ads'
 								) }
 								<br />

--- a/js/src/dashboard/all-programs-table-card/campaign-assets-tour.js
+++ b/js/src/dashboard/all-programs-table-card/campaign-assets-tour.js
@@ -21,9 +21,9 @@ const TOUR_ID = 'dashboard-feature--campaign-assets';
  * @param {string} props.referenceElementCssSelector The CSS selector to find the first DOM to render this tour nearby.
  */
 export default function CampaignAssetsTour( { referenceElementCssSelector } ) {
-	const { showTour, setTourChecked } = useTour( TOUR_ID );
+	const { tourChecked, setTourChecked } = useTour( TOUR_ID );
 
-	if ( ! showTour ) {
+	if ( tourChecked ) {
 		return null;
 	}
 

--- a/js/src/dashboard/all-programs-table-card/campaign-assets-tour.js
+++ b/js/src/dashboard/all-programs-table-card/campaign-assets-tour.js
@@ -68,7 +68,7 @@ export default function CampaignAssetsTour( { referenceElementCssSelector } ) {
 			},
 		],
 		options: {
-			classNames: 'gla-campaign-assets-tour',
+			classNames: 'gla-admin-page,gla-campaign-assets-tour',
 			effects: { overlay: false },
 		},
 		placement: 'top',

--- a/js/src/dashboard/all-programs-table-card/campaign-assets-tour.scss
+++ b/js/src/dashboard/all-programs-table-card/campaign-assets-tour.scss
@@ -1,0 +1,18 @@
+.gla-campaign-assets-tour {
+	.components-card__body .woocommerce-pill {
+		margin-left: $grid-unit-15;
+		border: none;
+		background-color: var(--wp-admin-theme-color);
+		color: $white;
+	}
+
+	// Hide the footer content but leave the padding-bottom because
+	// TourKit doesn't offer a way not to use the primary button.
+	.components-card__footer {
+		padding-top: 0;
+
+		> * {
+			display: none;
+		}
+	}
+}

--- a/js/src/dashboard/all-programs-table-card/campaign-assets-tour.scss
+++ b/js/src/dashboard/all-programs-table-card/campaign-assets-tour.scss
@@ -1,9 +1,16 @@
 .gla-campaign-assets-tour {
-	.components-card__body .woocommerce-pill {
-		margin-left: $grid-unit-15;
-		border: none;
-		background-color: var(--wp-admin-theme-color);
-		color: $white;
+	&__heading {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+		fill: $alert-green;
+
+		.woocommerce-pill {
+			margin-left: $grid-unit-05;
+			border: none;
+			background-color: var(--wp-admin-theme-color);
+			color: $white;
+		}
 	}
 
 	// Hide the footer content but leave the padding-bottom because

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -11,12 +12,12 @@ import EditProgramPromptModal from './edit-program-prompt-modal';
 import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
 
 const EditProgramButton = ( props ) => {
-	const { programId } = props;
+	const { className, programId } = props;
 
 	return (
 		<AppButtonModalTrigger
 			button={
-				<AppButton isLink>
+				<AppButton isLink className={ classnames( className ) }>
 					{ __( 'Edit', 'google-listings-and-ads' ) }
 				</AppButton>
 			}

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { getQuery, onQueryChange } from '@woocommerce/navigation';
 
@@ -20,6 +21,10 @@ import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
 import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
 import ProgramToggle from './program-toggle';
 import FreeListingsDisabledToggle from './free-listings-disabled-toggle';
+import CampaignAssetsTour from './campaign-assets-tour';
+
+const PROGRAMS_TABLE_CARD_CLASS_NAME = 'gla-all-programs-table-card';
+const CAMPAIGN_EDIT_BUTTON_CLASS_NAME = 'gla-campaign-edit-button';
 
 const headers = [
 	{
@@ -81,6 +86,15 @@ const AllProgramsTableCard = ( props ) => {
 		return <AppSpinner />;
 	}
 
+	let campaignAssetsTour = null;
+
+	if ( adsCampaignsData.length ) {
+		const selector = `.${ PROGRAMS_TABLE_CARD_CLASS_NAME } .${ CAMPAIGN_EDIT_BUTTON_CLASS_NAME }`;
+		campaignAssetsTour = (
+			<CampaignAssetsTour referenceElementCssSelector={ selector } />
+		);
+	}
+
 	const data = [
 		{
 			id: FREE_LISTINGS_PROGRAM_ID,
@@ -110,9 +124,9 @@ const AllProgramsTableCard = ( props ) => {
 		} ),
 	];
 
-	return (
+	const tableCard = (
 		<AppTableCard
-			className="gla-all-programs-table-card"
+			className={ PROGRAMS_TABLE_CARD_CLASS_NAME }
 			title={ __( 'Programs', 'google-listings-and-ads' ) }
 			actions={
 				<AddPaidCampaignButton
@@ -121,6 +135,11 @@ const AllProgramsTableCard = ( props ) => {
 			}
 			headers={ headers }
 			rows={ data.map( ( el ) => {
+				const isFreeListings = el.id === FREE_LISTINGS_PROGRAM_ID;
+				const editButtonClassName = classnames( {
+					[ CAMPAIGN_EDIT_BUTTON_CLASS_NAME ]: ! isFreeListings,
+				} );
+
 				// Since the <Table> component uses array index as key to render rows,
 				// it might cause incorrect state control if a column has an internal state.
 				// So we have to specific `key` prop on some components of the `display` to work around it.
@@ -130,17 +149,19 @@ const AllProgramsTableCard = ( props ) => {
 					{ display: el.country },
 					{ display: el.dailyBudget },
 					{
-						display:
-							el.id === FREE_LISTINGS_PROGRAM_ID ? (
-								<FreeListingsDisabledToggle />
-							) : (
-								<ProgramToggle key={ el.id } program={ el } />
-							),
+						display: isFreeListings ? (
+							<FreeListingsDisabledToggle />
+						) : (
+							<ProgramToggle key={ el.id } program={ el } />
+						),
 					},
 					{
 						display: (
 							<div className="program-actions" key={ el.id }>
-								<EditProgramButton programId={ el.id } />
+								<EditProgramButton
+									className={ editButtonClassName }
+									programId={ el.id }
+								/>
 								{ el.id !== FREE_LISTINGS_PROGRAM_ID && (
 									<RemoveProgramButton programId={ el.id } />
 								) }
@@ -155,6 +176,13 @@ const AllProgramsTableCard = ( props ) => {
 			onQueryChange={ onQueryChange }
 			{ ...props }
 		/>
+	);
+
+	return (
+		<>
+			{ campaignAssetsTour }
+			{ tableCard }
+		</>
 	);
 };
 

--- a/js/src/dashboard/all-programs-table-card/index.scss
+++ b/js/src/dashboard/all-programs-table-card/index.scss
@@ -7,7 +7,7 @@
 
 	.program-actions {
 		display: flex;
-		justify-content: flex-end;
+		justify-content: space-between;
 		gap: $grid-unit-15;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements 📌 [Programs table on the Dashboard page](https://github.com/woocommerce/google-listings-and-ads/issues/1787#fe-dashboard-programs) in #1787.

- Add a tour to the Dashboard page for introducing this new feature.

:warning: Steps to merge this PR (@eason9487):

- Wait for #1879 being merged onto `develop`
- Merge `develop` onto `feature/pmax-assets`
- Rebase this PR onto `feature/pmax-assets` and change the merge base to `feature/pmax-assets`
- Merge this PR

### Screenshots:

https://user-images.githubusercontent.com/17420811/218076585-3868c312-ca34-46aa-9c2c-96c8cf940072.mp4

### Detailed test instructions:

💡 Please note that the UI layout and style are not that similar to the design in Figma because the `TourKit` component imported from `@woocommerce/components` doesn't open up the custom renderer, and I think it should be fine leaving this tour aligning with the default layout and style as possible.

1. Go to the Dashboard.
2. If there is at least one campaign, the tour should be shown on the top of the edit button of the first one.
3. Click the X button on the tour, it should be closed after a moment.
4. Refresh the page.
5. The tour should not be shown.
6. To retry, the tour flag can be reset by running the following code via the Console panel in the DevTool:
   ```js
   wp.data.dispatch( 'wc/gla' ).upsertTour( { id: 'dashboard-feature--campaign-assets', checked: false } )
   ``` 

### Changelog entry

>
