### PR TITLE
Adjust the MCM filter to always show in channels

### DIFF
--- a/src/MultichannelMarketing/GLAChannel.php
+++ b/src/MultichannelMarketing/GLAChannel.php
@@ -70,7 +70,11 @@ class GLAChannel implements MarketingChannelInterface {
 		$this->ads                = $ads;
 		$this->merchant_statuses  = $merchant_statuses;
 		$this->product_sync_stats = $product_sync_stats;
-		$this->campaign_types     = $this->generate_campaign_types();
+		$this->campaign_types     = [];
+
+		if ( apply_filters( 'woocommerce_gla_enable_mcm', false ) === true ) {
+			$this->campaign_types = $this->generate_campaign_types();
+		}
 	}
 
 	/**

--- a/src/MultichannelMarketing/MarketingChannelRegistrar.php
+++ b/src/MultichannelMarketing/MarketingChannelRegistrar.php
@@ -43,8 +43,6 @@ class MarketingChannelRegistrar implements Service, Registerable {
 	 * Register as a WooCommerce marketing channel.
 	 */
 	public function register(): void {
-		if ( apply_filters( 'woocommerce_gla_enable_mcm', false ) === true ) {
-			$this->marketing_channels->register( $this->channel );
-		}
+		$this->marketing_channels->register( $this->channel );
 	}
 }

--- a/tests/Unit/MultichannelMarketing/GLAChannelTest.php
+++ b/tests/Unit/MultichannelMarketing/GLAChannelTest.php
@@ -197,6 +197,9 @@ class GLAChannelTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
+		// Enable campaign types for tests.
+		add_filter( 'woocommerce_gla_enable_mcm', '__return_true' );
+
 		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
 		$this->ads_campaign       = $this->createMock( AdsCampaign::class );
 		$this->ads                = $this->createMock( Ads::class );

--- a/tests/Unit/MultichannelMarketing/GLAChannelTest.php
+++ b/tests/Unit/MultichannelMarketing/GLAChannelTest.php
@@ -191,6 +191,19 @@ class GLAChannelTest extends UnitTest {
 		$this->assertNotFalse( filter_var( $campaign_1->get_manage_url(), FILTER_VALIDATE_URL ) );
 	}
 
+	public function test_disabled_filter_returns_no_campaign_types() {
+		remove_filter( 'woocommerce_gla_enable_mcm', '__return_true' );
+
+		$channel = new GLAChannel(
+			$this->merchant_center,
+			$this->ads_campaign,
+			$this->ads,
+			$this->merchant_statuses,
+			$this->product_sync_stats
+		);
+		$this->assertEquals( [], $channel->get_supported_campaign_types() );
+	}
+
 	/**
 	 * Runs before each test is executed.
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a followup to PR #1904 
The intention is to always show the extension as an integrated channel, but only add the supported campaign types when the filter has been enabled.

> **Note**
Even though there might not be any supported campaign types the "Create a campaign" button still shows. This is being discussed further: pe2C5g-He-p2#comment-639

### Detailed test instructions:
1. Ensure the GLA extension is setup and onboarded with a MC account (keep ads account disconnected)
2. Visit Marketing > Overview and confirm GLA is listed on the channel card
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/69e5e339-2774-411a-8e22-34c7608d1d99)
3. Complete onboarding for the ads account (and ensure at least 1 campaign is created)
4. Revisit Marketing > Overview and confirm the campaigns card still doesn't show
5. Enable the filter:
```php
add_filter( 'woocommerce_gla_enable_mcm', '__return_true' );
```
6. Revisit Marketing > Overview and confirm the campaigns card does show now
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/79386b88-c67d-4adf-ab84-0f97a085a73d)

### Changelog entry
* Tweak - Adjust the MCM filter to always show in channels.
