### PR TITLE
Update trigger method in Hooks Generator Workflow

### DIFF
--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -5,16 +5,7 @@ on:
     branches:
       - "release/**"
     paths:
-      - "**.php"
-      - .github/workflows/php-hook-documentation.yml
-  pull_request:
-    types:
-      - opened
-    branches:
-      - "release/**"
-    paths:
-      - "**.php"
-      - .github/workflows/php-hook-documentation.yml
+      - changelog.txt # Run the workflow only after the last commit of Woo Release. When it updates the changelog.
   workflow_dispatch:
     
 concurrency:
@@ -37,7 +28,6 @@ jobs:
         id: generate-hook-docs
         uses: woocommerce/grow/hook-documentation@actions-v1
         with:
-          debug-output: yes
           source-directories: src/,views/,google-listings-and-ads.php,uninstall.php
 
       - name: Commit hook documentation


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up PR after a comment here https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/293#discussion_r1301459977 i

In brief, the workflow doesn't trigger correctly when woorlease creates the release branch.

This PR updates the trigger following the suggested and already approved way to trigger the workflow. 

Now were trigger the workflow when changelog.txt is pushed, as this is the last commit woorelease does. 


### Detailed test instructions:

Checking the changes. We need to test it directly in the release after merge.
