### PR TITLE
Add section to privacy policy guide

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -269,12 +269,17 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 	 * @return void
 	 */
 	public function privacy_policy() {
-		$content = '<p class="privacy-policy-tutorial">' . sprintf(
+		$policy_text = sprintf(
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy.%2$s.', 'google-listings-and-ads' ),
+			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy%2$s.', 'google-listings-and-ads' ),
 			'<a href="https://support.google.com/adspolicy/answer/54817" target="_blank">',
 			'</a>'
-		) . '</p>';
+		);
+
+		// As the extension doesn't offer suggested privacy policy text, the button to copy it is hidden.
+		$content = '
+			<p class="privacy-policy-tutorial">' . $policy_text . '</p>
+			<style>#privacy-settings-accordion-block-google-listings-ads .privacy-settings-accordion-actions { display: none }</style>';
 
 		wp_add_privacy_policy_content( 'Google Listings & Ads', wpautop( $content, false ) );
 	}

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -270,7 +270,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 	 */
 	public function privacy_policy() {
 		$content = '<p class="privacy-policy-tutorial">' . sprintf(
-			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy.%2$s.', 'woocommerce-google-analytics-integration' ),
+			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy.%2$s.', 'google-listings-and-ads' ),
 			'<a href="https://support.google.com/adspolicy/answer/54817" target="_blank">',
 			'</a>'
 		) . '</p>';

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -102,7 +102,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 			20
 		);
 
-		add_action( 'admin_init', array( $this, 'privacy_policy' ) );
+		add_action( 'admin_init', [ $this, 'privacy_policy' ] );
 	}
 
 	/**
@@ -270,6 +270,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 	 */
 	public function privacy_policy() {
 		$content = '<p class="privacy-policy-tutorial">' . sprintf(
+			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy.%2$s.', 'google-listings-and-ads' ),
 			'<a href="https://support.google.com/adspolicy/answer/54817" target="_blank">',
 			'</a>'

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -101,6 +101,8 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 			},
 			20
 		);
+
+		add_action( 'admin_init', array( $this, 'privacy_policy' ) );
 	}
 
 	/**
@@ -259,6 +261,21 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 	 */
 	protected function enableReports(): bool {
 		return apply_filters( 'woocommerce_gla_enable_reports', true );
+	}
+
+	/**
+	 * Add suggested privacy policy content
+	 *
+	 * @return void
+	 */
+	public function privacy_policy() {
+		$content = '<p class="privacy-policy-tutorial">' . sprintf(
+			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about what data is collected by Google and what you may want to include in your privacy policy.%2$s.', 'woocommerce-google-analytics-integration' ),
+			'<a href="https://support.google.com/adspolicy/answer/54817" target="_blank">',
+			'</a>'
+		) . '</p>';
+
+		wp_add_privacy_policy_content( 'Google Listings & Ads', wpautop( $content, false ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a section to the privacy policy guide directing merchants to the Google Ads privacy documentation.

### Screenshots:

<img width="1004" alt="Screenshot 2023-09-20 at 18 32 37" src="https://github.com/woocommerce/google-listings-and-ads/assets/40762232/f8f53037-b72d-489c-98e8-55f4de0630f5">

### Detailed test instructions:

1. Checkout `add/privacy-policy-content`
2. Go to `wp-admin > Settings > Privacy > Policy Guide`
3. Check `Google Listings & Ads` section and confirm links work

### Changelog entry

> Add - Privacy policy guide section