### PR TITLE
Leverage project write access for Dependabot.

### DIFF
--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -9,6 +9,10 @@ on:
     types:
       - opened
 
+# Leverage project write access for dependabot.
+permissions:
+  repository-projects: write
+
 jobs:
   add-to-project:
     name: Add issue/PR to project


### PR DESCRIPTION
### Changes proposed in this Pull Request:

By default Dependabot, has read-only access.
This results in Dependabot\s PRs not being added to our project board with GH workflow.
https://github.com/woocommerce/google-listings-and-ads/actions/runs/4414431738/jobs/7736133383

This PR sets project write permissions, as suggested in the docs.
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions


### Screenshots:

![image](https://user-images.githubusercontent.com/17435/225361040-c73eab13-7f1d-43e7-a191-be14b3b9916f.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Merge this PR :godmode: 
2. Check Dependabot created PR's actions


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### No changelog entry

