### PR TITLE
Add PHP Code coverage report as a GitHub action

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+    require_ci_to_pass: yes
+
+coverage:
+    precision: 1
+    round: nearest
+    range: '50...80'
+
+    status:
+        project:
+            default:
+                target: auto
+        patch:
+            default:
+                target: auto
+
+ignore:
+    - 'bin/*'
+    - 'tests/*'
+    - 'vendor/*'
+    - 'node_modules/*'
+
+comment:
+    layout: 'reach, diff, flags, files'
+    behavior: default
+    require_changes: false
+    require_base: no
+    require_head: yes

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,14 +6,6 @@ coverage:
     round: nearest
     range: '50...80'
 
-    status:
-        project:
-            default:
-                target: auto
-        patch:
-            default:
-                target: auto
-
 ignore:
     - 'bin/*'
     - 'tests/*'
@@ -26,3 +18,4 @@ comment:
     require_changes: false
     require_base: no
     require_head: yes
+    show_carryforward_flags: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,8 +14,3 @@ ignore:
 
 comment:
     layout: 'reach, diff, flags, files'
-    behavior: default
-    require_changes: false
-    require_base: no
-    require_head: yes
-    show_carryforward_flags: false

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -51,5 +51,24 @@ jobs:
       - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }}
 
-      - name: Run PHP unit tests
+      - if: matrix.wp-version == 'latest' && matrix.php == 8.0
+        name: Set condition to generate coverage report (only on latest versions)
+        run: echo "generate_coverage=true" >> $GITHUB_ENV
+
+      - if: env.generate_coverage != 'true'
+        name: Run PHP unit tests
         run: composer test-unit
+
+      - if: env.generate_coverage == 'true'
+        name: Run PHP unit tests (with code coverage)
+        run: phpdbg -qrr vendor/bin/phpunit --coverage-clover=tests/coverage/report.xml
+
+      - if: env.generate_coverage == 'true'
+        name: PHP unit coverage report
+        uses: woocommerce/grow/packages/js/github-actions/actions/coverage-report@add/coverage-report
+        with:
+          base-branch: develop
+          report-name: php-coverage-report
+          report-path: tests/php-coverage
+          test-comment: "PHP unit test coverage"
+          workflow: .github/workflows/php-unit-tests.yml

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -65,10 +65,8 @@ jobs:
 
       - if: env.generate_coverage == 'true'
         name: PHP unit coverage report
-        uses: woocommerce/grow/packages/js/github-actions/actions/coverage-report@add/coverage-report
+        uses: codecov/codecov-action@v3
         with:
-          base-branch: develop
-          report-name: php-coverage-report
-          report-path: tests/php-coverage
-          test-comment: "PHP unit test coverage"
-          workflow: .github/workflows/php-unit-tests.yml
+          files: tests/php-coverage/report.xml
+          flags: php-unit-tests
+          name: php-coverage-report

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       - if: env.generate_coverage == 'true'
         name: Run PHP unit tests (with code coverage)
-        run: phpdbg -qrr vendor/bin/phpunit --coverage-clover=tests/coverage/report.xml
+        run: phpdbg -qrr vendor/bin/phpunit --coverage-clover=tests/php-coverage/report.xml
 
       - if: env.generate_coverage == 'true'
         name: PHP unit coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build-style
 languages/*
 !languages/README.md
 coverage
+tests/php-coverage
 .phpunit.result.cache
 tests/e2e/test-results.json
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,11 @@
 			<directory suffix=".php">./tests/integration</directory>
 		</testsuite>
 	</testsuites>
+    <coverage includeUncoveredFiles="true">
+        <include>
+	        <directory suffix=".php">./src</directory>
+	        <directory suffix=".php">./views</directory>
+			<file>./google-listings-and-ads.php</file>
+        </include>
+     </coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,11 +17,11 @@
 			<directory suffix=".php">./tests/integration</directory>
 		</testsuite>
 	</testsuites>
-    <coverage includeUncoveredFiles="true">
-        <include>
-	        <directory suffix=".php">./src</directory>
-	        <directory suffix=".php">./views</directory>
+	<coverage>
+		<include>
+			<directory suffix=".php">./src</directory>
+			<directory suffix=".php">./views</directory>
 			<file>./google-listings-and-ads.php</file>
-        </include>
-     </coverage>
+		</include>
+	</coverage>
 </phpunit>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolves part of #864 

This PR adds a code coverage report as a PR comment. Since we run multiple unit tests in GitHub actions the coverage report is only generated once when the tests are run with the latest WP version and for PHP 8.0.

I've added the coverage using a flag `php-unit-tests`, the intention is to also include the coverage report for the JS unit tests, but that will be part of a followup PR.

> **Note**
There is currently no report stored for the develop branch. So it's only producing a coverage report of the current PR and isn't able to compare the difference between the two. Once this PR is merged to develop it will generate the report for develop which will allow the comparison to appear in subsequent PR's.

### Detailed test instructions:
1. View the code coverage report here in the [PR comment](https://github.com/woocommerce/google-listings-and-ads/pull/1915#issuecomment-1483222517) and confirm it contains the right test results (no comparison data available)
2. Confirm that in [the workflow runs](https://github.com/woocommerce/google-listings-and-ads/actions/runs/4532661162/jobs/7984348011?pr=1915) the coverage report is only generated for PHP 8.0 and WP latest, we should see skipped tasks that differ:
![image](https://user-images.githubusercontent.com/11388669/228274433-38623a76-94a7-46da-a501-cc848e972de7.png)


### Changelog entry
* Dev - Add PHP Code coverage report as GitHub action.
