### PR TITLE
Clean up remaining WC < 6.8 workarounds

### DIFF
--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -138,6 +138,7 @@ const AllProgramsTableCard = ( props ) => {
 				/>
 			}
 			headers={ headers }
+			rowKey={ ( cells ) => cells[ 0 ].id }
 			rows={ data.map( ( el ) => {
 				const isFreeListings = el.id === FREE_LISTINGS_PROGRAM_ID;
 				const editButtonClassName = classnames( {
@@ -145,24 +146,21 @@ const AllProgramsTableCard = ( props ) => {
 						! isFreeListings && ! el.disabledEdit,
 				} );
 
-				// Since the <Table> component uses array index as key to render rows,
-				// it might cause incorrect state control if a column has an internal state.
-				// So we have to specific `key` prop on some components of the `display` to work around it.
-				// Ref: https://github.com/woocommerce/woocommerce-admin/blob/v2.1.2/packages/components/src/table/table.js#L288-L289
+				// The `id` property in the first cell is for the `rowKey` callback.
 				return [
-					{ display: el.title },
+					{ display: el.title, id: el.id.toString() },
 					{ display: el.country },
 					{ display: el.dailyBudget },
 					{
 						display: isFreeListings ? (
 							<FreeListingsDisabledToggle />
 						) : (
-							<ProgramToggle key={ el.id } program={ el } />
+							<ProgramToggle program={ el } />
 						),
 					},
 					{
 						display: (
-							<div className="program-actions" key={ el.id }>
+							<div className="program-actions">
 								<EditProgramButton
 									className={ editButtonClassName }
 									programId={ el.id }

--- a/js/src/hooks/useNavigateAwayPromptEffect.js
+++ b/js/src/hooks/useNavigateAwayPromptEffect.js
@@ -8,7 +8,7 @@ import { noop } from 'lodash';
 const alwaysTrue = () => true;
 
 /**
- * Returns a normalized location to handle the inconsistent pathname between history v5 (≥ WC 6.7) and v4 (< WC 6.7).
+ * Returns a normalized location to handle the inconsistent pathname in history v5 (≥ WC 6.7).
  *
  * Since WC calls `history.push()` with a path that starts with 'admin.php?...', it brings
  * the inconsistent `location` results.
@@ -18,11 +18,6 @@ const alwaysTrue = () => true;
  * @see https://github.com/remix-run/history/blob/v5.3.0/packages/history/index.ts#L735
  * @see https://github.com/remix-run/history/blob/v5.3.0/packages/history/index.ts#L701
  * @see https://github.com/remix-run/history/blob/v5.3.0/packages/history/index.ts#L1086
- *
- * The `pathname` in v4 is always '/admin.php'.
- *
- * @see https://github.com/remix-run/history/blob/v4/modules/createBrowserHistory.js#L166
- * @see https://github.com/remix-run/history/blob/v4/modules/LocationUtils.js#L57-L61
  *
  * @param {Object} location Location object to be normalized.
  * @return {Object} Normalized location object.
@@ -36,7 +31,6 @@ function normalizeLocation( location ) {
 
 /**
  * Show prompt when the user tries to unload/leave the page.
- * Adds and removed `beforeunload` event listener according to the given flag.
  *
  * @param {string} message Message to be shown. Note, some browsers may not support this when unloading the page.
  * @param {boolean} shouldBlock Boolean flag, whether the prompt should be shown.
@@ -47,31 +41,16 @@ export default function useNavigateAwayPromptEffect(
 	shouldBlock,
 	blockedLocation = alwaysTrue
 ) {
-	// history#v5 compatibility: As one of useEffect deps for triggering a new blocking after history is changed.
+	// history#v5: As one of useEffect deps for triggering a new blocking after history is changed.
 	const { key } = getHistory().location;
 
 	useEffect( () => {
-		/**
-		 * Bind beforeunload event for non `woocommerce/navigation` links and reloads.
-		 * history#v5 does bind `beforeunload` automatically, with v4 we need to do it ourselves.
-		 *
-		 * @param {Event} e Before Unload Event
-		 */
-		const eventListener = ( e ) => {
-			// If you prevent default behavior in Mozilla Firefox prompt will always be shown.
-			e.preventDefault();
-			// Chrome requires returnValue to be set.
-			e.returnValue = message;
-		};
-
 		let unblock = noop;
 
 		if ( shouldBlock ) {
 			// Block navigation in order to show a confirmation prompt.
 			unblock = getHistory().block( ( transition ) => {
-				// In history v4 (< WC 6.7) block method receives two parameter (the location and action).
-				// In v5 (>= WC 6.7) it has only one parameter that is a transition object with location, retry and action properties.
-				const { location = transition, retry = noop } = transition;
+				const { location, retry } = transition;
 				let shouldUnblock = true;
 
 				if ( blockedLocation( normalizeLocation( location ) ) ) {
@@ -79,22 +58,16 @@ export default function useNavigateAwayPromptEffect(
 					shouldUnblock = window.confirm( message ); // eslint-disable-line no-alert
 				}
 
-				// v5 compatibility requires the calls to unblock and retry functions.
+				// history v5 requires the calls to unblock and retry functions.
 				if ( shouldUnblock ) {
 					unblock();
 					retry();
 				}
-
-				// v4 compatibility requires a return boolean to tell whether actually to unblock the navigation.
-				return shouldUnblock;
 			} );
-
-			window.addEventListener( 'beforeunload', eventListener );
 		}
 
 		return () => {
 			unblock();
-			window.removeEventListener( 'beforeunload', eventListener );
 		};
 	}, [ key, message, shouldBlock, blockedLocation ] );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1715

- Remove the compatibilities for `history` v4 from the `useNavigateAwayPromptEffect` hook.
- Use `rowKey` prop to replace the `key`  prop workarounds in rendering the rows of `AllProgramsTableCard`.

### Detailed test instructions:

#### `useNavigateAwayPromptEffect`

1. Go to the Edit Free Listings page.
2. Ramdonly change some form values.
3. Refresh the page and click other page links to see if the navigation away prompt shows up.
4. Change those values back.
5. Refresh the page or click other page links to see if the navigation away prompt doesn't show up.

💡 The original issue: #1640

#### `AllProgramsTableCard`

1. Create at least two paid campaigns.
7. Disable the campaign that displays the order at the top.
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/98f32932-45e9-4fc3-b042-cea07663447c)
8. Delete the disabled campaign.
9. After the deletion is complete, another campaign should still be enabled status.

💡 The original issue: #762

### Changelog entry

> Dev - Clean up workarounds for WooCommerce < 6.8.
