### PR TITLE
Fix the problem of missing spaces between the Card layouts on the Get Started page

### DIFF
--- a/js/src/get-started-page/index.scss
+++ b/js/src/get-started-page/index.scss
@@ -2,7 +2,7 @@
 	max-width: 824px;
 	margin: 0 auto;
 
-	> * {
+	> .components-card {
 		margin-bottom: calc(var(--main-gap) * 1.5);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a layout issue introduced when solving a style conflict problem. (See https://github.com/woocommerce/google-listings-and-ads/pull/1880#issuecomment-1432763685) That fix also removes the spaces between the Card layouts on the Get Started page.

![2023-05-04 18 34 30](https://user-images.githubusercontent.com/17420811/236182606-df0508b6-d09b-4aeb-9dc7-5a74b492f630.png)


### Screenshots:


![2023-05-04 18 34 51](https://user-images.githubusercontent.com/17420811/236182565-25aa65bf-da8e-4bd4-bdf2-078baf155deb.png)

### Detailed test instructions:

1. Go to the Get Started page.
2. Check if the Card layouts have spaces between them.

### Changelog entry

> Fix - The missing spaces between the card layouts on the Get Started page.
