### PR TITLE
PMax Assets - Limit the asset suggestions fetched from other Asset Groups

### DIFF
--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -196,6 +196,17 @@ class AssetSuggestionsService implements Service {
 			return [];
 		}
 
+		// Limit the number of marketing images.
+		$limits = [
+			AssetFieldType::MARKETING_IMAGE          => self::IMAGE_REQUIREMENTS[ self::MARKETING_IMAGE_KEY ]['max_qty'],
+			AssetFieldType::SQUARE_MARKETING_IMAGE   => self::IMAGE_REQUIREMENTS[ self::SQUARE_MARKETING_IMAGE_KEY ]['max_qty'],
+			AssetFieldType::PORTRAIT_MARKETING_IMAGE => self::IMAGE_REQUIREMENTS[ self::PORTRAIT_MARKETING_IMAGE_KEY ]['max_qty'],
+		];
+
+		foreach ( $limits as $asset_type => $limit ) {
+			 $asset_group_assets[ $asset_type ] = array_slice( $asset_group_assets[ $asset_type ] ?? [], 0, $limit );
+		}
+
 		return array_merge( $this->get_suggestions_common_fields( [] ), [ 'final_url' => $final_url ], $asset_group_assets );
 
 	}

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -196,7 +196,7 @@ class AssetSuggestionsService implements Service {
 			return [];
 		}
 
-		// Limit the number of marketing images. This can be remove when the front-end supports multiple combinations of marketing images.
+		// Limit the number of marketing images. This code can be removed when the front end supports multiple combinations of marketing images.
 		// Currently the only combination possible is 8 marketing images, 8 square marketing images and 4 portrait marketing images, making a total of 20 marketing images.
 		$limits = [
 			AssetFieldType::MARKETING_IMAGE          => self::IMAGE_REQUIREMENTS[ self::MARKETING_IMAGE_KEY ]['max_qty'],

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -196,7 +196,8 @@ class AssetSuggestionsService implements Service {
 			return [];
 		}
 
-		// Limit the number of marketing images.
+		// Limit the number of marketing images. This can be remove when the front-end supports multiple combinations of marketing images.
+		// Currently the only combination possible is 8 marketing images, 8 square marketing images and 4 portrait marketing images, making a total of 20 marketing images.
 		$limits = [
 			AssetFieldType::MARKETING_IMAGE          => self::IMAGE_REQUIREMENTS[ self::MARKETING_IMAGE_KEY ]['max_qty'],
 			AssetFieldType::SQUARE_MARKETING_IMAGE   => self::IMAGE_REQUIREMENTS[ self::SQUARE_MARKETING_IMAGE_KEY ]['max_qty'],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/1780

For the MVP, the number of asset suggestions have been limited to 8 Landscape, 8 Square and 4 Portrait. At the moment, we are limiting the asset suggestions that are populated from WordPress but we were not limiting the number of assets that are fetched from other asset groups.

This PR adds limits to the number of assets suggested by other asset groups.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to [Google Ads ](https://ads.google.com/intl/en_EN/home/), choose a Campaign -> Asset Groups -> Edit Asset Group.
2. Add more than 8 marketing images and add some square and portrait marketing images.
3. Get the final URL from the asset group and force your local environment to have the same URL. The goal is that your asset group and your homepage have the same `final URL`. Use the following filter to change your local domain.

```
add_filter('home_url', function ($url) {
   return  str_replace('http://localhost', 'https://test.ngrok.io', $url);
}, 10, 1);
```

3. Make a request to `GET /gla/assets/suggestions?id=0&type=homepage`
6. If the homepage has the same URL than your asset group, the assets suggested should be the ones that are in the asset group. If there is more than one asset group with the same `final URL` the API will return only one.
7. Check that `marketing_image` and `square_marketing_image` does not exceed the maximum of 8 images, and `portrait_marketing_image` does not exceed 4 images.


### Additional details:

<details>
<summary> See some testing images and sizes. </summary>

### Marketing Images (Landscape)

https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_10.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_9.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_8.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_7.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_6.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_5.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_4.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_3.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_2.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/marketing_1.png

### Marketing Images (Square)
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_10.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_9.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_8.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_7.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_6.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_5.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_4.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_3.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_2.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/square_1.png

### Marketing Images (Portrait)

https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_10.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_9.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_8.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_7.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_6.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_5.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_4.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_3.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_2.jpeg
https://driving-butterfly.jurassic.ninja/wp-content/uploads/2023/02/portrait_1.png

</details>

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
