### PR TITLE
Show validation errors on step 3 of the onboarding flow when unable to continue

### DIFF
--- a/js/src/components/contact-information/__snapshots__/mapStoreAddressErrors.test.js.snap
+++ b/js/src/components/contact-information/__snapshots__/mapStoreAddressErrors.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mapStoreAddressErrors When newly added required fields are missing in store address, should map them to fallback error messages 1`] = `
+Array [
+  "The postcode/zip of store address is required.",
+  "The other newly added field of store address is required.",
+  "The another newly added field of store address is required.",
+]
+`;
+
+exports[`mapStoreAddressErrors When required store address fields are missing, should map them to corresponding error messages 1`] = `
+Array [
+  "The address line of store address is required.",
+  "The city of store address is required.",
+  "The country/state of store address is required.",
+  "The postcode/zip of store address is required.",
+]
+`;

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getEditPhoneNumberUrl, getEditStoreAddressUrl } from '.~/utils/urls';
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import Section from '.~/wcdl/section';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
@@ -88,6 +89,7 @@ export function ContactInformationPreview() {
  * @fires gla_documentation_link_click with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
  */
 const ContactInformation = ( { onPhoneNumberVerified } ) => {
+	const { adapter } = useAdaptiveFormContext();
 	const phone = useGoogleMCPhoneNumber();
 	const title = mcTitle;
 	const trackContext = 'setup-mc-contact-information';
@@ -118,7 +120,9 @@ const ContactInformation = ( { onPhoneNumberVerified } ) => {
 					phoneNumber={ phone }
 					onPhoneNumberVerified={ onPhoneNumberVerified }
 				/>
-				<StoreAddressCard />
+				<StoreAddressCard
+					showValidation={ adapter.requestedShowValidation }
+				/>
 			</VerticalGapLayout>
 		</Section>
 	);

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -118,6 +118,7 @@ const ContactInformation = ( { onPhoneNumberVerified } ) => {
 				<PhoneNumberCard
 					view="setup-mc"
 					phoneNumber={ phone }
+					showValidation={ adapter.requestedShowValidation }
 					onPhoneNumberVerified={ onPhoneNumberVerified }
 				/>
 				<StoreAddressCard

--- a/js/src/components/contact-information/mapStoreAddressErrors.js
+++ b/js/src/components/contact-information/mapStoreAddressErrors.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { __, _x, sprintf } from '@wordpress/i18n';
+
+/**
+ * @typedef {import('.~/hooks/types.js').StoreAddress} StoreAddress
+ */
+
+/**
+ * Maps the missing fields of store address to corresponding error messages.
+ *
+ * @param {StoreAddress} storeAddress [description]
+ * @return {string[]} Error massages of store address.
+ */
+export default function mapStoreAddressErrors( storeAddress ) {
+	// The sources of the possible field names:
+	// - https://github.com/woocommerce/google-listings-and-ads/blob/2.5.0/src/API/Google/Settings.php#L322-L339
+	// - https://github.com/woocommerce/woocommerce/blob/7.9.0/plugins/woocommerce/includes/class-wc-countries.php#L841-L1654
+	const fieldNameDict = {
+		address_1: _x(
+			'address line',
+			'The field name of the address line in store address',
+			'google-listings-and-ads'
+		),
+		city: _x(
+			'city',
+			'The field name of the city in store address',
+			'google-listings-and-ads'
+		),
+		country: _x(
+			'country/state',
+			'The field name of the country in store address',
+			'google-listings-and-ads'
+		),
+		postcode: _x(
+			'postcode/zip',
+			'The field name of the postcode in store address',
+			'google-listings-and-ads'
+		),
+	};
+
+	return storeAddress.missingRequiredFields.map( ( field ) => {
+		const fieldName = fieldNameDict[ field ] || field;
+		return sprintf(
+			// translators: %s: The missing field name of store address.
+			__(
+				'The %s of store address is required.',
+				'google-listings-and-ads'
+			),
+			fieldName
+		);
+	} );
+}

--- a/js/src/components/contact-information/mapStoreAddressErrors.js
+++ b/js/src/components/contact-information/mapStoreAddressErrors.js
@@ -14,9 +14,10 @@ import { __, _x, sprintf } from '@wordpress/i18n';
  * @return {string[]} Error massages of store address.
  */
 export default function mapStoreAddressErrors( storeAddress ) {
-	// The sources of the possible field names:
-	// - https://github.com/woocommerce/google-listings-and-ads/blob/2.5.0/src/API/Google/Settings.php#L322-L339
-	// - https://github.com/woocommerce/woocommerce/blob/7.9.0/plugins/woocommerce/includes/class-wc-countries.php#L841-L1654
+	// The possible fields to be mapped are defined in the first file,
+	// and their specs come from the second file:
+	// 1. https://github.com/woocommerce/google-listings-and-ads/blob/2.5.0/src/API/Google/Settings.php#L322-L339
+	// 2. https://github.com/woocommerce/woocommerce/blob/7.9.0/plugins/woocommerce/includes/class-wc-countries.php#L841-L1654
 	const fieldNameDict = {
 		address_1: _x(
 			'address line',

--- a/js/src/components/contact-information/mapStoreAddressErrors.test.js
+++ b/js/src/components/contact-information/mapStoreAddressErrors.test.js
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import mapStoreAddressErrors from './mapStoreAddressErrors';
+
+describe( 'mapStoreAddressErrors', () => {
+	let storeAddress;
+
+	beforeEach( () => {
+		storeAddress = {
+			isAddressFilled: true,
+			missingRequiredFields: [],
+		};
+	} );
+
+	it( 'When all fields are valid, should return an empty array.', () => {
+		expect( mapStoreAddressErrors( storeAddress ) ).toEqual( [] );
+	} );
+
+	it( 'When required store address fields are missing, should map them to corresponding error messages', () => {
+		storeAddress.isAddressFilled = false;
+		storeAddress.missingRequiredFields = [
+			'address_1',
+			'city',
+			'country',
+			'postcode',
+		];
+		const errors = mapStoreAddressErrors( storeAddress );
+
+		expect( errors.length ).toBe( 4 );
+		expect( errors ).toMatchSnapshot();
+	} );
+
+	it( 'When newly added required fields are missing in store address, should map them to fallback error messages', () => {
+		storeAddress.isAddressFilled = false;
+		storeAddress.missingRequiredFields = [
+			// Known field
+			'postcode',
+			// Newly added fields
+			'other newly added field',
+			'another newly added field',
+		];
+		const errors = mapStoreAddressErrors( storeAddress );
+
+		expect( errors.length ).toBe( 3 );
+		expect( errors ).toMatchSnapshot();
+	} );
+} );

--- a/js/src/components/contact-information/phone-number-card/phone-number-card.js
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card.js
@@ -12,6 +12,7 @@ import { Spinner } from '@woocommerce/components';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import AppButton from '.~/components/app-button';
 import AppSpinner from '.~/components/app-spinner';
+import ValidationErrors from '.~/components/validation-errors';
 import VerifyPhoneNumberContent from './verify-phone-number-content';
 import EditPhoneNumberContent from './edit-phone-number-content';
 import './phone-number-card.scss';
@@ -27,7 +28,11 @@ const basePhoneNumberCardProps = {
  * @typedef { import(".~/hooks/useGoogleMCPhoneNumber").PhoneNumber } PhoneNumber
  */
 
-function EditPhoneNumberCard( { phoneNumber, onPhoneNumberVerified } ) {
+function EditPhoneNumberCard( {
+	phoneNumber,
+	showValidation,
+	onPhoneNumberVerified,
+} ) {
 	const { loaded, data } = phoneNumber;
 	const [ verifying, setVerifying ] = useState( false );
 	const [ unverifiedPhoneNumber, setUnverifiedPhoneNumber ] = useState(
@@ -73,11 +78,22 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberVerified } ) {
 		/>
 	) : null;
 
+	const helper =
+		showValidation && ! data.isVerified ? (
+			<ValidationErrors
+				messages={ __(
+					'A verified phone number is required.',
+					'google-listings-and-ads'
+				) }
+			/>
+		) : null;
+
 	return (
 		<AccountCard
 			{ ...basePhoneNumberCardProps }
 			description={ description }
 			indicator={ indicator }
+			helper={ helper }
 		>
 			<CardDivider />
 			{ cardContent }
@@ -102,6 +118,7 @@ function EditPhoneNumberCard( { phoneNumber, onPhoneNumberVerified } ) {
  *     `true`: initialize with the editing UI for entering the phone number and proceeding with verification.
  *     `false`: initialize with the non-editing UI viewing the phone number and a button for switching to the editing UI.
  *     `null`: determine the initial UI state according to the `data.isVerified` after the `phoneNumber` loaded.
+ * @param {boolean} [props.showValidation=false] Whether to show validation error messages.
  * @param {Function} [props.onEditClick] Called when clicking on "Edit" button.
  *     If this callback is omitted, it will enter edit mode when clicking on "Edit" button.
  * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified or has been verified.
@@ -112,6 +129,7 @@ const PhoneNumberCard = ( {
 	view,
 	phoneNumber,
 	initEditing = null,
+	showValidation = false,
 	onEditClick,
 	onPhoneNumberVerified = noop,
 } ) => {
@@ -157,6 +175,7 @@ const PhoneNumberCard = ( {
 		return (
 			<EditPhoneNumberCard
 				phoneNumber={ phoneNumber }
+				showValidation={ showValidation }
 				onPhoneNumberVerified={ handlePhoneNumberVerified }
 			/>
 		);

--- a/js/src/components/contact-information/phone-number-card/phone-number-card.scss
+++ b/js/src/components/contact-information/phone-number-card/phone-number-card.scss
@@ -3,6 +3,10 @@
 		color: $gray-700;
 	}
 
+	.gla-account-card__helper {
+		font-style: normal;
+	}
+
 	// Country code selector
 	.wcdl-select-control {
 		.wcdl-select-control__input {

--- a/js/src/components/contact-information/store-address-card.js
+++ b/js/src/components/contact-information/store-address-card.js
@@ -16,8 +16,10 @@ import Section from '.~/wcdl/section';
 import Subsection from '.~/wcdl/subsection';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import AppButton from '.~/components/app-button';
+import ValidationErrors from '.~/components/validation-errors';
 import ContactInformationPreviewCard from './contact-information-preview-card';
 import TrackableLink from '.~/components/trackable-link';
+import mapStoreAddressErrors from './mapStoreAddressErrors';
 import './store-address-card.scss';
 
 /**
@@ -34,9 +36,12 @@ import './store-address-card.scss';
  *
  * @fires gla_edit_wc_store_address Whenever "Edit in WooCommerce Settings" button is clicked.
  *
+ * @param {Object} props React props.
+ * @param {boolean} [props.showValidation=false] Whether to show validation error messages.
+ *
  * @return {JSX.Element} Filled AccountCard component.
  */
-const StoreAddressCard = () => {
+const StoreAddressCard = ( { showValidation = false } ) => {
 	const { loaded, data, refetch } = useStoreAddress();
 	const { subpath } = getQuery();
 	const editButton = (
@@ -116,6 +121,11 @@ const StoreAddressCard = () => {
 					{ __( 'Store address', 'google-listings-and-ads' ) }
 				</Subsection.Title>
 				{ addressContent }
+				{ showValidation && (
+					<ValidationErrors
+						messages={ mapStoreAddressErrors( data ) }
+					/>
+				) }
 			</Section.Card.Body>
 		</AccountCard>
 	);

--- a/js/src/hooks/types.js
+++ b/js/src/hooks/types.js
@@ -8,5 +8,20 @@
  * @property {string} alt Alternate text.
  */
 
+/**
+ * @typedef {Object} StoreAddress
+ * @property {string} address Store address line 1.
+ * @property {string} address2 Address line 2.
+ * @property {string} city Store city.
+ * @property {string} state Store country state if available.
+ * @property {string} country Store country.
+ * @property {string} postcode Store postcode.
+ * @property {boolean|null} isAddressFilled Whether the minimum address data is filled in.
+ *                          `null` if data have not loaded yet.
+ * @property {boolean|null} isMCAddressDifferent Whether the address data from WC store and GMC are the same.
+ *                          `null` if data have not loaded yet.
+ * @property {string[]} missingRequiredFields The missing required fields of the store address.
+ */
+
 // This export is required for JSDoc in other files to import the type definitions from this file.
 export default {};

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -62,10 +62,12 @@ export default function useStoreAddress( source = 'wc' ) {
 		const postcode = storeAddress?.postal_code || '';
 
 		const [ address, address2 = '' ] = streetAddress.split( '\n' );
-		const country = countryNameDict[ storeAddress?.country ];
+		const country = countryNameDict[ storeAddress?.country ] || '';
+		const countryCode = storeAddress?.country || '';
 		const isAddressFilled = ! missingRequiredFields.length;
 
 		data = {
+			countryCode,
 			address,
 			address2,
 			city,

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -13,6 +13,7 @@ const emptyData = {
 	postcode: '',
 	isMCAddressDifferent: null,
 	isAddressFilled: null,
+	missingRequiredFields: [],
 };
 
 /**
@@ -27,6 +28,7 @@ const emptyData = {
  *                          `null` if data have not loaded yet.
  * @property {boolean|null} isMCAddressDifferent Whether the address data from WC store and GMC are the same.
  *                          `null` if data have not loaded yet.
+ * @property {string[]} missingRequiredFields The missing required fields of the store address.
  */
 /**
  * @typedef {Object} StoreAddressResult
@@ -54,7 +56,11 @@ export default function useStoreAddress( source = 'wc' ) {
 	let data = emptyData;
 
 	if ( loaded && contact ) {
-		const { is_mc_address_different: isMCAddressDifferent } = contact;
+		const {
+			is_mc_address_different: isMCAddressDifferent,
+			wc_address_errors: missingRequiredFields,
+		} = contact;
+
 		const storeAddress =
 			source === 'wc' ? contact.wc_address : contact.mc_address;
 
@@ -66,7 +72,7 @@ export default function useStoreAddress( source = 'wc' ) {
 
 		const [ address, address2 = '' ] = streetAddress.split( '\n' );
 		const country = countryNameDict[ storeAddress?.country ];
-		const isAddressFilled = ! contact.wc_address_errors.length;
+		const isAddressFilled = ! missingRequiredFields.length;
 
 		data = {
 			address,
@@ -77,6 +83,7 @@ export default function useStoreAddress( source = 'wc' ) {
 			postcode,
 			isAddressFilled,
 			isMCAddressDifferent,
+			missingRequiredFields,
 		};
 	}
 

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -4,6 +4,10 @@
 import useAppSelectDispatch from './useAppSelectDispatch';
 import useCountryKeyNameMap from './useCountryKeyNameMap';
 
+/**
+ * @typedef {import('.~/hooks/types.js').StoreAddress} StoreAddress
+ */
+
 const emptyData = {
 	address: '',
 	address2: '',
@@ -17,25 +21,12 @@ const emptyData = {
 };
 
 /**
- * @typedef {Object} StoreAddress
- * @property {string} address Store address line 1.
- * @property {string} address2 Address line 2.
- * @property {string} city Store city.
- * @property {string} state Store country state if available.
- * @property {string} country Store country.
- * @property {string} postcode Store postcode.
- * @property {boolean|null} isAddressFilled Whether the minimum address data is filled in.
- *                          `null` if data have not loaded yet.
- * @property {boolean|null} isMCAddressDifferent Whether the address data from WC store and GMC are the same.
- *                          `null` if data have not loaded yet.
- * @property {string[]} missingRequiredFields The missing required fields of the store address.
- */
-/**
  * @typedef {Object} StoreAddressResult
  * @property {Function} refetch Dispatch a refetch action to reload store address.
  * @property {boolean} loaded Whether the data have been loaded.
  * @property {StoreAddress} data Store address data.
  */
+
 /**
  * Get store address data and refectch function.
  *

--- a/js/src/settings/edit-store-address.js
+++ b/js/src/settings/edit-store-address.js
@@ -90,7 +90,9 @@ const EditStoreAddress = () => {
 						</div>
 					}
 				>
-					<StoreAddressCard />
+					<StoreAddressCard
+						showValidation={ ! address.isAddressFilled }
+					/>
 				</Section>
 				<Section>
 					<Flex justify="flex-end">

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -16,6 +16,7 @@ import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
 import AdaptiveForm from '.~/components/adaptive-form';
+import ValidationErrors from '.~/components/validation-errors';
 import ContactInformation from '.~/components/contact-information';
 import AppButton from '.~/components/app-button';
 import AppSpinner from '.~/components/app-spinner';
@@ -123,6 +124,21 @@ export default function StoreRequirements( { onContinue } ) {
 		return <AppSpinner />;
 	}
 
+	const extendAdapter = ( formContext ) => {
+		return {
+			renderRequestedValidation( key ) {
+				if ( formContext.adapter.requestedShowValidation ) {
+					return (
+						<ValidationErrors
+							messages={ formContext.errors[ key ] }
+						/>
+					);
+				}
+				return null;
+			},
+		};
+	};
+
 	return (
 		<StepContent>
 			<StepContentHeader
@@ -143,6 +159,7 @@ export default function StoreRequirements( { onContinue } ) {
 					refund_tos_visible: settings.refund_tos_visible,
 					contact_info_visible: settings.contact_info_visible,
 				} }
+				extendAdapter={ extendAdapter }
 				validate={ checkErrors }
 				onChange={ handleChangeCallback }
 				onSubmit={ handleSubmitCallback }

--- a/js/src/setup-mc/setup-stepper/store-requirements/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/index.js
@@ -150,11 +150,18 @@ export default function StoreRequirements( { onContinue } ) {
 				{ ( formContext ) => {
 					const { handleSubmit, isValidForm, adapter } = formContext;
 
-					const isReadyToComplete =
-						isValidForm &&
-						isPhoneNumberReady &&
-						address.isAddressFilled &&
-						settingsSaved;
+					const handleSubmitClick = ( event ) => {
+						const isReadyToComplete =
+							isValidForm &&
+							isPhoneNumberReady &&
+							address.isAddressFilled;
+
+						if ( isReadyToComplete ) {
+							return handleSubmit( event );
+						}
+
+						adapter.showValidation();
+					};
 
 					return (
 						<>
@@ -168,8 +175,8 @@ export default function StoreRequirements( { onContinue } ) {
 								<AppButton
 									isPrimary
 									loading={ adapter.isSubmitting }
-									disabled={ ! isReadyToComplete }
-									onClick={ handleSubmit }
+									disabled={ ! settingsSaved }
+									onClick={ handleSubmitClick }
 								>
 									{ __(
 										'Continue',

--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/checkErrors.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/checkErrors.js
@@ -6,40 +6,17 @@ import { __ } from '@wordpress/i18n';
 export default function checkErrors( values ) {
 	const errors = {};
 
-	/**
-	 * Pre-launch checklist.
-	 */
-	if ( values.website_live !== true ) {
-		errors.website_live = __(
-			'Please check the requirement.',
-			'google-listings-and-ads'
-		);
-	}
+	const preLaunchFields = [
+		'website_live',
+		'checkout_process_secure',
+		'payment_methods_visible',
+		'refund_tos_visible',
+		'contact_info_visible',
+	];
 
-	if ( values.checkout_process_secure !== true ) {
-		errors.checkout_process_secure = __(
-			'Please check the requirement.',
-			'google-listings-and-ads'
-		);
-	}
-
-	if ( values.payment_methods_visible !== true ) {
-		errors.payment_methods_visible = __(
-			'Please check the requirement.',
-			'google-listings-and-ads'
-		);
-	}
-
-	if ( values.refund_tos_visible !== true ) {
-		errors.refund_tos_visible = __(
-			'Please check the requirement.',
-			'google-listings-and-ads'
-		);
-	}
-
-	if ( values.contact_info_visible !== true ) {
-		errors.contact_info_visible = __(
-			'Please check the requirement.',
+	if ( preLaunchFields.some( ( field ) => values[ field ] !== true ) ) {
+		errors.preLaunchChecklist = __(
+			'Please check all requirements.',
 			'google-listings-and-ads'
 		);
 	}

--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/checkErrors.test.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/checkErrors.test.js
@@ -8,58 +8,38 @@ import checkErrors from './checkErrors';
  * set properties respectively with an error message to indicate it.
  */
 describe( 'checkErrors', () => {
-	describe( 'Should check the presence of required properties in the given object. Returned object should have error messages for respective properties.', () => {
-		for ( const property of [
-			'website_live',
-			'checkout_process_secure',
-			'payment_methods_visible',
-			'refund_tos_visible',
-			'contact_info_visible',
-		] ) {
-			it( `${ property } === true`, () => {
-				expect( checkErrors( {} ) ).toHaveProperty(
-					property,
-					'Please check the requirement.'
-				);
+	const preLaunchFields = [
+		'website_live',
+		'checkout_process_secure',
+		'payment_methods_visible',
+		'refund_tos_visible',
+		'contact_info_visible',
+	];
 
-				expect( checkErrors( { [ property ]: 'foo' } ) ).toHaveProperty(
-					property,
-					'Please check the requirement.'
-				);
+	let values;
 
-				expect(
-					checkErrors( { [ property ]: true } )
-				).not.toHaveProperty( property );
-			} );
-		}
-		it( 'When there are many missing/invalid properties, should report them all.', () => {
-			const values = {
-				website_live: false,
-				payment_methods_visible: 'true',
-				refund_tos_visible: [],
-				contact_info_visible: {},
-			};
-
-			const errorMessage = 'Please check the requirement.';
-			expect( checkErrors( values ) ).toEqual( {
-				website_live: errorMessage,
-				checkout_process_secure: errorMessage,
-				payment_methods_visible: errorMessage,
-				refund_tos_visible: errorMessage,
-				contact_info_visible: errorMessage,
-			} );
+	beforeEach( () => {
+		values = {};
+		preLaunchFields.forEach( ( field ) => {
+			values[ field ] = true;
 		} );
+	} );
 
+	describe( 'Should check the presence of required properties in the given object. Returned object should have error messages for respective properties.', () => {
 		it( 'When all properties are valid, should return an empty object.', () => {
-			const values = {
-				website_live: true,
-				checkout_process_secure: true,
-				payment_methods_visible: true,
-				refund_tos_visible: true,
-				contact_info_visible: true,
-			};
-
 			expect( checkErrors( values ) ).toEqual( {} );
 		} );
+
+		it.each( preLaunchFields )(
+			'When %s !== true, should have the error message for `preLaunchChecklist` property',
+			( field ) => {
+				values[ field ] = false;
+
+				expect( checkErrors( values ) ).toHaveProperty(
+					'preLaunchChecklist',
+					'Please check all requirements.'
+				);
+			}
+		);
 	} );
 } );

--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import PreLaunchCheckItem from '.~/components/pre-launch-check-item';
 import Section from '.~/wcdl/section';
@@ -15,6 +16,10 @@ import VerticalGapLayout from '.~/components/vertical-gap-layout';
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-checklist', link_id: 'checklist-requirements', href: 'https://support.google.com/merchants/answer/6363310' }`
  */
 const PreLaunchChecklist = () => {
+	const {
+		adapter: { renderRequestedValidation },
+	} = useAdaptiveFormContext();
+
 	return (
 		<div className="gla-pre-launch-checklist">
 			<Section
@@ -178,6 +183,7 @@ const PreLaunchChecklist = () => {
 								) }
 							</PreLaunchCheckItem>
 						</VerticalGapLayout>
+						{ renderRequestedValidation( 'preLaunchChecklist' ) }
 					</Section.Card.Body>
 				</Section.Card>
 			</Section>

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -243,7 +243,7 @@ When a documentation link is clicked.
 `href` | `string` | link's URL
 #### Emitters
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
-- [`ContactInformation`](../../js/src/components/contact-information/index.js#L90)
+- [`ContactInformation`](../../js/src/components/contact-information/index.js#L91)
 	- with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
 	- with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
 	- with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
@@ -251,9 +251,9 @@ When a documentation link is clicked.
 	- with `{ context: "dashboard", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-products", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
-- [`ChooseAudienceSection`](../../js/src/components/free-listings/choose-audience-section/choose-audience-section.js#L30) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
+- [`ChooseAudienceSection`](../../js/src/components/free-listings/choose-audience-section/choose-audience-section.js#L29) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
 - [`ShippingTimeSection`](../../js/src/components/free-listings/configure-product-listings/shipping-time-section.js#L17) with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
-- [`TaxRate`](../../js/src/components/free-listings/configure-product-listings/tax-rate.js#L21)
+- [`TaxRate`](../../js/src/components/free-listings/configure-product-listings/tax-rate.js#L22)
 	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-read-more', href: 'https://support.google.com/merchants/answer/160162' }`
 	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
 - [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
@@ -266,7 +266,7 @@ When a documentation link is clicked.
 - [`TermsModal`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L29) with `{ context: 'setup-mc', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
 - [`exports`](../../js/src/components/paid-ads/ads-campaign.js#L38) with `{ context: 'create-ads' | 'edit-ads' | 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
 - [`FaqsSection`](../../js/src/components/paid-ads/asset-group/faqs-section.js#L73) with `{ context: 'assets-faq', linkId: 'assets-faq-about-ad-formats-available-in-different-campaign-types', href: 'https://support.google.com/google-ads/answer/1722124' }`.
-- [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L22)
+- [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L23)
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
 - [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
@@ -301,7 +301,7 @@ Triggered when phone number edit button is clicked.
 #### Emitters
 - [`PhoneNumberCardPreview`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L33) Whenever "Edit" is clicked.
 
-### [`gla_edit_mc_store_address`](../../js/src/components/contact-information/store-address-card.js#L126)
+### [`gla_edit_mc_store_address`](../../js/src/components/contact-information/store-address-card.js#L172)
 Trigger when store address edit button is clicked.
  Before `1.5.0` this name was used for tracking clicking "Edit in settings" to edit the WC address. As of `>1.5.0`, that event is now tracked as `edit_wc_store_address`.
 #### Properties
@@ -310,7 +310,7 @@ Trigger when store address edit button is clicked.
 `path` | `string` | The path used in the page from which the link was clicked, e.g. `"/google/settings"`.
 `subpath` | `string\|undefined` | The subpath used in the page, e.g. `"/edit-store-address"` or `undefined` when there is no subpath.
 #### Emitters
-- [`StoreAddressCardPreview`](../../js/src/components/contact-information/store-address-card.js#L146) Whenever "Edit" is clicked.
+- [`StoreAddressCardPreview`](../../js/src/components/contact-information/store-address-card.js#L192) Whenever "Edit" is clicked.
 
 ### [`gla_edit_product_click`](../../js/src/product-feed/product-feed-table-card/index.js#L50)
 Triggered when edit links are clicked from product feed table.
@@ -330,7 +330,7 @@ Triggered when edit links are clicked from Issues to resolve table.
 `code` | `string` | Issue code returned from Google
 `issue` | `string` | Issue description returned from Google
 
-### [`gla_edit_wc_store_address`](../../js/src/components/contact-information/store-address-card.js#L23)
+### [`gla_edit_wc_store_address`](../../js/src/components/contact-information/store-address-card.js#L26)
 Triggered when store address "Edit in WooCommerce Settings" button is clicked.
  Before `1.5.0` it was called `edit_mc_store_address`.
 #### Properties
@@ -339,7 +339,7 @@ Triggered when store address "Edit in WooCommerce Settings" button is clicked.
 `path` | `string` | The path used in the page from which the link was clicked, e.g. `"/google/settings"`.
 `subpath` | `string\|undefined` | The subpath used in the page, e.g. `"/edit-store-address"` or `undefined` when there is no subpath.
 #### Emitters
-- [`StoreAddressCard`](../../js/src/components/contact-information/store-address-card.js#L39) Whenever "Edit in WooCommerce Settings" button is clicked.
+- [`StoreAddressCard`](../../js/src/components/contact-information/store-address-card.js#L56) Whenever "Edit in WooCommerce Settings" button is clicked.
 
 ### [`gla_faq`](../../js/src/components/faqs-panel/index.js#L22)
 Clicking on faq item to collapse or expand it.
@@ -528,14 +528,14 @@ Check for whether the phone number for Merchant Center exists or not.
 #### Emitters
 - [`usePhoneNumberCheckTrackEventEffect`](../../js/src/components/contact-information/usePhoneNumberCheckTrackEventEffect.js#L21)
 
-### [`gla_mc_phone_number_edit_button_click`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L88)
+### [`gla_mc_phone_number_edit_button_click`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L104)
 Clicking on the Merchant Center phone number edit button.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `view` | `string` | which view the edit button is in. Possible values: `setup-mc`, `settings`.
 #### Emitters
-- [`PhoneNumberCard`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L111)
+- [`PhoneNumberCard`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L128)
 
 ### [`gla_modal_closed`](../../js/src/utils/recordEvent.js#L110)
 A modal is closed.
@@ -739,6 +739,18 @@ Viewing tooltip
 `id` | `string` | Tooltip identifier.
 #### Emitters
 - [`HelpPopover`](../../js/src/components/help-popover/index.js#L32) with the given `id`.
+
+### [`gla_wc_store_address_validation`](../../js/src/components/contact-information/store-address-card.js#L35)
+Track how many times and what fields the store address is having validation errors.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`path` | `string` | The path used in the page from which the event tracking was sent, e.g. `"/google/setup-mc"` or `"/google/settings"`.
+`subpath` | `string\|undefined` | The subpath used in the page, e.g. `"/edit-store-address"` or `undefined` when there is no subpath.
+`country_code` | `string` | The country code of store address, e.g. `"US"`.
+`missing_fields` | `string` | The string of the missing required fields of store address separated by comma, e.g. `"city,postcode"`.
+#### Emitters
+- [`StoreAddressCard`](../../js/src/components/contact-information/store-address-card.js#L56) Whenever the new store address data is fetched after clicking "Refresh to sync" button.
 
 ### [`gla_wordpress_account_connect_button_click`](../../js/src/components/wpcom-account-card/connect-wpcom-account-card.js#L17)
 Clicking on the button to connect WordPress.com account.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #634 

This is the last part for #634 and for 📌 [Display form validation errors](https://github.com/woocommerce/google-listings-and-ads/issues/1993#tasks-display-validation-errors) in #1993.

To show validation errors on step 3 of the onboarding flow when unable to continue, this PR:

#### Adjust/add validator

- Adjust the error messages in the pre-launch checklist validator to a centralized one.
- Expose the missing required fields of store address from `useStoreAddress` hook and add new util to map the missing fields of store address to corresponding error messages.

#### Add the mechanism for showing validation errors

- Request showing validation errors when clicking the submit of store requirements form if any data is not ready.
- Add a function to render validation errors to the store requirements form.
- Add the rendering of validation errors for the phone number verification.
- Add the rendering of missing required fields for the store address setup.
- Add the rendering of validation errors to `PreLaunchChecklist`.

#### Event tracking

- Add event tracking to log how many times and what fields the store address is having validation errors.
- Update `src/Tracking/README.md`.

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/335d836b-7f79-483a-ade4-5e00493ebc44

### Detailed test instructions:

The country of WC store address data is unable to clean via WC Admin Settings. It might need to run the following SQL to clean it from database.

```sql
DELETE FROM wp_options WHERE option_name = 'woocommerce_default_country';
```

💡 WC/GLA will still use `US` as the fallback country code if the `woocommerce_default_country` is not available. Therefore, the case of missing country filed will not be able to test in practice.

1. Start the onboarding flow with a newly created Google Merchant Center account. So that it can test the verification of phone number later.
2. Proceed the flow until step 3
3. Before clicking the "Continue" button, the UI should not show any validation errors even if there is unverified phone number, invalid store address or unchecked pre-launch checklist.
4. With some invalid data, click the "Continue" button to see if the validation errors are shown in the corresponding places.
5. Update the data to view if the validation errors are shown or hidden accordingly.
6. Make all data valid and click the "Continue" button to check if it goes to step 4.

### Additional details:

The validation error message for phone number is placed in a different location from the other Card UI because the content of phone number card is more varied and complex, and there is no relatively suitable location at the bottom to display the validation error.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/1b136451-fc46-4e73-aa7e-2811d6d7b5cd)

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/4788f3cf-ddaa-4746-9f38-efa70eca2292)

### Changelog entry

> Update - Show validation errors on steps 2 and 3 of the onboarding flow when unable to continue.
