### PR TITLE
[SEMGREP] - Prevent Semgrep warnings in add_query vars and in Scripts loader

### DIFF
--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -118,8 +118,8 @@ class AccountController extends BaseOptionsController {
 			$redirect = admin_url( "admin.php?page=wc-admin&path={$path}" );
 			$auth_url = $this->manager->get_authorization_url( null, $redirect );
 
-			// Payments flow allows redirect back to the site without showing plans.
-			$auth_url = add_query_arg( [ 'from' => 'google-listings-and-ads' ], $auth_url );
+			// Payments flow allows redirect back to the site without showing plans. Escaping the URL preventing XSS.
+			$auth_url = esc_url( add_query_arg( [ 'from' => 'google-listings-and-ads' ], $auth_url ) );
 
 			return [
 				'url' => $auth_url,

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -119,7 +119,7 @@ class AccountController extends BaseOptionsController {
 			$auth_url = $this->manager->get_authorization_url( null, $redirect );
 
 			// Payments flow allows redirect back to the site without showing plans. Escaping the URL preventing XSS.
-			$auth_url = sanitize_url( add_query_arg( [ 'from' => 'google-listings-and-ads' ], $auth_url ) );
+			$auth_url = esc_url( add_query_arg( [ 'from' => 'google-listings-and-ads' ], $auth_url ), null, 'db' );
 			return [
 				'url' => $auth_url,
 			];

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -119,8 +119,7 @@ class AccountController extends BaseOptionsController {
 			$auth_url = $this->manager->get_authorization_url( null, $redirect );
 
 			// Payments flow allows redirect back to the site without showing plans. Escaping the URL preventing XSS.
-			$auth_url = esc_url( add_query_arg( [ 'from' => 'google-listings-and-ads' ], $auth_url ) );
-
+			$auth_url = sanitize_url( add_query_arg( [ 'from' => 'google-listings-and-ads' ], $auth_url ) );
 			return [
 				'url' => $auth_url,
 			];

--- a/src/Assets/ScriptWithBuiltDependenciesAsset.php
+++ b/src/Assets/ScriptWithBuiltDependenciesAsset.php
@@ -60,7 +60,7 @@ class ScriptWithBuiltDependenciesAsset extends ScriptAsset {
 				return $fallback;
 			}
 			// Reason of exclusion: These files are being loaded manually in the function call with no user input
-			// nosemgrep audit.php.lang.security.file.inclusion-arg
+			// nosemgrep: audit.php.lang.security.file.inclusion-arg
 			return new DependencyArray( include $build_dependency_path );
 		} catch ( Throwable $e ) {
 			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );

--- a/src/Assets/ScriptWithBuiltDependenciesAsset.php
+++ b/src/Assets/ScriptWithBuiltDependenciesAsset.php
@@ -59,7 +59,8 @@ class ScriptWithBuiltDependenciesAsset extends ScriptAsset {
 			if ( ! is_readable( $build_dependency_path ) ) {
 				return $fallback;
 			}
-
+			// Reason of exclusion: These files are being loaded manually in the function call with no user input
+			// nosemgrep audit.php.lang.security.file.inclusion-arg
 			return new DependencyArray( include $build_dependency_path );
 		} catch ( Throwable $e ) {
 			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR prevents two issues in SEMGREP to warn in the output:

- Potential Unsafe usage (non escaped) of remove_query_arg() or add_query_arg(), which could lead to XSS           
- Argument of a function used in an include/require, could lead to File Inclusion


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. ⚠️ **Verify you can connect to Wordpress.com from the Extension Setup  in Step 1.** 
2. Verify that running SEMGREP against the extension doesn't generate this warnings anymore

### Additional details:

For running semgrep:

- Install semgrep
- clone rules --> `git clone git@github.com:Automattic/wpscan-semgrep-rules.git`
- cd wpscan-semgrep-rules
- download last release google-listings-and-ads zip somewhere and unzip it.
- Run --> semgrep --no-git-ignore --text -c audit {UNZIPPED_GLA_PATH} 
- (You can also run it agains your locally cloned repo, but that would include noise in regards vendor files)

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix SEMGREP warnings
