### PR TITLE
Fix Taxonomy Attribute Mapping for Product Variations

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1139,8 +1139,9 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 
 	/**
 	 * Get a taxonomy term names from a product using
-	 * @param $product_id int The product ID to get the taxonomy term
-	 * @param $taxonomy string The taxonomy to get.
+	 *
+	 * @param int    $product_id - The product ID to get the taxonomy term
+	 * @param string $taxonomy - The taxonomy to get.
 	 * @return string[] An array of term names.
 	 */
 	protected function get_taxonomy_term_names( $product_id, $taxonomy ) {

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -1040,15 +1040,24 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		if ( $product->is_type( 'variation' ) ) {
 			$values = $product->get_attribute( $taxonomy );
 
-			if ( ! $values ) {
-				$parent = wc_get_product( $product->get_parent_id() );
-				$values = $parent->get_attribute( $taxonomy );
+			if ( ! $values ) { // if taxonomy is not a global attribute (ie product_tag), attempt to get is with wc_get_product_terms
+				$values = $this->get_taxonomy_term_names( $product->get_id(), $taxonomy );
 			}
 
-			$values = explode( ', ', $values );
+			if ( ! $values ) { // if the value is still not available at this point, we try to get it from the parent
+				$parent = wc_get_product( $product->get_parent_id() );
+				$values = $parent->get_attribute( $taxonomy );
+
+				if ( ! $values ) {
+					$values = $this->get_taxonomy_term_names( $parent->get_id(), $taxonomy );
+				}
+			}
+
+			if ( is_string( $values ) ) {
+				$values = explode( ', ', $values );
+			}
 		} else {
-			$values = wc_get_product_terms( $product->get_id(), $taxonomy );
-			$values = wp_list_pluck( $values, 'name' );
+			$values = $this->get_taxonomy_term_names( $product->get_id(), $taxonomy );
 		}
 
 		if ( empty( $values ) || is_wp_error( $values ) ) {
@@ -1126,5 +1135,16 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$values = explode( WC_DELIMITER, (string) $attribute_value );
 		$values = array_filter( array_map( 'trim', $values ) );
 		return empty( $values ) ? '' : $values[0];
+	}
+
+	/**
+	 * Get a taxonomy term names from a product using
+	 * @param $product_id int The product ID to get the taxonomy term
+	 * @param $taxonomy string The taxonomy to get.
+	 * @return string[] An array of term names.
+	 */
+	protected function get_taxonomy_term_names( $product_id, $taxonomy ) {
+		$values = wc_get_product_terms( $product_id, $taxonomy );
+		return wp_list_pluck( $values, 'name' );
 	}
 }

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -521,10 +521,16 @@ trait ProductTrait {
 	 * Creates a variant with variations ready for being tested in Attribute Mapping
 	 *
 	 * @param array $rules The Attribute Mapping rules to apply.
+	 * @param array $categories The Categories attached to the variation parent.
 	 * @return WCProductAdapter The adapted products with the rules applied.
 	 */
-	protected function generate_attribute_mapping_adapted_product_variant( $rules ) {
+	protected function generate_attribute_mapping_adapted_product_variant( $rules, $categories = [] ) {
 		$variable  = WC_Helper_Product::create_variation_product();
+		if ( ! empty( $categories ) ) {
+			$variable->set_category_ids( $categories );
+		}
+		$variable->save();
+
 		$variation = wc_get_product( $variable->get_children()[ count( $variable->get_children() ) - 1 ] );
 		$variation->set_stock_quantity( 1 );
 		$variation->set_weight( 1.2 );

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -525,7 +525,7 @@ trait ProductTrait {
 	 * @return WCProductAdapter The adapted products with the rules applied.
 	 */
 	protected function generate_attribute_mapping_adapted_product_variant( $rules, $categories = [] ) {
-		$variable  = WC_Helper_Product::create_variation_product();
+		$variable = WC_Helper_Product::create_variation_product();
 		if ( ! empty( $categories ) ) {
 			$variable->set_category_ids( $categories );
 		}

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -244,6 +244,30 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 	}
 
 	/**
+	 * Test taxonomy source like product_cat, product_tag
+	 */
+	public function test_maps_rules_product_cat() {
+		$rules = [
+			[
+				'attribute'               => Brand::get_id(),
+				'source'                  => 'taxonomy:product_cat',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			]
+		];
+
+		$category_1 = wp_insert_term( 'Zulu Category', 'product_cat' );
+		$category_2 = wp_insert_term( 'Alpha Category', 'product_cat' );
+
+		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules, [ $category_1['term_id'], $category_2['term_id'] ] );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules, [ $category_1['term_id'], $category_2['term_id'] ]  );
+
+		var_dump($adapted_variation->getBrand());
+		$this->assertEquals( 'Alpha Category', $adapted_product->getBrand() );
+		$this->assertEquals( 'Alpha Category', $adapted_variation->getBrand() );
+	}
+
+	/**
 	 * Test dynamic taxonomy not found
 	 */
 	public function test_maps_rules_product_taxonomies_null() {

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -253,14 +253,14 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 				'source'                  => 'taxonomy:product_cat',
 				'category_condition_type' => 'ALL',
 				'categories'              => '',
-			]
+			],
 		];
 
 		$category_1 = wp_insert_term( 'Zulu Category', 'product_cat' );
 		$category_2 = wp_insert_term( 'Alpha Category', 'product_cat' );
 
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules, [ $category_1['term_id'], $category_2['term_id'] ] );
-		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules, [ $category_1['term_id'], $category_2['term_id'] ]  );
+		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules, [ $category_1['term_id'], $category_2['term_id'] ] );
 
 		$this->assertEquals( 'Alpha Category', $adapted_product->getBrand() );
 		$this->assertEquals( 'Alpha Category', $adapted_variation->getBrand() );

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -262,7 +262,6 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules, [ $category_1['term_id'], $category_2['term_id'] ] );
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules, [ $category_1['term_id'], $category_2['term_id'] ]  );
 
-		var_dump($adapted_variation->getBrand());
 		$this->assertEquals( 'Alpha Category', $adapted_product->getBrand() );
 		$this->assertEquals( 'Alpha Category', $adapted_variation->getBrand() );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2071 

- Adjusts `WCProductAdapter::get_product_taxonomy` method to return Parent terms as a fallback for taxonomies like product_tag, product_cat etc... 
- Adding some tests covering this edge case

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow the use case in #2071 and see it solved.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fix Taxonomy Attribute Mapping for Product Variations. 
