### PR TITLE
Refactor to get the first element independently of its key

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1023,7 +1023,9 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			return null;
 		}
 
-		return wp_list_pluck( $values, 'name' )[0];
+		$term_names = wp_list_pluck( $values, 'name' );
+		$term_name  = reset( $term_names );
+		return $term_name ?: null;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #1943 

Even tho this is likely not happening because Wp_Terms are ordered starting from 0. I added this fix to be sure we return the first element of the array independently of the key. 

That way we can be sure we can prevent the warning of `Warning: Undefined array key 0`


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create  a new attribute mapping rule with a taxonomy Color
2. See the attribute mapping rule working as normally. 


ℹ️  For not waiting the 30 minutes in order to sync the rules you can sync a specific product via connection test. 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent potential warning when accessing undefined index.
