### PR TITLE
Apply `AdaptiveForm` and its abilities to steps 2 and 3 of the onboarding flow for higher code consistent

### DIFF
--- a/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
+++ b/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
@@ -8,6 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import AppRadioContentControl from '.~/components/app-radio-content-control';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import Section from '.~/wcdl/section';
@@ -23,12 +24,10 @@ import './choose-audience-section.scss';
  * To be used in onboarding and further editing.
  * Does not provide any save strategy, this is to be bound externaly.
  *
- * @param {Object} props React props.
- * @param {Object} props.formProps Form props forwarded from `Form` component.
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
  */
-const ChooseAudienceSection = ( { formProps } ) => {
-	const { values, getInputProps } = formProps;
+const ChooseAudienceSection = () => {
+	const { values, getInputProps } = useAdaptiveFormContext();
 	const { locale, language } = values;
 
 	return (

--- a/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
@@ -14,10 +14,7 @@ import ShippingTimeSetup from './shipping-time/shipping-time-setup';
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
  */
 
-const ShippingTimeSection = ( {
-	formProps,
-	countries: selectedCountryCodes,
-} ) => {
+const ShippingTimeSection = ( { countries: selectedCountryCodes } ) => {
 	return (
 		<Section
 			title={ __( 'Shipping times', 'google-listings-and-ads' ) }
@@ -51,7 +48,6 @@ const ShippingTimeSection = ( {
 					</Section.Card.Title>
 					<ShippingTimeSetup
 						selectedCountryCodes={ selectedCountryCodes }
-						formProps={ formProps }
 					/>
 				</Section.Card.Body>
 			</Section.Card>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
@@ -14,7 +14,7 @@ import ShippingTimeSetup from './shipping-time/shipping-time-setup';
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
  */
 
-const ShippingTimeSection = ( { countries: selectedCountryCodes } ) => {
+const ShippingTimeSection = () => {
 	return (
 		<Section
 			title={ __( 'Shipping times', 'google-listings-and-ads' ) }
@@ -46,9 +46,7 @@ const ShippingTimeSection = ( { countries: selectedCountryCodes } ) => {
 							'google-listings-and-ads'
 						) }
 					</Section.Card.Title>
-					<ShippingTimeSetup
-						selectedCountryCodes={ selectedCountryCodes }
-					/>
+					<ShippingTimeSetup />
 				</Section.Card.Body>
 			</Section.Card>
 		</Section>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -18,19 +18,19 @@ import getCountriesTimeArray from './getCountriesTimeArray';
  *
  * @param {Object} props
  * @param {Array<ShippingTime>} props.value Array of individual shipping times to be used as the initial values of the form.
- * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
+ * @param {Array<CountryCode>} props.audienceCountries Array of selected audience country codes.
  * @param {(newValue: Object) => void} props.onChange Callback called with new data once shipping times are changed.
  */
 export default function ShippingCountriesForm( {
 	value: shippingTimes,
-	selectedCountryCodes,
+	audienceCountries,
 	onChange,
 } ) {
 	const actualCountryCount = shippingTimes.length;
 	const actualCountries = new Map(
 		shippingTimes.map( ( time ) => [ time.countryCode, time ] )
 	);
-	const remainingCountryCodes = selectedCountryCodes.filter(
+	const remainingCountryCodes = audienceCountries.filter(
 		( el ) => ! actualCountries.has( el )
 	);
 	const remainingCount = remainingCountryCodes.length;
@@ -41,7 +41,7 @@ export default function ShippingCountriesForm( {
 	// Prefill to-be-added time.
 	if ( countriesTimeArray.length === 0 ) {
 		countriesTimeArray.push( {
-			countries: selectedCountryCodes,
+			countries: audienceCountries,
 			time: null,
 		} );
 	}
@@ -92,7 +92,7 @@ export default function ShippingCountriesForm( {
 						>
 							<CountriesTimeInput
 								value={ el }
-								audienceCountries={ selectedCountryCodes }
+								audienceCountries={ audienceCountries }
 								onChange={ handleChange }
 								onDelete={ handleDelete }
 							/>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import AppSpinner from '.~/components/app-spinner';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import ShippingCountriesForm from './countries-form';
@@ -14,11 +15,10 @@ import './index.scss';
  * Form control to edit shipping rate settings.
  *
  * @param {Object} props React props.
- * @param {Object} props.formProps Form props forwarded from `Form` component.
  * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
  */
-const ShippingTimeSetup = ( { formProps, selectedCountryCodes } ) => {
-	const { getInputProps } = formProps;
+const ShippingTimeSetup = ( { selectedCountryCodes } ) => {
+	const { getInputProps } = useAdaptiveFormContext();
 
 	if ( ! selectedCountryCodes ) {
 		return <AppSpinner />;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
@@ -8,19 +8,12 @@ import ShippingCountriesForm from './countries-form';
 import './index.scss';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
- */
-
-/**
  * Form control to edit shipping rate settings.
- *
- * @param {Object} props React props.
- * @param {Array<CountryCode>} props.selectedCountryCodes Array of country codes of all audience countries.
  */
-const ShippingTimeSetup = ( { selectedCountryCodes } ) => {
-	const { getInputProps } = useAdaptiveFormContext();
+const ShippingTimeSetup = () => {
+	const { getInputProps, adapter } = useAdaptiveFormContext();
 
-	if ( ! selectedCountryCodes ) {
+	if ( ! adapter.audienceCountries ) {
 		return <AppSpinner />;
 	}
 
@@ -29,7 +22,7 @@ const ShippingTimeSetup = ( { selectedCountryCodes } ) => {
 			<VerticalGapLayout>
 				<ShippingCountriesForm
 					{ ...getInputProps( 'shipping_country_times' ) }
-					selectedCountryCodes={ selectedCountryCodes }
+					audienceCountries={ adapter.audienceCountries }
 				/>
 			</VerticalGapLayout>
 		</div>

--- a/js/src/components/free-listings/configure-product-listings/tax-rate.js
+++ b/js/src/components/free-listings/configure-product-listings/tax-rate.js
@@ -7,6 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import Section from '.~/wcdl/section';
 import RadioHelperText from '.~/wcdl/radio-helper-text';
 import AppRadioContentControl from '.~/components/app-radio-content-control';
@@ -18,10 +19,8 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
  */
 
-const TaxRate = ( props ) => {
-	const {
-		formProps: { getInputProps },
-	} = props;
+const TaxRate = () => {
+	const { getInputProps } = useAdaptiveFormContext();
 
 	return (
 		<Section

--- a/js/src/components/free-listings/setup-free-listings/form-content.js
+++ b/js/src/components/free-listings/setup-free-listings/form-content.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
 import TaxRate from '.~/components/free-listings/configure-product-listings/tax-rate';
@@ -25,17 +26,15 @@ import ConditionalSection from '.~/components/conditional-section';
  *
  * @param {Object} props React props.
  * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to ShippingRateSection and ShippingTimeSection.
- * @param {Object} props.formProps Form props forwarded from `Form` component, containing free listings settings.
  * @param {boolean} [props.saving=false] Is the form currently beign saved?
  * @param {string} [props.submitLabel="Complete setup"] Submit button label.
  */
 const FormContent = ( {
 	countries,
-	formProps,
 	saving = false,
 	submitLabel = __( 'Complete setup', 'google-listings-and-ads' ),
 } ) => {
-	const { values, isValidForm, handleSubmit } = formProps;
+	const { values, isValidForm, handleSubmit } = useAdaptiveFormContext();
 	const shouldDisplayTaxRate = useDisplayTaxRate( countries );
 	const shouldDisplayShippingTime = values.shipping_time === 'flat';
 	const isCompleteSetupDisabled =
@@ -43,19 +42,13 @@ const FormContent = ( {
 
 	return (
 		<StepContent>
-			<ChooseAudienceSection formProps={ formProps } />
-			<ShippingRateSection
-				formProps={ formProps }
-				audienceCountries={ countries }
-			/>
+			<ChooseAudienceSection />
+			<ShippingRateSection audienceCountries={ countries } />
 			{ shouldDisplayShippingTime && (
-				<ShippingTimeSection
-					formProps={ formProps }
-					countries={ countries }
-				/>
+				<ShippingTimeSection countries={ countries } />
 			) }
 			<ConditionalSection show={ shouldDisplayTaxRate }>
-				<TaxRate formProps={ formProps } />
+				<TaxRate />
 			</ConditionalSection>
 			<StepContentFooter>
 				<AppButton

--- a/js/src/components/free-listings/setup-free-listings/form-content.js
+++ b/js/src/components/free-listings/setup-free-listings/form-content.js
@@ -26,15 +26,18 @@ import ConditionalSection from '.~/components/conditional-section';
  *
  * @param {Object} props React props.
  * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to ShippingRateSection and ShippingTimeSection.
- * @param {boolean} [props.saving=false] Is the form currently beign saved?
  * @param {string} [props.submitLabel="Complete setup"] Submit button label.
  */
 const FormContent = ( {
 	countries,
-	saving = false,
 	submitLabel = __( 'Complete setup', 'google-listings-and-ads' ),
 } ) => {
-	const { values, isValidForm, handleSubmit } = useAdaptiveFormContext();
+	const {
+		values,
+		isValidForm,
+		handleSubmit,
+		adapter,
+	} = useAdaptiveFormContext();
 	const shouldDisplayTaxRate = useDisplayTaxRate( countries );
 	const shouldDisplayShippingTime = values.shipping_time === 'flat';
 	const isCompleteSetupDisabled =
@@ -54,7 +57,7 @@ const FormContent = ( {
 				<AppButton
 					isPrimary
 					disabled={ isCompleteSetupDisabled }
-					loading={ saving }
+					loading={ adapter.isSubmitting }
 					onClick={ handleSubmit }
 				>
 					{ submitLabel }

--- a/js/src/components/free-listings/setup-free-listings/form-content.js
+++ b/js/src/components/free-listings/setup-free-listings/form-content.js
@@ -18,18 +18,12 @@ import AppButton from '.~/components/app-button';
 import ConditionalSection from '.~/components/conditional-section';
 
 /**
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
- */
-
-/**
  * Form to configure free listigns.
  *
  * @param {Object} props React props.
- * @param {Array<CountryCode>} props.countries List of available countries to be forwarded to ShippingRateSection and ShippingTimeSection.
  * @param {string} [props.submitLabel="Complete setup"] Submit button label.
  */
 const FormContent = ( {
-	countries,
 	submitLabel = __( 'Complete setup', 'google-listings-and-ads' ),
 } ) => {
 	const {
@@ -38,7 +32,7 @@ const FormContent = ( {
 		handleSubmit,
 		adapter,
 	} = useAdaptiveFormContext();
-	const shouldDisplayTaxRate = useDisplayTaxRate( countries );
+	const shouldDisplayTaxRate = useDisplayTaxRate( adapter.audienceCountries );
 	const shouldDisplayShippingTime = values.shipping_time === 'flat';
 	const isCompleteSetupDisabled =
 		shouldDisplayTaxRate === null || ! isValidForm;
@@ -46,10 +40,8 @@ const FormContent = ( {
 	return (
 		<StepContent>
 			<ChooseAudienceSection />
-			<ShippingRateSection audienceCountries={ countries } />
-			{ shouldDisplayShippingTime && (
-				<ShippingTimeSection countries={ countries } />
-			) }
+			<ShippingRateSection />
+			{ shouldDisplayShippingTime && <ShippingTimeSection /> }
 			<ConditionalSection show={ shouldDisplayTaxRate }>
 				<TaxRate />
 			</ConditionalSection>

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -214,12 +214,13 @@ const SetupFreeListings = ( {
 				validate={ handleValidate }
 				onSubmit={ handleSubmit }
 			>
-				{ ( formProps ) => {
-					const countries = resolveFinalCountries( formProps.values );
+				{ ( formContext ) => {
+					const countries = resolveFinalCountries(
+						formContext.values
+					);
 
 					return (
 						<FormContent
-							formProps={ formProps }
 							countries={ countries }
 							submitLabel={ submitLabel }
 							saving={ saving }

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { pick, noop } from 'lodash';
 
 /**
@@ -91,7 +91,6 @@ const SetupFreeListings = ( {
 	headerTitle,
 } ) => {
 	const formRef = useRef();
-	const [ saving, setSaving ] = useState( false );
 
 	if ( ! ( targetAudience && settings && shippingRates && shippingTimes ) ) {
 		return <AppSpinner />;
@@ -102,12 +101,6 @@ const SetupFreeListings = ( {
 		const { shipping_country_times: shippingTimesData } = values;
 
 		return checkErrors( values, shippingTimesData, countries );
-	};
-
-	const handleSubmit = async () => {
-		setSaving( true );
-		await onContinue();
-		setSaving( false );
 	};
 
 	const handleChange = ( change, values ) => {
@@ -212,7 +205,7 @@ const SetupFreeListings = ( {
 				} }
 				onChange={ handleChange }
 				validate={ handleValidate }
-				onSubmit={ handleSubmit }
+				onSubmit={ onContinue }
 			>
 				{ ( formContext ) => {
 					const countries = resolveFinalCountries(
@@ -223,7 +216,6 @@ const SetupFreeListings = ( {
 						<FormContent
 							countries={ countries }
 							submitLabel={ submitLabel }
-							saving={ saving }
 						/>
 					);
 				} }

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -175,6 +175,12 @@ const SetupFreeListings = ( {
 		}
 	};
 
+	const extendAdapter = ( formContext ) => {
+		return {
+			audienceCountries: resolveFinalCountries( formContext.values ),
+		};
+	};
+
 	return (
 		<div className="gla-setup-free-listings">
 			<Hero headerTitle={ headerTitle } />
@@ -203,22 +209,12 @@ const SetupFreeListings = ( {
 					shipping_country_rates: shippingRates,
 					shipping_country_times: shippingTimes,
 				} }
+				extendAdapter={ extendAdapter }
 				onChange={ handleChange }
 				validate={ handleValidate }
 				onSubmit={ onContinue }
 			>
-				{ ( formContext ) => {
-					const countries = resolveFinalCountries(
-						formContext.values
-					);
-
-					return (
-						<FormContent
-							countries={ countries }
-							submitLabel={ submitLabel }
-						/>
-					);
-				} }
+				<FormContent submitLabel={ submitLabel } />
 			</AdaptiveForm>
 		</div>
 	);

--- a/js/src/components/pre-launch-check-item/index.js
+++ b/js/src/components/pre-launch-check-item/index.js
@@ -10,6 +10,7 @@ import { useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import AppButton from '.~/components/app-button';
 import './index.scss';
 
@@ -21,13 +22,12 @@ const getPanelToggleHandler = ( id ) => ( isOpened ) => {
 };
 
 export default function PreLaunchCheckItem( {
-	formProps,
 	fieldName,
 	firstPersonTitle,
 	secondPersonTitle,
 	children,
 } ) {
-	const { getInputProps, setValue, values } = formProps;
+	const { getInputProps, setValue, values } = useAdaptiveFormContext();
 	const checked = values[ fieldName ];
 	const initialCheckedRef = useRef( checked );
 

--- a/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
+++ b/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
@@ -7,9 +7,8 @@ import EstimatedShippingRatesCard from './estimated-shipping-rates-card';
 import OfferFreeShippingCard from './offer-free-shipping-card';
 import MinimumOrderCard from './minimum-order-card';
 
-const FlatShippingRatesInputCards = ( props ) => {
-	const { audienceCountries } = props;
-	const { getInputProps, values } = useAdaptiveFormContext();
+const FlatShippingRatesInputCards = () => {
+	const { getInputProps, values, adapter } = useAdaptiveFormContext();
 	const displayFreeShippingCards = values.shipping_country_rates.some(
 		isNonFreeShippingRate
 	);
@@ -17,7 +16,7 @@ const FlatShippingRatesInputCards = ( props ) => {
 	return (
 		<>
 			<EstimatedShippingRatesCard
-				audienceCountries={ audienceCountries }
+				audienceCountries={ adapter.audienceCountries }
 				{ ...getInputProps( 'shipping_country_rates' ) }
 			/>
 			{ displayFreeShippingCards && (

--- a/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
+++ b/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
@@ -2,13 +2,14 @@
  * Internal dependencies
  */
 import isNonFreeShippingRate from '.~/utils/isNonFreeShippingRate';
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import EstimatedShippingRatesCard from './estimated-shipping-rates-card';
 import OfferFreeShippingCard from './offer-free-shipping-card';
 import MinimumOrderCard from './minimum-order-card';
 
 const FlatShippingRatesInputCards = ( props ) => {
-	const { audienceCountries, formProps } = props;
-	const { getInputProps, values } = formProps;
+	const { audienceCountries } = props;
+	const { getInputProps, values } = useAdaptiveFormContext();
 	const displayFreeShippingCards = values.shipping_country_rates.some(
 		isNonFreeShippingRate
 	);

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -20,7 +20,7 @@ import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
  */
 
-const ShippingRateSection = ( { audienceCountries } ) => {
+const ShippingRateSection = () => {
 	const { getInputProps, values } = useAdaptiveFormContext();
 	const inputProps = getInputProps( 'shipping_rate' );
 
@@ -112,9 +112,7 @@ const ShippingRateSection = ( { audienceCountries } ) => {
 					</Section.Card.Body>
 				</Section.Card>
 				{ values.shipping_rate === 'flat' && (
-					<FlatShippingRatesInputCards
-						audienceCountries={ audienceCountries }
-					/>
+					<FlatShippingRatesInputCards />
 				) }
 			</VerticalGapLayout>
 		</Section>

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -7,6 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import Section from '.~/wcdl/section';
 import AppRadioContentControl from '.~/components/app-radio-content-control';
 import RadioHelperText from '.~/wcdl/radio-helper-text';
@@ -19,8 +20,8 @@ import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
  */
 
-const ShippingRateSection = ( { formProps, audienceCountries } ) => {
-	const { getInputProps, values } = formProps;
+const ShippingRateSection = ( { audienceCountries } ) => {
+	const { getInputProps, values } = useAdaptiveFormContext();
 	const inputProps = getInputProps( 'shipping_rate' );
 
 	return (
@@ -113,7 +114,6 @@ const ShippingRateSection = ( { formProps, audienceCountries } ) => {
 				{ values.shipping_rate === 'flat' && (
 					<FlatShippingRatesInputCards
 						audienceCountries={ audienceCountries }
-						formProps={ formProps }
 					/>
 				) }
 			</VerticalGapLayout>

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -43,7 +43,6 @@ export default function StoreRequirements( { onContinue } ) {
 	const [ isPhoneNumberReady, setPhoneNumberReady ] = useState( false );
 	const [ settingsSaved, setSettingsSaved ] = useState( true );
 	const [ preprocessed, setPreprocessed ] = useState( false );
-	const [ completing, setCompleting ] = useState( false );
 
 	const handleChangeCallback = async ( _, values ) => {
 		try {
@@ -66,13 +65,9 @@ export default function StoreRequirements( { onContinue } ) {
 
 	const handleSubmitCallback = async () => {
 		try {
-			setCompleting( true );
-
 			await updateGoogleMCContactInformation();
 			onContinue();
 		} catch ( error ) {
-			setCompleting( false );
-
 			createNotice(
 				'error',
 				__(
@@ -153,7 +148,7 @@ export default function StoreRequirements( { onContinue } ) {
 				onSubmit={ handleSubmitCallback }
 			>
 				{ ( formContext ) => {
-					const { handleSubmit, isValidForm } = formContext;
+					const { handleSubmit, isValidForm, adapter } = formContext;
 
 					const isReadyToComplete =
 						isValidForm &&
@@ -172,7 +167,7 @@ export default function StoreRequirements( { onContinue } ) {
 							<StepContentFooter>
 								<AppButton
 									isPrimary
-									loading={ completing }
+									loading={ adapter.isSubmitting }
 									disabled={ ! isReadyToComplete }
 									onClick={ handleSubmit }
 								>

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { Form } from '@woocommerce/components';
 import { isEqual } from 'lodash';
 
 /**
@@ -16,6 +15,7 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
+import AdaptiveForm from '.~/components/adaptive-form';
 import ContactInformation from '.~/components/contact-information';
 import AppButton from '.~/components/app-button';
 import AppSpinner from '.~/components/app-spinner';
@@ -140,7 +140,7 @@ export default function StoreRequirements( { onContinue } ) {
 					'google-listings-and-ads'
 				) }
 			/>
-			<Form
+			<AdaptiveForm
 				initialValues={ {
 					website_live: settings.website_live,
 					checkout_process_secure: settings.checkout_process_secure,
@@ -152,8 +152,8 @@ export default function StoreRequirements( { onContinue } ) {
 				onChange={ handleChangeCallback }
 				onSubmit={ handleSubmitCallback }
 			>
-				{ ( formProps ) => {
-					const { handleSubmit, isValidForm } = formProps;
+				{ ( formContext ) => {
+					const { handleSubmit, isValidForm } = formContext;
 
 					const isReadyToComplete =
 						isValidForm &&
@@ -168,7 +168,7 @@ export default function StoreRequirements( { onContinue } ) {
 									setPhoneNumberReady( true )
 								}
 							/>
-							<PreLaunchChecklist formProps={ formProps } />
+							<PreLaunchChecklist />
 							<StepContentFooter>
 								<AppButton
 									isPrimary
@@ -185,7 +185,7 @@ export default function StoreRequirements( { onContinue } ) {
 						</>
 					);
 				} }
-			</Form>
+			</AdaptiveForm>
 		</StepContent>
 	);
 }

--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
@@ -14,9 +14,7 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
 /*
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-checklist', link_id: 'checklist-requirements', href: 'https://support.google.com/merchants/answer/6363310' }`
  */
-const PreLaunchChecklist = ( props ) => {
-	const { formProps } = props;
-
+const PreLaunchChecklist = () => {
 	return (
 		<div className="gla-pre-launch-checklist">
 			<Section
@@ -51,7 +49,6 @@ const PreLaunchChecklist = ( props ) => {
 					<Section.Card.Body>
 						<VerticalGapLayout size="large">
 							<PreLaunchCheckItem
-								formProps={ formProps }
 								fieldName="website_live"
 								firstPersonTitle={ __(
 									'My store is live and accessible to all users',
@@ -79,7 +76,6 @@ const PreLaunchChecklist = ( props ) => {
 								</AppDocumentationLink>
 							</PreLaunchCheckItem>
 							<PreLaunchCheckItem
-								formProps={ formProps }
 								fieldName="payment_methods_visible"
 								firstPersonTitle={ __(
 									'I have a complete checkout process',
@@ -107,7 +103,6 @@ const PreLaunchChecklist = ( props ) => {
 								</AppDocumentationLink>
 							</PreLaunchCheckItem>
 							<PreLaunchCheckItem
-								formProps={ formProps }
 								fieldName="checkout_process_secure"
 								firstPersonTitle={ __(
 									'I have a secure checkout process',
@@ -140,7 +135,6 @@ const PreLaunchChecklist = ( props ) => {
 								</AppDocumentationLink>
 							</PreLaunchCheckItem>
 							<PreLaunchCheckItem
-								formProps={ formProps }
 								fieldName="refund_tos_visible"
 								firstPersonTitle={ __(
 									'My refund policy and terms of service are visible on my online store',
@@ -168,7 +162,6 @@ const PreLaunchChecklist = ( props ) => {
 								</AppDocumentationLink>
 							</PreLaunchCheckItem>
 							<PreLaunchCheckItem
-								formProps={ formProps }
 								fieldName="contact_info_visible"
 								firstPersonTitle={ __(
 									"My store's phone number, email and/or address are visible on my website",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With #2014, this is another pre-processing PR for #634 and for 📌 [Display form validation errors](https://github.com/woocommerce/google-listings-and-ads/issues/1993#tasks-display-validation-errors) in #1993.

To apply `AdaptiveForm` and its abilities to steps 2 and 3 of the onboarding flow, and make the uses of `formContext` ( the former `formProps`) higher consistent, this PR:

- Change to use the `adapter.isSubmitting` of `AdaptiveForm` as the loading state of submit button in `SetupFreeListings` and `StoreRequirements`
- Apply `useAdaptiveFormContext` instead of `formProps` prop drilling for `SetupFreeListings` and the relevant components.
- Apply `AdaptiveForm` and `useAdaptiveFormContext` instead of `Form` and `formProps` for `StoreRequirements` and the relevant components
- Extend the adapter to avoid `audienceCountries` prop drilling for `SetupFreeListings` and the relevant components.

💡 It's possible to continue the subsequent implementation without this PR, but the uses of form and the relevant states will become scattered and more difficult to maintain. Therefore, I would like to tweak the codebase first.

### Detailed test instructions:

#### This PR only changes the code used in steps 2 and 3 of the onboarding flow but doesn't change the UI behaviors.

1. Go to step 2 of the onboarding flow.
2. Repeatedly fill in and clean up the audience countries and shipping settings.
3. Check if the form-related behaviors are still the same as before.
4. Proceed to step 3.
5. Similar to above, check if the form-related behaviors are still the same as before.
6. Click "Continue" button to go to step 4 and see if the loading state work well.

#### The `SetupFreeListings` component is used in the Edit free listings page as well.

1. Go to the Edit free listings page.
2. Repeatedly fill in and clean up the audience countries and shipping settings.
3. Check if the form-related behaviors are still the same as before.
4. Click "Save changes" button and see if the loading state work well.

### Changelog entry
