### PR TITLE
Prevent creating assets for non PMax campaigns

### DIFF
--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -70,6 +70,9 @@ export const CATEGORY_CONDITION_SELECT_TYPES = {
 
 export const CATEGORIES_TO_SHOW_IN_TOOLTIP = 5;
 
+// Campaign related
+export const CAMPAIGN_TYPE_PMAX = 'performance_max';
+
 // Assets of Performance Max Campaign related
 export const ASSET_KEY = {
 	BUSINESS_NAME: 'business_name',

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
@@ -12,12 +12,16 @@ import EditProgramPromptModal from './edit-program-prompt-modal';
 import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
 
 const EditProgramButton = ( props ) => {
-	const { className, programId } = props;
+	const { className, programId, ...buttonProps } = props;
 
 	return (
 		<AppButtonModalTrigger
 			button={
-				<AppButton isLink className={ classnames( className ) }>
+				<AppButton
+					{ ...buttonProps }
+					isLink
+					className={ classnames( className ) }
+				>
 					{ __( 'Edit', 'google-listings-and-ads' ) }
 				</AppButton>
 			}

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -17,7 +17,7 @@ import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
 import useAdsCurrency from '.~/hooks/useAdsCurrency';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import AppSpinner from '.~/components/app-spinner';
-import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
+import { FREE_LISTINGS_PROGRAM_ID, CAMPAIGN_TYPE_PMAX } from '.~/constants';
 import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
 import ProgramToggle from './program-toggle';
 import FreeListingsDisabledToggle from './free-listings-disabled-toggle';
@@ -107,6 +107,7 @@ const AllProgramsTableCard = ( props ) => {
 				/>
 			),
 			active: true,
+			disabledEdit: false,
 		},
 		...adsCampaignsData.map( ( el ) => {
 			return {
@@ -120,6 +121,7 @@ const AllProgramsTableCard = ( props ) => {
 					/>
 				),
 				active: el.status === 'enabled',
+				disabledEdit: el.type !== CAMPAIGN_TYPE_PMAX,
 			};
 		} ),
 	];
@@ -161,6 +163,7 @@ const AllProgramsTableCard = ( props ) => {
 								<EditProgramButton
 									className={ editButtonClassName }
 									programId={ el.id }
+									disabled={ el.disabledEdit }
 								/>
 								{ el.id !== FREE_LISTINGS_PROGRAM_ID && (
 									<RemoveProgramButton programId={ el.id } />

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -86,9 +86,12 @@ const AllProgramsTableCard = ( props ) => {
 		return <AppSpinner />;
 	}
 
+	const pmaxCampaigns = adsCampaignsData.filter(
+		( { type } ) => type === CAMPAIGN_TYPE_PMAX
+	);
 	let campaignAssetsTour = null;
 
-	if ( adsCampaignsData.length ) {
+	if ( pmaxCampaigns.length ) {
 		const selector = `.${ PROGRAMS_TABLE_CARD_CLASS_NAME } .${ CAMPAIGN_EDIT_BUTTON_CLASS_NAME }`;
 		campaignAssetsTour = (
 			<CampaignAssetsTour referenceElementCssSelector={ selector } />
@@ -139,7 +142,8 @@ const AllProgramsTableCard = ( props ) => {
 			rows={ data.map( ( el ) => {
 				const isFreeListings = el.id === FREE_LISTINGS_PROGRAM_ID;
 				const editButtonClassName = classnames( {
-					[ CAMPAIGN_EDIT_BUTTON_CLASS_NAME ]: ! isFreeListings,
+					[ CAMPAIGN_EDIT_BUTTON_CLASS_NAME ]:
+						! isFreeListings && ! el.disabledEdit,
 				} );
 
 				// Since the <Table> component uses array index as key to render rows,

--- a/js/src/dashboard/all-programs-table-card/index.test.js
+++ b/js/src/dashboard/all-programs-table-card/index.test.js
@@ -1,0 +1,232 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { screen, within, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AllProgramsTableCard from './';
+import CampaignAssetsTour from './campaign-assets-tour';
+import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
+import useAdsCurrency from '.~/hooks/useAdsCurrency';
+
+jest.mock( './campaign-assets-tour', () =>
+	jest
+		.fn()
+		.mockReturnValue( <div role="dialog" aria-label="tour" /> )
+		.mockName( 'CampaignAssetsTour' )
+);
+
+jest.mock( '.~/hooks/useCountryKeyNameMap', () =>
+	jest
+		.fn()
+		.mockReturnValue( { US: 'United States (US)', JP: 'Japan' } )
+		.mockName( 'useCountryKeyNameMap' )
+);
+
+jest.mock( '.~/hooks/useAdsCurrency', () =>
+	jest.fn().mockReturnValue( {
+		formatAmount: jest.fn().mockName( 'formatAmount' ),
+	} )
+);
+
+jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
+	jest
+		.fn()
+		.mockReturnValue( { data: [ 'US', 'JP' ] } )
+		.mockName( 'useTargetAudienceFinalCountryCodes' )
+);
+
+jest.mock( '.~/hooks/useAdsCampaigns', () =>
+	jest.fn().mockName( 'useAdsCampaigns' )
+);
+
+describe( 'AllProgramsTableCard', () => {
+	const pmaxCampaign = {
+		id: 10,
+		name: 'PMax Campaign',
+		status: 'enabled',
+		type: 'performance_max',
+		amount: 20,
+		displayCountries: [ 'US' ],
+	};
+
+	const pmaxCampaignDisabled = {
+		id: 11,
+		name: 'Disabled PMax Campaign',
+		status: 'disabled',
+		type: 'performance_max',
+		amount: 30,
+		displayCountries: [ 'US', 'JP' ],
+	};
+
+	const shoppingCampaign = {
+		id: 12,
+		name: 'Shopping Campaign',
+		status: 'enabled',
+		type: 'shopping',
+		amount: 50,
+		displayCountries: [ 'JP' ],
+	};
+
+	const getEditButton = ( container ) =>
+		within( container ).queryByRole( 'button', { name: /edit/i } );
+
+	const getRemoveButton = ( container ) =>
+		within( container ).queryByRole( 'button', { name: /remove/i } );
+
+	let mockCampaigns;
+
+	beforeEach( () => {
+		let mockedCampaigns = [];
+
+		useAdsCampaigns.mockImplementation( () => {
+			return { data: mockedCampaigns };
+		} );
+
+		mockCampaigns = ( ...campaigns ) => {
+			mockedCampaigns = campaigns;
+		};
+	} );
+
+	it( 'Should render the free listings row with a checked toggle in the disabled state', () => {
+		render( <AllProgramsTableCard /> );
+
+		const row = screen.getByRole( 'row', { name: /free listings/i } );
+		const checkbox = within( row ).getByRole( 'checkbox' );
+
+		expect( row ).toBeInTheDocument();
+		expect( checkbox ).toBeChecked();
+		expect( checkbox ).toBeDisabled();
+	} );
+
+	it( 'Should render the free listings row without the remove button', () => {
+		render( <AllProgramsTableCard /> );
+
+		const row = screen.getByRole( 'row', { name: /free listings/i } );
+		const button = getRemoveButton( row );
+
+		expect( button ).not.toBeInTheDocument();
+	} );
+
+	it( 'Should render the free listings row with a free daily budget text', () => {
+		render( <AllProgramsTableCard /> );
+
+		const row = screen.getByRole( 'row', { name: /free listings/i } );
+		const budget = within( row ).getByRole( 'cell', { name: /free/i } );
+
+		expect( budget ).toBeInTheDocument();
+	} );
+
+	it( 'Should render campaign rows', () => {
+		mockCampaigns( pmaxCampaign, pmaxCampaignDisabled, shoppingCampaign );
+		render( <AllProgramsTableCard /> );
+
+		const rows = screen.getAllByRole( 'row', { name: /campaign/i } );
+		expect( rows ).toHaveLength( 3 );
+	} );
+
+	it( 'Should render campaign rows with toggles in checked or unchecked state accordingly', () => {
+		mockCampaigns( pmaxCampaign, pmaxCampaignDisabled );
+		render( <AllProgramsTableCard /> );
+
+		const rows = screen.getAllByRole( 'row', { name: /campaign/i } );
+		const checkbox1 = within( rows[ 0 ] ).getByRole( 'checkbox' );
+		const checkbox2 = within( rows[ 1 ] ).getByRole( 'checkbox' );
+
+		expect( checkbox1 ).toBeChecked();
+		expect( checkbox2 ).not.toBeChecked();
+	} );
+
+	it( 'Should call to formatAmount with the budget for each campaign rows', () => {
+		const { formatAmount } = useAdsCurrency();
+
+		mockCampaigns( pmaxCampaign, pmaxCampaignDisabled );
+		render( <AllProgramsTableCard /> );
+
+		expect( formatAmount ).toHaveBeenCalledWith(
+			pmaxCampaign.amount,
+			true
+		);
+		expect( formatAmount ).toHaveBeenCalledWith(
+			pmaxCampaignDisabled.amount,
+			true
+		);
+	} );
+
+	it( 'Should render campaign rows with remove buttons', () => {
+		mockCampaigns( pmaxCampaign, shoppingCampaign );
+		render( <AllProgramsTableCard /> );
+
+		const rows = screen.getAllByRole( 'row', { name: /campaign/i } );
+		const button1 = getRemoveButton( rows[ 0 ] );
+		const button2 = getRemoveButton( rows[ 1 ] );
+
+		expect( button1 ).toBeEnabled();
+		expect( button2 ).toBeEnabled();
+	} );
+
+	it( 'Should render the free listings and PMax campaign rows with edit buttons', () => {
+		mockCampaigns( pmaxCampaign );
+		render( <AllProgramsTableCard /> );
+
+		const freeRow = screen.getByRole( 'row', { name: /free listings/i } );
+		const pmaxRow = screen.getByRole( 'row', { name: /campaign/i } );
+		const freeButton = getEditButton( freeRow );
+		const pmaxButton = getEditButton( pmaxRow );
+
+		expect( freeButton ).toBeEnabled();
+		expect( pmaxButton ).toBeEnabled();
+	} );
+
+	it( 'Should render non-PMax campaign with an disabled edit button', () => {
+		mockCampaigns( shoppingCampaign );
+		render( <AllProgramsTableCard /> );
+
+		const row = screen.getByRole( 'row', { name: /campaign/i } );
+		const button = getEditButton( row );
+
+		expect( button ).toBeDisabled();
+	} );
+
+	it( 'Should only attach the dedicated CSS class to the edit buttons of PMax campaign rows', () => {
+		mockCampaigns( shoppingCampaign, pmaxCampaign );
+		render( <AllProgramsTableCard /> );
+
+		const rows = screen.getAllByRole( 'row', {
+			name: /free listings|campaign/i,
+		} );
+		const [ freeRow, shoppingRow, pmaxRow ] = rows;
+		const className = 'gla-campaign-edit-button';
+
+		expect( getEditButton( freeRow ) ).not.toHaveClass( className );
+		expect( getEditButton( shoppingRow ) ).not.toHaveClass( className );
+		expect( getEditButton( pmaxRow ) ).toHaveClass( className );
+	} );
+
+	it( 'When there is no PMax campaign, should not render the campaign assets tour', () => {
+		mockCampaigns( shoppingCampaign );
+		render( <AllProgramsTableCard /> );
+
+		const tour = screen.queryByRole( 'dialog', { name: 'tour' } );
+
+		expect( tour ).not.toBeInTheDocument();
+	} );
+
+	it( 'When there is any PMax campaign, should render the campaign assets tour', () => {
+		mockCampaigns( shoppingCampaign, pmaxCampaign );
+		render( <AllProgramsTableCard /> );
+
+		const tour = screen.getByRole( 'dialog', { name: 'tour' } );
+		const expectedProps = expect.objectContaining( {
+			referenceElementCssSelector: expect.stringMatching(
+				/\.gla-campaign-edit-button\b/
+			),
+		} );
+
+		expect( tour ).toBeInTheDocument();
+		expect( CampaignAssetsTour ).toHaveBeenCalledWith( expectedProps, {} );
+	} );
+} );

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Stepper } from '@woocommerce/components';
 import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ import AppSpinner from '.~/components/app-spinner';
 import AssetGroup, {
 	ACTION_SUBMIT_CAMPAIGN_AND_ASSETS,
 } from '.~/components/paid-ads/asset-group';
-import { CAMPAIGN_STEP as STEP } from '.~/constants';
+import { CAMPAIGN_STEP as STEP, CAMPAIGN_TYPE_PMAX } from '.~/constants';
 
 const dashboardURL = getDashboardUrl();
 const helpButton = <HelpIconButton eventContext="edit-ads" />;
@@ -56,6 +57,12 @@ const EditPaidAdsCampaign = () => {
 	} = useAppSelectDispatch( 'getCampaignAssetGroups', id );
 	const campaign = campaigns?.find( ( el ) => el.id === id );
 	const assetEntityGroup = assetEntityGroups?.at( 0 );
+
+	useEffect( () => {
+		if ( campaign && campaign.type !== CAMPAIGN_TYPE_PMAX ) {
+			getHistory().replace( dashboardURL );
+		}
+	}, [ campaign ] );
 
 	const setStep = ( step ) => {
 		const url = getNewPath( { ...getQuery(), step } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1931 

To prevent creating assets for nonPMax campaigns, this PR

- Disable the "Edit" button for non-pmax campaigns on the Dashboard page.
- Only show the campaign assets tour when there is at least one pmax campaign.
- Redirect back to the Dashboard page when entering campaign editing page with a non-pmax campaign.

### Screenshots:

![image](https://user-images.githubusercontent.com/17420811/230358433-5e37f368-f775-49ce-985e-8061ec1d654f.png)

![image](https://user-images.githubusercontent.com/17420811/230363866-4b6b0e05-a313-4992-8a28-3e181cad7bb4.png)

### Detailed test instructions:

#### Reset tour flag

Reset tour flag by running the following code via the Console panel in the DevTool:

```js
wp.data.dispatch( 'wc/gla' ).upsertTour( { id: 'dashboard-feature--campaign-assets', checked: false } )
```

Or by running SQL:
```sql
DELETE FROM wp_options WHERE option_name = 'gla_tours';
```

#### Create a non-pmax campaign

1. Go to https://ads.google.com/
1. Create a new campaign
   ![image](https://user-images.githubusercontent.com/17420811/230359827-23be7240-8c06-4542-bc5a-57ca8584e3b5.png)
1. Select "Standard Shopping campaign"
   ![image](https://user-images.githubusercontent.com/17420811/230360028-dd238483-b555-4dd6-b865-d19571d9db5c.png)
1. Finish the rest steps.

#### Testing

1. Go to the Dashboard page.
2. Check if the "Edit" button of the non-pmax campaign is disabled.
3. Find out the ID of the non-pmax campaign and go to its editing page directly: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Fcampaigns%2Fedit&programId={non-pmax-campaign-id}`
4. Check if the page redirects back to the Dashboard page.
5. Filter out all pmax campaigns to see if the tour is not shown when there are only non-pmax campaigns.
   - It would be easier to filter out by locally changing [this line of code](https://github.com/woocommerce/google-listings-and-ads/blob/1031dcd617cc258acb443883bfd504e97e8cafab/js/src/data/resolvers.js#L209) with:
   ```js
   adsCampaigns: campaigns.filter( c => c.type ==='shopping' ).map( adaptAdsCampaign ),
   ```
6. Switch the order of the campaign data to see if the tour shows on the first pmax campaign
   - It would be easier to filter out by locally sorting at [this line of code](https://github.com/woocommerce/google-listings-and-ads/blob/1031dcd617cc258acb443883bfd504e97e8cafab/js/src/data/resolvers.js#L205) with:
   ```js
   campaigns.sort( ( a, b ) => a.type ==='shopping' ? -1 : 1 )
   ```
### Changelog entry

> Fix - Prevent creating assets for non-Performance Max campaigns.
