### PR TITLE
E2E - Ads Paid Campaign Step 1 - Connect Ads Account

### DIFF
--- a/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
@@ -120,7 +120,9 @@ test.describe( 'Set up Ads account', () => {
 			).toBeVisible();
 
 			await createAccountButton.click();
+		} );
 
+		test( 'Create account button should be disable if the ToS have not been accepted.', async () => {
 			await expect(
 				page.getByRole( 'heading', {
 					name: 'Create Google Ads Account',
@@ -136,13 +138,17 @@ test.describe( 'Set up Ads account', () => {
 			await expect(
 				setupAdsAccounts.getCreateAdsAccountButtonModal()
 			).toBeDisabled();
+		} );
 
+		test( 'Accept terms and conditions to enable the create account button', async () => {
 			await setupAdsAccounts.getAcceptTermCreateAccount().check();
 
 			await expect(
 				setupAdsAccounts.getCreateAdsAccountButtonModal()
 			).toBeEnabled();
+		} );
 
+		test( 'Create Ads account', async () => {
 			//Intercept Ads connection request
 			const connectAdsAccountRequest =
 				setupAdsAccounts.registerConnectAdsAccountRequests();

--- a/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
@@ -82,7 +82,7 @@ test.describe( 'Set up Ads account', () => {
 			await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 		} );
 
-		test( 'Page header should be Set up your accounts', async () => {
+		test( 'Page header should be "Set up your accounts"', async () => {
 			await expect(
 				page.getByRole( 'heading', { name: 'Set up your accounts' } )
 			).toBeVisible();

--- a/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
@@ -64,14 +64,11 @@ test.describe( 'Set up Ads account', () => {
 	test( 'Dashboard page contains Add Paid campaign buttons', async () => {
 		//Add page campaign in the Performance (Paid Campaigns) section
 		await expect(
-			await dashboardPage.getAdsConnectionAllProgramsButton(
-				'summary-card'
-			)
+			dashboardPage.getAdsConnectionAllProgramsButton( 'summary-card' )
 		).toBeEnabled();
 
 		//Add page campaign in the programs section.
-		adsConnectionButton =
-			await dashboardPage.getAdsConnectionAllProgramsButton();
+		adsConnectionButton = dashboardPage.getAdsConnectionAllProgramsButton();
 		await expect( adsConnectionButton ).toBeEnabled();
 	} );
 
@@ -102,9 +99,7 @@ test.describe( 'Set up Ads account', () => {
 		} );
 
 		test( 'Continue Button should be disabled', async () => {
-			await expect(
-				await setupAdsAccounts.getContinueButton()
-			).toBeDisabled();
+			await expect( setupAdsAccounts.getContinueButton() ).toBeDisabled();
 		} );
 	} );
 
@@ -116,9 +111,7 @@ test.describe( 'Set up Ads account', () => {
 
 			await expect( createAccountButton ).toBeVisible();
 
-			await expect(
-				await setupAdsAccounts.getContinueButton()
-			).toBeDisabled();
+			await expect( setupAdsAccounts.getContinueButton() ).toBeDisabled();
 
 			await expect(
 				page.getByText(
@@ -170,9 +163,7 @@ test.describe( 'Set up Ads account', () => {
 
 			await connectAdsAccountRequest;
 
-			await expect(
-				await setupAdsAccounts.getContinueButton()
-			).toBeEnabled();
+			await expect( setupAdsAccounts.getContinueButton() ).toBeEnabled();
 
 			await expect(
 				page.getByRole( 'link', {
@@ -199,7 +190,7 @@ test.describe( 'Set up Ads account', () => {
 			const adsAccountSelected = `${ ADS_ACCOUNTS[ 1 ].id }`;
 
 			await expect(
-				await setupAdsAccounts.getConnectAdsButton()
+				setupAdsAccounts.getConnectAdsButton()
 			).toBeDisabled();
 
 			await setupAdsAccounts.selectAnExistingAdsAccount(
@@ -207,7 +198,7 @@ test.describe( 'Set up Ads account', () => {
 			);
 
 			await expect(
-				await setupAdsAccounts.getConnectAdsButton()
+				setupAdsAccounts.getConnectAdsButton()
 			).toBeEnabled();
 
 			//Intercept Ads connection request
@@ -227,9 +218,7 @@ test.describe( 'Set up Ads account', () => {
 			await setupAdsAccounts.clickConnectAds();
 			await connectAdsAccountRequest;
 
-			await expect(
-				await setupAdsAccounts.getContinueButton()
-			).toBeEnabled();
+			await expect( setupAdsAccounts.getContinueButton() ).toBeEnabled();
 		} );
 
 		test( 'Continue to create paid campaign', async () => {

--- a/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
@@ -1,0 +1,254 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+/**
+ * Internal dependencies
+ */
+import { clearOnboardedMerchant, setOnboardedMerchant } from '../../utils/api';
+import DashboardPage from '../../utils/pages/dashboard.js';
+import SetupAdsAccountsPage from '../../utils/pages/setup-ads/setup-ads-accounts.js';
+import { LOAD_STATE } from '../../utils/constants';
+
+const ADS_ACCOUNTS = [
+	{
+		id: 1111111,
+		name: 'Test 1',
+	},
+	{
+		id: 2222222,
+		name: 'Test 2',
+	},
+];
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/dashboard.js').default} dashboardPage
+ */
+let dashboardPage = null;
+
+/**
+ * @type {import('../../utils/pages/setup-ads/setup-ads-accounts').default} setupAdsAccounts
+ */
+let setupAdsAccounts = null;
+
+/**
+ * @type {import('@playwright/test').Locator} adsConnectionButton
+ */
+let adsConnectionButton = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Set up Ads account', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		dashboardPage = new DashboardPage( page );
+		setupAdsAccounts = new SetupAdsAccountsPage( page );
+		await setOnboardedMerchant();
+		await setupAdsAccounts.mockAdsAccountsResponse( [] );
+		await dashboardPage.mockRequests();
+		await dashboardPage.goto();
+	} );
+
+	test.afterAll( async () => {
+		await clearOnboardedMerchant();
+		await page.close();
+	} );
+
+	test( 'Dashboard page contains Add Paid campaign buttons', async () => {
+		//Add page campaign in the Performance (Paid Campaigns) section
+		await expect(
+			await dashboardPage.getAdsConnectionAllProgramsButton(
+				'summary-card'
+			)
+		).toBeEnabled();
+
+		//Add page campaign in the programs section.
+		adsConnectionButton =
+			await dashboardPage.getAdsConnectionAllProgramsButton();
+		await expect( adsConnectionButton ).toBeEnabled();
+	} );
+
+	test.describe( 'Set up your accounts page', async () => {
+		test.beforeAll( async () => {
+			await setupAdsAccounts.mockAdsAccountsResponse( [] );
+			await adsConnectionButton.click();
+			await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+		} );
+
+		test( 'Page header should be Set up your accounts', async () => {
+			await expect(
+				page.getByRole( 'heading', { name: 'Set up your accounts' } )
+			).toBeVisible();
+			await expect(
+				page.getByText(
+					'Connect your Google account and your Google Ads account to set up a paid Performance Max campaign.'
+				)
+			).toBeVisible();
+		} );
+
+		test( 'Google Account should show as connected', async () => {
+			await expect(
+				page.getByText(
+					'This Google account is connected to your store’s product feed.'
+				)
+			).toBeVisible();
+		} );
+
+		test( 'Continue Button should be disabled', async () => {
+			await expect(
+				await setupAdsAccounts.getContinueButton()
+			).toBeDisabled();
+		} );
+	} );
+
+	test.describe( 'Add paid campaigns with no Ads account', async () => {
+		test( 'Create an account should be visible', async () => {
+			const createAccountButton = page.getByRole( 'button', {
+				name: 'Create account',
+			} );
+
+			await expect( createAccountButton ).toBeVisible();
+
+			await expect(
+				await setupAdsAccounts.getContinueButton()
+			).toBeDisabled();
+
+			await expect(
+				page.getByText(
+					'Connect with millions of shoppers who are searching for products like yours and drive sales with Google.'
+				)
+			).toBeVisible();
+
+			await createAccountButton.click();
+
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'Create Google Ads Account',
+				} )
+			).toBeVisible();
+
+			await expect(
+				page.getByText(
+					'By creating a Google Ads account, you agree to the following terms and conditions:'
+				)
+			).toBeVisible();
+
+			await expect(
+				setupAdsAccounts.getCreateAdsAccountButtonModal()
+			).toBeDisabled();
+
+			await setupAdsAccounts.getAcceptTermCreateAccount().check();
+
+			await expect(
+				setupAdsAccounts.getCreateAdsAccountButtonModal()
+			).toBeEnabled();
+
+			//Intercept Ads connection request
+			const connectAdsAccountRequest =
+				setupAdsAccounts.registerConnectAdsAccountRequests();
+
+			await setupAdsAccounts.mockAdsAccountsResponse( [
+				ADS_ACCOUNTS[ 1 ],
+			] );
+
+			//Mock request to fulfill Ads connection
+			setupAdsAccounts.fulfillAdsConnection( {
+				id: ADS_ACCOUNTS[ 1 ].id,
+				currency: 'EUR',
+				symbol: '\u20ac',
+				status: 'connected',
+			} );
+
+			await setupAdsAccounts.getCreateAdsAccountButtonModal().click();
+
+			await connectAdsAccountRequest;
+
+			await expect(
+				await setupAdsAccounts.getContinueButton()
+			).toBeEnabled();
+
+			await expect(
+				page.getByRole( 'link', {
+					name: `Account ${ ADS_ACCOUNTS[ 1 ].id }`,
+				} )
+			).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Add paid campaigns with existing Ads accounts', () => {
+		test.beforeAll( async () => {
+			await setupAdsAccounts.mockAdsAccountsResponse( ADS_ACCOUNTS );
+			//Disconnect the account from the previous test
+			setupAdsAccounts.fulfillAdsConnection( {
+				id: ADS_ACCOUNTS[ 1 ].id,
+				currency: 'EUR',
+				symbol: '\u20ac',
+				status: 'disconnected',
+			} );
+			await page.reload();
+		} );
+
+		test( 'Select one existing account', async () => {
+			const adsAccountSelected = `${ ADS_ACCOUNTS[ 1 ].id }`;
+
+			await expect(
+				await setupAdsAccounts.getConnectAdsButton()
+			).toBeDisabled();
+
+			await setupAdsAccounts.selectAnExistingAdsAccount(
+				adsAccountSelected
+			);
+
+			await expect(
+				await setupAdsAccounts.getConnectAdsButton()
+			).toBeEnabled();
+
+			//Intercept Ads connection request
+			const connectAdsAccountRequest =
+				setupAdsAccounts.registerConnectAdsAccountRequests(
+					adsAccountSelected
+				);
+
+			//Mock request to fulfill Ads connection
+			setupAdsAccounts.fulfillAdsConnection( {
+				id: ADS_ACCOUNTS[ 1 ].id,
+				currency: 'EUR',
+				symbol: '\u20ac',
+				status: 'connected',
+			} );
+
+			await setupAdsAccounts.clickConnectAds();
+			await connectAdsAccountRequest;
+
+			await expect(
+				await setupAdsAccounts.getContinueButton()
+			).toBeEnabled();
+		} );
+
+		test( 'Continue to create paid campaign', async () => {
+			await setupAdsAccounts.clickContinue();
+			await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'Create your paid campaign',
+				} )
+			).toBeVisible();
+
+			await expect(
+				page.getByRole( 'heading', { name: 'Ads audience' } )
+			).toBeVisible();
+
+			await expect(
+				page.getByRole( 'heading', { name: 'Set your budget' } )
+			).toBeVisible();
+		} );
+	} );
+} );

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -194,6 +194,16 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the Ads Account request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillAdsAccounts( payload ) {
+		await this.fulfillRequest( /\/wc\/gla\/ads\/accounts\b/, payload );
+	}
+
+	/**
 	 * Fulfill the Sync Settings Connection request.
 	 *
 	 * @param {Object} payload

--- a/tests/e2e/utils/pages/dashboard.js
+++ b/tests/e2e/utils/pages/dashboard.js
@@ -127,4 +127,23 @@ export default class DashboardPage extends MockRequests {
 		const continueToEditButton = await this.getContinueToEditButton();
 		await continueToEditButton.click();
 	}
+
+	/**
+	 * Get the Ads connection button located in the all programs table.
+	 *
+	 * @param  {('programs-table'|'summary-card')} [type] The type of button to get. Either 'programs-table' or 'summary-card'.
+	 * @return {Promise<import('@playwright/test').Locator>} Get the Ads connection button.
+	 */
+	async getAdsConnectionAllProgramsButton( type = 'programs-table' ) {
+		return this.page.locator(
+			`${
+				type === 'programs-table'
+					? '.gla-all-programs-table-card button'
+					: '.gla-summary-card'
+			}`,
+			{
+				hasText: 'Add paid campaign',
+			}
+		);
+	}
 }

--- a/tests/e2e/utils/pages/dashboard.js
+++ b/tests/e2e/utils/pages/dashboard.js
@@ -129,12 +129,12 @@ export default class DashboardPage extends MockRequests {
 	}
 
 	/**
-	 * Get the Ads connection button located in the all programs table.
+	 * Get the Ads connection button.
 	 *
 	 * @param  {('programs-table'|'summary-card')} [type] The type of button to get. Either 'programs-table' or 'summary-card'.
-	 * @return {Promise<import('@playwright/test').Locator>} Get the Ads connection button.
+	 * @return {import('@playwright/test').Locator} Get the Ads connection button.
 	 */
-	async getAdsConnectionAllProgramsButton( type = 'programs-table' ) {
+	getAdsConnectionAllProgramsButton( type = 'programs-table' ) {
 		return this.page.locator(
 			`${
 				type === 'programs-table'

--- a/tests/e2e/utils/pages/dashboard.js
+++ b/tests/e2e/utils/pages/dashboard.js
@@ -63,11 +63,7 @@ export default class DashboardPage extends MockRequests {
 			email: 'john@email.com',
 		} );
 
-		await this.fulfillGoogleConnection( {
-			active: 'yes',
-			email: 'john@email.com',
-			scope: [],
-		} );
+		await this.mockGoogleConnected();
 
 		await this.fulfillAdsConnection( {
 			id: 0,

--- a/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
@@ -15,9 +15,9 @@ export default class SetupAdsAccount extends MockRequests {
 	/**
 	 * Get Continue button.
 	 *
-	 * @return {Promise<import('@playwright/test').Locator>} The Continue button.
+	 * @return {import('@playwright/test').Locator} The Continue button.
 	 */
-	async getContinueButton() {
+	getContinueButton() {
 		return this.page.getByRole( 'button', {
 			name: 'Continue',
 			exact: true,
@@ -27,9 +27,9 @@ export default class SetupAdsAccount extends MockRequests {
 	/**
 	 * Get Connect Account button.
 	 *
-	 * @return {Promise<import('@playwright/test').Locator>} The Connect button.
+	 * @return {import('@playwright/test').Locator} The Connect button.
 	 */
-	async getConnectAdsButton() {
+	getConnectAdsButton() {
 		return this.page.getByRole( 'button', {
 			name: 'Connect',
 			exact: true,
@@ -42,7 +42,7 @@ export default class SetupAdsAccount extends MockRequests {
 	 * @return {Promise<void>}
 	 */
 	async clickContinue() {
-		await ( await this.getContinueButton() ).click();
+		await this.getContinueButton().click();
 	}
 
 	/**
@@ -51,7 +51,7 @@ export default class SetupAdsAccount extends MockRequests {
 	 * @return {Promise<void>}
 	 */
 	async clickConnectAds() {
-		await ( await this.getConnectAdsButton() ).click();
+		await this.getConnectAdsButton().click();
 	}
 
 	/**

--- a/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
@@ -1,0 +1,123 @@
+/**
+ * Internal dependencies
+ */
+import MockRequests from '../../mock-requests';
+
+export default class SetupAdsPage extends MockRequests {
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 */
+	constructor( page ) {
+		super( page );
+		this.page = page;
+	}
+
+	/**
+	 * Get Continues button.
+	 *
+	 * @return {Promise<import('@playwright/test').Locator>} The Continue button.
+	 */
+	async getContinueButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Continue',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get Connect Account button.
+	 *
+	 * @return {Promise<import('@playwright/test').Locator>} The Connect button.
+	 */
+	async getConnectAdsButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Connect',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Click the Continue button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickContinue() {
+		await ( await this.getContinueButton() ).click();
+	}
+
+	/**
+	 * Click the Connect Ads button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickConnectAds() {
+		await ( await this.getConnectAdsButton() ).click();
+	}
+
+	/**
+	 * Selects the ads account.
+	 *
+	 * @param {string} accountNumber The Ads account number.
+	 * @return {Promise<void>}
+	 */
+	async selectAnExistingAdsAccount( accountNumber ) {
+		await this.page
+			.locator( '.gla-connect-ads select' )
+			.selectOption( accountNumber );
+	}
+
+	/**
+	 * Mock the Ads accounts response.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async mockAdsAccountsResponse( payload ) {
+		await this.fulfillAdsAccounts( payload );
+	}
+
+	getCreateAccountModal() {
+		return this.page.locator( '.gla-ads-terms-modal' );
+	}
+
+	/**
+	 * Get Accept terms checkbox.
+	 *
+	 * @return {import('@playwright/test').Locator} Get Accept terms checkbox.
+	 */
+	getAcceptTermCreateAccount() {
+		return this.getCreateAccountModal().locator(
+			'text=I have read and accept these terms'
+		);
+	}
+
+	getCreateAdsAccountButtonModal() {
+		return this.getCreateAccountModal().getByRole( 'button', {
+			name: 'Create account',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Register the requests when the save button is clicked.
+	 *
+	 * @param {string} [adsAccountID] The Ads account ID.
+	 * @return {Promise<import('@playwright/test').Request>} The request.
+	 */
+	async registerConnectAdsAccountRequests( adsAccountID = null ) {
+		return this.page.waitForRequest( ( request ) => {
+			if ( adsAccountID ) {
+				return (
+					request.url().includes( '/gla/ads/accounts' ) &&
+					request.method() === 'POST' &&
+					request.postDataJSON().id === adsAccountID
+				);
+			}
+
+			return (
+				request.url().includes( '/gla/ads/accounts' ) &&
+				request.method() === 'POST'
+			);
+		} );
+	}
+}

--- a/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
@@ -3,7 +3,7 @@
  */
 import MockRequests from '../../mock-requests';
 
-export default class SetupAdsPage extends MockRequests {
+export default class SetupAdsAccount extends MockRequests {
 	/**
 	 * @param {import('@playwright/test').Page} page
 	 */
@@ -13,7 +13,7 @@ export default class SetupAdsPage extends MockRequests {
 	}
 
 	/**
-	 * Get Continues button.
+	 * Get Continue button.
 	 *
 	 * @return {Promise<import('@playwright/test').Locator>} The Continue button.
 	 */
@@ -76,6 +76,11 @@ export default class SetupAdsPage extends MockRequests {
 		await this.fulfillAdsAccounts( payload );
 	}
 
+	/**
+	 * Get the create account modal.
+	 *
+	 * @return {import('@playwright/test').Locator} The create account modal.
+	 */
 	getCreateAccountModal() {
 		return this.page.locator( '.gla-ads-terms-modal' );
 	}
@@ -91,6 +96,11 @@ export default class SetupAdsPage extends MockRequests {
 		);
 	}
 
+	/**
+	 * Get Create account button located in the modal.
+	 *
+	 * @return {import('@playwright/test').Locator} Get Create account button.
+	 */
 	getCreateAdsAccountButtonModal() {
 		return this.getCreateAccountModal().getByRole( 'button', {
 			name: 'Create account',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/2070.

This PR includes E2E tests for the initial stage of setting up an Ads Campaign, which involves connecting the accounts.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow these steps to set up the e2e env: https://github.com/woocommerce/google-listings-and-ads#e2e-testing
2. Run `npm run test:e2e -- ./tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js`, the test should pass.
3. Or, run `npm run test:e2e-dev -- ./tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js`, check the test in the chromium step by step.
4. Run npm run test:e2e to make sure all tests are passed. (The tests associated with the gtag event are currently failing, but there has already been a fix implemented in this PR https://github.com/woocommerce/google-listings-and-ads/issues/2095)

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - E2E - Ads a paid campaign Step 1 - Connect Ads Account
