### PR TITLE
Provide more detailed error reasons when unable to complete site verification

### DIFF
--- a/src/API/Google/SiteVerification.php
+++ b/src/API/Google/SiteVerification.php
@@ -139,7 +139,7 @@ class SiteVerification implements ContainerAwareInterface, OptionsAwareInterface
 	 *
 	 * @param string $identifier The URL of the site to verify (including protocol).
 	 *
-	 * @throws Exception When unable to verify token.
+	 * @throws ExceptionWithResponseData When unable to verify token.
 	 */
 	protected function insert( string $identifier ) {
 		/** @var SiteVerificationService $service */
@@ -160,9 +160,15 @@ class SiteVerification implements ContainerAwareInterface, OptionsAwareInterface
 			$service->webResource->insert( self::VERIFICATION_METHOD, $post_body );
 		} catch ( GoogleServiceException $e ) {
 			do_action( 'woocommerce_gla_sv_client_exception', $e, __METHOD__ );
-			throw new Exception(
-				__( 'Unable to insert site verification.', 'google-listings-and-ads' ),
-				$e->getCode()
+
+			$errors = $this->get_exception_errors( $e );
+
+			throw new ExceptionWithResponseData(
+				/* translators: %s Error message */
+				sprintf( __( 'Unable to insert site verification: %s', 'google-listings-and-ads' ), reset( $errors ) ),
+				$e->getCode(),
+				null,
+				[ 'errors' => $errors ]
 			);
 		}
 	}

--- a/tests/Unit/API/Google/SiteVerificationTest.php
+++ b/tests/Unit/API/Google/SiteVerificationTest.php
@@ -91,18 +91,15 @@ class SiteVerificationTest extends UnitTest {
 
 		$this->verification_service->webResource
 			->method( 'insert' )
-			->willThrowException( new GoogleServiceException( 'error', 400 ) );
+			->willThrowException( $this->get_google_service_exception( 400, 'No necessary verification token.' ) );
 
-		try {
-			$this->verification->verify_site( $this->site_url );
-		} catch ( Exception $e ) {
-			$this->assertEquals( 1, did_action( 'woocommerce_gla_site_verify_failure' ) );
-			$this->assertEquals( 400, $e->getCode() );
-			$this->assertEquals(
-				'Unable to insert site verification.',
-				$e->getMessage()
-			);
-		}
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionCode( 400 );
+		$this->expectExceptionMessage( 'Unable to insert site verification: No necessary verification token.' );
+
+		$this->verification->verify_site( $this->site_url );
+
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_site_verify_failure' ) );
 	}
 
 	public function test_verify_site() {

--- a/tests/Unit/API/Google/SiteVerificationTest.php
+++ b/tests/Unit/API/Google/SiteVerificationTest.php
@@ -4,8 +4,10 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\Exception as GoogleServiceException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\SiteVerification as SiteVerificationService;
@@ -22,6 +24,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
  */
 class SiteVerificationTest extends UnitTest {
+
+	use MerchantTrait;
 
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
@@ -71,18 +75,15 @@ class SiteVerificationTest extends UnitTest {
 	public function test_verify_site_token_exception() {
 		$this->verification_service->webResource
 			->method( 'getToken' )
-			->willThrowException( new GoogleServiceException( 'error', 400 ) );
+			->willThrowException( $this->get_google_service_exception( 400, 'No available tokens' ) );
 
-		try {
-			$this->verification->verify_site( $this->site_url );
-		} catch ( Exception $e ) {
-			$this->assertEquals( 1, did_action( 'woocommerce_gla_site_verify_failure' ) );
-			$this->assertEquals( 400, $e->getCode() );
-			$this->assertEquals(
-				'Unable to retrieve site verification token.',
-				$e->getMessage()
-			);
-		}
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionCode( 400 );
+		$this->expectExceptionMessage( 'Unable to retrieve site verification token: No available tokens' );
+
+		$this->verification->verify_site( $this->site_url );
+
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_site_verify_failure' ) );
 	}
 
 	public function test_verify_site_insert_exception() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1725

This PR solves a task of 📌 [Clarify API error messages](https://github.com/woocommerce/google-listings-and-ads/issues/1993#tasks-clarify-api-errors) in #1993.

In #2007, the handler for `GoogleServiceException` has been added. It also adjusted the errors that may occur when connecting to a Google Merchant Center account. This is the pre-process that must be passed through before doing the site verification process.

This PR is based on the same direction as #2007 to adjust the error handling for site verification methods:
- `SiteVerification::get_token`: retrieve a site meta token
- `SiteVerification::insert`: verify a site token

### Screenshots:

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/aa205d34-d924-4a66-9816-c6f2cfabe838)

### Detailed test instructions:

1. Disconnect Google Merchant Center account (via the Connection Test page) if there is a connected one.
1. Go to step 1 of the onboarding flow
1. `SiteVerification::get_token`
   1. Since this error is easier to be tested in an intentional way, it's recommended to tweak some local code below, such as the invalid `type` or forced to throw a `GoogleServiceException` error.
      https://github.com/woocommerce/google-listings-and-ads/blob/2cab1cd369be2b7f5cfb7945617ba8160bc828bc/src/API/Google/SiteVerification.php#L101-L118
   1. Connect to a Google Merchant Center account.
   1. It should show a clearer error message in the notification UI than before. Previously, the message was "Unable to retrieve site verification token."
1. `SiteVerification::insert`
   1. Use a coming soon plugin, or use a hosting option to prevent the site from being public.
      - I tested with [this one](https://wordpress.org/plugins/minimal-coming-soon-maintenance-mode/) and ticked the "Enable Maintenance Mode" option on its setting page.
   1. Connect to a new Google Merchant Center account, or to the existing account with the same site URL.
   1. It should show a clearer error message in the notification UI than before. Previously, the message was "Unable to insert site verification."

### Additional details:

💡 There are still a few error handling that can continue to be improved along the same direction as #2007 and this PR, but they are outside the scope of #1725. I will open a follow-up issue ~once this PR gets merged~. Created: #2013

### Changelog entry

> Tweak - Provide more detailed error reasons when unable to complete site verification for the Google Merchant Center account being connected in the onboarding flow.
