### PR TITLE
Add filter to be able to build custom shipping method rate handers.

### DIFF
--- a/src/Shipping/ZoneMethodsParser.php
+++ b/src/Shipping/ZoneMethodsParser.php
@@ -96,8 +96,17 @@ class ZoneMethodsParser implements Service {
 				$shipping_rates[] = $shipping_rate;
 				break;
 			default:
-				// We don't support other shipping methods.
-				return [];
+				/**
+				 * Filter the shipping rates for a shipping method that is not supported.
+				 *
+				 * @param ShippingRate[] $shipping_rates The shipping rates.
+				 * @param object|WC_Shipping_Method $method The shipping method.
+				 */
+				return apply_filters(
+					'woocommerce_gla_handle_shipping_method_to_rates',
+					$shipping_rates,
+					$method
+				);
 		}
 
 		return $shipping_rates;


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Allows other plugins to be able to extend the capabilities to handle shipping method rates.

This adds a `woocommerce_gla_handle_shipping_method_to_rates` filter to the `shipping_method_to_rates` function for the unhandled shipping type method so that other plugins can implement handlers for those shipping methods.