### PR TITLE
Add UTM parameters to documentation link

### DIFF
--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -152,7 +152,7 @@ trait PluginHelper {
 	 * @return string
 	 */
 	protected function get_documentation_url(): string {
-		return 'https://docs.woocommerce.com/document/google-listings-and-ads/';
+		return 'https://docs.woocommerce.com/document/google-listings-and-ads/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=google-listings-and-ads';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project: peeuvX-WJ-p2

This PR adds UTM parameters to the documentation link so we can track the incoming source from the plugins page.

### Detailed test instructions:
1. Go to the plugins page and ensure GLA is activated 
2. Ensure the plugin link Documentation is present and includes the correct UTM parameters
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/ad17dad3-1dd1-4a24-9996-d3403f83037b)

### Changelog entry
* Tweak - Add UTM parameters to documentation link.