### PR TITLE
Add Empty Data placeholder in Attribute Mapping Table

### DIFF
--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -106,6 +106,10 @@ const AttributeMappingTable = () => {
 						/>
 					) : (
 						<Table
+							emptyMessage={ __(
+								'You have no attribute rules',
+								'google-listings-and-ads'
+							) }
 							caption={ __(
 								'Attribute Mapping configuration',
 								'google-listings-and-ads'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1830 

After `woocommerce/components ` was bumped, `emptyMessage` property is now available for the tables so we can add the empty data placeholder. 

### Screenshots:

<img width="1613" alt="Screenshot 2023-06-16 at 12 02 47" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/7474feb5-7ebe-47eb-8044-7894e50829cf">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this PR and compile assets with `npm run start`
2. Go to the Attribute Mapping tab
3. If you have no rules it should show --> "You have no attribute rules"


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Add placeholder in the Attribute Mapping table when there are no rules available.
