### PR TITLE
Move the verification request from `CampaignAssetsForm` to `AdaptiveForm`

### DIFF
--- a/js/src/components/adaptive-form/adaptive-form-context.js
+++ b/js/src/components/adaptive-form/adaptive-form-context.js
@@ -23,6 +23,10 @@ import { createContext, useContext } from '@wordpress/element';
  * @property {boolean} isSubmitting `true` if the form is currently being submitted.
  * @property {boolean} isSubmitted Set to `true` after the form is submitted. Initial value and during submission are set to `false`.
  * @property { HTMLElement | null} submitter Set to the element triggering the `handleSubmit` callback until the processing of `onSubmit` is completed. `null` otherwise.
+ * @property {number} validationRequestCount The current validation request count.
+ * @property {boolean} requestedShowValidation Whether have requested verification. It will be reset to false after calling hideValidation.
+ * @property {() => void} showValidation Increase the validation request count by 1.
+ * @property {() => void} hideValidation Reset the validation request count to 0.
  */
 
 /**

--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -81,6 +81,15 @@ function AdaptiveForm( { onSubmit, extendAdapter, children, ...props }, ref ) {
 
 	const isMounted = useIsMounted();
 
+	// Add states for form user sides to determine whether to show validation results.
+	const [ validationRequestCount, setValidationRequestCount ] = useState( 0 );
+	const showValidation = useCallback( () => {
+		setValidationRequestCount( ( count ) => count + 1 );
+	}, [] );
+	const hideValidation = useCallback( () => {
+		setValidationRequestCount( 0 );
+	}, [] );
+
 	// Add `isSubmitting` and `isSubmitted` states for facilitating across multiple layers of
 	// component controlling, such as disabling inputs or buttons.
 	const [ submission, setSubmission ] = useState( null );
@@ -208,6 +217,10 @@ function AdaptiveForm( { onSubmit, extendAdapter, children, ...props }, ref ) {
 					isSubmitting,
 					isSubmitted,
 					submitter: adapterRef.current.submitter,
+					validationRequestCount,
+					requestedShowValidation: validationRequestCount > 0,
+					showValidation,
+					hideValidation,
 				};
 
 				if ( typeof extendAdapter === 'function' ) {

--- a/js/src/components/adaptive-form/adaptive-form.test.js
+++ b/js/src/components/adaptive-form/adaptive-form.test.js
@@ -15,7 +15,7 @@ const alwaysValid = () => ( {} );
 const delayOneSecond = () => new Promise( ( r ) => setTimeout( r, 1000 ) );
 
 describe( 'AdaptiveForm', () => {
-	it( 'Should have `formContext.adapter` with initial states', () => {
+	it( 'Should have `formContext.adapter` with functions and initial states', () => {
 		const children = jest.fn();
 
 		render(
@@ -27,6 +27,10 @@ describe( 'AdaptiveForm', () => {
 				isSubmitting: false,
 				isSubmitted: false,
 				submitter: null,
+				validationRequestCount: 0,
+				requestedShowValidation: false,
+				showValidation: expect.any( Function ),
+				hideValidation: expect.any( Function ),
 			} ),
 		} );
 
@@ -147,5 +151,49 @@ describe( 'AdaptiveForm', () => {
 			{},
 			expect.objectContaining( { submitter: buttonB } )
 		);
+	} );
+
+	it( 'Should be able to accumulate and reset the validation request count and requested state', async () => {
+		const inspect = jest.fn();
+
+		render(
+			<AdaptiveForm validate={ alwaysValid }>
+				{ ( { adapter } ) => {
+					inspect(
+						adapter.requestedShowValidation,
+						adapter.validationRequestCount
+					);
+
+					return (
+						<>
+							<button onClick={ adapter.showValidation }>
+								request
+							</button>
+
+							<button onClick={ adapter.hideValidation }>
+								reset
+							</button>
+						</>
+					);
+				} }
+			</AdaptiveForm>
+		);
+
+		const requestButton = screen.getByRole( 'button', { name: 'request' } );
+		const resetButton = screen.getByRole( 'button', { name: 'reset' } );
+
+		expect( inspect ).toHaveBeenLastCalledWith( false, 0 );
+
+		await userEvent.click( requestButton );
+
+		expect( inspect ).toHaveBeenLastCalledWith( true, 1 );
+
+		await userEvent.click( requestButton );
+
+		expect( inspect ).toHaveBeenLastCalledWith( true, 2 );
+
+		await userEvent.click( resetButton );
+
+		expect( inspect ).toHaveBeenLastCalledWith( false, 0 );
 	} );
 } );

--- a/js/src/components/adaptive-form/adaptive-form.test.js
+++ b/js/src/components/adaptive-form/adaptive-form.test.js
@@ -1,0 +1,151 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { screen, render, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import AdaptiveForm from './adaptive-form';
+
+const alwaysValid = () => ( {} );
+
+const delayOneSecond = () => new Promise( ( r ) => setTimeout( r, 1000 ) );
+
+describe( 'AdaptiveForm', () => {
+	it( 'Should have `formContext.adapter` with initial states', () => {
+		const children = jest.fn();
+
+		render(
+			<AdaptiveForm validate={ alwaysValid }>{ children }</AdaptiveForm>
+		);
+
+		const formContextSchema = expect.objectContaining( {
+			adapter: expect.objectContaining( {
+				isSubmitting: false,
+				isSubmitted: false,
+				submitter: null,
+			} ),
+		} );
+
+		expect( children ).toHaveBeenLastCalledWith( formContextSchema );
+	} );
+
+	it( 'Should provide `isSubmitting` and `isSubmitted` states via adapter', async () => {
+		const inspect = jest.fn();
+
+		render(
+			<AdaptiveForm validate={ alwaysValid } onSubmit={ delayOneSecond }>
+				{ ( formContext ) => {
+					const { isSubmitting, isSubmitted } = formContext.adapter;
+					inspect( isSubmitting, isSubmitted );
+
+					return <button onClick={ formContext.handleSubmit } />;
+				} }
+			</AdaptiveForm>
+		);
+
+		expect( inspect ).toHaveBeenLastCalledWith( false, false );
+
+		await act( async () => {
+			return userEvent.click( screen.getByRole( 'button' ) );
+		} );
+
+		expect( inspect ).toHaveBeenLastCalledWith( true, false );
+
+		await act( async () => {
+			jest.runOnlyPendingTimers();
+		} );
+
+		expect( inspect ).toHaveBeenLastCalledWith( false, true );
+	} );
+
+	it( 'Should be able to signal failed submission to reset `isSubmitting` and `isSubmitted` states', async () => {
+		const inspect = jest.fn();
+
+		const onSubmit = ( values, enhancer ) => {
+			enhancer.signalFailedSubmission();
+			return delayOneSecond();
+		};
+
+		render(
+			<AdaptiveForm validate={ alwaysValid } onSubmit={ onSubmit }>
+				{ ( formContext ) => {
+					const { isSubmitting, isSubmitted } = formContext.adapter;
+					inspect( isSubmitting, isSubmitted );
+
+					return <button onClick={ formContext.handleSubmit } />;
+				} }
+			</AdaptiveForm>
+		);
+
+		await act( async () => {
+			return userEvent.click( screen.getByRole( 'button' ) );
+		} );
+
+		expect( inspect ).toHaveBeenLastCalledWith( true, false );
+
+		await act( async () => {
+			jest.runOnlyPendingTimers();
+		} );
+
+		expect( inspect ).toHaveBeenLastCalledWith( false, false );
+	} );
+
+	it( 'Should provide the element triggering the form submission via `submitter` until the processing is completed', async () => {
+		const inspectOnSubmit = jest.fn();
+		const inspectSubmitter = jest.fn();
+
+		render(
+			<AdaptiveForm validate={ alwaysValid } onSubmit={ inspectOnSubmit }>
+				{ ( formContext ) => {
+					inspectSubmitter( formContext.adapter.submitter );
+
+					return (
+						<>
+							<button onClick={ formContext.handleSubmit }>
+								A
+							</button>
+
+							<button onClick={ formContext.handleSubmit }>
+								B
+							</button>
+						</>
+					);
+				} }
+			</AdaptiveForm>
+		);
+
+		const [ buttonA, buttonB ] = screen.getAllByRole( 'button' );
+
+		expect( inspectOnSubmit ).toHaveBeenCalledTimes( 0 );
+
+		await act( async () => {
+			return userEvent.click( buttonA );
+		} );
+
+		expect( inspectSubmitter ).toHaveBeenCalledWith( buttonA );
+		expect( inspectSubmitter ).toHaveBeenLastCalledWith( null );
+		expect( inspectOnSubmit ).toHaveBeenCalledTimes( 1 );
+		expect( inspectOnSubmit ).toHaveBeenLastCalledWith(
+			{},
+			expect.objectContaining( { submitter: buttonA } )
+		);
+
+		inspectSubmitter.mockClear();
+
+		await act( async () => {
+			return userEvent.click( buttonB );
+		} );
+
+		expect( inspectSubmitter ).toHaveBeenCalledWith( buttonB );
+		expect( inspectSubmitter ).toHaveBeenLastCalledWith( null );
+		expect( inspectOnSubmit ).toHaveBeenCalledTimes( 2 );
+		expect( inspectOnSubmit ).toHaveBeenLastCalledWith(
+			{},
+			expect.objectContaining( { submitter: buttonB } )
+		);
+	} );
+} );

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -76,7 +76,6 @@ export default function CampaignAssetsForm( {
 	}, [ assetEntityGroup ] );
 
 	const [ baseAssetGroup, setBaseAssetGroup ] = useState( initialAssetGroup );
-	const [ validationRequestCount, setValidationRequestCount ] = useState( 0 );
 	const [ hasImportedAssets, setHasImportedAssets ] = useState( false );
 
 	const extendAdapter = ( formContext ) => {
@@ -89,7 +88,6 @@ export default function CampaignAssetsForm( {
 			// provide different special business logic.
 			isEmptyAssetEntityGroup: ! finalUrl,
 			baseAssetGroup,
-			validationRequestCount,
 			assetGroupErrors,
 			/*
 			  In order to show a Tip in the UI when assets are imported we created the hasImportedAssets
@@ -111,10 +109,7 @@ export default function CampaignAssetsForm( {
 
 				setHasImportedAssets( hasNonEmptyAssets );
 				setBaseAssetGroup( nextAssetGroup );
-				setValidationRequestCount( 0 );
-			},
-			showValidation() {
-				setValidationRequestCount( validationRequestCount + 1 );
+				formContext.adapter.hideValidation();
 			},
 		};
 	};

--- a/js/src/components/paid-ads/campaign-assets-form.test.js
+++ b/js/src/components/paid-ads/campaign-assets-form.test.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import CampaignAssetsForm from './campaign-assets-form';
+
+const alwaysValid = () => ( {} );
+
+describe( 'CampaignAssetsForm', () => {
+	it( 'Should extend adapter to meet the required states or functions of assets form', () => {
+		const children = jest.fn();
+
+		render(
+			<CampaignAssetsForm validate={ alwaysValid }>
+				{ children }
+			</CampaignAssetsForm>
+		);
+
+		const formContextSchema = expect.objectContaining( {
+			adapter: expect.objectContaining( {
+				assetGroupErrors: expect.any( Object ),
+				baseAssetGroup: expect.any( Object ),
+				hasImportedAssets: false,
+				isEmptyAssetEntityGroup: true,
+				isValidAssetGroup: expect.any( Boolean ),
+				resetAssetGroup: expect.any( Function ),
+				showValidation: expect.any( Function ),
+				validationRequestCount: 0,
+			} ),
+		} );
+
+		expect( children ).toHaveBeenLastCalledWith( formContextSchema );
+	} );
+
+	it( 'Should be able to accumulate and reset the validation request count', async () => {
+		const inspect = jest.fn();
+
+		render(
+			<CampaignAssetsForm validate={ alwaysValid }>
+				{ ( { adapter } ) => {
+					inspect( adapter.validationRequestCount );
+
+					return (
+						<>
+							<button onClick={ adapter.showValidation }>
+								request
+							</button>
+
+							<button onClick={ adapter.resetAssetGroup }>
+								reset
+							</button>
+						</>
+					);
+				} }
+			</CampaignAssetsForm>
+		);
+
+		const requestButton = screen.getByRole( 'button', { name: 'request' } );
+		const resetButton = screen.getByRole( 'button', { name: 'reset' } );
+
+		expect( inspect ).toHaveBeenLastCalledWith( 0 );
+
+		await userEvent.click( requestButton );
+
+		expect( inspect ).toHaveBeenLastCalledWith( 1 );
+
+		await userEvent.click( requestButton );
+
+		expect( inspect ).toHaveBeenLastCalledWith( 2 );
+
+		await userEvent.click( resetButton );
+
+		expect( inspect ).toHaveBeenLastCalledWith( 0 );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a pre-processing PR for #634 and for 📌 [Display form validation errors](https://github.com/woocommerce/google-listings-and-ads/issues/1993#tasks-display-validation-errors) in #1993.

To have a form state to determine whether to start showing validation errors to users, this PR:

- Add the relevant tests for the `CampaignAssetsForm` component first.
- Add basic tests for the `AdaptiveForm` component.
- Move the state and functions associated with the request verification from `CampaignAssetsForm` to `AdaptiveForm`.

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/0b02b078-5952-4215-8c85-c3459ecebba6

### Detailed test instructions:

This PR only changes the code used in the campaign assets management.

1. Start creating a campaign and proceed to step 2.
2. Import a Final URL.
3. Click the "Save changes" button with invalid asset form data.
4. Check if the UI shows validation errors and also scroll page to the position of the first error.
5. Click the "Or, select a different Final URL" button to see if the UI hides all validation errors.
6. Repeat this test steps 3-5 again to see if the behavior of validation errors still works well.

### Changelog entry
