### PR TITLE
PMax Assets: Prevent the edited asset values from being reset after toggling asset fields

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.js
@@ -138,8 +138,8 @@ function AssetField(
 					/>
 				</div>
 			</header>
-			<div className="gla-asset-field__content">
-				{ shouldExpand && children }
+			<div className="gla-asset-field__content" hidden={ ! shouldExpand }>
+				{ children }
 			</div>
 		</div>
 	);

--- a/js/src/components/paid-ads/asset-group/asset-field.scss
+++ b/js/src/components/paid-ads/asset-group/asset-field.scss
@@ -93,6 +93,10 @@
 	}
 
 	&__content {
+		&[hidden] {
+			display: none !important;
+		}
+
 		&:not(:empty) {
 			padding-top: $grid-unit-20;
 		}

--- a/js/src/components/paid-ads/asset-group/asset-field.test.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.test.js
@@ -59,16 +59,33 @@ describe( 'AssetField', () => {
 		expect( screen.getByText( '(Optional)' ) ).toBeInTheDocument();
 	} );
 
+	it( 'Regardless of whether it is collapsed or expanded, it should always render the children', () => {
+		// In order not to reset children's states.
+		const { rerender } = render(
+			<AssetField key="1">Children</AssetField>
+		);
+
+		expect( screen.queryByText( 'Children' ) ).toBeInTheDocument();
+
+		rerender(
+			<AssetField key="2" initialExpanded>
+				Children
+			</AssetField>
+		);
+
+		expect( screen.queryByText( 'Children' ) ).toBeInTheDocument();
+	} );
+
 	it( 'When not setting `initialExpanded`, it should collapse to hide the children', () => {
 		render( <AssetField>Children</AssetField> );
 
-		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Children' ) ).not.toBeVisible();
 	} );
 
-	it( 'When setting `initialExpanded`, it should expand to render the children', () => {
+	it( 'When setting `initialExpanded`, it should expand to show the children', () => {
 		render( <AssetField initialExpanded>Children</AssetField> );
 
-		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Children' ) ).toBeVisible();
 	} );
 
 	it( 'When disabling, it should also collapse to hide the children', () => {
@@ -76,7 +93,7 @@ describe( 'AssetField', () => {
 			<AssetField initialExpanded>Children</AssetField>
 		);
 
-		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Children' ) ).toBeVisible();
 
 		rerender(
 			<AssetField initialExpanded disabled>
@@ -84,7 +101,7 @@ describe( 'AssetField', () => {
 			</AssetField>
 		);
 
-		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Children' ) ).not.toBeVisible();
 	} );
 
 	it( 'When disabled, it should also disable the toggle button and help button', async () => {
@@ -102,14 +119,14 @@ describe( 'AssetField', () => {
 	it( 'When clicking on the toggle button, it should toggle to show or hide the children', async () => {
 		render( <AssetField>Children</AssetField> );
 
-		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Children' ) ).not.toBeVisible();
 
 		await userEvent.click( getToggleButton() );
 
-		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Children' ) ).toBeVisible();
 
 		await userEvent.click( getToggleButton() );
 
-		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Children' ) ).not.toBeVisible();
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug and it relates to #1787.

#### Problem

Edited images or texts will be reset back to the fetched asset suggestion after collapsing and expanding the `AssetField`.

https://user-images.githubusercontent.com/17420811/221122703-b55d9203-8f33-41bb-9574-295c1c41c708.mp4

#### Solution

This PR changes to hide/show the children via the `hidden` attribute on the wrapper instead of whether to render the children to the DOM tree. In this way, the children won't be unmounted and remounted so their states can be kept.

### Screenshots:

https://user-images.githubusercontent.com/17420811/221123913-dfeae92f-1145-4936-98e0-afdf2d3da0a9.mp4


### Detailed test instructions:

1. Go to step 2 of the campaign creation or editing page.
2. After assets are loaded on UI, change asset images and texts.
3. Collapse and expand asset fields to see if the edited values are kept.
4. Check if the toggle function of all asset fields works well.

### Changelog entry
