### PR TITLE
PMax Assets: Add a workaround to reset the selection area of jQuery plugin `imgAreaSelect`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,9 @@ module.exports = {
 		],
 		'import/resolver': { webpack: webpackResolver },
 	},
+	globals: {
+		getComputedStyle: 'readonly',
+	},
 	rules: {
 		'@wordpress/no-unsafe-wp-apis': 1,
 		'react-hooks/exhaustive-deps': [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a workaround for a bug in the 3rd party library and it relates to https://github.com/woocommerce/google-listings-and-ads/issues/1787.

In https://github.com/woocommerce/google-listings-and-ads/pull/1903#pullrequestreview-1313543345:

> I saw that some images are not appropriately cropped using the media selector, for example, the picture of "Polo" from the sample products.
> 
> See video:
> 
> https://user-images.githubusercontent.com/2488994/221201426-b4af064a-e24a-4cee-8363-4bc5a761cf1a.mp4
>
> .
> See payload when cropping the image:
> 
> ![image](https://user-images.githubusercontent.com/2488994/221201552-96a46694-3099-4195-83d7-dc363361a74a.png)

The jQuery plugin `imgAreaSelect` has a bug that the coordinates, width and height in the initial `selection` are miscalculated as `NaN` when the preview `<img>` is scaled to have a decimal point that >= 0.5 in width or height. This causes the crop selection area not to appear and further skips the crop processing. This PR uses a workaround to force the selection area reset.

### Screenshots:

https://user-images.githubusercontent.com/17420811/221503353-9d18dcf4-5995-404c-9a87-1bc45f9dedaf.mp4

### Detailed test instructions:

1. Go to step 2 of the campaign creation page.
2. Start selecting a landscape image.
3. Select an image that has a bit different in its size. For example, the "polo-2.jpg" (801x800) or "logo-1.jpg" (800x799).
4. In the crop step, inspect the preview img element (`<img class="crop-image">`) and resize the window of the page to make the img element have a decimal point that >= 0.5 in width or height. For example:
   ![2023-02-27 15 56 20](https://user-images.githubusercontent.com/17420811/221506123-5a270063-6d1a-484c-8ffd-f4049c104285.png)
   ```js
   // Another way to get the size via the Console panel:
   jQuery('.crop-image').innerWidth()
   jQuery('.crop-image').innerHeight()
   ```
5. Close the image selector popup
6. Reselect the same image again and continue to the crop step.
7. Check if the selection area appears.
8. Click the Crop image button to see if the image is cropped.

### Changelog entry
