### PR TITLE
Prefix Psr Container Package

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -17,6 +17,11 @@ declare( strict_types=1 );
  */
 $packages = [
 	[
+		'namespace' => 'Psr\\Container',
+		'package'   => 'psr/container',
+		'strict'    => false,
+	],
+	[
 		'namespace' => 'League\\Container',
 		'package'   => 'league/container',
 		'strict'    => false,
@@ -74,6 +79,9 @@ $dependencies = [
 		'google/apiclient',
 		'google/auth',
 		'google/gax',
+	],
+	'psr/container'    => [
+		'league/container',
 	],
 ];
 

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
 		"google/apiclient": "^2.13",
 		"google/apiclient-services": "~0.286",
 		"googleads/google-ads-php": "^17.1",
-		"league/container": "^3.3",
+		"league/container": "^3.4",
 		"league/iso3166": "^4.1",
 		"phpseclib/bcmath_compat": "^2.0",
-		"psr/container": "^1.0",
+		"psr/container": "^1.1",
 		"symfony/polyfill-intl-normalizer": "^1.26",
 		"symfony/polyfill-mbstring": "^1.26",
 		"symfony/validator": "^5.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d27a5e47bfc44babb60f1b0d9d7b8085",
+    "content-hash": "74d7a5e9248b2ecad58244836957a162",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1843,20 +1843,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -1885,9 +1885,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/http-client",

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -25,8 +25,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Autoloader;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\PluginValidator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\VersionValidator;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginFactory;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
-use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -14,9 +14,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\TosAccepted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use DateTime;
 use Exception;
-use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientExceptionInterface;
 
 defined( 'ABSPATH' ) || exit;

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -17,7 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingCo
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountTax;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountTaxTaxRule as TaxRule;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ShippingSettings;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/API/Site/Controllers/BaseReportsController.php
+++ b/src/API/Site/Controllers/BaseReportsController.php
@@ -5,8 +5,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use DateTime;
-use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 
 defined( 'ABSPATH' ) || exit;

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166AwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 

--- a/src/API/Site/RESTControllers.php
+++ b/src/API/Site/RESTControllers.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseControl
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class RESTControllers

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -14,8 +14,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Exception;
-use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -29,8 +29,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncerException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Jetpack_Options;
-use Psr\Container\ContainerInterface;
 use WP_REST_Request as Request;
 
 /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -15,16 +15,16 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\RE
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\ThirdPartyServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container as LeagueContainer;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerExceptionInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\NotFoundExceptionInterface;
 
 /**
  * PSR11 compliant dependency injection container for Google Listings and Ads.
  *
  * Classes in the `src` directory should specify dependencies from that directory via constructor arguments
  * with type hints. If an instance of the container itself is needed, the type hint to use is
- * \Psr\Container\ContainerInterface.
+ * Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface.
  *
  * Classes in the `src` directory should interact with anything outside (especially WordPress functions) by using
  * the classes in the `Proxies` directory. The exception is idempotent functions (e.g. `wp_parse_url`), which

--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements\PluginValidator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class GoogleListingsAndAdsPlugin

--- a/src/Internal/ContainerAwareTrait.php
+++ b/src/Internal/ContainerAwareTrait.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal;
 
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -122,8 +122,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ISOUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
-use Psr\Container\ContainerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use wpdb;
 

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -43,8 +43,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\Requ
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Argument\RawArgument;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\Definition;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Jetpack_Options;
-use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -72,7 +72,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingSuggestionServi
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\AddressUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\DefinitionInterface;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class RESTServiceProvider

--- a/src/Internal/Interfaces/ContainerAwareInterface.php
+++ b/src/Internal/Interfaces/ContainerAwareInterface.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces;
 
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -20,8 +20,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Exception;
-use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/Tracking/EventTracking.php
+++ b/src/Tracking/EventTracking.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\ActivatedEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\BaseEvent;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteClaimEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteVerificationEvents;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Wire up the Google Listings and Ads events to Tracks.

--- a/tests/Framework/ContainerAwareUnitTest.php
+++ b/tests/Framework/ContainerAwareUnitTest.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework;
 
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class ContainerAwareUnitTest

--- a/tests/Unit/MerchantCenter/ValidateAddressTest.php
+++ b/tests/Unit/MerchantCenter/ValidateAddressTest.php
@@ -6,8 +6,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Container\ContainerInterface;
 
 defined( 'ABSPATH' ) || exit;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR prefixes the Psr\Container package to ensure that we don't conflict with other plugins using version 2.x of the same package. I also updated the container packages to the latest compatible versions:

`composer update league/container --with-all-dependencies`
```
- Upgrading psr/container (1.1.1 => 1.1.2)
```

I did experiment with updating the container package to 2.x and league container 4.x however that requires some substantial changes, so I left it as is. In the newer version we can no longer share providers using just strings we need to provide an instance to the container.

Closes #1938 

### Detailed test instructions:
1. Checkout the regular develop branch
2. Install the [PublishPress Revisions](https://wordpress.org/plugins/revisionary/) plugin
3. Notice a fatal error as soon as the plugin is activated
4. Check out this branch `fix/1938-prefix-psr-container-package` and re-run `composer install`
5. Activate the two plugins together and confirm that this time there are no errors

### Changelog entry
* Fix - Prefix Psr\Container package to prevent conflicts with other plugins.

