### PR TITLE
Release 2.3.10

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
+= 2.3.10 - 2023-02-21 =
+* Add "Working with DEWP.md" to exclude list.
+* Add - Integration with WooCommerce Multichannel Marketing.
+* Tweak - Remove unnecessary PMax migration banners.
+* Tweak - Remove unnecessary woocommerce_loop_add_to_cart_link filter param.
+
 = 2.3.9 - 2023-02-15 =
 * Dev - Update phpunit to version 9.5.
 * Fix - Prefix Google Service packages to prevent plugin conflicts.

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google Listings and Ads
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 2.3.9
+ * Version: 2.3.10
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -30,7 +30,7 @@ use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '2.3.9' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '2.3.10' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
 define( 'WC_GLA_MIN_WC_VER', '6.9' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "2.3.9",
+	"version": "2.3.10",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-listings-and-ads",
 	"title": "Google Listings and Ads",
-	"version": "2.3.9",
+	"version": "2.3.10",
 	"description": "google-listings-and-ads",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 5.9
 Tested up to: 6.1.1
 Requires PHP: 7.4
 Requires PHP Architecture: 64 Bits
-Stable tag: 2.3.9
+Stable tag: 2.3.10
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -123,12 +123,4 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 = 2.3.8 - 2023-01-24 =
 * Fix - Product feed table footer rendering a zero when there are no products.
 
-= 2.3.7 - 2023-01-17 =
-* Tweak - Pre-select a default MC account.
-
-= 2.3.6 - 2023-01-10 =
-* Dev - Use extracted Button component from @wordpress/components package.
-* Fix - i18n for "View Reports" button.
-* Tweak - WooCommerce 7.3 Compatibility with Customer Effort Score prompt.
-
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,12 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 
 == Changelog ==
 
+= 2.3.10 - 2023-02-21 =
+* Add "Working with DEWP.md" to exclude list.
+* Add - Integration with WooCommerce Multichannel Marketing.
+* Tweak - Remove unnecessary PMax migration banners.
+* Tweak - Remove unnecessary woocommerce_loop_add_to_cart_link filter param.
+
 = 2.3.9 - 2023-02-15 =
 * Dev - Update phpunit to version 9.5.
 * Fix - Prefix Google Service packages to prevent plugin conflicts.

--- a/src/MultichannelMarketing/GLAChannel.php
+++ b/src/MultichannelMarketing/GLAChannel.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\MultichannelMarketing
  *
- * @since   x.x.x
+ * @since   2.3.10
  */
 class GLAChannel implements MarketingChannelInterface {
 	/**

--- a/src/MultichannelMarketing/MarketingChannelRegistrar.php
+++ b/src/MultichannelMarketing/MarketingChannelRegistrar.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\MultichannelMarketing
  *
- * @since   x.x.x
+ * @since   2.3.10
  */
 class MarketingChannelRegistrar implements Service, Registerable {
 	/**

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -208,7 +208,7 @@ class WC {
 	 *
 	 * @return Container
 	 *
-	 * @since x.x.x
+	 * @since 2.3.10
 	 */
 	public function wc_get_container(): Container {
 		return wc_get_container();


### PR DESCRIPTION
### Release 2.3.10:

* Add - Integration with WooCommerce Multichannel Marketing.
* Fix - Add "Working with DEWP.md" to exclude list.
* Tweak - Remove unnecessary PMax migration banners.
* Tweak - Remove unnecessary woocommerce_loop_add_to_cart_link filter param.
