### PR TITLE
PMax Assets: Tweak copy and add the optional labels

### DIFF
--- a/js/src/components/paid-ads/__snapshots__/validateAssetGroup.test.js.snap
+++ b/js/src/components/paid-ads/__snapshots__/validateAssetGroup.test.js.snap
@@ -15,7 +15,7 @@ Array [
 
 exports[`validateAssetGroup Image assets When the length of values.logo is less than 1, it should not pass 1`] = `"Add at least 1 logo image"`;
 
-exports[`validateAssetGroup Image assets When the length of values.marketing_image is less than 1, it should not pass 1`] = `"Add at least 1 rectangular image"`;
+exports[`validateAssetGroup Image assets When the length of values.marketing_image is less than 1, it should not pass 1`] = `"Add at least 1 landscape image"`;
 
 exports[`validateAssetGroup Image assets When the length of values.square_marketing_image is less than 1, it should not pass 1`] = `"Add at least 1 square image"`;
 

--- a/js/src/components/paid-ads/asset-group/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { useReducedMotion } from '@wordpress/compose';
 import {
 	useState,
@@ -35,6 +35,7 @@ import './asset-field.scss';
  * @param {JSX.Element} props.help Help content to be shown after clicking on the help icon.
  * @param {number} [props.numOfIssues=0] The number of issues used to label on UI. It only labels when the number is greater than 0.
  * @param {boolean} [props.initialExpanded=false] Whether the UI is initialized expanded.
+ * @param {boolean} [props.markOptional=false] Whether mark this field as optional.
  * @param {boolean} [props.disabled=false] Whether display the UI in disabled style. It will collapse the content when disabled.
  * @param {JSX.Element} [props.children] Content to be rendered.
  * @param {import('react').MutableRefObject<AssetFieldHandler>} ref React ref to be attached to the handler of this component.
@@ -47,6 +48,7 @@ function AssetField(
 		help,
 		numOfIssues = 0,
 		initialExpanded = false,
+		markOptional = false,
 		disabled = false,
 		children,
 	},
@@ -91,6 +93,15 @@ function AssetField(
 				<div className="gla-asset-field__heading-part">
 					<h2 className="gla-asset-field__heading">
 						{ heading }
+						{ markOptional && (
+							<span className="gla-asset-field__optional-label">
+								{ _x(
+									'(Optional)',
+									'A label behind the heading to indicate a field is optional',
+									'google-listings-and-ads'
+								) }
+							</span>
+						) }
 						<HelpPopover
 							className="gla-asset-field__help-popover"
 							position="top"

--- a/js/src/components/paid-ads/asset-group/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.js
@@ -108,7 +108,9 @@ function AssetField(
 							iconSize={ 20 }
 							disabled={ disabled }
 						>
-							{ help }
+							<div className="gla-asset-field__help-popover__content">
+								{ help }
+							</div>
 						</HelpPopover>
 					</h2>
 					{ subheading && (

--- a/js/src/components/paid-ads/asset-group/asset-field.scss
+++ b/js/src/components/paid-ads/asset-group/asset-field.scss
@@ -34,6 +34,13 @@
 		color: $gray-700;
 	}
 
+	&__optional-label {
+		margin-left: $grid-unit-05;
+		font-weight: normal;
+		font-size: $gla-font-smaller;
+		color: $gray-700;
+	}
+
 	&__help-popover {
 		margin-left: $grid-unit-05;
 

--- a/js/src/components/paid-ads/asset-group/asset-field.scss
+++ b/js/src/components/paid-ads/asset-group/asset-field.scss
@@ -48,20 +48,26 @@
 			padding: 0;
 		}
 
-		.components-popover__content {
-			width: 400px;
-			padding: $grid-unit-05 * 7.5;
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 1.5em;
 			line-height: $gla-line-height-smaller;
 			color: $gray-800;
 
-			p {
+			ul {
 				margin: 0;
-				line-height: $gla-line-height-smaller;
+				color: $gray-700;
 
-				& + p {
-					margin-top: 1.5em;
+				li {
+					margin: 0;
 				}
 			}
+		}
+
+		.components-popover__content {
+			width: 400px;
+			padding: $grid-unit-05 * 7.5;
 		}
 	}
 

--- a/js/src/components/paid-ads/asset-group/asset-field.test.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.test.js
@@ -47,6 +47,18 @@ describe( 'AssetField', () => {
 		expect( screen.queryByText( '0 issues' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'When not setting `markOptional`, it should not render the optional label', () => {
+		render( <AssetField /> );
+
+		expect( screen.queryByText( '(Optional)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'When setting `markOptional`, it should render the optional label', () => {
+		render( <AssetField markOptional /> );
+
+		expect( screen.getByText( '(Optional)' ) ).toBeInTheDocument();
+	} );
+
 	it( 'When not setting `initialExpanded`, it should collapse to hide the children', () => {
 		render( <AssetField>Children</AssetField> );
 

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -191,18 +191,18 @@ export default function AssetGroupCard() {
 				subheading={ hostname }
 				help={
 					<>
-						<p>
+						<div>
 							{ __(
 								`The display URL gives potential customers a clear idea of what webpage they'll reach once they click your ad, so your path text should describe your ad's landing page.`,
 								'google-listings-and-ads'
 							) }
-						</p>
-						<p>
+						</div>
+						<div>
 							{ __(
 								`To create your display URL, Google Ads will combine the domain (for example, "www.google.com" in www.google.com/nonprofits) from your final URL and the path text (for example, "nonprofits" in www.google.com/nonprofits).`,
 								'google-listings-and-ads'
 							) }
-						</p>
+						</div>
 					</>
 				}
 				numOfIssues={ getNumOfIssues(

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -139,7 +139,7 @@ export default function AssetGroupCard() {
 								{ index === 0 && isSelectedFinalUrl && (
 									<ExternalLink href="https://support.google.com/google-ads/answer/6167101">
 										{ __(
-											'Learn how to write effective ad copy',
+											'Learn how to write effective ads',
 											'google-listings-and-ads'
 										) }
 									</ExternalLink>

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -110,6 +110,7 @@ export default function AssetGroupCard() {
 						subheading={ spec.subheading }
 						help={ spec.help }
 						numOfIssues={ getNumOfIssues( spec.key ) }
+						markOptional={ spec.min === 0 }
 						disabled={ ! isSelectedFinalUrl }
 						initialExpanded={ isSelectedFinalUrl }
 					>
@@ -207,6 +208,7 @@ export default function AssetGroupCard() {
 				numOfIssues={ getNumOfIssues(
 					ASSET_FORM_KEY.DISPLAY_URL_PATH
 				) }
+				markOptional
 				disabled={ ! isSelectedFinalUrl }
 				initialExpanded={ isSelectedFinalUrl }
 			>

--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -10,7 +10,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { ASSET_FORM_KEY } from '.~/constants';
 import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import Section from '.~/wcdl/section';
-import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import FinalUrlCard from './final-url-card';
 import AssetGroupCard from './asset-group-card';
@@ -30,7 +29,7 @@ export default function AssetGroupSection() {
 			className="gla-asset-group-section"
 			title={ createInterpolateElement(
 				__(
-					'Add assets <optional>(Optional)</optional>',
+					'Add dynamic ad assets <optional>(Optional)</optional>',
 					'google-listings-and-ads'
 				),
 				{
@@ -40,23 +39,12 @@ export default function AssetGroupSection() {
 				}
 			) }
 			description={
-				<>
-					<p className="gla-asset-group-section__primary-description">
-						{ __(
-							'Upload additional creative assets and Google will mix and match these assets to build ads that lead to a page in your site. Adding more assets typically boosts your campaign’s performance.',
-							'google-listings-and-ads'
-						) }
-					</p>
-					<p>
-						<AppDocumentationLink
-							context="manage-campaign-asset-group"
-							linkId="about-campaign-assets"
-							href="https://support.google.com/google-ads/answer/7331111"
-						>
-							{ __( 'Learn more', 'google-listings-and-ads' ) }
-						</AppDocumentationLink>
-					</p>
-				</>
+				<p className="gla-asset-group-section__primary-description">
+					{ __(
+						'Create ads that effectively boost visibility and generate maximum conversions. Google will mix and match assets to create optimized ads— maximizing your campaign’s performance.',
+						'google-listings-and-ads'
+					) }
+				</p>
 			}
 		>
 			<VerticalGapLayout size="medium">

--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -41,7 +41,7 @@ export default function AssetGroupSection() {
 			description={
 				<p className="gla-asset-group-section__primary-description">
 					{ __(
-						'Create ads that effectively boost visibility and generate maximum conversions. Google will mix and match assets to create optimized ads— maximizing your campaign’s performance.',
+						'Create ads that effectively boost visibility and generate maximum conversions. Google will mix and match assets to create optimized ads in a variety of formats— maximizing your campaign’s performance.',
 						'google-listings-and-ads'
 					) }
 				</p>

--- a/js/src/components/paid-ads/asset-group/asset-group.js
+++ b/js/src/components/paid-ads/asset-group/asset-group.js
@@ -110,7 +110,7 @@ export default function AssetGroup( { campaign } ) {
 			<StepContentHeader
 				title={ __( 'Boost your campaign', 'google-listings-and-ads' ) }
 				description={ __(
-					'Get more conversions by adding creative assets to your campaign',
+					'Take your campaign to the next level with dynamic ad assets',
 					'google-listings-and-ads'
 				) }
 			/>
@@ -135,10 +135,7 @@ export default function AssetGroup( { campaign } ) {
 						}
 						onClick={ handleSkipClick }
 					>
-						{ __(
-							'Skip adding assets',
-							'google-listings-and-ads'
-						) }
+						{ __( 'Skip this step', 'google-listings-and-ads' ) }
 					</AppButton>
 				) }
 				<AppButton

--- a/js/src/components/paid-ads/asset-group/assets-loader.js
+++ b/js/src/components/paid-ads/asset-group/assets-loader.js
@@ -197,9 +197,7 @@ export default function AssetsLoader( { onAssetsLoaded } ) {
 			<AppButton
 				isSecondary
 				text={
-					fetching
-						? __( 'Scanning…', 'google-listings-and-ads' )
-						: __( 'Scan for assets', 'google-listings-and-ads' )
+					fetching ? '' : __( 'Select', 'google-listings-and-ads' )
 				}
 				eventName="gla_import_assets_by_final_url_button_click"
 				eventProps={ { type: finalUrl?.type } }

--- a/js/src/components/paid-ads/asset-group/faqs-section.js
+++ b/js/src/components/paid-ads/asset-group/faqs-section.js
@@ -54,7 +54,7 @@ const faqItems = [
 				</div>
 				<div>
 					{ __(
-						'Compared to product ads—which showcase individual products and are designed to drive direct sales and revenue—responsive ads with dynamic ad assets are typically used to highlight your business, generate interest, and attract new customers. While both types of ads can drive conversions, using them together can generate even greater results.',
+						'Compared to product ads—which showcase individual products and are designed to drive direct sales and revenue— ads with dynamic assets are typically used to highlight your business, generate interest, and attract new customers. While both types of ads can drive conversions, using them together can generate even greater results.',
 						'google-listings-and-ads'
 					) }
 				</div>

--- a/js/src/components/paid-ads/asset-group/final-url-card.js
+++ b/js/src/components/paid-ads/asset-group/final-url-card.js
@@ -79,7 +79,7 @@ export default function FinalUrlCard( {
 					<AppButton
 						isTertiary
 						text={ __(
-							'Or, select another page',
+							'Or, select a different Final URL',
 							'google-listings-and-ads'
 						) }
 						eventName="gla_reselect_another_final_url_button_click"

--- a/js/src/components/paid-ads/asset-group/final-url-card.js
+++ b/js/src/components/paid-ads/asset-group/final-url-card.js
@@ -47,7 +47,7 @@ export default function FinalUrlCard( {
 		<ExternalLink href={ finalUrl }>{ finalUrl }</ExternalLink>
 	) : (
 		__(
-			'Choose a page that people reach after clicking your ad. This might be your homepage, or a more specific page.',
+			'Choose a page that you want people to reach after clicking your ad. This might be your homepage, or a more specific page.',
 			'google-listings-and-ads'
 		)
 	);

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -40,7 +40,7 @@ const ASSET_IMAGE_SPECS = [
 			suggestedHeight: 628,
 		},
 		heading: _x(
-			'Rectangular images',
+			'Landscape images',
 			'Plural asset field name as the heading',
 			'google-listings-and-ads'
 		),
@@ -50,7 +50,7 @@ const ASSET_IMAGE_SPECS = [
 			'google-listings-and-ads'
 		),
 		lowercaseName: _x(
-			'rectangular',
+			'landscape',
 			'Lowercase asset field name',
 			'google-listings-and-ads'
 		),
@@ -123,7 +123,7 @@ const ASSET_IMAGE_SPECS = [
 			'google-listings-and-ads'
 		),
 		helpSubheading: _x(
-			'Square logo (1:1)',
+			'Logo (1:1)',
 			'Asset field name with its aspect ratio as the subheading within a help tip',
 			'google-listings-and-ads'
 		),

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -271,15 +271,27 @@ const ASSET_TEXT_SPECS = [
 // functions inside are for initialization purposes only and are not expected to be exposed
 // outside this module.
 {
-	function getSubheading( min, max ) {
+	function getSubheading( spec, shownAsSharedMax ) {
+		if ( shownAsSharedMax ) {
+			if ( spec.min === 0 ) {
+				return;
+			}
+
+			return sprintf(
+				// translators: 1: The minimal number of this item.
+				__( 'At least %d required', 'google-listings-and-ads' ),
+				spec.min
+			);
+		}
+
 		return sprintf(
 			// translators: 1: The minimal number of this item. 2: The maximum number of this item.
 			__(
 				'At least %1$d required. Add up to %2$d.',
 				'google-listings-and-ads'
 			),
-			min,
-			max
+			spec.min,
+			spec.max
 		);
 	}
 
@@ -314,8 +326,14 @@ const ASSET_TEXT_SPECS = [
 	}
 
 	ASSET_IMAGE_SPECS_GROUPS.forEach( ( specs ) => {
+		// Currently, the PMax Assets feature in this extension doesn't offer managing the landscape_logo
+		// asset but only the logo asset. So the logo asset shares the total number of images by itself.
+		// To avoid confusing extension users, the UI and wording are shown the shared max concept when
+		// the number of manageable images in the same group is > 1.
+		const shownAsSharedMax = specs.length > 1;
+
 		specs.forEach( ( spec ) => {
-			spec.subheading = getSubheading( spec.min, spec.max );
+			spec.subheading = getSubheading( spec, shownAsSharedMax );
 			spec.help = getImageHelpContent(
 				spec.helpSubheading,
 				spec.imageConfig
@@ -324,7 +342,7 @@ const ASSET_TEXT_SPECS = [
 	} );
 
 	ASSET_TEXT_SPECS.forEach( ( spec ) => {
-		spec.subheading = getSubheading( spec.min, spec.max );
+		spec.subheading = getSubheading( spec );
 	} );
 }
 

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -195,18 +195,18 @@ const ASSET_TEXT_SPECS = [
 		),
 		help: (
 			<>
-				<p>
+				<div>
 					{ __(
 						'The long headline is the first line of your ad, and appears instead of your short headline in larger ads. Long headlines can be up to 90 characters, and may appear with or without your description.',
 						'google-listings-and-ads'
 					) }
-				</p>
-				<p>
+				</div>
+				<div>
 					{ __(
 						'The length of the rendered headline will depend on the site it appears on. If shortened, it will end with an ellipsis(…).',
 						'google-listings-and-ads'
 					) }
-				</p>
+				</div>
 			</>
 		),
 	},
@@ -239,18 +239,18 @@ const ASSET_TEXT_SPECS = [
 		),
 		help: (
 			<>
-				<p>
+				<div>
 					{ __(
 						'The description adds to the headline and provides additional context or details. It can be up to 90 characters, and may appear after the headline.',
 						'google-listings-and-ads'
 					) }
-				</p>
-				<p>
+				</div>
+				<div>
 					{ __(
 						`The length of the rendered description will depend on the site it appears on. If it's shortened, it will end with an ellipsis(…). The description doesn't show in all sizes and formats.`,
 						'google-listings-and-ads'
 					) }
-				</p>
+				</div>
 			</>
 		),
 	},
@@ -276,7 +276,7 @@ const ASSET_TEXT_SPECS = [
 		const size = sprintf(
 			// translators: 1: Recommended width. 2: Recommended height. 3: Minimal width. 4: Minimal height.
 			__(
-				'Recommended size: %1$d x %2$d<newline />Min. size: %3$d x %4$d',
+				'<listItem>Recommended size: %1$d x %2$d</listItem><listItem>Min. size: %3$d x %4$d</listItem>',
 				'google-listings-and-ads'
 			),
 			imageConfig.suggestedWidth,
@@ -286,16 +286,18 @@ const ASSET_TEXT_SPECS = [
 		);
 		return (
 			<>
-				<p>
+				<div>
 					{ __(
 						'Add images that meet or can be cropped to the recommended sizes. Note: The maximum file size for any image is 5120 KB.',
 						'google-listings-and-ads'
 					) }
-				</p>
-				<p>
+				</div>
+				<div>
 					<strong>{ subheading }</strong>
-				</p>
-				<p>{ createInterpolateElement( size, { newline: <br /> } ) }</p>
+				</div>
+				<ul>
+					{ createInterpolateElement( size, { listItem: <li /> } ) }
+				</ul>
 			</>
 		);
 	}

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -28,7 +28,7 @@ const ASSET_DISPLAY_URL_PATH_SPECS = [
 	},
 ];
 
-const ASSET_IMAGE_SPECS = [
+const ASSET_MARKETING_IMAGE_SPECS = [
 	{
 		key: ASSET_FORM_KEY.MARKETING_IMAGE,
 		min: 1,
@@ -107,6 +107,9 @@ const ASSET_IMAGE_SPECS = [
 			'google-listings-and-ads'
 		),
 	},
+];
+
+const ASSET_LOGO_SPECS = [
 	{
 		key: ASSET_FORM_KEY.LOGO,
 		min: 1,
@@ -134,6 +137,14 @@ const ASSET_IMAGE_SPECS = [
 		),
 	},
 ];
+
+// The max number of asset images is shared across different types of asset images.
+const ASSET_IMAGE_SPECS_GROUPS = [
+	ASSET_MARKETING_IMAGE_SPECS,
+	ASSET_LOGO_SPECS,
+];
+
+const ASSET_IMAGE_SPECS = ASSET_IMAGE_SPECS_GROUPS.flat();
 
 const ASSET_TEXT_SPECS = [
 	{
@@ -302,12 +313,14 @@ const ASSET_TEXT_SPECS = [
 		);
 	}
 
-	ASSET_IMAGE_SPECS.forEach( ( spec ) => {
-		spec.subheading = getSubheading( spec.min, spec.max );
-		spec.help = getImageHelpContent(
-			spec.helpSubheading,
-			spec.imageConfig
-		);
+	ASSET_IMAGE_SPECS_GROUPS.forEach( ( specs ) => {
+		specs.forEach( ( spec ) => {
+			spec.subheading = getSubheading( spec.min, spec.max );
+			spec.help = getImageHelpContent(
+				spec.helpSubheading,
+				spec.imageConfig
+			);
+		} );
 	} );
 
 	ASSET_TEXT_SPECS.forEach( ( spec ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a part of 📌 [Assets form and related components](https://github.com/woocommerce/google-listings-and-ads/issues/1787#fe-misc) in #1787.

- Align with the finalized copy.
- Add the missed optional labels for the Display URL Path and Portrait images.
- Adjust the layout and style for the help content of the asset fields.
- Adjust the subheading of all marketing images to show the required minimum number only.
- Adjust the help content in the popover of asset images to show different copies according to whether the max number is shared.

### Screenshots:

#### 📷 The optional label

![image](https://user-images.githubusercontent.com/17420811/218401183-a2017fb6-98c8-4de2-9838-e00c116d5318.png)

#### 📷 The help content

![image](https://user-images.githubusercontent.com/17420811/220069257-10b90fe1-22ef-4bcb-aff6-4c208aae32f0.png)
![image](https://user-images.githubusercontent.com/17420811/220069525-6862c67f-b8e2-47ac-ba12-4f31e3c1ea38.png)

### Detailed test instructions:

💡 The Figma link of the finalized copy is the **i2 final** version in the Links section of https://github.com/woocommerce/google-listings-and-ads/issues/1787.

💡 Adjusting to the shared maximum number and the tip floating on the disabled "Add image" button will be done in another PR.

1. Go to step 2 of the campaign creation or editing page.
2. Check if the "(Optional)" label is shown on the fields of Display URL Path and Portrait images.
3. Check if the copy is the same as in the design document.

### Changelog entry
