### PR TITLE
WP 6.3 Compatibility: Fix the errors of "setImmediate is not defined"

### DIFF
--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -196,12 +196,12 @@ function AdaptiveForm( { onSubmit, extendAdapter, children, ...props }, ref ) {
 				// Related to WC 6.9. Only one delegate can be consumed at a time in this render prop to
 				// ensure the updating states will always be the latest when calling.
 				if ( batchQueue.length ) {
-					// Use `setImmediate` to avoid the warning of request state updates while rendering.
+					// Use `setTimeout` to avoid the warning of request state updates while rendering.
 					// Mutating a React hook state is an anti-pattern in most cases. Here is done intentionally
 					// because it's necessary to ensure this component will be triggered re-rendering through
 					// `setBatchQueue`, but also to avoid calling `setBatchQueue` here and triggering additional
 					// rendering again.
-					setImmediate( () => setDelegation( batchQueue.shift() ) );
+					setTimeout( () => setDelegation( batchQueue.shift() ) );
 				}
 
 				/* === Start of enhancement-related codes === */

--- a/js/src/components/adaptive-form/adaptive-form.test.js
+++ b/js/src/components/adaptive-form/adaptive-form.test.js
@@ -197,7 +197,7 @@ describe( 'AdaptiveForm', () => {
 		expect( inspect ).toHaveBeenLastCalledWith( false, 0 );
 	} );
 
-	describe( 'Compatibly patches', () => {
+	describe( 'Compatibility patches', () => {
 		it( 'Should update all changes to values for the synchronous multiple calls to `setValue`', async () => {
 			render(
 				<AdaptiveForm

--- a/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
+++ b/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
@@ -315,7 +315,7 @@ export default function useCroppedImageSelector( {
 				// since `toolbar` will be triggered the refresh event at the end, so this function
 				// must be called after that.
 				if ( this === frame ) {
-					setImmediate( handleSelectionToggle );
+					setTimeout( handleSelectionToggle );
 					return;
 				}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2040 

WordPress 6.3 will remove `setImmediate`, so the following errors were found while testing with WP 6.3-rc3.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/03a42894-ba44-4003-bdf6-bb0475ae5134)

Ref:
- [Polyfills: exclude web.immediate](https://github.com/WordPress/gutenberg/pull/49234)
- [WP 6.3 includes the exclusion](https://github.com/WordPress/gutenberg/blob/wp/6.3/packages/babel-preset-default/CHANGELOG.md#7140-2023-03-29)

To fix it, this PR:
- Replace the deprecated `setImmediate` with `setTimeout`.
- Added test cases about compatibility to `AdaptiveForm` component.

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/2a9db3da-197a-4c47-8c72-82958981ccdf

### Detailed test instructions:

WP 6.3 is not yet released. One of the ways to test this PR with a RC version is using WP-CLI:
```bash
wp core update --version=6.3-RC3
```

#### `AdaptiveForm`

1. Go to the onboarding flow or the Edit Free Listings page.
2. On the shipping section, select some audience countries and set up shipping config.
3. Remove one of the audience countries.
4. Check if the shipping config of the removed country is removed as well.

#### `useCroppedImageSelector`

Refer to the test instructions in #1906.

### Changelog entry

> Fix - WordPress 6.3 compatibility: The forms and image selector may not work due to "setImmediate" deprecation.
