### PR TITLE
PMax Assets: Adjust the tip of the disabled "Add image" buttons

### DIFF
--- a/js/src/components/paid-ads/__snapshots__/assetSpecs.test.js.snap
+++ b/js/src/components/paid-ads/__snapshots__/assetSpecs.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ASSET_IMAGE_SPECS getMaxNumberTip Asset image is shown as the shared max concept When the total number of the selected images is equal to the shared maximum number, it should not include the minimum image requirements 1`] = `"The maximum number of images that can be uploaded is 20."`;
+
+exports[`ASSET_IMAGE_SPECS getMaxNumberTip Asset image is shown as the shared max concept When the total number of the selected images is less than the shared maximum number, it should include the minimum image requirements 1`] = `"Maximum 20 images can be uploaded, with a minimum of 1 landscape and 1 square image."`;

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -143,7 +143,9 @@ export default function AssetGroupCard() {
 						<ImagesSelector
 							initialImageUrls={ initialImageUrls }
 							maxNumberOfImages={ spec.getMax( values ) }
-							reachedMaxNumberTip={ spec.reachedMaxNumberTip }
+							reachedMaxNumberTip={ spec.getMaxNumberTip(
+								values
+							) }
 							imageConfig={ spec.imageConfig }
 							onChange={ imageProps.onChange }
 						>

--- a/js/src/components/paid-ads/asset-group/images-selector.scss
+++ b/js/src/components/paid-ads/asset-group/images-selector.scss
@@ -61,5 +61,9 @@
 		width: $gla-popover-width;
 		white-space: normal;
 		text-align: left;
+
+		> div {
+			padding: 0.25em 0.5em;
+		}
 	}
 }

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -488,9 +488,6 @@ const ASSET_TEXT_SPECS = [
 		);
 	}
 
-	// Maximum 20 images can be uploaded, with a minimum of 1 landscape and 1 square image.
-	// The maximum number of images that can be uploaded is 20.
-
 	ASSET_IMAGE_SPECS_GROUPS.forEach( ( specs ) => {
 		// Currently, the PMax Assets feature in this extension doesn't offer managing the landscape_logo
 		// asset but only the logo asset. So the logo asset shares the total number of images by itself.

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -312,6 +312,20 @@ const ASSET_TEXT_SPECS = [
 // functions inside are for initialization purposes only and are not expected to be exposed
 // outside this module.
 {
+	function concatenateAssetStrings( strings ) {
+		const separator = _x(
+			', ',
+			'The separator for concatenating the types of assets',
+			'google-listings-and-ads'
+		);
+		return sprintf(
+			// translators: 1: Concatenated text for the types of assets except for the last one. 2: The last type of assets.
+			__( '%1$s and %2$s', 'google-listings-and-ads' ),
+			strings.slice( 0, -1 ).join( separator ),
+			strings.at( -1 )
+		);
+	}
+
 	function getSubheading( spec, shownAsSharedMax ) {
 		if ( shownAsSharedMax ) {
 			if ( spec.min === 0 ) {
@@ -374,17 +388,6 @@ const ASSET_TEXT_SPECS = [
 
 	function getImageSharedMaxHelpContent( specs ) {
 		const names = specs.map( ( spec ) => spec.lowercaseName );
-		const separator = _x(
-			', ',
-			'The separator for concatenating the types of image assets',
-			'google-listings-and-ads'
-		);
-		const concatenatedNamesText = sprintf(
-			// translators: 1: Concatenated text for the types of image assets except for the last one. 2: The last type of image assets.
-			__( '%1$s and %2$s', 'google-listings-and-ads' ),
-			names.slice( 0, -1 ).join( separator ),
-			names.at( -1 )
-		);
 		const content = sprintf(
 			// translators: 1: The maximum number of this image assets. 2: Text for the types of image assets.
 			__(
@@ -392,7 +395,7 @@ const ASSET_TEXT_SPECS = [
 				'google-listings-and-ads'
 			),
 			specs[ sharedMaxSymbol ],
-			concatenatedNamesText
+			concatenateAssetStrings( names )
 		);
 
 		return <div>{ content }</div>;
@@ -435,6 +438,59 @@ const ASSET_TEXT_SPECS = [
 		}, sharedMax );
 	}
 
+	/**
+	 * Gets the conditional tip of the maximum number of this type of asset images.
+	 *
+	 * If the total number of the selected images is less than the shared maximum number,
+	 * the tip will include the minimum image requirements.
+	 *
+	 * @param {number} sharedMax The shared maximum number of the grouped types of image assets.
+	 * @param {Object[]} specs The image specs in the same group.
+	 * @param {AssetGroupFormValues} values The assets form values to be calculated for the total number of selected asset images.
+	 * @return {string} The tip of the maximum number of this type of asset images.
+	 */
+	function getMaxNumberTip( sharedMax, specs, values ) {
+		const totalSelected = specs.reduce(
+			( acc, spec ) => acc + values[ spec.key ].length,
+			0
+		);
+
+		if ( totalSelected === sharedMax ) {
+			return sprintf(
+				// translators: The shared maximum number of the grouped types of image assets.
+				__(
+					'The maximum number of images that can be uploaded is %d.',
+					'google-listings-and-ads'
+				),
+				sharedMax
+			);
+		}
+
+		const names = specs
+			.filter( ( spec ) => spec.min > 0 )
+			.map( ( spec ) =>
+				sprintf(
+					// translators: 1: The minimum number of this asset field. 2: Asset field name.
+					__( '%1$d %2$s', 'google-listings-and-ads' ),
+					spec.min,
+					spec.lowercaseName
+				)
+			);
+
+		return sprintf(
+			// translators: 1: The shared maximum number of the grouped types of image assets. 2: Text for the minimum number and type of each image asset.
+			__(
+				'Maximum %1$d images can be uploaded, with a minimum of %2$s image.',
+				'google-listings-and-ads'
+			),
+			sharedMax,
+			concatenateAssetStrings( names )
+		);
+	}
+
+	// Maximum 20 images can be uploaded, with a minimum of 1 landscape and 1 square image.
+	// The maximum number of images that can be uploaded is 20.
+
 	ASSET_IMAGE_SPECS_GROUPS.forEach( ( specs ) => {
 		// Currently, the PMax Assets feature in this extension doesn't offer managing the landscape_logo
 		// asset but only the logo asset. So the logo asset shares the total number of images by itself.
@@ -444,14 +500,6 @@ const ASSET_TEXT_SPECS = [
 		const sharedMax = specs[ sharedMaxSymbol ];
 
 		const help = getImageHelpContent( specs, shownAsSharedMax );
-		const reachedMaxNumberTip = sprintf(
-			// translators: The shared maximum number of the grouped types of image assets.
-			__(
-				'You have reached the maximum of %d total ad images. Please remove some images to continue uploading.',
-				'google-listings-and-ads'
-			),
-			sharedMax
-		);
 
 		specs.forEach( ( spec ) => {
 			// Currently, the logo asset is not shown as shared max on UI, so it still needs to
@@ -464,9 +512,9 @@ const ASSET_TEXT_SPECS = [
 			spec.help = help;
 
 			spec.getMax = getMax.bind( spec, sharedMax, specs );
-			spec.reachedMaxNumberTip = shownAsSharedMax
-				? reachedMaxNumberTip
-				: null;
+			spec.getMaxNumberTip = shownAsSharedMax
+				? getMaxNumberTip.bind( null, sharedMax, specs )
+				: () => null;
 		} );
 	} );
 

--- a/js/src/components/paid-ads/assetSpecs.test.js
+++ b/js/src/components/paid-ads/assetSpecs.test.js
@@ -4,20 +4,20 @@
 import { ASSET_IMAGE_SPECS, ASSET_TEXT_SPECS } from './assetSpecs';
 
 describe( 'ASSET_IMAGE_SPECS', () => {
+	const specs = ASSET_IMAGE_SPECS;
+	const keys = specs.map( ( spec ) => spec.key );
+
+	let values;
+
+	function setImagesValues( ...numbersOfImages ) {
+		values = {};
+		keys.forEach( ( key, i ) => {
+			const num = numbersOfImages[ i ] ?? 0;
+			values[ key ] = Array.from( { length: num } );
+		} );
+	}
+
 	describe( 'getMax', () => {
-		const specs = ASSET_IMAGE_SPECS;
-		const keys = specs.map( ( spec ) => spec.key );
-
-		let values;
-
-		function setImagesValues( ...numbersOfImages ) {
-			values = {};
-			keys.forEach( ( key, i ) => {
-				const num = numbersOfImages[ i ] ?? 0;
-				values[ key ] = Array.from( { length: num } );
-			} );
-		}
-
 		function getMaxNumbers() {
 			return specs.map( ( spec ) => spec.getMax( values ) );
 		}
@@ -60,6 +60,66 @@ describe( 'ASSET_IMAGE_SPECS', () => {
 			setImagesValues( 2, 4, 6 );
 
 			expect( getMaxNumbers() ).toEqual( [ 10, 12, 14, 5 ] );
+		} );
+	} );
+
+	describe( 'getMaxNumberTip', () => {
+		describe( `Asset image is not shown as the shared max concept`, () => {
+			const { getMaxNumberTip } = specs.find( ( spec ) => spec.max );
+
+			it( 'Should always be null', () => {
+				setImagesValues( 0, 0, 0 );
+
+				expect( getMaxNumberTip( values ) ).toBe( null );
+
+				setImagesValues( 9, 9, 1 );
+
+				expect( getMaxNumberTip( values ) ).toBe( null );
+
+				setImagesValues( 10, 10, 0 );
+
+				expect( getMaxNumberTip( values ) ).toBe( null );
+
+				setImagesValues( 8, 8, 4 );
+
+				expect( getMaxNumberTip( values ) ).toBe( null );
+			} );
+		} );
+
+		describe( `Asset image is shown as the shared max concept`, () => {
+			const { getMaxNumberTip } = specs.find( ( spec ) => ! spec.max );
+
+			it( 'When the total number of the selected images is equal to the shared maximum number, it should not include the minimum image requirements', () => {
+				setImagesValues( 10, 10, 0 );
+
+				const tip = getMaxNumberTip( values );
+
+				expect( tip ).toMatchSnapshot();
+
+				setImagesValues( 1, 1, 18 );
+
+				expect( getMaxNumberTip( values ) ).toBe( tip );
+
+				setImagesValues( 8, 8, 4 );
+
+				expect( getMaxNumberTip( values ) ).toBe( tip );
+			} );
+
+			it( 'When the total number of the selected images is less than the shared maximum number, it should include the minimum image requirements', () => {
+				setImagesValues( 0, 0, 0 );
+
+				const tip = getMaxNumberTip( values );
+
+				expect( tip ).toMatchSnapshot();
+
+				setImagesValues( 0, 0, 18 );
+
+				expect( getMaxNumberTip( values ) ).toBe( tip );
+
+				setImagesValues( 9, 9, 1 );
+
+				expect( getMaxNumberTip( values ) ).toBe( tip );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up and relates to #1787.

In the last section of https://github.com/woocommerce/google-listings-and-ads/pull/1894#issuecomment-1439874287, the wording may confuse users:

![2023-02-22 19 24 55](https://user-images.githubusercontent.com/17420811/220606952-74f9a89b-362b-4e35-91bb-013051baee22.png)

The conclusion is to use different tip messages based on the condition:
- If the total number of the selected images is less than the shared maximum number, the tip will include the minimum image requirements.
- Otherwise, the tip only tells the limit of the maximum number.

### Screenshots:

#### 📷 All buttons are disabled

![image](https://user-images.githubusercontent.com/17420811/221817213-b6129bd0-0eb7-4306-b5f9-7eade317a474.png)

#### 📷 Only some buttons are disabled

![image](https://user-images.githubusercontent.com/17420811/221817437-e665ba84-2760-4146-83dc-0bf17975575d.png)

### Detailed test instructions:

💡  Considering the max limit of 20 is not that easy to test, it would be easier by changing the number in the following line to a smaller one:

https://github.com/woocommerce/google-listings-and-ads/blob/3fb9600eb5cd92cd5805378388aa89796d891457/js/src/components/paid-ads/assetSpecs.js#L147

1. Go to step 2 of the campaign creation or editing page.
2. Select 19 or **N** images for the square and portrait fields to make "Add image" buttons partially disabled.
   - **N**: The number of locally adjusted --> `ASSET_MARKETING_IMAGE_SPECS[ sharedMaxSymbol ] - 1`
3. Hover over the disabled button. The tooltip should include the minimum requirements.
4. Select the last image to make all buttons disabled.
5. Hover over the disabled button. The tooltip should not include the minimum requirements.

### Additional details:

Related Figma: fqR0EHi63lWahRcVTKCcba-fi-5434%3A227215

### Changelog entry
