### PR TITLE
Unit test support for PHP 8.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8323a1d460b1fef47a0150020cfc1f00",
+    "content-hash": "d27a5e47bfc44babb60f1b0d9d7b8085",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -828,16 +828,16 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v3.21.12",
+            "version": "v3.22.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "93019df2df0f8c5c01757ef79f3f077d2cb35b65"
+                "reference": "ff28a64946708e13f2be627b5e5561f247ecf95c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/93019df2df0f8c5c01757ef79f3f077d2cb35b65",
-                "reference": "93019df2df0f8c5c01757ef79f3f077d2cb35b65",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/ff28a64946708e13f2be627b5e5561f247ecf95c",
+                "reference": "ff28a64946708e13f2be627b5e5561f247ecf95c",
                 "shasum": ""
             },
             "require": {
@@ -866,9 +866,9 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.21.12"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.22.2"
             },
-            "time": "2022-12-14T14:50:49+00:00"
+            "time": "2023-03-10T17:52:03+00:00"
         },
         {
             "name": "googleads/google-ads-php",

--- a/composer.lock
+++ b/composer.lock
@@ -442,16 +442,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.3.2",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "ea7dda77098b96e666c5ef382452f94841e439cd"
+                "reference": "4dd1e007f22a927ac77da5a3fbb067b42d3bc224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/ea7dda77098b96e666c5ef382452f94841e439cd",
-                "reference": "ea7dda77098b96e666c5ef382452f94841e439cd",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/4dd1e007f22a927ac77da5a3fbb067b42d3bc224",
+                "reference": "4dd1e007f22a927ac77da5a3fbb067b42d3bc224",
                 "shasum": ""
             },
             "require": {
@@ -466,6 +466,7 @@
                 "psr/http-factory": "^1.0"
             },
             "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
                 "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
             },
             "type": "library",
@@ -498,22 +499,22 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.3.2"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.4.0"
             },
-            "time": "2022-12-19T17:10:46+00:00"
+            "time": "2023-02-09T21:01:23+00:00"
         },
         {
             "name": "google/apiclient",
-            "version": "v2.13.0",
+            "version": "v2.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "b653a338c5a658adf6df4bb2f44c2cc02fe7eb1d"
+                "reference": "53c3168fd1836ec21d28a768f78a8c0e44046ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/b653a338c5a658adf6df4bb2f44c2cc02fe7eb1d",
-                "reference": "b653a338c5a658adf6df4bb2f44c2cc02fe7eb1d",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/53c3168fd1836ec21d28a768f78a8c0e44046ec4",
+                "reference": "53c3168fd1836ec21d28a768f78a8c0e44046ec4",
                 "shasum": ""
             },
             "require": {
@@ -568,22 +569,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.13.0"
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.13.2"
             },
-            "time": "2022-12-19T22:17:11+00:00"
+            "time": "2023-04-06T14:59:47+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.286.0",
+            "version": "v0.295.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "4a00eb9803e01f97d96e49fd82dbb03802610def"
+                "reference": "c2f808705d054015adbbbd6c819626843c64b34b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/4a00eb9803e01f97d96e49fd82dbb03802610def",
-                "reference": "4a00eb9803e01f97d96e49fd82dbb03802610def",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/c2f808705d054015adbbbd6c819626843c64b34b",
+                "reference": "c2f808705d054015adbbbd6c819626843c64b34b",
                 "shasum": ""
             },
             "require": {
@@ -612,22 +613,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.286.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.295.0"
             },
-            "time": "2023-02-05T01:20:11+00:00"
+            "time": "2023-04-08T01:08:13+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "0865c44ab50378f7b145827dfcbd1e7a238f7759"
+                "reference": "f1f0d0319e2e7750ebfaa523c78819792a9ed9f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/0865c44ab50378f7b145827dfcbd1e7a238f7759",
-                "reference": "0865c44ab50378f7b145827dfcbd1e7a238f7759",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/f1f0d0319e2e7750ebfaa523c78819792a9ed9f7",
+                "reference": "f1f0d0319e2e7750ebfaa523c78819792a9ed9f7",
                 "shasum": ""
             },
             "require": {
@@ -640,8 +641,8 @@
             },
             "require-dev": {
                 "guzzlehttp/promises": "0.1.1|^1.3",
-                "kelvinmo/simplejwt": "^0.2.5|^0.5.1",
-                "phpseclib/phpseclib": "^2.0.31",
+                "kelvinmo/simplejwt": "0.7.0",
+                "phpseclib/phpseclib": "^2.0.31||^3.0",
                 "phpspec/prophecy-phpunit": "^1.1||^2.0",
                 "phpunit/phpunit": "^7.5||^9.0.0",
                 "sebastian/comparator": ">=1.2.3",
@@ -670,9 +671,9 @@
             "support": {
                 "docs": "https://googleapis.github.io/google-auth-library-php/main/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.25.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.26.0"
             },
-            "time": "2023-01-26T22:04:14+00:00"
+            "time": "2023-04-05T15:11:57+00:00"
         },
         {
             "name": "google/common-protos",
@@ -1147,16 +1148,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.3",
+            "version": "2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "67c26b443f348a51926030c83481b85718457d3d"
+                "reference": "3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/67c26b443f348a51926030c83481b85718457d3d",
-                "reference": "67c26b443f348a51926030c83481b85718457d3d",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf",
+                "reference": "3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf",
                 "shasum": ""
             },
             "require": {
@@ -1246,7 +1247,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.4"
             },
             "funding": [
                 {
@@ -1262,7 +1263,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-26T14:07:24+00:00"
+            "time": "2023-03-09T13:19:02+00:00"
         },
         {
             "name": "league/container",
@@ -1683,16 +1684,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.18",
+            "version": "3.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "f28693d38ba21bb0d9f0c411ee5dae2b178201da"
+                "reference": "cc181005cf548bfd8a4896383bb825d859259f95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/f28693d38ba21bb0d9f0c411ee5dae2b178201da",
-                "reference": "f28693d38ba21bb0d9f0c411ee5dae2b178201da",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/cc181005cf548bfd8a4896383bb825d859259f95",
+                "reference": "cc181005cf548bfd8a4896383bb825d859259f95",
                 "shasum": ""
             },
             "require": {
@@ -1773,7 +1774,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.18"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.19"
             },
             "funding": [
                 {
@@ -1789,7 +1790,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-17T18:26:50+00:00"
+            "time": "2023-03-05T17:13:09+00:00"
         },
         {
             "name": "psr/cache",
@@ -1890,21 +1891,21 @@
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -1924,7 +1925,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP clients",
@@ -1936,27 +1937,27 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/master"
+                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
             },
-            "time": "2020-06-29T06:28:15+00:00"
+            "time": "2023-04-10T20:12:12+00:00"
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -1976,7 +1977,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for PSR-7 HTTP message factories",
@@ -1991,31 +1992,31 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -2044,9 +2045,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -61,20 +61,26 @@ use Google\ApiCore\PagedListResponse;
 /**
  * Trait GoogleAdsClient
  *
- * @property int                                      $ads_id
- * @property MockObject|ConversionActionServiceClient $conversion_action_service
- * @property MockObject|CustomerServiceClient         $customer_service
- * @property MockObject|GoogleAdsClient               $client
- * @property MockObject|GoogleAdsServiceClient        $service_client
- *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait
  */
 trait GoogleAdsClientTrait {
 
 	use MicroTrait;
 
+	/** @var MockObject|ConversionActionServiceClient $conversion_action_service */
+	protected $conversion_action_service;
+
+	/** @var MockObject|CustomerServiceClient $customer_service */
+	protected $customer_service;
+
+	/** @var MockObject|GoogleAdsClient $client */
 	protected $client;
+
+	/** @var MockObject|GoogleAdsServiceClient $service_client */
 	protected $service_client;
+
+	/** @var int $ads_id */
+	protected $ads_id;
 
 	/**
 	 * Generate a mocked GoogleAdsClient.

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -19,13 +19,19 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsAssetGroupAssetTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|OptionsInterface $options
- * @property AdsAssetGroupAsset          $asset_group_asset
  */
 class AdsAssetGroupAssetTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var MockObject|AdsAsset $asset */
+	protected $asset;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var AdsAssetGroupAsset $asset_group_asset */
+	protected $asset_group_asset;
 
 	protected const TEST_CAMPAIGN_ID      = 1234567890;
 	protected const TEST_ASSET_GROUP_ID   = 5566778899;

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -22,13 +22,19 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsAssetGroupTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|OptionsInterface $options
- * @property AdsAssetGroup               $asset_group
  */
 class AdsAssetGroupTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var MockObject|AdsAssetGroupAsset $asset_group_asset */
+	protected $asset_group_asset;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var AdsAssetGroup $asset_group */
+	protected $asset_group;
 
 	protected const TEST_CAMPAIGN_ID      = 1234567890;
 	protected const TEST_ASSET_GROUP_ID   = 5566778899;

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -23,14 +23,19 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsAssetTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|OptionsInterface $options
- * @property AdsAsset                    $asset
- * @property MockObject|WP               $wp
  */
 class AdsAssetTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/** @var AdsAsset $asset */
+	protected $asset;
 
 	protected const MAX_PAYLOAD_BYTES = 30 * 1024 * 1024;
 	protected const TEMPORARY_ID      = -5;

--- a/tests/Unit/API/Google/AdsCampaignBudgetTest.php
+++ b/tests/Unit/API/Google/AdsCampaignBudgetTest.php
@@ -15,13 +15,16 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsCampaignBudgetTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|OptionsInterface $options
- * @property AdsCampaignBudget           $budget
  */
 class AdsCampaignBudgetTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var AdsCampaignBudget $budget */
+	protected $budget;
 
 	protected const TEST_CAMPAIGN_ID = 1234567890;
 	protected const TEST_BUDGET_ID   = 4455667788;

--- a/tests/Unit/API/Google/AdsCampaignCriterionTest.php
+++ b/tests/Unit/API/Google/AdsCampaignCriterionTest.php
@@ -14,12 +14,13 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsCampaignCriterionTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property AdsCampaignCriterion $campaign_criterion
  */
 class AdsCampaignCriterionTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var AdsCampaignCriterion $campaign_criterion */
+	protected $campaign_criterion;
 
 	protected const TEST_CAMPAIGN_ID = 1234567890;
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -25,19 +25,34 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsCampaignTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|AdsAssetGroup        $asset_group
- * @property MockObject|AdsCampaignBudget    $budget
- * @property MockObject|AdsCampaignCriterion $criterion
- * @property MockObject|OptionsInterface     $options
- * @property AdsCampaign                     $campaign
- * @property Container                       $container
- * @property GoogleHelper                    $google_helper
- * @property WC                              $wc
  */
 class AdsCampaignTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var MockObject|AdsAssetGroup $asset_group */
+	protected $asset_group;
+
+	/** @var MockObject|AdsCampaignBudget $budget */
+	protected $budget;
+
+	/** @var MockObject|AdsCampaignCriterion $criterion */
+	protected $criterion;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var AdsCampaign $campaign */
+	protected $campaign;
+
+	/** @var Container $container */
+	protected $container;
+
+	/** @var GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var WC $wc */
+	protected $wc;
 
 	protected const TEST_CAMPAIGN_ID = 1234567890;
 	protected const BASE_COUNTRY     = 'US';

--- a/tests/Unit/API/Google/AdsConversionActionTest.php
+++ b/tests/Unit/API/Google/AdsConversionActionTest.php
@@ -18,13 +18,16 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsConversionActionTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|OptionsInterface  $options
- * @property AdsConversionAction          $conversion_action
  */
 class AdsConversionActionTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var AdsConversionAction $conversion_action */
+	protected $conversion_action;
 
 	protected const TEST_CONVERSION_ACTION_ID = 1234567890;
 	protected const TEST_CONVERSION_NAME      = '[a12b] Google Listings and Ads purchase action';

--- a/tests/Unit/API/Google/AdsReportTest.php
+++ b/tests/Unit/API/Google/AdsReportTest.php
@@ -20,15 +20,22 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsReportTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|AdsCampaign      $ads_campaign
- * @property MockObject|OptionsInterface $options
- * @property AdsReport                   $report
- * @property Container                   $container
  */
 class AdsReportTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var MockObject|AdsCampaign $ads_campaign */
+	protected $ads_campaign;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var AdsReport $report */
+	protected $report;
+
+	/** @var Container $container */
+	protected $container;
 
 	protected const TEST_ADS_ID = 1234567890;
 

--- a/tests/Unit/API/Google/AdsTest.php
+++ b/tests/Unit/API/Google/AdsTest.php
@@ -21,13 +21,16 @@ defined( 'ABSPATH' ) || exit;
  * Class AdsTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|OptionsInterface  $options
- * @property Ads                          $ads
  */
 class AdsTest extends UnitTest {
 
 	use GoogleAdsClientTrait;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var Ads $ads */
+	protected $ads;
 
 	protected const TEST_ADS_ID      = 1234567890;
 	protected const TEST_MERCHANT_ID = 2345678901;

--- a/tests/Unit/API/Google/MerchantMetricsTest.php
+++ b/tests/Unit/API/Google/MerchantMetricsTest.php
@@ -29,14 +29,23 @@ defined( 'ABSPATH' ) || exit;
  * Class MerchantTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property  MockObject|ShoppingContent  $shopping_client
- * @property  MockObject|GoogleAdsClient  $ads_client
- * @property  MockObject|OptionsInterface $options
- * @property  MerchantMetrics             $metrics
- * @property  string                      $tomorrow
  */
 class MerchantMetricsTest extends UnitTest {
+
+	/** @var MockObject|ShoppingContent $shopping_client */
+	protected $shopping_client;
+
+	/** @var MockObject|GoogleAdsClient $ads_client */
+	protected $ads_client;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MerchantMetrics $metrics */
+	protected $metrics;
+
+	/** @var string $tomorrow */
+	protected $tomorrow;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -34,14 +34,22 @@ defined( 'ABSPATH' ) || exit;
  * Class MerchantTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property  MockObject|ShoppingContent  $service
- * @property  MockObject|OptionsInterface $options
- * @property  Merchant                    $merchant
  */
 class MerchantTest extends UnitTest {
 
 	use MerchantTrait;
+
+	/** @var MockObject|ShoppingContent $service */
+	protected $service;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var Merchant $merchant */
+	protected $merchant;
+
+	/** @var int $merchant_id */
+	protected $merchant_id;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -25,20 +25,37 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
  * @group Middleware
- *
- * @property MockObject|Ads                  $ads
- * @property MockObject|DateTimeUtility      $date_utility
- * @property MockObject|GoogleHelper         $google_helper
- * @property MockObject|Merchant             $merchant
- * @property MockObject|WP                   $wp
- * @property MockObject|OptionsInterface     $options
- * @property MockObject|TransientsInterface  $transients
- * @property Middleware                      $middleware
- * @property Container                       $container
  */
 class MiddlewareTest extends UnitTest {
 
 	use GuzzleClientTrait;
+
+	/** @var MockObject|Ads $ads */
+	protected $ads;
+
+	/** @var MockObject|DateTimeUtility $date_utility */
+	protected $date_utility;
+
+	/** @var MockObject|GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var MockObject|Merchant $merchant */
+	protected $merchant;
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|TransientsInterface $transients */
+	protected $transients;
+
+	/** @var Middleware $middleware */
+	protected $middleware;
+
+	/** @var Container $container */
+	protected $container;
 
 	protected const TEST_ADS_ID      = 12345678;
 	protected const TEST_MERCHANT_ID = 23456781;

--- a/tests/Unit/API/Google/SiteVerificationTest.php
+++ b/tests/Unit/API/Google/SiteVerificationTest.php
@@ -20,14 +20,23 @@ defined( 'ABSPATH' ) || exit;
  * Class SiteVerificationTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
- *
- * @property MockObject|OptionsInterface       $options
- * @property MockObject|SiteVerficationService $verification_service
- * @property SiteVerification                  $verficiation
- * @property Container                         $container
- * @property string                            $site_url
  */
 class SiteVerificationTest extends UnitTest {
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|SiteVerficationService $verification_service */
+	protected $verification_service;
+
+	/** @var SiteVerification $verification */
+	protected $verification;
+
+	/** @var Container $container */
+	protected $container;
+
+	/** @var string $site_url */
+	protected $site_url;
 
 	protected const TEST_META_TAG = '<meta name="google-site-verification" content="abc" />';
 

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -14,11 +13,14 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class AccountControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
- *
- * @property RESTServer                $rest_server
- * @property AccountService|MockObject $account
  */
 class AccountControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|AccountService $account */
+	protected $account;
+
+	/** @var AccountController $controller */
+	protected $controller;
 
 	protected const ROUTE_ACCOUNTS           = '/wc/gla/ads/accounts';
 	protected const ROUTE_CONNECTION         = '/wc/gla/ads/connection';

--- a/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AssetGroupController;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
@@ -13,11 +12,14 @@ use Exception;
  * Class AssetSuggestionsControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
- *
- * @property RESTServer               $rest_server
- * @property AdsAssetGroup|MockObject $asset_group
  */
 class AssetGroupControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|AdsAssetGroup $asset_group */
+	protected $asset_group;
+
+	/** @var AssetGroupController $controller */
+	protected $controller;
 
 	protected const TEST_CAMPAIGN_ID       = 1234567890;
 	protected const TEST_ASSET_GROUP_ID    = 9876543210;

--- a/tests/Unit/API/Site/Controllers/Ads/AssetSuggestionsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetSuggestionsControllerTest.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AssetSuggestionsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AssetSuggestionsController;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
@@ -13,11 +12,14 @@ use Exception;
  * Class AssetSuggestionsControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
- *
- * @property RESTServer                         $rest_server
- * @property AssetSuggestionsService|MockObject $assets_suggestions
  */
 class AssetSuggestionsControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|AssetSuggestionsService $assets_suggestions */
+	protected $assets_suggestions;
+
+	/** @var AssetsSuggestionsController $controller */
+	protected $controller;
 
 	protected const ROUTE_FINAL_URL_SUGGESTIONS = '/wc/gla/assets/final-url/suggestions';
 	protected const ROUTE_ASSETS_SUGGESTIONS    = '/wc/gla/assets/suggestions';

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -14,13 +14,20 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class BudgetRecommendationControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
- *
- * @property Ads|MockObject                       $ads
- * @property BudgetRecommendationQuery|MockObject $budget_recommendation_query
- * @property ISO3166DataProvider|MockObject       $iso_provider;
- * @property BudgetRecommendationController       $controller
  */
 class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|Ads $ads */
+	protected $ads;
+
+	/** @var MockObject|BudgetRecommendationQuery $budget_recommendation_query */
+	protected $budget_recommendation_query;
+
+	/** @var MockObject|ISO3166DataProvider $iso_provider; */
+	protected $iso_provider;
+
+	/** @var BudgetRecommendationController $controller */
+	protected $controller;
 
 	protected const ROUTE_BUDGET_RECOMMENDATION = '/wc/gla/ads/campaigns/budget-recommendation';
 

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -23,7 +23,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|BudgetRecommendationQuery $budget_recommendation_query */
 	protected $budget_recommendation_query;
 
-	/** @var MockObject|ISO3166DataProvider $iso_provider; */
+	/** @var MockObject|ISO3166DataProvider $iso_provider */
 	protected $iso_provider;
 
 	/** @var BudgetRecommendationController $controller */

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -14,12 +14,23 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class CampaignControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
- *
- * @property AdsCampaign|MockObject         $ads_campaign
- * @property ISO3166DataProvider|MockObject $iso_provider;
- * @property CampaignController             $controller
  */
 class CampaignControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|AdsCampaign $ads_campaign */
+	protected $ads_campaign;
+
+	/** @var MockObject|ISO3166DataProvider $iso_provider */
+	protected $iso_provider;
+
+	/** @var MockObject|GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var CampaignController $controller */
+	protected $controller;
+
+	/** @var bool $country_supported */
+	protected $country_supported;
 
 	protected const TEST_CAMPAIGN_ID = 1234567890;
 	protected const ROUTE_CAMPAIGNS  = '/wc/gla/ads/campaigns';

--- a/tests/Unit/API/Site/Controllers/Google/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Google/AccountControllerTest.php
@@ -14,11 +14,14 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class AccountControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Google
- *
- * @property Connection|MockObject $connection
- * @property AccountController     $controller
  */
 class AccountControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|Connection $connection */
+	protected $connection;
+
+	/** @var AccountController $controller */
+	protected $controller;
 
 	protected const ROUTE_CONNECT     = '/wc/gla/google/connect';
 	protected const ROUTE_CONNECTED   = '/wc/gla/google/connected';

--- a/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
@@ -15,14 +15,23 @@ use WP_Error;
  * Class AccountControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Jetpack
- *
- * @property Manager|MockObject    $manager
- * @property Middleware|MockObject $middleware
- * @property Options|MockObject    $options
- * @property Tokens|MockObject     $tokens
- * @property AccountController     $controller
  */
 class AccountControllerTest extends RESTControllerUnitTest {
+
+	/** @var Manager|MockObject $manager */
+	protected $manager;
+
+	/** @var Middleware|MockObject $middleware */
+	protected $middleware;
+
+	/** @var Options|MockObject $options */
+	protected $options;
+
+	/** @var Tokens|MockObject $tokens */
+	protected $tokens;
+
+	/** @var AccountController $controller */
+	protected $controller;
 
 	protected const ROUTE_CONNECT   = '/wc/gla/jetpack/connect';
 	protected const ROUTE_CONNECTED = '/wc/gla/jetpack/connected';

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -21,6 +21,12 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class AccountControllerTest extends RESTControllerUnitTest {
 
+	/** @var MockObject|AccountService $account */
+	protected $account;
+
+	/** @var AccountController $controller */
+	protected $controller;
+
 	protected const ROUTE_ACCOUNTS        = '/wc/gla/mc/accounts';
 	protected const ROUTE_CLAIM_OVERWRITE = '/wc/gla/mc/accounts/claim-overwrite';
 	protected const ROUTE_SWITCH_URL      = '/wc/gla/mc/accounts/switch-url';

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ContactInformationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ContactInformationControllerTest.php
@@ -19,16 +19,29 @@ defined( 'ABSPATH' ) || exit;
  * Class PhoneNumberControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
- *
- * @property MockObject|ContactInformation $contact_information
- * @property MockObject|Settings           $google_settings
- * @property MockObject|Merchant           $merchant
- * @property MockObject|OptionsInterface   $options
- * @property MockObject|AddressUtility     $address_utility
- * @property RESTServer                    $rest_server
- * @property ContactInformationController  $contact_information_controller
  */
 class ContactInformationControllerTest extends ContainerAwareUnitTest {
+
+	/** @var MockObject|ContactInformation $contact_information */
+	protected $contact_information;
+
+	/** @var MockObject|Settings $google_settings */
+	protected $google_settings;
+
+	/** @var MockObject|Merchant $merchant */
+	protected $merchant;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|AddressUtility $address_utility */
+	protected $address_utility;
+
+	/** @var RESTServer $rest_server */
+	protected $rest_server;
+
+	/** @var ContactInformationController $contact_information_controller */
+	protected $contact_information_controller;
 
 	use MerchantTrait;
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
@@ -6,7 +6,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerificationException;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\PhoneNumber;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -15,11 +14,14 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class PhoneNumberControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
- *
- * @property RESTServer                   $rest_server
- * @property PhoneVerification|MockObject $phone_verification
  */
 class PhoneVerificationControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|PhoneVerification $phone_verification */
+	protected $phone_verification;
+
+	/** @var PhoneVerificationController $controller */
+	protected $controller;
 
 	protected const ROUTE_REQUEST_VERIFICATION     = '/wc/gla/mc/phone-verification/request';
 	protected const ROUTE_VERIFY_PHONE             = '/wc/gla/mc/phone-verification/verify';

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PolicyComplianceCheckControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PolicyComplianceCheckControllerTest.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\PolicyComplianceCheckController;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PolicyComplianceCheck;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -12,11 +11,14 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class PolicyComplianceCheckControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
- *
- * @property RESTServer                   $rest_server
- * @property PolicyComplianceCheck|MockObject $policy_check
  */
 class PolicyComplianceCheckControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|PolicyComplianceCheck $policy_compliance_check */
+	protected $policy_compliance_check;
+
+	/** @var PolicyComplianceCheckController $controller */
+	protected $controller;
 
 	protected const POLICY_CHECK = '/wc/gla/mc/policy_check';
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingRateControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingRateControllerTest.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingRateController;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -12,11 +11,14 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class ShippingRateControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
- *
- * @property RESTServer                   $rest_server
- * @property ShippingRateQuery|MockObject $shipping_rate_query
  */
 class ShippingRateControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|ShippingRateQuery $shipping_rate_query */
+	protected $shipping_rate_query;
+
+	/** @var ShippingRateController $controller */
+	protected $controller;
 
 	protected const ROUTE_RATES = '/wc/gla/mc/shipping/rates';
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SupportedCountriesControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SupportedCountriesControllerTest.php
@@ -14,12 +14,17 @@ defined( 'ABSPATH' ) || exit;
  * Class SupportedCountriesControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
- *
- * @property MockObject|GoogleHelper      $google_helper
- * @property MockObject|WC                $wc
- * @property SupportedCountriesController $supported_countries_controller
  */
 class SupportedCountriesControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
+
+	/** @var SupportedCountriesController $supported_countries_controller */
+	protected $supported_countries_controller;
 
 	protected const ROUTE = '/wc/gla/mc/countries';
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SyncableProductsCountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SyncableProductsCountControllerTest.php
@@ -14,14 +14,16 @@ defined( 'ABSPATH' ) || exit;
  * Class SyncableProductsCountControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
- *
- * @property JobRepository|MockObject      $job_repository
- * @property OptionsInterface|MockObject   $options
  */
 class SyncableProductsCountControllerTest extends RESTControllerUnitTest {
 
+	/** @var MockObject|JobRepository|MockObject $job_repository */
+	protected $job_repository;
+
+	/** @var OptionsInterface|MockObject $options */
+	protected $options;
+
 	protected const ROUTE_REQUEST = '/wc/gla/mc/syncable-products-count';
-	private $job_repository;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/Admin/RedirectsTest.php
+++ b/tests/Unit/Admin/RedirectsTest.php
@@ -15,6 +15,18 @@ use PHPUnit\Framework\TestCase;
 
 class RedirectsTest extends TestCase {
 
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/** @var MockObject|Redirect $redirects */
+	protected $redirects;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
 	/**
 	 * Setup tests
 	 *

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -23,17 +23,32 @@ defined( 'ABSPATH' ) || exit;
  * Class AccountServiceTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads
- *
- * @property MockObject|Ads                 $ads
- * @property MockObject|AdsConversionAction $conversion_action
- * @property MockObject|Merchant            $merchant
- * @property MockObject|Middleware          $middleware
- * @property MockObject|AdsAccountState     $state
- * @property AccountService                 $account
- * @property Container                      $container
- * @property OptionsInterface               $options
  */
 class AccountServiceTest extends UnitTest {
+
+	/** @var MockObject|Ads $ads */
+	protected $ads;
+
+	/** @var MockObject|AdsConversionAction $conversion_action */
+	protected $conversion_action;
+
+	/** @var MockObject|Merchant $merchant */
+	protected $merchant;
+
+	/** @var MockObject|Middleware $middleware */
+	protected $middleware;
+
+	/** @var MockObject|AdsAccountState $state */
+	protected $state;
+
+	/** @var AccountService $account */
+	protected $account;
+
+	/** @var Container $container */
+	protected $container;
+
+	/** @var OptionsInterface $options */
+	protected $options;
 
 	protected const TEST_ACCOUNT_ID        = 1234567890;
 	protected const TEST_OLD_ACCOUNT_ID    = 2345678901;

--- a/tests/Unit/Ads/AdsServiceTest.php
+++ b/tests/Unit/Ads/AdsServiceTest.php
@@ -14,12 +14,17 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads
  *
  * @group AdsService
- *
- * @property MockObject|AdsAccountState     $state
- * @property AdsService                     $ads_service
- * @property OptionsInterface               $options
  */
 class AdsServiceTest extends UnitTest {
+
+	/** @var MockObject|AdsAccountState $state */
+	protected $state;
+
+	/** @var AdsService $ads_service */
+	protected $ads_service;
+
+	/** @var OptionsInterface $options */
+	protected $options;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -33,7 +33,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 	/** @var MockObject|ImageUtility $image_utility */
 	protected $image_utility;
 
-	/** @var MockObject|AdsAssetGroupAsset asset_group_asset */
+	/** @var MockObject|AdsAssetGroupAsset $asset_group_asset */
 	protected $asset_group_asset;
 
 	/** @var AssetSuggestionsService $asset_suggestions */

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -25,27 +25,58 @@ defined( 'ABSPATH' ) || exit;
  * Class AssetSuggestionsServiceTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads
- *
- * @property MockObject|WP  $wp
- * @property MockObject|WC  $wc
- * @property MockObject|ImageUtility  $image_utility
- * @property MockObject|wpdb  $wpdb
- * @property MockObject|AdsAssetGroupAsset  $asset_group_asset
- * @property AssetSuggestionsService  $asset_suggestions
- * @property \WP_Post  $post
- * @property \WP_Term  $term
- * @property array  $suggested_post
- * @property array  $suggested_term
- * @property DimensionUtility  $big_image
- * @property DimensionUtility  $small_image
- * @property DimensionUtility  $normal_image
- * @property DimensionUtility  $suggested_image_square
- * @property DimensionUtility  $suggested_image_landscape
- * @property DimensionUtility  $suggested_image_portrait
  */
 class AssetSuggestionsServiceTest extends UnitTest {
 
 	use DataTrait;
+
+	/** @var MockObject|ImageUtility $image_utility */
+	protected $image_utility;
+
+	/** @var MockObject|AdsAssetGroupAsset asset_group_asset */
+	protected $asset_group_asset;
+
+	/** @var AssetSuggestionsService $asset_suggestions */
+	protected $asset_suggestions;
+
+	/** @var DimensionUtility $big_image */
+	protected $big_image;
+
+	/** @var DimensionUtility $small_image */
+	protected $small_image;
+
+	/** @var DimensionUtility $normal_image */
+	protected $normal_image;
+
+	/** @var DimensionUtility $suggested_image_square */
+	protected $suggested_image_square;
+
+	/** @var DimensionUtility $suggested_image_landscape */
+	protected $suggested_image_landscape;
+
+	/** @var DimensionUtility $suggested_image_portrait */
+	protected $suggested_image_portrait;
+
+	/** @var \WP_Post $post */
+	protected $post;
+
+	/** @var \WP_Term $term */
+	protected $term;
+
+	/** @var array $suggested_post */
+	protected $suggested_post;
+
+	/** @var array $suggested_term */
+	protected $suggested_term;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/** @var MockObject|wpdb $wpdb */
+	protected $wpdb;
 
 	protected const DEFAULT_PER_PAGE                 = 30;
 	protected const DEFAULT_PER_PAGE_POSTS           = 15;

--- a/tests/Unit/Coupon/CouponMetaHandlerTest.php
+++ b/tests/Unit/Coupon/CouponMetaHandlerTest.php
@@ -14,11 +14,13 @@ use WP_UnitTestCase;
  * Class ProductMetaHandlerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon
- *
- * @property CouponMetaHandler $coupon_meta_handler
  */
 class CouponMetaHandlerTest extends WP_UnitTestCase {
+
 	use CouponTrait;
+
+	/** @var CouponMetaHandler $coupon_meta_handler */
+	protected $coupon_meta_handler;
 
 	public function test_magic_call_throws_exception_invalid_method_name() {
 		$this->expectException( BadMethodCallException::class );

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -22,20 +22,35 @@ use WC_Coupon;
  * Class CouponSyncerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon
- *
- * @property MockObject|GooglePromotionService $google_service
- * @property MockObject|MerchantCenterService  $merchant_center
- * @property MockObject|TargetAudience         $target_audience
- * @property MockObject|ValidatorInterface     $validator
- * @property CouponMetaHandler                 $coupon_meta
- * @property CouponHelper                      $coupon_helper
- * @property WC                                $wc
- * @property CouponSyncer                      $coupon_syncer
  */
 class CouponSyncerTest extends ContainerAwareUnitTest {
 
 	use SettingsTrait;
 	use CouponTrait;
+
+	/** @var MockObject|GooglePromotionService $google_service */
+	protected $google_service;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|TargetAudience $target_audience */
+	protected $target_audience;
+
+	/** @var MockObject|ValidatorInterface $validator */
+	protected $validator;
+
+	/** @var CouponMetaHandler $coupon_meta */
+	protected $coupon_meta;
+
+	/** @var CouponHelper $coupon_helper */
+	protected $coupon_helper;
+
+	/** @var CouponSyncer $coupon_syncer */
+	protected $coupon_syncer;
+
+	/** @var WC $wc */
+	protected $wc;
 
 	public function test_update_succeed() {
 		$coupon = $this->create_ready_to_sync_coupon();

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -20,15 +20,31 @@ use WC_Coupon;
  * Class SyncerHooksTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property MockObject|MerchantCenterService $merchant_center
- * @property MockObject|JobRepository $job_repository
- * @property MockObject|UpdateCoupon $update_coupon_job
- * @property WC $wc
- * @property SyncerHooks $syncer_hooks
  */
 class SyncerHooksTest extends ContainerAwareUnitTest {
+
 	use CouponTrait;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|JobRepository $job_repository */
+	protected $job_repository;
+
+	/** @var MockObject|DeleteCoupon $delete_coupon_job */
+	protected $delete_coupon_job;
+
+	/** @var MockObject|UpdateCoupon $update_coupon_job */
+	protected $update_coupon_job;
+
+	/** @var CouponHelper $coupon_helper */
+	protected $coupon_helper;
+
+	/** @var WC $wc */
+	protected $wc;
+
+	/** @var SyncerHooks $syncer_hooks */
+	protected $syncer_hooks;
 
 	public function test_create_new_simple_coupon_schedules_update_job() {
 		$this->update_coupon_job->expects( $this->once() )

--- a/tests/Unit/DB/ProductFeedQueryHelperTest.php
+++ b/tests/Unit/DB/ProductFeedQueryHelperTest.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use PHPUnit\Framework\MockObject\MockObject;
+
 use WP_REST_Request;
 use wpdb;
 
@@ -19,6 +21,27 @@ use wpdb;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB
  */
 class ProductFeedQueryHelperTest extends UnitTest {
+
+	/** @var MockObject|wpdb $wpdb */
+	protected $wpdb;
+
+	/** @var MockObject|ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var MockObject|MerchantCenterService $mc_service */
+	protected $mc_service;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
+
+	/** @var MockObject|ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|WP_REST_Request $request */
+	protected $request;
+
+	/** @var ProductFeedQueryHelper $product_feed_query_helper */
+	protected $product_feed_query_helper;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
+++ b/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
@@ -6,13 +6,24 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Table;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\BudgetRecommendationTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use PHPUnit\Framework\MockObject\MockObject;
 use wpdb;
+
 /**
  * Class MigratorTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Migration
  */
 class BudgetRecommendationTableTest extends UnitTest {
+
+	/** @var MockObject|BudgetRecommendationTable $mock_budget_recommendation */
+	protected $mock_budget_recommendation;
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/** @var MockObject|wpdb $wpdb */
+	protected $wpdb;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/Google/GoogleHelperTest.php
+++ b/tests/Unit/Google/GoogleHelperTest.php
@@ -12,11 +12,14 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class GoogleHelperTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
- *
- * @property MockObject|WC $wc
- * @property GoogleHelper  $google_helper
  */
 class GoogleHelperTest extends UnitTest {
+
+	/** @var GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
 
 	public function test_get_mc_supported_countries_currencies() {
 		$supported = $this->google_helper->get_mc_supported_countries_currencies();

--- a/tests/Unit/Google/SiteVerificationMetaTest.php
+++ b/tests/Unit/Google/SiteVerificationMetaTest.php
@@ -14,11 +14,14 @@ defined( 'ABSPATH' ) || exit;
  * Class SiteVerificationMetaTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google
- *
- * @property MockObject|OptionsInterface $options
- * @property SiteVerificationMeta        $meta
  */
 class SiteVerificationMetaTest extends UnitTest {
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var SiteVerificationMeta $meta */
+	protected $meta;
 
 	protected const TEST_META_TAG = '<meta name="google-site-verification" content="abc" />';
 

--- a/tests/Unit/Integration/YoastWooCommerceSeoTest.php
+++ b/tests/Unit/Integration/YoastWooCommerceSeoTest.php
@@ -12,10 +12,11 @@ use WC_Helper_Product;
  * Class YoastWooCommerceSeoTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration
- *
- * @property YoastWooCommerceSeo $integration
  */
 class YoastWooCommerceSeoTest extends UnitTest {
+
+	/** @var YoastWooCommerceSeo $integration */
+	protected $integration;
 
 	protected const TEST_MPN  = '1234567';
 	protected const TEST_GTIN = '34567890';

--- a/tests/Unit/Jobs/CleanupSyncedProductsTest.php
+++ b/tests/Unit/Jobs/CleanupSyncedProductsTest.php
@@ -18,18 +18,31 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class CleanupSyncedProductsTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
- *
- * @property MockObject|ActionScheduler           $action_scheduler
- * @property MockObject|ActionSchedulerJobMonitor $monitor
- * @property MockObject|ProductSyncer             $product_syncer
- * @property MockObject|ProductRepository         $product_repository
- * @property MockObject|BatchProductHelper        $batch_product_helper
- * @property MockObject|MerchantCenterService     $merchant_center
- * @property CleanupSyncedProducts                $job
  */
 class CleanupSyncedProductsTest extends UnitTest {
 
 	use ProductTrait;
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|ProductSyncer $product_syncer */
+	protected $product_syncer;
+
+	/** @var MockObject|ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var MockObject|BatchProductHelper $batch_product_helper */
+	protected $batch_product_helper;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var CleanupSyncedProducts $job */
+	protected $job;
 
 	protected const JOB_NAME          = 'cleanup_synced_products';
 	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -23,20 +23,35 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class UpdateProductsTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
-
- * @property MockObject|ActionScheduler           $action_scheduler
- * @property MockObject|ActionSchedulerJobMonitor $monitor
- * @property MockObject|ProductSyncer             $product_syncer
- * @property MockObject|ProductRepository         $product_repository
- * @property MockObject|OptionsInterface         $options
- * @property MockObject|BatchProductHelper        $product_helper
- * @property MockObject|MerchantCenterService     $merchant_center
- * @property UpdateAllProducts                    $job
  */
 class UpdateAllProductsTest extends UnitTest {
 
 	use ProductTrait;
 	use JobTrait;
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|ProductSyncer $product_syncer */
+	protected $product_syncer;
+
+	/** @var MockObject|ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|BatchProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var UpdateAllProducts $job */
+	protected $job;
 
 	protected const JOB_NAME          = 'update_all_products';
 	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';

--- a/tests/Unit/Jobs/UpdateProductsTest.php
+++ b/tests/Unit/Jobs/UpdateProductsTest.php
@@ -19,18 +19,29 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class UpdateProductsTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
- *
- * @property MockObject|ActionScheduler           $action_scheduler
- * @property MockObject|ActionSchedulerJobMonitor $monitor
- * @property MockObject|ProductSyncer             $product_syncer
- * @property MockObject|ProductRepository         $product_repository
- * @property MockObject|MerchantCenterService     $merchant_center
- * @property UpdateProducts                       $job
  */
 class UpdateProductsTest extends UnitTest {
 
 	use ProductTrait;
 	use JobTrait;
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|ProductSyncer $product_syncer */
+	protected $product_syncer;
+
+	/** @var MockObject|ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var UpdateProducts $job */
+	protected $job;
 
 	protected const JOB_NAME          = 'update_products';
 	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -16,14 +16,23 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class UpdateShippingSettingsTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
- *
- * @property MockObject|ActionScheduler           $action_scheduler
- * @property MockObject|ActionSchedulerJobMonitor $monitor
- * @property MockObject|MerchantCenterService     $merchant_center
- * @property MockObject|GoogleSettings            $google_settings
- * @property UpdateShippingSettings               $job
  */
 class UpdateShippingSettingsTest extends UnitTest {
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|GoogleSettings $google_settings */
+	protected $google_settings;
+
+	/** @var UpdateShippingSettings $job */
+	protected $job;
 
 	public function test_job_is_scheduled() {
 		$this->merchant_center->expects( $this->any() )

--- a/tests/Unit/Jobs/UpdateSyncableProductsCountTest.php
+++ b/tests/Unit/Jobs/UpdateSyncableProductsCountTest.php
@@ -20,17 +20,28 @@ use WC_Helper_Product;
  * Class UpdateSyncableProductsCountTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
- *
- * @property MockObject|ActionScheduler           $action_scheduler
- * @property MockObject|ActionSchedulerJobMonitor $monitor
- * @property MockObject|ProductHelper             $product_helper
- * @property MockObject|ProductRepository         $product_repository
- * @property MockObject|OptionsInterface          $options
- * @property UpdateSyncableProductsCount          $job
  */
 class UpdateSyncableProductsCountTest extends UnitTest {
 
 	use ProductTrait;
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var UpdateSyncableProductsCount $job */
+	protected $job;
 
 	protected const BATCH_SIZE        = 2;
 	protected const JOB_NAME          = 'update_syncable_products_count';

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -31,24 +31,52 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
  * @group AccountService
- * @property MockObject|CleanupSyncedProducts $cleanup_synced
- * @property MockObject|Merchant              $merchant
- * @property MockObject|MerchantCenterService $mc_service
- * @property MockObject|MerchantIssueTable    $issue_table
- * @property MockObject|MerchantStatuses      $merchant_statuses
- * @property MockObject|Middleware            $middleware
- * @property MockObject|OptionsInterface      $options
- * @property MockObject|SiteVerification      $site_verification
- * @property MockObject|ShippingRateTable     $rate_table
- * @property MockObject|ShippingTimeTable     $time_table
- * @property MockObject|MerchantAccountState  $state
- * @property MockObject|TransientsInterface   $transients
- * @property AccountService                   $account
- * @property Container                        $container
  */
 class AccountServiceTest extends UnitTest {
 
 	use MerchantTrait;
+
+	/** @var MockObject|CleanupSyncedProducts $cleanup_synced */
+	protected $cleanup_synced;
+
+	/** @var MockObject|Merchant $merchant */
+	protected $merchant;
+
+	/** @var MockObject|MerchantCenterService $mc_service */
+	protected $mc_service;
+
+	/** @var MockObject|MerchantIssueTable $issue_table */
+	protected $issue_table;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
+
+	/** @var MockObject|Middleware $middleware */
+	protected $middleware;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|SiteVerification $site_verification */
+	protected $site_verification;
+
+	/** @var MockObject|ShippingRateTable $rate_table */
+	protected $rate_table;
+
+	/** @var MockObject|ShippingTimeTable $time_table */
+	protected $time_table;
+
+	/** @var MockObject|MerchantAccountState $state */
+	protected $state;
+
+	/** @var MockObject|TransientsInterface $transients */
+	protected $transients;
+
+	/** @var AccountService $account */
+	protected $account;
+
+	/** @var Container $container */
+	protected $container;
 
 	protected const TEST_ACCOUNT_ID     = 12345678;
 	protected const TEST_OLD_ACCOUNT_ID = 23456781;

--- a/tests/Unit/MerchantCenter/ContactInformationTest.php
+++ b/tests/Unit/MerchantCenter/ContactInformationTest.php
@@ -16,14 +16,19 @@ defined( 'ABSPATH' ) || exit;
  * Class ContactInformationTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
- *
- * @property  MockObject|Merchant $merchant
- * @property  MockObject|Settings $google_settings
- * @property  ContactInformation  $contact_information
  */
 class ContactInformationTest extends ContainerAwareUnitTest {
 
 	use MerchantTrait;
+
+	/** @var MockObject|Merchant $merchant */
+	protected $merchant;
+
+	/** @var MockObject|Settings $google_settings */
+	protected $google_settings;
+
+	/** @var ContactInformation $contact_information */
+	protected $contact_information;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -65,7 +65,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	/** @var MockObject|TargetAudience $target_audience */
 	protected $target_audience;
 
-	/** @var MockObject|TransientsInterface  $transients */
+	/** @var MockObject|TransientsInterface $transients */
 	protected $transients;
 
 	/** @var MerchantCenterService $mc_service */

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -30,27 +30,58 @@ defined( 'ABSPATH' ) || exit;
  * Class MerchantCenterServiceTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
- *
- * @property MockObject|AddressUtility       $address_utility
- * @property MockObject|ContactInformation   $contact_information
- * @property MockObject|GoogleHelper         $google_helper
- * @property MockObject|Merchant             $merchant
- * @property MockObject|MerchantAccountState $merchant_account_state
- * @property MockObject|MerchantStatuses     $merchant_statuses
- * @property MockObject|Settings             $settings
- * @property MockObject|ShippingRateQuery    $shipping_rate_query
- * @property MockObject|ShippingTimeQuery    $shipping_time_query
- * @property MockObject|TargetAudience       $target_audience
- * @property MockObject|TransientsInterface  $transients
- * @property MockObject|WC                   $wc
- * @property MockObject|WP                   $wp
- * @property MerchantCenterService           $mc_service
- * @property Container                       $container
- * @property OptionsInterface                $options
  */
 class MerchantCenterServiceTest extends UnitTest {
 
 	use MerchantTrait;
+
+	/** @var MockObject|AddressUtility $address_utility */
+	protected $address_utility;
+
+	/** @var MockObject|ContactInformation $contact_information */
+	protected $contact_information;
+
+	/** @var MockObject|GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var MockObject|Merchant $merchant */
+	protected $merchant;
+
+	/** @var MockObject|MerchantAccountState $merchant_account_state */
+	protected $merchant_account_state;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
+
+	/** @var MockObject|Settings $settings */
+	protected $settings;
+
+	/** @var MockObject|ShippingRateQuery $shipping_rate_query */
+	protected $shipping_rate_query;
+
+	/** @var MockObject|ShippingTimeQuery $shipping_time_query */
+	protected $shipping_time_query;
+
+	/** @var MockObject|TargetAudience $target_audience */
+	protected $target_audience;
+
+	/** @var MockObject|TransientsInterface  $transients */
+	protected $transients;
+
+	/** @var MerchantCenterService $mc_service */
+	protected $mc_service;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/** @var Container $container */
+	protected $container;
+
+	/** @var OptionsInterface $options */
+	protected $options;
 
 	protected const TEST_SETUP_COMPLETED = 1641038400;
 

--- a/tests/Unit/MerchantCenter/PhoneVerificationTest.php
+++ b/tests/Unit/MerchantCenter/PhoneVerificationTest.php
@@ -18,13 +18,20 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class PhoneVerificationTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
- *
- * @property MockObject|Merchant   $merchant
- * @property MockObject|WP         $wp
- * @property MockObject|ISOUtility $iso_utility
- * @property PhoneVerification     $phone_verification
  */
 class PhoneVerificationTest extends UnitTest {
+
+	/** @var MockObject|Merchant $merchant */
+	protected $merchant;
+
+	/** @var MockObject|ISOUtility $iso_utility */
+	protected $iso_utility;
+
+	/** @var PhoneVerification $phone_verification */
+	protected $phone_verification;
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
 
 	public function test_request_phone_verification() {
 		$this->iso_utility->expects( $this->any() )

--- a/tests/Unit/MerchantCenter/PolicyComplianceCheckTest.php
+++ b/tests/Unit/MerchantCenter/PolicyComplianceCheckTest.php
@@ -18,13 +18,20 @@ defined( 'ABSPATH' ) || exit;
  * Class PolicyComplianceCheckTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
- *
- * @property  MockObject|WC             $wc
- * @property  MockObject|GoogleHelper   $google_helper
- * @property  MockObject|TargetAudience $target_audience
- * @property  PolicyComplianceCheck     $policy_compliance_check
  */
 class PolicyComplianceCheckTest extends WPRequestUnitTest {
+
+	/** @var MockObject|GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var MockObject|TargetAudience $target_audience */
+	protected $target_audience;
+
+	/** @var PolicyComplianceCheck $policy_compliance_check */
+	protected $policy_compliance_check;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/MerchantCenter/ValidateAddressTest.php
+++ b/tests/Unit/MerchantCenter/ValidateAddressTest.php
@@ -15,13 +15,22 @@ defined( 'ABSPATH' ) || exit;
  * Class ContactInformationTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
- *
- * @property  MockObject|ContainerInterface $container_interface
- * @property  Settings $google_settings
  */
 class ValidateAddressTest extends ContainerAwareUnitTest {
 
 	use MerchantTrait;
+
+	/** @var MockObject|ContainerInterface $container_interface */
+	protected $container_interface;
+
+	/** @var Settings $google_settings */
+	protected $google_settings;
+
+	/** @var array $fields_to_validate */
+	protected $fields_to_validate;
+
+	/** @var array $locale_settings */
+	protected $locale_settings;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/MultichannelMarketing/GLAChannelTest.php
+++ b/tests/Unit/MultichannelMarketing/GLAChannelTest.php
@@ -24,16 +24,29 @@ defined( 'ABSPATH' ) || exit;
  * Class GLAChannelTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MultichannelMarketing
- *
- * @property GLAChannel                       $gla_channel
- * @property MockObject|MerchantCenterService $merchant_center
- * @property MockObject|AdsCampaign           $ads_campaign
- * @property MockObject|Ads                   $ads
- * @property MockObject|MerchantStatuses      $merchant_statuses
- * @property MockObject|ProductSyncStats      $product_sync_stats
- * @property MockObject|WC                    $wc
  */
 class GLAChannelTest extends UnitTest {
+
+	/** @var GLAChannel $gla_channel */
+	protected $gla_channel;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|AdsCampaign $ads_campaign */
+	protected $ads_campaign;
+
+	/** @var MockObject|Ads $ads */
+	protected $ads;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
+
+	/** @var MockObject|ProductSyncStats $product_sync_stats */
+	protected $product_sync_stats;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
 
 	public function test_get_slug_is_not_empty() {
 		$this->assertNotEmpty( $this->gla_channel->get_slug() );

--- a/tests/Unit/Notes/AttributeMappingNewFeatureTest.php
+++ b/tests/Unit/Notes/AttributeMappingNewFeatureTest.php
@@ -16,11 +16,14 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes
  *
  * @group AttributeMapping
- *
- * @property OptionsInterface        $options
- * @property AttributeMappingNewFeature  $note
  */
 class AttributeMappingNewFeatureTest extends UnitTest {
+
+	/** @var OptionsInterface $options */
+	protected $options;
+
+	/** @var AttributeMappingNewFeature $note */
+	protected $note;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/Notes/ReconnectWordPressTest.php
+++ b/tests/Unit/Notes/ReconnectWordPressTest.php
@@ -16,13 +16,20 @@ defined( 'ABSPATH' ) || exit;
  * Class ReconnectWordPressTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes
- *
- * @property MockObject|Connection $connection
- * @property OptionsInterface      $options
- * @property MerchantCenterService $merchant_center
- * @property ReconnectWordPress    $note
  */
 class ReconnectWordPressTest extends UnitTest {
+
+	/** @var MockObject|Connection $connection */
+	protected $connection;
+
+	/** @var OptionsInterface $options */
+	protected $options;
+
+	/** @var MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var ReconnectWordPress $note */
+	protected $note;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/Product/Attributes/AttributeManagerTest.php
+++ b/tests/Unit/Product/Attributes/AttributeManagerTest.php
@@ -19,12 +19,13 @@ use WC_Helper_Product;
  * Class AttributeManagerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property AttributeManager $attribute_manager
  */
 class AttributeManagerTest extends ContainerAwareUnitTest {
 
 	use PluginHelper;
+
+	/** @var AttributeManager $attribute_manager */
+	protected $attribute_manager;
 
 	public function test_update_throws_exception_if_attribute_inapplicable_to_product() {
 		$variable  = WC_Helper_Product::create_variation_product();

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -33,20 +33,35 @@ use WC_Product_Variation;
  * Class BatchProductHelperTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property WC                            $wc
- * @property ProductMetaHandler            $product_meta
- * @property ProductHelper                 $product_helper
- * @property MockObject|ValidatorInterface $validator
- * @property ProductFactory                $product_factory
- * @property MockObject|TargetAudience     $target_audience
- * @property BatchProductHelper            $batch_product_helper
- * @property AttributeMappingRulesQuery    $rules_query
  */
 class BatchProductHelperTest extends ContainerAwareUnitTest {
 
 	use ProductMetaTrait;
 	use ProductTrait;
+
+	/** @var ProductMetaHandler $product_meta */
+	protected $product_meta;
+
+	/** @var ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|ValidatorInterface $validator */
+	protected $validator;
+
+	/** @var ProductFactory $product_factory */
+	protected $product_factory;
+
+	/** @var MockObject|TargetAudience $target_audience */
+	protected $target_audience;
+
+	/** @var BatchProductHelper $batch_product_helper */
+	protected $batch_product_helper;
+
+	/** @var AttributeMappingRulesQuery $rules_query */
+	protected $rules_query;
+
+	/** @var WC $wc */
+	protected $wc;
 
 	public function test_filter_synced_products_all_synced() {
 		$synced_product = WC_Helper_Product::create_simple_product();

--- a/tests/Unit/Product/ProductFactoryTest.php
+++ b/tests/Unit/Product/ProductFactoryTest.php
@@ -19,15 +19,22 @@ use WC_Product;
  * Class ProductFactoryTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property MockObject|AttributeManager $attribute_manager
- * @property WC                          $wc
- * @property ProductFactory              $product_factory
- * @property AttributeMappingRulesQuery  $rules_query
  */
 class ProductFactoryTest extends ContainerAwareUnitTest {
 
 	use ProductTrait;
+
+	/** @var MockObject|AttributeManager $attribute_manager */
+	protected $attribute_manager;
+
+	/** @var ProductFactory $product_factory */
+	protected $product_factory;
+
+	/** @var AttributeMappingRulesQuery $rules_query */
+	protected $rules_query;
+
+	/** @var WC $wc */
+	protected $wc;
 
 	public function test_create() {
 		$product = WC_Helper_Product::create_simple_product();

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -25,17 +25,24 @@ use WC_Product;
  * Class ProductHelperTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property ProductMetaHandler        $product_meta
- * @property WC                        $wc
- * @property MockObject|TargetAudience $target_audience
- * @property ProductHelper             $product_helper
  */
 class ProductHelperTest extends ContainerAwareUnitTest {
 
 	use ProductMetaTrait;
 	use ProductTrait;
 	use SettingsTrait;
+
+	/** @var ProductMetaHandler $product_meta */
+	protected $product_meta;
+
+	/** @var MockObject|TargetAudience $target_audience */
+	protected $target_audience;
+
+	/** @var ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var WC $wc */
+	protected $wc;
 
 	/**
 	 * @param WC_Product $product

--- a/tests/Unit/Product/ProductMetaHandlerTest.php
+++ b/tests/Unit/Product/ProductMetaHandlerTest.php
@@ -14,12 +14,13 @@ use WP_UnitTestCase;
  * Class ProductMetaHandlerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property ProductMetaHandler $product_meta_handler
  */
 class ProductMetaHandlerTest extends WP_UnitTestCase {
 
 	use ProductTrait;
+
+	/** @var ProductMetaHandler $product_meta_handler */
+	protected $product_meta_handler;
 
 	public function test_magic_call_throws_exception_invalid_method_name() {
 		$this->expectException( BadMethodCallException::class );

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -19,14 +19,19 @@ use WC_Product;
  * Class ProductRepositoryTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property ProductRepository  $product_repository
- * @property ProductMetaHandler $product_meta
- * @property ProductHelper      $product_helper
  */
 class ProductRepositoryTest extends ContainerAwareUnitTest {
 
 	use ProductTrait;
+
+	/** @var ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var ProductMetaHandler $product_meta */
+	protected $product_meta;
+
+	/** @var ProductHelper $product_helper */
+	protected $product_helper;
 
 	public function test_find_returns_all_supported_products() {
 		// supported

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -34,21 +34,40 @@ use WC_Product;
  * Class ProductSyncerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property MockObject|GoogleProductService  $google_service
- * @property MockObject|TargetAudience        $target_audience
- * @property MockObject|MerchantCenterService $merchant_center
- * @property ProductMetaHandler               $product_meta
- * @property BatchProductHelper               $batch_helper
- * @property ProductHelper                    $product_helper
- * @property WC                               $wc
- * @property ProductSyncer                    $product_syncer
- * @property ProductRepository                $product_repository
- * @property AttributeMappingRulesQuery       $rules_query
  */
 class ProductSyncerTest extends ContainerAwareUnitTest {
 
 	use ProductTrait;
+
+	/** @var MockObject|GoogleProductService $google_service */
+	protected $google_service;
+
+	/** @var MockObject|TargetAudience $target_audience */
+	protected $target_audience;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var ProductMetaHandler $product_meta */
+	protected $product_meta;
+
+	/** @var BatchProductHelper $batch_helper */
+	protected $batch_helper;
+
+	/** @var ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var ProductSyncer $product_syncer */
+	protected $product_syncer;
+
+	/** @var ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var AttributeMappingRulesQuery $rules_query */
+	protected $rules_query;
+
+	/** @var WC $wc */
+	protected $wc;
 
 	public function test_update() {
 		$validator       = $this->createMock( ValidatorInterface::class );

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -20,19 +20,34 @@ use WC_Helper_Product;
  * Class SyncerHooksTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
- *
- * @property MockObject|MerchantCenterService $merchant_center
- * @property BatchProductHelper               $batch_helper
- * @property ProductHelper                    $product_helper
- * @property MockObject|JobRepository         $job_repository
- * @property MockObject|UpdateProducts        $update_products_job
- * @property MockObject|DeleteProducts        $delete_products_job
- * @property WC                               $wc
- * @property SyncerHooks                      $syncer_hooks
  */
 class SyncerHooksTest extends ContainerAwareUnitTest {
 
 	use ProductTrait;
+
+	/*** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var BatchProductHelper $batch_helper */
+	protected $batch_helper;
+
+	/** @var ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|JobRepository $job_repository */
+	protected $job_repository;
+
+	/** @var MockObject|UpdateProducts $update_products_job */
+	protected $update_products_job;
+
+	/** @var MockObject|DeleteProducts $delete_products_job */
+	protected $delete_products_job;
+
+	/** @var WC $wc */
+	protected $wc;
+
+	/** @var SyncerHooks $syncer_hooks */
+	protected $syncer_hooks;
 
 	public function test_create_new_simple_product_schedules_update_job() {
 		$this->update_products_job->expects( $this->once() )

--- a/tests/Unit/Shipping/LocationRatesProcessorTest.php
+++ b/tests/Unit/Shipping/LocationRatesProcessorTest.php
@@ -13,10 +13,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
  * Class LocationRatesProcessorTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
- *
- * @property LocationRatesProcessor $rates_processor
  */
 class LocationRatesProcessorTest extends UnitTest {
+
+	/** @var LocationRatesProcessor $rates_processor */
+	protected $rates_processor;
 
 	public function test_process_returns_only_most_expensive_flat_rate() {
 		$location       = new ShippingLocation( 21137, 'US', 'CA' );

--- a/tests/Unit/Shipping/ShippingSuggestionServiceTest.php
+++ b/tests/Unit/Shipping/ShippingSuggestionServiceTest.php
@@ -16,12 +16,18 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Class ShippingSuggestionServiceTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
- *
- * @property MockObject|ShippingZone   $shipping_zone
- * @property MockObject|WC             $wc
- * @property ShippingSuggestionService $suggestion_service
  */
 class ShippingSuggestionServiceTest extends UnitTest {
+
+	/** @var ShippingSuggestionService $suggestion_service */
+	protected $suggestion_service;
+
+	/** @var MockObject|ShippingZone $shipping_zone */
+	protected $shipping_zone;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
+
 	public function test_get_suggestions_returns_correct_data() {
 		$location = new ShippingLocation( 21137, 'US', 'CA' );
 

--- a/tests/Unit/Shipping/ShippingZoneTest.php
+++ b/tests/Unit/Shipping/ShippingZoneTest.php
@@ -20,14 +20,24 @@ use WC_Shipping_Zone;
  * Class ShippingZoneTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
- *
- * @property MockObject|WC                     $wc
- * @property MockObject|ZoneLocationsParser    $locations_parser
- * @property MockObject|ZoneMethodsParser      $methods_parser
- * @property MockObject|LocationRatesProcessor $rates_processor
- * @property ShippingZone                      $shipping_zone
  */
 class ShippingZoneTest extends UnitTest {
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
+
+	/** @var MockObject|ZoneLocationsParser $locations_parser */
+	protected $locations_parser;
+
+	/** @var MockObject|ZoneMethodsParser $methods_parser */
+	protected $methods_parser;
+
+	/** @var MockObject|LocationRatesProcessor $rates_processor */
+	protected $rates_processor;
+
+	/** @var ShippingZone $shipping_zone */
+	protected $shipping_zone;
+
 	public function test_returns_shipping_countries() {
 		$this->locations_parser->expects( $this->once() )
 			->method( 'parse' )

--- a/tests/Unit/Shipping/SyncerHooksTest.php
+++ b/tests/Unit/Shipping/SyncerHooksTest.php
@@ -18,14 +18,23 @@ use WC_Shipping_Zones;
  * Class SyncerHooksTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
- *
- * @property MockObject|MerchantCenterService  $merchant_center
- * @property MockObject|GoogleSettings         $google_settings
- * @property MockObject|UpdateShippingSettings $update_shipping_job
- * @property MockObject|JobRepository          $job_repository
- * @property SyncerHooks                       $syncer_hooks
  */
 class SyncerHooksTest extends UnitTest {
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|GoogleSettings $google_settings */
+	protected $google_settings;
+
+	/** @var MockObject|UpdateShippingSettings $update_shipping_job */
+	protected $update_shipping_job;
+
+	/** @var MockObject|JobRepository $job_repository */
+	protected $job_repository;
+
+	/** @var SyncerHooks $syncer_hooks */
+	protected $syncer_hooks;
 
 	/**
 	 * @var int The ID of an example shipping zone stored in DB.

--- a/tests/Unit/Shipping/ZoneLocationsParserTest.php
+++ b/tests/Unit/Shipping/ZoneLocationsParserTest.php
@@ -19,6 +19,10 @@ use WC_Shipping_Zone;
  * @property ZoneLocationsParser     $locations_parser
  */
 class ZoneLocationsParserTest extends UnitTest {
+
+	protected $google_helper;
+	protected $locations_parser;
+
 	public function test_returns_state_locations_if_regional_shipping_supported() {
 		$zone_locations = [
 			(object) [

--- a/tests/Unit/Shipping/ZoneMethodsParserTest.php
+++ b/tests/Unit/Shipping/ZoneMethodsParserTest.php
@@ -16,11 +16,15 @@ use WC_Shipping_Zone;
  * Class ZoneMethodsParserTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
- *
- * @property MockObject|WC     $wc
- * @property ZoneMethodsParser $methods_parser
  */
 class ZoneMethodsParserTest extends UnitTest {
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
+
+	/** @var ZoneMethodsParser $methods_parser */
+	protected $methods_parser;
+
 	public function test_returns_flat_rate_methods() {
 		$flat_rate     = $this->createMock( WC_Shipping_Flat_Rate::class );
 		$flat_rate->id = ZoneMethodsParser::METHOD_FLAT_RATE;

--- a/tests/Unit/Utility/AddressUtilityTest.php
+++ b/tests/Unit/Utility/AddressUtilityTest.php
@@ -11,10 +11,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingCo
  * Class AddressUtilityTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
- *
- * @property AddressUtility $address_utility
  */
 class AddressUtilityTest extends UnitTest {
+
+	/** @var AddressUtility $address_utility */
+	protected $address_utility;
 
 	public function test_returns_true_if_addresses_are_same() {
 		$address_1 = new AccountAddress();

--- a/tests/Unit/Utility/DateTimeUtilityTest.php
+++ b/tests/Unit/Utility/DateTimeUtilityTest.php
@@ -10,10 +10,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
  * Class DateTimeUtilityTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
- *
- * @property DateTimeUtility $datetime_utility
  */
 class DateTimeUtilityTest extends UnitTest {
+
+	/** @var DateTimeUtility $datetime_utility */
+	protected $datetime_utility;
 
 	public function test_returns_tz_as_is_if_not_offset() {
 		$this->assertEquals( 'Europe/London', $this->datetime_utility->maybe_convert_tz_string( 'Europe/London' ) );

--- a/tests/Unit/Utility/ISOUtilityTest.php
+++ b/tests/Unit/Utility/ISOUtilityTest.php
@@ -10,10 +10,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ISOUtility;
  * Class ISOUtilityTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
- *
- * @property ISOUtility $iso_utility
  */
 class ISOUtilityTest extends ContainerAwareUnitTest {
+
+	/** @var ISOUtility $iso_utility */
+	protected $iso_utility;
 
 	public function test_is_iso3166_alpha2_country_code() {
 		$this->assertTrue( $this->iso_utility->is_iso3166_alpha2_country_code( 'US' ) );

--- a/tests/Unit/Utility/ImageUtilityTest.php
+++ b/tests/Unit/Utility/ImageUtilityTest.php
@@ -18,7 +18,13 @@ class ImageUtilityTest extends UnitTest {
 
 	use DataTrait;
 
-	protected const SUBSIZE_IMAGE_KEY = 'test_subisize_key';
+	protected const SUBSIZE_IMAGE_KEY = 'test_subsize_key';
+
+	/** @var ImageUtility $image_utility */
+	protected $image_utility;
+
+	/** @var WP $wp */
+	protected $wp;
 
 	/**
 	 * Runs before each test is executed.

--- a/tests/Unit/View/PHPViewFactoryTest.php
+++ b/tests/Unit/View/PHPViewFactoryTest.php
@@ -13,12 +13,13 @@ use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
  * Class PHPViewFactoryTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
- *
- * @property PHPViewFactory $view_factory
  */
 class PHPViewFactoryTest extends UnitTest {
 
 	use DataTrait;
+
+	/** @var PHPViewFactory $view_factory */
+	protected $view_factory;
 
 	public function test_create_view() {
 		$view = $this->view_factory->create( $this->get_data_file_path( 'test-php-view.php' ) );

--- a/tests/Unit/View/PHPViewTest.php
+++ b/tests/Unit/View/PHPViewTest.php
@@ -13,12 +13,13 @@ use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
  * Class PHPViewTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
- *
- * @property PHPViewFactory $view_factory
  */
 class PHPViewTest extends UnitTest {
 
 	use DataTrait;
+
+	/** @var PHPViewFactory $view_factory */
+	protected $view_factory;
 
 	public function test_view_construct_fails_if_non_existing_view_file() {
 		$this->expectException( ViewException::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR prepares support for running our unit tests in PHP 8.2. The main change in this PR is to get rid of the deprecation messages for creating dynamic properties. In our unit tests we've been following that pattern a lot by declaring them as properties within the doc block, but not as actual properties in the class. This PR changes that to move them from the docblock to actual declarations.

In addition to that one of the library packages `google/protobuf` was also generating a substantial amount of warnings. In the latest version they get around that by declaring `#[\AllowDynamicProperties]` in the Message base class. So I've upgraded the library to take advantage of this change:

`composer update google/protobuf --with-all-dependencies`
```
- Upgrading google/protobuf (v3.21.12 => v3.22.2)
```

In short the changes in this PR bring down the errors from 500+, to just 5 errors left when running the unit tests.

Two of the errors are coming from the same error that prevents us from running tests on PHP 8.1, see: https://github.com/woocommerce/google-listings-and-ads/issues/1758#issuecomment-1415897005
It has already been fixed but we are still waiting on a [2.13.2 release](https://github.com/googleapis/google-api-php-client/releases) to take advantage of the fix.

##### Update
2.13.2 has been released so I went ahead and updated the google apiclient package which reduces the error count to just 3.
`composer update google/apiclient --with-all-dependencies`
```
- Upgrading firebase/php-jwt (v6.3.2 => v6.4.0)
- Upgrading google/apiclient (v2.13.0 => v2.13.2)
- Upgrading google/apiclient-services (v0.286.0 => v0.295.0)
- Upgrading google/auth (v1.25.0 => v1.26.0)
- Upgrading guzzlehttp/psr7 (2.4.3 => 2.4.4)
- Upgrading phpseclib/phpseclib (3.0.18 => 3.0.19)
- Upgrading psr/http-client (1.0.1 => 1.0.2)
- Upgrading psr/http-factory (1.0.1 => 1.0.2)
- Upgrading psr/http-message (1.0.1 => 1.1)
```

The other three errors are coming from WooCommerce core, which has already been fixed, but at the moment the [PR is still a draft](https://github.com/woocommerce/woocommerce/pull/37063) and we would have to wait till it's included within a release.

Luckily enough all our code (which is covered by unit tests) did conform to PHP 8.2 standards, so we didn't need any changes there.


### Detailed test instructions:
1. Run `composer install` to upgrade composer packages
2. Install unit tests `bin/install-wp-tests.sh <db> <db_user> <db_pass>` 
3. Run unit tests in PHP 8.2 `/usr/bin/php8.2 vendor/bin/phpunit`
4. Confirm that there are only 5 errors left when running the unit tests with PHP 8.2


### Changelog entry
* Dev - Unit test support for PHP 8.2.