### PR TITLE
PMax Assets: Change the max number of image assets to be the shared max across the same group

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -117,6 +117,7 @@ export default function AssetGroupCard() {
 						<ImagesSelector
 							initialImageUrls={ initialImageUrls }
 							maxNumberOfImages={ spec.getMax( values ) }
+							reachedMaxNumberTip={ spec.reachedMaxNumberTip }
 							imageConfig={ spec.imageConfig }
 							onChange={ imageProps.onChange }
 						>

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -116,7 +116,7 @@ export default function AssetGroupCard() {
 					>
 						<ImagesSelector
 							initialImageUrls={ initialImageUrls }
-							maxNumberOfImages={ spec.max }
+							maxNumberOfImages={ spec.getMax( values ) }
 							imageConfig={ spec.imageConfig }
 							onChange={ imageProps.onChange }
 						>

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -11,6 +11,7 @@ import GridiconCrossCircle from 'gridicons/dist/cross-circle';
  */
 import AppButton from '.~/components/app-button';
 import useCroppedImageSelector from '.~/hooks/useCroppedImageSelector';
+import AppTooltip from '.~/components/app-tooltip';
 import AddAssetItemButton from './add-asset-item-button';
 import './images-selector.scss';
 
@@ -29,6 +30,7 @@ import './images-selector.scss';
  * @param {AssetImageConfig} props.imageConfig The config of the asset image.
  * @param {string[]} props.initialImageUrls The initial image URLs.
  * @param {number} [props.maxNumberOfImages=0] The maximum number of images. 0 by default and it means unlimited number.
+ * @param {string} [props.reachedMaxNumberTip] The tooltip content floating on the add button when reaching the max number of images.
  * @param {JSX.Element} [props.children] Content to be rendered above the add button.
  * @param {(urls: Array<string>) => void} [props.onChange] Callback function to be called when the texts are changed.
  */
@@ -36,6 +38,7 @@ export default function ImagesSelector( {
 	imageConfig,
 	initialImageUrls = [],
 	maxNumberOfImages = 0,
+	reachedMaxNumberTip,
 	children,
 	onChange = noop,
 } ) {
@@ -99,6 +102,28 @@ export default function ImagesSelector( {
 		handle.openSelector( image?.id );
 	};
 
+	const renderAddButton = () => {
+		const disabled =
+			maxNumberOfImages !== 0 && images.length >= maxNumberOfImages;
+		const button = (
+			<AddAssetItemButton
+				disabled={ disabled }
+				text={ __( 'Add image', 'google-listings-and-ads' ) }
+				onClick={ handleUpsertImageClick }
+			/>
+		);
+
+		if ( disabled && reachedMaxNumberTip ) {
+			return (
+				<AppTooltip position="top center" text={ reachedMaxNumberTip }>
+					{ button }
+				</AppTooltip>
+			);
+		}
+
+		return button;
+	};
+
 	return (
 		<div className="gla-images-selector">
 			<div className="gla-images-selector__image-list">
@@ -139,14 +164,7 @@ export default function ImagesSelector( {
 				} ) }
 			</div>
 			{ children }
-			<AddAssetItemButton
-				disabled={
-					maxNumberOfImages !== 0 &&
-					images.length >= maxNumberOfImages
-				}
-				text={ __( 'Add image', 'google-listings-and-ads' ) }
-				onClick={ handleUpsertImageClick }
-			/>
+			{ renderAddButton() }
 		</div>
 	);
 }

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -29,7 +29,7 @@ import './images-selector.scss';
  * @param {Object} props React props.
  * @param {AssetImageConfig} props.imageConfig The config of the asset image.
  * @param {string[]} props.initialImageUrls The initial image URLs.
- * @param {number} [props.maxNumberOfImages=0] The maximum number of images. 0 by default and it means unlimited number.
+ * @param {number} [props.maxNumberOfImages=-1] The maximum number of images. -1 by default and it means unlimited number.
  * @param {string} [props.reachedMaxNumberTip] The tooltip content floating on the add button when reaching the max number of images.
  * @param {JSX.Element} [props.children] Content to be rendered above the add button.
  * @param {(urls: Array<string>) => void} [props.onChange] Callback function to be called when the texts are changed.
@@ -37,7 +37,7 @@ import './images-selector.scss';
 export default function ImagesSelector( {
 	imageConfig,
 	initialImageUrls = [],
-	maxNumberOfImages = 0,
+	maxNumberOfImages = -1,
 	reachedMaxNumberTip,
 	children,
 	onChange = noop,
@@ -63,7 +63,7 @@ export default function ImagesSelector( {
 	};
 
 	useEffect( () => {
-		if ( maxNumberOfImages > 0 && images.length > maxNumberOfImages ) {
+		if ( maxNumberOfImages > -1 && images.length > maxNumberOfImages ) {
 			updateImagesRef.current( images.slice( 0, maxNumberOfImages ) );
 		}
 	}, [ images, maxNumberOfImages ] );
@@ -104,7 +104,7 @@ export default function ImagesSelector( {
 
 	const renderAddButton = () => {
 		const disabled =
-			maxNumberOfImages !== 0 && images.length >= maxNumberOfImages;
+			maxNumberOfImages !== -1 && images.length >= maxNumberOfImages;
 		const button = (
 			<AddAssetItemButton
 				disabled={ disabled }

--- a/js/src/components/paid-ads/asset-group/images-selector.scss
+++ b/js/src/components/paid-ads/asset-group/images-selector.scss
@@ -53,4 +53,10 @@
 	&__image-item:hover &__remove-image-button {
 		display: flex;
 	}
+
+	.components-popover__content {
+		width: $gla-popover-width;
+		white-space: normal;
+		text-align: left;
+	}
 }

--- a/js/src/components/paid-ads/asset-group/images-selector.test.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.test.js
@@ -156,7 +156,7 @@ describe( 'ImagesSelector', () => {
 		expect( onChange ).toHaveBeenLastCalledWith( [ urlA ] );
 	} );
 
-	it( 'When reaching the maximum number of images and the relevant tip is specified, it should use the tooltip', async () => {
+	it( 'When reaching the maximum number of images and the relevant tip is specified, it should use the tooltip', () => {
 		const props = { imageConfig, initialImageUrls: [ urlA ] };
 		const tip = 'tip-content';
 		const { rerender } = render(

--- a/js/src/components/paid-ads/asset-group/images-selector.test.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.test.js
@@ -10,9 +10,14 @@ import userEvent from '@testing-library/user-event';
  */
 import ImagesSelector from './images-selector';
 import useCroppedImageSelector from '.~/hooks/useCroppedImageSelector';
+import AppTooltip from '.~/components/app-tooltip';
 
 jest.mock( '.~/hooks/useCroppedImageSelector', () =>
 	jest.fn().mockName( 'useCroppedImageSelector' )
+);
+
+jest.mock( '.~/components/app-tooltip', () =>
+	jest.fn( ( props ) => <div { ...props } /> ).mockName( 'AppTooltip' )
 );
 
 describe( 'ImagesSelector', () => {
@@ -149,6 +154,33 @@ describe( 'ImagesSelector', () => {
 		expect( getImgUrls() ).toEqual( [ urlA ] );
 		expect( onChange ).toHaveBeenCalledTimes( 2 );
 		expect( onChange ).toHaveBeenLastCalledWith( [ urlA ] );
+	} );
+
+	it( 'When reaching the maximum number of images and the relevant tip is specified, it should use the tooltip', async () => {
+		const props = { imageConfig, initialImageUrls: [ urlA ] };
+		const tip = 'tip-content';
+		const { rerender } = render(
+			<ImagesSelector { ...props } maxNumberOfImages={ 2 } />
+		);
+
+		expect( AppTooltip ).toHaveBeenCalledTimes( 0 );
+
+		rerender( <ImagesSelector { ...props } maxNumberOfImages={ 1 } /> );
+
+		expect( AppTooltip ).toHaveBeenCalledTimes( 0 );
+
+		rerender(
+			<ImagesSelector
+				{ ...props }
+				maxNumberOfImages={ 1 }
+				reachedMaxNumberTip={ tip }
+			/>
+		);
+
+		expect( AppTooltip ).toHaveBeenCalledWith(
+			expect.objectContaining( { text: tip } ),
+			{}
+		);
 	} );
 
 	it( 'When an image is called back for addition, it should be pushed to the image list.', async () => {

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -116,7 +116,6 @@ const ASSET_LOGO_SPECS = [
 	{
 		key: ASSET_FORM_KEY.LOGO,
 		min: 1,
-		max: 5,
 		imageConfig: {
 			minWidth: 128,
 			minHeight: 128,
@@ -417,6 +416,12 @@ const ASSET_TEXT_SPECS = [
 		);
 
 		specs.forEach( ( spec ) => {
+			// Currently, the logo asset is not shown as shared max on UI, so it still needs to
+			// set `spec.max` for generating its subheading.
+			if ( ! shownAsSharedMax && Number.isInteger( sharedMax ) ) {
+				spec.max = sharedMax;
+			}
+
 			spec.subheading = getSubheading( spec, shownAsSharedMax );
 			spec.help = help;
 

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -354,7 +354,7 @@ const ASSET_TEXT_SPECS = [
 				'You can add up to a maximum of %1$d image assets, which can be a combination of %2$s images.',
 				'google-listings-and-ads'
 			),
-			20,
+			specs[ sharedMaxSymbol ],
 			concatenatedNamesText
 		);
 

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -407,12 +407,23 @@ const ASSET_TEXT_SPECS = [
 		const sharedMax = specs[ sharedMaxSymbol ];
 
 		const help = getImageHelpContent( specs, shownAsSharedMax );
+		const reachedMaxNumberTip = sprintf(
+			// translators: The shared maximum number of the grouped types of image assets.
+			__(
+				'You have reached the maximum of %d total ad images. Please remove some images to continue uploading.',
+				'google-listings-and-ads'
+			),
+			sharedMax
+		);
 
 		specs.forEach( ( spec ) => {
 			spec.subheading = getSubheading( spec, shownAsSharedMax );
 			spec.help = help;
 
 			spec.getMax = getMax.bind( spec, sharedMax, specs );
+			spec.reachedMaxNumberTip = shownAsSharedMax
+				? reachedMaxNumberTip
+				: null;
 		} );
 	} );
 

--- a/js/src/components/paid-ads/assetSpecs.test.js
+++ b/js/src/components/paid-ads/assetSpecs.test.js
@@ -1,0 +1,65 @@
+/**
+ * Internal dependencies
+ */
+import { ASSET_IMAGE_SPECS } from './assetSpecs';
+
+describe( 'ASSET_IMAGE_SPECS', () => {
+	describe( 'getMax', () => {
+		const specs = ASSET_IMAGE_SPECS;
+		const keys = specs.map( ( spec ) => spec.key );
+
+		let values;
+
+		function setImagesValues( ...numbersOfImages ) {
+			values = {};
+			keys.forEach( ( key, i ) => {
+				const num = numbersOfImages[ i ] ?? 0;
+				values[ key ] = Array.from( { length: num } );
+			} );
+		}
+
+		function getMaxNumbers() {
+			return specs.map( ( spec ) => spec.getMax( values ) );
+		}
+
+		it( 'When other numbers of asset images in form values are ≤ spec.min, should consider other spec.min as occupied numbers', () => {
+			setImagesValues( 0, 0, 0, 0 );
+
+			expect( getMaxNumbers() ).toEqual( [ 19, 19, 18, 5 ] );
+
+			setImagesValues( 1, 1, 0, 1 );
+
+			expect( getMaxNumbers() ).toEqual( [ 19, 19, 18, 5 ] );
+		} );
+
+		it( 'When other numbers of asset images in form values are > spec.min, should consider them as occupied numbers', () => {
+			setImagesValues( 2, 1, 0, 2 );
+
+			expect( getMaxNumbers() ).toEqual( [ 19, 18, 17, 5 ] );
+
+			setImagesValues( 1, 10, 0, 5 );
+
+			expect( getMaxNumbers() ).toEqual( [ 10, 19, 9, 5 ] );
+
+			setImagesValues( 5, 15, 0 );
+
+			expect( getMaxNumbers() ).toEqual( [ 5, 15, 0, 5 ] );
+
+			setImagesValues( 1, 1, 1 );
+
+			expect( getMaxNumbers() ).toEqual( [ 18, 18, 18, 5 ] );
+
+			setImagesValues( 9, 1, 10 );
+
+			expect( getMaxNumbers() ).toEqual( [ 9, 1, 10, 5 ] );
+
+			setImagesValues( 5, 5, 5 );
+
+			expect( getMaxNumbers() ).toEqual( [ 10, 10, 10, 5 ] );
+
+			setImagesValues( 2, 4, 6 );
+
+			expect( getMaxNumbers() ).toEqual( [ 10, 12, 14, 5 ] );
+		} );
+	} );
+} );

--- a/js/src/css/abstracts/_variables.scss
+++ b/js/src/css/abstracts/_variables.scss
@@ -30,6 +30,7 @@ $gla-line-height-large: 32px;
 
 $gla-border-radius: 3px;
 $gla-size-control-height: 36px;
+$gla-popover-width: 200px;
 $gla-width-small: 250px;
 $gla-width-medium: 300px;
 $gla-width-medium-large: 360px;

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/product-feed-status-section.scss
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/product-feed-status-section.scss
@@ -35,7 +35,7 @@
 	}
 
 	.components-popover__content {
-		width: 200px;
+		width: $gla-popover-width;
 		white-space: normal;
 		font-weight: normal;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a part of Assets form in 📌 [Assets form and related components](https://github.com/woocommerce/google-listings-and-ads/issues/1787#fe-misc) in #1787.

This PR changes the implementation to share the maximum number of image assets across all types of **marketing** image assets.
- Add a new prop `props.reachedMaxNumberTip` to ImagesSelector component.
- Change the default of `maxNumberOfImages` prop to -1 for ImagesSelector since 0 will be a valid max value.
- Change the max number of image assets to be the shared number across the same group of types.
- Add the tip to the add button in the asset images selector when the selected number of images reaches the shared max.
- Replace the hard-coded number in `getImageSharedMaxHelpContent` with the actual shared max value.

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/220077430-a1e2688b-7996-40d6-aa2a-6a1e9490f021.png)

https://user-images.githubusercontent.com/17420811/220082073-9fcc422c-3819-440b-a4a7-2bd0dd942b52.mp4

### Detailed test instructions:

💡  Considering the max limit of 20 is not that easy to test, it would be easier by changing the number in the following line to a smaller one:

https://github.com/woocommerce/google-listings-and-ads/blob/3ca5e71b58a863bfab520bd8143493ad3709374e/js/src/components/paid-ads/assetSpecs.js#L147

1. Go to step 2 of the campaign creation or editing page.
2. Manage the assets of "Landscape", "Square" and "Portrait" images to see if the shared max number work correctly.
3. When reaching the max number, it should show a tip floating on the "Add image" button after hovering on the disabled button.

### Additional details:

Detailed context:
- Main discussion thread: pcTzPl-12o-p2#comment-2268
- Adopted solution: pcTzPl-12o-p2#comment-2281

### Changelog entry
