### PR TITLE
E2E tests: Onboarding Step 3 - Confirm store requirements

### DIFF
--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -390,6 +390,8 @@ test.describe( 'Configure product listings', () => {
 
 	test.describe( 'Click "Continue" button', () => {
 		test.beforeAll( async () => {
+			// Mock MC contact information
+			productListingsPage.mockContactInformation();
 			productListingsPage.checkRecommendedShippingRateRadioButton();
 			await productListingsPage.fillEstimatedShippingTimes( '14' );
 		} );

--- a/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
@@ -213,6 +213,36 @@ test.describe( 'Confirm store requirements', () => {
 		} );
 	} );
 
+	test.describe( 'Links', () => {
+		test( 'should contain the correct URL for "Learn more" link', async () => {
+			const link = storeRequirements.getLearnMoreLink();
+			await expect( link ).toBeVisible();
+			await expect( link ).toHaveAttribute(
+				'href',
+				'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information'
+			);
+		} );
+
+		test( 'should contain the correct URL for "Read Google Merchant Center requirements" link', async () => {
+			const link =
+				storeRequirements.getReadGoogleMerchantCenterRequirementsLink();
+			await expect( link ).toBeVisible();
+			await expect( link ).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/google-listings-and-ads/compliance-policy'
+			);
+		} );
+
+		test( 'should contain the correct URL for "WooCommerce settings" link', async () => {
+			const link = storeRequirements.getWooCommerceSettingsLink();
+			await expect( link ).toBeVisible();
+			await expect( link ).toHaveAttribute(
+				'href',
+				'admin.php?page=wc-settings'
+			);
+		} );
+	} );
+
 	test.describe( 'Pre-Launch Checklist', () => {
 		test.beforeAll( async () => {
 			// Mock MC contact information

--- a/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
@@ -1,0 +1,173 @@
+/**
+ * External dependencies
+ */
+import { parsePhoneNumberFromString as parsePhoneNumber } from 'libphonenumber-js';
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import StoreRequirements from '../../utils/pages/setup-mc/step-3-confirm-store-requirements';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/setup-mc/step-1-set-up-accounts.js').default} storeRequirements
+ */
+let storeRequirements = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Confirm store requirements', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		storeRequirements = new StoreRequirements( page );
+		await Promise.all( [
+			// Mock Jetpack as connected
+			storeRequirements.mockJetpackConnected(),
+
+			// Mock google as connected.
+			storeRequirements.mockGoogleConnected(),
+
+			// Mock Merchant Center as connected
+			storeRequirements.mockMCConnected(),
+
+			// Mock MC step as store_requirements
+			storeRequirements.mockMCSetup( 'incomplete', 'store_requirements' ),
+
+			// Mock MC contact information
+			storeRequirements.mockContactInformation(),
+		] );
+	} );
+
+	test.afterAll( async () => {
+		await storeRequirements.closePage();
+	} );
+
+	test( 'should see the heading and the texts below', async () => {
+		await storeRequirements.goto();
+
+		await expect(
+			page.getByRole( 'heading', {
+				name: 'Confirm store requirements',
+			} )
+		).toBeVisible();
+
+		await expect(
+			page.getByText(
+				'Review and confirm that your store meets Google Merchant Center requirements.'
+			)
+		).toBeVisible();
+	} );
+
+	test.describe( 'Phone verification', () => {
+		test.beforeAll( async () => {
+			await storeRequirements.fulfillPhoneVerificationRequest( {
+				verification_id: 'abc-123-def',
+			} );
+		} );
+
+		test( 'should see the correct texts in phone verification card', async () => {
+			const phoneNumberDescriptionRow =
+				storeRequirements.getPhoneNumberDescriptionRow();
+			await expect( phoneNumberDescriptionRow ).toContainText(
+				'Please enter a phone number to be used for verification.'
+			);
+		} );
+
+		test( 'should see the "Send verfication code" button to be disabled', async () => {
+			const sendCodeButton =
+				storeRequirements.getSendVerificationCodeButton();
+			await expect( sendCodeButton ).toBeDisabled();
+		} );
+
+		test( 'should see the "Send verfication code" button to be disabled when enter a phone number with wrong format', async () => {
+			const sendCodeButton =
+				storeRequirements.getSendVerificationCodeButton();
+			await storeRequirements.selectCountryCodeOption(
+				'United States (US) (+1)'
+			);
+			await expect( sendCodeButton ).toBeDisabled();
+			await storeRequirements.fillPhoneNumber( '9999999999' );
+			await expect( sendCodeButton ).toBeDisabled();
+		} );
+
+		test( 'should see the "Send verfication code" button to be enabled when country code and phone number are entered', async () => {
+			const sendCodeButton =
+				storeRequirements.getSendVerificationCodeButton();
+			await storeRequirements.selectCountryCodeOption(
+				'United States (US) (+1)'
+			);
+			await expect( sendCodeButton ).toBeDisabled();
+			await storeRequirements.fillPhoneNumber( '8888888888' );
+			await expect( sendCodeButton ).toBeEnabled();
+		} );
+
+		test( 'should see "Verify phone number" button is disabled after clicking "Send verification code" button', async () => {
+			await storeRequirements.clickSendVerificationCodeButton();
+			const verifyNumberButton =
+				storeRequirements.getVerifyPhoneNumberButton();
+			await expect( verifyNumberButton ).toBeDisabled();
+		} );
+
+		test( 'should see "Verify phone number" button is enabled after entering the verification code', async () => {
+			await storeRequirements.fillVerificationCode();
+			const verifyNumberButton =
+				storeRequirements.getVerifyPhoneNumberButton();
+			await expect( verifyNumberButton ).toBeEnabled();
+		} );
+
+		test( 'should see an error notice after entering wrong verification code', async () => {
+			// Mock phone verification request as failed
+			await storeRequirements.fulfillPhoneVerificationVerifyRequest(
+				{
+					message: '[verificationCode] Wrong code.',
+					reason: 'badRequest',
+				},
+				400
+			);
+			await storeRequirements.clickVerifyPhoneNumberButon();
+
+			const errorNotice =
+				storeRequirements.getPhoneNumberErrorNotice();
+			await expect( errorNotice ).toContainText(
+				'Wrong verification code. Please try again.'
+			);
+		} );
+
+		test( 'should see phone number and the "Edit" button after entering correct verification code', async () => {
+			// Mock MC contact information
+			await storeRequirements.mockContactInformation( {
+				phoneNumber: '+18888888888',
+				phoneVerificationStatus: 'verified',
+			} );
+
+			// Mock phone verification request as successful
+			await storeRequirements.fulfillPhoneVerificationVerifyRequest(
+				null,
+				204
+			);
+
+			await storeRequirements.fillVerificationCode( '654321' );
+			await storeRequirements.clickVerifyPhoneNumberButon();
+
+			const parsedNumber = parsePhoneNumber( '8888888888', 'US' );
+			const expectedNumber = parsedNumber.formatInternational();
+
+			const phoneNumberDescriptionRow =
+				storeRequirements.getPhoneNumberDescriptionRow();
+			await expect( phoneNumberDescriptionRow ).toContainText(
+				expectedNumber
+			);
+
+			const phoneNumberEditButton =
+				storeRequirements.getPhoneNumberEditButton();
+			await expect( phoneNumberEditButton ).toBeVisible();
+		} );
+	} );
+} );

--- a/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
@@ -15,7 +15,7 @@ test.use( { storageState: process.env.ADMINSTATE } );
 test.describe.configure( { mode: 'serial' } );
 
 /**
- * @type {import('../../utils/pages/setup-mc/step-1-set-up-accounts.js').default} storeRequirements
+ * @type {import('../../utils/pages/setup-mc/step-3-confirm-store-requirements.js').default} storeRequirements
  */
 let storeRequirements = null;
 

--- a/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
@@ -171,6 +171,48 @@ test.describe( 'Confirm store requirements', () => {
 		} );
 	} );
 
+	test.describe( 'Store address', () => {
+		test.beforeAll( async () => {
+			// Mock MC contact information
+			await storeRequirements.mockContactInformation( {
+				phoneNumber: '+18888888888',
+				phoneVerificationStatus: 'verified',
+				streetAddress: 'Automata Road',
+			} );
+			await storeRequirements.goto();
+		} );
+
+		test( 'should see "Refresh to sync" button', async () => {
+			const refreshToSyncButton =
+				storeRequirements.getStoreAddressRefreshToSyncButton();
+			await expect( refreshToSyncButton ).toBeVisible();
+			await expect( refreshToSyncButton ).toBeEnabled();
+		} );
+
+		test( 'should see store address contains "Automata Road"', async () => {
+			const storeAddressCard = storeRequirements.getStoreAddressCard();
+			await expect( storeAddressCard ).toContainText( 'Automata Road' );
+		} );
+
+		test( 'should see store address contains "WooCommerce Road" after clicking "Refresh to sync" button', async () => {
+			// Mock MC contact information
+			await storeRequirements.mockContactInformation( {
+				phoneNumber: '+18888888888',
+				phoneVerificationStatus: 'verified',
+				streetAddress: 'WooCommerce Road',
+			} );
+
+			const refreshToSyncButton =
+				storeRequirements.getStoreAddressRefreshToSyncButton();
+			await refreshToSyncButton.click();
+			await page.waitForLoadState( LOAD_STATE.NETWORK_IDLE );
+			const storeAddressCard = storeRequirements.getStoreAddressCard();
+			await expect( storeAddressCard ).toContainText(
+				'WooCommerce Road'
+			);
+		} );
+	} );
+
 	test.describe( 'Pre-Launch Checklist', () => {
 		test.beforeAll( async () => {
 			// Mock MC contact information

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -183,6 +183,16 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the Settings request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillSettings( payload ) {
+		await this.fulfillRequest( /\/wc\/gla\/mc\/settings\b/, payload );
+	}
+
+	/**
 	 * Fulfill the Sync Settings Connection request.
 	 *
 	 * @param {Object} payload
@@ -231,6 +241,16 @@ export default class MockRequests {
 			payload,
 			status
 		);
+	}
+
+	/**
+	 * Fulfill policy check request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillPolicyCheckRequest( payload ) {
+		await this.fulfillRequest( /\/wc\/gla\/mc\/policy_check\b/, payload );
 	}
 
 	/**

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -197,10 +197,17 @@ export default class MockRequests {
 	 * Fulfill the Settings request.
 	 *
 	 * @param {Object} payload
+	 * @param {number} status
+	 * @param {Array}  methods
 	 * @return {Promise<void>}
 	 */
-	async fulfillSettings( payload ) {
-		await this.fulfillRequest( /\/wc\/gla\/mc\/settings\b/, payload );
+	async fulfillSettings( payload, status = 200, methods = [] ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/settings\b/,
+			payload,
+			status,
+			methods
+		);
 	}
 
 	/**

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -193,6 +193,47 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill contact information request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillContactInformation( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/contact-information\b/,
+			payload
+		);
+	}
+
+	/**
+	 * Fulfill phone verification request request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillPhoneVerificationRequest( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/phone-verification\/request\b/,
+			payload
+		);
+	}
+
+	/**
+	 * Fulfill phone verification verify request.
+	 *
+	 * @param {Object} payload
+	 * @param {number} status
+	 * @return {Promise<void>}
+	 */
+	async fulfillPhoneVerificationVerifyRequest( payload, status = 204 ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/phone-verification\/verify\b/,
+			payload,
+			status
+		);
+	}
+
+	/**
 	 * Mock the request to connect Jetpack
 	 *
 	 * @param {string} url
@@ -366,6 +407,45 @@ export default class MockRequests {
 		await this.fulfillMCSetup( {
 			status,
 			step,
+		} );
+	}
+
+	/**
+	 * Mock contact information.
+	 *
+	 * @param {Object} options
+	 */
+	async mockContactInformation( options = {} ) {
+		const defaultOptions = {
+			id: 12345,
+			phoneNumber: null,
+			phoneVerificationStatus: null,
+			mcAddress: null,
+			streetAddress: 'Automata Road',
+			locality: 'Taipei',
+			region: null,
+			postalCode: '999',
+			country: 'TW',
+			isMCAddressDifferent: true,
+			wcAddressErrors: [],
+		};
+
+		options = { ...defaultOptions, ...options };
+
+		await this.fulfillContactInformation( {
+			id: options.id,
+			phone_number: options.phoneNumber,
+			phone_verification_status: options.phoneVerificationStatus,
+			mc_address: options.mcAddress,
+			wc_address: {
+				street_address: options.streetAddress,
+				locality: options.locality,
+				region: options.region,
+				postal_code: options.postalCode,
+				country: options.country,
+			},
+			is_mc_address_different: options.isMCAddressDifferent,
+			wc_address_errors: options.wcAddressErrors,
 		} );
 	}
 }

--- a/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
+++ b/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
@@ -165,6 +165,56 @@ export default class StoreRequirements extends MockRequests {
 	}
 
 	/**
+	 * Get pre-launch checklist checkboxes.
+	 *
+	 * @return {import('@playwright/test').Locator} Get pre-launch checklist checkboxes.
+	 */
+	getPrelaunchChecklistCheckboxes() {
+		return this.getChecklistCard().getByRole( 'checkbox' );
+	}
+
+	/**
+	 * Get pre-launch checklist panels.
+	 *
+	 * @return {import('@playwright/test').Locator} Get pre-launch checklist panels.
+	 */
+	getPrelaunchChecklistPanels() {
+		return this.getChecklistCard().locator( '.components-panel__body' );
+	}
+
+	/**
+	 * Get pre-launch checklist toggles.
+	 *
+	 * @return {import('@playwright/test').Locator} Get pre-launch checklist toggles.
+	 */
+	getPrelaunchChecklistToggles() {
+		return this.getPrelaunchChecklistPanels().locator(
+			'.components-button.components-panel__body-toggle'
+		);
+	}
+
+	/**
+	 * Get Continue button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get Continue button.
+	 */
+	getContinueButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Continue',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get error message row.
+	 *
+	 * @return {import('@playwright/test').Locator} Get error message row.
+	 */
+	getErrorMessageRow() {
+		return this.page.locator( '.gla-validation-errors' );
+	}
+
+	/**
 	 * Fill country code.
 	 *
 	 * @param {string} code

--- a/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
+++ b/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
@@ -165,6 +165,18 @@ export default class StoreRequirements extends MockRequests {
 	}
 
 	/**
+	 * Get store address refresh to sync button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get store address refresh to sync button.
+	 */
+	getStoreAddressRefreshToSyncButton() {
+		return this.getStoreAddressCard().getByRole( 'button', {
+			name: 'Refresh to sync',
+			exact: true,
+		} );
+	}
+
+	/**
 	 * Get pre-launch checklist checkboxes.
 	 *
 	 * @return {import('@playwright/test').Locator} Get pre-launch checklist checkboxes.

--- a/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
+++ b/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
@@ -227,6 +227,42 @@ export default class StoreRequirements extends MockRequests {
 	}
 
 	/**
+	 * Get learn more link.
+	 *
+	 * @return {import('@playwright/test').Locator} Get learn more link.
+	 */
+	getLearnMoreLink() {
+		return this.page.getByRole( 'link', {
+			name: 'Learn more',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get read google merchant center requirements link.
+	 *
+	 * @return {import('@playwright/test').Locator} Get read google merchant center requirements link.
+	 */
+	getReadGoogleMerchantCenterRequirementsLink() {
+		return this.page.getByRole( 'link', {
+			name: 'Read Google Merchant Center requirements',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get WooCommerce settings link.
+	 *
+	 * @return {import('@playwright/test').Locator} Get WooCommerce settings link.
+	 */
+	getWooCommerceSettingsLink() {
+		return this.page.getByRole( 'link', {
+			name: 'WooCommerce settings',
+			exact: true,
+		} );
+	}
+
+	/**
 	 * Fill country code.
 	 *
 	 * @param {string} code

--- a/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
+++ b/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
@@ -33,7 +33,7 @@ export default class StoreRequirements extends MockRequests {
 	async goto() {
 		await this.page.goto(
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc&google-mc=connected',
-			{ waitUntil: LOAD_STATE.NETWORK_IDLE }
+			{ waitUntil: LOAD_STATE.DOM_CONTENT_LOADED }
 		);
 	}
 

--- a/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
+++ b/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
@@ -1,0 +1,254 @@
+/**
+ * Internal dependencies
+ */
+import { LOAD_STATE } from '../../constants';
+import MockRequests from '../../mock-requests';
+
+/**
+ * Configure product listings page object class.
+ */
+export default class StoreRequirements extends MockRequests {
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 */
+	constructor( page ) {
+		super( page );
+		this.page = page;
+	}
+
+	/**
+	 * Close the current page.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async closePage() {
+		await this.page.close();
+	}
+
+	/**
+	 * Go to the set up mc page.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async goto() {
+		await this.page.goto(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc&google-mc=connected',
+			{ waitUntil: LOAD_STATE.NETWORK_IDLE }
+		);
+	}
+
+	/**
+	 * Get components-card class.
+	 *
+	 * @return {import('@playwright/test').Locator} Get components-card class.
+	 */
+	getComponentsCard() {
+		return this.page.locator( '.components-card' );
+	}
+
+	/**
+	 * Get phone verification card.
+	 *
+	 * @return {import('@playwright/test').Locator} Get phone verification card.
+	 */
+	getPhoneVerificationCard() {
+		return this.getComponentsCard().first();
+	}
+
+	/**
+	 * Get store address card.
+	 *
+	 * @return {import('@playwright/test').Locator} Get store address card.
+	 */
+	getStoreAddressCard() {
+		return this.getComponentsCard().nth( 1 );
+	}
+
+	/**
+	 * Get checklist card.
+	 *
+	 * @return {import('@playwright/test').Locator} Get checklist card.
+	 */
+	getChecklistCard() {
+		return this.getComponentsCard().nth( 2 );
+	}
+
+	/**
+	 * Get phone number description text.
+	 *
+	 * @return {import('@playwright/test').Locator} Get checklist card.
+	 */
+	getPhoneNumberDescriptionRow() {
+		return this.getPhoneVerificationCard().locator(
+			'.gla-account-card__description'
+		);
+	}
+
+	/**
+	 * Get "Send verification code" button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Send verification code" button.
+	 */
+	getSendVerificationCodeButton() {
+		return this.getPhoneVerificationCard().getByRole( 'button', {
+			name: 'Send verification code',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get "Verify phone number" button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get "Verify phone number" button.
+	 */
+	getVerifyPhoneNumberButton() {
+		return this.getPhoneVerificationCard().getByRole( 'button', {
+			name: 'Verify phone number',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get country code input box.
+	 *
+	 * @return {import('@playwright/test').Locator} Get country code input box.
+	 */
+	getCountryCodeInputBox() {
+		return this.getPhoneVerificationCard().locator(
+			'input[id*="woocommerce-select-control"]'
+		);
+	}
+
+	/**
+	 * Get phone number input box.
+	 *
+	 * @return {import('@playwright/test').Locator} Get phone number input box.
+	 */
+	getPhoneNumberInputBox() {
+		return this.getPhoneVerificationCard().locator(
+			'input[id*="inspector-input-control"]'
+		);
+	}
+
+	/**
+	 * Get verification code input boxes.
+	 *
+	 * @return {import('@playwright/test').Locator} Get verification code input box.
+	 */
+	getVerificationCodeInputBoxes() {
+		return this.getPhoneVerificationCard().locator(
+			'.wcdl-subsection .app-input-control input'
+		);
+	}
+
+	/**
+	 * Get phone number error notice.
+	 *
+	 * @return {import('@playwright/test').Locator} Get phone number error notice.
+	 */
+	getPhoneNumberErrorNotice() {
+		return this.getPhoneVerificationCard().locator(
+			'.components-notice.is-error'
+		);
+	}
+
+	/**
+	 * Get phone number edit button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get phone number edit button.
+	 */
+	getPhoneNumberEditButton() {
+		return this.getPhoneVerificationCard().getByRole( 'button', {
+			name: 'Edit',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Fill country code.
+	 *
+	 * @param {string} code
+	 *
+	 * @return {Promise<void>}
+	 */
+	async fillCountryCode( code = 'United States (US) (+1)' ) {
+		const countryCodeInputBox = this.getCountryCodeInputBox();
+		await countryCodeInputBox.fill( code );
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Select country code option.
+	 *
+	 * @param {string} code
+	 *
+	 * @return {Promise<void>}
+	 */
+	async selectCountryCodeOption( code = 'United States (US) (+1)' ) {
+		await this.fillCountryCode( code );
+		const countryCodeOption = this.page.getByRole( 'option', {
+			name: code,
+		} );
+		await countryCodeOption.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Fill phone number.
+	 *
+	 * @param {string} number
+	 *
+	 * @return {Promise<void>}
+	 */
+	async fillPhoneNumber( number = '8888888888' ) {
+		const phoneNumberInputBox = this.getPhoneNumberInputBox();
+		await phoneNumberInputBox.fill( number );
+
+		// A hack to finish typing in the input box, similar to pressing anywhere in the page.
+		await phoneNumberInputBox.press( 'Tab' );
+
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Click send verification code button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickSendVerificationCodeButton() {
+		const sendCodeButton = this.getSendVerificationCodeButton();
+		await sendCodeButton.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Fill verification code.
+	 *
+	 * @param {string} code
+	 *
+	 * @return {Promise<void>}
+	 */
+	async fillVerificationCode( code = '123456' ) {
+		const verificationInputBoxes = this.getVerificationCodeInputBoxes();
+		const count = await verificationInputBoxes.count();
+
+		for ( let i = 0; i < count; i++ ) {
+			const input = await verificationInputBoxes.nth( i );
+			const digit = code[ i ];
+			await input.fill( digit );
+		}
+
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Click verify phone number button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickVerifyPhoneNumberButon() {
+		const verifyPhoneNumberButton = this.getVerifyPhoneNumberButton();
+		await verifyPhoneNumberButton.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+}

--- a/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
+++ b/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
@@ -263,6 +263,29 @@ export default class StoreRequirements extends MockRequests {
 	}
 
 	/**
+	 * Register settings request when the confirm button or checkbox in pre-lauch checklist is checked.
+	 *
+	 * @param {Array} settings
+	 * @return {Promise<import('@playwright/test').Request[]>} The requests.
+	 */
+	registerPrelaunchChecklistConfirmCheckedRequest( settings = [] ) {
+		const promises = [];
+
+		for ( const setting of settings ) {
+			promises.push(
+				this.page.waitForRequest(
+					( request ) =>
+						request.url().includes( '/gla/mc/settings' ) &&
+						request.method() === 'POST' &&
+						request.postDataJSON()[ setting ] === true
+				)
+			);
+		}
+
+		return Promise.all( promises );
+	}
+
+	/**
 	 * Fill country code.
 	 *
 	 * @param {string} code


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of #2070, this PR adds E2E tests for [📌 Onboarding Step 3 - Confirm store requirements][1].

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow these steps to set up the e2e env: https://github.com/woocommerce/google-listings-and-ads#e2e-testing
2. Run `npm run test:e2e -- ./tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js`, the test should pass.
3. Or, run `npm run test:e2e-dev -- ./tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js`, check the test in the chromium step by step.
4. Run `npm run test:e2e` to make sure all tests are passed.

### Changelog entry

> Dev - E2E - Onboarding Step 3 - Confirm store requirements

[1]: https://github.com/woocommerce/google-listings-and-ads/issues/2070#onboarding-step-3