### PR TITLE
Prefix psr/http-client package

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -17,6 +17,11 @@ declare( strict_types=1 );
  */
 $packages = [
 	[
+		'namespace' => 'Psr\\Http\\Client',
+		'package'   => 'psr/http-client',
+		'strict'    => false,
+	],
+	[
 		'namespace' => 'Psr\\Http\\Message',
 		'package'   => 'psr/http-message',
 		'strict'    => false,
@@ -92,6 +97,10 @@ $dependencies = [
 	],
 	'psr/container'    => [
 		'league/container',
+	],
+	'psr/http-client'  => [
+		'firebase/php-jwt',
+		'guzzlehttp/guzzle',
 	],
 	'psr/http-message' => [
 		'google/apiclient',

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -267,7 +267,7 @@ function prefix_uses( &$contents, $package ) {
 	// Replace direct class implements.
 	$contents = preg_replace(
 		"#(\s*)(class .* implements)\s*([a-zA-Z0-9_\\,]*\s*)(\\\\{$quoted}\\\\[a-zA-Z0-9_]+\s*\{?)$#m",
-		"\$1\$2 \$3 \\\\{$namespace_prefix}\$4",
+		"\$1\$2 \$3\\\\{$namespace_prefix}\$4",
 		$contents
 	);
 

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -264,6 +264,13 @@ function prefix_uses( &$contents, $package ) {
 		$contents
 	);
 
+	// Replace direct class implements.
+	$contents = preg_replace(
+		"#(\s*)(class .* implements)\s*([a-zA-Z0-9_\\,]*\s*)(\\\\{$quoted}\\\\[a-zA-Z0-9_]+\s*\{?)$#m",
+		"\$1\$2 \$3 \\\\{$namespace_prefix}\$4",
+		$contents
+	);
+
 	if ( $package['strict'] && ! empty( $package['extra_namespaces'] ) ) {
 		foreach ( $package['extra_namespaces'] as $namespace ) {
 			prefix_uses(

--- a/src/API/Google/ApiExceptionTrait.php
+++ b/src/API/Google/ApiExceptionTrait.php
@@ -4,9 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\BadResponseException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
 use Google\ApiCore\ApiException;
 use Google\Rpc\Code;
-use Psr\Http\Client\ClientExceptionInterface;
 
 /**
  * Trait ApiExceptionTrait

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -9,8 +9,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -15,9 +15,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\TosAccepted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
 use DateTime;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 
 defined( 'ABSPATH' ) || exit;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a followup to #1977 where we prefixed the `psr/http-message` and `psr/http-factory` classes.

In the following scenario it still generates a fatal error because we didn't prefix `psr/http-client`:
A plugin gets activated before `google-listings-and-ads` (plugins are activated in alphabetical order) and the plugin has the package `vendor/psr/http-client`. 

This PR resolves that by prefixing the `psr/http-client` package.

> **Note**
There is an instance where a class implements a directly namespaced class without a use line, to get round this I added another regex to replace those instances.

### Detailed test instructions:
1. Install and activate Google Listings & Ads
2. Install and activate a conflicting plugin, such as: https://wordpress.org/plugins/backwpup/
3. Notice the fatal error in the logs:
```
PHP Fatal error:  Declaration of Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client::sendRequest(Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\RequestInterface $request): Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\ResponseInterface must be compatible with Psr\Http\Client\ClientInterface::sendRequest(Psr\Http\Message\RequestInterface $request): Psr\Http\Message\ResponseInterface in google-listings-and-ads/vendor/guzzlehttp/guzzle/src/Client.php on line 132
```
3. Install the GLA version from this PR
4. Clear out the vendor folder and rerun composer install: `rm -rf vendor && composer install` 
5. Confirm that we can now activate both extensions and the site functions normally

### Changelog entry
* Fix - Prefix psr/http-client package.
>
