### PR TITLE
Apply consistent admin theme colors to common UI components

### DIFF
--- a/js/src/components/pre-launch-check-item/index.scss
+++ b/js/src/components/pre-launch-check-item/index.scss
@@ -8,13 +8,8 @@
 			align-items: flex-start;
 			gap: 1em;
 		}
-
-		.components-panel__body-title {
-			.components-panel__body-toggle.components-button {
-				color: #007cba;
-			}
-		}
 	}
+
 	.gla-pre-launch-checklist__checkbox {
 		display: flex;
 		justify-content: stretch;

--- a/js/src/components/stepper/top-bar/index.js
+++ b/js/src/components/stepper/top-bar/index.js
@@ -23,15 +23,15 @@ const TopBar = ( { title, backHref, helpButton, onBackButtonClick } ) => {
 	return (
 		<div className="gla-stepper-top-bar">
 			<Link
-				className="back-button"
+				className="components-button gla-stepper-top-bar__back-button"
 				href={ backHref }
 				type="wc-admin"
 				onClick={ onBackButtonClick }
 			>
 				<GridiconChevronLeft />
 			</Link>
-			<span className="title">{ title }</span>
-			<div className="actions">{ helpButton }</div>
+			<span className="gla-stepper-top-bar__title">{ title }</span>
+			{ helpButton }
 		</div>
 	);
 };

--- a/js/src/components/stepper/top-bar/index.scss
+++ b/js/src/components/stepper/top-bar/index.scss
@@ -1,28 +1,22 @@
 .gla-stepper-top-bar {
 	display: flex;
-	align-items: stretch;
+	align-items: center;
 	min-height: $grid-unit-40 * 2;
 	background-color: $white;
 	box-shadow: 0 -1px 0 0 $gray-400 inset;
 
-	.back-button {
-		display: flex;
-		align-items: center;
+	.components-button {
+		height: auto;
+		align-self: stretch;
+	}
+
+	&__back-button {
 		padding: 0 calc(var(--main-gap) / 2);
 	}
 
-	.title {
-		align-self: center;
+	&__title {
 		flex: 1;
 		font-size: $editor-font-size;
-		font-weight: 400;
-		line-height: $gla-line-height-medium-large;
 		letter-spacing: 0;
-	}
-
-	.actions {
-		.components-button {
-			height: 100%;
-		}
 	}
 }

--- a/js/src/external-components/wordpress/guide/icons.js
+++ b/js/src/external-components/wordpress/guide/icons.js
@@ -10,13 +10,8 @@
  */
 import { SVG, Circle } from '@wordpress/primitives';
 
-export const PageControlIcon = ( { isSelected } ) => (
+export const PageControlIcon = () => (
 	<SVG width="8" height="8" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<Circle
-			cx="4"
-			cy="4"
-			r="4"
-			fill={ isSelected ? '#419ECD' : '#E1E3E6' }
-		/>
+		<Circle cx="4" cy="4" r="4" />
 	</SVG>
 );

--- a/js/src/external-components/wordpress/guide/index.js
+++ b/js/src/external-components/wordpress/guide/index.js
@@ -18,6 +18,7 @@ import { Modal, Button, KeyboardShortcuts } from '@wordpress/components';
  */
 import PageControl from './page-control';
 import FinishButton from './finish-button';
+import './index.scss';
 
 /**
  * @callback renderFinishCallback
@@ -88,9 +89,17 @@ export default function Guide( {
 		finishBlock = renderFinish( finishButton );
 	}
 
+	const guideClassName = classnames(
+		// gla-admin-page is for scoping particular styles to components that are used by
+		// a GLA admin page and are rendered via ReactDOM.createPortal.
+		'gla-admin-page',
+		'components-guide',
+		className
+	);
+
 	return (
 		<Modal
-			className={ classnames( 'components-guide', className ) }
+			className={ guideClassName }
 			contentLabel={ contentLabel }
 			onRequestClose={ onFinish }
 		>

--- a/js/src/external-components/wordpress/guide/index.scss
+++ b/js/src/external-components/wordpress/guide/index.scss
@@ -1,0 +1,7 @@
+.gla-admin-page .components-guide {
+	&__page-control {
+		> li[aria-current="step"] .components-button {
+			color: var(--wp-admin-theme-color);
+		}
+	}
+}

--- a/js/src/external-components/wordpress/guide/page-control.js
+++ b/js/src/external-components/wordpress/guide/page-control.js
@@ -35,11 +35,7 @@ export default function PageControl( {
 				>
 					<Button
 						key={ page }
-						icon={
-							<PageControlIcon
-								isSelected={ page === currentPage }
-							/>
-						}
+						icon={ <PageControlIcon /> }
 						aria-label={ sprintf(
 							/* translators: 1: current page number 2: total number of pages */
 							__( 'Page %1$d of %2$d' ),

--- a/js/src/get-started-page/unsupported-notices/index.js
+++ b/js/src/get-started-page/unsupported-notices/index.js
@@ -49,14 +49,12 @@ const UnsupportedLanguage = () => {
 					language: <strong>{ data.language }</strong>,
 					settingsLink: (
 						<Link
-							className="gla-get-started-notice__link"
 							type="wp-admin"
 							href="/wp-admin/options-general.php"
 						/>
 					),
 					supportedLanguagesLink: (
 						<AppDocumentationLink
-							className="gla-get-started-notice__link"
 							href="https://support.google.com/merchants/answer/160637"
 							context="get-started"
 							linkId="supported-languages"
@@ -94,14 +92,12 @@ const UnsupportedCountry = () => {
 					country: <strong>{ countryName }</strong>,
 					settingsLink: (
 						<Link
-							className="gla-get-started-notice__link"
 							type="wp-admin"
 							href="/wp-admin/admin.php?page=wc-settings"
 						/>
 					),
 					supportedCountriesLink: (
 						<AppDocumentationLink
-							className="gla-get-started-notice__link"
 							href="https://support.google.com/merchants/answer/160637"
 							context="get-started"
 							linkId="supported-countries"

--- a/js/src/get-started-page/unsupported-notices/index.scss
+++ b/js/src/get-started-page/unsupported-notices/index.scss
@@ -11,10 +11,6 @@
 		margin-left: $grid-unit-20;
 	}
 
-	&__link {
-		color: currentcolor;
-	}
-
 	&__icon {
 		margin-left: 0.2em;
 		vertical-align: middle;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2058

This PR applies the admin theme colors for:

- The links within the unsupported notices on the Get Started page.
- The active dot icon of the page control in `Guide` component.
- The chevron icon in `TopBar` component.

In addition, this PR also simplifies the layout and style of `TopBar` component.

💡 The color of native `<select>` won't be fixed in this PR as it's specified in WP core.

### Screenshots:

#### 📷 Link color on the Get Started page

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/99fb4366-8348-403a-8812-e2138aa9fcd9)

#### 📷 Active dot in the page control

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/3b094504-f4ef-4535-bec9-5d5356e4c6b8)

#### 📷 Icon color when hovering

![Kapture 2023-08-17 at 15 52 50](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/ee95c6ab-f368-4c9b-b46c-cb7e68403350)

### Detailed test instructions:

Locally change the value of `mcSupportedCountry`, `mcSupportedLanguage`, and `adsSetupComplete` to `false`:

https://github.com/woocommerce/google-listings-and-ads/blob/2df2bd89df1bb185385fffca4047c7ec75558c12/src/Admin/Admin.php#L130-L133

1. Use a WP version >= 6.1
2. Install a [nightly build WooCommerce](https://github.com/woocommerce/woocommerce/releases/tag/nightly) to have the latest color fixes in WC core
3. Go to WP Admin > Users > Profile page: `/wp-admin/profile.php`
    - In the **Admin Color Scheme** setting, select an option rather than "Default", such as "Modern"
    - Click the "Update Profile" button at the bottom to save the change
4. Go to the Get Started page
   - Check the color of links within the unsupported notices
5. Go to this page: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed&guide=submission-success`
   - Check the color of the active dot icon of the page control
6. Go to the Edit Free Listings page
   - Over the chevron icon at the top-left corner to check its `:hover` color
   - Check if the `TopBar` component layout is rendered as it was before

### Changelog entry

> Tweak - Apply consistent admin theme colors to common UI components.
