### PR TITLE
Enable unit testing for PHP 8.1

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -49,6 +49,8 @@ jobs:
         include:
           - php: 7.4
             wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
+          - php: 8.1
+            wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We had one [pending point](https://github.com/woocommerce/google-listings-and-ads/issues/1758#issuecomment-1415897005) to enable unit testing for PHP 8.1. The package has been updated so this PR enables unit testing for PHP 8.1 in GitHub actions.

> **Note**
Enabling it for PHP 8.2 is still too premature as there are several warning still coming from WooCommerce:
```
There were 3 errors:

1) Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter\ContactInformationControllerTest::test_register_route
Creation of dynamic property WC_Email_New_Order::$email_type is deprecated

2) Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping\SyncerHooksTest::test_deleting_method_from_shipping_zone_schedules_update_job
Creation of dynamic property WC_Shipping_Free_Shipping::$ignore_discounts is deprecated

3) Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping\SyncerHooksTest::test_updating_method_options_schedules_update_job
Creation of dynamic property WC_Shipping_Free_Shipping::$ignore_discounts is deprecated
```

Closes #1758 

### Detailed test instructions:
1. Confirm unit tests in this PR runs for PHP versions 7.4, 8.0 (various WP versions), and PHP 8.1 

### Changelog entry
* Dev - Enable unit testing for PHP 8.1.
