### PR TITLE
Run PHP unit tests GH workflow with L-2 versions

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -22,8 +22,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  GetMatrix:
+    name: Get WP version Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      wp-matrix: ${{ steps.wp.outputs.matrix }}
+    steps:
+      - name: Get Release versions from Wordpress
+        id: wp
+        uses: woocommerce/grow/get-plugin-releases@actions-v1.5.0-pre
+        with:
+          slug: wordpress
+          
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}
+    needs: GetMatrix
     runs-on: ubuntu-latest
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
@@ -31,7 +44,7 @@ jobs:
     strategy:
       matrix:
         php: [8.0]
-        wp-version: ["6.0", "6.1", latest]
+        wp-version: ${{ needs.GetMatrix.outputs.wp-matrix }}
         include:
           - php: 7.4
             wp-version: latest

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         php: [8.0]
-        wp-version: ${{ needs.GetMatrix.outputs.wp-matrix }}
+        wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-matrix) }}
         include:
           - php: 7.4
             wp-version: latest

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -26,11 +26,11 @@ jobs:
     name: Get WP version Matrix
     runs-on: ubuntu-latest
     outputs:
-      wp-matrix: ${{ steps.wp.outputs.matrix }}
+      wp-versions: ${{ steps.wp.outputs.versions }}
     steps:
       - name: Get Release versions from Wordpress
         id: wp
-        uses: woocommerce/grow/get-plugin-releases@actions-v1.5.0-pre
+        uses: woocommerce/grow/get-plugin-releases@actions-v1
         with:
           slug: wordpress
           
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         php: [8.0]
-        wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-matrix) }}
+        wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions) }}
         include:
           - php: 7.4
             wp-version: latest


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implementing the new action get-releases-version in GLA. This action allows getting automatically the latest releases from WordPress dynamically.

### Screenshots:

<img width="978" alt="Screenshot 2023-04-21 at 16 21 17" src="https://user-images.githubusercontent.com/5908855/233634044-1ebff09f-927a-46af-8969-dc0134a21d6a.png">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. [Check the action fetching correctly the WP releases](https://github.com/woocommerce/google-listings-and-ads/pull/1954/checks?sha=d1afbd0acceb771eb1069ffe2b4360c0a05d3f79)

### Changelog entry
