### PR TITLE
Replace undefined $border-width-focus var

### DIFF
--- a/js/src/components/app-tab-nav/index.scss
+++ b/js/src/components/app-tab-nav/index.scss
@@ -29,12 +29,12 @@
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: inset 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 
 		&.is-active {
 			// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-			box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 - $border-width-tab 0 0 var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 0 - $border-width-tab 0 0 var(--wp-admin-theme-color);
 			position: relative;
 
 			// This border appears in Windows High Contrast mode instead of the box-shadow.
@@ -50,11 +50,11 @@
 		}
 
 		&:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 
 		&.is-active:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 - $border-width-tab 0 0 var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 - $border-width-tab 0 0 var(--wp-admin-theme-color);
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove an undefined CSS variable that once existed in a Gutenberg package.

When working on setting the npm engines in the repo I found an issue with an undefined CSS variable: $border-width-focus. 

Apparently, this variable once existed in the Gutenberg code but doesn't seem to any more. I think it was [renamed to](https://github.com/WordPress/gutenberg/blob/b3ea2b6a80ee92f26148899455669c53ae2f49de/packages/base-styles/_variables.scss#L87) $border-width-focus-fallback and its recommended to use `--wp-admin-border-width-focus`.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. See the error compiling the app with `npm run start` (might need to remove `package-lock.json` first, and run `npm i`).
2. Checkout this PR and see the error not happening
3. See Nav Tabs in GLA plugin looking good 


### Additional details:

ℹ️  I was thinking to replace it with `$border-width-focus-fallback` or just `2px` but since it's the written recommendation I guess it's better `--wp-admin-border-width-focus` 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Remove deprecated $border-width-focus variable.  
