### PR TITLE
PHP 8.2 Deprecation Messages

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -51,6 +51,8 @@ jobs:
             wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
           - php: 8.1
             wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
+          - php: 8.2
+            wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
 
     steps:
       - name: Checkout repository

--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -105,14 +105,14 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	public function get_classes(): array {
 		$shown_types = array_map(
 			function ( string $product_type ) {
-				return "show_if_${product_type}";
+				return "show_if_{$product_type}";
 			},
 			ProductSyncer::get_supported_product_types()
 		);
 
 		$hidden_types = array_map(
 			function ( string $product_type ) {
-				return "hide_if_${product_type}";
+				return "hide_if_{$product_type}";
 			},
 			ProductSyncer::get_hidden_product_types()
 		);

--- a/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php
@@ -110,14 +110,14 @@ class CouponChannelVisibilityMetaBox extends SubmittableMetaBox {
 	public function get_classes(): array {
 		$shown_types = array_map(
 			function ( string $coupon_type ) {
-				return "show_if_${coupon_type}";
+				return "show_if_{$coupon_type}";
 			},
 			CouponSyncer::get_supported_coupon_types()
 		);
 
 		$hidden_types = array_map(
 			function ( string $coupon_type ) {
-				return "hide_if_${coupon_type}";
+				return "hide_if_{$coupon_type}";
 			},
 			CouponSyncer::get_hidden_coupon_types()
 		);

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -102,14 +102,14 @@ class AttributesTab implements Service, Registerable, Conditional {
 	private function add_tab( array $tabs ): array {
 		$shown_types = array_map(
 			function ( string $product_type ) {
-				return "show_if_${product_type}";
+				return "show_if_{$product_type}";
 			},
 			$this->get_applicable_product_types()
 		);
 
 		$hidden_types = array_map(
 			function ( string $product_type ) {
-				return "hide_if_${product_type}";
+				return "hide_if_{$product_type}";
 			},
 			ProductSyncer::get_hidden_product_types()
 		);

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -34,6 +34,13 @@ class WC {
 	 */
 	protected $countries;
 
+	/**
+	 * List of countries the WC store sells to.
+	 *
+	 * @var array
+	 */
+	protected $allowed_countries;
+
 	/** @var WC_Countries */
 	protected $wc_countries;
 

--- a/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
+++ b/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
@@ -25,6 +25,9 @@ class CountryCodeTraitTest extends TestCase {
 	/** @var MockObject|GoogleHelper $google_helper */
 	protected $google_helper;
 
+	/** @var CountryCodeTrait $trait */
+	protected $trait;
+
 	/** @var bool $country_supported */
 	protected $country_supported;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR handles some PHP 8.2 deprecation messages. They were not caught in the original PR #1937 for PHP 8.2 because that code is not covered in unit testing. The code is mainly used for conditionally display on product and coupon pages which means it would fit better in E2E testing.

Closes #2021 

### Detailed test instructions:
1. Run the extension on a PHP 8.2 site 
2. Confirm that there are no deprecation warnings when loading the plugin
3. View the products screen and edit an individual product
4. View the coupons screen and edit an individual coupon

### Additional details:
With the latest version of WooCommerce and WordPress there are no longer any PHP 8.2 deprecation warnings. So this PR also enables PHP 8.2 unit testing in GitHub actions.

### Changelog entry
* Fix - Prevent PHP 8.2 deprecation messages.
