### PR TITLE
Remove unnecessary filter param from woocommerce_loop_add_to_cart_link

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -150,12 +150,12 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		// Add product data for any add_to_cart link.
 		add_filter(
 			'woocommerce_loop_add_to_cart_link',
-			function ( $link, $product, $args ) {
+			function ( $link, $product ) {
 				$this->add_product_data( $product );
 				return $link;
 			},
 			10,
-			3
+			2
 		);
 
 		// Add display name for an available variation.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce-blocks/issues/8020. (Heads-up that issue will also be closed by https://github.com/woocommerce/woocommerce-blocks/pull/8422, but I think it makes sense to improve that part of the codebase in GL&A too just to be extra-cautious)

When hooking into `woocommerce_loop_add_to_cart_link`, GL&A was declaring the three params of the function, but in fact, it was only using the second one (`$product`).

In WC Blocks, the Products was incorrectly only passing two filter arguments, so that caused an issue because GL&A expects it to have three. While this will be fixed in WC Blocks as mentioned, it's also a good idea to only declare the params which are actually used. This PR removes the `$args` param which was unused.

### Detailed test instructions:

1. With a block theme (ie: TT3), go to Appearance > Editor and edit the Product Catalog template.
2. Remove the default placeholder block and in its place add the _Product (Beta)_ block.
3. In the frontend, load the Shop page.
4. Verify that the script `gla-gtag-events` and the variable `glaGtagData` contain a list of products with their name and price.

See video:

https://user-images.githubusercontent.com/2488994/218812249-ac16566e-7232-4318-ac08-0f68a40e2b49.mov

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Remove unnecessary woocommerce_loop_add_to_cart_link filter param
