### PR TITLE
Externalize `NavigableMenu`, `Dropdown` and `Modal` components imported from `@wordpress/components`

### DIFF
--- a/js/src/components/app-modal/index.js
+++ b/js/src/components/app-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Modal } from '@wordpress/components';
+import { Modal } from 'extracted/@wordpress/components';
 import classnames from 'classnames';
 
 /**

--- a/js/src/components/app-sub-nav/index.js
+++ b/js/src/components/app-sub-nav/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Fragment } from '@wordpress/element';
-import { NavigableMenu } from '@wordpress/components';
+import { NavigableMenu } from 'extracted/@wordpress/components';
 import { Link } from '@woocommerce/components';
 import classnames from 'classnames';
 

--- a/js/src/components/app-tab-nav/index.js
+++ b/js/src/components/app-tab-nav/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { NavigableMenu } from '@wordpress/components';
+import { NavigableMenu } from 'extracted/@wordpress/components';
 import { Link } from '@woocommerce/components';
 import classnames from 'classnames';
 

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -62,24 +62,3 @@
 .components-input-control__suffix {
 	margin-right: $grid-unit;
 }
-
-// Hack to fix the Tooltip position of the top-right side close button in a Modal component.
-// The follow up can be found here: https://github.com/woocommerce/google-listings-and-ads/issues/203
-.components-modal {
-	&__screen-overlay {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-	}
-
-	&__frame {
-		@include break-small {
-			transform: initial;
-			position: relative;
-			top: 0;
-			bottom: 0;
-			left: 0;
-			right: 0;
-		}
-	}
-}

--- a/js/src/external-components/woocommerce/filter-picker/index.js
+++ b/js/src/external-components/woocommerce/filter-picker/index.js
@@ -8,8 +8,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown } from '@wordpress/components';
-import { Button } from 'extracted/@wordpress/components';
+import { Dropdown, Button } from 'extracted/@wordpress/components';
 import { focus } from '@wordpress/dom';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -11,8 +11,11 @@
 import classnames from 'classnames';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Modal } from '@wordpress/components';
-import { Button, KeyboardShortcuts } from 'extracted/@wordpress/components';
+import {
+	Modal,
+	Button,
+	KeyboardShortcuts,
+} from 'extracted/@wordpress/components';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's part of #1833

- Externalize `NavigableMenu`, `Dropdown` and `Modal` components.
- Remove an invalid CSS hack that had fixed the `Tooltip` position within a `Modal` before.
   - Currently, the minimum supported version of this extension is WP 5.9.
      - This hack doesn't work for WP 5.9 and 6.0.
      - WP >= 6.1 itself has already fixed this issue, so it's no longer needed.

### Screenshots:

#### 📷 `NavigableMenu` component on the Reports page

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/4de90001-65af-4445-b218-30146d16434c)

#### 📷 `Dropdown` component on the Reports page

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/f383e2ae-ebc3-45c9-a844-a23e71156793)

#### 📷 `Modal` component on the Edit Free Listings page

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/6ffa0c04-196b-4a23-a2bf-c81968c907ce)

#### 📷 `Tooltip` position of the close button within a `Modal` for WP >= 6.1

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/fd400337-096a-42f4-92fe-33704f4d8248)

### Detailed test instructions:

1. Go to the Reports page
2. Check if the `NavigableMenu` component works well
   - `AppTabNav`: The main menu items
   - `AppSubNav`: The sub-menu items on the Reports page
3. Check if the `Dropdown` component works well
   - The filter to select program(s)
4. Go to the following pages to check if the `Modal` component works well
    - The welcome modal of completing onboarding: Open with a site URL with path: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed&guide=submission-success`
    - The modal to confirm account(s) disconnection
    - The shipping modals on the Edit Free Listings page
5. Search the codebase to check if all these components are imported from `'extracted/@wordpress/components'`.

### Changelog entry
