### PR TITLE
Fix undesired margin in Paid Campaign Creation Success modal

### DIFF
--- a/js/src/dashboard/campaign-creation-success-guide/index.scss
+++ b/js/src/dashboard/campaign-creation-success-guide/index.scss
@@ -15,6 +15,8 @@
 		&__content {
 			padding-left: 0;
 			padding-right: 0;
+			padding-top: 0;
+			margin-top: 0;
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes sa bug in Paid Campaign Creation Success Modal. An undesired margin was in the modal.

### Screenshots:

**Before:**

<img width="637" alt="Screenshot 2023-09-13 at 15 52 09" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/2788d15c-e3de-4191-9275-1efaf2616511">

**After:**

<img width="652" alt="Screenshot 2023-09-13 at 16 06 50" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/6201605b-1827-4c4a-8def-2f7bd4ddae3d">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a new PaidCampaign
2. See that the modal looks like the "After" section in screenshots. . 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> FIx - Undesired margin in Paid Campaign Creation Success Modal
