### PR TITLE
Add Tip component when assets are imported

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
+import { Tip } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import './asset-group-section.scss';
  */
 export default function AssetGroupSection() {
 	const { adapter } = useAdaptiveFormContext();
+	const showTip = adapter.hasImportedAssets;
 
 	return (
 		<Section
@@ -70,6 +72,14 @@ export default function AssetGroupSection() {
 					// reselect button in the card footer.
 					hideFooter={ ! adapter.isEmptyAssetEntityGroup }
 				/>
+				{ showTip && (
+					<Tip>
+						{ __(
+							'We auto-populated assets directly from your Final URL. We encourage you to edit or add more in order to best showcase your business.',
+							'google-listings-and-ads'
+						) }
+					</Tip>
+				) }
 				<AssetGroupCard />
 			</VerticalGapLayout>
 		</Section>

--- a/js/src/components/paid-ads/asset-group/asset-group-section.scss
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.scss
@@ -11,11 +11,8 @@
 		background: #f0f6fc;
 		border: $border-width solid #c5d9ed;
 		line-height: $gla-line-height-medium;
+		color: $gray-900;
 
-		> p {
-			color: $gray-900;
-			font-size: $default-font-size;
-		}
 		> svg {
 			fill: #007cba;
 			align-self: initial;

--- a/js/src/components/paid-ads/asset-group/asset-group-section.scss
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.scss
@@ -5,4 +5,20 @@
 		font-size: $default-font-size;
 		color: $gray-700;
 	}
+
+	.components-tip {
+		padding: $grid-unit-15 $grid-unit-20;
+		background: #F0F6FC;
+		border: $border-width solid #C5D9ED;
+		line-height: $gla-line-height-medium;
+
+		> p {
+			color: $gray-900;
+			font-size: $default-font-size;
+		}
+		> svg {
+			fill: #007CBA;
+			align-self: initial;
+		}
+	}
 }

--- a/js/src/components/paid-ads/asset-group/asset-group-section.scss
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.scss
@@ -8,8 +8,8 @@
 
 	.components-tip {
 		padding: $grid-unit-15 $grid-unit-20;
-		background: #F0F6FC;
-		border: $border-width solid #C5D9ED;
+		background: #f0f6fc;
+		border: $border-width solid #c5d9ed;
 		line-height: $gla-line-height-medium;
 
 		> p {
@@ -17,7 +17,7 @@
 			font-size: $default-font-size;
 		}
 		> svg {
-			fill: #007CBA;
+			fill: #007cba;
 			align-self: initial;
 		}
 	}

--- a/js/src/components/paid-ads/asset-group/asset-group-section.test.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.test.js
@@ -18,7 +18,7 @@ jest.mock( '.~/components/adaptive-form', () => ( {
  * External dependencies
  */
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -32,14 +32,16 @@ jest.mock( '.~/components/paid-ads/asset-group/asset-group-card', () =>
 
 describe( 'AssetGroupSection', () => {
 	test( 'Component renders', () => {
-		const { queryByText } = render( <AssetGroupSection /> );
-		expect( queryByText( /Add additional assets/i ) ).toBeInTheDocument();
+		render( <AssetGroupSection /> );
+		expect(
+			screen.queryByText( /Add additional assets/i )
+		).toBeInTheDocument();
 	} );
 
 	test( 'Component not showing Tip if there are no imported assets', () => {
-		const { queryByText } = render( <AssetGroupSection /> );
+		render( <AssetGroupSection /> );
 		expect(
-			queryByText(
+			screen.queryByText(
 				'We auto-populated assets directly from your Final URL. We encourage you to edit or add more in order to best showcase your business.'
 			)
 		).not.toBeInTheDocument();
@@ -56,9 +58,9 @@ describe( 'AssetGroupSection', () => {
 				},
 			};
 		} );
-		const { queryByText } = render( <AssetGroupSection /> );
+		render( <AssetGroupSection /> );
 		expect(
-			queryByText(
+			screen.queryByText(
 				'We auto-populated assets directly from your Final URL. We encourage you to edit or add more in order to best showcase your business.'
 			)
 		).toBeInTheDocument();

--- a/js/src/components/paid-ads/asset-group/asset-group-section.test.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.test.js
@@ -1,0 +1,66 @@
+jest.mock( '.~/components/adaptive-form', () => ( {
+	useAdaptiveFormContext: jest
+		.fn()
+		.mockName( 'useAdaptiveFormContext' )
+		.mockImplementation( () => {
+			return {
+				adapter: {
+					baseAssetGroup: { final_url: 'https://example.com' },
+					hasImportedAssets: false,
+					isEmptyAssetEntityGroup: false,
+					resetAssetGroup: jest.fn(),
+				},
+			};
+		} ),
+} ) );
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AssetGroupSection from '.~/components/paid-ads/asset-group/asset-group-section';
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
+
+jest.mock( '.~/components/paid-ads/asset-group/asset-group-card', () =>
+	jest.fn( ( props ) => <div { ...props } /> ).mockName( 'AssetGroupCard' )
+);
+
+describe( 'AssetGroupSection', () => {
+	test( 'Component renders', () => {
+		const { queryByText } = render( <AssetGroupSection /> );
+		expect( queryByText( /Add additional assets/i ) ).toBeInTheDocument();
+	} );
+
+	test( 'Component not showing Tip if there are no imported assets', () => {
+		const { queryByText } = render( <AssetGroupSection /> );
+		expect(
+			queryByText(
+				'We auto-populated assets directly from your Final URL. We encourage you to edit or add more in order to best showcase your business.'
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'Component showing Tip if there are imported assets', () => {
+		useAdaptiveFormContext.mockImplementation( () => {
+			return {
+				adapter: {
+					baseAssetGroup: { final_url: 'https://example.com' },
+					hasImportedAssets: true,
+					isEmptyAssetEntityGroup: false,
+					resetAssetGroup: jest.fn(),
+				},
+			};
+		} );
+		const { queryByText } = render( <AssetGroupSection /> );
+		expect(
+			queryByText(
+				'We auto-populated assets directly from your Final URL. We encourage you to edit or add more in order to best showcase your business.'
+			)
+		).toBeInTheDocument();
+	} );
+} );

--- a/js/src/components/paid-ads/asset-group/asset-group-section.test.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.test.js
@@ -34,7 +34,7 @@ describe( 'AssetGroupSection', () => {
 	test( 'Component renders', () => {
 		render( <AssetGroupSection /> );
 		expect(
-			screen.queryByText( /Add additional assets/i )
+			screen.getByText( /Add additional assets/i )
 		).toBeInTheDocument();
 	} );
 
@@ -60,7 +60,7 @@ describe( 'AssetGroupSection', () => {
 		} );
 		render( <AssetGroupSection /> );
 		expect(
-			screen.queryByText(
+			screen.getByText(
 				'We auto-populated assets directly from your Final URL. We encourage you to edit or add more in order to best showcase your business.'
 			)
 		).toBeInTheDocument();

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.scss
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.scss
@@ -13,7 +13,7 @@
 
 	.components-tip {
 		padding: $grid-unit-15 $grid-unit-20;
-		background-color: #F0F6FC;
+		background-color: #f0f6fc;
 
 		> p {
 			line-height: $gla-line-height-medium;

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.scss
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.scss
@@ -13,7 +13,7 @@
 
 	.components-tip {
 		padding: $grid-unit-15 $grid-unit-20;
-		background-color: #f0f6fc;
+		background-color: #F0F6FC;
 
 		> p {
 			line-height: $gla-line-height-medium;

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -77,6 +77,7 @@ export default function CampaignAssetsForm( {
 
 	const [ baseAssetGroup, setBaseAssetGroup ] = useState( initialAssetGroup );
 	const [ validationRequestCount, setValidationRequestCount ] = useState( 0 );
+	const [ hasImportedAssets, setHasImportedAssets ] = useState( false );
 
 	const extendAdapter = ( formContext ) => {
 		const assetGroupErrors = validateAssetGroup( formContext.values );
@@ -90,13 +91,20 @@ export default function CampaignAssetsForm( {
 			baseAssetGroup,
 			validationRequestCount,
 			assetGroupErrors,
+			hasImportedAssets,
 			isValidAssetGroup: Object.keys( assetGroupErrors ).length === 0,
 			resetAssetGroup( assetGroup ) {
 				const nextAssetGroup = assetGroup || initialAssetGroup;
+				let hasNonEmptyAssets = false;
 
 				Object.keys( emptyAssetGroup ).forEach( ( key ) => {
+					if ( assetGroup && assetGroup[ key ]?.length ) {
+						hasNonEmptyAssets = true;
+					}
 					formContext.setValue( key, nextAssetGroup[ key ] );
 				} );
+
+				setHasImportedAssets( hasNonEmptyAssets );
 				setBaseAssetGroup( nextAssetGroup );
 				setValidationRequestCount( 0 );
 			},

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -91,6 +91,11 @@ export default function CampaignAssetsForm( {
 			baseAssetGroup,
 			validationRequestCount,
 			assetGroupErrors,
+			/*
+			  In order to show a Tip in the UI when assets are imported we created the hasImportedAssets
+			  property. When the Final URL changes resetAssetGroup is called with the new Asset Group,
+			  We check if any of the assets has been populated and update this property based on that.
+			*/
 			hasImportedAssets,
 			isValidAssetGroup: Object.keys( assetGroupErrors ).length === 0,
 			resetAssetGroup( assetGroup ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a component when assets are imported from the URL, based on the Figma project

Figma - fqR0EHi63lWahRcVTKCcba-fi-5568%3A228053
Project - P2 - pcTzPl-1ue-p2

### Screenshots:

Implementation:

<img width="1630" alt="Screenshot 2023-07-11 at 13 13 07" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/045226c8-8951-4704-a4f4-f8a6c78d9faa">

Figma:

<img width="1038" alt="Screenshot 2023-07-11 at 14 09 14" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/e0b10b83-e5ac-43bd-941e-a5500e0445c1">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a new Paid Campaign
2. In step 2 select a URL
3. When the assets are imported, see the Tip appearing 
4. See the Tip matching Figma content and design
5. Select another URL
6. See the TIp disappears
7. Choose an URL
8. When the assets are imported, see the Tip appearing 
9. Co to a previously created Campaign with Assets
10. See the TIp not appearing


### Additional details:

 - I added a new `hasImportedAssets`  prop in the adapter. This prop is updated every time the Final URL changes. It iterates over the Assets and if any of them is filled, then it sets the prop as TRUE.  
 - I added some tests for `<AssetsGroupSection>`. I wanted to add also test covering the resetForm functionality. However, I didn't find any test created yet for that functionality, so I suggest approaching it in future PRs.    

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Add Tip with information with Campaign assets are imported
