### PR TITLE
PMax Assets: Prevent the edited asset values from being reset after switching between steps

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -96,10 +96,24 @@ export default function AssetGroupCard() {
 		firstErrorRef.current = ref;
 	}
 
+	// Currently, because WC's `Form` component can not properly set the multiple values
+	// synchronously. So, it needs to distinguish whether the `baseAssetGroup` is already
+	// set when mounting and not being cleaned. If yes, it means the `values` are also
+	// available and include the changes made by the user. Otherwise, it should need to
+	// wait for the `baseAssetGroup` to be set from the `AssetGroupSection`. So that the
+	// edited values in `AssetField` won't be reset after remounting the `AssetGroupCard`.
+	const isSelectedAssetGroupInitiallyRef = useRef( isSelectedFinalUrl );
+	if ( ! isSelectedFinalUrl ) {
+		isSelectedAssetGroupInitiallyRef.current = isSelectedFinalUrl;
+	}
+	const initialValues = isSelectedAssetGroupInitiallyRef.current
+		? values
+		: baseAssetGroup;
+
 	return (
 		<div key={ finalUrl } className="gla-asset-group-card">
 			{ ASSET_IMAGE_SPECS.map( ( spec ) => {
-				const initialImageUrls = baseAssetGroup[ spec.key ];
+				const initialImageUrls = initialValues[ spec.key ];
 				const imageProps = getInputProps( spec.key );
 
 				return (
@@ -127,7 +141,7 @@ export default function AssetGroupCard() {
 				);
 			} ) }
 			{ ASSET_TEXT_SPECS.map( ( spec, index ) => {
-				const initialTexts = baseAssetGroup[ spec.key ];
+				const initialTexts = initialValues[ spec.key ];
 				const textProps = getInputProps( spec.key );
 
 				return (

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -96,12 +96,25 @@ export default function AssetGroupCard() {
 		firstErrorRef.current = ref;
 	}
 
-	// Currently, because WC's `Form` component can not properly set the multiple values
-	// synchronously. So, it needs to distinguish whether the `baseAssetGroup` is already
-	// set when mounting and not being cleaned. If yes, it means the `values` are also
-	// available and include the changes made by the user. Otherwise, it should need to
-	// wait for the `baseAssetGroup` to be set from the `AssetGroupSection`. So that the
-	// edited values in `AssetField` won't be reset after remounting the `AssetGroupCard`.
+	// Ideally, the initial data for `ImagesSelector` and `TextsEditor` should be `values` directly.
+	// But the current WC's `Form` component can not properly set the multiple values synchronously.
+	// Therefore, an additional `baseAssetGroup` is used to ensure that the updates of multiple values
+	// can be performed simultaneously.
+	//
+	// There are three moments that need to ensure the initial data:
+	// 1. After importing assets by a final URL, the asset values are set from the `AssetGroupSection`.
+	//    - The fetched multiple values are set to `baseAssetGroup`.
+	//    - The final URL in `baseAssetGroup` must be a valid value.
+	// 2. After clearing the selected final URL, the asset values are set from the `AssetGroupSection`.
+	//    - The default empty asset values are set to `baseAssetGroup`.
+	//    - The final URL in `baseAssetGroup` must be null.
+	// 3. When mounting this component, the asset values already synchronously exist in `values`.
+	//    - The final URL in `baseAssetGroup` must be a valid value.
+	//    - The value changes made by the user are only kept in `values`.
+	//
+	// Thus, when mounting, it needs to distinguish whether the final URL in `baseAssetGroup` is
+	// already set, and it's not cleared afterward. If yes, it means the `values` should be used as
+	// the initial data. Otherwise, the `baseAssetGroup` should be used.
 	const isSelectedAssetGroupInitiallyRef = useRef( isSelectedFinalUrl );
 	if ( ! isSelectedFinalUrl ) {
 		isSelectedAssetGroupInitiallyRef.current = isSelectedFinalUrl;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug and it relates to #1787.

#### Problem

Edited images or texts will be reset back to the fetched asset suggestion after switching between steps.

https://user-images.githubusercontent.com/17420811/221531053-b2918a0b-ed88-49ce-873f-7ddffb8420d6.mp4

#### Solution

Distinguish whether it should use `values` or `baseAssetGroup` as the initial values.

### Screenshots:

https://user-images.githubusercontent.com/17420811/221531090-6432d08d-fe75-49c6-b618-0e5b68931f93.mp4

### Detailed test instructions:

1. Go to step 2 of the campaign creation or editing page.
2. After assets are loaded on UI, change asset images and texts.
3. Switch to step 1 and back to step 2.
4. Check if the edited values are kept.
5. Select another final URL and see if the loaded assets are presented on the UI.

### Changelog entry
