### PR TITLE
Show a general error message when the phone number verification request is failed

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -610,6 +610,21 @@ export function* requestPhoneVerificationCode( country, phoneNumber, method ) {
 			verificationId: response.verification_id,
 		};
 	} catch ( error ) {
+		// TODO: Remove the handling of 'backendError' and add the case for 'badRequest'.
+		//
+		// Currently, 'badRequest' won't be presented but maybe someday it can be handled.
+		// Ref:
+		// - https://github.com/woocommerce/google-listings-and-ads/issues/1101
+		// - https://github.com/woocommerce/google-listings-and-ads/issues/1998
+		if ( error.reason === 'backendError' ) {
+			throw {
+				display: __(
+					'Unable to request the verification code. This may be due to an invalid phone number or the limit of five attempts to verify the same phone number every four hours.',
+					'google-listings-and-ads'
+				),
+			};
+		}
+
 		if ( error.reason === 'rateLimitExceeded' ) {
 			throw {
 				...error,

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -610,9 +610,10 @@ export function* requestPhoneVerificationCode( country, phoneNumber, method ) {
 			verificationId: response.verification_id,
 		};
 	} catch ( error ) {
-		// TODO: Remove the handling of 'backendError' and add the case for 'badRequest'.
+		// Currently, 'badRequest' won't be presented and all error responses return the
+		// same reason 'backendError'. Maybe someday the error reason can be distinguished
+		// and then we can recheck if there is a better way to handle errors.
 		//
-		// Currently, 'badRequest' won't be presented but maybe someday it can be handled.
 		// Ref:
 		// - https://github.com/woocommerce/google-listings-and-ads/issues/1101
 		// - https://github.com/woocommerce/google-listings-and-ads/issues/1998


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR solves a task of 📌 [Clarify API error messages](https://github.com/woocommerce/google-listings-and-ads/issues/1993#tasks-clarify-api-errors) in #1993

Closes #1101 

This PR fixes the blank error message when requesting verification with an invalid phone number. Please also refer to #1998 for why this PR can only show a general error message.

### Screenshots:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/b907b2ab-1222-4810-bcc1-4500620130b4)

### Detailed test instructions:

1. Go to the phone number editing page under the settings page or step 3 of the onboarding flow.
2. Request verification with an invalid phone number. For example, `+31` and `111111111`.
3. Check if the UI shows a proper error message.

### Additional details:

I didn't add tests in this PR as I hope to add more comprehensive tests for the `VerifyPhoneNumberContent` component before the end of the project if there is still time. Added a follow-up item to 📌 [Add tests](https://github.com/woocommerce/google-listings-and-ads/issues/1993#fe-tests).

### Changelog entry

> Fix - Show a general error message when the phone number verification request is failed.
