### PR TITLE
Add client name and version as request headers

### DIFF
--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -134,6 +134,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			$handler_stack->remove( 'http_errors' );
 			$handler_stack->push( $this->error_handler(), 'http_errors' );
 			$handler_stack->push( $this->add_auth_header() );
+			$handler_stack->push( $this->add_plugin_version_header() );
 
 			// Override endpoint URL if we are using http locally.
 			if ( 0 === strpos( $this->get_connect_server_url_root()->getValue(), 'http://' ) ) {
@@ -247,6 +248,26 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 					$this->set_jetpack_connected( false );
 					throw AccountReconnect::jetpack_disconnected();
+				}
+
+				return $handler( $request, $options );
+			};
+		};
+	}
+
+	/**
+	 * Add client name and version headers to request
+	 *
+	 * @return callable
+	 */
+	protected function add_plugin_version_header(): callable {
+		return function( callable $handler ) {
+			return function( RequestInterface $request, array $options ) use ( $handler ) {
+				try {
+					$request = $request->withHeader( 'x-client-name', $this->get_client_name() );
+					$request = $request->withHeader( 'x-client-version', $this->get_version() );
+				} catch ( WPError $error ) {
+					do_action( 'woocommerce_gla_guzzle_client_exception', $error, __METHOD__ . ' in add_plugin_version_header()' );
 				}
 
 				return $handler( $request, $options );

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -134,7 +134,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			$handler_stack->remove( 'http_errors' );
 			$handler_stack->push( $this->error_handler(), 'http_errors' );
 			$handler_stack->push( $this->add_auth_header() );
-			$handler_stack->push( $this->add_plugin_version_header() );
+			$handler_stack->push( $this->add_plugin_version_header(), 'plugin_version_header' );
 
 			// Override endpoint URL if we are using http locally.
 			if ( 0 === strpos( $this->get_connect_server_url_root()->getValue(), 'http://' ) ) {
@@ -258,18 +258,19 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Add client name and version headers to request
 	 *
+	 * @since x.x.x
+	 *
 	 * @return callable
 	 */
-	protected function add_plugin_version_header(): callable {
+	public function add_plugin_version_header(): callable {
 		return function( callable $handler ) {
 			return function( RequestInterface $request, array $options ) use ( $handler ) {
 				try {
-					$request = $request->withHeader( 'x-client-name', $this->get_client_name() );
-					$request = $request->withHeader( 'x-client-version', $this->get_version() );
+					$request = $request->withHeader( 'x-client-name', $this->get_client_name() )
+									   ->withHeader( 'x-client-version', $this->get_version() );
 				} catch ( WPError $error ) {
 					do_action( 'woocommerce_gla_guzzle_client_exception', $error, __METHOD__ . ' in add_plugin_version_header()' );
 				}
-
 				return $handler( $request, $options );
 			};
 		};

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -265,12 +265,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	public function add_plugin_version_header(): callable {
 		return function( callable $handler ) {
 			return function( RequestInterface $request, array $options ) use ( $handler ) {
-				try {
-					$request = $request->withHeader( 'x-client-name', $this->get_client_name() )
-									   ->withHeader( 'x-client-version', $this->get_version() );
-				} catch ( WPError $error ) {
-					do_action( 'woocommerce_gla_guzzle_client_exception', $error, __METHOD__ . ' in add_plugin_version_header()' );
-				}
+				$request = $request->withHeader( 'x-client-name', $this->get_client_name() )
+								   ->withHeader( 'x-client-version', $this->get_version() );
 				return $handler( $request, $options );
 			};
 		};

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -40,6 +40,15 @@ trait PluginHelper {
 	}
 
 	/**
+	 * Get the client name for this plugin.
+	 *
+	 * @return string
+	 */
+	protected function get_client_name(): string {
+		return 'google-listings-and-ads';
+	}
+
+	/**
 	 * Get the plugin slug.
 	 *
 	 * @return string

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends ContainerAwareUnitTest {
 	use PluginHelper;
 
 	/**
-	 * Confirm that the client handler stack includes the `plugin_version_header
+	 * Confirm that the client handler stack includes the `plugin_version_header`
 	 *
 	 * @return void
 	 */

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -1,0 +1,58 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\RequestInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use ReflectionClass;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ClientTest
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API
+ */
+class ClientTest extends ContainerAwareUnitTest {
+	use PluginHelper;
+
+	/**
+	 * Confirm that the client handler stack includes the `plugin_version_header
+	 *
+	 * @return void
+	 */
+	public function test_plugin_version_header_in_handler_stack(): void {
+		$client     = $this->container->get( Client::class );
+		$handler    = $client->getConfig( 'handler' );
+		$reflection = new ReflectionClass( $handler );
+
+		$property = $reflection->getProperty( 'stack' );
+		$property->setAccessible( true );
+
+		$handler_stack = $property->getValue( $handler );
+
+		$this->assertNotFalse( array_search( 'plugin_version_header', array_column( $handler_stack, 1 ), true ) );
+	}
+
+	/**
+	 * Confirm that withHeader is called on RequestInterface in
+	 * add_plugin_version_header to set the x-client-name header.
+	 *
+	 * @return void
+	 */
+	public function test_plugin_version_headers(): void {
+		$service = new GoogleServiceProvider();
+
+		$request = $this->createMock( RequestInterface::class );
+		$request->expects( $this->once() )
+				->method( 'withHeader' )
+				->withConsecutive( [ 'x-client-name', $this->get_client_name() ] );
+
+		$service->add_plugin_version_header()( function(){ } )( $request, [] );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds two additional headers to requests sent to the WooCommerce Connect Server:

- `x-client-name`
- `x-client-version`

### Detailed test instructions:
1. Checkout `add/plugin-version-header` on a new test site
2. Work through onboarding and establish a connection to a Google account
3. Navigate to `Marketing > Google Listings & Ads` and visit various sections
4. Confirm that no errors are reported and all data is loaded as expected

### Changelog entry

> Add - Client name and plugin version to requests