### PR TITLE
Fix the blank Product Feed page after completing the onboarding flow

### DIFF
--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -11,8 +11,8 @@
 import classnames from 'classnames';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Modal, KeyboardShortcuts } from '@wordpress/components';
-import { Button } from 'extracted/@wordpress/components';
+import { Modal } from '@wordpress/components';
+import { Button, KeyboardShortcuts } from 'extracted/@wordpress/components';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While testing the PMax Assets feature (#1912), I found that the Product Feed is a blank page after completing the onboarding flow. The problem is the `KeyboardShortcuts` calls to an undefined function `isAppleOS`.

![image](https://user-images.githubusercontent.com/17420811/222410366-c2129d31-69ea-41a8-bcc9-09f1c6d2bcef.png)

This problem could be simply fixed by externalizing `KeyboardShortcuts`, which is also a part of #1833 - Gradually externalize `@wordpress/components`. (See the Additional details section for more details)

Additional details

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/222410981-0ce9ce6b-d402-4305-9118-aef6d95f2af1.png)

### Detailed test instructions:

1. Set up a WP version < 6.1.
2. Go to the Product Feed page with the opened submission success guild: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed&guide=submission-success`
3. The page and guild should be rendered.

### Additional details:

#### The root cause

In #1779:

> Moreover, to avoid conflict between WC and WP packages and different `react` versions, we also have to bump all `@woocommerce/*` packages to align with WC 6.9, and all `@wordpress/*` packages need to be aligned with the corresponding versions used in `@woocommerce/components` 10.3.0. Otherwise, the JS unit test would encounter a lot of "Invalid hook call" errors due to multiple `react` versions.

the version of all `@wordpress/*` packages was aligned to the corresponding versions in WC 6.9 rather than the actual versions in WP 5.9. Another weird thing is the `@wordpress/*` packages [used by WC 6.9](https://github.com/woocommerce/woocommerce/blob/6.9.4/packages/js/components/package.json) doesn't match [its min WP version](https://github.com/woocommerce/woocommerce/blob/6.9.4/plugins/woocommerce/woocommerce.php#L11) - 5.8.

The inconsistency of the versions between GLA, WC and WP, although most of the components still functioned properly, this problem occurred after all.

In WP 5.9.5, the provided core packages are
- `@wordpress/components` 19.2.3 for `KeyboardShortcuts` component
- `@wordpress/compose` 5.0.7 for `useKeyboardShortcut` hook, and there is a function `isAppleOS` within the hook
- `@wordpress/keycodes` 3.2.4` but it doesn't expose `isAppleOS` function

However, GLA depends on
- `@wordpress/components` 19.17.0 for `KeyboardShortcuts`
- `@wordpress/compose` 5.20.0 for `useKeyboardShortcut`, and it depends on `isAppleOS` exported from `@wordpress/keycodes`
- DEWPed `@wordpress/keycodes`

This causes the bundled `KeyboardShortcuts` to call the `isAppleOS` via WP core but it's not yet exposed in WP 5.9.x.

### Changelog entry

> Fix - The blank Product Feed page after completing the onboarding flow.
> Dev - Externalize the KeyboardShortcuts component.