### PR TITLE
Avoid continuing to sync settings with GMC after shipping time API failed

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -254,63 +254,45 @@ export function* fetchShippingTimes() {
  * Updates or inserts given aggregated shipping rate.
  *
  * @param {AggregatedShippingTime} shippingTime
+ * @throws Will throw an error if the request failed.
  */
 export function* upsertShippingTimes( shippingTime ) {
 	const { countryCodes, time } = shippingTime;
 
-	try {
-		yield apiFetch( {
-			path: `${ API_NAMESPACE }/mc/shipping/times/batch`,
-			method: 'POST',
-			data: {
-				country_codes: countryCodes,
-				time,
-			},
-		} );
+	yield apiFetch( {
+		path: `${ API_NAMESPACE }/mc/shipping/times/batch`,
+		method: 'POST',
+		data: {
+			country_codes: countryCodes,
+			time,
+		},
+	} );
 
-		return {
-			type: TYPES.UPSERT_SHIPPING_TIMES,
-			shippingTime,
-		};
-	} catch ( error ) {
-		yield handleFetchError(
-			error,
-			__(
-				'There was an error trying to add / update shipping times. Please try again later.',
-				'google-listings-and-ads'
-			)
-		);
-	}
+	return {
+		type: TYPES.UPSERT_SHIPPING_TIMES,
+		shippingTime,
+	};
 }
 
 /**
  * Deletes shipping times associated with given country codes.
  *
  * @param {Array<CountryCode>} countryCodes
+ * @throws Will throw an error if the request failed.
  */
 export function* deleteShippingTimes( countryCodes ) {
-	try {
-		yield apiFetch( {
-			path: `${ API_NAMESPACE }/mc/shipping/times/batch`,
-			method: 'DELETE',
-			data: {
-				country_codes: countryCodes,
-			},
-		} );
+	yield apiFetch( {
+		path: `${ API_NAMESPACE }/mc/shipping/times/batch`,
+		method: 'DELETE',
+		data: {
+			country_codes: countryCodes,
+		},
+	} );
 
-		return {
-			type: TYPES.DELETE_SHIPPING_TIMES,
-			countryCodes,
-		};
-	} catch ( error ) {
-		yield handleFetchError(
-			error,
-			__(
-				'There was an error trying to delete shipping times. Please try again later.',
-				'google-listings-and-ads'
-			)
-		);
-	}
+	return {
+		type: TYPES.DELETE_SHIPPING_TIMES,
+		countryCodes,
+	};
 }
 
 export function* fetchSettings() {

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -158,6 +158,7 @@ export function* fetchShippingRates() {
  *
  * @param {Array<ShippingRate>} shippingRates Shipping rates to be upserted.
  * @return {Object} Action object to update shipping rates.
+ * @throws Will throw an error if the request failed.
  */
 export function* upsertShippingRates( shippingRates ) {
 	const data = yield apiFetch( {
@@ -186,6 +187,7 @@ export function* upsertShippingRates( shippingRates ) {
  *
  * @param {Array<string>} ids IDs of shiping rates to be deleted.
  * @return {Object} Action object to delete shipping rates.
+ * @throws Will throw an error if the request failed.
  */
 export function* deleteShippingRates( ids ) {
 	yield apiFetch( {

--- a/js/src/hooks/useSaveShippingRates.js
+++ b/js/src/hooks/useSaveShippingRates.js
@@ -36,6 +36,7 @@ const useSaveShippingRates = () => {
 		 * and then upserting the new shipping rates.
 		 *
 		 * @param {Array<ShippingRate>} newShippingRates
+		 * @throws Will throw an error if any request failed.
 		 */
 		async ( newShippingRates ) => {
 			const deleteIds = getDeleteIds(

--- a/js/src/hooks/useSaveShippingTimes.js
+++ b/js/src/hooks/useSaveShippingTimes.js
@@ -65,6 +65,7 @@ const useSaveShippingTimes = () => {
 		 * and then upserting the new shipping times.
 		 *
 		 * @param {Array<ShippingTime>} newShippingTimes
+		 * @throws Will throw an error if any request failed.
 		 */
 		async ( newShippingTimes ) => {
 			const deletedCountryCodes = getDeletedCountryCodes(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1331
Closes #489

This PR solves two tasks of 📌 [Deal with technical error handling](https://github.com/woocommerce/google-listings-and-ads/issues/1993#tasks-error-handling) in #1993.

- Fixes the issue of continuing to sync settings with GMC after shipping time API failed, like the following screenshot.
- Extra change: Update JSDoc of shipping rates related actions and hooks to indicate they may throw an error.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/83433703-ff0e-4699-8d50-eb185d9b0da2)

#### Summary for #1331

In order to solve #1331, it needs to:
- Throw out errors from shipping rate actions ([#1313](https://github.com/woocommerce/google-listings-and-ads/pull/1313))
- Throw out errors from the `saveTargetAudience` action ([#1586](https://github.com/woocommerce/google-listings-and-ads/pull/1586))
- Throw out errors from the `saveSettings ` action ([#1598](https://github.com/woocommerce/google-listings-and-ads/pull/1598))
- Hande multiple errors for failed API calls ([#1602](https://github.com/woocommerce/google-listings-and-ads/pull/1602))
- This PR is the last piece - Throw out errors from shipping time actions

#### Summary for #489

In order to handle errors from the outside of **wp-data** actions

- [#1313](https://github.com/woocommerce/google-listings-and-ads/pull/1313) removed the `try...catch` block from a shipping rate action
- This PR removes the `try...catch` blocks from shipping time actions

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/10fb6bd3-6418-4eaf-8acf-05ad865ed84c

### Detailed test instructions:

To trigger API failures, one of the easier ways is to change the API endpoint(s) in actions.js:

https://github.com/woocommerce/google-listings-and-ads/blob/f1775c2696ee930595ea9a33ba116c4234c90a1c/js/src/data/actions.js#L265

https://github.com/woocommerce/google-listings-and-ads/blob/f1775c2696ee930595ea9a33ba116c4234c90a1c/js/src/data/actions.js#L287

and rebuild the client side JS files.

1. Go to step 2 of the onboarding flow.
2. Make some changes to the shipping time setting.
3. Check if an error message is displayed via a notification at the bottom left of the page.
4. Go to the free listings editing page.
5. Make some changes to the shipping time setting and save changes.
6. Check if an error message is displayed via a notification at the bottom left of the page and if there is no success notification at the same time.

### Changelog entry

> Fix - Avoid continuing to save settings to Google Merchant Center after the shipping time save failed on the Edit Free Listings page.
