### PR TITLE
Add prepare release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,44 @@
+name: 'Prepare New Release'
+run-name:  Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
+
+# **What it does**: Does release preparation: creates the release branch and the PR with a checklist.
+# **Why we have it**: To support devs automating a few manual steps, and to leave a nice reference for consumers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ## In the future we could infer that version from the changelog, or bump it via major|minor|patch.
+      version:
+        description: 'Version number to be released'
+        required: true
+      type:
+        description: 'Type of the release (release|hotfix)'
+        required: true
+        default: 'release'
+      wp-version:
+        description: 'WordPress tested up to'
+      wc-version:
+        description: 'WooCommerce tested up to'
+
+
+jobs:
+  PrepareRelease:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create branch & PR
+        uses: woocommerce/grow/prepare-extension-release@actions-v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          type: ${{ github.event.inputs.type }}
+          wp-version: ${{ github.event.inputs.wp-version }}
+          wc-version: ${{ github.event.inputs.wc-version }}
+          main-branch: 'trunk'
+          pre-steps: |
+            1. [ ] Remove older changelog entries from `readme.txt` (keep the last two versions, since we will be adding a third during the release), commit changes.
+            1. [ ] If there are new database migration classes (under `src/DB/Migration/`), modify their applicable version set in the `get_applicable_version` class of each migration class to be the same value as the version that is to be released.
+               :warning: Notice that `x.x.x` is not a valid version and should be set manually with the new version. So, for example, if we are releasing version 1.12.0 and there is a file `Migration20211228T1640692399.php` inside `src/DB/Migration/`, you should open that file and in the method `get_applicable_version` return `1.12.0`.
+            1. [ ] :exclamation: If this release has updated composer packages, we should test [Composer package conflicts with other plugins](https://github.com/woocommerce/google-listings-and-ads/wiki/Smoke-tests#composer-package-conflicts-with-other-plugins).


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add prepare release workflow, to serve a consistent, easy-to-follow release checklist and reduce redundancy in wiki pages.

Requires https://github.com/woocommerce/grow/pull/58

### Screenshots:
![image](https://github.com/woocommerce/google-listings-and-ads/assets/17435/4ad3db72-e33a-446d-a48e-a18779854dc8)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Unfortunately, manual workflows are not accessible before being merged into the main branch.

1. Create a test repo with proposed workflow merged to the main branch.
2. Go to `https://github.com/{org}/{repo}/actions/workflows/prepare-release.yml`, like https://github.com/woocommerce/automatewoo/actions/workflows/prepare-release.yml
3. Click the "Run workflow" dropdown, fill in the details, and click "Run..."
4. Wait for the workflow to finish
5. Check the created PR


### Additional details:

1. I'll update the wiki once this PR is merged

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - add the release PR & checklist.
