### PR TITLE
Make the gtag-events.js work with the Fast Refresh development mode

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -286,12 +286,12 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 		$plugin_url = $this->get_plugin_url();
 
 		$scripts->add(
-			'gla-webpack-rumtime',
+			'gla-webpack-runtime',
 			"{$plugin_url}/js/build/runtime.js",
 			[],
 			(string) filemtime( $runtime_path )
 		);
-		$react_script->deps[] = 'gla-webpack-rumtime';
+		$react_script->deps[] = 'gla-webpack-runtime';
 
 		if ( ! in_array( 'wp-react-refresh-entry', $react_script->deps, true ) ) {
 			$scripts->add(

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -504,7 +504,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		$plugin_url = $this->get_plugin_url();
 
 		wp_enqueue_script(
-			'gla-webpack-rumtime',
+			'gla-webpack-runtime',
 			"{$plugin_url}/js/build/runtime.js",
 			[],
 			(string) filemtime( $runtime_path ),
@@ -516,7 +516,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		wp_register_script(
 			'wp-react-refresh-runtime',
 			"{$plugin_url}/js/build-dev/react-refresh-runtime.js",
-			[ 'gla-webpack-rumtime' ],
+			[ 'gla-webpack-runtime' ],
 			$this->get_version(),
 			false
 		);

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -202,6 +202,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 					]
 				);
 
+				$this->register_js_for_fast_refresh_dev();
 				$this->assets_handler->enqueue( $gtag_events );
 			}
 		);
@@ -484,5 +485,40 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		$query->set( 'customer', $customer_email );
 		$orders = $query->get_orders();
 		return count( $orders ) === 1 ? true : false;
+	}
+
+	/**
+	 * This method ONLY works during development in the Fast Refresh mode.
+	 *
+	 * The runtime.js and react-refresh-runtime.js files are created when the front-end development is
+	 * running `npm run start:hot`, and they need to be loaded to make the gtag-events scrips work.
+	 */
+	private function register_js_for_fast_refresh_dev() {
+		// This file exists only when running `npm run start:hot`
+		$runtime_path = "{$this->get_root_dir()}/js/build/runtime.js";
+
+		if ( ! file_exists( $runtime_path ) ) {
+			return;
+		}
+
+		$plugin_url = $this->get_plugin_url();
+
+		wp_enqueue_script(
+			'gla-webpack-rumtime',
+			"{$plugin_url}/js/build/runtime.js",
+			[],
+			(string) filemtime( $runtime_path ),
+			false
+		);
+
+		// This script is one of the gtag-events dependencies, and its handle is wp-react-refresh-runtime.
+		// Ref: js/build/gtag-events.asset.php
+		wp_register_script(
+			'wp-react-refresh-runtime',
+			"{$plugin_url}/js/build-dev/react-refresh-runtime.js",
+			[ 'gla-webpack-rumtime' ],
+			$this->get_version(),
+			false
+		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1842 

This PR makes the gtag-events.js work with the Fast Refresh development mode.

- [x] Update the [Smoke-tests page](https://github.com/woocommerce/google-listings-and-ads/wiki/Smoke-tests#gtag-events) once this PR getting merged

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/70621f34-43a2-463f-b01f-05ba519272b1

### Detailed test instructions:

1. Confirm the `SCRIPT_DEBUG` flag is not enabled in your test env. It's usually defined in the wp-config.php.
2. Start the Fast Refresh development mode: `npm run start:hot`.
3. Open the Network tab of the browser DevTool.
4. Visit a single product page.
5. Select the "JS" category and check if the `/wp-content/plugins/google-listings-and-ads/js/build/gtag-events.js` script is loaded.
6. Select the "All" category, check "Preserve log", and filter by `google.com/pagead`.
7. Add a product to cart.
8. Check if there is a request is sent to `https://www.google.com/pagead` with the `add_to_cart` event.
9. Modify the `js/src/gtag-events/index.js` file and save. Wait a few seconds and see if the product page is reloaded automatically.

### Changelog entry

