### PR TITLE
Add action for Hook Documentation Generation

### DIFF
--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -1,0 +1,47 @@
+name: PHP Hook Documentation Generator
+
+on:
+  pull_request:
+    paths:
+      - "**.php"
+      - .github/workflows/php-hook-documentation.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  HookDocumentation:
+    name: Hook Documentation Generator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          # Checks out a branch instead of a commit in detached HEAD state
+          ref: ${{ github.head_ref }}
+
+        # This generates the documentation string. The `id` property is used to reference the output in the next step.
+      - name: Generate hook documentation
+        id: generate-hook-docs
+        uses: woocommerce/grow/hook-documentation@actions-v1
+        with:
+          debug-output: yes
+          source-directories: src/,templates/
+
+      - name: Commit hook documentation
+        shell: bash
+        # Use the github-actions bot account to commit.
+        # https://api.github.com/users/github-actions%5Bbot%5D
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          echo "${{ steps.generate-hook-docs.outputs.hook-docs }}" > src/Hooks/README.md
+          git add src/Hooks/README.md
+          if git diff --cached --quiet; then
+            echo "*No documentation changes to commit.*" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "*Committing documentation changes.*" >> $GITHUB_STEP_SUMMARY
+            git commit -q -m "Update hooks documentation from ${{ github.head_ref }} branch."
+            git push
+          fi

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -27,7 +27,7 @@ jobs:
         uses: woocommerce/grow/hook-documentation@actions-v1
         with:
           debug-output: yes
-          source-directories: src/,templates/
+          source-directories: src/,views/
 
       - name: Commit hook documentation
         shell: bash

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -2,6 +2,8 @@ name: PHP Hook Documentation Generator
 
 on:
   pull_request:
+    branches:
+      - 'release/**'
     paths:
       - "**.php"
       - .github/workflows/php-hook-documentation.yml

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -38,7 +38,7 @@ jobs:
         uses: woocommerce/grow/hook-documentation@actions-v1
         with:
           debug-output: yes
-          source-directories: src/,views/,google-listings-and-ads.php,unistall.php
+          source-directories: src/,views/,google-listings-and-ads.php,uninstall.php
 
       - name: Commit hook documentation
         shell: bash

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -1,9 +1,17 @@
 name: PHP Hook Documentation Generator
 
 on:
-  pull_request:
+  push:
     branches:
-      - 'release/**'
+      - "release/**"
+    paths:
+      - "**.php"
+      - .github/workflows/php-hook-documentation.yml
+  pull_request:
+    types:
+      - opened
+    branches:
+      - "release/**"
     paths:
       - "**.php"
       - .github/workflows/php-hook-documentation.yml

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -38,7 +38,7 @@ jobs:
         uses: woocommerce/grow/hook-documentation@actions-v1
         with:
           debug-output: yes
-          source-directories: src/,views/
+          source-directories: src/,views/,google-listings-and-ads.php,unistall.php
 
       - name: Commit hook documentation
         shell: bash

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -15,7 +15,8 @@ on:
     paths:
       - "**.php"
       - .github/workflows/php-hook-documentation.yml
-
+  workflow_dispatch:
+    
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/src/Hooks/README.md
+++ b/src/Hooks/README.md
@@ -1,6 +1,6 @@
 # Hooks Reference
 
-A list of hooks, i.e `actions` and `filters`, that are defined or used in this project.
+A list of hooks, e.g. `actions` and `filters`, that are defined or used in this project.
 
 ## bulk_edit_save_post
 
@@ -8,7 +8,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/BulkEdit/BulkEditInitializer.php#L36">BulkEditInitializer.php#L36</a>
+- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
 
 ## woocommerce_admin_disabled
 
@@ -16,7 +16,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Internal/Requirements/WCAdminValidator.php#L38">WCAdminValidator.php#L38</a>
+- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Internal/Requirements/WCAdminValidator.php#L38)
 
 ## woocommerce_gla_ads_billing_setup_status
 
@@ -24,8 +24,8 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L112">Ads.php#L112</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L121">Ads.php#L121</a>
+- [Ads.php#L112](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L112)
+- [Ads.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L121)
 
 ## woocommerce_gla_ads_client_exception
 
@@ -33,24 +33,24 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L73">Ads.php#L73</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L117">Ads.php#L117</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L172">Ads.php#L172</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L214">Ads.php#L214</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Ads.php#L298">Ads.php#L298</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsAssetGroup.php#L113">AdsAssetGroup.php#L113</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsAssetGroup.php#L304">AdsAssetGroup.php#L304</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsAssetGroup.php#L369">AdsAssetGroup.php#L369</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsAssetGroupAsset.php#L135">AdsAssetGroupAsset.php#L135</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsAssetGroupAsset.php#L202">AdsAssetGroupAsset.php#L202</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L127">AdsCampaign.php#L127</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L170">AdsCampaign.php#L170</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L230">AdsCampaign.php#L230</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L285">AdsCampaign.php#L285</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsCampaign.php#L319">AdsCampaign.php#L319</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsConversionAction.php#L97">AdsConversionAction.php#L97</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsConversionAction.php#L143">AdsConversionAction.php#L143</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsReport.php#L105">AdsReport.php#L105</a>
+- [Ads.php#L73](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L73)
+- [Ads.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L117)
+- [Ads.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L172)
+- [Ads.php#L214](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L214)
+- [Ads.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L298)
+- [AdsCampaign.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L127)
+- [AdsCampaign.php#L170](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L170)
+- [AdsCampaign.php#L230](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L230)
+- [AdsCampaign.php#L285](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L285)
+- [AdsCampaign.php#L319](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L319)
+- [AdsAssetGroup.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroup.php#L113)
+- [AdsAssetGroup.php#L304](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroup.php#L304)
+- [AdsAssetGroup.php#L369](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroup.php#L369)
+- [AdsReport.php#L105](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsReport.php#L105)
+- [AdsConversionAction.php#L97](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsConversionAction.php#L97)
+- [AdsConversionAction.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsConversionAction.php#L143)
+- [AdsAssetGroupAsset.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroupAsset.php#L135)
+- [AdsAssetGroupAsset.php#L202](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroupAsset.php#L202)
 
 ## woocommerce_gla_ads_setup_completed
 
@@ -58,24 +58,24 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/Ads/SetupCompleteController.php#L46">SetupCompleteController.php#L46</a>
+- [SetupCompleteController.php#L46](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/Ads/SetupCompleteController.php#L46)
 
-## woocommerce_gla_attribute_applicable_product_types_$ATTRIBUTE_ID
-
-**Type**: filter
-
-**Used in**:
-
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/Attributes/AttributeManager.php#L295">AttributeManager.php#L295</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Product/Attributes/AttributesForm.php#L69">AttributesForm.php#L69</a>
-
-## woocommerce_gla_attribute_hidden_product_types_$ATTRIBUTE_ID
+## woocommerce_gla_attribute_applicable_product_types_
 
 **Type**: filter
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Product/Attributes/AttributesForm.php#L74">AttributesForm.php#L74</a>
+- [AttributeManager.php#L295](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/Attributes/AttributeManager.php#L295)
+- [AttributesForm.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Product/Attributes/AttributesForm.php#L69)
+
+## woocommerce_gla_attribute_hidden_product_types_
+
+**Type**: filter
+
+**Used in**:
+
+- [AttributesForm.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Product/Attributes/AttributesForm.php#L74)
 
 ## woocommerce_gla_attribute_mapping_sources
 
@@ -83,7 +83,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31">IsFieldTrait.php#L31</a>
+- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
 
 ## woocommerce_gla_attribute_mapping_sources_custom_attributes
 
@@ -91,7 +91,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125">IsFieldTrait.php#L125</a>
+- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
 
 ## woocommerce_gla_attribute_mapping_sources_global_attributes
 
@@ -99,7 +99,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64">IsFieldTrait.php#L64</a>
+- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
 
 ## woocommerce_gla_attribute_mapping_sources_product_fields
 
@@ -107,7 +107,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115">IsFieldTrait.php#L115</a>
+- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
 
 ## woocommerce_gla_attribute_mapping_sources_taxonomies
 
@@ -115,7 +115,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65">IsFieldTrait.php#L65</a>
+- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
 
 ## woocommerce_gla_attributes_tab_applicable_product_types
 
@@ -123,7 +123,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Product/Attributes/AttributesTab.php#L190">AttributesTab.php#L190</a>
+- [AttributesTab.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Product/Attributes/AttributesTab.php#L190)
 
 ## woocommerce_gla_batch_deleted_products
 
@@ -131,7 +131,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L229">ProductSyncer.php#L229</a>
+- [ProductSyncer.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L229)
 
 ## woocommerce_gla_batch_retry_delete_products
 
@@ -139,7 +139,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L354">ProductSyncer.php#L354</a>
+- [ProductSyncer.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L354)
 
 ## woocommerce_gla_batch_retry_update_products
 
@@ -147,7 +147,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L298">ProductSyncer.php#L298</a>
+- [ProductSyncer.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L298)
 
 ## woocommerce_gla_batch_updated_products
 
@@ -155,7 +155,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L143">ProductSyncer.php#L143</a>
+- [ProductSyncer.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L143)
 
 ## woocommerce_gla_batched_job_size
 
@@ -163,8 +163,8 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104">AbstractBatchedActionSchedulerJob.php#L104</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/UpdateSyncableProductsCount.php#L74">UpdateSyncableProductsCount.php#L74</a>
+- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/UpdateSyncableProductsCount.php#L74)
+- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
 
 ## woocommerce_gla_bulk_update_coupon
 
@@ -172,7 +172,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/BulkEdit/CouponBulkEdit.php#L134">CouponBulkEdit.php#L134</a>
+- [CouponBulkEdit.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/BulkEdit/CouponBulkEdit.php#L134)
 
 ## woocommerce_gla_conversion_action_name
 
@@ -180,7 +180,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/AdsConversionAction.php#L66">AdsConversionAction.php#L66</a>
+- [AdsConversionAction.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsConversionAction.php#L66)
 
 ## woocommerce_gla_coupons_delete_retry_on_failure
 
@@ -188,7 +188,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L437">CouponSyncer.php#L437</a>
+- [CouponSyncer.php#L437](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L437)
 
 ## woocommerce_gla_coupons_update_retry_on_failure
 
@@ -196,7 +196,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L399">CouponSyncer.php#L399</a>
+- [CouponSyncer.php#L399](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L399)
 
 ## woocommerce_gla_custom_merchant_issues
 
@@ -204,7 +204,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L435">MerchantStatuses.php#L435</a>
+- [MerchantStatuses.php#L435](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L435)
 
 ## woocommerce_gla_debug_message
 
@@ -212,38 +212,38 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantCenterService.php#L305">MerchantCenterService.php#L305</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L334">MerchantStatuses.php#L334</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L357">MerchantStatuses.php#L357</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/DB/ProductMetaQueryHelper.php#L92">ProductMetaQueryHelper.php#L92</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/DB/ProductMetaQueryHelper.php#L123">ProductMetaQueryHelper.php#L123</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/BatchProductHelper.php#L208">BatchProductHelper.php#L208</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/BatchProductHelper.php#L231">BatchProductHelper.php#L231</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L459">ProductHelper.php#L459</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L491">ProductHelper.php#L491</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductRepository.php#L304">ProductRepository.php#L304</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L149">ProductSyncer.php#L149</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L159">ProductSyncer.php#L159</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L235">ProductSyncer.php#L235</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L245">ProductSyncer.php#L245</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/SyncerHooks.php#L197">SyncerHooks.php#L197</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L203">WCProductAdapter.php#L203</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponHelper.php#L255">CouponHelper.php#L255</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponHelper.php#L292">CouponHelper.php#L292</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L102">CouponSyncer.php#L102</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L115">CouponSyncer.php#L115</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L140">CouponSyncer.php#L140</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L154">CouponSyncer.php#L154</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L171">CouponSyncer.php#L171</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L194">CouponSyncer.php#L194</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L259">CouponSyncer.php#L259</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L308">CouponSyncer.php#L308</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L327">CouponSyncer.php#L327</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/SyncerHooks.php#L177">SyncerHooks.php#L177</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/ActionSchedulerJobMonitor.php#L117">ActionSchedulerJobMonitor.php#L117</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/ActionSchedulerJobMonitor.php#L126">ActionSchedulerJobMonitor.php#L126</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/CleanupSyncedProducts.php#L74">CleanupSyncedProducts.php#L74</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L96">IssuesController.php#L96</a>
+- [IssuesController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L96)
+- [WCProductAdapter.php#L203](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L203)
+- [ProductSyncer.php#L149](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L149)
+- [ProductSyncer.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L159)
+- [ProductSyncer.php#L235](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L235)
+- [ProductSyncer.php#L245](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L245)
+- [ProductRepository.php#L304](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductRepository.php#L304)
+- [SyncerHooks.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/SyncerHooks.php#L197)
+- [ProductHelper.php#L459](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L459)
+- [ProductHelper.php#L491](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L491)
+- [BatchProductHelper.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/BatchProductHelper.php#L208)
+- [BatchProductHelper.php#L231](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/BatchProductHelper.php#L231)
+- [SyncerHooks.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/SyncerHooks.php#L177)
+- [CouponHelper.php#L255](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponHelper.php#L255)
+- [CouponHelper.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponHelper.php#L292)
+- [CouponSyncer.php#L102](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L102)
+- [CouponSyncer.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L115)
+- [CouponSyncer.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L140)
+- [CouponSyncer.php#L154](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L154)
+- [CouponSyncer.php#L171](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L171)
+- [CouponSyncer.php#L194](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L194)
+- [CouponSyncer.php#L259](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L259)
+- [CouponSyncer.php#L308](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L308)
+- [CouponSyncer.php#L327](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L327)
+- [MerchantStatuses.php#L334](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L334)
+- [MerchantStatuses.php#L357](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L357)
+- [MerchantCenterService.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantCenterService.php#L305)
+- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/ActionSchedulerJobMonitor.php#L117)
+- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/ActionSchedulerJobMonitor.php#L126)
+- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/CleanupSyncedProducts.php#L74)
+- [ProductMetaQueryHelper.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/DB/ProductMetaQueryHelper.php#L92)
+- [ProductMetaQueryHelper.php#L123](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/DB/ProductMetaQueryHelper.php#L123)
 
 ## woocommerce_gla_deleted_promotions
 
@@ -251,7 +251,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L321">CouponSyncer.php#L321</a>
+- [CouponSyncer.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L321)
 
 ## woocommerce_gla_dimension_unit
 
@@ -259,7 +259,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L427">WCProductAdapter.php#L427</a>
+- [WCProductAdapter.php#L427](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L427)
 
 ## woocommerce_gla_disable_gtag_tracking
 
@@ -267,7 +267,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Google/GlobalSiteTag.php#L463">GlobalSiteTag.php#L463</a>
+- [GlobalSiteTag.php#L464](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Google/GlobalSiteTag.php#L464)
 
 ## woocommerce_gla_enable_connection_test
 
@@ -275,7 +275,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/ConnectionTest.php#L87">ConnectionTest.php#L87</a>
+- [ConnectionTest.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/ConnectionTest.php#L87)
 
 ## woocommerce_gla_enable_debug_logging
 
@@ -283,7 +283,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Logging/DebugLogger.php#L33">DebugLogger.php#L33</a>
+- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Logging/DebugLogger.php#L33)
 
 ## woocommerce_gla_enable_mcm
 
@@ -291,7 +291,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MultichannelMarketing/GLAChannel.php#L75">GLAChannel.php#L75</a>
+- [GLAChannel.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MultichannelMarketing/GLAChannel.php#L75)
 
 ## woocommerce_gla_enable_reports
 
@@ -299,7 +299,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Admin.php#L250">Admin.php#L250</a>
+- [Admin.php#L250](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Admin.php#L250)
 
 ## woocommerce_gla_error
 
@@ -307,23 +307,23 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/DB/ProductMetaQueryHelper.php#L139">ProductMetaQueryHelper.php#L139</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/BatchProductHelper.php#L248">BatchProductHelper.php#L248</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L351">ProductHelper.php#L351</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L567">ProductHelper.php#L567</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductMetaHandler.php#L173">ProductMetaHandler.php#L173</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L301">ProductSyncer.php#L301</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L324">ProductSyncer.php#L324</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L357">ProductSyncer.php#L357</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L372">ProductSyncer.php#L372</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/Attributes/AttributeManager.php#L269">AttributeManager.php#L269</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponMetaHandler.php#L220">CouponMetaHandler.php#L220</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L409">CouponSyncer.php#L409</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L447">CouponSyncer.php#L447</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L465">CouponSyncer.php#L465</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L136">PHPView.php#L136</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L164">PHPView.php#L164</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L208">PHPView.php#L208</a>
+- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/View/PHPView.php#L136)
+- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/View/PHPView.php#L164)
+- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/View/PHPView.php#L208)
+- [ProductMetaHandler.php#L173](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductMetaHandler.php#L173)
+- [ProductSyncer.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L301)
+- [ProductSyncer.php#L324](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L324)
+- [ProductSyncer.php#L357](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L357)
+- [ProductSyncer.php#L372](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L372)
+- [ProductHelper.php#L351](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L351)
+- [ProductHelper.php#L567](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L567)
+- [BatchProductHelper.php#L248](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/BatchProductHelper.php#L248)
+- [AttributeManager.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/Attributes/AttributeManager.php#L269)
+- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponMetaHandler.php#L220)
+- [CouponSyncer.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L409)
+- [CouponSyncer.php#L447](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L447)
+- [CouponSyncer.php#L465](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L465)
+- [ProductMetaQueryHelper.php#L139](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/DB/ProductMetaQueryHelper.php#L139)
 
 ## woocommerce_gla_exception
 
@@ -331,27 +331,27 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66">ScriptWithBuiltDependenciesAsset.php#L66</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Integration/WooCommercePreOrders.php#L111">WooCommercePreOrders.php#L111</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Integration/WooCommercePreOrders.php#L131">WooCommercePreOrders.php#L131</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Notes/NoteInitializer.php#L74">NoteInitializer.php#L74</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Notes/NoteInitializer.php#L116">NoteInitializer.php#L116</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L134">ProductSyncer.php#L134</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L220">ProductSyncer.php#L220</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L202">CouponSyncer.php#L202</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L292">CouponSyncer.php#L292</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/View/PHPView.php#L87">PHPView.php#L87</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Input/DateTime.php#L44">DateTime.php#L44</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Input/DateTime.php#L80">DateTime.php#L80</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L190">ChannelVisibilityMetaBox.php#L190</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197">CouponChannelVisibilityMetaBox.php#L197</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/Update/PluginUpdate.php#L75">PluginUpdate.php#L75</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Internal/DependencyManagement/GoogleServiceProvider.php#L223">GoogleServiceProvider.php#L223</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242">ContactInformationController.php#L242</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193">ProductVisibilityController.php#L193</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L79">SettingsSyncController.php#L79</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L95">Connection.php#L95</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Event/ClearProductStatsCache.php#L61">ClearProductStatsCache.php#L61</a>
+- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/View/PHPView.php#L87)
+- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L95)
+- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
+- [SettingsSyncController.php#L79](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L79)
+- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
+- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Notes/NoteInitializer.php#L74)
+- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Notes/NoteInitializer.php#L116)
+- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Event/ClearProductStatsCache.php#L61)
+- [GoogleServiceProvider.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Internal/DependencyManagement/GoogleServiceProvider.php#L223)
+- [ProductSyncer.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L134)
+- [ProductSyncer.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L220)
+- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
+- [CouponSyncer.php#L202](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L202)
+- [CouponSyncer.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L292)
+- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Input/DateTime.php#L44)
+- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Input/DateTime.php#L80)
+- [ChannelVisibilityMetaBox.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L190)
+- [CouponChannelVisibilityMetaBox.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197)
+- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Integration/WooCommercePreOrders.php#L111)
+- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Integration/WooCommercePreOrders.php#L131)
+- [PluginUpdate.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/Update/PluginUpdate.php#L75)
 
 ## woocommerce_gla_force_run_install
 
@@ -359,7 +359,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Installer.php#L82">Installer.php#L82</a>
+- [Installer.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Installer.php#L82)
 
 ## woocommerce_gla_get_google_product_offer_id
 
@@ -367,7 +367,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L280">WCProductAdapter.php#L280</a>
+- [WCProductAdapter.php#L280](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L280)
 
 ## woocommerce_gla_get_sync_ready_products_filter
 
@@ -375,7 +375,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductFilter.php#L61">ProductFilter.php#L61</a>
+- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductFilter.php#L61)
 
 ## woocommerce_gla_get_sync_ready_products_pre_filter
 
@@ -383,7 +383,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductFilter.php#L47">ProductFilter.php#L47</a>
+- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductFilter.php#L47)
 
 ## woocommerce_gla_get_wc_product_id
 
@@ -391,7 +391,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L278">ProductHelper.php#L278</a>
+- [ProductHelper.php#L278](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L278)
 
 ## woocommerce_gla_guzzle_client_exception
 
@@ -399,20 +399,20 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Internal/DependencyManagement/GoogleServiceProvider.php#L247">GoogleServiceProvider.php#L247</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L70">Connection.php#L70</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L91">Connection.php#L91</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L126">Connection.php#L126</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L80">Middleware.php#L80</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L178">Middleware.php#L178</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L228">Middleware.php#L228</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L273">Middleware.php#L273</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L344">Middleware.php#L344</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L394">Middleware.php#L394</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L418">Middleware.php#L418</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L452">Middleware.php#L452</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L552">Middleware.php#L552</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L611">Middleware.php#L611</a>
+- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L70)
+- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L91)
+- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L126)
+- [Middleware.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L80)
+- [Middleware.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L178)
+- [Middleware.php#L228](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L228)
+- [Middleware.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L273)
+- [Middleware.php#L344](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L344)
+- [Middleware.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L394)
+- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L418)
+- [Middleware.php#L452](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L452)
+- [Middleware.php#L552](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L552)
+- [Middleware.php#L611](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L611)
+- [GoogleServiceProvider.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Internal/DependencyManagement/GoogleServiceProvider.php#L247)
 
 ## woocommerce_gla_guzzle_invalid_response
 
@@ -420,15 +420,15 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L66">Connection.php#L66</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Connection.php#L121">Connection.php#L121</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L159">Middleware.php#L159</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L223">Middleware.php#L223</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L267">Middleware.php#L267</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L339">Middleware.php#L339</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L389">Middleware.php#L389</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L548">Middleware.php#L548</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L599">Middleware.php#L599</a>
+- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L66)
+- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L121)
+- [Middleware.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L159)
+- [Middleware.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L223)
+- [Middleware.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L267)
+- [Middleware.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L339)
+- [Middleware.php#L389](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L389)
+- [Middleware.php#L548](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L548)
+- [Middleware.php#L599](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L599)
 
 ## woocommerce_gla_hidden_coupon_types
 
@@ -436,7 +436,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L378">CouponSyncer.php#L378</a>
+- [CouponSyncer.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L378)
 
 ## woocommerce_gla_hidden_product_types
 
@@ -444,7 +444,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L275">ProductSyncer.php#L275</a>
+- [ProductSyncer.php#L275](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L275)
 
 ## woocommerce_gla_job_failure_rate_threshold
 
@@ -452,7 +452,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/ActionSchedulerJobMonitor.php#L186">ActionSchedulerJobMonitor.php#L186</a>
+- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/ActionSchedulerJobMonitor.php#L186)
 
 ## woocommerce_gla_job_failure_timeframe
 
@@ -460,7 +460,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Jobs/ActionSchedulerJobMonitor.php#L195">ActionSchedulerJobMonitor.php#L195</a>
+- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/ActionSchedulerJobMonitor.php#L195)
 
 ## woocommerce_gla_mapping_rules_change
 
@@ -468,9 +468,9 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143">AttributeMappingRulesController.php#L143</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166">AttributeMappingRulesController.php#L166</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188">AttributeMappingRulesController.php#L188</a>
+- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
+- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
+- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
 
 ## woocommerce_gla_mc_account_review_lifetime
 
@@ -478,7 +478,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Google/RequestReviewStatuses.php#L146">RequestReviewStatuses.php#L146</a>
+- [RequestReviewStatuses.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Google/RequestReviewStatuses.php#L146)
 
 ## woocommerce_gla_mc_client_exception
 
@@ -486,14 +486,14 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L92">Merchant.php#L92</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L140">Merchant.php#L140</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L172">Merchant.php#L172</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L191">Merchant.php#L191</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L247">Merchant.php#L247</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L292">Merchant.php#L292</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L354">Merchant.php#L354</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/MerchantReport.php#L95">MerchantReport.php#L95</a>
+- [MerchantReport.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/MerchantReport.php#L95)
+- [Merchant.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L92)
+- [Merchant.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L140)
+- [Merchant.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L172)
+- [Merchant.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L191)
+- [Merchant.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L247)
+- [Merchant.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L292)
+- [Merchant.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L354)
 
 ## woocommerce_gla_mc_settings_sync
 
@@ -501,7 +501,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69">SettingsSyncController.php#L69</a>
+- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
 
 ## woocommerce_gla_mc_status_lifetime
 
@@ -509,7 +509,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L778">MerchantStatuses.php#L778</a>
+- [MerchantStatuses.php#L778](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L778)
 
 ## woocommerce_gla_merchant_issue_override
 
@@ -517,7 +517,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L86">IssuesController.php#L86</a>
+- [IssuesController.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L86)
 
 ## woocommerce_gla_merchant_status_google_ids_chunk
 
@@ -525,7 +525,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L191">MerchantStatuses.php#L191</a>
+- [MerchantStatuses.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L191)
 
 ## woocommerce_gla_merchant_status_presync_issues_chunk
 
@@ -533,32 +533,32 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantStatuses.php#L531">MerchantStatuses.php#L531</a>
+- [MerchantStatuses.php#L531](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L531)
 
-## woocommerce_gla_options_deleted_$NAME
-
-**Type**: action
-
-**Used in**:
-
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Options/Options.php#L103">Options.php#L103</a>
-
-## woocommerce_gla_options_updated_$NAME
+## woocommerce_gla_options_deleted_
 
 **Type**: action
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Options/Options.php#L65">Options.php#L65</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Options/Options.php#L85">Options.php#L85</a>
+- [Options.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Options/Options.php#L103)
 
-## woocommerce_gla_prepared_response_$THIS->GET_ROUTE_NAME$REQUEST
+## woocommerce_gla_options_updated_
+
+**Type**: action
+
+**Used in**:
+
+- [Options.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Options/Options.php#L65)
+- [Options.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Options/Options.php#L85)
+
+## woocommerce_gla_prepared_response_->GET_ROUTE_NAME
 
 **Type**: filter
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/BaseController.php#L158">BaseController.php#L158</a>
+- [BaseController.php#L158](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/BaseController.php#L158)
 
 ## woocommerce_gla_product_attribute_types
 
@@ -566,16 +566,16 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/Attributes/AttributeManager.php#L243">AttributeManager.php#L243</a>
+- [AttributeManager.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/Attributes/AttributeManager.php#L243)
 
-## woocommerce_gla_product_attribute_value_$ATTRIBUTE_ID
+## woocommerce_gla_product_attribute_value_
 
 **Type**: filter
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L901">WCProductAdapter.php#L901</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L952">WCProductAdapter.php#L952</a>
+- [WCProductAdapter.php#L901](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L901)
+- [WCProductAdapter.php#L952](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L952)
 
 ## woocommerce_gla_product_attribute_value_description
 
@@ -583,15 +583,15 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L348">WCProductAdapter.php#L348</a>
+- [WCProductAdapter.php#L348](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L348)
 
-## woocommerce_gla_product_attribute_value_options_$ATTRIBUTE::get_id
+## woocommerce_gla_product_attribute_value_options_::get_id
 
 **Type**: filter
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Admin/Product/Attributes/AttributesForm.php#L108">AttributesForm.php#L108</a>
+- [AttributesForm.php#L108](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Product/Attributes/AttributesForm.php#L108)
 
 ## woocommerce_gla_product_attribute_value_price
 
@@ -599,7 +599,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L630">WCProductAdapter.php#L630</a>
+- [WCProductAdapter.php#L630](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L630)
 
 ## woocommerce_gla_product_attribute_value_sale_price
 
@@ -607,7 +607,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L680">WCProductAdapter.php#L680</a>
+- [WCProductAdapter.php#L680](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L680)
 
 ## woocommerce_gla_product_attribute_values
 
@@ -615,7 +615,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L167">WCProductAdapter.php#L167</a>
+- [WCProductAdapter.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L167)
 
 ## woocommerce_gla_product_description_apply_shortcodes
 
@@ -623,7 +623,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L317">WCProductAdapter.php#L317</a>
+- [WCProductAdapter.php#L317](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L317)
 
 ## woocommerce_gla_product_property_value_is_virtual
 
@@ -631,7 +631,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L767">WCProductAdapter.php#L767</a>
+- [WCProductAdapter.php#L767](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L767)
 
 ## woocommerce_gla_product_query_args
 
@@ -639,7 +639,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductRepository.php#L360">ProductRepository.php#L360</a>
+- [ProductRepository.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductRepository.php#L360)
 
 ## woocommerce_gla_products_delete_retry_on_failure
 
@@ -647,7 +647,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L353">ProductSyncer.php#L353</a>
+- [ProductSyncer.php#L353](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L353)
 
 ## woocommerce_gla_products_update_retry_on_failure
 
@@ -655,7 +655,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L297">ProductSyncer.php#L297</a>
+- [ProductSyncer.php#L297](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L297)
 
 ## woocommerce_gla_ready_for_syncing
 
@@ -663,7 +663,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/MerchantCenterService.php#L118">MerchantCenterService.php#L118</a>
+- [MerchantCenterService.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantCenterService.php#L118)
 
 ## woocommerce_gla_request_review_failure
 
@@ -671,9 +671,9 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110">RequestReviewController.php#L110</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122">RequestReviewController.php#L122</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L592">Middleware.php#L592</a>
+- [Middleware.php#L592](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L592)
+- [RequestReviewController.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110)
+- [RequestReviewController.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122)
 
 ## woocommerce_gla_request_review_response
 
@@ -681,7 +681,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L545">Middleware.php#L545</a>
+- [Middleware.php#L545](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L545)
 
 ## woocommerce_gla_retry_delete_coupons
 
@@ -689,7 +689,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L442">CouponSyncer.php#L442</a>
+- [CouponSyncer.php#L442](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L442)
 
 ## woocommerce_gla_retry_update_coupons
 
@@ -697,7 +697,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L404">CouponSyncer.php#L404</a>
+- [CouponSyncer.php#L404](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L404)
 
 ## woocommerce_gla_site_claim_failure
 
@@ -705,10 +705,10 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L365">AccountService.php#L365</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L93">Merchant.php#L93</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L268">Middleware.php#L268</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L274">Middleware.php#L274</a>
+- [Middleware.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L268)
+- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L274)
+- [Merchant.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L93)
+- [AccountService.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/AccountService.php#L365)
 
 ## woocommerce_gla_site_claim_overwrite_required
 
@@ -716,7 +716,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L360">AccountService.php#L360</a>
+- [AccountService.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/AccountService.php#L360)
 
 ## woocommerce_gla_site_claim_success
 
@@ -724,8 +724,8 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Merchant.php#L90">Merchant.php#L90</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/Middleware.php#L263">Middleware.php#L263</a>
+- [Middleware.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L263)
+- [Merchant.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L90)
 
 ## woocommerce_gla_site_url
 
@@ -733,7 +733,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/PluginHelper.php#L189">PluginHelper.php#L189</a>
+- [PluginHelper.php#L189](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/PluginHelper.php#L189)
 
 ## woocommerce_gla_site_verify_failure
 
@@ -741,9 +741,9 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L58">SiteVerification.php#L58</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L66">SiteVerification.php#L66</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L87">SiteVerification.php#L87</a>
+- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L58)
+- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L66)
+- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L87)
 
 ## woocommerce_gla_site_verify_success
 
@@ -751,7 +751,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L85">SiteVerification.php#L85</a>
+- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L85)
 
 ## woocommerce_gla_supported_coupon_types
 
@@ -759,7 +759,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L365">CouponSyncer.php#L365</a>
+- [CouponSyncer.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L365)
 
 ## woocommerce_gla_supported_product_types
 
@@ -767,7 +767,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductSyncer.php#L264">ProductSyncer.php#L264</a>
+- [ProductSyncer.php#L264](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L264)
 
 ## woocommerce_gla_sv_client_exception
 
@@ -775,8 +775,8 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L120">SiteVerification.php#L120</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/API/Google/SiteVerification.php#L162">SiteVerification.php#L162</a>
+- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L120)
+- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L162)
 
 ## woocommerce_gla_tax_excluded
 
@@ -784,7 +784,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L591">WCProductAdapter.php#L591</a>
+- [WCProductAdapter.php#L591](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L591)
 
 ## woocommerce_gla_updated_coupon
 
@@ -792,7 +792,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Coupon/CouponSyncer.php#L168">CouponSyncer.php#L168</a>
+- [CouponSyncer.php#L168](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L168)
 
 ## woocommerce_gla_url_switch_required
 
@@ -800,7 +800,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L445">AccountService.php#L445</a>
+- [AccountService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/AccountService.php#L445)
 
 ## woocommerce_gla_url_switch_success
 
@@ -808,7 +808,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/MerchantCenter/AccountService.php#L468">AccountService.php#L468</a>
+- [AccountService.php#L468](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/AccountService.php#L468)
 
 ## woocommerce_gla_use_short_description
 
@@ -816,7 +816,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L294">WCProductAdapter.php#L294</a>
+- [WCProductAdapter.php#L294](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L294)
 
 ## woocommerce_gla_wcs_url
 
@@ -824,8 +824,8 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/PluginHelper.php#L174">PluginHelper.php#L174</a>
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/PluginHelper.php#L178">PluginHelper.php#L178</a>
+- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/PluginHelper.php#L174)
+- [PluginHelper.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/PluginHelper.php#L178)
 
 ## woocommerce_gla_weight_unit
 
@@ -833,7 +833,7 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/WCProductAdapter.php#L428">WCProductAdapter.php#L428</a>
+- [WCProductAdapter.php#L428](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L428)
 
 ## woocommerce_hide_invisible_variations
 
@@ -841,5 +841,5 @@ A list of hooks, i.e `actions` and `filters`, that are defined or used in this p
 
 **Used in**:
 
-- <a href="https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Product/ProductHelper.php#L366">ProductHelper.php#L366</a>
+- [ProductHelper.php#L366](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L366)
 

--- a/src/Hooks/README.md
+++ b/src/Hooks/README.md
@@ -8,7 +8,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
+- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
 
 ## woocommerce_admin_disabled
 
@@ -16,7 +16,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Internal/Requirements/WCAdminValidator.php#L38)
+- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Internal/Requirements/WCAdminValidator.php#L38)
 
 ## woocommerce_gla_ads_billing_setup_status
 
@@ -24,8 +24,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Ads.php#L112](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L112)
-- [Ads.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L121)
+- [Ads.php#L112](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Ads.php#L112)
+- [Ads.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Ads.php#L121)
 
 ## woocommerce_gla_ads_client_exception
 
@@ -33,24 +33,24 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Ads.php#L73](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L73)
-- [Ads.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L117)
-- [Ads.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L172)
-- [Ads.php#L214](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L214)
-- [Ads.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Ads.php#L298)
-- [AdsCampaign.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L127)
-- [AdsCampaign.php#L170](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L170)
-- [AdsCampaign.php#L230](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L230)
-- [AdsCampaign.php#L285](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L285)
-- [AdsCampaign.php#L319](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsCampaign.php#L319)
-- [AdsAssetGroup.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroup.php#L113)
-- [AdsAssetGroup.php#L304](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroup.php#L304)
-- [AdsAssetGroup.php#L369](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroup.php#L369)
-- [AdsReport.php#L105](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsReport.php#L105)
-- [AdsConversionAction.php#L97](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsConversionAction.php#L97)
-- [AdsConversionAction.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsConversionAction.php#L143)
-- [AdsAssetGroupAsset.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroupAsset.php#L135)
-- [AdsAssetGroupAsset.php#L202](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsAssetGroupAsset.php#L202)
+- [Ads.php#L73](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Ads.php#L73)
+- [Ads.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Ads.php#L117)
+- [Ads.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Ads.php#L172)
+- [Ads.php#L214](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Ads.php#L214)
+- [Ads.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Ads.php#L298)
+- [AdsReport.php#L105](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsReport.php#L105)
+- [AdsAssetGroupAsset.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsAssetGroupAsset.php#L135)
+- [AdsAssetGroupAsset.php#L202](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsAssetGroupAsset.php#L202)
+- [AdsAssetGroup.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsAssetGroup.php#L113)
+- [AdsAssetGroup.php#L304](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsAssetGroup.php#L304)
+- [AdsAssetGroup.php#L369](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsAssetGroup.php#L369)
+- [AdsConversionAction.php#L97](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsConversionAction.php#L97)
+- [AdsConversionAction.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsConversionAction.php#L143)
+- [AdsCampaign.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsCampaign.php#L127)
+- [AdsCampaign.php#L170](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsCampaign.php#L170)
+- [AdsCampaign.php#L230](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsCampaign.php#L230)
+- [AdsCampaign.php#L285](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsCampaign.php#L285)
+- [AdsCampaign.php#L319](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsCampaign.php#L319)
 
 ## woocommerce_gla_ads_setup_completed
 
@@ -58,7 +58,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SetupCompleteController.php#L46](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/Ads/SetupCompleteController.php#L46)
+- [SetupCompleteController.php#L46](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/Ads/SetupCompleteController.php#L46)
 
 ## woocommerce_gla_attribute_applicable_product_types_
 
@@ -66,8 +66,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L295](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/Attributes/AttributeManager.php#L295)
-- [AttributesForm.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Product/Attributes/AttributesForm.php#L69)
+- [AttributesForm.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/Product/Attributes/AttributesForm.php#L69)
+- [AttributeManager.php#L295](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/Attributes/AttributeManager.php#L295)
 
 ## woocommerce_gla_attribute_hidden_product_types_
 
@@ -75,7 +75,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Product/Attributes/AttributesForm.php#L74)
+- [AttributesForm.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/Product/Attributes/AttributesForm.php#L74)
 
 ## woocommerce_gla_attribute_mapping_sources
 
@@ -83,7 +83,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
+- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
 
 ## woocommerce_gla_attribute_mapping_sources_custom_attributes
 
@@ -91,7 +91,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
+- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
 
 ## woocommerce_gla_attribute_mapping_sources_global_attributes
 
@@ -99,7 +99,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
+- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
 
 ## woocommerce_gla_attribute_mapping_sources_product_fields
 
@@ -107,7 +107,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
+- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
 
 ## woocommerce_gla_attribute_mapping_sources_taxonomies
 
@@ -115,7 +115,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
+- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
 
 ## woocommerce_gla_attributes_tab_applicable_product_types
 
@@ -123,7 +123,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesTab.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Product/Attributes/AttributesTab.php#L190)
+- [AttributesTab.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/Product/Attributes/AttributesTab.php#L190)
 
 ## woocommerce_gla_batch_deleted_products
 
@@ -131,7 +131,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L229)
+- [ProductSyncer.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L229)
 
 ## woocommerce_gla_batch_retry_delete_products
 
@@ -139,7 +139,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L354)
+- [ProductSyncer.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L354)
 
 ## woocommerce_gla_batch_retry_update_products
 
@@ -147,7 +147,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L298)
+- [ProductSyncer.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L298)
 
 ## woocommerce_gla_batch_updated_products
 
@@ -155,7 +155,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L143)
+- [ProductSyncer.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L143)
 
 ## woocommerce_gla_batched_job_size
 
@@ -163,8 +163,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/UpdateSyncableProductsCount.php#L74)
-- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
+- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Jobs/UpdateSyncableProductsCount.php#L74)
+- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
 
 ## woocommerce_gla_bulk_update_coupon
 
@@ -172,7 +172,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponBulkEdit.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/BulkEdit/CouponBulkEdit.php#L134)
+- [CouponBulkEdit.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/BulkEdit/CouponBulkEdit.php#L134)
 
 ## woocommerce_gla_conversion_action_name
 
@@ -180,7 +180,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsConversionAction.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/AdsConversionAction.php#L66)
+- [AdsConversionAction.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/AdsConversionAction.php#L66)
 
 ## woocommerce_gla_coupons_delete_retry_on_failure
 
@@ -188,7 +188,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L437](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L437)
+- [CouponSyncer.php#L437](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L437)
 
 ## woocommerce_gla_coupons_update_retry_on_failure
 
@@ -196,7 +196,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L399](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L399)
+- [CouponSyncer.php#L399](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L399)
 
 ## woocommerce_gla_custom_merchant_issues
 
@@ -204,7 +204,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L435](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L435)
+- [MerchantStatuses.php#L435](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/MerchantStatuses.php#L435)
 
 ## woocommerce_gla_debug_message
 
@@ -212,38 +212,38 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IssuesController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L96)
-- [WCProductAdapter.php#L203](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L203)
-- [ProductSyncer.php#L149](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L149)
-- [ProductSyncer.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L159)
-- [ProductSyncer.php#L235](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L235)
-- [ProductSyncer.php#L245](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L245)
-- [ProductRepository.php#L304](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductRepository.php#L304)
-- [SyncerHooks.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/SyncerHooks.php#L197)
-- [ProductHelper.php#L459](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L459)
-- [ProductHelper.php#L491](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L491)
-- [BatchProductHelper.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/BatchProductHelper.php#L208)
-- [BatchProductHelper.php#L231](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/BatchProductHelper.php#L231)
-- [SyncerHooks.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/SyncerHooks.php#L177)
-- [CouponHelper.php#L255](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponHelper.php#L255)
-- [CouponHelper.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponHelper.php#L292)
-- [CouponSyncer.php#L102](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L102)
-- [CouponSyncer.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L115)
-- [CouponSyncer.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L140)
-- [CouponSyncer.php#L154](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L154)
-- [CouponSyncer.php#L171](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L171)
-- [CouponSyncer.php#L194](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L194)
-- [CouponSyncer.php#L259](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L259)
-- [CouponSyncer.php#L308](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L308)
-- [CouponSyncer.php#L327](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L327)
-- [MerchantStatuses.php#L334](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L334)
-- [MerchantStatuses.php#L357](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L357)
-- [MerchantCenterService.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantCenterService.php#L305)
-- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/ActionSchedulerJobMonitor.php#L117)
-- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/ActionSchedulerJobMonitor.php#L126)
-- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/CleanupSyncedProducts.php#L74)
-- [ProductMetaQueryHelper.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/DB/ProductMetaQueryHelper.php#L92)
-- [ProductMetaQueryHelper.php#L123](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/DB/ProductMetaQueryHelper.php#L123)
+- [ProductMetaQueryHelper.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/DB/ProductMetaQueryHelper.php#L92)
+- [ProductMetaQueryHelper.php#L123](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/DB/ProductMetaQueryHelper.php#L123)
+- [IssuesController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L96)
+- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Jobs/ActionSchedulerJobMonitor.php#L117)
+- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Jobs/ActionSchedulerJobMonitor.php#L126)
+- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Jobs/CleanupSyncedProducts.php#L74)
+- [CouponHelper.php#L255](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponHelper.php#L255)
+- [CouponHelper.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponHelper.php#L292)
+- [CouponSyncer.php#L102](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L102)
+- [CouponSyncer.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L115)
+- [CouponSyncer.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L140)
+- [CouponSyncer.php#L154](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L154)
+- [CouponSyncer.php#L171](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L171)
+- [CouponSyncer.php#L194](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L194)
+- [CouponSyncer.php#L259](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L259)
+- [CouponSyncer.php#L308](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L308)
+- [CouponSyncer.php#L327](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L327)
+- [SyncerHooks.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/SyncerHooks.php#L177)
+- [WCProductAdapter.php#L203](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L203)
+- [BatchProductHelper.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/BatchProductHelper.php#L208)
+- [BatchProductHelper.php#L231](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/BatchProductHelper.php#L231)
+- [ProductSyncer.php#L149](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L149)
+- [ProductSyncer.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L159)
+- [ProductSyncer.php#L235](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L235)
+- [ProductSyncer.php#L245](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L245)
+- [SyncerHooks.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/SyncerHooks.php#L197)
+- [ProductRepository.php#L304](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductRepository.php#L304)
+- [ProductHelper.php#L459](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductHelper.php#L459)
+- [ProductHelper.php#L491](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductHelper.php#L491)
+- [MerchantCenterService.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/MerchantCenterService.php#L305)
+- [MerchantStatuses.php#L334](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/MerchantStatuses.php#L334)
+- [MerchantStatuses.php#L357](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/MerchantStatuses.php#L357)
 
 ## woocommerce_gla_deleted_promotions
 
@@ -251,7 +251,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L321)
+- [CouponSyncer.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L321)
 
 ## woocommerce_gla_dimension_unit
 
@@ -259,7 +259,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L427](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L427)
+- [WCProductAdapter.php#L427](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L427)
 
 ## woocommerce_gla_disable_gtag_tracking
 
@@ -267,7 +267,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L464](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Google/GlobalSiteTag.php#L464)
+- [GlobalSiteTag.php#L464](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Google/GlobalSiteTag.php#L464)
 
 ## woocommerce_gla_enable_connection_test
 
@@ -275,7 +275,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ConnectionTest.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/ConnectionTest.php#L87)
+- [ConnectionTest.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/ConnectionTest.php#L87)
 
 ## woocommerce_gla_enable_debug_logging
 
@@ -283,7 +283,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Logging/DebugLogger.php#L33)
+- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Logging/DebugLogger.php#L33)
 
 ## woocommerce_gla_enable_mcm
 
@@ -291,7 +291,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GLAChannel.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MultichannelMarketing/GLAChannel.php#L75)
+- [GLAChannel.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MultichannelMarketing/GLAChannel.php#L75)
 
 ## woocommerce_gla_enable_reports
 
@@ -299,7 +299,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Admin.php#L250](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Admin.php#L250)
+- [Admin.php#L250](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/Admin.php#L250)
 
 ## woocommerce_gla_error
 
@@ -307,23 +307,23 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/View/PHPView.php#L136)
-- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/View/PHPView.php#L164)
-- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/View/PHPView.php#L208)
-- [ProductMetaHandler.php#L173](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductMetaHandler.php#L173)
-- [ProductSyncer.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L301)
-- [ProductSyncer.php#L324](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L324)
-- [ProductSyncer.php#L357](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L357)
-- [ProductSyncer.php#L372](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L372)
-- [ProductHelper.php#L351](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L351)
-- [ProductHelper.php#L567](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L567)
-- [BatchProductHelper.php#L248](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/BatchProductHelper.php#L248)
-- [AttributeManager.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/Attributes/AttributeManager.php#L269)
-- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponMetaHandler.php#L220)
-- [CouponSyncer.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L409)
-- [CouponSyncer.php#L447](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L447)
-- [CouponSyncer.php#L465](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L465)
-- [ProductMetaQueryHelper.php#L139](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/DB/ProductMetaQueryHelper.php#L139)
+- [ProductMetaQueryHelper.php#L139](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/DB/ProductMetaQueryHelper.php#L139)
+- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/View/PHPView.php#L136)
+- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/View/PHPView.php#L164)
+- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/View/PHPView.php#L208)
+- [CouponSyncer.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L409)
+- [CouponSyncer.php#L447](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L447)
+- [CouponSyncer.php#L465](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L465)
+- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponMetaHandler.php#L220)
+- [BatchProductHelper.php#L248](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/BatchProductHelper.php#L248)
+- [ProductSyncer.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L301)
+- [ProductSyncer.php#L324](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L324)
+- [ProductSyncer.php#L357](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L357)
+- [ProductSyncer.php#L372](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L372)
+- [AttributeManager.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/Attributes/AttributeManager.php#L269)
+- [ProductHelper.php#L351](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductHelper.php#L351)
+- [ProductHelper.php#L567](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductHelper.php#L567)
+- [ProductMetaHandler.php#L173](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductMetaHandler.php#L173)
 
 ## woocommerce_gla_exception
 
@@ -331,27 +331,27 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/View/PHPView.php#L87)
-- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L95)
-- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
-- [SettingsSyncController.php#L79](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L79)
-- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
-- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Notes/NoteInitializer.php#L74)
-- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Notes/NoteInitializer.php#L116)
-- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Event/ClearProductStatsCache.php#L61)
-- [GoogleServiceProvider.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Internal/DependencyManagement/GoogleServiceProvider.php#L223)
-- [ProductSyncer.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L134)
-- [ProductSyncer.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L220)
-- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
-- [CouponSyncer.php#L202](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L202)
-- [CouponSyncer.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L292)
-- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Input/DateTime.php#L44)
-- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Input/DateTime.php#L80)
-- [ChannelVisibilityMetaBox.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L190)
-- [CouponChannelVisibilityMetaBox.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197)
-- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Integration/WooCommercePreOrders.php#L111)
-- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Integration/WooCommercePreOrders.php#L131)
-- [PluginUpdate.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/Update/PluginUpdate.php#L75)
+- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/View/PHPView.php#L87)
+- [SettingsSyncController.php#L79](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L79)
+- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
+- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
+- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Connection.php#L95)
+- [PluginUpdate.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Jobs/Update/PluginUpdate.php#L75)
+- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Integration/WooCommercePreOrders.php#L111)
+- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Integration/WooCommercePreOrders.php#L131)
+- [CouponSyncer.php#L202](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L202)
+- [CouponSyncer.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L292)
+- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/Input/DateTime.php#L44)
+- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/Input/DateTime.php#L80)
+- [CouponChannelVisibilityMetaBox.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197)
+- [ChannelVisibilityMetaBox.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L190)
+- [GoogleServiceProvider.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Internal/DependencyManagement/GoogleServiceProvider.php#L223)
+- [ProductSyncer.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L134)
+- [ProductSyncer.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L220)
+- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
+- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Event/ClearProductStatsCache.php#L61)
+- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Notes/NoteInitializer.php#L74)
+- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Notes/NoteInitializer.php#L116)
 
 ## woocommerce_gla_force_run_install
 
@@ -359,7 +359,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Installer.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Installer.php#L82)
+- [Installer.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Installer.php#L82)
 
 ## woocommerce_gla_get_google_product_offer_id
 
@@ -367,7 +367,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L280](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L280)
+- [WCProductAdapter.php#L280](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L280)
 
 ## woocommerce_gla_get_sync_ready_products_filter
 
@@ -375,7 +375,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductFilter.php#L61)
+- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductFilter.php#L61)
 
 ## woocommerce_gla_get_sync_ready_products_pre_filter
 
@@ -383,7 +383,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductFilter.php#L47)
+- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductFilter.php#L47)
 
 ## woocommerce_gla_get_wc_product_id
 
@@ -391,7 +391,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L278](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L278)
+- [ProductHelper.php#L278](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductHelper.php#L278)
 
 ## woocommerce_gla_guzzle_client_exception
 
@@ -399,20 +399,20 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L70)
-- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L91)
-- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L126)
-- [Middleware.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L80)
-- [Middleware.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L178)
-- [Middleware.php#L228](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L228)
-- [Middleware.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L273)
-- [Middleware.php#L344](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L344)
-- [Middleware.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L394)
-- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L418)
-- [Middleware.php#L452](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L452)
-- [Middleware.php#L552](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L552)
-- [Middleware.php#L611](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L611)
-- [GoogleServiceProvider.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Internal/DependencyManagement/GoogleServiceProvider.php#L247)
+- [Middleware.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L80)
+- [Middleware.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L178)
+- [Middleware.php#L228](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L228)
+- [Middleware.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L273)
+- [Middleware.php#L344](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L344)
+- [Middleware.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L394)
+- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L418)
+- [Middleware.php#L452](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L452)
+- [Middleware.php#L552](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L552)
+- [Middleware.php#L611](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L611)
+- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Connection.php#L70)
+- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Connection.php#L91)
+- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Connection.php#L126)
+- [GoogleServiceProvider.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Internal/DependencyManagement/GoogleServiceProvider.php#L247)
 
 ## woocommerce_gla_guzzle_invalid_response
 
@@ -420,15 +420,15 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L66)
-- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Connection.php#L121)
-- [Middleware.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L159)
-- [Middleware.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L223)
-- [Middleware.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L267)
-- [Middleware.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L339)
-- [Middleware.php#L389](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L389)
-- [Middleware.php#L548](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L548)
-- [Middleware.php#L599](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L599)
+- [Middleware.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L159)
+- [Middleware.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L223)
+- [Middleware.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L267)
+- [Middleware.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L339)
+- [Middleware.php#L389](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L389)
+- [Middleware.php#L548](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L548)
+- [Middleware.php#L599](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L599)
+- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Connection.php#L66)
+- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Connection.php#L121)
 
 ## woocommerce_gla_hidden_coupon_types
 
@@ -436,7 +436,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L378)
+- [CouponSyncer.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L378)
 
 ## woocommerce_gla_hidden_product_types
 
@@ -444,7 +444,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L275](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L275)
+- [ProductSyncer.php#L275](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L275)
 
 ## woocommerce_gla_job_failure_rate_threshold
 
@@ -452,7 +452,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/ActionSchedulerJobMonitor.php#L186)
+- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Jobs/ActionSchedulerJobMonitor.php#L186)
 
 ## woocommerce_gla_job_failure_timeframe
 
@@ -460,7 +460,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Jobs/ActionSchedulerJobMonitor.php#L195)
+- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Jobs/ActionSchedulerJobMonitor.php#L195)
 
 ## woocommerce_gla_mapping_rules_change
 
@@ -468,9 +468,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
-- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
-- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
+- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
+- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
+- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
 
 ## woocommerce_gla_mc_account_review_lifetime
 
@@ -478,7 +478,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewStatuses.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Google/RequestReviewStatuses.php#L146)
+- [RequestReviewStatuses.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Google/RequestReviewStatuses.php#L146)
 
 ## woocommerce_gla_mc_client_exception
 
@@ -486,14 +486,14 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantReport.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/MerchantReport.php#L95)
-- [Merchant.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L92)
-- [Merchant.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L140)
-- [Merchant.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L172)
-- [Merchant.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L191)
-- [Merchant.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L247)
-- [Merchant.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L292)
-- [Merchant.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L354)
+- [MerchantReport.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/MerchantReport.php#L95)
+- [Merchant.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L92)
+- [Merchant.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L140)
+- [Merchant.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L172)
+- [Merchant.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L191)
+- [Merchant.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L247)
+- [Merchant.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L292)
+- [Merchant.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L354)
 
 ## woocommerce_gla_mc_settings_sync
 
@@ -501,7 +501,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
+- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
 
 ## woocommerce_gla_mc_status_lifetime
 
@@ -509,7 +509,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L778](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L778)
+- [MerchantStatuses.php#L778](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/MerchantStatuses.php#L778)
 
 ## woocommerce_gla_merchant_issue_override
 
@@ -517,7 +517,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IssuesController.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L86)
+- [IssuesController.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L86)
 
 ## woocommerce_gla_merchant_status_google_ids_chunk
 
@@ -525,7 +525,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L191)
+- [MerchantStatuses.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/MerchantStatuses.php#L191)
 
 ## woocommerce_gla_merchant_status_presync_issues_chunk
 
@@ -533,7 +533,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L531](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantStatuses.php#L531)
+- [MerchantStatuses.php#L531](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/MerchantStatuses.php#L531)
 
 ## woocommerce_gla_options_deleted_
 
@@ -541,7 +541,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Options/Options.php#L103)
+- [Options.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Options/Options.php#L103)
 
 ## woocommerce_gla_options_updated_
 
@@ -549,8 +549,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Options/Options.php#L65)
-- [Options.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Options/Options.php#L85)
+- [Options.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Options/Options.php#L65)
+- [Options.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Options/Options.php#L85)
 
 ## woocommerce_gla_prepared_response_->GET_ROUTE_NAME
 
@@ -558,7 +558,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BaseController.php#L158](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/BaseController.php#L158)
+- [BaseController.php#L158](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/BaseController.php#L158)
 
 ## woocommerce_gla_product_attribute_types
 
@@ -566,7 +566,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/Attributes/AttributeManager.php#L243)
+- [AttributeManager.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/Attributes/AttributeManager.php#L243)
 
 ## woocommerce_gla_product_attribute_value_
 
@@ -574,8 +574,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L901](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L901)
-- [WCProductAdapter.php#L952](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L952)
+- [WCProductAdapter.php#L901](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L901)
+- [WCProductAdapter.php#L952](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L952)
 
 ## woocommerce_gla_product_attribute_value_description
 
@@ -583,7 +583,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L348](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L348)
+- [WCProductAdapter.php#L348](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L348)
 
 ## woocommerce_gla_product_attribute_value_options_::get_id
 
@@ -591,7 +591,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L108](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Admin/Product/Attributes/AttributesForm.php#L108)
+- [AttributesForm.php#L108](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Admin/Product/Attributes/AttributesForm.php#L108)
 
 ## woocommerce_gla_product_attribute_value_price
 
@@ -599,7 +599,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L630](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L630)
+- [WCProductAdapter.php#L630](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L630)
 
 ## woocommerce_gla_product_attribute_value_sale_price
 
@@ -607,7 +607,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L680](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L680)
+- [WCProductAdapter.php#L680](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L680)
 
 ## woocommerce_gla_product_attribute_values
 
@@ -615,7 +615,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L167)
+- [WCProductAdapter.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L167)
 
 ## woocommerce_gla_product_description_apply_shortcodes
 
@@ -623,7 +623,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L317](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L317)
+- [WCProductAdapter.php#L317](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L317)
 
 ## woocommerce_gla_product_property_value_is_virtual
 
@@ -631,7 +631,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L767](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L767)
+- [WCProductAdapter.php#L767](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L767)
 
 ## woocommerce_gla_product_query_args
 
@@ -639,7 +639,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductRepository.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductRepository.php#L360)
+- [ProductRepository.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductRepository.php#L360)
 
 ## woocommerce_gla_products_delete_retry_on_failure
 
@@ -647,7 +647,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L353](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L353)
+- [ProductSyncer.php#L353](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L353)
 
 ## woocommerce_gla_products_update_retry_on_failure
 
@@ -655,7 +655,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L297](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L297)
+- [ProductSyncer.php#L297](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L297)
 
 ## woocommerce_gla_ready_for_syncing
 
@@ -663,7 +663,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantCenterService.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/MerchantCenterService.php#L118)
+- [MerchantCenterService.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/MerchantCenterService.php#L118)
 
 ## woocommerce_gla_request_review_failure
 
@@ -671,9 +671,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Middleware.php#L592](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L592)
-- [RequestReviewController.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110)
-- [RequestReviewController.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122)
+- [RequestReviewController.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110)
+- [RequestReviewController.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122)
+- [Middleware.php#L592](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L592)
 
 ## woocommerce_gla_request_review_response
 
@@ -681,7 +681,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Middleware.php#L545](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L545)
+- [Middleware.php#L545](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L545)
 
 ## woocommerce_gla_retry_delete_coupons
 
@@ -689,7 +689,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L442](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L442)
+- [CouponSyncer.php#L442](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L442)
 
 ## woocommerce_gla_retry_update_coupons
 
@@ -697,7 +697,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L404](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L404)
+- [CouponSyncer.php#L404](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L404)
 
 ## woocommerce_gla_site_claim_failure
 
@@ -705,10 +705,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Middleware.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L268)
-- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L274)
-- [Merchant.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L93)
-- [AccountService.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/AccountService.php#L365)
+- [Middleware.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L268)
+- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L274)
+- [Merchant.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L93)
+- [AccountService.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/AccountService.php#L365)
 
 ## woocommerce_gla_site_claim_overwrite_required
 
@@ -716,7 +716,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/AccountService.php#L360)
+- [AccountService.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/AccountService.php#L360)
 
 ## woocommerce_gla_site_claim_success
 
@@ -724,8 +724,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Middleware.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Middleware.php#L263)
-- [Merchant.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/Merchant.php#L90)
+- [Middleware.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Middleware.php#L263)
+- [Merchant.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/Merchant.php#L90)
 
 ## woocommerce_gla_site_url
 
@@ -733,7 +733,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L189](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/PluginHelper.php#L189)
+- [PluginHelper.php#L189](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/PluginHelper.php#L189)
 
 ## woocommerce_gla_site_verify_failure
 
@@ -741,9 +741,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L58)
-- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L66)
-- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L87)
+- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/SiteVerification.php#L58)
+- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/SiteVerification.php#L66)
+- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/SiteVerification.php#L87)
 
 ## woocommerce_gla_site_verify_success
 
@@ -751,7 +751,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L85)
+- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/SiteVerification.php#L85)
 
 ## woocommerce_gla_supported_coupon_types
 
@@ -759,7 +759,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L365)
+- [CouponSyncer.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L365)
 
 ## woocommerce_gla_supported_product_types
 
@@ -767,7 +767,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L264](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductSyncer.php#L264)
+- [ProductSyncer.php#L264](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductSyncer.php#L264)
 
 ## woocommerce_gla_sv_client_exception
 
@@ -775,8 +775,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L120)
-- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/API/Google/SiteVerification.php#L162)
+- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/SiteVerification.php#L120)
+- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/API/Google/SiteVerification.php#L162)
 
 ## woocommerce_gla_tax_excluded
 
@@ -784,7 +784,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L591](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L591)
+- [WCProductAdapter.php#L591](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L591)
 
 ## woocommerce_gla_updated_coupon
 
@@ -792,7 +792,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L168](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Coupon/CouponSyncer.php#L168)
+- [CouponSyncer.php#L168](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Coupon/CouponSyncer.php#L168)
 
 ## woocommerce_gla_url_switch_required
 
@@ -800,7 +800,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/AccountService.php#L445)
+- [AccountService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/AccountService.php#L445)
 
 ## woocommerce_gla_url_switch_success
 
@@ -808,7 +808,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L468](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/MerchantCenter/AccountService.php#L468)
+- [AccountService.php#L468](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/MerchantCenter/AccountService.php#L468)
 
 ## woocommerce_gla_use_short_description
 
@@ -816,7 +816,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L294](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L294)
+- [WCProductAdapter.php#L294](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L294)
 
 ## woocommerce_gla_wcs_url
 
@@ -824,8 +824,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/PluginHelper.php#L174)
-- [PluginHelper.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/PluginHelper.php#L178)
+- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/PluginHelper.php#L174)
+- [PluginHelper.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/PluginHelper.php#L178)
 
 ## woocommerce_gla_weight_unit
 
@@ -833,7 +833,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L428](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/WCProductAdapter.php#L428)
+- [WCProductAdapter.php#L428](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/WCProductAdapter.php#L428)
 
 ## woocommerce_hide_invisible_variations
 
@@ -841,5 +841,5 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L366](https://github.com/woocommerce/google-listings-and-ads/blob/1acb216497f7e17ad88c7149ee10c1d1cc0d7045/src/Product/ProductHelper.php#L366)
+- [ProductHelper.php#L366](https://github.com/woocommerce/google-listings-and-ads/blob/c78c08efd35a54a74bc1daa16e02e13472ffd384/src/Product/ProductHelper.php#L366)
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR creates an Action for generating PHP Hooks documentation when PHP files change.

It will commit a README.md in src/Hooks/README.md

### Screenshots

<img width="1478" alt="Screenshot 2023-08-17 at 15 04 53" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/7008f9f6-3202-4886-a016-2f839fa75ae2">

<img width="1279" alt="Screenshot 2023-08-17 at 15 03 52" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/6b47afd1-79c1-43be-bc2c-fc5ed9097606">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Verify how the [README.md ](https://github.com/woocommerce/google-listings-and-ads/blob/0c8537f7e8d3f1b6d7ac3d651fe61d4e38b16e63/src/Hooks/README.md) has been generated in src/HOOKS/README.md 
2. Check [in the file diff ](https://github.com/woocommerce/google-listings-and-ads/pull/2060/files#diff-712190684cdb42bf9516f3e2ebe570a0fe642f133b7797dd03c31899195b3241) the links working and it's most likely as it was before. 
3. See the workflow is triggered on release branches. https://github.com/woocommerce/google-listings-and-ads/pull/2064

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add Action for Hooks Documentation Generator

