### PR TITLE
Fix the coverage report of PHP unit tests not being performed in GitHub Actions

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       wp-versions: ${{ steps.wp.outputs.versions }}
+      latest-wp-version: ${{ fromJson(steps.wp.outputs.versions)[0] }}
     steps:
       - name: Get Release versions from Wordpress
         id: wp
@@ -47,7 +48,7 @@ jobs:
         wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions) }}
         include:
           - php: 7.4
-            wp-version: latest
+            wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
 
     steps:
       - name: Checkout repository
@@ -64,7 +65,7 @@ jobs:
       - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }}
 
-      - if: matrix.wp-version == 'latest' && matrix.php == 8.0
+      - if: matrix.wp-version == needs.GetMatrix.outputs.latest-wp-version && matrix.php == 8.0
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After #1954, the coverage report of PHP unit tests was not performed. For example: https://github.com/woocommerce/google-listings-and-ads/actions/runs/5128471767/jobs/9225190107

This PR fixes it by getting the first index of WP versions from the result of `woocommerce/grow/get-plugin-releases@actions-v1` action.

### Detailed test instructions:

1. View https://github.com/woocommerce/google-listings-and-ads/actions/runs/5131127786/jobs/9230809054 to check the `if` condition matching in the GHA job results.
2. View the coverage report comment in https://github.com/woocommerce/google-listings-and-ads/pull/1968#issuecomment-1569828593.

### Changelog entry
