### PR TITLE
E2E tests: Onboarding Step 2 - Configure product listings

### DIFF
--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -56,7 +56,7 @@ module.exports = async ( config ) => {
 				.locator( 'input[name="pwd"]' )
 				.fill( admin.password );
 			await adminPage.locator( 'text=Log In' ).click();
-			await adminPage.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+			await adminPage.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 			await adminPage.goto( `/wp-admin` );
 			await adminPage.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 

--- a/tests/e2e/specs/get-started.test.js
+++ b/tests/e2e/specs/get-started.test.js
@@ -27,13 +27,13 @@ test( 'Merchant who is getting started clicks on the Marketing > GLA link, click
 	// the submenu is now opened, the GLA sub menu item is now visible to the user,
 	// we can call `click` now.
 	await page.getByRole( 'link', { name: 'Google Listings & Ads' } ).click();
-	await page.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+	await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 
 	await expect( page ).toHaveTitle( /Google Listings & Ads/ );
 
 	// click on the call-to-action button.
 	await page.getByText( 'Start listing products →' ).first().click();
-	await page.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+	await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 
 	// Check we are in the Setup MC page.
 	await expect(

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -104,7 +104,7 @@ test.describe( 'Set up accounts', () => {
 			page.locator(
 				"//button[text()='Connect'][not(@disabled)]"
 			).click();
-			await page.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+			await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 
 			// Expect the user to be redirected
 			await page.waitForURL( baseURL + 'auth_url' );
@@ -169,7 +169,7 @@ test.describe( 'Set up accounts', () => {
 			page.locator(
 				"//button[text()='Connect'][not(@disabled)]"
 			).click();
-			await page.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+			await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 
 			// Expect the user to be redirected
 			await page.waitForURL( baseURL + 'google_auth' );
@@ -269,7 +269,7 @@ test.describe( 'Set up accounts', () => {
 						const createAccountButtonFromModal =
 							setUpAccountsPage.getMCCreateAccountButtonFromModal();
 						await createAccountButtonFromModal.click();
-						await page.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+						await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 						const mcConnectedLabel =
 							setUpAccountsPage.getMCConnectedLabel();
 						await expect( mcConnectedLabel ).toContainText(
@@ -330,7 +330,7 @@ test.describe( 'Set up accounts', () => {
 									setUpAccountsPage.getMCCreateAccountButtonFromModal();
 								await createAccountButtonFromModal.click();
 								await page.waitForLoadState(
-									LOAD_STATE.NETWORK_IDLE
+									LOAD_STATE.DOM_CONTENT_LOADED
 								);
 
 								const reclaimButton =
@@ -371,7 +371,7 @@ test.describe( 'Set up accounts', () => {
 									setUpAccountsPage.getReclaimMyURLButton();
 								await reclaimButton.click();
 								await page.waitForLoadState(
-									LOAD_STATE.NETWORK_IDLE
+									LOAD_STATE.DOM_CONTENT_LOADED
 								);
 
 								const mcConnectedLabel =
@@ -471,7 +471,7 @@ test.describe( 'Set up accounts', () => {
 					// Click connect button
 					const connectButton = setUpAccountsPage.getConnectButton();
 					await connectButton.click();
-					await page.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+					await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 
 					const mcConnectedLabel =
 						setUpAccountsPage.getMCConnectedLabel();

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -269,7 +269,9 @@ test.describe( 'Set up accounts', () => {
 						const createAccountButtonFromModal =
 							setUpAccountsPage.getMCCreateAccountButtonFromModal();
 						await createAccountButtonFromModal.click();
-						await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+						await page.waitForLoadState(
+							LOAD_STATE.DOM_CONTENT_LOADED
+						);
 						const mcConnectedLabel =
 							setUpAccountsPage.getMCConnectedLabel();
 						await expect( mcConnectedLabel ).toContainText(
@@ -471,7 +473,9 @@ test.describe( 'Set up accounts', () => {
 					// Click connect button
 					const connectButton = setUpAccountsPage.getConnectButton();
 					await connectButton.click();
-					await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+					await page.waitForLoadState(
+						LOAD_STATE.DOM_CONTENT_LOADED
+					);
 
 					const mcConnectedLabel =
 						setUpAccountsPage.getMCConnectedLabel();

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -13,7 +13,7 @@ test.use( { storageState: process.env.ADMINSTATE } );
 test.describe.configure( { mode: 'serial' } );
 
 /**
- * @type {import('../../utils/pages/setup-mc/step-1-set-up-accounts.js').default} productListingsPage
+ * @type {import('../../utils/pages/setup-mc/step-2-product-listings.js').default} productListingsPage
  */
 let productListingsPage = null;
 

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -180,7 +180,9 @@ test.describe( 'Configure product listings', () => {
 
 		test( 'should see "Minimum order to qualify for free shipping" text if "offer free shipping for order..." is "Yes"', async () => {
 			// Check the "Yes" button of "Offer free shipping for orders".
-			await productListingsPage.checkOfferFreeShippingForOrdersRadioButton( 'Yes' );
+			await productListingsPage.checkOfferFreeShippingForOrdersRadioButton(
+				'Yes'
+			);
 			const minimumOrderForFreeShippingText =
 				productListingsPage.getMinimumOrderForFreeShippingText();
 			await expect( minimumOrderForFreeShippingText ).toBeVisible();
@@ -279,7 +281,7 @@ test.describe( 'Configure product listings', () => {
 
 	test.describe( 'Click "Continue" button', () => {
 		test( 'should see the heading of next step after clicking "Continue"', async () => {
-			await productListingsPage.fillEstimatedShippingRates( '0' );
+			productListingsPage.fillEstimatedShippingRates( '0' );
 			await productListingsPage.fillEstimatedShippingTimes( '14' );
 			await productListingsPage.clickContinueButton();
 			await expect(

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -54,6 +54,20 @@ test.describe( 'Configure product listings', () => {
 			productListingsPage.fulfillWCDefaultCountry( {
 				woocommerce_default_country: 'US',
 			} ),
+
+			// Mock MC settings
+			productListingsPage.fulfillSettings(
+				{
+					shipping_rate: 'automatic',
+					website_live: false,
+					checkout_process_secure: false,
+					payment_methods_visible: false,
+					refund_tos_visible: false,
+					contact_info_visible: false,
+				},
+				200,
+				[ 'GET' ]
+			),
 		] );
 
 		await productListingsPage.goto();
@@ -343,6 +357,12 @@ test.describe( 'Configure product listings', () => {
 				'Successfully added time for country: "US".'
 			);
 		} );
+
+		test( 'should show error message if clicking "Continue" button when tax rate is not chosen', async () => {
+			await productListingsPage.clickContinueButton();
+			const taxRateError = productListingsPage.getTaxRateError();
+			await expect( taxRateError ).toBeVisible();
+		} );
 	} );
 
 	test.describe( 'Links', () => {
@@ -392,6 +412,7 @@ test.describe( 'Configure product listings', () => {
 		test.beforeAll( async () => {
 			productListingsPage.checkRecommendedShippingRateRadioButton();
 			await productListingsPage.fillEstimatedShippingTimes( '14' );
+			await productListingsPage.checkNonDestinationBasedTaxRateRadioButton();
 		} );
 
 		test( 'should see the heading of next step and send two requests after clicking "Continue"', async () => {

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -85,9 +85,12 @@ test.describe( 'Configure product listings', () => {
 		await expect( languageRadioRow ).toBeChecked();
 	} );
 
-	test( 'should not see UK in the country search box', async () => {
+	test( 'should see US but should not see UK in the country search box', async () => {
 		const countrySearchBoxContainer =
 			productListingsPage.getCountryInputSearchBoxContainer();
+		await expect( countrySearchBoxContainer ).toContainText(
+			'United States (US)'
+		);
 		await expect( countrySearchBoxContainer ).not.toContainText(
 			'United Kingdom (UK)'
 		);

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -52,6 +52,8 @@ test.describe( 'Configure product listings', () => {
 				woocommerce_default_country: 'US',
 			} ),
 		] );
+
+		await productListingsPage.goto();
 	} );
 
 	test.afterAll( async () => {
@@ -59,8 +61,6 @@ test.describe( 'Configure product listings', () => {
 	} );
 
 	test( 'should see the heading and the texts below', async () => {
-		await productListingsPage.goto();
-
 		await expect(
 			page.getByRole( 'heading', {
 				name: 'Configure your product listings',
@@ -134,7 +134,7 @@ test.describe( 'Configure product listings', () => {
 		await productListingsPage.fulfillWCDefaultCountry( {
 			woocommerce_default_country: 'TW',
 		} );
-		await productListingsPage.goto();
+		await page.reload();
 
 		// Check the radio button of "Selected countries only" first in order to ensure the country search box is visible.
 		await productListingsPage.checkSelectedCountriesOnlyRadioButton();
@@ -151,7 +151,7 @@ test.describe( 'Configure product listings', () => {
 
 	test.describe( 'Shipping rate is simple', () => {
 		test.beforeAll( async () => {
-			await productListingsPage.goto();
+			await page.reload();
 			await productListingsPage.checkSimpleShippingRateRadioButton();
 		} );
 

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -276,4 +276,18 @@ test.describe( 'Configure product listings', () => {
 			);
 		} );
 	} );
+
+	test.describe( 'Click "Continue" button', () => {
+		test( 'should see the heading of next step after clicking "Continue"', async () => {
+			await productListingsPage.fillEstimatedShippingRates( '0' );
+			await productListingsPage.fillEstimatedShippingTimes( '14' );
+			await productListingsPage.clickContinueButton();
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'Confirm store requirements',
+					exact: true,
+				} )
+			).toBeVisible();
+		} );
+	} );
 } );

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -1,0 +1,275 @@
+/**
+ * Internal dependencies
+ */
+import ProductListingsPage from '../../utils/pages/setup-mc/step-2-product-listings';
+
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/setup-mc/step-1-set-up-accounts.js').default} productListingsPage
+ */
+let productListingsPage = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Configure product listings', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		productListingsPage = new ProductListingsPage( page );
+		await Promise.all( [
+			// Mock Jetpack as connected
+			productListingsPage.mockJetpackConnected(),
+
+			// Mock google as connected.
+			productListingsPage.mockGoogleConnected(),
+
+			// Mock Merchant Center as connected
+			productListingsPage.mockMCConnected(),
+
+			// Mock MC step as product_listings
+			productListingsPage.mockMCSetup( 'incomplete', 'product_listings' ),
+
+			// Mock MC target audience
+			productListingsPage.fulfillTargetAudience( {
+				location: 'selected',
+				countries: [ 'US' ],
+				locale: 'en_US',
+				language: 'English',
+			} ),
+
+			// Mock WC default country as US
+			productListingsPage.fulfillWCDefaultCountry( {
+				woocommerce_default_country: 'US',
+			} ),
+		] );
+	} );
+
+	test.afterAll( async () => {
+		await productListingsPage.closePage();
+	} );
+
+	test( 'should see the heading and the texts below', async () => {
+		await productListingsPage.goto();
+
+		await expect(
+			page.getByRole( 'heading', {
+				name: 'Configure your product listings',
+			} )
+		).toBeVisible();
+
+		await expect(
+			page.getByText(
+				'Your product listings will look something like this.'
+			)
+		).toBeVisible();
+
+		await expect(
+			page.getByText(
+				'our product details, estimated shipping info and tax details will be displayed across Google.'
+			)
+		).toBeVisible();
+	} );
+
+	test( 'should select the default language English', async () => {
+		const languageRadioRow = productListingsPage.getLanguageRadioRow();
+		await expect( languageRadioRow ).toBeChecked();
+	} );
+
+	test( 'should not see UK in the country search box', async () => {
+		const countrySearchBoxContainer =
+			productListingsPage.getCountryInputSearchBoxContainer();
+		await expect( countrySearchBoxContainer ).not.toContainText(
+			'United Kingdom (UK)'
+		);
+	} );
+
+	test( 'should see UK in the country search box after selecting UK', async () => {
+		const countrySearchBoxContainer =
+			productListingsPage.getCountryInputSearchBoxContainer();
+		await expect( countrySearchBoxContainer ).not.toContainText(
+			'United Kingdom (UK)'
+		);
+		await productListingsPage.selectCountryFromSearchBox(
+			'United Kingdom (UK)'
+		);
+		await expect( countrySearchBoxContainer ).toContainText(
+			'United Kingdom (UK)'
+		);
+	} );
+
+	test( 'should hide country search box after clicking "All countries"', async () => {
+		const countrySearchBox = productListingsPage.getCountryInputSearchBox();
+		await expect( countrySearchBox ).toBeVisible();
+		await productListingsPage.checkAllCountriesRadioButton();
+		await expect( countrySearchBox ).not.toBeVisible();
+
+		// Check the radio button of "Selected countries only" first in order to make the country search box visible again.
+		await productListingsPage.checkSelectedCountriesOnlyRadioButton();
+	} );
+
+	test( 'should still see "Tax rate (required for U.S. only)" even if deselect US when the default country is US', async () => {
+		const taxRateSection = productListingsPage.getTaxRateSection();
+		await expect( taxRateSection ).toBeVisible();
+		await productListingsPage.removeCountryFromSearchBox(
+			'United States (US)'
+		);
+		await expect( taxRateSection ).toBeVisible();
+	} );
+
+	test( 'should hide "Tax rate (required for U.S. only)" if deselect US when the default country is not US', async () => {
+		// Mock WC default country as TW, because Tax rate will always be shown if the default country is US.
+		await productListingsPage.fulfillWCDefaultCountry( {
+			woocommerce_default_country: 'TW',
+		} );
+		await productListingsPage.goto();
+
+		// Check the radio button of "Selected countries only" first in order to ensure the country search box is visible.
+		await productListingsPage.checkSelectedCountriesOnlyRadioButton();
+
+		const taxRateSection = productListingsPage.getTaxRateSection();
+		await expect( taxRateSection ).toBeVisible();
+
+		await productListingsPage.removeCountryFromSearchBox(
+			'United States (US)'
+		);
+
+		await expect( taxRateSection ).not.toBeVisible();
+	} );
+
+	test.describe( 'Shipping rate is simple', () => {
+		test.beforeAll( async () => {
+			await productListingsPage.goto();
+			await productListingsPage.checkSimpleShippingRateRadioButton();
+		} );
+
+		test( 'should see "Estimated shipping rates" field', async () => {
+			const estimatedRatesCard =
+				productListingsPage.getEstimatedShippingRatesCard();
+			const estimatedRatesInputBox =
+				productListingsPage.getEstimatedShippingRatesInputBox();
+			await expect( estimatedRatesCard ).toBeVisible();
+			await expect( estimatedRatesInputBox ).toBeVisible();
+		} );
+
+		test( 'should see "Free shipping for all orders" tag if shipping rate is 0', async () => {
+			await productListingsPage.fillEstimatedShippingRates( '0' );
+			const freeShippingForAllOrdersTag =
+				productListingsPage.getFreeShippingForAllOrdersTag();
+			await expect( freeShippingForAllOrdersTag ).toBeVisible();
+		} );
+
+		test( 'should see "I offer free shipping for orders over a certain price" text if shipping rate is > 0', async () => {
+			await productListingsPage.fillEstimatedShippingRates( '1' );
+			const offerFreeShippingForOrdersText =
+				productListingsPage.getOfferFreeShippingForOrdersText();
+			await expect( offerFreeShippingForOrdersText ).toBeVisible();
+		} );
+
+		test( 'should see "Minimum order to qualify for free shipping" text if "offer free shipping for order..." is "Yes"', async () => {
+			await productListingsPage.checkOfferFreeShippingForOrdersYesRadioButton();
+			const minimumOrderForFreeShippingText =
+				productListingsPage.getMinimumOrderForFreeShippingText();
+			await expect( minimumOrderForFreeShippingText ).toBeVisible();
+		} );
+
+		test( 'should show error message if clicking "Continue" button when shipping time is < 0', async () => {
+			await productListingsPage.fillEstimatedShippingTimes( '-1' );
+			await productListingsPage.clickContinueButton();
+			const estimatedTimesError =
+				productListingsPage.getEstimatedShippingTimesError();
+			await expect( estimatedTimesError ).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Shipping rate is complex', () => {
+		let estimatedRatesCard;
+		let estimatedTimesCard;
+
+		test.beforeAll( async () => {
+			// Check simple shipping rate first so we can get "Shipping rates" and "Shipping times" fields.
+			await productListingsPage.checkSimpleShippingRateRadioButton();
+			estimatedRatesCard =
+				productListingsPage.getEstimatedShippingRatesCard();
+			estimatedTimesCard =
+				productListingsPage.getEstimatedShippingTimesCard();
+
+			// Check complex shipping rate
+			await productListingsPage.checkComplexShippingRateRadioButton();
+		} );
+
+		test( 'should not see "Estimated shipping rates" and "Estimated shipping times" field', async () => {
+			await expect( estimatedRatesCard ).not.toBeVisible();
+			await expect( estimatedTimesCard ).not.toBeVisible();
+		} );
+
+		test( 'should see the "Continue" to be enabled', async () => {
+			const continueButton = productListingsPage.getContinueButton();
+			await expect( continueButton ).toBeEnabled();
+		} );
+	} );
+
+	test.describe( 'Shipping rate is recommended', () => {
+		test.beforeAll( async () => {
+			await productListingsPage.checkRecommendedShippingRateRadioButton();
+		} );
+
+		test( 'should see "Estimated shipping times" field', async () => {
+			const estimatedTimesCard =
+				productListingsPage.getEstimatedShippingTimesCard();
+			await expect( estimatedTimesCard ).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Links', () => {
+		test.beforeAll( async () => {
+			// Check simple shipping rate first so we can get "Shipping rates" and "Shipping times" fields.
+			await productListingsPage.checkSimpleShippingRateRadioButton();
+		} );
+
+		test( 'should contain the correct URL for "Read more for Language" link', async () => {
+			const link = productListingsPage.getReadMoreLanguageLink();
+			await expect( link ).toBeVisible();
+			await expect( link ).toHaveAttribute(
+				'href',
+				'https://support.google.com/merchants/answer/160637'
+			);
+		} );
+
+		test( 'should contain the correct URL for "Read more for Shipping Rates" link', async () => {
+			const link = productListingsPage.getReadMoreShippingRatesLink();
+			await expect( link ).toBeVisible();
+			await expect( link ).toHaveAttribute(
+				'href',
+				'https://support.google.com/merchants/answer/7050921'
+			);
+		} );
+
+		test( 'should contain the correct URL for "Read more for Shipping Times" link', async () => {
+			const link = productListingsPage.getReadMoreShippingTimesLink();
+			await expect( link ).toBeVisible();
+			await expect( link ).toHaveAttribute(
+				'href',
+				'https://support.google.com/merchants/answer/7050921'
+			);
+		} );
+
+		test( 'should contain the correct URL for "Read more for Tax Rate" link', async () => {
+			const link = productListingsPage.getReadMoreTaxRateLink();
+			await expect( link ).toBeVisible();
+			await expect( link ).toHaveAttribute(
+				'href',
+				'https://support.google.com/merchants/answer/160162'
+			);
+		} );
+	} );
+} );

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -179,7 +179,8 @@ test.describe( 'Configure product listings', () => {
 		} );
 
 		test( 'should see "Minimum order to qualify for free shipping" text if "offer free shipping for order..." is "Yes"', async () => {
-			await productListingsPage.checkOfferFreeShippingForOrdersYesRadioButton();
+			// Check the "Yes" button of "Offer free shipping for orders".
+			await productListingsPage.checkOfferFreeShippingForOrdersRadioButton( 'Yes' );
 			const minimumOrderForFreeShippingText =
 				productListingsPage.getMinimumOrderForFreeShippingText();
 			await expect( minimumOrderForFreeShippingText ).toBeVisible();

--- a/tests/e2e/utils/constants.js
+++ b/tests/e2e/utils/constants.js
@@ -1,4 +1,3 @@
 export const LOAD_STATE = {
-	NETWORK_IDLE: 'networkidle',
 	DOM_CONTENT_LOADED: 'domcontentloaded',
 };

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -31,7 +31,7 @@ export async function singleProductAddToCart( page, productID ) {
 	).toBeVisible();
 
 	// Wait till all tracking event request have been sent after page reloaded.
-	await page.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+	await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 }
 
 /**

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -14,20 +14,28 @@ export default class MockRequests {
 	/**
 	 * Fulfill a request with a payload.
 	 *
-	 * @param {RegExp|string}  url The url to fulfill.
-	 * @param {Object} payload The payload to send.
-	 * @param {number} status  The HTTP status in the response.
+	 * @param {RegExp|string} url      The url to fulfill.
+	 * @param {Object}        payload  The payload to send.
+	 * @param {number}        status   The HTTP status in the response.
+	 * @param {Array}         methods  The HTTP methods in the request to be fulfill.
 	 * @return {Promise<void>}
 	 */
-	async fulfillRequest( url, payload, status = 200 ) {
-		await this.page.route( url, ( route ) =>
-			route.fulfill( {
-				status,
-				content: 'application/json',
-				headers: { 'Access-Control-Allow-Origin': '*' },
-				body: JSON.stringify( payload ),
-			} )
-		);
+	async fulfillRequest( url, payload, status = 200, methods = [] ) {
+		await this.page.route( url, ( route ) => {
+			if (
+				methods.length === 0 ||
+				methods.includes( route.request().method() )
+			) {
+				route.fulfill( {
+					status,
+					content: 'application/json',
+					headers: { 'Access-Control-Allow-Origin': '*' },
+					body: JSON.stringify( payload ),
+				} );
+			} else {
+				route.continue();
+			}
+		} );
 	}
 
 	/**
@@ -60,12 +68,15 @@ export default class MockRequests {
 	 * Fulfill the Target Audience request.
 	 *
 	 * @param {Object} payload
+	 * @param {Array} methods
 	 * @return {Promise<void>}
 	 */
-	async fulfillTargetAudience( payload ) {
+	async fulfillTargetAudience( payload, methods = [] ) {
 		await this.fulfillRequest(
 			/\/wc\/gla\/mc\/target_audience\b/,
-			payload
+			payload,
+			200,
+			methods
 		);
 	}
 

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -194,6 +194,23 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the Settings request.
+	 *
+	 * @param {Object} payload
+	 * @param {number} status
+	 * @param {Array}  methods
+	 * @return {Promise<void>}
+	 */
+	async fulfillSettings( payload, status = 200, methods = [] ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/settings\b/,
+			payload,
+			status,
+			methods
+		);
+	}
+
+	/**
 	 * Fulfill the Sync Settings Connection request.
 	 *
 	 * @param {Object} payload

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -31,6 +31,19 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the WC options default country request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillWCDefaultCountry( payload ) {
+		await this.fulfillRequest(
+			/wc-admin\/options\?options=woocommerce_default_country\b/,
+			payload
+		);
+	}
+
+	/**
 	 * Fulfill the MC Report Program request.
 	 *
 	 * @param {Object} payload
@@ -52,6 +65,19 @@ export default class MockRequests {
 	async fulfillTargetAudience( payload ) {
 		await this.fulfillRequest(
 			/\/wc\/gla\/mc\/target_audience\b/,
+			payload
+		);
+	}
+
+	/**
+	 * Fulfill the Target Audience suggestions request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillTargetAudienceSuggestions( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/target_audience\/suggestions\b/,
 			payload
 		);
 	}
@@ -94,6 +120,16 @@ export default class MockRequests {
 	 */
 	async fulfillMCConnection( payload ) {
 		await this.fulfillRequest( /\/wc\/gla\/mc\/connection\b/, payload );
+	}
+
+	/**
+	 * Fulfill the MC setup request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillMCSetup( payload ) {
+		await this.fulfillRequest( /\/wc\/gla\/mc\/setup\b/, payload );
 	}
 
 	/**
@@ -317,6 +353,19 @@ export default class MockRequests {
 			subaccount: null,
 			name: null,
 			domain: null,
+		} );
+	}
+
+	/**
+	 * Mock MC setup.
+	 *
+	 * @param {string} status
+	 * @param {string} step
+	 */
+	async mockMCSetup( status = 'incomplete', step = 'accounts' ) {
+		await this.fulfillMCSetup( {
+			status,
+			step,
 		} );
 	}
 }

--- a/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
+++ b/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
@@ -33,7 +33,7 @@ export default class SetUpAccountsPage extends MockRequests {
 	async goto() {
 		await this.page.goto(
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc',
-			{ waitUntil: LOAD_STATE.NETWORK_IDLE }
+			{ waitUntil: LOAD_STATE.DOM_CONTENT_LOADED }
 		);
 	}
 

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -33,7 +33,7 @@ export default class ProductListingsPage extends MockRequests {
 	async goto() {
 		await this.page.goto(
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc&google-mc=connected',
-			{ waitUntil: LOAD_STATE.NETWORK_IDLE }
+			{ waitUntil: LOAD_STATE.DOM_CONTENT_LOADED }
 		);
 	}
 

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -360,6 +360,45 @@ export default class ProductListingsPage extends MockRequests {
 	}
 
 	/**
+	 * Register the requests when the continue button is clicked.
+	 *
+	 * @return {Promise<import('@playwright/test').Request[]>} The requests.
+	 */
+	registerContinueRequests() {
+		const contactInfoRequestPromise = this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/mc/contact-information' ) &&
+				request.method() === 'GET'
+		);
+
+		const policyCheckRequestPromise = this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/mc/policy_check' ) &&
+				request.method() === 'GET'
+		);
+
+		return Promise.all( [
+			contactInfoRequestPromise,
+			policyCheckRequestPromise,
+		] );
+	}
+
+	/**
+	 * Register settings request when the shipping rate radio button is checked.
+	 *
+	 * @param {string} shippingRate
+	 * @return {Promise<import('@playwright/test').Request>} The requests.
+	 */
+	registerShippingRateRadioButtonRequests( shippingRate ) {
+		return this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/mc/settings' ) &&
+				request.method() === 'POST' &&
+				request.postDataJSON().shipping_rate === shippingRate
+		);
+	}
+
+	/**
 	 * Click "Continue" button.
 	 *
 	 * @return {Promise<void>}

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -112,6 +112,8 @@ export default class ProductListingsPage extends MockRequests {
 	/**
 	 * Get offer free shipping for orders button.
 	 *
+	 * @param {string} name
+	 *
 	 * @return {import('@playwright/test').Locator} Get offer free shipping for orders button.
 	 */
 	getOfferFreeShippingForOrdersRadioRow( name = 'Yes' ) {
@@ -457,6 +459,8 @@ export default class ProductListingsPage extends MockRequests {
 
 	/**
 	 * Check offer free shipping for order "Yes" radio button.
+	 *
+	 * @param {string} name
 	 *
 	 * @return {Promise<void>}
 	 */

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -1,0 +1,514 @@
+/**
+ * Internal dependencies
+ */
+import { LOAD_STATE } from '../../constants';
+import MockRequests from '../../mock-requests';
+
+/**
+ * Configure product listings page object class.
+ */
+export default class ProductListingsPage extends MockRequests {
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 */
+	constructor( page ) {
+		super( page );
+		this.page = page;
+	}
+
+	/**
+	 * Close the current page.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async closePage() {
+		await this.page.close();
+	}
+
+	/**
+	 * Go to the set up mc page.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async goto() {
+		await this.page.goto(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc&google-mc=connected',
+			{ waitUntil: LOAD_STATE.NETWORK_IDLE }
+		);
+	}
+
+	/**
+	 * Get language radio row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get language radio row.
+	 */
+	getLanguageRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'English',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get selected countries only radio row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get selected countries only radio row.
+	 */
+	getSelectedCountriesOnlyRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'Selected countries only',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get all countries radio row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get all countries radio row.
+	 */
+	getAllCountriesRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'All countries',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get recommended shipping rate radio row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get recommended shipping rate radio row.
+	 */
+	getRecommendedShippingRateRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'Recommended: Automatically sync my store’s shipping settings to Google.',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get simple shipping rate radio row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get simple shipping rate radio row.
+	 */
+	getSimpleShippingRateRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'My shipping settings are simple. I can manually estimate flat shipping rates.',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get complex shipping rate radio row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get complex shipping rate radio row.
+	 */
+	getComplexShippingRateRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get offer free shipping for order "Yes" button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get offer free shipping for order "Yes" button.
+	 */
+	getOfferFreeShippingForOrdersYesRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'Yes',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get offer free shipping for order "No" button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get offer free shipping for order "No" button.
+	 */
+	getOfferFreeShippingForOrdersNoRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'No',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get country input search box container.
+	 *
+	 * @return {import('@playwright/test').Locator} Get country input search box container.
+	 */
+	getCountryInputSearchBoxContainer() {
+		return this.page.locator(
+			'.woocommerce-tree-select-control > .components-base-control'
+		);
+	}
+
+	/**
+	 * Get country input search box.
+	 *
+	 * @return {import('@playwright/test').Locator} Get country input search box.
+	 */
+	getCountryInputSearchBox() {
+		return this.getCountryInputSearchBoxContainer().locator(
+			'input[id*="woocommerce-tree-select-control"]'
+		);
+	}
+
+	/**
+	 * Get tree item by country name.
+	 *
+	 * @param {string} name
+	 *
+	 * @return {import('@playwright/test').Locator} Get tree item by country name.
+	 */
+	getTreeItemByCountryName( name = 'United States (US)' ) {
+		return this.page.getByRole( 'treeitem', { name } );
+	}
+
+	/**
+	 * Get remove country button by country name.
+	 *
+	 * @param {string} name
+	 *
+	 * @return {import('@playwright/test').Locator} Get tree item by country name.
+	 */
+	getRemoveCountryButtonByName( name = 'United States (US)' ) {
+		return this.page.getByRole( 'button', { name: `Remove ${ name }` } );
+	}
+
+	/**
+	 * Get shipping rates section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get shipping rates section.
+	 */
+	getShippingRatesSection() {
+		return this.page
+			.locator( 'section' )
+			.filter( { hasText: 'Shipping rates' } );
+	}
+
+	/**
+	 * Get shipping times section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get shipping times section.
+	 */
+	getShippingTimesSection() {
+		return this.page
+			.locator( 'section' )
+			.filter( { hasText: 'Shipping times' } );
+	}
+
+	/**
+	 * Get tax rate section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get tax rate section.
+	 */
+	getTaxRateSection() {
+		return this.page
+			.locator( 'section' )
+			.filter( { hasText: 'Tax rate (required for U.S. only)' } );
+	}
+
+	/**
+	 * Get audience card.
+	 *
+	 * @return {import('@playwright/test').Locator} Get audience card.
+	 */
+	getAudienceCard() {
+		return this.page
+			.locator( '.components-card' )
+			.filter( { hasText: 'Selected countries only' } );
+	}
+
+	/**
+	 * Get estimated shipping rates card.
+	 *
+	 * @return {import('@playwright/test').Locator} Get estimated shipping rates card.
+	 */
+	getEstimatedShippingRatesCard() {
+		return this.page
+			.locator( '.components-card' )
+			.filter( { hasText: 'Estimated shipping rates' } );
+	}
+
+	/**
+	 * Get estimated shipping times card.
+	 *
+	 * @return {import('@playwright/test').Locator} Get estimated shipping times card.
+	 */
+	getEstimatedShippingTimesCard() {
+		return this.page
+			.locator( '.components-card' )
+			.filter( { hasText: 'Estimated shipping times' } );
+	}
+
+	/**
+	 * Get estimated shipping rates input box.
+	 *
+	 * @return {import('@playwright/test').Locator} Get estimated shipping rates input box.
+	 */
+	getEstimatedShippingRatesInputBox() {
+		return this.getEstimatedShippingRatesCard().locator(
+			'input[id*="inspector-input-control"]'
+		);
+	}
+
+	/**
+	 * Get estimated shipping times input box.
+	 *
+	 * @return {import('@playwright/test').Locator} Get estimated shipping times input box.
+	 */
+	getEstimatedShippingTimesInputBox() {
+		return this.getEstimatedShippingTimesCard().locator(
+			'input[id*="inspector-input-control"]'
+		);
+	}
+
+	/**
+	 * Get estimated shipping times error.
+	 *
+	 * @return {import('@playwright/test').Locator} Get estimated shipping times error.
+	 */
+	getEstimatedShippingTimesError() {
+		return this.getEstimatedShippingTimesCard().getByText(
+			'Please specify estimated shipping times for all the countries, and the time cannot be less than 0'
+		);
+	}
+
+	/**
+	 * Get "Free shipping for all orders" tag.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Free shipping for all orders" tag.
+	 */
+	getFreeShippingForAllOrdersTag() {
+		return this.getEstimatedShippingRatesCard().getByText(
+			'Free shipping for all orders'
+		);
+	}
+
+	/**
+	 * Get "I offer free shipping for orders over a certain price" text.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "I offer free shipping for orders over a certain price" text.
+	 */
+	getOfferFreeShippingForOrdersText() {
+		return this.page.getByText(
+			'I offer free shipping for orders over a certain price'
+		);
+	}
+
+	/**
+	 * Get "Minimum order to qualify for free shipping" text.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Minimum order to qualify for free shipping" text.
+	 */
+	getMinimumOrderForFreeShippingText() {
+		return this.page.getByText(
+			'Minimum order to qualify for free shipping'
+		);
+	}
+
+	/**
+	 * Get "Continue" button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Continue" button.
+	 */
+	getContinueButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Continue',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get "Read more" for Language link.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Read more" for Language link.
+	 */
+	getReadMoreLanguageLink() {
+		return this.getAudienceCard().getByRole( 'link', {
+			name: 'Read more',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get "Read more" for Shipping rates link.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Read more" for Shipping rates link.
+	 */
+	getReadMoreShippingRatesLink() {
+		return this.getShippingRatesSection().getByRole( 'link', {
+			name: 'Read more',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get "Read more" for Shipping times link.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Read more" for Shipping times link.
+	 */
+	getReadMoreShippingTimesLink() {
+		return this.getShippingTimesSection().getByRole( 'link', {
+			name: 'Read more',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get "Read more" for Tax rate link.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Read more" for Tax rate link.
+	 */
+	getReadMoreTaxRateLink() {
+		return this.getTaxRateSection().getByRole( 'link', {
+			name: 'Read more',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Click "Continue" button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickContinueButton() {
+		const continueButton = this.getContinueButton();
+		await continueButton.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Select a country from the search box.
+	 *
+	 * @param {string} name
+	 *
+	 * @return {Promise<void>}
+	 */
+	async selectCountryFromSearchBox( name = 'United States (US)' ) {
+		const countrySearchBox = this.getCountryInputSearchBox();
+		await countrySearchBox.fill( name );
+		await this.getTreeItemByCountryName( name ).click();
+		await countrySearchBox.press( 'Escape' );
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Remove a country from the search box.
+	 *
+	 * @param {string} name
+	 *
+	 * @return {Promise<void>}
+	 */
+	async removeCountryFromSearchBox( name = 'United States (US)' ) {
+		const removeButton = this.getRemoveCountryButtonByName( name );
+		await removeButton.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Check all countries radio button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async checkAllCountriesRadioButton() {
+		const allCountriesRadioRow = this.getAllCountriesRadioRow();
+		await allCountriesRadioRow.check();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Check selected countries only radio button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async checkSelectedCountriesOnlyRadioButton() {
+		const selectedCountriesOnlyRadioButton =
+			this.getSelectedCountriesOnlyRadioRow();
+		await selectedCountriesOnlyRadioButton.check();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Check recommended shipping rate radio button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async checkRecommendedShippingRateRadioButton() {
+		const recommendedShippingRateRadioButton =
+			this.getRecommendedShippingRateRadioRow();
+		await recommendedShippingRateRadioButton.check();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Check simple shipping rate radio button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async checkSimpleShippingRateRadioButton() {
+		const simpleShippingRateRadioButton =
+			this.getSimpleShippingRateRadioRow();
+		await simpleShippingRateRadioButton.check();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Check simple shipping rate radio button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async checkComplexShippingRateRadioButton() {
+		const complexShippingRateRadioButton =
+			this.getComplexShippingRateRadioRow();
+		await complexShippingRateRadioButton.check();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Check offer free shipping for order "Yes" radio button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async checkOfferFreeShippingForOrdersYesRadioButton() {
+		const yesRadio = this.getOfferFreeShippingForOrdersYesRadioRow();
+		await yesRadio.check();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Fill estimated shipping rates.
+	 *
+	 * @param {string} rate
+	 *
+	 * @return {Promise<void>}
+	 */
+	async fillEstimatedShippingRates( rate = '0' ) {
+		const estimatedRatesInputBox = this.getEstimatedShippingRatesInputBox();
+		await estimatedRatesInputBox.fill( rate );
+
+		// A hack to finish typing in the input box, similar to pressing anywhere in the page.
+		await estimatedRatesInputBox.press( 'Tab' );
+
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Fill estimated shipping times.
+	 *
+	 * @param {string} days
+	 *
+	 * @return {Promise<void>}
+	 */
+	async fillEstimatedShippingTimes( days = '0' ) {
+		const estimatedTimesInputBox = this.getEstimatedShippingTimesInputBox();
+		await estimatedTimesInputBox.fill( days );
+
+		// A hack to finish typing in the input box, similar to pressing anywhere in the page.
+		await estimatedTimesInputBox.press( 'Tab' );
+
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+}

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -124,6 +124,30 @@ export default class ProductListingsPage extends MockRequests {
 	}
 
 	/**
+	 * Get destination-based tax rate radio row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get destination-based tax rate radio row.
+	 */
+	getDestinationBasedTaxRateRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'My store uses destination-based tax rates.',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get non-destination-based tax rate radio row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get non-destination-based tax rate radio row.
+	 */
+	getNonDestinationBasedTaxRateRadioRow() {
+		return this.page.getByRole( 'radio', {
+			name: 'My store does not use destination-based tax rates.',
+			exact: true,
+		} );
+	}
+
+	/**
 	 * Get country input search box container.
 	 *
 	 * @return {import('@playwright/test').Locator} Get country input search box container.
@@ -263,6 +287,17 @@ export default class ProductListingsPage extends MockRequests {
 	getEstimatedShippingTimesError() {
 		return this.getEstimatedShippingTimesCard().getByText(
 			'Please specify estimated shipping times for all the countries, and the time cannot be less than 0'
+		);
+	}
+
+	/**
+	 * Get tax rate error.
+	 *
+	 * @return {import('@playwright/test').Locator} Get tax rate error.
+	 */
+	getTaxRateError() {
+		return this.getTaxRateSection().getByText(
+			'Please specify tax rate option.'
 		);
 	}
 
@@ -505,6 +540,28 @@ export default class ProductListingsPage extends MockRequests {
 	 */
 	async checkOfferFreeShippingForOrdersRadioButton( name = 'Yes' ) {
 		const radio = this.getOfferFreeShippingForOrdersRadioRow( name );
+		await radio.check();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Check destination-based tax rate radio button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async checkDestinationBasedTaxRateRadioButton() {
+		const radio = this.getDestinationBasedTaxRateRadioRow();
+		await radio.check();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Check non-destination-based tax rate radio button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async checkNonDestinationBasedTaxRateRadioButton() {
+		const radio = this.getNonDestinationBasedTaxRateRadioRow();
 		await radio.check();
 		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -110,25 +110,13 @@ export default class ProductListingsPage extends MockRequests {
 	}
 
 	/**
-	 * Get offer free shipping for order "Yes" button.
+	 * Get offer free shipping for orders button.
 	 *
-	 * @return {import('@playwright/test').Locator} Get offer free shipping for order "Yes" button.
+	 * @return {import('@playwright/test').Locator} Get offer free shipping for orders button.
 	 */
-	getOfferFreeShippingForOrdersYesRadioRow() {
+	getOfferFreeShippingForOrdersRadioRow( name = 'Yes' ) {
 		return this.page.getByRole( 'radio', {
-			name: 'Yes',
-			exact: true,
-		} );
-	}
-
-	/**
-	 * Get offer free shipping for order "No" button.
-	 *
-	 * @return {import('@playwright/test').Locator} Get offer free shipping for order "No" button.
-	 */
-	getOfferFreeShippingForOrdersNoRadioRow() {
-		return this.page.getByRole( 'radio', {
-			name: 'No',
+			name,
 			exact: true,
 		} );
 	}
@@ -472,9 +460,9 @@ export default class ProductListingsPage extends MockRequests {
 	 *
 	 * @return {Promise<void>}
 	 */
-	async checkOfferFreeShippingForOrdersYesRadioButton() {
-		const yesRadio = this.getOfferFreeShippingForOrdersYesRadioRow();
-		await yesRadio.check();
+	async checkOfferFreeShippingForOrdersRadioButton( name = 'Yes' ) {
+		const radio = this.getOfferFreeShippingForOrdersRadioRow( name );
+		await radio.check();
 		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}
 

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -171,7 +171,7 @@ export default class ProductListingsPage extends MockRequests {
 	 *
 	 * @param {string} name
 	 *
-	 * @return {import('@playwright/test').Locator} Get tree item by country name.
+	 * @return {import('@playwright/test').Locator} Get remove country button by country name.
 	 */
 	getRemoveCountryButtonByName( name = 'United States (US)' ) {
 		return this.page.getByRole( 'button', { name: `Remove ${ name }` } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of #2070, this PR adds E2E tests for [📌 Onboarding Step 2 - Configure product listings][1].

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow these steps to set up the e2e env: https://github.com/woocommerce/google-listings-and-ads#e2e-testing
2. Run `npm run test:e2e -- ./tests/e2e/specs/setup-mc/step-2-product-listings.test.js`, the test should pass.
3. Or, run `npm run test:e2e-dev -- ./tests/e2e/specs/setup-mc/step-2-product-listings.test.js`, check the test in the chromium step by step.
4. Run `npm run test:e2e` to make sure all tests are passed.

### Changelog entry

> Dev - E2E - Onboarding Step 2 - Configure product listings

[1]: https://github.com/woocommerce/google-listings-and-ads/issues/2070#onboarding-step-2