### PR TITLE
Update the token in backlog-automation.yml to the PAT of `botwoo` account

### DIFF
--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/woocommerce/projects/119
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.BOT_GH_TOKEN }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `ADD_TO_PROJECT_PAT` token seems to be expired. This PR does the same change as  1432-gh-woocommerce/automatewoo. So that it will be a PAT from Woo's bot and won't link to a dev's PAT.

- [x] After merging this PR, remove the `ADD_TO_PROJECT_PAT` secret from this repo.

### Changelog entry
