### PR TITLE
Fix the parent options being rendered as the selected tags in the TreeSelectControl

### DIFF
--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -152,13 +152,15 @@ const TreeSelectControl = ( {
 		cacheRef.current.filteredOptionsMap.clear();
 
 		function loadOption( option, parentId ) {
+			const { children = [] } = option;
 			option.parent = parentId;
 
-			option.children?.forEach( ( el ) =>
-				loadOption( el, option.value )
-			);
+			children.forEach( ( el ) => loadOption( el, option.value ) );
 
-			repository[ option.key ?? option.value ] = option;
+			// Only children can be rendered as selected tags.
+			if ( ! children.length ) {
+				repository[ option.key ?? option.value ] = option;
+			}
 		}
 
 		treeOptions.forEach( loadOption );

--- a/js/src/components/tree-select-control/index.test.js
+++ b/js/src/components/tree-select-control/index.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
@@ -20,6 +20,11 @@ const options = [
 	{
 		value: 'AS',
 		label: 'Asia',
+	},
+	{
+		value: 'same-value',
+		label: 'Parent - same value',
+		children: [ { value: 'same-value', label: 'Child - same value' } ],
 	},
 ];
 
@@ -78,6 +83,7 @@ describe( 'TreeSelectControl Component', () => {
 	} );
 
 	it( 'Renders the All Options', () => {
+		const allValues = [ 'ES', 'FR', 'IT', 'AS', 'same-value' ];
 		const onChange = jest.fn().mockName( 'onChange' );
 		const { queryByLabelText, queryByRole, rerender } = render(
 			<TreeSelectControl options={ options } onChange={ onChange } />
@@ -90,11 +96,11 @@ describe( 'TreeSelectControl Component', () => {
 		expect( allCheckbox ).toBeTruthy();
 
 		fireEvent.click( allCheckbox );
-		expect( onChange ).toHaveBeenCalledWith( [ 'ES', 'FR', 'IT', 'AS' ] );
+		expect( onChange ).toHaveBeenCalledWith( allValues );
 
 		rerender(
 			<TreeSelectControl
-				value={ [ 'ES', 'FR', 'IT', 'AS' ] }
+				value={ allValues }
 				options={ options }
 				onChange={ onChange }
 			/>
@@ -116,6 +122,31 @@ describe( 'TreeSelectControl Component', () => {
 		const allCheckbox = queryByLabelText( 'All countries' );
 
 		expect( allCheckbox ).toBeTruthy();
+	} );
+
+	it( 'Should only allow children to be rendered as selected tags', () => {
+		render(
+			<TreeSelectControl
+				value={ [ 'EU', 'AS', 'FR' ] }
+				options={ options }
+			/>
+		);
+
+		const buttons = screen.getAllByRole( 'button', { name: /remove/i } );
+
+		expect( buttons.length ).toBe( 2 );
+		expect( screen.queryByText( 'Europe' ) ).toBeFalsy();
+	} );
+
+	it( 'When a parent and a child have the same value and be selected, the rendered tag should be the child', () => {
+		render(
+			<TreeSelectControl value={ [ 'same-value' ] } options={ options } />
+		);
+
+		const buttons = screen.getAllByRole( 'button', { name: /remove/i } );
+
+		expect( buttons.length ).toBe( 1 );
+		expect( screen.queryByText( 'Child - same value' ) ).toBeTruthy();
 	} );
 
 	it( 'Filters Options on Search', () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1986

The country code of Saudi Arabia and the continent code of South America are the same - "SA". The `TreeSelectControl` component should only render children as selected tags, but incorrectly render the parent option as the selected tag when a parent and a child have the same option value.

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/8163160e-97c8-4dea-afe7-1df89ec80c87

### Detailed test instructions:

1. Go to the "Edit your listings" page.
2. Select the Saudi Arabia option.
3. The selected tag should be Saudi Arabia as well

### Changelog entry

> Fix - Incorrectly display South America in the audience location selector after selecting Saudi Arabia.
