### PR TITLE
Update maximum payload size in the test proxy

### DIFF
--- a/tests/proxy/index.js
+++ b/tests/proxy/index.js
@@ -54,6 +54,7 @@ const init = async () => {
 			},
 			payload: {
 				parse: false,
+				maxBytes: 40 * 1024 * 1024,
 			},
 		},
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR increase the maximum payload size in the test proxy so we are consistent with a similar change done in WCS. See PR [2025](https://github.com/Automattic/woocommerce-connect-server/pull/2025).

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout `develop` branch.
2. Download this image, it is around 4.8MB. 

![z4WUK9.png](https://user-images.githubusercontent.com/2488994/221231711-98f38c41-c34e-4354-8966-ce29c9f30e15.png)

3. Send a POST request to `http://YOUR_LOCAL_TEST_PROXY/google/google-ads/v11/customers/123456789/assets:mutate`,  use the previous image as payload. You can use Postman to make the request:

![image](https://user-images.githubusercontent.com/2488994/221234284-f2367cdf-e3dc-4904-bda3-1ce2781a115c.png)

4. You should get 413 error - Payload content length greater than maximum allowed: 1048576
5. Checkout this branch and restart the server.
6. You will get the following error which means that the request has not been rejected because of the payload size.
```
{
    "statusCode": 401,
    "error": "Unauthorized",
    "message": "Missing authentication"
}
```


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Increase maximum payload size in the test proxy. 