### PR TITLE
Performance issue:  Move GoogleAdsFailures::init to error_handler middleware

### DIFF
--- a/src/Google/Ads/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAdsClient.php
@@ -13,7 +13,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Auth\Credentials\InsecureCredentials;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Auth\HttpHandler\HttpHandlerFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
-use Google\Ads\GoogleAds\Util\V14\GoogleAdsFailures;
 
 /**
  * A Google Ads API client for handling common configuration and OAuth2 settings.
@@ -32,8 +31,6 @@ class GoogleAdsClient {
 	public function __construct( string $endpoint ) {
 		$this->oAuth2Credential = new InsecureCredentials();
 		$this->endpoint         = $endpoint;
-
-		GoogleAdsFailures::init();
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -46,6 +46,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definiti
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\RequestInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\ResponseInterface;
+use Google\Ads\GoogleAds\Util\V14\GoogleAdsFailures;
 use Jetpack_Options;
 
 defined( 'ABSPATH' ) || exit;
@@ -192,6 +193,14 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 				return $handler( $request, $options )->then(
 					function ( ResponseInterface $response ) use ( $request ) {
 						$code = $response->getStatusCode();
+
+						$path = $request->getUri()->getPath();
+
+						// Partial Failures come back with a status code of 200, so it's necessary to call GoogleAdsFailures:init every time..
+						if ( strpos( $path, 'google-ads' ) !== false ) {
+							GoogleAdsFailures::init();
+						}
+
 						if ( $code < 400 ) {
 							return $response;
 						}

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -196,7 +196,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 						$path = $request->getUri()->getPath();
 
-						// Partial Failures come back with a status code of 200, so it's necessary to call GoogleAdsFailures:init every time..
+						// Partial Failures come back with a status code of 200, so it's necessary to call GoogleAdsFailures:init every time.
 						if ( strpos( $path, 'google-ads' ) !== false ) {
 							GoogleAdsFailures::init();
 						}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of #1250

The `GoogleAdsClient:init` is an expensive operation that is currently loaded whenever the Google Ads client is created. It gets triggered by the [GoogleServiceProvider](https://github.com/woocommerce/google-listings-and-ads/blob/9895a35a1439a57fbdb48f9694986bcb823fce98/src/Internal/DependencyManagement/GoogleServiceProvider.php#L154-L163) and is executed each time there's an admin page load or a request to `wp-json`.

See the full details of this issue: https://github.com/woocommerce/google-listings-and-ads/issues/1250#issuecomment-1723187436

In this PR, we relocate `GoogleAdsFailures::init` from the GoogleAdsClient constructor to the `error_handler` middleware. This change means that GoogleAdsFailure will only be loaded when there is a request made to the `google-ads` API.

Before this PR:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/5de1cf35-e73c-49c9-aedf-81b6f6c66a73)

After this PR:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/7c76875d-075f-4834-8f5b-8b078ef33282)

Shifting `GoogleAdsFailure:init` to the `error_handler` will help in cutting down the time allocated for the Google protobufs functions. However, the GL&A container is still consuming roughly 4.88% of the total loading process, therefore still some room for improvement. 


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### General Testing
1. Connect your Ads account and test that you can create, edit, and delete ads campaigns.

#### Simulate an Ads API error
1. Change this line: https://github.com/woocommerce/google-listings-and-ads/blob/9546add794d96e5ea571fdc1b84e058ba72a6449/src/API/Google/AdsCampaign.php#L268

To:  `$campaign_fields['status'] = 999999`

2. Go to the dashboard page, and change the status of one of your campaigns. 
3. You should see the following error:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/6289f513-4c8c-4f47-841f-896b17f39932)


#### Simulate a partial failure error.

1. Keep the change that you made in the previous testing (campaign_status = 99999).
2. Change this:

https://github.com/woocommerce/google-listings-and-ads/blob/9546add794d96e5ea571fdc1b84e058ba72a6449/src/API/Google/AdsCampaign.php#L557-L560

With:

```
		$responses = $this->client->getGoogleAdsServiceClient()->mutate(
			$this->options->get_ads_id(),
			$operations,
			[
				'partialFailure' => true,
			]
		);
```
3. You should see the following error:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/9b134538-f6b0-4653-abc8-75fe25139516)

It shows an invalid campaign ID, because the current code is not expecting partial failures.

4. If you comment out `GoogleAdsFailures::init();` and try to change the campaign status, you will get the following error:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/c8de2809-4d2f-445b-8b51-da62deff6cf7)


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Performance issue with GoogleAdsFailures::init
