### PR TITLE
Use willReturnOnConsecutiveCalls instead of `at` for Unit Tests

### DIFF
--- a/tests/Unit/MultichannelMarketing/GLAChannelTest.php
+++ b/tests/Unit/MultichannelMarketing/GLAChannelTest.php
@@ -69,10 +69,11 @@ class GLAChannelTest extends UnitTest {
 
 	public function test_get_setup_url_changes_based_on_setup_status() {
 		// Return TRUE the first time `is_setup_complete` is called.
-		$this->merchant_center->expects( $this->at( 0 ) )->method( 'is_setup_complete' )->willReturn( true );
-
 		// Return FALSE the second time `is_setup_complete` is called. To test that the setup URL changes.
-		$this->merchant_center->expects( $this->at( 1 ) )->method( 'is_setup_complete' )->willReturn( false );
+		$this->merchant_center
+			->expects( $this->exactly( 2 ) )
+			->method( 'is_setup_complete' )
+			->willReturnOnConsecutiveCalls( true, false );
 
 		$setup_url_complete = $this->gla_channel->get_setup_url();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR replaces any calls to `at()` in the unit tests which is a deprecated function. There was only one location where this was being used and it's been replaced with `willReturnOnConsecutiveCalls`

Closes #1932


### Detailed test instructions:
1. Setup unit test `bin/install-wp-tests.sh <db_name> <db_user> <db_pass>`
2. Run unit tests `vendor/bin/phpunit`
3. Confirm that there are no longer any warnings


### Changelog entry
* Dev - Use "willReturnOnConsecutiveCalls" instead of "at" for unit tests.
