### PR TITLE
PMax Assets: Prevent the button styles in `ImagesSelector` from overriding by AutomateWoo

### DIFF
--- a/js/src/components/paid-ads/asset-group/images-selector.scss
+++ b/js/src/components/paid-ads/asset-group/images-selector.scss
@@ -14,44 +14,47 @@
 		display: flex;
 	}
 
-	&__replace-image-button {
-		justify-content: center;
-		width: 100px;
-		height: 100px;
-		padding: 0;
-		border: 1px solid $gray-200;
-		border-radius: 2px;
-		overflow: hidden;
-		background-color: $white;
-	}
-
 	&__image {
 		max-width: 100%;
 		max-height: 100%;
 	}
 
-	&__remove-image-button {
-		display: none;
-		position: absolute;
-		top: 0;
-		right: 0;
-		transform: translate(50%, -50%);
-		color: $gray-500;
-
-		// Fill in the background color under the SVG icon.
-		&::after {
-			content: "";
-			position: absolute;
-			z-index: -1;
-			width: 30%;
-			height: 30%;
-			margin: auto;
+	// Prevent the button styles from overriding by AutomateWoo.
+	.gla-admin-page & {
+		&__replace-image-button {
+			justify-content: center;
+			width: 100px;
+			height: 100px;
+			padding: 0;
+			border: 1px solid $gray-200;
+			border-radius: 2px;
+			overflow: hidden;
 			background-color: $white;
 		}
-	}
 
-	&__image-item:hover &__remove-image-button {
-		display: flex;
+		&__remove-image-button {
+			display: none;
+			position: absolute;
+			top: 0;
+			right: 0;
+			transform: translate(50%, -50%);
+			color: $gray-500;
+
+			// Fill in the background color under the SVG icon.
+			&::after {
+				content: "";
+				position: absolute;
+				z-index: -1;
+				width: 30%;
+				height: 30%;
+				margin: auto;
+				background-color: $white;
+			}
+		}
+
+		&__image-item:hover .gla-images-selector__remove-image-button {
+			display: flex;
+		}
 	}
 
 	.components-popover__content {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up and relates to #1787.

In https://github.com/woocommerce/google-listings-and-ads/pull/1873#pullrequestreview-1288947337 and https://github.com/woocommerce/google-listings-and-ads/pull/1873#issuecomment-1423979040:
> I think the delete button looks too big compared with the preview images, what do you think? Or comparing with the Figma file, it seems that the preview images should be bigger.

> The conflict with the styling is with AutomateWoo 5.6.6 when I disable AW loads correctly.

This PR fixes the style conflict that results in style problems in the `ImagesSelector`:

![2023-02-28 14 12 17](https://user-images.githubusercontent.com/17420811/221778783-8a1c0552-18a2-4c68-adc9-280e6b14498e.png)

In the screenshot, the style problems are:
1. Incorrect image button size.
2. The border of Image buttons disappears.
3. The X button should show up when hovering over the image button.
4. Incorrect background color of X button.

### Screenshots:

![2023-02-28 14 21 56](https://user-images.githubusercontent.com/17420811/221778969-2af464a4-291c-417a-bdaa-aba101dcfcca.png)

### Detailed test instructions:

1. Install and activate AutomateWoo.
2. Go to step 2 of the campaign creation page.
3. Select some images to see if the style looks good and is similar to the design in Figma.

### Changelog entry
