### PR TITLE
E2E tests: Onboarding Step 4 - Complete your campaign

### DIFF
--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -134,7 +134,7 @@ test.describe( 'GTag events', () => {
 		await page.goto( 'shop?orderby=date' );
 		const addToCart = `[data-product_id="${ simpleProductID }"]`;
 		const addToCartButton = await page.locator( addToCart ).first();
-		addToCartButton.click();
+		await addToCartButton.click();
 		await expect( addToCartButton.getByText( '1 in cart' ) ).toBeVisible();
 
 		await event.then( ( request ) => {

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -3,6 +3,11 @@
  */
 import SetUpAccountsPage from '../../utils/pages/setup-mc/step-1-set-up-accounts';
 import { LOAD_STATE } from '../../utils/constants';
+import {
+	getFAQPanelTitle,
+	getFAQPanelRow,
+	checkFAQExpandable,
+} from '../../utils/page';
 
 /**
  * External dependencies
@@ -66,30 +71,17 @@ test.describe( 'Set up accounts', () => {
 
 	test.describe( 'FAQ panels', () => {
 		test( 'should see two questions in FAQ', async () => {
-			const faqTitles = setUpAccountsPage.getFAQPanelTitle();
+			const faqTitles = getFAQPanelTitle( page );
 			await expect( faqTitles ).toHaveCount( 2 );
 		} );
 
 		test( 'should not see FAQ rows when FAQ titles are not clicked', async () => {
-			const faqRows = setUpAccountsPage.getFAQPanelRow();
+			const faqRows = getFAQPanelRow( page );
 			await expect( faqRows ).toHaveCount( 0 );
 		} );
 
-		test( 'should see one FAQ rows when the first FAQ title is clicked', async () => {
-			const faqTitle = setUpAccountsPage.getFAQPanelTitle().first();
-			await faqTitle.click();
-			const faqRow = setUpAccountsPage.getFAQPanelRow();
-			await expect( faqRow ).toBeVisible();
-		} );
-
-		test( 'should see two FAQ rows when two FAQ titles are clicked', async () => {
-			const faqTitle2 = setUpAccountsPage.getFAQPanelTitle().nth( 1 );
-			await faqTitle2.click();
-			const faqRows = setUpAccountsPage.getFAQPanelRow();
-			await expect( faqRows ).toHaveCount( 2 );
-			for ( const faqRow of await faqRows.all() ) {
-				await expect( faqRow ).toBeVisible();
-			}
+		test( 'should see FAQ rows when all FAQ titles are clicked', async () => {
+			await checkFAQExpandable( page );
 		} );
 	} );
 
@@ -576,7 +568,7 @@ test.describe( 'Set up accounts', () => {
 			await expect( link ).toBeVisible();
 			await expect( link ).toHaveAttribute( 'href', cssPartersLink );
 
-			const faqTitle2 = setUpAccountsPage.getFAQPanelTitle().nth( 1 );
+			const faqTitle2 = getFAQPanelTitle( page ).nth( 1 );
 			await faqTitle2.click();
 			const linkInFAQ = setUpAccountsPage.getCSSPartnersLink(
 				'Please find more information here'

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -298,7 +298,7 @@ test.describe( 'Set up accounts', () => {
 									setUpAccountsPage.mockMCNotConnected(),
 								] );
 
-								await setUpAccountsPage.goto();
+								await page.reload();
 
 								// Mock Merchant Center create accounts
 								await setUpAccountsPage.mockMCCreateAccountWebsiteClaimed(

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -5,6 +5,7 @@ import ProductListingsPage from '../../utils/pages/setup-mc/step-2-product-listi
 import {
 	getCountryInputSearchBoxContainer,
 	getCountryInputSearchBox,
+	removeCountryFromSearchBox,
 	selectCountryFromSearchBox,
 } from '../../utils/page';
 
@@ -162,9 +163,7 @@ test.describe( 'Configure product listings', () => {
 	test( 'should still see "Tax rate (required for U.S. only)" even if deselect US when the default country is US', async () => {
 		const taxRateSection = productListingsPage.getTaxRateSection();
 		await expect( taxRateSection ).toBeVisible();
-		await productListingsPage.removeCountryFromSearchBox(
-			'United States (US)'
-		);
+		await removeCountryFromSearchBox( page, 'United States (US)' );
 		await expect( taxRateSection ).toBeVisible();
 	} );
 
@@ -181,9 +180,7 @@ test.describe( 'Configure product listings', () => {
 		const taxRateSection = productListingsPage.getTaxRateSection();
 		await expect( taxRateSection ).toBeVisible();
 
-		await productListingsPage.removeCountryFromSearchBox(
-			'United States (US)'
-		);
+		await removeCountryFromSearchBox( page, 'United States (US)' );
 
 		await expect( taxRateSection ).not.toBeVisible();
 	} );

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -2,6 +2,11 @@
  * Internal dependencies
  */
 import ProductListingsPage from '../../utils/pages/setup-mc/step-2-product-listings';
+import {
+	getCountryInputSearchBoxContainer,
+	getCountryInputSearchBox,
+	selectCountryFromSearchBox,
+} from '../../utils/page';
 
 /**
  * External dependencies
@@ -104,7 +109,7 @@ test.describe( 'Configure product listings', () => {
 
 	test( 'should see US but should not see UK in the country search box', async () => {
 		const countrySearchBoxContainer =
-			productListingsPage.getCountryInputSearchBoxContainer();
+			getCountryInputSearchBoxContainer( page );
 		await expect( countrySearchBoxContainer ).toContainText(
 			'United States (US)'
 		);
@@ -115,7 +120,7 @@ test.describe( 'Configure product listings', () => {
 
 	test( 'should see UK in the country search box and send the target audience POST request after selecting UK', async () => {
 		const countrySearchBoxContainer =
-			productListingsPage.getCountryInputSearchBoxContainer();
+			getCountryInputSearchBoxContainer( page );
 		await expect( countrySearchBoxContainer ).not.toContainText(
 			'United Kingdom (UK)'
 		);
@@ -127,9 +132,7 @@ test.describe( 'Configure product listings', () => {
 				request.postDataJSON().countries.includes( 'GB' )
 		);
 
-		await productListingsPage.selectCountryFromSearchBox(
-			'United Kingdom (UK)'
-		);
+		await selectCountryFromSearchBox( page, 'United Kingdom (UK)' );
 
 		await expect( countrySearchBoxContainer ).toContainText(
 			'United Kingdom (UK)'
@@ -147,7 +150,7 @@ test.describe( 'Configure product listings', () => {
 	} );
 
 	test( 'should hide country search box after clicking "All countries"', async () => {
-		const countrySearchBox = productListingsPage.getCountryInputSearchBox();
+		const countrySearchBox = getCountryInputSearchBox( page );
 		await expect( countrySearchBox ).toBeVisible();
 		await productListingsPage.checkAllCountriesRadioButton();
 		await expect( countrySearchBox ).not.toBeVisible();

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -7,6 +7,7 @@ const { test, expect } = require( '@playwright/test' );
  * Internal dependencies
  */
 import CompleteCampaign from '../../utils/pages/setup-mc/step-4-complete-campaign';
+import SetupAdsAccountPage from '../../utils/pages/setup-ads/setup-ads-accounts';
 import {
 	getFAQPanelTitle,
 	getFAQPanelRow,
@@ -23,6 +24,11 @@ test.describe.configure( { mode: 'serial' } );
 let completeCampaign = null;
 
 /**
+ * @type {import('../../utils/pages/setup-ads/setup-ads-accounts.js').default} completeCampaign
+ */
+let setupAdsAccountPage = null;
+
+/**
  * @type {import('@playwright/test').Page} page
  */
 let page = null;
@@ -31,6 +37,7 @@ test.describe( 'Complete your campaign', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
 		completeCampaign = new CompleteCampaign( page );
+		setupAdsAccountPage = new SetupAdsAccountPage( page );
 		await Promise.all( [
 			// Mock Jetpack as connected
 			completeCampaign.mockJetpackConnected(),
@@ -43,6 +50,17 @@ test.describe( 'Complete your campaign', () => {
 
 			// Mock MC step as paid_ads
 			completeCampaign.mockMCSetup( 'incomplete', 'paid_ads' ),
+
+			// Mock MC target audience, only mocks GET method
+			completeCampaign.fulfillTargetAudience(
+				{
+					location: 'selected',
+					countries: [ 'US', 'TW', 'GB' ],
+					locale: 'en_US',
+					language: 'English',
+				},
+				[ 'GET' ]
+			),
 
 			// Mock syncable products count
 			completeCampaign.fulfillSyncableProductsCountRequest( {
@@ -114,7 +132,7 @@ test.describe( 'Complete your campaign', () => {
 					scheduled_sync: 1,
 				} ),
 			] );
-			await completeCampaign.clickSkipStepButtonButon();
+			await completeCampaign.clickSkipStepButton();
 		} );
 
 		test( 'should see the setup success modal', async () => {
@@ -129,6 +147,230 @@ test.describe( 'Complete your campaign', () => {
 
 		test( 'should see the url contains product-feed', async () => {
 			expect( page.url() ).toMatch( /path=%2Fgoogle%2Fproduct-feed/ );
+		} );
+	} );
+
+	test.describe( 'Set up paid ads', () => {
+		test.beforeAll( async () => {
+			await Promise.all( [
+				// Mock settings sync request
+				completeCampaign.mockSuccessfulSettingsSyncRequest(),
+
+				// Mock product statistics request
+				completeCampaign.fulfillProductStatisticsRequest( {
+					timestamp: 1695011644,
+					statistics: {
+						active: 0,
+						expiring: 0,
+						pending: 0,
+						disapproved: 0,
+						not_synced: 1137,
+					},
+					scheduled_sync: 1,
+				} ),
+			] );
+			await completeCampaign.goto();
+		} );
+
+		test( 'should see the "Create a paid ad campaign" button is enabled', async () => {
+			const button = completeCampaign.getCreatePaidAdButton();
+			await expect( button ).toBeVisible();
+			await expect( button ).toBeEnabled();
+		} );
+
+		test.describe( 'Click "Create a paid ad campaign" button', () => {
+			test.beforeAll( async () => {
+				await completeCampaign.clickCreatePaidAdButton();
+				await setupAdsAccountPage.mockAdsAccountsResponse( [] );
+			} );
+
+			test( 'should see "Complete setup" button is disabled', async () => {
+				const completeSetupButton =
+					completeCampaign.getCompleteSetupButton();
+				await expect( completeSetupButton ).toBeVisible();
+				await expect( completeSetupButton ).toBeDisabled();
+			} );
+
+			test( 'should see "Skip paid ads creation" button is enabled', async () => {
+				const skipPaidAdsCreationButton =
+					completeCampaign.getSkipPaidAdsCreationButton();
+				await expect( skipPaidAdsCreationButton ).toBeVisible();
+				await expect( skipPaidAdsCreationButton ).toBeEnabled();
+			} );
+
+			test( 'should see "Google Ads" section is enabled', async () => {
+				const googleAdsSection =
+					completeCampaign.getAdsAccountSection();
+				await expect( googleAdsSection ).toBeVisible();
+
+				// Cannot use toBeEnabled() because <section> is not a native control element
+				// such as <button> or <input> so it will be always enabled.
+				await expect( googleAdsSection ).not.toHaveClass(
+					/wcdl-section--is-disabled/
+				);
+			} );
+
+			test( 'should see "Ads audience" section is disabled', async () => {
+				const adsAudienceSection =
+					completeCampaign.getAdsAudienceSection();
+				await expect( adsAudienceSection ).toBeVisible();
+
+				// Cannot use toBeDisabled() because <section> is not a native control element
+				// such as <button> or <input> so it will be always enabled.
+				await expect( adsAudienceSection ).toHaveClass(
+					/wcdl-section--is-disabled/
+				);
+			} );
+
+			test( 'should see "Set your budget" section is disabled', async () => {
+				const budgetSection = completeCampaign.getBudgetSection();
+				await expect( budgetSection ).toBeVisible();
+
+				// Cannot use toBeDisabled() because <section> is not a native control element
+				// such as <button> or <input> so it will be always enabled.
+				await expect( budgetSection ).toHaveClass(
+					/wcdl-section--is-disabled/
+				);
+			} );
+
+			test.describe( 'Create account', () => {
+				test.beforeAll( async () => {
+					await completeCampaign.clickCreateAccountButton();
+				} );
+
+				test( 'should see "Create Google Ads Account" modal', async () => {
+					const modal = setupAdsAccountPage.getCreateAccountModal();
+					await expect( modal ).toBeVisible();
+				} );
+
+				test( 'should see "ToS checkbox" from modal is unchecked', async () => {
+					const checkbox =
+						setupAdsAccountPage.getAcceptTermCreateAccount();
+					await expect( checkbox ).toBeVisible();
+					await expect( checkbox ).not.toBeChecked();
+				} );
+
+				test( 'should see "Create account" from modal is disabled', async () => {
+					const button =
+						setupAdsAccountPage.getCreateAdsAccountButtonModal();
+					await expect( button ).toBeVisible();
+					await expect( button ).toBeDisabled();
+				} );
+
+				test( 'should see "Create account" from modal is enabled when ToS checkbox is checked', async () => {
+					const button =
+						setupAdsAccountPage.getCreateAdsAccountButtonModal();
+					await setupAdsAccountPage.clickToSCheckboxFromModal();
+					await expect( button ).toBeEnabled();
+				} );
+
+				test( 'should see ads account connected after creating a new ads account', async () => {
+					await setupAdsAccountPage.mockAdsAccountsResponse( [
+						{
+							id: 12345,
+							name: 'Test Ad',
+						},
+					] );
+
+					await setupAdsAccountPage.fulfillAdsConnection( {
+						id: 12345,
+						currency: 'TWD',
+						symbol: 'NT$',
+						status: 'connected',
+					} );
+
+					await setupAdsAccountPage.clickCreateAccountButtonFromModal();
+					const connectedText =
+						completeCampaign.getAdsAccountConnectedText();
+					await expect( connectedText ).toBeVisible();
+				} );
+			} );
+
+			test.describe( 'Connect to an existing account', () => {
+				test.beforeAll( async () => {
+					await setupAdsAccountPage.mockAdsAccountsResponse( [
+						{
+							id: 12345,
+							name: 'Test Ad 1',
+						},
+						{
+							id: 23456,
+							name: 'Test Ad 2',
+						},
+					] );
+
+					await setupAdsAccountPage.fulfillAdsConnection( {
+						id: 12345,
+						currency: 'TWD',
+						symbol: 'NT$',
+						status: 'disconnected',
+					} );
+
+					await setupAdsAccountPage.clickConnectDifferentAccountButton();
+				} );
+
+				test( 'should see the ads account select', async () => {
+					const select = setupAdsAccountPage.getAdsAccountSelect();
+					await expect( select ).toBeVisible();
+				} );
+
+				test( 'should see connect button is disabled when no ads account is selected', async () => {
+					const button = setupAdsAccountPage.getConnectAdsButton();
+					await expect( button ).toBeVisible();
+					await expect( button ).toBeDisabled();
+				} );
+
+				test( 'should see connect button is enabled when an ads account is selected', async () => {
+					await setupAdsAccountPage.selectAnExistingAdsAccount(
+						'23456'
+					);
+					const button = setupAdsAccountPage.getConnectAdsButton();
+					await expect( button ).toBeVisible();
+					await expect( button ).toBeEnabled();
+				} );
+
+				test( 'should see ads account connected text, audience and budget sections are enabled, and ads/accounts request is triggered after clicking connect button', async () => {
+					await setupAdsAccountPage.mockAdsAccountsResponse( [
+						{
+							id: 23456,
+							name: 'Test Ad 2',
+						},
+					] );
+
+					await setupAdsAccountPage.fulfillAdsConnection( {
+						id: 23456,
+						currency: 'TWD',
+						symbol: 'NT$',
+						status: 'connected',
+					} );
+
+					const requestPromise =
+						setupAdsAccountPage.registerConnectAdsAccountRequests(
+							'23456'
+						);
+
+					await setupAdsAccountPage.clickConnectAds();
+
+					await requestPromise;
+
+					const connectedText =
+						completeCampaign.getAdsAccountConnectedText();
+					await expect( connectedText ).toBeVisible();
+
+					const adsAudienceSection =
+						completeCampaign.getAdsAudienceSection();
+					const budgetSection = completeCampaign.getBudgetSection();
+
+					// Cannot use toBeDisabled() because <section> is not a native control element
+					// such as <button> or <input> so it will be always enabled.
+					await expect( adsAudienceSection ).not.toHaveClass(
+						/wcdl-section--is-disabled/
+					);
+					await expect( budgetSection ).not.toHaveClass(
+						/wcdl-section--is-disabled/
+					);
+				} );
+			} );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -25,7 +25,7 @@ test.use( { storageState: process.env.ADMINSTATE } );
 test.describe.configure( { mode: 'serial' } );
 
 /**
- * @type {import('../../utils/pages/setup-ads/stepup-budget.js').default} setupBudgetPage
+ * @type {import('../../utils/pages/setup-ads/setup-budget.js').default} setupBudgetPage
  */
 let setupBudgetPage = null;
 
@@ -494,11 +494,11 @@ test.describe( 'Complete your campaign', () => {
 					const popup = await popupPromise;
 					await popup.waitForLoadState();
 					const popupTitle = await popup.title();
-					const popupURL = await popup.url();
-					await expect( popupTitle ).toBe(
+					const popupURL = popup.url();
+					expect( popupTitle ).toBe(
 						'Add a new payment method in Google Ads - Google Ads Help'
 					);
-					await expect( popupURL ).toBe(
+					expect( popupURL ).toBe(
 						'https://support.google.com/google-ads/answer/2375375'
 					);
 					await popup.close();
@@ -510,11 +510,11 @@ test.describe( 'Complete your campaign', () => {
 					newPage = await newPagePromise;
 					await newPage.waitForLoadState();
 					const newPageTitle = await newPage.title();
-					const newPageURL = await newPage.url();
-					await expect( newPageTitle ).toBe(
+					const newPageURL = newPage.url();
+					expect( newPageTitle ).toBe(
 						'Add a new payment method in Google Ads - Google Ads Help'
 					);
-					await expect( newPageURL ).toBe(
+					expect( newPageURL ).toBe(
 						'https://support.google.com/google-ads/answer/2375375'
 					);
 				} );

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import CompleteCampaign from '../../utils/pages/setup-mc/step-4-complete-campaign';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/setup-mc/step-4-complete-campaign.js').default} completeCampaign
+ */
+let completeCampaign = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Complete your campaign', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		completeCampaign = new CompleteCampaign( page );
+		await Promise.all( [
+			// Mock Jetpack as connected
+			completeCampaign.mockJetpackConnected(),
+
+			// Mock google as connected.
+			completeCampaign.mockGoogleConnected(),
+
+			// Mock Merchant Center as connected
+			completeCampaign.mockMCConnected(),
+
+			// Mock MC step as paid_ads
+			completeCampaign.mockMCSetup( 'incomplete', 'paid_ads' ),
+
+			// Mock syncable products count
+			completeCampaign.fulfillSyncableProductsCountRequest( {
+				count: 1024,
+			} ),
+		] );
+
+		await completeCampaign.goto();
+	} );
+
+	test.afterAll( async () => {
+		await completeCampaign.closePage();
+	} );
+
+	test( 'should see the heading and the texts below', async () => {
+		await expect(
+			page.getByRole( 'heading', {
+				name: 'Complete your campaign with paid ads',
+			} )
+		).toBeVisible();
+
+		await expect(
+			page.getByText(
+				'As soon as your products are approved, your listings and ads will be live. In the meantime, let’s set up your ads.'
+			)
+		).toBeVisible();
+	} );
+
+	test.describe( 'Product feed status', () => {
+		test( 'should see the correct syncable products count', async () => {
+			const syncableProductCountTooltip =
+				completeCampaign.getSyncableProductsCountTooltip();
+			await expect( syncableProductCountTooltip ).toContainText( '1024' );
+		} );
+	} );
+
+	test.describe( 'Click "Skip this step for now"', () => {
+		test.beforeAll( async () => {
+			await Promise.all( [
+				// Mock settings sync request
+				completeCampaign.mockSuccessfulSettingsSyncRequest(),
+
+				// Mock product statistics request
+				completeCampaign.fulfillProductStatisticsRequest( {
+					timestamp: 1695011644,
+					statistics: {
+						active: 0,
+						expiring: 0,
+						pending: 0,
+						disapproved: 0,
+						not_synced: 1137,
+					},
+					scheduled_sync: 1,
+				} ),
+			] );
+			await completeCampaign.clickSkipStepButtonButon();
+		} );
+
+		test( 'should see the setup success modal', async () => {
+			const setupSuccessModal = page
+				.locator( '.components-modal__content' )
+				.filter( {
+					hasText:
+						'You’ve successfully set up Google Listings & Ads!',
+				} );
+			await expect( setupSuccessModal ).toBeVisible();
+		} );
+
+		test( 'should see the url contains product-feed', async () => {
+			expect( page.url() ).toMatch( /path=%2Fgoogle%2Fproduct-feed/ );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -7,6 +7,11 @@ const { test, expect } = require( '@playwright/test' );
  * Internal dependencies
  */
 import CompleteCampaign from '../../utils/pages/setup-mc/step-4-complete-campaign';
+import {
+	getFAQPanelTitle,
+	getFAQPanelRow,
+	checkFAQExpandable,
+} from '../../utils/page';
 
 test.use( { storageState: process.env.ADMINSTATE } );
 
@@ -71,6 +76,22 @@ test.describe( 'Complete your campaign', () => {
 			const syncableProductCountTooltip =
 				completeCampaign.getSyncableProductsCountTooltip();
 			await expect( syncableProductCountTooltip ).toContainText( '1024' );
+		} );
+	} );
+
+	test.describe( 'FAQ panels', () => {
+		test( 'should see five questions in FAQ', async () => {
+			const faqTitles = getFAQPanelTitle( page );
+			await expect( faqTitles ).toHaveCount( 5 );
+		} );
+
+		test( 'should not see FAQ rows when FAQ titles are not clicked', async () => {
+			const faqRows = getFAQPanelRow( page );
+			await expect( faqRows ).toHaveCount( 0 );
+		} );
+
+		test( 'should see FAQ rows when all FAQ titles are clicked', async () => {
+			await checkFAQExpandable( page );
 		} );
 	} );
 

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -524,17 +524,8 @@ test.describe( 'Complete your campaign', () => {
 						status: 'approved',
 					} );
 
-					const responsePromise = page.waitForResponse(
-						/\/gla\/ads\/billing-status/
-					);
-
 					await newPage.close();
-
-					const billingSetupSection =
-						setupBudgetPage.getBillingSetupSection();
-					await billingSetupSection.focus();
-
-					await responsePromise;
+					await page.reload();
 
 					const billingSetupSuccessSection =
 						setupBudgetPage.getBillingSetupSuccessSection();

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -46,7 +46,7 @@ export async function relatedProductAddToCart( page ) {
 		: '.wp-block-woocommerce-related-products .add_to_cart_button';
 
 	const addToCartButton = await page.locator( addToCart ).first();
-	addToCartButton.click();
+	await addToCartButton.click();
 	await expect( addToCartButton.getByText( '1 in cart' ) ).toBeVisible();
 	return await page.$eval( addToCart, ( el ) => el.dataset.product_id );
 }

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -282,6 +282,32 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill syncable products count request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillSyncableProductsCountRequest( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/syncable-products-count\b/,
+			payload
+		);
+	}
+
+	/**
+	 * Fulfill product statistics request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillProductStatisticsRequest( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/product-statistics\b/,
+			payload
+		);
+	}
+
+	/**
 	 * Mock the request to connect Jetpack
 	 *
 	 * @param {string} url
@@ -494,6 +520,18 @@ export default class MockRequests {
 			},
 			is_mc_address_different: options.isMCAddressDifferent,
 			wc_address_errors: options.wcAddressErrors,
+		} );
+	}
+
+	/**
+	 * Mock the successful settings sync requesst.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockSuccessfulSettingsSyncRequest() {
+		await this.fulfillSettingsSync( {
+			status: 'success',
+			message: 'Successfully synchronized settings with Google.',
 		} );
 	}
 }

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -308,6 +308,29 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill billing status request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillBillingStatusRequest( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/ads\/billing-status\b/,
+			payload
+		);
+	}
+
+	/**
+	 * Fulfill ads campaigns request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillAdsCampaignsRequest( payload ) {
+		await this.fulfillRequest( /\/wc\/gla\/ads\/campaigns\b/, payload );
+	}
+
+	/**
 	 * Mock the request to connect Jetpack
 	 *
 	 * @param {string} url

--- a/tests/e2e/utils/page.js
+++ b/tests/e2e/utils/page.js
@@ -37,6 +37,62 @@ export function getFAQPanelRow( page ) {
 }
 
 /**
+ * Get country input search box container.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ *
+ * @return {import('@playwright/test').Locator} Get country input search box container.
+ */
+export function getCountryInputSearchBoxContainer( page ) {
+	return page.locator(
+		'.woocommerce-tree-select-control > .components-base-control'
+	);
+}
+
+/**
+ * Get country input search box.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ *
+ * @return {import('@playwright/test').Locator} Get country input search box.
+ */
+export function getCountryInputSearchBox( page ) {
+	return getCountryInputSearchBoxContainer( page ).locator(
+		'input[id*="woocommerce-tree-select-control"]'
+	);
+}
+
+/**
+ * Get tree item by country name.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ * @param {string} name
+ *
+ * @return {import('@playwright/test').Locator} Get tree item by country name.
+ */
+export function getTreeItemByCountryName( page, name = 'United States (US)' ) {
+	return page.getByRole( 'treeitem', { name } );
+}
+
+/**
+ * Select a country from the search box.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ * @param {string} name
+ *
+ * @return {Promise<void>}
+ */
+export async function selectCountryFromSearchBox(
+	page,
+	name = 'United States (US)'
+) {
+	const countrySearchBox = getCountryInputSearchBox( page );
+	await countrySearchBox.fill( name );
+	await getTreeItemByCountryName( page, name ).click();
+	await countrySearchBox.press( 'Escape' );
+}
+
+/**
  * Check if FAQs are expandable.
  *
  * @param {import('@playwright/test').Page} page The current page.

--- a/tests/e2e/utils/page.js
+++ b/tests/e2e/utils/page.js
@@ -50,6 +50,19 @@ export function getCountryInputSearchBoxContainer( page ) {
 }
 
 /**
+ * Get country tags from input search box container.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ *
+ * @return {import('@playwright/test').Locator} Get country tags from input search box container.
+ */
+export function getCountryTagsFromInputSearchBoxContainer( page ) {
+	return getCountryInputSearchBoxContainer( page ).locator(
+		'.woocommerce-tag'
+	);
+}
+
+/**
  * Get country input search box.
  *
  * @param {import('@playwright/test').Page} page The current page.
@@ -60,6 +73,17 @@ export function getCountryInputSearchBox( page ) {
 	return getCountryInputSearchBoxContainer( page ).locator(
 		'input[id*="woocommerce-tree-select-control"]'
 	);
+}
+
+/**
+ * Get tree select menu.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ *
+ * @return {import('@playwright/test').Locator} Get tree select menu.
+ */
+export function getTreeSelectMenu( page ) {
+	return page.locator( '.woocommerce-tree-select-control__main' );
 }
 
 /**
@@ -75,6 +99,53 @@ export function getTreeItemByCountryName( page, name = 'United States (US)' ) {
 }
 
 /**
+ * Get remove country button by country name.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ * @param {string} name
+ *
+ * @return {import('@playwright/test').Locator} Get remove country button by country name.
+ */
+export function getRemoveCountryButtonByName(
+	page,
+	name = 'United States (US)'
+) {
+	return page.getByRole( 'button', { name: `Remove ${ name }` } );
+}
+
+/**
+ * Remove a country from the search box.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ * @param {string} name
+ *
+ * @return {Promise<void>}
+ */
+export async function removeCountryFromSearchBox(
+	page,
+	name = 'United States (US)'
+) {
+	const removeButton = getRemoveCountryButtonByName( page, name );
+	await removeButton.click();
+}
+
+/**
+ * Fill a country in the search box.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ * @param {string} name
+ *
+ * @return {Promise<void>}
+ */
+export async function fillCountryInSearchBox(
+	page,
+	name = 'United States (US)'
+) {
+	const countrySearchBox = getCountryInputSearchBox( page );
+	await countrySearchBox.fill( name );
+}
+
+/**
  * Select a country from the search box.
  *
  * @param {import('@playwright/test').Page} page The current page.
@@ -86,9 +157,10 @@ export async function selectCountryFromSearchBox(
 	page,
 	name = 'United States (US)'
 ) {
+	await fillCountryInSearchBox( page, name );
+	const treeItem = getTreeItemByCountryName( page, name );
+	await treeItem.click();
 	const countrySearchBox = getCountryInputSearchBox( page );
-	await countrySearchBox.fill( name );
-	await getTreeItemByCountryName( page, name ).click();
 	await countrySearchBox.press( 'Escape' );
 }
 

--- a/tests/e2e/utils/page.js
+++ b/tests/e2e/utils/page.js
@@ -4,6 +4,66 @@
 const { expect } = require( '@playwright/test' );
 
 /**
+ * Get FAQ panel.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ *
+ * @return {import('@playwright/test').Locator} Get FAQ panel.
+ */
+export function getFAQPanel( page ) {
+	return page.locator( '.gla-faqs-panel' );
+}
+
+/**
+ * Get FAQ panel title.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ *
+ * @return {import('@playwright/test').Locator} Get FAQ panel title.
+ */
+export function getFAQPanelTitle( page ) {
+	return getFAQPanel( page ).locator( '.components-panel__body-title' );
+}
+
+/**
+ * Get FAQ panel row.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ *
+ * @return {import('@playwright/test').Locator} Get FAQ panel row.
+ */
+export function getFAQPanelRow( page ) {
+	return getFAQPanel( page ).locator( '.components-panel__row' );
+}
+
+/**
+ * Check if FAQs are expandable.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ *
+ * @return {Promise<void>}
+ */
+export async function checkFAQExpandable( page ) {
+	const faqTitles = getFAQPanelTitle( page );
+	const count = await faqTitles.count();
+
+	if ( count === 1 ) {
+		await faqTitles.click();
+		const faqRow = getFAQPanelRow( page );
+		await expect( faqRow ).toBeVisible();
+	} else if ( count > 1 ) {
+		for ( const faqTitle of await faqTitles.all() ) {
+			await faqTitle.click();
+		}
+		const faqRows = getFAQPanelRow( page );
+		await expect( faqRows ).toHaveCount( count );
+		for ( const faqRow of await faqRows.all() ) {
+			await expect( faqRow ).toBeVisible();
+		}
+	}
+}
+
+/**
  * Check the snackbar message.
  *
  * @param {import('@playwright/test').Page} page The current page.

--- a/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
@@ -37,6 +37,15 @@ export default class SetupAdsAccount extends MockRequests {
 	}
 
 	/**
+	 * Get ads account select.
+	 *
+	 * @return {import('@playwright/test').Locator} Get ads account select.
+	 */
+	getAdsAccountSelect() {
+		return this.page.locator( '.gla-connect-ads select' );
+	}
+
+	/**
 	 * Click the Continue button.
 	 *
 	 * @return {Promise<void>}
@@ -61,9 +70,7 @@ export default class SetupAdsAccount extends MockRequests {
 	 * @return {Promise<void>}
 	 */
 	async selectAnExistingAdsAccount( accountNumber ) {
-		await this.page
-			.locator( '.gla-connect-ads select' )
-			.selectOption( accountNumber );
+		await this.getAdsAccountSelect().selectOption( accountNumber );
 	}
 
 	/**
@@ -91,9 +98,9 @@ export default class SetupAdsAccount extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Accept terms checkbox.
 	 */
 	getAcceptTermCreateAccount() {
-		return this.getCreateAccountModal().locator(
-			'text=I have read and accept these terms'
-		);
+		return this.getCreateAccountModal().getByRole( 'checkbox', {
+			name: 'I have read and accept these terms',
+		} );
 	}
 
 	/**
@@ -109,25 +116,60 @@ export default class SetupAdsAccount extends MockRequests {
 	}
 
 	/**
+	 * Get connect to a different account button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get connect to a different account button.
+	 */
+	getConnectDifferentAccountButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Or, connect to a different Google Ads account',
+			exact: true,
+		} );
+	}
+
+	/**
 	 * Register the requests when the save button is clicked.
 	 *
 	 * @param {string} [adsAccountID] The Ads account ID.
 	 * @return {Promise<import('@playwright/test').Request>} The request.
 	 */
 	async registerConnectAdsAccountRequests( adsAccountID = null ) {
-		return this.page.waitForRequest( ( request ) => {
-			if ( adsAccountID ) {
-				return (
-					request.url().includes( '/gla/ads/accounts' ) &&
-					request.method() === 'POST' &&
-					request.postDataJSON().id === adsAccountID
-				);
-			}
+		return this.page.waitForRequest( ( request ) =>
+			request.url().includes( '/gla/ads/accounts' ) &&
+			request.method() === 'POST' &&
+			adsAccountID
+				? request.postDataJSON().id === adsAccountID
+				: true
+		);
+	}
 
-			return (
-				request.url().includes( '/gla/ads/accounts' ) &&
-				request.method() === 'POST'
-			);
-		} );
+	/**
+	 * Click ToS checkbox from modal.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickToSCheckboxFromModal() {
+		const checkbox = this.getAcceptTermCreateAccount();
+		await checkbox.check();
+	}
+
+	/**
+	 * Click create account button from modal.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickCreateAccountButtonFromModal() {
+		const button = this.getCreateAdsAccountButtonModal();
+		await button.click();
+	}
+
+	/**
+	 * Click connect to a different account button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickConnectDifferentAccountButton() {
+		const button = this.getConnectDifferentAccountButton();
+		await button.click();
 	}
 }

--- a/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
@@ -46,44 +46,6 @@ export default class SetupAdsAccount extends MockRequests {
 	}
 
 	/**
-	 * Click the Continue button.
-	 *
-	 * @return {Promise<void>}
-	 */
-	async clickContinue() {
-		await this.getContinueButton().click();
-	}
-
-	/**
-	 * Click the Connect Ads button.
-	 *
-	 * @return {Promise<void>}
-	 */
-	async clickConnectAds() {
-		await this.getConnectAdsButton().click();
-	}
-
-	/**
-	 * Selects the ads account.
-	 *
-	 * @param {string} accountNumber The Ads account number.
-	 * @return {Promise<void>}
-	 */
-	async selectAnExistingAdsAccount( accountNumber ) {
-		await this.getAdsAccountSelect().selectOption( accountNumber );
-	}
-
-	/**
-	 * Mock the Ads accounts response.
-	 *
-	 * @param {Object} payload
-	 * @return {Promise<void>}
-	 */
-	async mockAdsAccountsResponse( payload ) {
-		await this.fulfillAdsAccounts( payload );
-	}
-
-	/**
 	 * Get the create account modal.
 	 *
 	 * @return {import('@playwright/test').Locator} The create account modal.
@@ -125,6 +87,44 @@ export default class SetupAdsAccount extends MockRequests {
 			name: 'Or, connect to a different Google Ads account',
 			exact: true,
 		} );
+	}
+
+	/**
+	 * Click the Continue button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickContinue() {
+		await this.getContinueButton().click();
+	}
+
+	/**
+	 * Click the Connect Ads button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickConnectAds() {
+		await this.getConnectAdsButton().click();
+	}
+
+	/**
+	 * Selects the ads account.
+	 *
+	 * @param {string} accountNumber The Ads account number.
+	 * @return {Promise<void>}
+	 */
+	async selectAnExistingAdsAccount( accountNumber ) {
+		await this.getAdsAccountSelect().selectOption( accountNumber );
+	}
+
+	/**
+	 * Mock the Ads accounts response.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async mockAdsAccountsResponse( payload ) {
+		await this.fulfillAdsAccounts( payload );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -42,6 +42,49 @@ export default class SetupBudget extends MockRequests {
 	}
 
 	/**
+	 * Get billing setup section.
+	 *
+	 * @return {import('@playwright/test').Locator} The billing setup section.
+	 */
+	getBillingSetupSection() {
+		return this.page.locator( '.gla-google-ads-billing-setup-card' );
+	}
+
+	/**
+	 * Get set up billing button.
+	 *
+	 * @return {import('@playwright/test').Locator} The set up billing button.
+	 */
+	getSetUpBillingButton() {
+		return this.getBillingSetupSection().getByRole( 'button', {
+			name: 'Set up billing',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get set up billing link.
+	 *
+	 * @return {import('@playwright/test').Locator} The set up billing link.
+	 */
+	getSetUpBillingLink() {
+		return this.getBillingSetupSection().getByRole( 'link', {
+			name: 'click here instead',
+		} );
+	}
+
+	/**
+	 * Get billing setup success section.
+	 *
+	 * @return {import('@playwright/test').Locator} The billing setup success section.
+	 */
+	getBillingSetupSuccessSection() {
+		return this.page.locator(
+			'.gla-google-ads-billing-card__success-status'
+		);
+	}
+
+	/**
 	 * Extract budget recommendation range.
 	 *
 	 * @param {string} text
@@ -72,14 +115,34 @@ export default class SetupBudget extends MockRequests {
 	}
 
 	/**
-	 * Fill the budget
+	 * Fill the budget.
 	 *
 	 * @param {string} budget
 	 *
-	 * @return {Promise<import('@playwright/test').Response>} The response.
+	 * @return {Promise<void>}
 	 */
 	async fillBudget( budget = '0' ) {
 		const input = this.getBudgetInput();
 		await input.fill( budget );
+	}
+
+	/**
+	 * Click set up billing button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickSetUpBillingButton() {
+		const button = this.getSetUpBillingButton();
+		await button.click();
+	}
+
+	/**
+	 * Click set up billing link.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickSetUpBillingLink() {
+		const link = this.getSetUpBillingLink();
+		await link.click();
 	}
 }

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -1,0 +1,85 @@
+/**
+ * Internal dependencies
+ */
+import MockRequests from '../../mock-requests';
+
+export default class SetupBudget extends MockRequests {
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 */
+	constructor( page ) {
+		super( page );
+		this.page = page;
+	}
+
+	/**
+	 * Get budget recommendation text row.
+	 *
+	 * @return {import('@playwright/test').Locator} The budget recommendation text row.
+	 */
+	getBudgetRecommendationTextRow() {
+		return this.page.locator( '.components-tip p > em > strong' );
+	}
+
+	/**
+	 * Get budget input.
+	 *
+	 * @return {import('@playwright/test').Locator} The budget input box.
+	 */
+	getBudgetInput() {
+		return this.page
+			.locator( '.gla-budget-section__card-body__cost' )
+			.getByLabel( 'Daily average cost' );
+	}
+
+	/**
+	 * Get lower budget tip.
+	 *
+	 * @return {import('@playwright/test').Locator} The lower budget tip.
+	 */
+	getLowerBudgetTip() {
+		return this.page.locator( '.gla-budget-recommendation__low-budget' );
+	}
+
+	/**
+	 * Extract budget recommendation range.
+	 *
+	 * @param {string} text
+	 *
+	 * @return {string} The budget recommendation range.
+	 */
+	extractBudgetRecommendationRange( text ) {
+		const match = text.match( /set a daily budget of (\d+ to \d+)/ );
+		if ( match ) {
+			return match[ 1 ];
+		}
+		return '';
+	}
+
+	/**
+	 * Register the responses when removing an ads audience.
+	 *
+	 * @return {Promise<import('@playwright/test').Response>} The response.
+	 */
+	registerBudgetRecommendationResponse() {
+		return this.page.waitForResponse(
+			( response ) =>
+				response
+					.url()
+					.includes( '/gla/ads/campaigns/budget-recommendation' ) &&
+				response.status() === 200
+		);
+	}
+
+	/**
+	 * Fill the budget
+	 *
+	 * @param {string} budget
+	 *
+	 * @return {Promise<import('@playwright/test').Response>} The response.
+	 */
+	async fillBudget( budget = '0' ) {
+		const input = this.getBudgetInput();
+		await input.fill( budget );
+	}
+}

--- a/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
+++ b/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
@@ -352,33 +352,6 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
-	 * Get FAQ panel.
-	 *
-	 * @return {import('@playwright/test').Locator} Get FAQ panel.
-	 */
-	getFAQPanel() {
-		return this.page.locator( '.gla-faqs-panel' );
-	}
-
-	/**
-	 * Get FAQ panel title.
-	 *
-	 * @return {import('@playwright/test').Locator} Get FAQ panel title.
-	 */
-	getFAQPanelTitle() {
-		return this.getFAQPanel().locator( '.components-panel__body-title' );
-	}
-
-	/**
-	 * Get FAQ panel row.
-	 *
-	 * @return {import('@playwright/test').Locator} Get FAQ panel row.
-	 */
-	getFAQPanelRow() {
-		return this.getFAQPanel().locator( '.components-panel__row' );
-	}
-
-	/**
 	 * Get link of Google Merchant Center Help.
 	 *
 	 * @return {import('@playwright/test').Locator} Get link of Google Merchant Center Help.

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -148,17 +148,6 @@ export default class ProductListingsPage extends MockRequests {
 	}
 
 	/**
-	 * Get remove country button by country name.
-	 *
-	 * @param {string} name
-	 *
-	 * @return {import('@playwright/test').Locator} Get remove country button by country name.
-	 */
-	getRemoveCountryButtonByName( name = 'United States (US)' ) {
-		return this.page.getByRole( 'button', { name: `Remove ${ name }` } );
-	}
-
-	/**
 	 * Get shipping rates section.
 	 *
 	 * @return {import('@playwright/test').Locator} Get shipping rates section.
@@ -408,19 +397,6 @@ export default class ProductListingsPage extends MockRequests {
 	async clickContinueButton() {
 		const continueButton = this.getContinueButton();
 		await continueButton.click();
-		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
-	}
-
-	/**
-	 * Remove a country from the search box.
-	 *
-	 * @param {string} name
-	 *
-	 * @return {Promise<void>}
-	 */
-	async removeCountryFromSearchBox( name = 'United States (US)' ) {
-		const removeButton = this.getRemoveCountryButtonByName( name );
-		await removeButton.click();
 		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}
 

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -148,39 +148,6 @@ export default class ProductListingsPage extends MockRequests {
 	}
 
 	/**
-	 * Get country input search box container.
-	 *
-	 * @return {import('@playwright/test').Locator} Get country input search box container.
-	 */
-	getCountryInputSearchBoxContainer() {
-		return this.page.locator(
-			'.woocommerce-tree-select-control > .components-base-control'
-		);
-	}
-
-	/**
-	 * Get country input search box.
-	 *
-	 * @return {import('@playwright/test').Locator} Get country input search box.
-	 */
-	getCountryInputSearchBox() {
-		return this.getCountryInputSearchBoxContainer().locator(
-			'input[id*="woocommerce-tree-select-control"]'
-		);
-	}
-
-	/**
-	 * Get tree item by country name.
-	 *
-	 * @param {string} name
-	 *
-	 * @return {import('@playwright/test').Locator} Get tree item by country name.
-	 */
-	getTreeItemByCountryName( name = 'United States (US)' ) {
-		return this.page.getByRole( 'treeitem', { name } );
-	}
-
-	/**
 	 * Get remove country button by country name.
 	 *
 	 * @param {string} name
@@ -441,21 +408,6 @@ export default class ProductListingsPage extends MockRequests {
 	async clickContinueButton() {
 		const continueButton = this.getContinueButton();
 		await continueButton.click();
-		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
-	}
-
-	/**
-	 * Select a country from the search box.
-	 *
-	 * @param {string} name
-	 *
-	 * @return {Promise<void>}
-	 */
-	async selectCountryFromSearchBox( name = 'United States (US)' ) {
-		const countrySearchBox = this.getCountryInputSearchBox();
-		await countrySearchBox.fill( name );
-		await this.getTreeItemByCountryName( name ).click();
-		await countrySearchBox.press( 'Escape' );
 		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}
 

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -1,0 +1,71 @@
+/**
+ * Internal dependencies
+ */
+import { LOAD_STATE } from '../../constants';
+import MockRequests from '../../mock-requests';
+
+/**
+ * Configure product listings page object class.
+ */
+export default class CompleteCampaign extends MockRequests {
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 */
+	constructor( page ) {
+		super( page );
+		this.page = page;
+	}
+
+	/**
+	 * Close the current page.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async closePage() {
+		await this.page.close();
+	}
+
+	/**
+	 * Go to the set up mc page.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async goto() {
+		await this.page.goto(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc&google-mc=connected',
+			{ waitUntil: LOAD_STATE.NETWORK_IDLE }
+		);
+	}
+
+	/**
+	 * Get gla-tooltip__children-container class.
+	 *
+	 * @return {import('@playwright/test').Locator} Get gla-tooltip__children-container class.
+	 */
+	getSyncableProductsCountTooltip() {
+		return this.page.locator( '.gla-tooltip__children-container' );
+	}
+
+	/**
+	 * Get skip this step for now button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get skip this step for now button.
+	 */
+	getSkipStepButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Skip this step for now',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Click skip this step for now button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickSkipStepButtonButon() {
+		const button = this.getSkipStepButton();
+		await button.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+}

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -212,4 +212,39 @@ export default class CompleteCampaign extends MockRequests {
 		await button.click();
 		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}
+
+	/**
+	 * Click complete setup button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickCompleteSetupButton() {
+		const button = this.getCompleteSetupButton();
+		await button.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Register the requests when completing setup.
+	 *
+	 * @return {Promise<import('@playwright/test').Request[]>} The request.
+	 */
+	registerCompleteSetupRequests() {
+		const campaignsRequestPromise = this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/ads/campaigns' ) &&
+				request.method() === 'POST'
+		);
+
+		const mcSettingsSyncRequestPromise = this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/mc/settings/sync' ) &&
+				request.method() === 'POST'
+		);
+
+		return Promise.all( [
+			campaignsRequestPromise,
+			mcSettingsSyncRequestPromise,
+		] );
+	}
 }

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -33,8 +33,62 @@ export default class CompleteCampaign extends MockRequests {
 	async goto() {
 		await this.page.goto(
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc&google-mc=connected',
-			{ waitUntil: LOAD_STATE.NETWORK_IDLE }
+			{ waitUntil: LOAD_STATE.DOM_CONTENT_LOADED }
 		);
+	}
+
+	/**
+	 * Get sections by .wcdl-section class.
+	 *
+	 * @return {import('@playwright/test').Locator} Get sections by .wcdl-section class.
+	 */
+	getSections() {
+		return this.page.locator( '.wcdl-section' );
+	}
+
+	/**
+	 * Get product feed status section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get product feed status section.
+	 */
+	getProductFeedStatusSection() {
+		return this.getSections().first();
+	}
+
+	/**
+	 * Get paid ads features section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get paid ads features section.
+	 */
+	getPaidAdsFeaturesSection() {
+		return this.getSections().nth( 1 );
+	}
+
+	/**
+	 * Get ads account section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get ads account section.
+	 */
+	getAdsAccountSection() {
+		return this.getSections().nth( 2 );
+	}
+
+	/**
+	 * Get ads audience section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get ads audience section.
+	 */
+	getAdsAudienceSection() {
+		return this.getSections().nth( 3 );
+	}
+
+	/**
+	 * Get budget section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get budget section.
+	 */
+	getBudgetSection() {
+		return this.getSections().nth( 4 );
 	}
 
 	/**
@@ -59,12 +113,102 @@ export default class CompleteCampaign extends MockRequests {
 	}
 
 	/**
+	 * Get create a paid ad button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get create a paid ad button.
+	 */
+	getCreatePaidAdButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Create a paid ad campaign',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get complete setup button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get complete setup button.
+	 */
+	getCompleteSetupButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Complete setup',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get skip paid ads creation button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get skip paid ads creation button.
+	 */
+	getSkipPaidAdsCreationButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Skip paid ads creation',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get create account button.
+	 *
+	 * @return {import('@playwright/test').Locator} Get create account button.
+	 */
+	getCreateAccountButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Create account',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Get ads account connected text.
+	 *
+	 * @return {import('@playwright/test').Locator} Get ads account connected text.
+	 */
+	getAdsAccountConnectedText() {
+		return this.getAdsAccountSection().getByText( 'Connected' );
+	}
+
+	/**
 	 * Click skip this step for now button.
 	 *
 	 * @return {Promise<void>}
 	 */
-	async clickSkipStepButtonButon() {
+	async clickSkipStepButton() {
 		const button = this.getSkipStepButton();
+		await button.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Click skip paid ads creation button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickSkipPaidAdsCreationButon() {
+		const button = this.getSkipPaidAdsCreationButton();
+		await button.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Click create a paid ad campaign button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickCreatePaidAdButton() {
+		const button = this.getCreatePaidAdButton();
+		await button.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Click create account button.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clickCreateAccountButton() {
+		const button = this.getCreateAccountButton();
 		await button.click();
 		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of #2070, this PR adds E2E tests for [📌 Onboarding Step 4 - Complete your campaign][1].

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow these steps to set up the e2e env: https://github.com/woocommerce/google-listings-and-ads#e2e-testing
2. Run `npm run test:e2e -- tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js`, the test should pass.
3. Or, run `npm run test:e2e-dev -- tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js`, check the test in the chromium step by step.
4. Run `npm run test:e2e` to make sure all tests are passed.

### Additional information

This PR added 2 extra commits to:
- fixed a failed test in onboarding step 1 in 8127446b601bbe542a20cfe759fbe6a470acf596
- added a missing `await` for async actions in 2b0114ca6fdfc9676d62bb9168b1de48ff71d648

### Changelog entry

> Dev - E2E - Onboarding Step 4 - Complete your campaign

[1]: https://github.com/woocommerce/google-listings-and-ads/issues/2070#onboarding-step-4