### PR TITLE
PMax Assets: Support editing the Business name asset

### DIFF
--- a/js/src/components/app-button/index.scss
+++ b/js/src/components/app-button/index.scss
@@ -1,4 +1,8 @@
 .app-button {
+	&[hidden] {
+		display: none !important;
+	}
+
 	white-space: nowrap;
 
 	svg {

--- a/js/src/components/paid-ads/__snapshots__/validateAssetGroup.test.js.snap
+++ b/js/src/components/paid-ads/__snapshots__/validateAssetGroup.test.js.snap
@@ -19,6 +19,12 @@ exports[`validateAssetGroup Image assets When the length of values.marketing_ima
 
 exports[`validateAssetGroup Image assets When the length of values.square_marketing_image is less than 1, it should not pass 1`] = `"Add at least 1 square image"`;
 
+exports[`validateAssetGroup Text assets When the character limit is exceeded in values.business_name, it should not pass 1`] = `
+Array [
+  "Character limit exceeded",
+]
+`;
+
 exports[`validateAssetGroup Text assets When the character limit is exceeded in values.description, it should not pass 1`] = `
 Array [
   "Description 1: Character limit exceeded",
@@ -49,6 +55,12 @@ Array [
 exports[`validateAssetGroup Text assets When the first value of headline is an empty string, it should not pass 1`] = `
 Array [
   "The headline in the first field is required",
+]
+`;
+
+exports[`validateAssetGroup Text assets When the length of values.business_name is less than 1 after omitting empty strings, it should not pass 1`] = `
+Array [
+  "The business name is required",
 ]
 `;
 

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useRef, useEffect, Fragment } from '@wordpress/element';
-import { ExternalLink } from 'extracted/@wordpress/components';
 import { SelectControl } from '@wordpress/components';
 
 /**
@@ -138,15 +137,7 @@ export default function AssetGroupCard() {
 						subheading={
 							<>
 								{ spec.subheading }
-								{ spec.key === ASSET_FORM_KEY.HEADLINE &&
-									isSelectedFinalUrl && (
-										<ExternalLink href="https://support.google.com/google-ads/answer/6167101">
-											{ __(
-												'Learn how to write effective ads',
-												'google-listings-and-ads'
-											) }
-										</ExternalLink>
-									) }
+								{ isSelectedFinalUrl && spec.extraSubheading }
 							</>
 						}
 						help={ spec.help }

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -127,7 +127,7 @@ export default function AssetGroupCard() {
 				);
 			} ) }
 			{ ASSET_TEXT_SPECS.map( ( spec, index ) => {
-				const initialTexts = baseAssetGroup[ spec.key ];
+				const initialTexts = [ baseAssetGroup[ spec.key ] ].flat();
 				const textProps = getInputProps( spec.key );
 
 				return (
@@ -160,7 +160,13 @@ export default function AssetGroupCard() {
 							maxCharacterCounts={ spec.maxCharacterCounts }
 							placeholder={ spec.capitalizedName }
 							addButtonText={ spec.addButtonText }
-							onChange={ textProps.onChange }
+							onChange={ ( texts ) => {
+								if ( spec.requiredSingleValue ) {
+									textProps.onChange( texts[ 0 ] );
+								} else {
+									textProps.onChange( texts );
+								}
+							} }
 						>
 							{ renderErrors( spec.key ) }
 						</TextsEditor>

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -126,7 +126,7 @@ export default function AssetGroupCard() {
 					</AssetField>
 				);
 			} ) }
-			{ ASSET_TEXT_SPECS.map( ( spec, index ) => {
+			{ ASSET_TEXT_SPECS.map( ( spec ) => {
 				const initialTexts = [ baseAssetGroup[ spec.key ] ].flat();
 				const textProps = getInputProps( spec.key );
 
@@ -138,14 +138,15 @@ export default function AssetGroupCard() {
 						subheading={
 							<>
 								{ spec.subheading }
-								{ index === 0 && isSelectedFinalUrl && (
-									<ExternalLink href="https://support.google.com/google-ads/answer/6167101">
-										{ __(
-											'Learn how to write effective ads',
-											'google-listings-and-ads'
-										) }
-									</ExternalLink>
-								) }
+								{ spec.key === ASSET_FORM_KEY.HEADLINE &&
+									isSelectedFinalUrl && (
+										<ExternalLink href="https://support.google.com/google-ads/answer/6167101">
+											{ __(
+												'Learn how to write effective ads',
+												'google-listings-and-ads'
+											) }
+										</ExternalLink>
+									) }
 							</>
 						}
 						help={ spec.help }

--- a/js/src/components/paid-ads/asset-group/texts-editor.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.js
@@ -134,6 +134,10 @@ export default function TextsEditor( {
 			</div>
 			{ children }
 			<AddAssetItemButton
+				hidden={
+					minNumberOfTexts > 0 &&
+					minNumberOfTexts === maxNumberOfTexts
+				}
 				aria-label={ __( 'Add text', 'google-listings-and-ads' ) }
 				disabled={
 					maxNumberOfTexts > 0 && texts.length >= maxNumberOfTexts

--- a/js/src/components/paid-ads/asset-group/texts-editor.test.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.test.js
@@ -134,6 +134,39 @@ describe( 'TextsEditor', () => {
 		expect( addButton ).toBeEnabled();
 	} );
 
+	it( 'When the `minNumberOfTexts` and `maxNumberOfTexts` are the same and greater than 1, it should hide the add button`', () => {
+		const { rerender } = render( <TextsEditor /> );
+		const addButton = screen.getByRole( 'button', { name: 'Add text' } );
+
+		expect( addButton ).toBeVisible();
+
+		rerender( <TextsEditor minNumberOfTexts={ 1 } /> );
+
+		expect( addButton ).toBeVisible();
+
+		rerender( <TextsEditor maxNumberOfTexts={ 1 } /> );
+
+		expect( addButton ).toBeVisible();
+
+		rerender(
+			<TextsEditor minNumberOfTexts={ 1 } maxNumberOfTexts={ 5 } />
+		);
+
+		expect( addButton ).toBeVisible();
+
+		rerender(
+			<TextsEditor minNumberOfTexts={ 1 } maxNumberOfTexts={ 1 } />
+		);
+
+		expect( addButton ).not.toBeVisible();
+
+		rerender(
+			<TextsEditor minNumberOfTexts={ 5 } maxNumberOfTexts={ 5 } />
+		);
+
+		expect( addButton ).not.toBeVisible();
+	} );
+
 	it( 'When the length of `initialTexts` or `texts` is greater than `maxNumberOfTexts`, it should truncate the excess', () => {
 		const initialTexts = [ 'Text 1', 'Text 2', 'Text 3' ];
 		const { rerender } = render(

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
+import { ExternalLink } from 'extracted/@wordpress/components';
 import { Fragment, createInterpolateElement } from '@wordpress/element';
 
 /**
@@ -188,6 +189,14 @@ const ASSET_TEXT_SPECS = [
 			'Headlines',
 			'Plural asset field name as the heading',
 			'google-listings-and-ads'
+		),
+		extraSubheading: (
+			<ExternalLink href="https://support.google.com/google-ads/answer/6167101">
+				{ __(
+					'Learn how to write effective ads',
+					'google-listings-and-ads'
+				) }
+			</ExternalLink>
 		),
 		addButtonText: __( 'Add headline', 'google-listings-and-ads' ),
 		capitalizedName: _x(

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -155,6 +155,31 @@ const ASSET_IMAGE_SPECS = ASSET_IMAGE_SPECS_GROUPS.flat();
 
 const ASSET_TEXT_SPECS = [
 	{
+		key: ASSET_FORM_KEY.BUSINESS_NAME,
+		min: 1,
+		max: 1,
+		maxCharacterCounts: 25,
+		heading: _x(
+			'Business name',
+			'Plural asset field name as the heading',
+			'google-listings-and-ads'
+		),
+		capitalizedName: _x(
+			'Business name',
+			'Capitalized asset field name as the placeholder or the start of an error message',
+			'google-listings-and-ads'
+		),
+		lowercaseSingularName: _x(
+			'business name',
+			'Singular and lowercase asset field name',
+			'google-listings-and-ads'
+		),
+		help: __(
+			'The business name is the name of your business or brand. In certain layouts, it may appear in the text of your ad.',
+			'google-listings-and-ads'
+		),
+	},
+	{
 		key: ASSET_FORM_KEY.HEADLINE,
 		min: 3,
 		max: 5,
@@ -289,6 +314,10 @@ const ASSET_TEXT_SPECS = [
 				__( 'At least %d required', 'google-listings-and-ads' ),
 				spec.min
 			);
+		}
+
+		if ( spec.requiredSingleValue ) {
+			return;
 		}
 
 		return sprintf(
@@ -433,6 +462,7 @@ const ASSET_TEXT_SPECS = [
 	} );
 
 	ASSET_TEXT_SPECS.forEach( ( spec ) => {
+		spec.requiredSingleValue = spec.min === 1 && spec.max === 1;
 		spec.subheading = getSubheading( spec );
 	} );
 }

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -19,7 +19,7 @@ import validateAssetGroup from '.~/components/paid-ads/validateAssetGroup';
 
 const emptyAssetGroup = {
 	[ ASSET_FORM_KEY.FINAL_URL ]: null,
-	[ ASSET_FORM_KEY.BUSINESS_NAME ]: null,
+	[ ASSET_FORM_KEY.BUSINESS_NAME ]: '',
 	[ ASSET_FORM_KEY.MARKETING_IMAGE ]: [],
 	[ ASSET_FORM_KEY.SQUARE_MARKETING_IMAGE ]: [],
 	[ ASSET_FORM_KEY.PORTRAIT_MARKETING_IMAGE ]: [],

--- a/js/src/components/paid-ads/validateAssetGroup.js
+++ b/js/src/components/paid-ads/validateAssetGroup.js
@@ -49,7 +49,7 @@ export default function validateAssetGroup( values ) {
 
 	ASSET_TEXT_SPECS.forEach( ( spec ) => {
 		const messages = [];
-		const texts = values[ spec.key ];
+		const texts = [ values[ spec.key ] ].flat();
 		const filledTexts = texts.filter( Boolean );
 
 		if ( spec.min >= 2 && Array.isArray( spec.maxCharacterCounts ) ) {
@@ -75,12 +75,13 @@ export default function validateAssetGroup( values ) {
 					? spec.lowercaseSingularName
 					: spec.lowercasePluralName;
 
-			const message = sprintf(
-				// translators: 1: The minimal number of this item. 2: Asset field name.
-				__( 'Add at least %1$d %2$s', 'google-listings-and-ads' ),
-				spec.min,
-				name
-			);
+			const format = spec.requiredSingleValue
+				? // translators: 1: (This variable is omitted). 2: Asset field name.
+				  __( 'The %2$s is required', 'google-listings-and-ads' )
+				: // translators: 1: The minimal number of this item. 2: Asset field name.
+				  __( 'Add at least %1$d %2$s', 'google-listings-and-ads' );
+
+			const message = sprintf( format, spec.min, name );
 
 			messages.push( message );
 		}
@@ -103,12 +104,19 @@ export default function validateAssetGroup( values ) {
 				normalizedMaxCharacterCounts[ 0 ];
 
 			if ( countCharacter( text ) > maxCharacterCount ) {
+				const format = spec.requiredSingleValue
+					? __(
+							'Character limit exceeded',
+							'google-listings-and-ads'
+					  )
+					: // translators: 1: Asset field name. 2: The sequential number of the asset field.
+					  __(
+							'%1$s %2$d: Character limit exceeded',
+							'google-listings-and-ads'
+					  );
+
 				const message = sprintf(
-					// translators: 1: Asset field name. 2: The sequential number of the asset field.
-					__(
-						'%1$s %2$d: Character limit exceeded',
-						'google-listings-and-ads'
-					),
+					format,
 					spec.capitalizedName,
 					index + 1
 				);

--- a/js/src/components/paid-ads/validateAssetGroup.js
+++ b/js/src/components/paid-ads/validateAssetGroup.js
@@ -76,12 +76,12 @@ export default function validateAssetGroup( values ) {
 					: spec.lowercasePluralName;
 
 			const format = spec.requiredSingleValue
-				? // translators: 1: (This variable is omitted). 2: Asset field name.
-				  __( 'The %2$s is required', 'google-listings-and-ads' )
-				: // translators: 1: The minimal number of this item. 2: Asset field name.
-				  __( 'Add at least %1$d %2$s', 'google-listings-and-ads' );
+				? // translators: 1: Asset field name.
+				  __( 'The %1$s is required', 'google-listings-and-ads' )
+				: // translators: 1: Asset field name. 2: The minimal number of this item.
+				  __( 'Add at least %2$d %1$s', 'google-listings-and-ads' );
 
-			const message = sprintf( format, spec.min, name );
+			const message = sprintf( format, name, spec.min );
 
 			messages.push( message );
 		}

--- a/js/src/components/paid-ads/validateAssetGroup.test.js
+++ b/js/src/components/paid-ads/validateAssetGroup.test.js
@@ -32,6 +32,7 @@ describe( 'validateAssetGroup', () => {
 			[ ASSET_FORM_KEY.SQUARE_MARKETING_IMAGE ]: [ 'https://image_1' ],
 			[ ASSET_FORM_KEY.PORTRAIT_MARKETING_IMAGE ]: [ 'https://image_1' ],
 			[ ASSET_FORM_KEY.LOGO ]: [ 'https://logo_1' ],
+			[ ASSET_FORM_KEY.BUSINESS_NAME ]: 'business name',
 			[ ASSET_FORM_KEY.HEADLINE ]: [
 				'headline 1',
 				'headline 2',
@@ -107,7 +108,11 @@ describe( 'validateAssetGroup', () => {
 			}
 		);
 
-		it.each( ASSET_TEXT_SPECS.map( ( spec ) => [ spec.key, spec ] ) )(
+		it.each(
+			ASSET_TEXT_SPECS.filter(
+				( spec ) => spec.max > 1
+			).map( ( spec ) => [ spec.key, spec ] )
+		)(
 			'When there is duplication in values.%s, it should not pass',
 			( key, spec ) => {
 				const texts = Array.from( { length: spec.min + 1 }, toText );
@@ -123,7 +128,11 @@ describe( 'validateAssetGroup', () => {
 			}
 		);
 
-		it.each( ASSET_TEXT_SPECS.map( ( spec ) => [ spec.key, spec ] ) )(
+		it.each(
+			ASSET_TEXT_SPECS.filter(
+				( spec ) => spec.max > 1
+			).map( ( spec ) => [ spec.key, spec ] )
+		)(
 			'When checking duplication, it should ignore empty strings',
 			( key, spec ) => {
 				const texts = Array.from( { length: spec.min + 2 }, toText );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR relates to https://github.com/woocommerce/google-listings-and-ads/issues/1787 and implements the missing Business name asset.

- Let `AppButton` support the `hidden` attribute.
- Make related modules support the single text value:
   - Update `validateAssetGroup` to check it.
   - `AssetGroupCard` handle it with `TextsEditor`.
   - Hide the Add button in `TextsEditor` when the min and max limits are the same and bigger than 1.
- Support editing the business name asset in the `AssetGroupCard`.

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/221552698-37215beb-a5c0-4451-b23e-608d1f187e8a.png)

![image](https://user-images.githubusercontent.com/17420811/221552776-bfdb82c7-9d6d-4e5d-a88a-ec883ff5acd4.png)

![image](https://user-images.githubusercontent.com/17420811/221553025-5a93d635-6a37-4c82-b569-f255a32fc5f8.png)

![image](https://user-images.githubusercontent.com/17420811/221552814-dc64d673-383b-4328-bd48-3209bdba5a43.png)

![image](https://user-images.githubusercontent.com/17420811/221552861-1b396bf0-126e-4b80-9bb8-031b3c6ab22b.png)

![image](https://user-images.githubusercontent.com/17420811/221552895-9090c995-4853-48d1-b720-0bad46185ffd.png)

### Detailed test instructions:

#### 💡 Additional notes before testing

Google Ads side will check if the domain in the Final URL matches the claimed domain of the linked Merchant Center account. Therefore, it may need to make the local env have the same domain by switching the local env to be accessible publicly or replacing the domain temporarily. The way I used:
- Replace [this line](https://github.com/woocommerce/google-listings-and-ads/blob/2f448130ce83497e46102a63e28464505f30e146/js/src/components/paid-ads/convertToAssetGroupUpdateBody.js#L86) with:
   ```js
   final_url: values.final_url.replace( 'your local domain', 'GMC domain' ),
   ```
- Add the following at [this line](https://github.com/woocommerce/google-listings-and-ads/blob/2f448130ce83497e46102a63e28464505f30e146/src/Ads/AssetSuggestionsService.php#L191):
   ```php
   $final_url = str_replace( 'your local domain', 'GMC domain', $final_url );
   ```
- Add the following at the end of **google-listings-and-ads.php** if got the "cURL error 60" issue with `wp_remote_get`:
   ```php
   add_filter( 'https_ssl_verify', '__return_false' );
   add_filter( 'https_local_ssl_verify', '__return_false' );
   ```

#### Testing

1. Go to step 2 of the campaign creation or editing page.
2. Check if the Business name field works well.
3. Check if the Business name is able to update.

### Additional details:

The discussion of this change: pcTzPl-12o-p2#comment-2294

### Changelog entry
