### PR TITLE
Add PHP tests for `CountryCodeTrait` and two related API controllers

### DIFF
--- a/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
+++ b/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
@@ -1,0 +1,248 @@
+<?php
+// This namespace must be identical to CountryCodeTrait for replacing and
+// mocking the global function rest_validate_request_arg.
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers {
+	use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\CountryCodeTraitTest;
+
+	/**
+	 * Replace and mock the global function rest_validate_request_arg.
+	 */
+	function rest_validate_request_arg() {
+		$mocked_callback = CountryCodeTraitTest::$rest_validate_request_arg_callback;
+
+		if ( is_null( $mocked_callback ) ) {
+			return \rest_validate_request_arg( ...func_get_args() );
+		}
+
+		return $mocked_callback( ...func_get_args() );
+	}
+};
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers {
+	use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
+	use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+	use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+	use PHPUnit\Framework\MockObject\MockObject;
+	use PHPUnit\Framework\TestCase;
+	use Exception;
+	use WP_Error;
+	use WP_REST_Request as Request;
+
+	/**
+	 * Class CountryCodeTraitTest
+	 *
+	 * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers
+	 * @phpcs:disable Squiz.Classes.ClassDeclaration.SpaceBeforeKeyword
+	 * @phpcs:disable Squiz.Classes.ClassDeclaration.SpaceBeforeCloseBrace
+	 */
+	class CountryCodeTraitTest extends TestCase {
+
+		/** @var callable $rest_validate_request_arg_callback */
+		public static $rest_validate_request_arg_callback = null;
+
+		/** @var MockObject|ISO3166DataProvider $iso_provider */
+		protected $iso_provider;
+
+		/** @var MockObject|GoogleHelper $google_helper */
+		protected $google_helper;
+
+		/** @var bool $country_supported */
+		protected $country_supported;
+
+		/**
+		 * Runs before each test is executed.
+		 */
+		public function setUp(): void {
+			parent::setUp();
+
+			$this->iso_provider  = $this->createMock( ISO3166DataProvider::class );
+			$this->google_helper = $this->createMock( GoogleHelper::class );
+
+			// phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
+			$this->trait = new class {
+				use CountryCodeTrait {
+					get_country_code_sanitize_callback as public;
+					get_country_code_validate_callback as public;
+					get_supported_country_code_validate_callback as public;
+				}
+			};
+
+			$this->trait->set_iso3166_provider( $this->iso_provider );
+			$this->trait->set_google_helper_object( $this->google_helper );
+
+			$this->country_supported = true;
+
+			$this->google_helper->method( 'is_country_supported' )
+				->willReturnCallback(
+					function () {
+						return $this->country_supported;
+					}
+				);
+		}
+
+		/**
+		 * Runs after each test is executed.
+		 */
+		public function tearDown(): void {
+			self::$rest_validate_request_arg_callback = null;
+		}
+
+		/**
+		 * Test all get_*_callback methods return a callable.
+		 */
+		public function test_all_get_callbacks_return_callable() {
+			$this->assertIsCallable( $this->trait->get_country_code_sanitize_callback() );
+			$this->assertIsCallable( $this->trait->get_country_code_validate_callback() );
+			$this->assertIsCallable( $this->trait->get_supported_country_code_validate_callback() );
+		}
+
+		/**
+		 * Test the get_country_code_validate_callback and get_supported_country_code_validate_callback
+		 * methods will apply arguments to rest_validate_request_arg_callback and return early if invalid.
+		 */
+		public function test_all_get_validate_callbacks_with_rest_validate_request_arg() {
+			$called_count = 0;
+
+			self::$rest_validate_request_arg_callback = function () use ( &$called_count ) {
+				// When it returns a value other than `true`, it means the validation did not pass,
+				// and here we also make it return a called count.
+				$called_count++;
+				return [ $called_count, func_get_args() ];
+			};
+
+			$args = [ 'US', new Request(), 'country_code' ];
+
+			$callback = $this->trait->get_country_code_validate_callback();
+			$results  = $callback( ...$args );
+
+			$this->assertEquals( [ 1, $args ], $results );
+
+			$callback = $this->trait->get_supported_country_code_validate_callback();
+			$results  = $callback( ...$args );
+
+			$this->assertEquals( [ 2, $args ], $results );
+		}
+
+		/**
+		 * Test a sanitized country code with a string.
+		 */
+		public function test_get_country_code_sanitize_callback_with_string() {
+			$callback = $this->trait->get_country_code_sanitize_callback();
+			$result   = $callback( 'us' );
+
+			$this->assertEquals( 'US', $result );
+		}
+
+		/**
+		 * Test sanitized country codes with an array.
+		 */
+		public function test_get_country_code_sanitize_callback_with_array() {
+			$callback = $this->trait->get_country_code_sanitize_callback();
+			$results  = $callback( [ 'us', 'gb', 'jp' ] );
+
+			$this->assertEquals( [ 'US', 'GB', 'JP' ], $results );
+		}
+
+		/**
+		 * Test a valid country code with a string.
+		 */
+		public function test_get_country_code_validate_callback_with_string() {
+			$callback = $this->trait->get_country_code_validate_callback();
+			$result   = $callback( 'US', new Request(), 'country_code' );
+
+			$this->assertTrue( $result );
+		}
+
+		/**
+		 * Test valid country codes with an array.
+		 */
+		public function test_get_country_code_validate_callback_with_array() {
+			$callback = $this->trait->get_country_code_validate_callback();
+			$result   = $callback( [ 'US', 'GB' ], new Request(), 'country_codes' );
+
+			$this->assertTrue( $result );
+		}
+
+		/**
+		 * Test valid country codes with unsupported countries.
+		 *
+		 * It determines as valid since this method only checks if the countries match ISO 3166
+		 * but won't check if Google Merchant Center supports the countries.
+		 */
+		public function test_get_country_code_validate_callback_with_unsupported_country() {
+			$this->country_supported = false;
+
+			$callback = $this->trait->get_country_code_validate_callback();
+			$result   = $callback( [ 'CN', 'KP' ], new Request(), 'country_codes' );
+
+			$this->assertTrue( $result );
+		}
+
+		/**
+		 * Test an invalid country code.
+		 */
+		public function test_get_country_code_validate_callback_with_invalid_country_code() {
+			$this->iso_provider
+				->method( 'alpha2' )
+				->willThrowException( new Exception( 'Country is invalid' ) );
+
+			$callback = $this->trait->get_country_code_validate_callback();
+			$result   = $callback( [ 'United States' ], new Request(), 'country_codes' );
+
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
+			$this->assertEquals( 'Country is invalid', $result->get_error_message() );
+		}
+
+		/**
+		 * Test a valid country code with a string.
+		 */
+		public function test_get_supported_country_code_validate_callback_with_string() {
+			$callback = $this->trait->get_supported_country_code_validate_callback();
+			$result   = $callback( 'US', new Request(), 'country_code' );
+
+			$this->assertTrue( $result );
+		}
+
+		/**
+		 * Test valid country codes with an array.
+		 */
+		public function test_get_supported_country_code_validate_callback_with_array() {
+			$callback = $this->trait->get_supported_country_code_validate_callback();
+			$result   = $callback( [ 'US', 'GB' ], new Request(), 'country_codes' );
+
+			$this->assertTrue( $result );
+		}
+
+		/**
+		 * Test unsupported country codes.
+		 */
+		public function test_get_supported_country_code_validate_callback_with_unsupported_country() {
+			$this->country_supported = false;
+
+			$callback = $this->trait->get_supported_country_code_validate_callback();
+			$result   = $callback( [ 'CN', 'KP' ], new Request(), 'country_codes' );
+
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
+			$this->assertEquals( 'Country is not supported', $result->get_error_message() );
+		}
+
+		/**
+		 * Test an invalid country code.
+		 */
+		public function test_get_supported_country_code_validate_callback_with_invalid_country_code() {
+			$this->iso_provider
+				->method( 'alpha2' )
+				->willThrowException( new Exception( 'Country is invalid' ) );
+
+			$callback = $this->trait->get_supported_country_code_validate_callback();
+			$result   = $callback( [ 'United States' ], new Request(), 'country_codes' );
+
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
+			$this->assertEquals( 'Country is invalid', $result->get_error_message() );
+		}
+	}
+
+};

--- a/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
+++ b/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
@@ -1,251 +1,248 @@
 <?php
 declare( strict_types=1 );
 
-namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers {
-	use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
-	use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
-	use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
-	use PHPUnit\Framework\MockObject\MockObject;
-	use PHPUnit\Framework\TestCase;
-	use Exception;
-	use WP_Error;
-	use WP_REST_Request as Request;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Exception;
+use WP_Error;
+use WP_REST_Request as Request;
+
+/**
+ * Class CountryCodeTraitTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers
+ */
+class CountryCodeTraitTest extends TestCase {
+
+	/** @var MockObject|ISO3166DataProvider $iso_provider */
+	protected $iso_provider;
+
+	/** @var MockObject|GoogleHelper $google_helper */
+	protected $google_helper;
+
+	/** @var bool $country_supported */
+	protected $country_supported;
 
 	/**
-	 * Class CountryCodeTraitTest
-	 *
-	 * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers
-	 * @phpcs:disable Squiz.Classes.ClassDeclaration.SpaceBeforeKeyword
-	 * @phpcs:disable Squiz.Classes.ClassDeclaration.SpaceBeforeCloseBrace
+	 * Runs before each test is executed.
 	 */
-	class CountryCodeTraitTest extends TestCase {
+	public function setUp(): void {
+		parent::setUp();
 
-		/** @var MockObject|ISO3166DataProvider $iso_provider */
-		protected $iso_provider;
+		$this->iso_provider  = $this->createMock( ISO3166DataProvider::class );
+		$this->google_helper = $this->createMock( GoogleHelper::class );
 
-		/** @var MockObject|GoogleHelper $google_helper */
-		protected $google_helper;
-
-		/** @var bool $country_supported */
-		protected $country_supported;
-
-		/**
-		 * Runs before each test is executed.
-		 */
-		public function setUp(): void {
-			parent::setUp();
-
-			$this->iso_provider  = $this->createMock( ISO3166DataProvider::class );
-			$this->google_helper = $this->createMock( GoogleHelper::class );
-
-			// phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
-			$this->trait = new class {
-				use CountryCodeTrait {
-					get_country_code_sanitize_callback as public;
-					get_country_code_validate_callback as public;
-					get_supported_country_code_validate_callback as public;
-				}
-			};
-
-			$this->trait->set_iso3166_provider( $this->iso_provider );
-			$this->trait->set_google_helper_object( $this->google_helper );
-
-			$this->country_supported = true;
-
-			$this->google_helper->method( 'is_country_supported' )
-				->willReturnCallback(
-					function () {
-						return $this->country_supported;
-					}
-				);
-		}
-
-		/**
-		 * Test all get_*_callback methods return a callable.
-		 */
-		public function test_all_get_callbacks_return_callable() {
-			$this->assertIsCallable( $this->trait->get_country_code_sanitize_callback() );
-			$this->assertIsCallable( $this->trait->get_country_code_validate_callback() );
-			$this->assertIsCallable( $this->trait->get_supported_country_code_validate_callback() );
-		}
-
-		/**
-		 * Test the get_country_code_validate_callback and get_supported_country_code_validate_callback
-		 * methods will apply arguments to rest_validate_request_arg.
-		 *
-		 * Replacing the global `rest_validate_request_arg` function to verify if it's called would
-		 * require multiple namespaces in this file and increase the test complexity.
-		 *
-		 * As an alternative, here using the I/O of callbacks to verify that their return value matches
-		 * the result of `rest_validate_request_arg`, thereby indirectly verifying that it will be called
-		 * by these callbacks.
-		 */
-		public function test_all_get_validate_callbacks_with_rest_validate_request_arg() {
-			$callbacks = [
-				$this->trait->get_country_code_validate_callback(),
-				$this->trait->get_supported_country_code_validate_callback(),
-			];
-
-			$request = new Request();
-			$request->set_attributes(
-				[
-					'args' => [
-						'country_codes' => [
-							'type'        => 'array',
-							'items'       => [ 'type' => 'string' ],
-							'minItems'    => 2,
-							'uniqueItems' => true,
-						],
-					],
-				]
-			);
-
-			foreach ( $callbacks as $callback ) {
-				// Valid case
-				$result = $callback( [ 'US', 'GB' ], $request, 'country_codes' );
-
-				$this->assertTrue( $result );
-
-				// Invalid due to the 'items' schema
-				$result = $callback( [ 'US', 123 ], $request, 'country_codes' );
-
-				$this->assertInstanceOf( WP_Error::class, $result );
-				$this->assertArrayHasKey( 'rest_invalid_type', $result->errors );
-				$this->assertContains( 'country_codes[1] is not of type string.', $result->errors['rest_invalid_type'] );
-
-				// Invalid due to the 'minItems' schema
-				$result = $callback( [ 'US' ], $request, 'country_codes' );
-
-				$this->assertInstanceOf( WP_Error::class, $result );
-				$this->assertArrayHasKey( 'rest_too_few_items', $result->errors );
-				$this->assertContains( 'country_codes must contain at least 2 items.', $result->errors['rest_too_few_items'] );
-
-				// Invalid due to the 'uniqueItems' schema
-				$result = $callback( [ 'US', 'GB', 'US' ], $request, 'country_codes' );
-
-				$this->assertInstanceOf( WP_Error::class, $result );
-				$this->assertArrayHasKey( 'rest_duplicate_items', $result->errors );
-				$this->assertContains( 'country_codes has duplicate items.', $result->errors['rest_duplicate_items'] );
+		// phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
+		$this->trait = new class {
+			use CountryCodeTrait {
+				get_country_code_sanitize_callback as public;
+				get_country_code_validate_callback as public;
+				get_supported_country_code_validate_callback as public;
 			}
-		}
+		};
 
-		/**
-		 * Test a sanitized country code with a string.
-		 */
-		public function test_get_country_code_sanitize_callback_with_string() {
-			$this->assertEquals( 'US', $this->trait->get_country_code_sanitize_callback()( 'us' ) );
-		}
+		$this->trait->set_iso3166_provider( $this->iso_provider );
+		$this->trait->set_google_helper_object( $this->google_helper );
 
-		/**
-		 * Test sanitized country codes with an array.
-		 */
-		public function test_get_country_code_sanitize_callback_with_array() {
-			$callback = $this->trait->get_country_code_sanitize_callback();
-			$results  = $callback( [ 'us', 'gb', 'jp' ] );
+		$this->country_supported = true;
 
-			$this->assertEquals( [ 'US', 'GB', 'JP' ], $results );
-		}
+		$this->google_helper->method( 'is_country_supported' )
+			->willReturnCallback(
+				function () {
+					return $this->country_supported;
+				}
+			);
+	}
 
-		/**
-		 * Test a valid country code with a string.
-		 */
-		public function test_get_country_code_validate_callback_with_string() {
-			$callback = $this->trait->get_country_code_validate_callback();
-			$result   = $callback( 'US', new Request(), 'country_code' );
+	/**
+	 * Test all get_*_callback methods return a callable.
+	 */
+	public function test_all_get_callbacks_return_callable() {
+		$this->assertIsCallable( $this->trait->get_country_code_sanitize_callback() );
+		$this->assertIsCallable( $this->trait->get_country_code_validate_callback() );
+		$this->assertIsCallable( $this->trait->get_supported_country_code_validate_callback() );
+	}
+
+	/**
+	 * Test the get_country_code_validate_callback and get_supported_country_code_validate_callback
+	 * methods will apply arguments to rest_validate_request_arg.
+	 *
+	 * Replacing the global `rest_validate_request_arg` function to verify if it's called would
+	 * require multiple namespaces in this file and increase the test complexity.
+	 *
+	 * As an alternative, here using the I/O of callbacks to verify that their return value matches
+	 * the result of `rest_validate_request_arg`, thereby indirectly verifying that it will be called
+	 * by these callbacks.
+	 */
+	public function test_all_get_validate_callbacks_with_rest_validate_request_arg() {
+		$callbacks = [
+			$this->trait->get_country_code_validate_callback(),
+			$this->trait->get_supported_country_code_validate_callback(),
+		];
+
+		$request = new Request();
+		$request->set_attributes(
+			[
+				'args' => [
+					'country_codes' => [
+						'type'        => 'array',
+						'items'       => [ 'type' => 'string' ],
+						'minItems'    => 2,
+						'uniqueItems' => true,
+					],
+				],
+			]
+		);
+
+		foreach ( $callbacks as $callback ) {
+			// Valid case
+			$result = $callback( [ 'US', 'GB' ], $request, 'country_codes' );
 
 			$this->assertTrue( $result );
-		}
 
-		/**
-		 * Test valid country codes with an array.
-		 */
-		public function test_get_country_code_validate_callback_with_array() {
-			$callback = $this->trait->get_country_code_validate_callback();
-			$result   = $callback( [ 'US', 'GB' ], new Request(), 'country_codes' );
-
-			$this->assertTrue( $result );
-		}
-
-		/**
-		 * Test valid country codes with unsupported countries.
-		 *
-		 * It determines as valid since this method only checks if the countries match ISO 3166
-		 * but won't check if Google Merchant Center supports the countries.
-		 */
-		public function test_get_country_code_validate_callback_with_unsupported_country() {
-			$this->country_supported = false;
-
-			$callback = $this->trait->get_country_code_validate_callback();
-			$result   = $callback( [ 'CN', 'KP' ], new Request(), 'country_codes' );
-
-			$this->assertTrue( $result );
-		}
-
-		/**
-		 * Test an invalid country code.
-		 */
-		public function test_get_country_code_validate_callback_with_invalid_country_code() {
-			$this->iso_provider
-				->method( 'alpha2' )
-				->willThrowException( new Exception( 'Country is invalid' ) );
-
-			$callback = $this->trait->get_country_code_validate_callback();
-			$result   = $callback( [ 'United States' ], new Request(), 'country_codes' );
+			// Invalid due to the 'items' schema
+			$result = $callback( [ 'US', 123 ], $request, 'country_codes' );
 
 			$this->assertInstanceOf( WP_Error::class, $result );
-			$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
-			$this->assertEquals( 'Country is invalid', $result->get_error_message() );
-		}
+			$this->assertArrayHasKey( 'rest_invalid_type', $result->errors );
+			$this->assertContains( 'country_codes[1] is not of type string.', $result->errors['rest_invalid_type'] );
 
-		/**
-		 * Test a valid country code with a string.
-		 */
-		public function test_get_supported_country_code_validate_callback_with_string() {
-			$callback = $this->trait->get_supported_country_code_validate_callback();
-			$result   = $callback( 'US', new Request(), 'country_code' );
-
-			$this->assertTrue( $result );
-		}
-
-		/**
-		 * Test valid country codes with an array.
-		 */
-		public function test_get_supported_country_code_validate_callback_with_array() {
-			$callback = $this->trait->get_supported_country_code_validate_callback();
-			$result   = $callback( [ 'US', 'GB' ], new Request(), 'country_codes' );
-
-			$this->assertTrue( $result );
-		}
-
-		/**
-		 * Test unsupported country codes.
-		 */
-		public function test_get_supported_country_code_validate_callback_with_unsupported_country() {
-			$this->country_supported = false;
-
-			$callback = $this->trait->get_supported_country_code_validate_callback();
-			$result   = $callback( [ 'CN', 'KP' ], new Request(), 'country_codes' );
+			// Invalid due to the 'minItems' schema
+			$result = $callback( [ 'US' ], $request, 'country_codes' );
 
 			$this->assertInstanceOf( WP_Error::class, $result );
-			$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
-			$this->assertEquals( 'Country is not supported', $result->get_error_message() );
-		}
+			$this->assertArrayHasKey( 'rest_too_few_items', $result->errors );
+			$this->assertContains( 'country_codes must contain at least 2 items.', $result->errors['rest_too_few_items'] );
 
-		/**
-		 * Test an invalid country code.
-		 */
-		public function test_get_supported_country_code_validate_callback_with_invalid_country_code() {
-			$this->iso_provider
-				->method( 'alpha2' )
-				->willThrowException( new Exception( 'Country is invalid' ) );
-
-			$callback = $this->trait->get_supported_country_code_validate_callback();
-			$result   = $callback( [ 'United States' ], new Request(), 'country_codes' );
+			// Invalid due to the 'uniqueItems' schema
+			$result = $callback( [ 'US', 'GB', 'US' ], $request, 'country_codes' );
 
 			$this->assertInstanceOf( WP_Error::class, $result );
-			$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
-			$this->assertEquals( 'Country is invalid', $result->get_error_message() );
+			$this->assertArrayHasKey( 'rest_duplicate_items', $result->errors );
+			$this->assertContains( 'country_codes has duplicate items.', $result->errors['rest_duplicate_items'] );
 		}
 	}
 
-};
+	/**
+	 * Test a sanitized country code with a string.
+	 */
+	public function test_get_country_code_sanitize_callback_with_string() {
+		$this->assertEquals( 'US', $this->trait->get_country_code_sanitize_callback()( 'us' ) );
+	}
+
+	/**
+	 * Test sanitized country codes with an array.
+	 */
+	public function test_get_country_code_sanitize_callback_with_array() {
+		$callback = $this->trait->get_country_code_sanitize_callback();
+		$results  = $callback( [ 'us', 'gb', 'jp' ] );
+
+		$this->assertEquals( [ 'US', 'GB', 'JP' ], $results );
+	}
+
+	/**
+	 * Test a valid country code with a string.
+	 */
+	public function test_get_country_code_validate_callback_with_string() {
+		$callback = $this->trait->get_country_code_validate_callback();
+		$result   = $callback( 'US', new Request(), 'country_code' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test valid country codes with an array.
+	 */
+	public function test_get_country_code_validate_callback_with_array() {
+		$callback = $this->trait->get_country_code_validate_callback();
+		$result   = $callback( [ 'US', 'GB' ], new Request(), 'country_codes' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test valid country codes with unsupported countries.
+	 *
+	 * It determines as valid since this method only checks if the countries match ISO 3166
+	 * but won't check if Google Merchant Center supports the countries.
+	 */
+	public function test_get_country_code_validate_callback_with_unsupported_country() {
+		$this->country_supported = false;
+
+		$callback = $this->trait->get_country_code_validate_callback();
+		$result   = $callback( [ 'CN', 'KP' ], new Request(), 'country_codes' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test an invalid country code.
+	 */
+	public function test_get_country_code_validate_callback_with_invalid_country_code() {
+		$this->iso_provider
+			->method( 'alpha2' )
+			->willThrowException( new Exception( 'Country is invalid' ) );
+
+		$callback = $this->trait->get_country_code_validate_callback();
+		$result   = $callback( [ 'United States' ], new Request(), 'country_codes' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
+		$this->assertEquals( 'Country is invalid', $result->get_error_message() );
+	}
+
+	/**
+	 * Test a valid country code with a string.
+	 */
+	public function test_get_supported_country_code_validate_callback_with_string() {
+		$callback = $this->trait->get_supported_country_code_validate_callback();
+		$result   = $callback( 'US', new Request(), 'country_code' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test valid country codes with an array.
+	 */
+	public function test_get_supported_country_code_validate_callback_with_array() {
+		$callback = $this->trait->get_supported_country_code_validate_callback();
+		$result   = $callback( [ 'US', 'GB' ], new Request(), 'country_codes' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test unsupported country codes.
+	 */
+	public function test_get_supported_country_code_validate_callback_with_unsupported_country() {
+		$this->country_supported = false;
+
+		$callback = $this->trait->get_supported_country_code_validate_callback();
+		$result   = $callback( [ 'CN', 'KP' ], new Request(), 'country_codes' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
+		$this->assertEquals( 'Country is not supported', $result->get_error_message() );
+	}
+
+	/**
+	 * Test an invalid country code.
+	 */
+	public function test_get_supported_country_code_validate_callback_with_invalid_country_code() {
+		$this->iso_provider
+			->method( 'alpha2' )
+			->willThrowException( new Exception( 'Country is invalid' ) );
+
+		$callback = $this->trait->get_supported_country_code_validate_callback();
+		$result   = $callback( [ 'United States' ], new Request(), 'country_codes' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'gla_invalid_country', $result->get_error_code() );
+		$this->assertEquals( 'Country is invalid', $result->get_error_message() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
+++ b/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
@@ -127,10 +127,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 		 * Test a sanitized country code with a string.
 		 */
 		public function test_get_country_code_sanitize_callback_with_string() {
-			$callback = $this->trait->get_country_code_sanitize_callback();
-			$result   = $callback( 'us' );
-
-			$this->assertEquals( 'US', $result );
+			$this->assertEquals( 'US', $this->trait->get_country_code_sanitize_callback()( 'us' ) );
 		}
 
 		/**

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUn
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use Exception;
 use WP_REST_Response as Response;
 
 /**
@@ -98,6 +99,25 @@ class ShippingTimeBatchControllerTest extends RESTControllerUnitTest {
 	public function test_create_shipping_time_batch_duplicate_country_codes() {
 		$payload = [
 			'country_codes' => [ 'US', 'GB', 'US' ],
+		];
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIME_BATCH, 'POST', $payload );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): country_codes', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test a failed batch creation of shipping times with invalid country codes.
+	 */
+	public function test_create_shipping_time_batch_invalid_country_codes() {
+		$this->iso_provider
+			->method( 'alpha2' )
+			->willThrowException( new Exception( 'invalid_country' ) );
+
+		$payload = [
+			'country_codes' => [ 'United States' ],
 		];
 
 		$response = $this->do_request( self::ROUTE_SHIPPING_TIME_BATCH, 'POST', $payload );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/TargetAudienceControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/TargetAudienceControllerTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -100,5 +101,25 @@ class TargetAudienceControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 'success', $response->get_data()['status'] );
 		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	/**
+	 * Test a failed update of target audience with invalid country codes.
+	 */
+	public function test_update_target_audience_invalid_countries() {
+		$this->iso_provider
+			->method( 'alpha2' )
+			->willThrowException( new Exception( 'invalid_country' ) );
+
+		$payload = [
+			'location'  => 'selected',
+			'countries' => [ 'United States' ],
+		];
+
+		$response = $this->do_request( self::ROUTE_TARGET_AUDIENCE, 'POST', $payload );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): countries', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up PR of https://github.com/woocommerce/google-listings-and-ads/pull/2003#issuecomment-1612941617

- Add test cases for asserting failed requests with invalid country codes.
   - `TargetAudienceController`
   - `ShippingTimeBatchController`
- Add tests for the `CountryCodeTrait`

P.S. I didn't add test cases for "requests should be successful with unsupported country codes" as they seem to be missing data validations from the APIs rather than missing these test cases.

### Detailed test instructions:

1. Check if the PHP unit tests can pass.
2. Check if the test cases fit with the test purpose.

### Additional details:

My original idea was to cover the test objectives more comprehensively by:

1. Test all cases for `CountryCodeTrait`
2. Assert whether the `args` of the API endpoints in the related controllers like `TargetAudienceController` has specified `minItems` and use `CountryCodeTrait::get_country_code_validate_callback` as its callable `validate_callback`.

Because the invalid/unsupported country codes will already be covered by `CountryCodeTraitTest`, and the schema validations are already tested by WP core. Therefore, this way should be able to ensure that the validations in these API controllers will work well.

Unfortunately, after some time I still couldn't figure out how to verify the second point robustly. Several of my attempts have been relatively indirect and have too much relied on internal implementation. Perhaps the concept of PHPUnit doesn't advocate this but should focus on testing the I/O of public methods.

In view of the above and I have already spent too much time on this follow-up work, I have instead added similar test cases for these API controllers and also kept the newly added `CountryCodeTraitTest`.

### Changelog entry
