### PR TITLE
Add a step to publish the latest extension build for the `develop` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Publish dev build to GitHub
         # For temporary testing
         if: ${{ github.event_name == 'push' && github.ref_name == 'dev/gh-actions-build' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v1
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v1.8.0-pre
         # if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
         # uses: woocommerce/grow/publish-extension-dev-build@actions-v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Publish dev build to GitHub
         # For temporary testing
         if: ${{ github.event_name == 'push' && github.ref_name == 'dev/gh-actions-build' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v1.8.0-pre
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v1
         # if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
         # uses: woocommerce/grow/publish-extension-dev-build@actions-v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - trunk
       - develop
-      # For temporary testing
-      - dev/gh-actions-build
   pull_request:
 
 concurrency:
@@ -47,9 +45,7 @@ jobs:
       # - https://github.com/bundlewatch/bundlewatch/issues/423
       # - https://github.com/bundlewatch/bundlewatch/issues/220
       - name: Prepare BundleWatch env values - push
-        # For temporary testing
-        if: ${{ github.event_name == 'push' && github.ref_name != 'dev/gh-actions-build' }}
-        # if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           BRANCH=$(echo '${{ github.event.ref }}' | sed 's/^refs\/heads\///')
           echo "CI_BRANCH=$BRANCH" >> $GITHUB_ENV
@@ -69,10 +65,7 @@ jobs:
         run: node ./node_modules/bundlewatch/lib/bin/index.js
 
       - name: Publish dev build to GitHub
-        # For temporary testing
-        if: ${{ github.event_name == 'push' && github.ref_name == 'dev/gh-actions-build' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v1.8.0-pre
-        # if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-        # uses: woocommerce/grow/publish-extension-dev-build@actions-v1
+        if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v1
         with:
           extension-asset-path: google-listings-and-ads.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Bundle Size
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - trunk
       - develop
+      # For temporary testing
+      - dev/gh-actions-build
   pull_request:
 
 concurrency:
@@ -45,7 +47,9 @@ jobs:
       # - https://github.com/bundlewatch/bundlewatch/issues/423
       # - https://github.com/bundlewatch/bundlewatch/issues/220
       - name: Prepare BundleWatch env values - push
-        if: ${{ github.event_name == 'push' }}
+        # For temporary testing
+        if: ${{ github.event_name == 'push' && github.ref_name != 'dev/gh-actions-build' }}
+        # if: ${{ github.event_name == 'push' }}
         run: |
           BRANCH=$(echo '${{ github.event.ref }}' | sed 's/^refs\/heads\///')
           echo "CI_BRANCH=$BRANCH" >> $GITHUB_ENV
@@ -65,7 +69,10 @@ jobs:
         run: node ./node_modules/bundlewatch/lib/bin/index.js
 
       - name: Publish dev build to GitHub
-        if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v1
+        # For temporary testing
+        if: ${{ github.event_name == 'push' && github.ref_name == 'dev/gh-actions-build' }}
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v1.8.0-pre
+        # if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
+        # uses: woocommerce/grow/publish-extension-dev-build@actions-v1
         with:
           extension-asset-path: google-listings-and-ads.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  BundleSize:
-    name: Bundle size
+  BuildExtensionBundle:
+    name: Build extension bundle
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 2
@@ -63,3 +63,9 @@ jobs:
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
         run: node ./node_modules/bundlewatch/lib/bin/index.js
+
+      - name: Publish dev build to GitHub
+        if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v1
+        with:
+          extension-asset-path: google-listings-and-ads.zip

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![JavaScript Unit Tests](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-unit-tests.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-unit-tests.yml)
 [![PHP Coding Standards](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/php-coding-standards.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/php-coding-standards.yml)
 [![JavaScript and CSS Linting](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-css-linting.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-css-linting.yml)
-[![Bundle Size](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/bundle-size.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/bundle-size.yml)
+[![Build](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/build.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/build.yml)
 
 A native integration with Google offering free listings and Performance Max ads to WooCommerce merchants.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The idea is to keep collaborators informed of what contents are coming but not yet released at any time, and to be the latest test build for download, without waiting for developers to build one.

In particular, it might help with the mentioned question of collaboration with our Product Ambassador: “What process can we put in place to help remind us to get the Product Ambassador involved at an early stage?”

Ref: peeuvX-AL-p2

### 📌 Checklist before merging (@eason9487)

💡 To verify the new GH action, this PR temporarily added 52abc574d15001302ea52bcc7af4b55346364729 and it will be reverted before merging.

- [x] Wait for https://github.com/woocommerce/grow/pull/60 to be approved, merged and released
- [x] Check if the workflow runs successfully with the released GH action
- [x] Revert 2f3d6e8352781bad86e26ed0eea6fae97a582e5b and 52abc574d15001302ea52bcc7af4b55346364729

### Screenshots:

#### 📷 First run: Create a new pre-release when there is no existing release with the same tag name `gha-dev-build`

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/7f1e7cd1-6f66-4b68-ab4c-753c7ededc73)

#### 📷 Second run: Update the existing pre-release when the same tag name `gha-dev-build` was found

![2](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/9a432b3d-8cc6-47ed-916d-8e6a81cf7e2a)

### Detailed test instructions:

1. View the published release for the `develop` branch: https://github.com/woocommerce/google-listings-and-ads/releases/tag/gha-dev-build
2. View the workflow job logs: https://github.com/woocommerce/google-listings-and-ads/actions/runs/5277027865
3. Rerun the above workflow job to see if it can update the **google-listings-and-ads.zip** asset file.
   - The file content and changelog won't be changed as there should be no new updates after the rerun.

### Changelog entry
