### PR TITLE
Prefix Psr Http Message Package

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -88,7 +88,7 @@ $dependencies = [
 	'psr/container'    => [
 		'league/container',
 	],
-	'psr/http-message'    => [
+	'psr/http-message' => [
 		'firebase/php-jwt',
 		'google/apiclient',
 		'google/auth',

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -22,6 +22,11 @@ $packages = [
 		'strict'    => false,
 	],
 	[
+		'namespace' => 'Psr\\Http\\Message',
+		'package'   => 'psr/http-factory',
+		'strict'    => false,
+	],
+	[
 		'namespace' => 'Psr\\Container',
 		'package'   => 'psr/container',
 		'strict'    => false,
@@ -89,14 +94,16 @@ $dependencies = [
 		'league/container',
 	],
 	'psr/http-message' => [
-		'firebase/php-jwt',
 		'google/apiclient',
 		'google/auth',
 		'google/gax',
 		'guzzlehttp/guzzle',
 		'guzzlehttp/psr7',
 		'psr/http-client',
-		'psr/http-factory',
+	],
+	'psr/http-factory' => [
+		'firebase/php-jwt',
+		'guzzlehttp/psr7',
 	],
 ];
 

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -17,6 +17,11 @@ declare( strict_types=1 );
  */
 $packages = [
 	[
+		'namespace' => 'Psr\\Http\\Message',
+		'package'   => 'psr/http-message',
+		'strict'    => false,
+	],
+	[
 		'namespace' => 'Psr\\Container',
 		'package'   => 'psr/container',
 		'strict'    => false,
@@ -82,6 +87,16 @@ $dependencies = [
 	],
 	'psr/container'    => [
 		'league/container',
+	],
+	'psr/http-message'    => [
+		'firebase/php-jwt',
+		'google/apiclient',
+		'google/auth',
+		'google/gax',
+		'guzzlehttp/guzzle',
+		'guzzlehttp/psr7',
+		'psr/http-client',
+		'psr/http-factory',
 	],
 ];
 

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -44,9 +44,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Argument\RawArgument;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\Definition;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\RequestInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\ResponseInterface;
 use Jetpack_Options;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/tests/Tools/HelperTrait/GuzzleClientTrait.php
+++ b/tests/Tools/HelperTrait/GuzzleClientTrait.php
@@ -6,9 +6,9 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\BadResponseException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\RequestInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\ResponseInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\StreamInterface;
 
 /**
  * Trait GuzzleClient


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR prefixes the `Psr\Http\Message` package to ensure that we don't conflict with other plugins using version < 2 of the same package.

Closes #1976.

### Detailed test instructions:

1. Install GLA 2.4.7 and [flexible-shipping-ups](https://wordpress.org/plugins/flexible-shipping-ups/) plugin.
2. Go to `wp-admin/admin.php?page=wc-settings&tab=shipping`, add `UPS Live Rates` shipping method to the shipping zone you're testing.
3. Go to cart and checkout page, notice the fatal error. 
4. Checkout this branch `fix/1976-prefix-psr-http-message-package`, remove the `vendor/` directory, and run `composer install`
5. Go to the cart/checkout page again and confirm there are no errors.

### Changelog entry

> Fix - Prefix Psr\Http\Message package to prevent conflicts with other plugins.
