### PR TITLE
PMax Assets -  Update Error message for Duplicated images

### DIFF
--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -374,6 +374,9 @@ class AdsAssetGroup implements OptionsAwareInterface {
 			} else {
 				$errors = $this->get_api_exception_errors( $e );
 				$code   = $this->map_grpc_code_to_http_status_code( $e );
+				if ( array_key_exists( 'DUPLICATE_ASSETS_WITH_DIFFERENT_FIELD_VALUE', $errors ) ) {
+					$errors['DUPLICATE_ASSETS_WITH_DIFFERENT_FIELD_VALUE'] = __( 'Each image type (landscape, square, portrait or logo) cannot contain duplicated images.', 'google-listings-and-ads' );
+				}
 			}
 
 			throw new ExceptionWithResponseData(

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -168,6 +168,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				->where( 'asset_group_asset.field_type', $this->get_asset_field_types_query(), 'IN' )
 				->where( 'asset_group_asset.status', 'REMOVED', '!=' )
 				->where( 'asset_group.status', 'REMOVED', '!=' )
+				->where( 'campaign.status', 'REMOVED', '!=' )
 				->get_results();
 
 			/** @var GoogleAdsRow $row */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of: #1780 

When duplicated images with the exact size are added multiple times in one of the marketing images (landscape, square, portrait or logo) the Ads API will throw the following error: `Duplicate Assets across mutates cannot have different asset level fields`, this error does not help the user to understand the issue, so this PR overrides the error with the following message: `Each image type (landscape, square, portrait or logo) cannot contain duplicated images.`

Besides that, when a campaign is removed, the asset group is still active, therefore I have updated the query to suggest assets from other's final URLs to not include assets from removed campaigns. 

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Testing the error message

1. Go to Marketing -> GLA -> Edit Campaign ->  Edit asset group
2. In one of the image types for example landscape add an image and cropped it.
3. Add again the same image, choose the original and crop the image again.
4. Fill in the others fields if needed.
5. Click "Save Changes"
6. The new error should be displayed.

https://user-images.githubusercontent.com/2488994/222229570-86686ebf-621d-4dab-9687-33e12af29ec7.mov

#### Testing Asset Suggestions from other Asset Groups

1. Go to [Google Ads](https://ads.google.com/), choose a campaign and one asset group.
2. If the Asset Group final URL is different from your homepage URL, set your homepage URL. 
3. Send a request to `GET gla/assets/suggestions?id=0&type=homepage`
4. The suggestion should be the ones that are in the asset group.
5. Remove the campaign

![image](https://user-images.githubusercontent.com/2488994/222235467-f0225e6c-b8d8-4a8f-a7c8-4ab65c25c00e.png)


6. The assets should be the ones from other active campaigns or wp assets if there are no active asset groups/campaigns using the same final URL. 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
