### PR TITLE
PMax Assets: Re-order the text-type assets and add a missed validation

### DIFF
--- a/js/src/components/paid-ads/__snapshots__/validateAssetGroup.test.js.snap
+++ b/js/src/components/paid-ads/__snapshots__/validateAssetGroup.test.js.snap
@@ -40,6 +40,18 @@ Array [
 ]
 `;
 
+exports[`validateAssetGroup Text assets When the first value of description is an empty string, it should not pass 1`] = `
+Array [
+  "The description in the first field is required",
+]
+`;
+
+exports[`validateAssetGroup Text assets When the first value of headline is an empty string, it should not pass 1`] = `
+Array [
+  "The headline in the first field is required",
+]
+`;
+
 exports[`validateAssetGroup Text assets When the length of values.description is less than 2 after omitting empty strings, it should not pass 1`] = `
 Array [
   "Add at least 2 descriptions",

--- a/js/src/components/paid-ads/assetSpecs.test.js
+++ b/js/src/components/paid-ads/assetSpecs.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ASSET_IMAGE_SPECS } from './assetSpecs';
+import { ASSET_IMAGE_SPECS, ASSET_TEXT_SPECS } from './assetSpecs';
 
 describe( 'ASSET_IMAGE_SPECS', () => {
 	describe( 'getMax', () => {
@@ -62,4 +62,40 @@ describe( 'ASSET_IMAGE_SPECS', () => {
 			expect( getMaxNumbers() ).toEqual( [ 10, 12, 14, 5 ] );
 		} );
 	} );
+} );
+
+describe( 'ASSET_TEXT_SPECS', () => {
+	const specs = ASSET_TEXT_SPECS;
+
+	it.each(
+		specs
+			.filter( ( spec ) => {
+				return (
+					spec.min >= 2 && Array.isArray( spec.maxCharacterCounts )
+				);
+			} )
+			.map( ( spec ) => [ spec.key, spec.maxCharacterCounts ] )
+	)(
+		'When the text-type asset "%s" requires at least two texts and has multiple maximum character counts, it should have only one smaller count and sort by number in ascending',
+		( key, maxCharacterCounts ) => {
+			// This test is to ensure the `spec.maxCharacterCounts` follows the specific form
+			// because the relevant adapter and validation rely on the specific form described
+			// in this test title. For example: `[ 15, 30, 30, 30 ]`.
+			//
+			// If this test fails, it may be:
+			// - there are `maxCharacterCounts` that mismatch the specific form,
+			// - a text asset has a single maximum character for its texts, please set its
+			//   `maxCharacterCounts` to a number instead of an array of numbers,
+			// - or the specific form has been changed, please adjust this test and also
+			//   check if the logic relied on `maxCharacterCounts` needs to be adjusted together.
+			//
+			// Ref: https://developers.google.com/google-ads/api/docs/performance-max/assets#ensure_minimum_asset_requirements_are_met
+			const counts = maxCharacterCounts.slice().sort( ( a, b ) => a - b );
+
+			expect( counts ).toEqual( maxCharacterCounts );
+			expect( counts.length > 1 ).toBe( true );
+			expect( counts[ 0 ] < counts[ 1 ] ).toBe( true );
+			expect( new Set( counts ).size ).toBe( 2 );
+		}
+	);
 } );

--- a/js/src/components/paid-ads/validateAssetGroup.js
+++ b/js/src/components/paid-ads/validateAssetGroup.js
@@ -52,6 +52,23 @@ export default function validateAssetGroup( values ) {
 		const texts = values[ spec.key ];
 		const filledTexts = texts.filter( Boolean );
 
+		if ( spec.min >= 2 && Array.isArray( spec.maxCharacterCounts ) ) {
+			const [ first, second ] = spec.maxCharacterCounts;
+
+			if ( first < second && texts[ 0 ] === '' ) {
+				const message = sprintf(
+					// translators: Asset field name.
+					__(
+						'The %s in the first field is required',
+						'google-listings-and-ads'
+					),
+					spec.lowercaseSingularName
+				);
+
+				messages.push( message );
+			}
+		}
+
 		if ( filledTexts.length < spec.min ) {
 			const name =
 				spec.min === 1

--- a/js/src/components/paid-ads/validateAssetGroup.test.js
+++ b/js/src/components/paid-ads/validateAssetGroup.test.js
@@ -71,6 +71,27 @@ describe( 'validateAssetGroup', () => {
 	} );
 
 	describe( 'Text assets', () => {
+		it.each(
+			ASSET_TEXT_SPECS.filter( ( spec ) => {
+				return (
+					spec.min >= 2 && Array.isArray( spec.maxCharacterCounts )
+				);
+			} ).map( ( spec ) => [ spec.key, spec ] )
+		)(
+			'When the first value of %s is an empty string, it should not pass',
+			( key, spec ) => {
+				const texts = Array.from( { length: spec.min + 1 }, toText );
+				texts[ 0 ] = '';
+				values[ key ] = texts;
+				const error = validateAssetGroup( values );
+
+				expect( error ).toHaveProperty( key );
+				expect( Array.isArray( error[ key ] ) ).toBe( true );
+				expect( error[ key ] ).toHaveLength( 1 );
+				expect( error[ key ] ).toMatchSnapshot();
+			}
+		);
+
 		it.each( ASSET_TEXT_SPECS.map( ( spec ) => [ spec.key, spec.min ] ) )(
 			'When the length of values.%s is less than %s after omitting empty strings, it should not pass',
 			( key, min ) => {
@@ -106,8 +127,8 @@ describe( 'validateAssetGroup', () => {
 			'When checking duplication, it should ignore empty strings',
 			( key, spec ) => {
 				const texts = Array.from( { length: spec.min + 2 }, toText );
-				texts[ 0 ] = '';
 				texts[ 1 ] = '';
+				texts[ 2 ] = '';
 				values[ key ] = texts;
 				const error = validateAssetGroup( values );
 

--- a/js/src/data/adapters.js
+++ b/js/src/data/adapters.js
@@ -1,5 +1,12 @@
 /**
+ * Internal dependencies
+ */
+import { ASSET_TEXT_SPECS } from '.~/components/paid-ads/assetSpecs';
+import getCharacterCounter from '.~/utils/getCharacterCounter';
+
+/**
  * @typedef {import('.~/data/actions').Campaign} Campaign
+ * @typedef {import('.~/data/types.js').AssetEntityGroup} AssetEntityGroup
  */
 
 /**
@@ -17,5 +24,75 @@ export function adaptAdsCampaign( campaign ) {
 		...campaign,
 		allowMultiple,
 		displayCountries,
+	};
+}
+
+/**
+ * Adapts the asset entity group received from API.
+ *
+ * The multi-value assets may not be sorted by their creation time in descending
+ * order when fetching the data from Google Ads API, and there are some text-type
+ * assets that have a smaller maximum character count for the first text.
+ *
+ * This may cause the fetched first text to exceed the smaller maximum count.
+ * For example, udpating headline assets with
+ * [
+ *   'My Shop',
+ *   '12345678901234567890 Foo Shop',
+ *   '12345678901234567890 Bar Shop',
+ * ],
+ * but getting
+ * [
+ *   '12345678901234567890 Foo Shop', // exceeds the 15-character-count limit
+ *   '12345678901234567890 Bar Shop',
+ *   'My Shop',
+ * ]
+ *
+ * When the case happens, this function will try to move an asset text that has a
+ * valid character count to the first index of the asset text array.
+ *
+ * @param {AssetEntityGroup} assetGroup The asset entity group to be adapted.
+ * @return {AssetEntityGroup} Adapted asset entity group.
+ */
+export function adaptAssetGroup( assetGroup ) {
+	const smallerMaxMap = new Map();
+
+	ASSET_TEXT_SPECS.forEach( ( spec ) => {
+		const { maxCharacterCounts } = spec;
+
+		if ( Array.isArray( maxCharacterCounts ) ) {
+			const [ first, second ] = maxCharacterCounts;
+
+			if ( first < second ) {
+				smallerMaxMap.set( spec.key, first );
+			}
+		}
+	} );
+
+	const countCharacter = getCharacterCounter( 'google-ads' );
+	const assets = { ...assetGroup.assets };
+
+	smallerMaxMap.forEach( ( smallerMax, key ) => {
+		const textEntities = assets[ key ];
+
+		if ( ! textEntities || textEntities.length < 2 ) {
+			return;
+		}
+
+		if ( countCharacter( textEntities[ 0 ].content ) > smallerMax ) {
+			const validIndex = textEntities.findIndex(
+				( { content } ) => countCharacter( content ) <= smallerMax
+			);
+
+			if ( validIndex > 0 ) {
+				textEntities.unshift( ...textEntities.splice( validIndex, 1 ) );
+				assets[ key ] = textEntities;
+			}
+		}
+	} );
+
+	return {
+		...assetGroup,
+		assets,
 	};
 }

--- a/js/src/data/adapters.test.js
+++ b/js/src/data/adapters.test.js
@@ -1,0 +1,78 @@
+/**
+ * Internal dependencies
+ */
+import { adaptAssetGroup } from './adapters';
+import { ASSET_KEY } from '.~/constants';
+
+describe( 'adaptAssetGroup', () => {
+	describe( 'Adapts the order of the multi-value text assets', () => {
+		const { HEADLINE, DESCRIPTION } = ASSET_KEY;
+		const text10Count = '1234567890';
+		const text15Count = '123456789012345';
+		const text20Count = text10Count.repeat( 2 );
+		const text30Count = text10Count.repeat( 3 );
+		const text60Count = text10Count.repeat( 6 );
+		const text90Count = text10Count.repeat( 9 );
+
+		const mapContent = ( { content } ) => content;
+
+		let assetGroup;
+
+		beforeEach( () => {
+			assetGroup = {
+				assets: {
+					[ HEADLINE ]: [
+						{ content: text15Count },
+						{ content: text20Count },
+						{ content: text30Count },
+					],
+					[ DESCRIPTION ]: [
+						{ content: text60Count },
+						{ content: text90Count },
+					],
+				},
+			};
+		} );
+
+		it( 'When the target assets do not exist, it should return the same asset group', () => {
+			assetGroup.assets = {};
+
+			expect( adaptAssetGroup( assetGroup ) ).toEqual( assetGroup );
+		} );
+
+		it( 'When the first text has a valid character count, it should not change the order', () => {
+			expect( adaptAssetGroup( assetGroup ) ).toEqual( assetGroup );
+		} );
+
+		it( 'When the first text has an invalid character count but there is no other valid one, it should not change the order', () => {
+			assetGroup.assets[ DESCRIPTION ].pop();
+			assetGroup.assets[ HEADLINE ] = [
+				{ content: text30Count },
+				{ content: text20Count },
+			];
+
+			expect( adaptAssetGroup( assetGroup ) ).toEqual( assetGroup );
+		} );
+
+		it( 'When the first text has an invalid character count, it should move the valid one to the first', () => {
+			assetGroup.assets[ DESCRIPTION ].reverse();
+			assetGroup.assets[ HEADLINE ] = [
+				{ content: text20Count },
+				{ content: text30Count },
+				{ content: text15Count },
+				{ content: text10Count },
+			];
+			const { assets } = adaptAssetGroup( assetGroup );
+			const descriptions = assets[ DESCRIPTION ].map( mapContent );
+			const headlines = assets[ HEADLINE ].map( mapContent );
+
+			expect( descriptions ).toEqual( [ text60Count, text90Count ] );
+			expect( headlines ).toEqual( [
+				text15Count,
+				text20Count,
+				text30Count,
+				text10Count,
+			] );
+		} );
+	} );
+} );

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -16,7 +16,7 @@ import {
 import TYPES from './action-types';
 import { API_NAMESPACE } from './constants';
 import { getReportKey } from './utils';
-import { adaptAdsCampaign } from './adapters';
+import { adaptAdsCampaign, adaptAssetGroup } from './adapters';
 import { fetchWithHeaders, awaitPromise } from './controls';
 
 import {
@@ -239,7 +239,7 @@ export function* getCampaignAssetGroups( campaignId ) {
 		return {
 			type: TYPES.RECEIVE_CAMPAIGN_ASSET_GROUPS,
 			campaignId,
-			assetGroups,
+			assetGroups: assetGroups.map( adaptAssetGroup ),
 		};
 	} catch ( error ) {
 		yield handleFetchError(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a part of 📌 [Integrating with backend APIs](https://github.com/woocommerce/google-listings-and-ads/issues/1787#fe-integrating-apis) in #1787.

Re-order the strings for the `headline` and `description` assets to prevent the first string from exceeding the smaller limit:
- Add the `adaptAssetGroup` function to fix the inconsistent order of multi-value assets.
- Add the test case to ensure the specific form of `spec.maxCharacterCounts` in the `assetSpecs` module.

Also adds an asset form validation:
- Add a missed asset validation for checking if the first headline or the first description is empty.

### Screenshots:

#### 📷 Re-order the strings

![2023-02-23 12 56 22](https://user-images.githubusercontent.com/17420811/220825882-60cea244-fd95-4717-ae2e-0dc19880e3ec.png)

#### 📷 Asset form validation

![1](https://user-images.githubusercontent.com/17420811/220825875-8f446314-2987-4868-a3c9-c2a5f40edd26.png)

### Detailed test instructions:

#### Re-order the strings

1. Go to step 2 of the campaign creation page.
2. Open the Network panel in the browser DevTool.
3. Produce the inconsistent order of text asset:
   1. Enter three previously unused strings into the Headlines asset and the last two with more than 15 characters.
   2. Create the campaign with assets.
   3. Go to edit the newly created campaign.
   4. Change the first string (the shorter one) in the Headlines asset.
   5. Save changes.
   6. Revisit the campaign editing page of the same campaign.
   7. Inspect the latest `ads/campaigns/asset-groups?campaign_id=` request via the Network panel, and check the `[0].asset.headline` path of the response body.
   8. Check if the string without over 15 characters is not in first place in the array. Redo from step 3.4 if the string is still the first.
4. Check if the shorter string is shown on the first field of the Headlines asset.
5. Test the same re-order handling for the Descriptions asset.

#### Asset form validation

1. Go to step 2 of the campaign creation page.
2. In the Headlines asset, add the fourth field.
3. Leave the first field empty and enter strings to the remaining three fields.
4. Submit by the "Launch paid campaign" button to see if the validation checks the missed first field.
5. Test the same validation for the Descriptions asset.

### Additional details:

The context about why it needs a workaround to deal with the order of text assets:

https://github.com/woocommerce/google-listings-and-ads/blob/50aea2dc35da5adf306fc5ce6012c8874d344900/js/src/data/adapters.js#L33-L49

### Changelog entry
