### PR TITLE
PMax Assets: Add event tracking

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group.js
+++ b/js/src/components/paid-ads/asset-group/asset-group.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -22,6 +23,29 @@ export const ACTION_SUBMIT_CAMPAIGN_ONLY = 'submit-campaign-only';
  */
 
 /**
+ * Clicking on the submit button on the campaign creation or editing page.
+ * If a value is recorded as `unknown`, it's because no assets are imported and therefore unknown.
+ *
+ * @event gla_submit_campaign_button_click
+ * @property {string} context Indicate the place where the button is located. Possible values: `campaign-creation`, `campaign-editing`.
+ * @property {string} action Indicate which submit button is clicked. Possible values: `submit-campaign-and-assets`, `submit-campaign-only`.
+ * @property {string} audiences Country codes of the campaign audience countries, e.g. `US,JP,AU`.
+ * @property {string} budget Daily average cost of the campaign.
+ * @property {string} assets_validation Whether all asset values are valid or at least one invalid. Possible values: `valid`, `invalid`, `unknown`.
+ * @property {string} number_of_business_name The number of this asset in string type or `unknown`.
+ * @property {string} number_of_marketing_image Same as above.
+ * @property {string} number_of_square_marketing_image Same as above.
+ * @property {string} number_of_portrait_marketing_image Same as above.
+ * @property {string} number_of_logo Same as above.
+ * @property {string} number_of_headline Same as above.
+ * @property {string} number_of_long_headline Same as above.
+ * @property {string} number_of_description Same as above.
+ * @property {string} number_of_call_to_action_selection Same as above.
+ * @property {string} number_of_final_url Same as above.
+ * @property {string} number_of_display_url_path Same as above.
+ */
+
+/**
  * Renders the container of the form content for managing an asset group of a campaign.
  *
  * Please note that this component relies on an AdaptiveForm's context, so it expects
@@ -29,19 +53,55 @@ export const ACTION_SUBMIT_CAMPAIGN_ONLY = 'submit-campaign-only';
  *
  * @param {Object} props React props.
  * @param {Campaign} [props.campaign] Campaign data to be edited. If not provided, this component will show campaign creation UI.
+ *
+ * @fires gla_submit_campaign_button_click
  */
 export default function AssetGroup( { campaign } ) {
 	const isCreation = ! campaign;
-	const { isValidForm, handleSubmit, adapter } = useAdaptiveFormContext();
+	const {
+		isValidForm,
+		handleSubmit,
+		adapter,
+		values,
+	} = useAdaptiveFormContext();
 	const { isValidAssetGroup, isSubmitting, isSubmitted, submitter } = adapter;
 	const currentAction = submitter?.dataset.action;
 
-	const handleLaunchClick = ( ...args ) => {
+	function recordSubmissionClickEvent( event ) {
+		const finalUrl = values[ ASSET_FORM_KEY.FINAL_URL ];
+		const eventProps = {
+			context: isCreation ? 'campaign-creation' : 'campaign-editing',
+			action: event.target.dataset.action,
+			audiences: values.countryCodes.join( ',' ),
+			budget: values.amount.toString(),
+			assets_validation: isValidAssetGroup ? 'valid' : 'invalid',
+		};
+
+		if ( ! finalUrl ) {
+			eventProps.assets_validation = 'unknown';
+		}
+
+		Object.values( ASSET_FORM_KEY ).forEach( ( key ) => {
+			const name = `number_of_${ key }`;
+			const num = [ values[ key ] ].flat().filter( Boolean ).length;
+			eventProps[ name ] = finalUrl ? num.toString() : 'unknown';
+		} );
+
+		recordEvent( 'gla_submit_campaign_button_click', eventProps );
+	}
+
+	const handleSkipClick = ( event ) => {
+		handleSubmit( event );
+		recordSubmissionClickEvent( event );
+	};
+
+	const handleLaunchClick = ( event ) => {
 		if ( isValidAssetGroup ) {
-			handleSubmit( ...args );
+			handleSubmit( event );
 		} else {
 			adapter.showValidation();
 		}
+		recordSubmissionClickEvent( event );
 	};
 
 	return (
@@ -71,7 +131,7 @@ export default function AssetGroup( { campaign } ) {
 							isSubmitting &&
 							currentAction === ACTION_SUBMIT_CAMPAIGN_ONLY
 						}
-						onClick={ handleSubmit }
+						onClick={ handleSkipClick }
 					>
 						{ __(
 							'Skip adding assets',

--- a/js/src/components/paid-ads/asset-group/assets-loader.js
+++ b/js/src/components/paid-ads/asset-group/assets-loader.js
@@ -78,11 +78,20 @@ function mapFinalUrlsToOptions( finalUrls, search ) {
 }
 
 /**
+ * Clicking on the "Scan for assets" button.
+ *
+ * @event gla_import_assets_by_final_url_button_click
+ * @property {string} type The type of the selected Final URL suggestion to be imported. Possible values: `post`, `term`, `homepage`.
+ */
+
+/**
  * Renders the UI for querying pages, selecting a wanted page as the final URL,
  * and then loading the suggested assets.
  *
  * @param {Object} props React props.
  * @param {(suggestedAssets: SuggestedAssets) => void} props.onAssetsLoaded Callback function when the suggested assets are loaded.
+ *
+ * @fires gla_import_assets_by_final_url_button_click
  */
 export default function AssetsLoader( { onAssetsLoaded } ) {
 	const cacheRef = useRef( {} );
@@ -162,6 +171,8 @@ export default function AssetsLoader( { onAssetsLoaded } ) {
 			} );
 	};
 
+	const { finalUrl } = selectedOptions[ 0 ] || {};
+
 	return (
 		<>
 			<SelectControl
@@ -190,7 +201,9 @@ export default function AssetsLoader( { onAssetsLoaded } ) {
 						? __( 'Scanning…', 'google-listings-and-ads' )
 						: __( 'Scan for assets', 'google-listings-and-ads' )
 				}
-				disabled={ ! selectedOptions[ 0 ]?.finalUrl }
+				eventName="gla_import_assets_by_final_url_button_click"
+				eventProps={ { type: finalUrl?.type } }
+				disabled={ ! finalUrl }
 				loading={ fetching }
 				onClick={ handleClick }
 			/>

--- a/js/src/components/paid-ads/asset-group/final-url-card.js
+++ b/js/src/components/paid-ads/asset-group/final-url-card.js
@@ -21,12 +21,20 @@ import './final-url-card.scss';
  */
 
 /**
+ * Clicking on the "Or, select another page" button.
+ *
+ * @event gla_reselect_another_final_url_button_click
+ */
+
+/**
  * Renders the Card UI for managing the final URL and getting the suggested assets.
  *
  * @param {Object} props React props.
  * @param {(suggestedAssets: SuggestedAssets | null) => void} props.onAssetsChange Callback function when the suggested assets are changed or reset to `null`.
  * @param {string} [props.initialFinalUrl] The initial final URL.
  * @param {boolean} [props.hideFooter=false] Whether to hide the card footer.
+ *
+ * @fires gla_reselect_another_final_url_button_click
  */
 export default function FinalUrlCard( {
 	onAssetsChange,
@@ -74,6 +82,7 @@ export default function FinalUrlCard( {
 							'Or, select another page',
 							'google-listings-and-ads'
 						) }
+						eventName="gla_reselect_another_final_url_button_click"
 						onClick={ handleReselectClick }
 					/>
 				) : (

--- a/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
+++ b/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
@@ -25,7 +25,7 @@ import './useCroppedImageSelector.scss';
  * @param {number} height The image height.
  * @param {number} widthScale The scale of width.
  * @param {number} heightScale The scale of height.
- * @return {[number, number]} The tuple of cropped width and height.
+ * @return {number[]} The tuple of cropped width and height.
  */
 export function calcMaxCroppingByFixedRatio(
 	width,

--- a/js/src/pages/create-paid-ads-campaign/index.js
+++ b/js/src/pages/create-paid-ads-campaign/index.js
@@ -6,7 +6,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { Stepper } from '@woocommerce/components';
 import { useState, useRef } from '@wordpress/element';
 import { getHistory } from '@woocommerce/navigation';
-import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -31,8 +30,6 @@ const dashboardURL = getDashboardUrl();
 
 /**
  * Renders the campaign creation page.
- *
- * @fires gla_launch_paid_campaign_button_click on submit
  */
 const CreatePaidAdsCampaign = () => {
 	useLayout( 'full-content' );
@@ -48,10 +45,6 @@ const CreatePaidAdsCampaign = () => {
 
 		try {
 			const { amount, countryCodes } = values;
-			recordEvent( 'gla_launch_paid_campaign_button_click', {
-				audiences: countryCodes.join( ',' ),
-				budget: amount,
-			} );
 
 			// Avoid re-creating a new campaign if the subsequent asset group update is failed.
 			if ( createdCampaignIdRef.current === null ) {

--- a/js/src/utils/recordEvent.js
+++ b/js/src/utils/recordEvent.js
@@ -82,7 +82,7 @@ export const recordTablePageEvent = ( context, page, direction ) => {
  */
 
 /**
- * Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign
+ * Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign in the Google Ads setup flow.
  *
  * @event gla_launch_paid_campaign_button_click
  * @property {string} audiences Country codes of the paid campaign audience countries, e.g. `'US,JP,AU'`. This means the campaign is created with the multi-country targeting feature. Before this feature support, it was implemented as 'audience'.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements 📌 [Event tracking](https://github.com/woocommerce/google-listings-and-ads/issues/1787#fe-event-tracking) in #1787.

- Add event tracking as per the referred link above.
- Remove the `gla_launch_paid_campaign_button_click` event tracking from the campaign creation page since it's replaced by the `gla_submit_campaign_button_click` event.

💡 As other PMax Assets PRs have not yet been merged, the update of **src/Tracking/README.md** will be added before merging `feature/pmax-assets` branch.

### Detailed test instructions:

1. Enable event tracking logging by running `localStorage.setItem( 'debug', 'wc-admin:*' )` in the Console tab of DevTool, and refresh page to make it effective.
2. Go to the campaign creation and editing pages.
3. Test the four buttons that are marked as **A**, **B**, **C**, **D** in the screenshots of the referred link above.
4. Check if the event names and their properties are the same as the requirements.

### Changelog entry
