### PR TITLE
Release 2.4.1 - WC & WP compatibility bump

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         php: [8.0]
-        wp-version: ["5.9", "6.0", latest]
+        wp-version: ["6.0", "6.1", latest]
         include:
           - php: 7.4
             wp-version: latest

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Google Listings and Ads Changelog ***
 
+= 2.4.1 - 2023-03-14 =
+* Tweak - WC 7.5 compatibility.
+* Tweak - WP 6.2 compatibility.
+
 = 2.4.0 - 2023-03-07 =
 * Add - Support for the Assets of Performance Max campaigns.
 * Dev - Externalize Panel, PanelBody, and PanelRow.

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,17 +3,17 @@
  * Plugin Name: Google Listings and Ads
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 2.4.0
+ * Version: 2.4.1
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
  * Requires at least: 5.9
- * Tested up to: 6.1
+ * Tested up to: 6.2
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits
  *
  * WC requires at least: 6.9
- * WC tested up to: 7.4
+ * WC tested up to: 7.5
  * Woo:
  *
  * @package WooCommerce\Admin
@@ -30,7 +30,7 @@ use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '2.4.0' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '2.4.1' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
 define( 'WC_GLA_MIN_WC_VER', '6.9' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-listings-and-ads",
 	"title": "Google Listings and Ads",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "google-listings-and-ads",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -125,16 +125,4 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 * Tweak - Remove unnecessary PMax migration banners.
 * Tweak - Remove unnecessary woocommerce_loop_add_to_cart_link filter param.
 
-= 2.3.9 - 2023-02-15 =
-* Dev - Update phpunit to version 9.5.
-* Fix - Prefix Google Service packages to prevent plugin conflicts.
-* Tweak - Improve PHP 8.1 compatibility.
-* Tweak - Show admin notice when PHP 32 bits is being used.
-* Tweak - WC 7.4 compatibility.
-* Update - Google Ads library to API V12.
-* Update - Google Content library to API 2.13.
-
-= 2.3.8 - 2023-01-24 =
-* Fix - Product feed table footer rendering a zero when there are no products.
-
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,10 @@ Yes, you can run both at the same time, and we recommend it! In the US, advertis
 
 == Changelog ==
 
+= 2.4.1 - 2023-03-14 =
+* Tweak - WC 7.5 compatibility.
+* Tweak - WP 6.2 compatibility.
+
 = 2.4.0 - 2023-03-07 =
 * Add - Support for the Assets of Performance Max campaigns.
 * Dev - Externalize Panel, PanelBody, and PanelRow.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, listings, ads
 Requires at least: 5.9
-Tested up to: 6.1.1
+Tested up to: 6.2
 Requires PHP: 7.4
 Requires PHP Architecture: 64 Bits
-Stable tag: 2.4.0
+Stable tag: 2.4.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
* Tweak - WC 7.5 compatibility.
* Tweak - WP 6.2 compatibility.

<!-- Release notes generated using configuration in .github/release.yml at 2.4.1 -->



**Full Changelog**: https://github.com/woocommerce/google-listings-and-ads/compare/2.4.0...2.4.1