### PR TITLE
Fix the fatal errors caused by adding any US Armed Forces location to WC Shipping setting

### DIFF
--- a/src/Shipping/ZoneLocationsParser.php
+++ b/src/Shipping/ZoneLocationsParser.php
@@ -74,8 +74,11 @@ class ZoneLocationsParser implements Service {
 
 					// Only add the state if the regional shipping is supported for the country.
 					if ( $this->google_helper->does_country_support_regional_shipping( $country ) ) {
-						$google_id                    = $this->google_helper->find_subdivision_id_by_code( $state, $country );
-						$locations[ $location->code ] = new ShippingLocation( $google_id, $country, $state, $region );
+						$google_id = $this->google_helper->find_subdivision_id_by_code( $state, $country );
+
+						if ( ! is_null( $google_id ) ) {
+							$locations[ $location->code ] = new ShippingLocation( $google_id, $country, $state, $region );
+						}
 					} else {
 						$google_id             = $this->google_helper->find_country_id_by_code( $country );
 						$locations[ $country ] = new ShippingLocation( $google_id, $country, null, $region );

--- a/tests/Unit/Shipping/ZoneLocationsParserTest.php
+++ b/tests/Unit/Shipping/ZoneLocationsParserTest.php
@@ -51,6 +51,36 @@ class ZoneLocationsParserTest extends UnitTest {
 		$this->assertEquals( 'NV', $parsed_locations[0]->get_state() );
 	}
 
+	public function test_returns_state_locations_if_subdivision_shipping_unsupported() {
+		$zone_locations = [
+			(object) [
+				'code' => 'US:AA',
+				'type' => 'state',
+			],
+		];
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			->method( 'get_zone_locations' )
+			->willReturn( $zone_locations );
+
+		$this->google_helper->expects( $this->any() )
+			->method( 'is_country_supported' )
+			->with( 'US' )
+			->willReturn( true );
+
+		$this->google_helper->expects( $this->any() )
+			->method( 'does_country_support_regional_shipping' )
+			->with( 'US' )
+			->willReturn( true );
+
+		$this->mock_find_subdivision_id_by_code( null );
+
+		$parsed_locations = $this->locations_parser->parse( $zone );
+
+		$this->assertCount( 0, $parsed_locations );
+	}
+
 	public function test_returns_country_locations_if_regional_shipping_unsupported() {
 		$zone_locations = [
 			(object) [

--- a/tests/Unit/Shipping/ZoneLocationsParserTest.php
+++ b/tests/Unit/Shipping/ZoneLocationsParserTest.php
@@ -42,6 +42,8 @@ class ZoneLocationsParserTest extends UnitTest {
 			->with( 'US' )
 			->willReturn( true );
 
+		$this->mock_find_subdivision_id_by_code();
+
 		$parsed_locations = $this->locations_parser->parse( $zone );
 
 		$this->assertCount( 1, $parsed_locations );
@@ -70,6 +72,7 @@ class ZoneLocationsParserTest extends UnitTest {
 			->method( 'does_country_support_regional_shipping' )
 			->with( 'XX' )
 			->willReturn( false );
+		$this->mock_find_subdivision_id_by_code();
 
 		$parsed_locations = $this->locations_parser->parse( $zone );
 
@@ -125,6 +128,7 @@ class ZoneLocationsParserTest extends UnitTest {
 					[ 'DK', false ],
 				]
 			);
+		$this->mock_find_subdivision_id_by_code();
 
 		$parsed_locations = $this->locations_parser->parse( $zone );
 
@@ -210,6 +214,7 @@ class ZoneLocationsParserTest extends UnitTest {
 					[ 'DE', false ],
 				]
 			);
+		$this->mock_find_subdivision_id_by_code();
 
 		$parsed_locations = $this->locations_parser->parse( $zone );
 
@@ -262,14 +267,26 @@ class ZoneLocationsParserTest extends UnitTest {
 					return rand();
 				}
 			);
+
+		$this->locations_parser = new ZoneLocationsParser( $this->google_helper );
+	}
+
+	/**
+	 * Mocks the returning value of google_helper->find_subdivision_id_by_code method.
+	 *
+	 * @param int|null $return_value The location id to be returned instead of a random int. -1 by default will return the random integer.
+	 * @return void
+	 */
+	private function mock_find_subdivision_id_by_code( $return_value = -1 ) {
 		$this->google_helper->expects( $this->any() )
 			->method( 'find_subdivision_id_by_code' )
 			->willReturnCallback(
-				function () {
+				function () use ( $return_value ) {
+					if ( -1 !== $return_value ) {
+						return $return_value;
+					}
 					return rand();
 				}
 			);
-
-		$this->locations_parser = new ZoneLocationsParser( $this->google_helper );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1910 

- Fix a fatal error by checking `null` before creating `ShippingLocation` instance in the ZoneLocationsParser.php.
- Add a new case to ZoneLocationsParserTest.php to test `null` value returned by `find_subdivision_id_by_code`.

### Detailed test instructions:

1. Go to the admin page: WooCommerce -> Settings -> Shipping -> Shipping zones
2. Add a shipping zone that includes 1-3 of the following locations and at least a shipping method:
   - Armed Forces (AA), United States (US)
   - Armed Forces (AE), United States (US)
   - Armed Forces (AP), United States (US)
   - For example:
   ![image](https://user-images.githubusercontent.com/17420811/229753067-d95c815d-47d9-4ca9-96e9-cc8cbcde049b.png)
3. Make a request to the endpoint: **GET** `/wp-json/wc/gla/mc/target_audience/suggestions`
   - The request can be issued by running a script via the Console tab of browser DevTool:
      ```js
      wp.apiFetch({path: 'wc/gla/mc/target_audience/suggestions'}).then(console.log)
      ```
4. Check if the response is successful without fatal errors.
5. Check if the `countries` property of the response body doesn't include `"US"`.
6. Add a supported US location to the same shipping zone. For example, `California, United States (US)`.
7. Make another request and check if the `countries` property includes `"US"`.

### Additional details:

In #1229, the source of subdivisions was:

> Google provides the location IDs in a [downloadable CSV file](https://developers.google.com/adwords/api/docs/appendix/geotargeting) on the AdWords API documentation. This file is regularly updated.

After searching for `"US","State",Active` in the raw content of [the latest CSV file (2023-03-28)](https://developers.google.com/static/google-ads/api/reference/data/geo/geotargets-2023-03-28.csv), there are 51 locations, and they are the same set as the `COUNTRY_SUBDIVISIONS['US']` in the GoogleHelper.php file.

Thus, this PR doesn't need to update GoogleHelper.php.

### Changelog entry

> Fix - The fatal errors caused by adding any US Armed Forces location to WooCommerce Shipping setting
