### PR TITLE
Add the built-in WP REST API validation to `CountryCodeTrait` to avoid errors when clearing all audience countries in the onboarding flow

### DIFF
--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -81,6 +81,7 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 					'type' => 'string',
 				],
 				'required'          => true,
+				'minItems'          => 1,
 			],
 		];
 	}

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -321,6 +321,7 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 				'sanitize_callback' => $this->get_country_code_sanitize_callback(),
 				'validate_callback' => $this->get_supported_country_code_validate_callback(),
 				'required'          => true,
+				'minItems'          => 1,
 				'items'             => [
 					'type' => 'string',
 				],

--- a/src/API/Site/Controllers/CountryCodeTrait.php
+++ b/src/API/Site/Controllers/CountryCodeTrait.php
@@ -49,10 +49,10 @@ trait CountryCodeTrait {
 	 * @throws OutOfBoundsException When the country code cannot be found.
 	 */
 	protected function validate_country_codes( bool $check_supported_country, $countries, $request, $param ) {
-		$valid = rest_validate_request_arg( $countries, $request, $param );
+		$validation_result = rest_validate_request_arg( $countries, $request, $param );
 
-		if ( true !== $valid ) {
-			return $valid;
+		if ( true !== $validation_result ) {
+			return $validation_result;
 		}
 
 		try {

--- a/src/API/Site/Controllers/CountryCodeTrait.php
+++ b/src/API/Site/Controllers/CountryCodeTrait.php
@@ -39,6 +39,11 @@ trait CountryCodeTrait {
 	 * Validate that a country or a list of countries is valid and supported,
 	 * and also validate the data by the built-in validation of WP REST API with parameter’s schema.
 	 *
+	 * Since this extension's all API endpoints that use this validation function specify both
+	 * `validate_callback` and `sanitize_callback`, this makes the built-in schema validation
+	 * in WP REST API not to be applied. Therefore, this function calls `rest_validate_request_arg`
+	 * first, so that the API endpoints can still benefit from the built-in schema validation.
+	 *
 	 * @param bool    $check_supported_country  Whether to check the country is supported.
 	 * @param mixed   $countries                An individual string or an array of strings.
 	 * @param Request $request                  The request to validate.

--- a/src/API/Site/Controllers/CountryCodeTrait.php
+++ b/src/API/Site/Controllers/CountryCodeTrait.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\WPErrorTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelperAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\ISO3166Awareness;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\Exception\OutOfBoundsException;
+use WP_REST_Request as Request;
 use Exception;
 use Throwable;
 
@@ -35,16 +36,25 @@ trait CountryCodeTrait {
 	}
 
 	/**
-	 * Validate that a country or a list of countries is valid and supported.
+	 * Validate that a country or a list of countries is valid and supported,
+	 * and also validate the data by the built-in validation of WP REST API with parameter’s schema.
 	 *
-	 * @param mixed $countries                An individual string or an array of strings.
-	 * @param bool  $check_supported_country  Whether to check the country is supported.
+	 * @param bool    $check_supported_country  Whether to check the country is supported.
+	 * @param mixed   $countries                An individual string or an array of strings.
+	 * @param Request $request                  The request to validate.
+	 * @param string  $param                    The parameter name, used in error messages.
 	 *
 	 * @return mixed
 	 * @throws Exception            When the country is not supported.
 	 * @throws OutOfBoundsException When the country code cannot be found.
 	 */
-	protected function validate_country_codes( $countries, bool $check_supported_country ) {
+	protected function validate_country_codes( bool $check_supported_country, $countries, $request, $param ) {
+		$valid = rest_validate_request_arg( $countries, $request, $param );
+
+		if ( true !== $valid ) {
+			return $valid;
+		}
+
 		try {
 			// This is used for individual strings and an array of strings.
 			$countries = (array) $countries;
@@ -91,24 +101,26 @@ trait CountryCodeTrait {
 	}
 
 	/**
-	 * Get a callable function for validating that a provided country code is recognized.
+	 * Get a callable function for validating that a provided country code is recognized
+	 * and fulfilled the given parameter's schema.
 	 *
 	 * @return callable
 	 */
 	protected function get_country_code_validate_callback(): callable {
-		return function( $value ) {
-			return $this->validate_country_codes( $value, false );
+		return function( ...$args ) {
+			return $this->validate_country_codes( false, ...$args );
 		};
 	}
 
 	/**
-	 * Get a callable function for validating that a provided country code is recognized and supported.
+	 * Get a callable function for validating that a provided country code is recognized, supported,
+	 * and fulfilled the given parameter's schema..
 	 *
 	 * @return callable
 	 */
 	protected function get_supported_country_code_validate_callback(): callable {
-		return function( $value ) {
-			return $this->validate_country_codes( $value, true );
+		return function( ...$args ) {
+			return $this->validate_country_codes( true, ...$args );
 		};
 	}
 }

--- a/src/API/Site/Controllers/CountryCodeTrait.php
+++ b/src/API/Site/Controllers/CountryCodeTrait.php
@@ -59,10 +59,6 @@ trait CountryCodeTrait {
 			// This is used for individual strings and an array of strings.
 			$countries = (array) $countries;
 
-			if ( empty( $countries ) ) {
-				throw new Exception( __( 'No countries provided.', 'google-listings-and-ads' ) );
-			}
-
 			foreach ( $countries as $country ) {
 				$this->validate_country_code( $country );
 				if ( $check_supported_country ) {

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -124,6 +124,21 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
+	/**
+	 * Test a failed query of budget recommendation with empty country codes.
+	 */
+	public function test_get_budget_recommendation_with_empty_country_codes() {
+		$budget_recommendation_params = [
+			'country_codes' => [],
+		];
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): country_codes', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
 	public function test_get_budget_recommendation_with_nonexistent_country_code() {
 		$budget_recommendation_params = [
 			'country_codes' => [ 'AAAAA' ],

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -259,12 +259,6 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 			'targeted_locations' => [],
 		];
 
-		$expected = [
-			'id'      => self::TEST_CAMPAIGN_ID,
-			'status'  => 'enabled',
-			'country' => self::BASE_COUNTRY,
-		] + $campaign_data;
-
 		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
 
 		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingTimeBatchController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_REST_Response as Response;
+
+/**
+ * Class ShippingTimeBatchControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
+ */
+class ShippingTimeBatchControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|Container $container */
+	protected $container;
+
+	/** @var MockObject|ISO3166DataProvider $iso_provider */
+	protected $iso_provider;
+
+	/** @var ShippingTimeBatchController $controller */
+	protected $controller;
+
+	protected const ROUTE_SHIPPING_TIME_BATCH = '/wc/gla/mc/shipping/times/batch';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->container    = $this->createMock( Container::class );
+		$this->iso_provider = $this->createMock( ISO3166DataProvider::class );
+
+		$this->container->method( 'get' )->willReturn( $this->server );
+
+		$this->server->register_route(
+			'/wc/gla',
+			'/mc/shipping/times',
+			[
+				'methods'  => TransportMethods::CREATABLE,
+				'callback' => function( $request ) {
+					return new Response( $request->get_param( 'country_code' ), 201 );
+				},
+			]
+		);
+
+		$this->controller = new ShippingTimeBatchController( $this->container );
+
+		$this->controller->set_iso3166_provider( $this->iso_provider );
+		$this->controller->register();
+	}
+
+	/**
+	 * Test a successful dispatch request for the batch creation of shipping times.
+	 */
+	public function test_create_shipping_time_batch() {
+		$payload = [
+			'country_codes' => [ 'US', 'GB' ],
+			'time'          => 5,
+		];
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIME_BATCH, 'POST', $payload );
+
+		$expected = [
+			'errors'  => [],
+			'success' => $payload['country_codes'],
+		];
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	/**
+	 * Test a failed batch creation of shipping times with empty country codes.
+	 */
+	public function test_create_shipping_time_batch_empty_country_codes() {
+		$payload = [
+			'country_codes' => [],
+		];
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIME_BATCH, 'POST', $payload );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): country_codes', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test a failed batch creation of shipping times with duplicate country codes.
+	 */
+	public function test_create_shipping_time_batch_duplicate_country_codes() {
+		$payload = [
+			'country_codes' => [ 'US', 'GB', 'US' ],
+		];
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIME_BATCH, 'POST', $payload );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): country_codes', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/TargetAudienceControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/TargetAudienceControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\TargetAudienceController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class TargetAudienceControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
+ */
+class TargetAudienceControllerTest extends RESTControllerUnitTest {
+
+	/** @var WP $wp */
+	protected $wp;
+
+	/** @var WC $wc */
+	protected $wc;
+
+	/** @var MockObject|ShippingZone $shipping_zone */
+	protected $shipping_zone;
+
+	/** @var MockObject|ISO3166DataProvider $iso_provider */
+	protected $iso_provider;
+
+	/** @var MockObject|GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var TargetAudienceController $controller */
+	protected $controller;
+
+	protected const ROUTE_TARGET_AUDIENCE = '/wc/gla/mc/target_audience';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->wp            = $this->createMock( WP::class );
+		$this->wc            = $this->createMock( WC::class );
+		$this->shipping_zone = $this->createMock( ShippingZone::class );
+		$this->iso_provider  = $this->createMock( ISO3166DataProvider::class );
+		$this->google_helper = $this->createMock( GoogleHelper::class );
+		$this->options       = $this->createMock( OptionsInterface::class );
+
+		$this->controller = new TargetAudienceController( $this->server, $this->wp, $this->wc, $this->shipping_zone, $this->google_helper );
+
+		$this->controller->set_iso3166_provider( $this->iso_provider );
+		$this->controller->set_options_object( $this->options );
+		$this->controller->register();
+
+		$this->google_helper->method( 'is_country_supported' )->willReturn( true );
+	}
+
+	/**
+	 * Test a successful update of target audience.
+	 */
+	public function test_update_target_audience() {
+		$payload = [
+			'location'  => 'selected',
+			'countries' => [ 'US', 'GB' ],
+		];
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::TARGET_AUDIENCE, $payload );
+
+		$response = $this->do_request( self::ROUTE_TARGET_AUDIENCE, 'POST', $payload );
+
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	/**
+	 * Test a successful update of target audience with empty country codes.
+	 */
+	public function test_update_target_audience_empty_countries() {
+		$payload = [
+			'location'  => 'all',
+			'countries' => [],
+		];
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::TARGET_AUDIENCE, $payload );
+
+		$response = $this->do_request( self::ROUTE_TARGET_AUDIENCE, 'POST', $payload );
+
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 201, $response->get_status() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR solves a task of 📌 [Clarify API error messages](https://github.com/woocommerce/google-listings-and-ads/issues/1993#tasks-clarify-api-errors) in #1993

Closes #1855

Originally, clearing the recipient country did not cause API errors. After #1327, the POST `/mc/target_audience` API was also validated by [this check](https://github.com/woocommerce/google-listings-and-ads/blob/3cc6936fc2938952f120f8c0478fccfaf2ba9eac/src/API/Site/Controllers/CountryCodeTrait.php#L52-L54), which causes the auto-saving behavior in the onboarding flow to get errors.

- Add the built-in validation of WP REST API for the country codes in `CountryCodeTrait`.
- Change to use the parameter's schema to validate if the country codes array is not empty for needed Controllers:
   - `BudgetRecommendationController`
   - `CampaignController`
- Add or adjust tests for the related Controllers:
   - Add basic tests for the `TargetAudienceController` and `ShippingTimeBatchController`.
   - Add the test case of empty country codes for the `BudgetRecommendationController`
   - Remove an unused variable from the `test_create_campaign_empty_targeted_locations` in CampaignControllerTest.php

📌 Please take a look at the **Additional details** for contexts and other solutions.

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/16973d6c-388c-4081-a4c5-25905a88a1ca

### Detailed test instructions:

1. Go to step 2 of the onboarding flow.
2. Remove all audience countries.
3. Check if there is no API error.

### <a href="#additional-details" id="additional-details">Additional details</a>:

#### About the validation mechanism of WP REST API

When extending the WP REST API, [the mechanism of `validate_callback` and `sanitize_callback`](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/#api) is somewhat surprising. In summary, the findings are:
1. If the `sanitize_callback` is not specified but `type` is specified, both built-in `validate_callback` and `sanitize_callback` will be applied no matter whether the `validate_callback` is a custom one.
2. If both `validate_callback` and `sanitize_callback` are specified with custom callbacks, the built-in schema validation won't be applied.
3. The built-in `validate_callback` may be applied two times if not specify both callbacks.
4. When the built-in `validate_callback` is skipped, the `required` specified in `args` will still work. This makes the validation options of `args` work or not, resulting in more unexpected inconsistencies.
5. Looks like there is no way to specify in `args` that when a custom `validate_callback` is specified, still uses the built-in schema validation.

This can be a bit confusing to use because the main goal of `sanitize_callback` doesn't seem to be data validation, but whether the built-in schema validation works in the end depends on `sanitize_callback` and not just `validate_callback`.

#### Why the current solution: Add the built-in validation to `CountryCodeTrait`

When dealing with this issue, I have thought about other possible solutions, and the reasons for choosing the current one so far are:
- The ability to use core validation that has been validated for a long time can prevent GLA from doing similar validation additionally.
- There are some GLA APIs that use validation schemas such as `minItems` and `uniqueItems` for country codes, but these have not really worked in the past. This solution will allow them to work together as well.
   - [BatchSchemaTrait](https://github.com/woocommerce/google-listings-and-ads/blob/3cc6936fc2938952f120f8c0478fccfaf2ba9eac/src/API/Site/Controllers/BatchSchemaTrait.php#L40-L45)
   - [ShippingRateSuggestionsController](https://github.com/woocommerce/google-listings-and-ads/blob/3cc6936fc2938952f120f8c0478fccfaf2ba9eac/src/API/Site/Controllers/MerchantCenter/ShippingRateSuggestionsController.php#L68-L73)
- There are a few similar implementations in the WP core.
   - [class-wp-rest-posts-controller.php](https://github.com/WordPress/wordpress-develop/blob/6.2.2/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2977-L2980)
   - [class-wp-rest-menus-controller.php](https://github.com/WordPress/wordpress-develop/blob/6.2.2/src/wp-includes/rest-api/endpoints/class-wp-rest-menus-controller.php#L538-L542)
   - [class-wp-rest-themes-controller.php](https://github.com/WordPress/wordpress-develop/blob/6.2.2/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php#L648-L652)

But I still have some doubts about whether doing so within `CountryCodeTrait` is too subtle and becomes inconsistent at a higher level concept.

#### Other possible solutions

1. Add the third parameter to [`CountryCodeTrait::validate_country_codes`](https://github.com/woocommerce/google-listings-and-ads/blob/3cc6936fc2938952f120f8c0478fccfaf2ba9eac/src/API/Site/Controllers/CountryCodeTrait.php#L47) and to all related callers.
2. Similar to the first one but don't add the parameter to callers. Instead, add a new method such as `get_country_code_and_allow_empty_validate_callback` to `CountryCodeTrait`.
3. Wrap [the `validate_callback` in `TargetAudienceController`](https://github.com/woocommerce/google-listings-and-ads/blob/3cc6936fc2938952f120f8c0478fccfaf2ba9eac/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php#L253) with an additional process: When `countries` is found to be empty, skip calling to the validation function returned by `get_country_code_validate_callback`.
4. Remove the custom `sanitize_callback` from all `CountryCodeTrait::validate_country_codes`-related callers so that the built-in `validate_callback` will be applied.
5. Add a new API dedicated to removing the audience countries and change the original POST `/mc/target_audience` to create audience countries instead of a PUT like the one defined in the RESTful API.
6. Any others?

### Changelog entry

> Fix - Avoid errors when clearing all audience countries in the onboarding flow.
