### PR TITLE
Fix attributes in variants for attribute mapping

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1093,6 +1093,11 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			$attribute_value = $product->get_meta( $attribute_name );
 		}
 
-		return is_scalar( $attribute_value ) ? $attribute_value : '';
+		// We only support scalar values.
+		if ( ! is_scalar( $attribute_value ) ) {
+			return '';
+		}
+
+		return explode( ' ' . WC_DELIMITER . ' ', $attribute_value )[0];
 	}
 }

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1098,6 +1098,6 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			return '';
 		}
 
-		return explode( ' ' . WC_DELIMITER . ' ', $attribute_value )[0];
+		return explode( ' ' . WC_DELIMITER . ' ', strval( $attribute_value ) )[0];
 	}
 }

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1104,6 +1104,6 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			return '';
 		}
 
-		return explode( ' ' . WC_DELIMITER . ' ', strval( $attribute_value ) )[0];
+		return explode( ' ' . WC_DELIMITER . ' ', (string) $attribute_value )[0];
 	}
 }

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1019,12 +1019,14 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$product = $this->get_wc_product();
 
 		if ( $product->is_type( 'variation' ) ) {
-			return $product->get_attribute( $taxonomy );
+			$value = $product->get_attribute( $taxonomy );
+			return empty( $value ) ? null : $value;
+
 		}
 
 		$values = get_the_terms( $product->get_id(), $taxonomy );
 
-		if ( ! $values ) {
+		if ( empty( $values ) || is_wp_error( $values ) ) {
 			return null;
 		}
 

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -954,7 +954,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 * Get a source value for attribute mapping
 	 *
 	 * @param string $source The source to get the value
-	 * @return string|null The source value for this product
+	 * @return string The source value for this product
 	 */
 	protected function get_source( string $source ) {
 		$source_type = null;
@@ -1026,8 +1026,8 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			$values = wp_list_pluck( $values, 'name' );
 		}
 
-		if ( empty( $values ) || is_wp_error( $values ) || empty( $values[0] ) ) {
-			return null;
+		if ( empty( $values ) || is_wp_error( $values ) ) {
+			return '';
 		}
 
 		return $values[0];
@@ -1053,7 +1053,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			return $product->$getter();
 		}
 
-		return null;
+		return '';
 	}
 
 	/**
@@ -1087,14 +1087,12 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	protected function get_custom_attribute( $attribute_name ) {
 		$product = $this->get_wc_product();
 
-		$attribute_values = $product->get_attribute( $attribute_name );
+		$attribute_value = $product->get_attribute( $attribute_name );
 
-		if ( ! $attribute_values ) {
-			$attribute_values = $product->get_meta( $attribute_name );
+		if ( ! $attribute_value ) {
+			$attribute_value = $product->get_meta( $attribute_name );
 		}
 
-		$attribute_values = explode( ', ', $attribute_values );
-
-		return empty( $attribute_values[0] ) ? null : $attribute_values[0];
+		return is_scalar( $attribute_value ) ? $attribute_value : '';
 	}
 }

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1019,18 +1019,18 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$product = $this->get_wc_product();
 
 		if ( $product->is_type( 'variation' ) ) {
-			$value = $product->get_attribute( $taxonomy );
-			return empty( $value ) ? null : $value;
-
+			$values = $product->get_attribute( $taxonomy );
+			$values = explode(', ', $values);
+		} else {
+			$values = wc_get_product_terms( $product->get_id(), $taxonomy );
+			$values = wp_list_pluck( $values, 'name' );
 		}
 
-		$values = get_the_terms( $product->get_id(), $taxonomy );
-
-		if ( empty( $values ) || is_wp_error( $values ) ) {
+		if ( empty( $values ) || is_wp_error( $values ) || empty( $values[0] ) ) {
 			return null;
 		}
 
-		return wp_list_pluck( $values, 'name' )[0];
+		return $values[0];
 	}
 
 	/**
@@ -1082,17 +1082,19 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 * Gets a custom attribute from a product
 	 *
 	 * @param string $attribute_name - The attribute name to get.
-	 * @return string The attribute value
+	 * @return string|null The attribute value or null if no value is found
 	 */
 	protected function get_custom_attribute( $attribute_name ) {
 		$product = $this->get_wc_product();
 
-		$attribute = $product->get_attribute( $attribute_name );
+		$attribute_values = $product->get_attribute( $attribute_name );
 
-		if ( ! $attribute ) {
-			$attribute = $product->get_meta( $attribute_name );
+		if ( ! $attribute_values ) {
+			$attribute_values = $product->get_meta( $attribute_name );
 		}
 
-		return $attribute;
+		$attribute_values = explode(', ', $attribute_values);
+
+		return empty( $attribute_values[0] ) ? null : $attribute_values[0];
 	}
 }

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1020,6 +1020,12 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 
 		if ( $product->is_type( 'variation' ) ) {
 			$values = $product->get_attribute( $taxonomy );
+
+			if ( ! $values ) {
+				$parent = wc_get_product( $product->get_parent_id() );
+				$values = $parent->get_attribute( $taxonomy );
+			}
+
 			$values = explode( ', ', $values );
 		} else {
 			$values = wc_get_product_terms( $product->get_id(), $taxonomy );

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1020,7 +1020,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 
 		if ( $product->is_type( 'variation' ) ) {
 			$values = $product->get_attribute( $taxonomy );
-			$values = explode(', ', $values);
+			$values = explode( ', ', $values );
 		} else {
 			$values = wc_get_product_terms( $product->get_id(), $taxonomy );
 			$values = wp_list_pluck( $values, 'name' );
@@ -1093,7 +1093,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			$attribute_values = $product->get_meta( $attribute_name );
 		}
 
-		$attribute_values = explode(', ', $attribute_values);
+		$attribute_values = explode( ', ', $attribute_values );
 
 		return empty( $attribute_values[0] ) ? null : $attribute_values[0];
 	}

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1104,6 +1104,8 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			return '';
 		}
 
-		return explode( ' ' . WC_DELIMITER . ' ', (string) $attribute_value )[0];
+		$values = explode( WC_DELIMITER, (string) $attribute_value );
+		$values = array_filter( array_map( 'trim', $values ) );
+		return empty( $values ) ? '' : $values[0];
 	}
 }

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -973,7 +973,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			case 'taxonomy':
 				return $this->get_product_taxonomy( $source_value );
 			case 'attribute':
-				return $this->get_wc_product()->get_meta( $source_value );
+				return $this->get_custom_attribute( $source_value );
 			default:
 				return $source;
 		}
@@ -1017,7 +1017,12 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 */
 	protected function get_product_taxonomy( $taxonomy ) {
 		$product = $this->get_wc_product();
-		$values  = get_the_terms( $product->get_id(), $taxonomy );
+
+		if ( $product->is_type( 'variation' ) ) {
+			return $product->get_attribute( $taxonomy );
+		}
+
+		$values = get_the_terms( $product->get_id(), $taxonomy );
 
 		if ( ! $values ) {
 			return null;
@@ -1069,5 +1074,23 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Gets a custom attribute from a product
+	 *
+	 * @param string $attribute_name - The attribute name to get.
+	 * @return string The attribute value
+	 */
+	protected function get_custom_attribute( $attribute_name ) {
+		$product = $this->get_wc_product();
+
+		$attribute = $product->get_attribute( $attribute_name );
+
+		if ( ! $attribute ) {
+			$attribute = $product->get_meta( $attribute_name );
+		}
+
+		return $attribute;
 	}
 }

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -472,4 +472,37 @@ trait ProductTrait {
 
 		return $attachment_id;
 	}
+
+	protected function generate_attribute_mapping_adapted_product( $rules ) {
+		$product = WC_Helper_Product::create_simple_product( false );
+		$product->set_stock_quantity(1);
+		$product->set_tax_class('mytax');
+
+		return new WCProductAdapter(
+			[
+				'wc_product'     => $product,
+				'mapping_rules'  => $rules,
+				'gla_attributes' => [],
+				'targetCountry'  => 'US',
+			]
+		);
+	}
+
+	protected function generate_attribute_mapping_adapted_product_variant( $rules ) {
+		$variable = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product( $variable->get_children()[1] );
+		$variation->set_stock_quantity(1);
+		$variation->set_weight(1.2);
+		$variation->set_tax_class('mytax');
+
+		return new WCProductAdapter(
+			[
+				'wc_product'     => $variation,
+				'parent_wc_product' => $variable,
+				'mapping_rules'  => $rules,
+				'gla_attributes' => [],
+				'targetCountry'  => 'US',
+			]
+		);
+	}
 }

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -473,7 +473,7 @@ trait ProductTrait {
 		return $attachment_id;
 	}
 
-	protected function generate_attribute_mapping_adapted_product( $rules ) {
+	protected function generate_attribute_mapping_adapted_product( $rules, $categories = [] ) {
 		$product = WC_Helper_Product::create_simple_product( false );
 
 		$attributes = [
@@ -482,6 +482,10 @@ trait ProductTrait {
 
 		$product->set_attributes( $attributes );
 		$product->add_meta_data('custom', 'test');
+
+		if ( ! empty( $categories ) ) {
+			$product->set_category_ids( $categories );
+		}
 
 		$product->save();
 

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -481,7 +481,7 @@ trait ProductTrait {
 		];
 
 		$product->set_attributes( $attributes );
-		$product->add_meta_data('custom', 'test');
+		$product->add_meta_data( 'custom', 'test' );
 
 		if ( ! empty( $categories ) ) {
 			$product->set_category_ids( $categories );
@@ -489,8 +489,8 @@ trait ProductTrait {
 
 		$product->save();
 
-		$product->set_stock_quantity(1);
-		$product->set_tax_class('mytax');
+		$product->set_stock_quantity( 1 );
+		$product->set_tax_class( 'mytax' );
 
 		return new WCProductAdapter(
 			[
@@ -503,20 +503,20 @@ trait ProductTrait {
 	}
 
 	protected function generate_attribute_mapping_adapted_product_variant( $rules ) {
-		$variable = WC_Helper_Product::create_variation_product();
+		$variable  = WC_Helper_Product::create_variation_product();
 		$variation = wc_get_product( $variable->get_children()[1] );
-		$variation->set_stock_quantity(1);
-		$variation->set_weight(1.2);
-		$variation->set_tax_class('mytax');
-		$variation->add_meta_data('custom', 'test');
+		$variation->set_stock_quantity( 1 );
+		$variation->set_weight( 1.2 );
+		$variation->set_tax_class( 'mytax' );
+		$variation->add_meta_data( 'custom', 'test' );
 
 		return new WCProductAdapter(
 			[
-				'wc_product'     => $variation,
+				'wc_product'        => $variation,
 				'parent_wc_product' => $variable,
-				'mapping_rules'  => $rules,
-				'gla_attributes' => [],
-				'targetCountry'  => 'US',
+				'mapping_rules'     => $rules,
+				'gla_attributes'    => [],
+				'targetCountry'     => 'US',
 			]
 		);
 	}

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -157,6 +157,12 @@ trait ProductTrait {
 		return $adapted;
 	}
 
+	/**
+	 * Get the product ID
+	 *
+	 * @param WC_Product $product The product for getting the ID
+	 * @return int The Product ID
+	 */
 	protected static function get_product_id( WC_Product $product ) {
 		return $product->get_id();
 	}
@@ -473,6 +479,13 @@ trait ProductTrait {
 		return $attachment_id;
 	}
 
+	/**
+	 * Creates a simple product ready for being tested in Attribute Mapping
+	 *
+	 * @param array $rules The Attribute Mapping rules to apply.
+	 * @param array $categories The Categories attached to this product.
+	 * @return WCProductAdapter The adapted products with the rules applied.
+	 */
 	protected function generate_attribute_mapping_adapted_product( $rules, $categories = [] ) {
 		$product = WC_Helper_Product::create_simple_product( false );
 
@@ -482,6 +495,8 @@ trait ProductTrait {
 
 		$product->set_attributes( $attributes );
 		$product->add_meta_data( 'custom', 'test' );
+		$product->add_meta_data( 'array', [ 'foo' => 'bar' ] );
+		$product->add_meta_data( 'multiple', 'Value1 | Value 2' );
 
 		if ( ! empty( $categories ) ) {
 			$product->set_category_ids( $categories );
@@ -502,6 +517,12 @@ trait ProductTrait {
 		);
 	}
 
+	/**
+	 * Creates a variant with variations ready for being tested in Attribute Mapping
+	 *
+	 * @param array $rules The Attribute Mapping rules to apply.
+	 * @return WCProductAdapter The adapted products with the rules applied.
+	 */
 	protected function generate_attribute_mapping_adapted_product_variant( $rules ) {
 		$variable  = WC_Helper_Product::create_variation_product();
 		$variation = wc_get_product( $variable->get_children()[1] );
@@ -509,6 +530,8 @@ trait ProductTrait {
 		$variation->set_weight( 1.2 );
 		$variation->set_tax_class( 'mytax' );
 		$variation->add_meta_data( 'custom', 'test' );
+		$variation->add_meta_data( 'array', [ 'foo' => 'bar' ] );
+		$variation->add_meta_data( 'multiple', 'Value1 | Value 2' );
 
 		return new WCProductAdapter(
 			[

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -525,7 +525,7 @@ trait ProductTrait {
 	 */
 	protected function generate_attribute_mapping_adapted_product_variant( $rules ) {
 		$variable  = WC_Helper_Product::create_variation_product();
-		$variation = wc_get_product( $variable->get_children()[1] );
+		$variation = wc_get_product( $variable->get_children()[ count( $variable->get_children() ) - 1 ] );
 		$variation->set_stock_quantity( 1 );
 		$variation->set_weight( 1.2 );
 		$variation->set_tax_class( 'mytax' );

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -475,6 +475,16 @@ trait ProductTrait {
 
 	protected function generate_attribute_mapping_adapted_product( $rules ) {
 		$product = WC_Helper_Product::create_simple_product( false );
+
+		$attributes = [
+			WC_Helper_Product::create_product_attribute_object( 'size', [ 's', 'xs' ] ),
+		];
+
+		$product->set_attributes( $attributes );
+		$product->add_meta_data('custom', 'test');
+
+		$product->save();
+
 		$product->set_stock_quantity(1);
 		$product->set_tax_class('mytax');
 
@@ -494,6 +504,7 @@ trait ProductTrait {
 		$variation->set_stock_quantity(1);
 		$variation->set_weight(1.2);
 		$variation->set_tax_class('mytax');
+		$variation->add_meta_data('custom', 'test');
 
 		return new WCProductAdapter(
 			[

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingHelperTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingHelperTest.php
@@ -1,0 +1,96 @@
+<?php
+	declare(strict_types=1);
+
+	namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\AttributeMapping;
+
+	use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
+	use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+
+	/**
+	 * Test suite for AttributeMappingHelper
+	 *
+	 * @group AttributeMapping
+	 */
+class AttributeMappingHelperTest extends UnitTest {
+
+	/**
+	 * Holds the AttributeMappingHelper object.
+	 *
+	 * @var AttributeMappingHelper
+	 */
+	public $attribute_mapping_helper;
+
+
+	/**
+	 * Test the AttributeMappingHelper::get_attributes function
+	 */
+	public function test_get_attributes(): void {
+		$attributes = $this->attribute_mapping_helper->get_attributes();
+
+		$this->assertIsArray( $attributes );
+		$this->assertNotEmpty( $attributes );
+
+		foreach ( $attributes as $attribute ) {
+			$this->assertArrayHasKey( 'id', $attribute );
+			$this->assertArrayHasKey( 'label', $attribute );
+			$this->assertArrayHasKey( 'enum', $attribute );
+		}
+	}
+
+	/**
+	 * Test the AttributeMappingHelper::get_attribute_by_id function
+	 */
+	public function test_get_attribute_by_id(): void {
+		$attributes = $this->attribute_mapping_helper->get_attributes();
+
+		foreach ( $attributes as $attribute ) {
+			$attribute_class = AttributeMappingHelper::get_attribute_by_id( $attribute['id'] );
+			$this->assertNotNull( $attribute_class );
+			$this->assertEquals( $attribute_class::get_id(), $attribute['id'] );
+		}
+
+		$this->assertNull( AttributeMappingHelper::get_attribute_by_id( 'non_existent_attribute_id' ) );
+	}
+
+	/**
+	 * Test the AttributeMappingHelper::get_sources_for_attribute function
+	 */
+	public function test_get_sources_for_attribute(): void {
+		$attributes = $this->attribute_mapping_helper->get_attributes();
+
+		foreach ( $attributes as $attribute ) {
+			$sources = $this->attribute_mapping_helper->get_sources_for_attribute( $attribute['id'] );
+
+			$this->assertIsArray( $sources );
+			$this->assertNotEmpty( $sources );
+
+			foreach ( $sources as $source ) {
+				$this->assertArrayHasKey( 'id', $source );
+				$this->assertArrayHasKey( 'label', $source );
+			}
+		}
+
+		$this->assertEmpty( $this->attribute_mapping_helper->get_sources_for_attribute( 'non_existent_attribute_id' ) );
+	}
+
+	/**
+	 * Test the AttributeMappingHelper::get_category_condition_types function
+	 */
+	public function test_get_category_condition_types(): void {
+		$category_condition_types = $this->attribute_mapping_helper->get_category_condition_types();
+
+		$this->assertIsArray( $category_condition_types );
+		$this->assertCount( 3, $category_condition_types );
+		$this->assertContains( AttributeMappingHelper::CATEGORY_CONDITION_TYPE_ALL, $category_condition_types );
+		$this->assertContains( AttributeMappingHelper::CATEGORY_CONDITION_TYPE_EXCEPT, $category_condition_types );
+		$this->assertContains( AttributeMappingHelper::CATEGORY_CONDITION_TYPE_ONLY, $category_condition_types );
+	}
+
+	/**
+	 * Test Setup Method
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->attribute_mapping_helper = new AttributeMappingHelper();
+	}
+}

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingHelperTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingHelperTest.php
@@ -1,16 +1,16 @@
 <?php
-	declare(strict_types=1);
+declare(strict_types=1);
 
-	namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\AttributeMapping;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\AttributeMapping;
 
-	use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
-	use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 
-	/**
-	 * Test suite for AttributeMappingHelper
-	 *
-	 * @group AttributeMapping
-	 */
+/**
+ * Test suite for AttributeMappingHelper
+ *
+ * @group AttributeMapping
+ */
 class AttributeMappingHelperTest extends UnitTest {
 
 	/**

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -282,34 +282,38 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	 * Test Rule Category Type ONLY and EXCEPT matching logic
 	 */
 	public function test_rule_only_categories() {
+
+		$category = wp_insert_term( 'Test Category', 'product_cat' );
+		$term = $category['term_id'];
+
 		$rules = [
 			[
 				'attribute'               => Color::get_id(),
 				'source'                  => 'test',
 				'category_condition_type' => 'ONLY',
-				'categories'              => '15',
+				'categories'              => strval( $term ),
 			],
 			[
 				'attribute'               => Brand::get_id(),
 				'source'                  => 'test',
 				'category_condition_type' => 'ONLY',
-				'categories'              => '12',
+				'categories'              => '999',
 			],
 			[
 				'attribute'               => GTIN::get_id(),
 				'source'                  => 'test',
 				'category_condition_type' => 'EXCEPT',
-				'categories'              => '12',
+				'categories'              => '999',
 			],
 			[
 				'attribute'               => MPN::get_id(),
 				'source'                  => 'test',
 				'category_condition_type' => 'EXCEPT',
-				'categories'              => '15',
+				'categories'              => strval( $term ),
 			],
 		];
 
-		$adapted_product = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_product = $this->generate_attribute_mapping_adapted_product( $rules, [ $term ] );
 
 		$this->assertEquals( 'test', $adapted_product->getColor() );
 		$this->assertNull( $adapted_product->getBrand() );
@@ -343,12 +347,6 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		\WC_Tax::create_tax_class( 'mytax' );
-		wc_create_attribute(
-			[
-				'id'   => 5,
-				'name' => 'test',
-			]
-		);
 	}
 
 	/**
@@ -357,6 +355,5 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	public function tearDown(): void {
 		parent::tearDown();
 		\WC_Tax::delete_tax_class_by( 'name', 'mytax' );
-		wc_delete_attribute( 5 );
 	}
 }

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -277,6 +277,47 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$this->assertEquals( 'test', $adapted_variation->getColor() );
 	}
 
+
+	/**
+	 * Test Rule Category Type ONLY and EXCEPT matching logic
+	 */
+	public function test_rule_only_categories() {
+		$rules = [
+			[
+				'attribute'               => Color::get_id(),
+				'source'                  => 'test',
+				'category_condition_type' => 'ONLY',
+				'categories'              => '15',
+			],
+			[
+				'attribute'               => Brand::get_id(),
+				'source'                  => 'test',
+				'category_condition_type' => 'ONLY',
+				'categories'              => '12',
+			],
+			[
+				'attribute'               => GTIN::get_id(),
+				'source'                  => 'test',
+				'category_condition_type' => 'EXCEPT',
+				'categories'              => '12',
+			],
+			[
+				'attribute'               => MPN::get_id(),
+				'source'                  => 'test',
+				'category_condition_type' => 'EXCEPT',
+				'categories'              => '15',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+
+		$this->assertEquals( 'test', $adapted_product->getColor() );
+		$this->assertNull( $adapted_product->getBrand() );
+		$this->assertEquals( 'test', $adapted_product->getGtin() );
+		$this->assertNull( $adapted_product->getMpn() );
+
+	}
+
 	/**
 	 * Test rules priority
 	 */

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -1,0 +1,253 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\AttributeMapping;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Brand;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Color;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\GTIN;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Material;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\MPN;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Multipack;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Pattern;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Size;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use WC_Helper_Product;
+
+/**
+ * Test suite for Attribute Mapping features in WC Product Adapter
+ *
+ * @group AttributeMapping
+ */
+class AttributeMappingWCProductAdapterTest extends UnitTest {
+	use ProductTrait;
+
+	/**
+	 * Test static sources for attributes
+	 */
+	public function test_maps_rules_static_attributes() {
+		$rules = $this->get_sample_rules();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'     => WC_Helper_Product::create_simple_product( false ),
+				'mapping_rules'  => $rules,
+				'gla_attributes' => [],
+				'targetCountry'  => 'US',
+			]
+		);
+
+		$this->assertEquals( $this->get_rule_attribute( 'gtin' ), $adapted_product->getGtin() );
+		$this->assertEquals( $this->get_rule_attribute( 'mpn' ), $adapted_product->getMpn() );
+		$this->assertEquals( $this->get_rule_attribute( 'brand' ), $adapted_product->getBrand() );
+		$this->assertEquals( $this->get_rule_attribute( 'condition' ), $adapted_product->getCondition() );
+		$this->assertEquals( $this->get_rule_attribute( 'gender' ), $adapted_product->getGender() );
+		$this->assertContains( $this->get_rule_attribute( 'size' ), $adapted_product->getSizes() );
+		$this->assertEquals( $this->get_rule_attribute( 'sizeSystem' ), $adapted_product->getSizeSystem() );
+		$this->assertEquals( $this->get_rule_attribute( 'sizeType' ), $adapted_product->getSizeType() );
+		$this->assertEquals( $this->get_rule_attribute( 'color' ), $adapted_product->getColor() );
+		$this->assertEquals( $this->get_rule_attribute( 'material' ), $adapted_product->getMaterial() );
+		$this->assertEquals( $this->get_rule_attribute( 'pattern' ), $adapted_product->getPattern() );
+		$this->assertEquals( $this->get_rule_attribute( 'ageGroup' ), $adapted_product->getAgeGroup() );
+		$this->assertEquals( 2, $adapted_product->getMultipack() );
+		$this->assertEquals( true, $adapted_product->getIsBundle() );
+		$this->assertEquals( true, $adapted_product->getAdult() );
+	}
+
+	/**
+	 * Test dynamic product title source
+	 */
+	public function test_maps_rules_taxonomy_product_fields_title() {
+		$rules = [
+			[
+				'attribute'               => Brand::get_id(),
+				'source'                  => 'product:title',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( 'Dummy Product', $adapted_product->getBrand() );
+		$this->assertEquals( 'Dummy Variable Product', $adapted_variation->getBrand() );
+	}
+
+	/**
+	 * Test dynamic product name source
+	 */
+	public function test_maps_rules_taxonomy_product_fields_name() {
+		$rules = [
+			[
+				'attribute'               => Size::get_id(),
+				'source'                  => 'product:name',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( [ 'Dummy Product' ], $adapted_product->getSizes() );
+		$this->assertEquals( [ 'Dummy Variable Product' ], $adapted_variation->getSizes() );
+	}
+
+	/**
+	 * Test dynamic product sku source
+	 */
+	public function test_maps_rules_taxonomy_product_fields_sku() {
+		$rules = [
+			[
+				'attribute'               => GTIN::get_id(),
+				'source'                  => 'product:sku',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( 'DUMMY SKU', $adapted_product->getGtin() );
+		$this->assertEquals( 'DUMMY SKU VARIABLE LARGE', $adapted_variation->getGtin() );
+	}
+
+	/**
+	 * Test dynamic stock quantity source
+	 */
+	public function test_maps_rules_taxonomy_product_fields_stock_quantity() {
+		$rules = [
+			[
+				'attribute'               => Multipack::get_id(),
+				'source'                  => 'product:stock_quantity',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( 1, $adapted_product->getMultipack() );
+		$this->assertEquals( 1, $adapted_variation->getMultipack() );
+	}
+
+	/**
+	 * Test dynamic product stock status source
+	 */
+	public function test_maps_rules_taxonomy_product_fields_stock_status() {
+		$rules = [
+			[
+				'attribute'               => Material::get_id(),
+				'source'                  => 'product:stock_status',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( 'instock', $adapted_product->getMaterial() );
+		$this->assertEquals( 'instock', $adapted_variation->getMaterial() );
+	}
+
+	/**
+	 * Test dynamic product weight source
+	 */
+	public function test_maps_rules_taxonomy_product_fields_weight() {
+		$rules = [
+			[
+				'attribute'               => MPN::get_id(),
+				'source'                  => 'product:weight',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( 1.1, $adapted_product->getMpn() );
+		$this->assertEquals( 1.2, $adapted_variation->getMpn() );
+	}
+
+	/**
+	 * Test dynamic product weight (with units) source
+	 */
+	public function test_maps_rules_taxonomy_product_fields_weight_with_units() {
+		$rules = [
+			[
+				'attribute'               => Pattern::get_id(),
+				'source'                  => 'product:weight_with_unit',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( '1.1 kg', $adapted_product->getPattern() );
+		$this->assertEquals( '1.2 kg', $adapted_variation->getPattern() );
+	}
+
+	/**
+	 * Test dynamic product tax class source
+	 */
+	public function test_maps_rules_taxonomy_product_fields_taxclass() {
+		$rules = [
+			[
+				'attribute'               => Color::get_id(),
+				'source'                  => 'product:tax_class',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( 'mytax', $adapted_product->getColor() );
+		$this->assertEquals( 'mytax', $adapted_variation->getColor() );
+	}
+
+	/**
+	 * Test rules priority
+	 */
+	public function test_gla_attribute_has_priority_over_attribute_mapping_rules() {
+		$rules = $this->get_sample_rules();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'     => WC_Helper_Product::create_simple_product( false ),
+				'mapping_rules'  => $rules,
+				'gla_attributes' => [ 'gender' => 'man' ],
+				'targetCountry'  => 'US',
+			]
+		);
+
+		$this->assertEquals( $this->get_rule_attribute( 'condition' ), $adapted_product->getCondition() );
+		$this->assertEquals( 'man', $adapted_product->getGender() );
+	}
+
+	/**
+	 * Test suite setup
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		\WC_Tax::create_tax_class( 'mytax' );
+	}
+
+	/**
+	 * Test suite tear down
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		\WC_Tax::delete_tax_class_by( 'name', 'mytax' );
+	}
+}

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -232,8 +232,8 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
 
-     	$this->assertEquals( ['s'], $adapted_product->getSizes() );
-     	$this->assertEquals( ['large'], $adapted_variation->getSizes() );
+		$this->assertEquals( [ 's' ], $adapted_product->getSizes() );
+		$this->assertEquals( [ 'large' ], $adapted_variation->getSizes() );
 	}
 
 	/**
@@ -253,7 +253,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
 
 		$this->assertNull( $adapted_product->getColor() );
-		$this->assertNull(  $adapted_variation->getColor() );
+		$this->assertNull( $adapted_variation->getColor() );
 	}
 
 
@@ -273,7 +273,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
 
-		$this->assertEquals( 'test' , $adapted_product->getColor() );
+		$this->assertEquals( 'test', $adapted_product->getColor() );
 		$this->assertEquals( 'test', $adapted_variation->getColor() );
 	}
 
@@ -309,7 +309,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 			],
 		];
 
-		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_product = $this->generate_attribute_mapping_adapted_product( $rules );
 
 		$this->assertEquals( 'test', $adapted_product->getColor() );
 		$this->assertNull( $adapted_product->getBrand() );
@@ -343,7 +343,12 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		\WC_Tax::create_tax_class( 'mytax' );
-		wc_create_attribute( [ 'id' => 5, 'name' => 'test'] );
+		wc_create_attribute(
+			[
+				'id'   => 5,
+				'name' => 'test',
+			]
+		);
 	}
 
 	/**
@@ -352,6 +357,6 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	public function tearDown(): void {
 		parent::tearDown();
 		\WC_Tax::delete_tax_class_by( 'name', 'mytax' );
-		wc_delete_attribute(5);
+		wc_delete_attribute( 5 );
 	}
 }

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -268,6 +268,18 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 				'category_condition_type' => 'ALL',
 				'categories'              => '',
 			],
+			[
+				'attribute'               => GTIN::get_id(),
+				'source'                  => 'attribute:array', // This won't be loaded because we only accept scalars.
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+			[
+				'attribute'               => Brand::get_id(),
+				'source'                  => 'attribute:multiple', // Only first value will be loaded.
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
 		];
 
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
@@ -275,6 +287,10 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 
 		$this->assertEquals( 'test', $adapted_product->getColor() );
 		$this->assertEquals( 'test', $adapted_variation->getColor() );
+		$this->assertEquals( '', $adapted_variation->getGtin() );
+		$this->assertEquals( '', $adapted_variation->getGtin() );
+		$this->assertEquals( 'Value1', $adapted_variation->getBrand() );
+		$this->assertEquals( 'Value1', $adapted_variation->getBrand() );
 	}
 
 
@@ -315,7 +331,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_product = $this->generate_attribute_mapping_adapted_product( $rules, [ $term ] );
 
 		$this->assertEquals( 'test', $adapted_product->getColor() );
-		$this->assertEquals( '',  $adapted_product->getBrand() );
+		$this->assertEquals( '', $adapted_product->getBrand() );
 		$this->assertEquals( 'test', $adapted_product->getGtin() );
 		$this->assertEquals( '', $adapted_product->getMpn() );
 

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -282,9 +282,8 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	 * Test Rule Category Type ONLY and EXCEPT matching logic
 	 */
 	public function test_rule_only_categories() {
-
 		$category = wp_insert_term( 'Test Category', 'product_cat' );
-		$term = $category['term_id'];
+		$term     = $category['term_id'];
 
 		$rules = [
 			[

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -113,7 +113,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
 
 		$this->assertEquals( 'DUMMY SKU', $adapted_product->getGtin() );
-		$this->assertEquals( 'DUMMY SKU VARIABLE LARGE', $adapted_variation->getGtin() );
+		$this->assertEquals( 'DUMMY SKU VARIABLE HUGE BLUE ANY NUMBER', $adapted_variation->getGtin() );
 	}
 
 	/**
@@ -227,13 +227,20 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 				'category_condition_type' => 'ALL',
 				'categories'              => '',
 			],
+			[
+				'attribute'               => Color::get_id(),
+				'source'                  => 'taxonomy:pa_number', // set as any
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
 		];
 
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
 
 		$this->assertEquals( [ 's' ], $adapted_product->getSizes() );
-		$this->assertEquals( [ 'large' ], $adapted_variation->getSizes() );
+		$this->assertEquals( [ 'huge' ], $adapted_variation->getSizes() );
+		$this->assertEquals( '0', $adapted_variation->getColor() );
 	}
 
 	/**

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -59,7 +59,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	/**
 	 * Test dynamic product title source
 	 */
-	public function test_maps_rules_taxonomy_product_fields_title() {
+	public function test_maps_rules_product_fields_title() {
 		$rules = [
 			[
 				'attribute'               => Brand::get_id(),
@@ -79,7 +79,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	/**
 	 * Test dynamic product name source
 	 */
-	public function test_maps_rules_taxonomy_product_fields_name() {
+	public function test_maps_rules_product_fields_name() {
 		$rules = [
 			[
 				'attribute'               => Size::get_id(),
@@ -99,7 +99,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	/**
 	 * Test dynamic product sku source
 	 */
-	public function test_maps_rules_taxonomy_product_fields_sku() {
+	public function test_maps_rules_product_fields_sku() {
 		$rules = [
 			[
 				'attribute'               => GTIN::get_id(),
@@ -119,7 +119,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	/**
 	 * Test dynamic stock quantity source
 	 */
-	public function test_maps_rules_taxonomy_product_fields_stock_quantity() {
+	public function test_maps_rules_product_fields_stock_quantity() {
 		$rules = [
 			[
 				'attribute'               => Multipack::get_id(),
@@ -139,7 +139,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	/**
 	 * Test dynamic product stock status source
 	 */
-	public function test_maps_rules_taxonomy_product_fields_stock_status() {
+	public function test_maps_rules_product_fields_stock_status() {
 		$rules = [
 			[
 				'attribute'               => Material::get_id(),
@@ -159,7 +159,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	/**
 	 * Test dynamic product weight source
 	 */
-	public function test_maps_rules_taxonomy_product_fields_weight() {
+	public function test_maps_rules_product_fields_weight() {
 		$rules = [
 			[
 				'attribute'               => MPN::get_id(),
@@ -179,7 +179,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	/**
 	 * Test dynamic product weight (with units) source
 	 */
-	public function test_maps_rules_taxonomy_product_fields_weight_with_units() {
+	public function test_maps_rules_product_fields_weight_with_units() {
 		$rules = [
 			[
 				'attribute'               => Pattern::get_id(),
@@ -199,7 +199,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	/**
 	 * Test dynamic product tax class source
 	 */
-	public function test_maps_rules_taxonomy_product_fields_taxclass() {
+	public function test_maps_rules_product_fields_taxclass() {
 		$rules = [
 			[
 				'attribute'               => Color::get_id(),
@@ -214,6 +214,67 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 
 		$this->assertEquals( 'mytax', $adapted_product->getColor() );
 		$this->assertEquals( 'mytax', $adapted_variation->getColor() );
+	}
+
+	/**
+	 * Test dynamic taxonomy source
+	 */
+	public function test_maps_rules_product_taxonomies() {
+		$rules = [
+			[
+				'attribute'               => Size::get_id(),
+				'source'                  => 'taxonomy:pa_size',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+     	$this->assertEquals( ['s'], $adapted_product->getSizes() );
+     	$this->assertEquals( ['large'], $adapted_variation->getSizes() );
+	}
+
+	/**
+	 * Test dynamic taxonomy not found
+	 */
+	public function test_maps_rules_product_taxonomies_null() {
+		$rules = [
+			[
+				'attribute'               => Color::get_id(),
+				'source'                  => 'taxonomy:pa_other',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertNull( $adapted_product->getColor() );
+		$this->assertNull(  $adapted_variation->getColor() );
+	}
+
+
+	/**
+	 * Test dynamic taxonomy not found
+	 */
+	public function test_maps_rules_custom_attributes() {
+		$rules = [
+			[
+				'attribute'               => Color::get_id(),
+				'source'                  => 'attribute:custom',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
+
+		$this->assertEquals( 'test' , $adapted_product->getColor() );
+		$this->assertEquals( 'test', $adapted_variation->getColor() );
 	}
 
 	/**
@@ -241,6 +302,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		\WC_Tax::create_tax_class( 'mytax' );
+		wc_create_attribute( [ 'id' => 5, 'name' => 'test'] );
 	}
 
 	/**
@@ -249,5 +311,6 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	public function tearDown(): void {
 		parent::tearDown();
 		\WC_Tax::delete_tax_class_by( 'name', 'mytax' );
+		wc_delete_attribute(5);
 	}
 }

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -252,8 +252,8 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
 
-		$this->assertNull( $adapted_product->getColor() );
-		$this->assertNull( $adapted_variation->getColor() );
+		$this->assertEquals( '', $adapted_product->getColor() );
+		$this->assertEquals( '', $adapted_variation->getColor() );
 	}
 
 
@@ -315,9 +315,9 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_product = $this->generate_attribute_mapping_adapted_product( $rules, [ $term ] );
 
 		$this->assertEquals( 'test', $adapted_product->getColor() );
-		$this->assertNull( $adapted_product->getBrand() );
+		$this->assertEquals( '',  $adapted_product->getBrand() );
 		$this->assertEquals( 'test', $adapted_product->getGtin() );
-		$this->assertNull( $adapted_product->getMpn() );
+		$this->assertEquals( '', $adapted_product->getMpn() );
 
 	}
 

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -86,35 +86,6 @@ class WCProductAdapterTest extends UnitTest {
 		);
 	}
 
-	public function test_maps_rules_attributes() {
-		$rules = $this->get_sample_rules();
-
-		$adapted_product = new WCProductAdapter(
-			[
-				'wc_product'     => WC_Helper_Product::create_simple_product( false ),
-				'mapping_rules'  => $rules,
-				'gla_attributes' => [],
-				'targetCountry'  => 'US',
-			]
-		);
-
-		$this->assertEquals( $this->get_rule_attribute( 'gtin' ), $adapted_product->getGtin() );
-		$this->assertEquals( $this->get_rule_attribute( 'mpn' ), $adapted_product->getMpn() );
-		$this->assertEquals( $this->get_rule_attribute( 'brand' ), $adapted_product->getBrand() );
-		$this->assertEquals( $this->get_rule_attribute( 'condition' ), $adapted_product->getCondition() );
-		$this->assertEquals( $this->get_rule_attribute( 'gender' ), $adapted_product->getGender() );
-		$this->assertContains( $this->get_rule_attribute( 'size' ), $adapted_product->getSizes() );
-		$this->assertEquals( $this->get_rule_attribute( 'sizeSystem' ), $adapted_product->getSizeSystem() );
-		$this->assertEquals( $this->get_rule_attribute( 'sizeType' ), $adapted_product->getSizeType() );
-		$this->assertEquals( $this->get_rule_attribute( 'color' ), $adapted_product->getColor() );
-		$this->assertEquals( $this->get_rule_attribute( 'material' ), $adapted_product->getMaterial() );
-		$this->assertEquals( $this->get_rule_attribute( 'pattern' ), $adapted_product->getPattern() );
-		$this->assertEquals( $this->get_rule_attribute( 'ageGroup' ), $adapted_product->getAgeGroup() );
-		$this->assertEquals( 2, $adapted_product->getMultipack() );
-		$this->assertEquals( true, $adapted_product->getIsBundle() );
-		$this->assertEquals( true, $adapted_product->getAdult() );
-	}
-
 	public function test_maps_extra_gla_attributes() {
 		$attributes = $this->get_sample_attributes();
 
@@ -142,22 +113,6 @@ class WCProductAdapterTest extends UnitTest {
 		$this->assertEquals( $attributes['multipack'], $adapted_product->getMultipack() );
 		$this->assertEquals( $attributes['isBundle'], $adapted_product->getIsBundle() );
 		$this->assertEquals( $attributes['adult'], $adapted_product->getAdult() );
-	}
-
-	public function test_gla_attribute_has_priority_over_rules() {
-		$rules = $this->get_sample_rules();
-
-		$adapted_product = new WCProductAdapter(
-			[
-				'wc_product'     => WC_Helper_Product::create_simple_product( false ),
-				'mapping_rules'  => $rules,
-				'gla_attributes' => [ 'gender' => 'man' ],
-				'targetCountry'  => 'US',
-			]
-		);
-
-		$this->assertEquals( $this->get_rule_attribute( 'condition' ), $adapted_product->getCondition() );
-		$this->assertEquals( 'man', $adapted_product->getGender() );
 	}
 
 	public function test_attribute_value_can_be_overridden_via_filter() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR Fixes reported bugs getting taxonomy and custom attributes based sources in Attribute Mapping on Variations. 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

**Testing Taxonomy based Attributes** 

1. Create a product variant with a Taxonomy based variations, like Color.
2. Create an attribute mapping rule as (target Color, source Product Color,  Apply to ALL)
3. Save
4. Sync your product (using connection test is ok)
5. See the Color attribute is being loaded in Merchant.
6. Create a simple product.
7. Add an attribute Color (or several colors) to it
8. Sync that product
9. See the Color attribute (first one) is being loaded in Merchant.

**Testing Custom based Attributes** 

Use this snippet to create a custom attribute: 

```php
add_filter(
		'woocommerce_gla_attribute_mapping_sources_custom_attributes',
		function( $values ) {
			return array_merge( $values, ['material']);
		}
	);
```

1. Create a product variant with a Custom attribute named "material" based variations.
2. Create an attribute mapping rule as (target Material, source material,  Apply to ALL)
3. Save
4. Sync your product (using connection test is ok)
5. See the Material attribute is being loaded in Merchant.
6. Create a simple product.
7. Add an attribute material
8. Sync that product
9. See the Material attribute is being loaded in Merchant.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Bug in Attribute Mapping  - with Taxonomy based rules not being applied in variations.
