### PR TITLE
Fetch WC L-1 versions

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -60,17 +60,17 @@ jobs:
       matrix:
         php: [8.0]
         wp-version: ${{ fromJson(needs.GetWPMatrix.outputs.wp-versions) }}
-        wc-version: ${{ fromJson(needs.GetWCMatrix.outputs.latest-wc-version) }}
+        wc-version: [latest]
         include:
           - php: 7.4
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ fromJson(needs.GetWCMatrix.outputs.previous-wc-version) }}
+            wc-version: ${{ needs.GetWPMatrix.outputs.previous-wc-version }}
           - php: 8.1
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ fromJson(needs.GetWCMatrix.outputs.previous-wc-version) }}
+            wc-version: [latest]
           - php: 8.2
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ fromJson(needs.GetWCMatrix.outputs.latest-wc-version) }}
+            wc-version: [latest]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
           slug: woocommerce
           
   UnitTests:
-    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-version || 'latest' }}
+    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     needs: GetMatrix
     runs-on: ubuntu-latest
     env:
@@ -79,7 +79,7 @@ jobs:
       - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
 
-      - if: matrix.wc-version == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.0
+      - if: matrix.wc-versions == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.0
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -51,7 +51,7 @@ jobs:
           
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}
-    needs: GetWPMatrix
+    needs: [GetWCMatrix, GetWPMatrix]
     runs-on: ubuntu-latest
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -60,17 +60,14 @@ jobs:
       matrix:
         php: [8.0]
         wp-version: ${{ fromJson(needs.GetWPMatrix.outputs.wp-versions) }}
-        wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
         include:
           - php: 7.4
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
             wc-version: ${{ needs.GetWCMatrix.outputs.previous-wc-version }}
           - php: 8.1
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
           - php: 8.2
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
           releases: 2
           
   UnitTests:
-    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}, WC ${{ matrix.wc-version }}
+    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}, WC ${{ matrix.wc-version || 'latest' }}
     needs: [GetWCMatrix, GetWPMatrix]
     runs-on: ubuntu-latest
     env:
@@ -60,7 +60,7 @@ jobs:
       matrix:
         php: [8.0]
         wp-version: ${{ fromJson(needs.GetWPMatrix.outputs.wp-versions) }}
-        wc-version: [ ${{ needs.GetWCMatrix.outputs.latest-wc-version }} ]
+        wc-version: [ latest ]
         include:
           - php: 7.4
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -22,55 +22,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  GetWPMatrix:
-    name: Get WP L-2 version Matrix
+  GetMatrix:
+    name: Get WP and WC version Matrix
     runs-on: ubuntu-latest
     outputs:
       wp-versions: ${{ steps.wp.outputs.versions }}
-      latest-wp-version: ${{ fromJson(steps.wp.outputs.versions)[0] }}
+      wc-versions: ${{ steps.wc.outputs.versions }}
+      latest-wc-version: ${{ fromJson(steps.wc.outputs.versions)[0] }}
     steps:
       - name: Get Release versions from Wordpress
         id: wp
         uses: woocommerce/grow/get-plugin-releases@actions-v1
         with:
           slug: wordpress
-          
-  GetWCMatrix:
-    name: Get WC L-1 version Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      previous-wc-version: ${{ fromJson(steps.wc.outputs.versions)[1] }}
-      latest-wc-version: ${{ fromJson(steps.wc.outputs.versions)[0] }}
-    steps:
       - name: Get Release versions from WooCommerce
         id: wc
         uses: woocommerce/grow/get-plugin-releases@actions-v1
         with:
-          slug: woocommerce 
-          releases: 2
+          slug: woocommerce
           
   UnitTests:
-    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}, WC ${{ matrix.wc-version || 'latest' }}
-    needs: [GetWCMatrix, GetWPMatrix]
+    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-version || 'latest' }}
+    needs: GetMatrix
     runs-on: ubuntu-latest
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
     strategy:
       matrix:
-        php: [8.0]
-        wp-version: ${{ fromJson(needs.GetWPMatrix.outputs.wp-versions) }}
-        wc-version: [ latest ]
+        php: [ 8.0 ]
+        wp-version: [ latest ]
+        wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions) }}
         include:
-          - php: 7.4
-            wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ needs.GetWCMatrix.outputs.previous-wc-version }}
-          - php: 8.1
-            wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
           - php: 8.2
-            wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
+            wp-version: latest
+            wc-versions: latest
+          - php: 7.4
+            wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[2] }} # L-2 WP Version support
+            wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions)[2] }} # L-2 WC Version support
+          - php: 8.1
+            wp-version: latest
+            wc-versions: latest
 
     steps:
       - name: Checkout repository
@@ -85,9 +77,9 @@ jobs:
         uses: woocommerce/grow/prepare-mysql@actions-v1
 
       - name: Install WP tests
-        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-version }}
+        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
 
-      - if: matrix.wp-version == needs.GetWPMatrix.outputs.latest-wp-version && matrix.php == 8.0
+      - if: matrix.wc-version == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.0
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -60,14 +60,17 @@ jobs:
       matrix:
         php: [8.0]
         wp-version: ${{ fromJson(needs.GetWPMatrix.outputs.wp-versions) }}
+        wc-version: [ ${{ needs.GetWCMatrix.outputs.latest-wc-version }} ]
         include:
           - php: 7.4
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
             wc-version: ${{ needs.GetWCMatrix.outputs.previous-wc-version }}
           - php: 8.1
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
+            wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
           - php: 8.2
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
+            wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
           releases: 2
           
   UnitTests:
-    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}
+    name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}, WC ${{ matrix.wc-version }}
     needs: [GetWCMatrix, GetWPMatrix]
     runs-on: ubuntu-latest
     env:
@@ -60,17 +60,17 @@ jobs:
       matrix:
         php: [8.0]
         wp-version: ${{ fromJson(needs.GetWPMatrix.outputs.wp-versions) }}
-        wc-version: [latest]
+        wc-version: ${{ needs.GetWPMatrix.outputs.latest-wc-version }}
         include:
           - php: 7.4
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
             wc-version: ${{ needs.GetWPMatrix.outputs.previous-wc-version }}
           - php: 8.1
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: [latest]
+            wc-version: ${{ needs.GetWPMatrix.outputs.latest-wc-version }}
           - php: 8.2
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: [latest]
+            wc-version: ${{ needs.GetWPMatrix.outputs.latest-wc-version }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -60,17 +60,17 @@ jobs:
       matrix:
         php: [8.0]
         wp-version: ${{ fromJson(needs.GetWPMatrix.outputs.wp-versions) }}
-        wc-version: ${{ needs.GetWPMatrix.outputs.latest-wc-version }}
+        wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
         include:
           - php: 7.4
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ needs.GetWPMatrix.outputs.previous-wc-version }}
+            wc-version: ${{ needs.GetWCMatrix.outputs.previous-wc-version }}
           - php: 8.1
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ needs.GetWPMatrix.outputs.latest-wc-version }}
+            wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
           - php: 8.2
             wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
-            wc-version: ${{ needs.GetWPMatrix.outputs.latest-wc-version }}
+            wc-version: ${{ needs.GetWCMatrix.outputs.latest-wc-version }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -22,8 +22,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  GetMatrix:
-    name: Get WP version Matrix
+  GetWPMatrix:
+    name: Get WP L-2 version Matrix
     runs-on: ubuntu-latest
     outputs:
       wp-versions: ${{ steps.wp.outputs.versions }}
@@ -35,9 +35,23 @@ jobs:
         with:
           slug: wordpress
           
+  GetWCMatrix:
+    name: Get WC L-1 version Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      previous-wc-version: ${{ fromJson(steps.wc.outputs.versions)[1] }}
+      latest-wc-version: ${{ fromJson(steps.wc.outputs.versions)[0] }}
+    steps:
+      - name: Get Release versions from WooCommerce
+        id: wc
+        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        with:
+          slug: woocommerce 
+          releases: 2
+          
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}
-    needs: GetMatrix
+    needs: GetWPMatrix
     runs-on: ubuntu-latest
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
@@ -45,14 +59,18 @@ jobs:
     strategy:
       matrix:
         php: [8.0]
-        wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions) }}
+        wp-version: ${{ fromJson(needs.GetWPMatrix.outputs.wp-versions) }}
+        wc-version: ${{ fromJson(needs.GetWCMatrix.outputs.latest-wc-version) }}
         include:
           - php: 7.4
-            wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
+            wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
+            wc-version: ${{ fromJson(needs.GetWCMatrix.outputs.previous-wc-version) }}
           - php: 8.1
-            wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
+            wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
+            wc-version: ${{ fromJson(needs.GetWCMatrix.outputs.previous-wc-version) }}
           - php: 8.2
-            wp-version: ${{ needs.GetMatrix.outputs.latest-wp-version }}
+            wp-version: ${{ needs.GetWPMatrix.outputs.latest-wp-version }}
+            wc-version: ${{ fromJson(needs.GetWCMatrix.outputs.latest-wc-version) }}
 
     steps:
       - name: Checkout repository
@@ -67,9 +85,9 @@ jobs:
         uses: woocommerce/grow/prepare-mysql@actions-v1
 
       - name: Install WP tests
-        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }}
+        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-version }}
 
-      - if: matrix.wp-version == needs.GetMatrix.outputs.latest-wp-version && matrix.php == 8.0
+      - if: matrix.wp-version == needs.GetWPMatrix.outputs.latest-wp-version && matrix.php == 8.0
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -36,6 +36,7 @@ define( 'WC_GLA_MIN_WC_VER', '6.9' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';
+
 if ( ! Autoloader::init() ) {
 	return;
 }

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -36,7 +36,6 @@ define( 'WC_GLA_MIN_WC_VER', '6.9' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';
-
 if ( ! Autoloader::init() ) {
 	return;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fetch WooCommerce L-1 versions for our tests using https://github.com/woocommerce/grow/tree/trunk/packages/github-actions/actions/get-plugin-releases


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Verify the WC version is properly fetched and the test passing
https://github.com/woocommerce/google-listings-and-ads/actions/runs/5787000158/job/15682944873?pr=2046


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fetch WooCommerce L-1 versions for our tests
