### PR TITLE
Fix e2e tests

### DIFF
--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -19,6 +19,9 @@ wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --acti
 # we just need to activate it here.
 wp plugin activate google-listings-and-ads
 
+# Activate twentytwentyone theme. Currently e2e tests wich Blcoks are not supported.
+wp theme activate twentytwentyone
+
 # GLA doesn't really need a customer account here,
 # but we are leaving it intact here just in case we want to run full WooCommerce core e2e test.
 wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=customer --path=/var/www/html


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

E2E tests are failing due to the fact that the shop page and product items are blockified when utilizing the twenty twenty three template. See here: https://github.com/woocommerce/google-listings-and-ads/actions/runs/5794717342/job/15705036856?pr=2049

For instance, when using the twenty twenty three template, the "add to cart" option appears as a button:

`<button href="?add-to-cart=34" class="wp-block-button__link wp-element-button wc-block-components-product-button__button add_to_cart_button ajax_add_to_cart product_type_simple has-font-size has-small-font-size has-text-align-center added" style="margin-bottom:1rem;" data-product_id="34" data-product_sku="" aria-label="Add “Simple product” to your cart" rel="nofollow">Add to cart</button><a href="http://localhost:8889/cart/" class="added_to_cart wc-forward" title="View cart">View cart</a>`

In contrast, when it is not blockified is rendered as a link:

`<a href="?add-to-cart=12" data-quantity="1" class="button product_type_simple add_to_cart_button ajax_add_to_cart" data-product_id="12" data-product_sku="" aria-label="Add “Simple product” to your cart" aria-describedby="" rel="nofollow">Add to cart</a>`

And the shopper utility from the e2e utils package is expecting a link: https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/e2e-utils/src/flows/shopper.js#L45C23-L45C23

As a result, causing the tests to not pass.

This PR sets the theme to `twentytwentyone` which does not use blocks.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check that e2e tests are OK.

### Additional details:

- In our new tests with PlayWright we should consider the case when the template uses blocks. 
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix E2E tests
