### PR TITLE
Add To Cart Tracking support for Products (Beta) Block

### DIFF
--- a/js/src/gtag-events/index.js
+++ b/js/src/gtag-events/index.js
@@ -75,6 +75,23 @@ document.defaultView.addEventListener( 'DOMContentLoaded', function () {
 			button.addEventListener( 'click', addToCartClick );
 		} );
 
+	/**
+	 * Fix for Products (Beta) block
+	 *
+	 * Products (Beta) block doesn't trigger addAction events. Also it's not being queried by the previous query selector
+	 * because we added :not( .wc-block-components-product-button__button ) to prevent tracking duplicates with
+	 * other blocks that yes trigger addAction events.
+	 *
+	 * So the fix is to query again specifically the add to cart button in Products (Beta) block
+	 */
+	document
+		.querySelectorAll(
+			'[data-block-name="woocommerce/product-button"] > .add_to_cart_button:not( .product_type_variable ):not( .product_type_grouped )'
+		)
+		.forEach( ( button ) => {
+			button.addEventListener( 'click', addToCartClick );
+		} );
+
 	document
 		.querySelectorAll( '.single_add_to_cart_button' )
 		.forEach( ( button ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2020 

This PR adds a fix for triggering the Add To Cart event when it takes place on Products (Beta) Block.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install Google Analytics Debugger extension
2. Install GLA, complete the setup and connect Google Ads as well
3. Install a theme with Blocks  support, for example Storefront
4. Create a new page (Page 1), and insert the block "All Products"
5. Crate a new page (Page 2), and insert the block "Products (beta)"
6. Go to Shop page in the store, click on Add to cart, see the 'add_to_cart' event is logged once by Google Analytics Debugger
7. Go to "Page 1", click on Add to cart, see the 'add_to_cart' event is logged once by Google Analytics Debugger
8. Go to "Page 2", click on Add to cart, see the 'add_to_cart' event is logged once by Google Analytics Debugger  


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fix support for "add_to_cart" event in Products (Beta) block
