### PR TITLE
Report the Ads account currency in Woo marketing dashboard

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -411,7 +411,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( AttributeMappingHelper::class );
 
 		if ( defined( 'WC_MCM_EXISTS' ) ) {
-			$this->share_with_tags( GLAChannel::class, MerchantCenterService::class, AdsCampaign::class, Ads::class, MerchantStatuses::class, ProductSyncStats::class, WC::class );
+			$this->share_with_tags( GLAChannel::class, MerchantCenterService::class, AdsCampaign::class, Ads::class, MerchantStatuses::class, ProductSyncStats::class );
 			$this->share_with_tags( MarketingChannelRegistrar::class, GLAChannel::class, WC::class );
 		}
 	}

--- a/src/MultichannelMarketing/GLAChannel.php
+++ b/src/MultichannelMarketing/GLAChannel.php
@@ -13,7 +13,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -52,11 +51,6 @@ class GLAChannel implements MarketingChannelInterface {
 	protected $product_sync_stats;
 
 	/**
-	 * @var WC
-	 */
-	protected $wc;
-
-	/**
 	 * @var MarketingCampaignType[]
 	 */
 	protected $campaign_types;
@@ -69,15 +63,13 @@ class GLAChannel implements MarketingChannelInterface {
 	 * @param Ads                   $ads
 	 * @param MerchantStatuses      $merchant_statuses
 	 * @param ProductSyncStats      $product_sync_stats
-	 * @param WC                    $wc
 	 */
-	public function __construct( MerchantCenterService $merchant_center, AdsCampaign $ads_campaign, Ads $ads, MerchantStatuses $merchant_statuses, ProductSyncStats $product_sync_stats, WC $wc ) {
+	public function __construct( MerchantCenterService $merchant_center, AdsCampaign $ads_campaign, Ads $ads, MerchantStatuses $merchant_statuses, ProductSyncStats $product_sync_stats ) {
 		$this->merchant_center    = $merchant_center;
 		$this->ads_campaign       = $ads_campaign;
 		$this->ads                = $ads;
 		$this->merchant_statuses  = $merchant_statuses;
 		$this->product_sync_stats = $product_sync_stats;
-		$this->wc                 = $wc;
 		$this->campaign_types     = $this->generate_campaign_types();
 	}
 
@@ -185,7 +177,7 @@ class GLAChannel implements MarketingChannelInterface {
 		}
 
 		try {
-			$currency = $this->wc->get_woocommerce_currency();
+			$currency = $this->ads->get_ads_currency();
 
 			return array_map(
 				function ( array $campaign_data ) use ( $currency ) {

--- a/tests/Unit/MultichannelMarketing/GLAChannelTest.php
+++ b/tests/Unit/MultichannelMarketing/GLAChannelTest.php
@@ -31,7 +31,6 @@ defined( 'ABSPATH' ) || exit;
  * @property MockObject|Ads                   $ads
  * @property MockObject|MerchantStatuses      $merchant_statuses
  * @property MockObject|ProductSyncStats      $product_sync_stats
- * @property MockObject|WC                    $wc
  */
 class GLAChannelTest extends UnitTest {
 

--- a/tests/Unit/MultichannelMarketing/GLAChannelTest.php
+++ b/tests/Unit/MultichannelMarketing/GLAChannelTest.php
@@ -152,7 +152,7 @@ class GLAChannelTest extends UnitTest {
 	}
 
 	public function test_get_campaigns_returns_marketing_campaigns() {
-		$this->wc->expects( $this->once() )->method( 'get_woocommerce_currency' )->willReturn( 'USD' );
+		$this->ads->expects( $this->once() )->method( 'get_ads_currency' )->willReturn( 'USD' );
 
 		$this->ads->expects( $this->once() )->method( 'ads_id_exists' )->willReturn( true );
 		$this->ads_campaign
@@ -193,15 +193,13 @@ class GLAChannelTest extends UnitTest {
 		$this->ads                = $this->createMock( Ads::class );
 		$this->merchant_statuses  = $this->createMock( MerchantStatuses::class );
 		$this->product_sync_stats = $this->createMock( ProductSyncStats::class );
-		$this->wc                 = $this->createMock( WC::class );
 
 		$this->gla_channel = new GLAChannel(
 			$this->merchant_center,
 			$this->ads_campaign,
 			$this->ads,
 			$this->merchant_statuses,
-			$this->product_sync_stats,
-			$this->wc
+			$this->product_sync_stats
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Previously the current store currency was used for the ad campaigns when returning them to WooCommerce multichannel marketing dashboard. This was inaccurate because when the user changes their store currency, the amount should still be displayed in the currency of the ads account, not the store's currency.

This PR changes the MCM channel code to use the ads account currency instead of WooCommerce currency. I've also removed the dependency on the WC service since it's no longer used and modified the unit tests accordingly.

Related to the issue reported in internal testing: pb22l9-1WT-p2#comment-2066

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Ensure you have the latest WooCommerce version and enable the new multichannel marketing feature in the Advanced section of WC settings (if you're using v 7.6+ it's enabled by default).

1. Connect a Google Ads account and create a campaign
2. Confirm that the currency displayed on the Campaigns card of the new marketing dashboard is the same as the ads account
3. Change your store's currency
4. Confirm step 2 again (the currency should not change)


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Use Ads account currency in the WooCommerce marketing dashboard
