### PR TITLE
Adjust the conditions for loading assets and configure lazy loading and code splitting

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { lazy } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
@@ -12,16 +13,40 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
  */
 import './css/index.scss';
 import withAdminPageShell from '.~/components/withAdminPageShell';
-import GetStartedPage from './get-started-page';
-import SetupMC from './setup-mc';
-import SetupAds from './setup-ads';
-import Dashboard from './dashboard';
-import Reports from './pages/reports';
-import ProductFeed from './product-feed';
-import Settings from './settings';
-import AttributeMapping from '.~/attribute-mapping';
 import './data';
 import isWCNavigationEnabled from './utils/isWCNavigationEnabled';
+
+const Dashboard = lazy( () =>
+	import( /* webpackChunkName: "dashboard" */ './dashboard' )
+);
+
+const GetStartedPage = lazy( () =>
+	import( /* webpackChunkName: "get-started-page" */ './get-started-page' )
+);
+
+const SetupMC = lazy( () =>
+	import( /* webpackChunkName: "setup-mc" */ './setup-mc' )
+);
+
+const SetupAds = lazy( () =>
+	import( /* webpackChunkName: "setup-ads" */ './setup-ads' )
+);
+
+const Reports = lazy( () =>
+	import( /* webpackChunkName: "reports" */ './pages/reports' )
+);
+
+const ProductFeed = lazy( () =>
+	import( /* webpackChunkName: "product-feed" */ './product-feed' )
+);
+
+const AttributeMapping = lazy( () =>
+	import( /* webpackChunkName: "attribute-mapping" */ './attribute-mapping' )
+);
+
+const Settings = lazy( () =>
+	import( /* webpackChunkName: "settings" */ './settings' )
+);
 
 const woocommerceTranslation =
 	getSetting( 'admin' )?.woocommerceTranslation ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "google-listings-and-ads",
-			"version": "2.5.3",
+			"version": "2.5.7",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@woocommerce/components": "^10.3.0",
@@ -61,6 +61,7 @@
 				"eslint-plugin-import": "^2.25.4",
 				"jest": "^29.6.2",
 				"jest-environment-jsdom": "^27.5.1",
+				"mini-css-extract-plugin": "^2.7.6",
 				"path-browserify": "^1.0.1",
 				"prettier": "npm:wp-prettier@2.6.2",
 				"react": "^17.0.2",
@@ -17850,72 +17851,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/mini-css-extract-plugin": {
-			"version": "2.7.6",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
-			"integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
-			"dev": true,
-			"dependencies": {
-				"schema-utils": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/mini-css-extract-plugin/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-			"dev": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3"
-			},
-			"peerDependencies": {
-				"ajv": "^8.8.2"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-			"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"ajv": "^8.9.0",
-				"ajv-formats": "^2.1.1",
-				"ajv-keywords": "^5.1.0"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -34632,6 +34567,78 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/mini-css-extract-plugin": {
+			"version": "2.7.6",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
+			"integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
+			"dev": true,
+			"dependencies": {
+				"schema-utils": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.0.0"
+			}
+		},
+		"node_modules/mini-css-extract-plugin/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+			"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/minimalistic-assert": {
@@ -57459,50 +57466,6 @@
 						"picomatch": "^2.3.1"
 					}
 				},
-				"mini-css-extract-plugin": {
-					"version": "2.7.6",
-					"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
-					"integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
-					"dev": true,
-					"requires": {
-						"schema-utils": "^4.0.0"
-					},
-					"dependencies": {
-						"ajv": {
-							"version": "8.12.0",
-							"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-							"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-							"dev": true,
-							"requires": {
-								"fast-deep-equal": "^3.1.1",
-								"json-schema-traverse": "^1.0.0",
-								"require-from-string": "^2.0.2",
-								"uri-js": "^4.2.2"
-							}
-						},
-						"ajv-keywords": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-							"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-							"dev": true,
-							"requires": {
-								"fast-deep-equal": "^3.1.3"
-							}
-						},
-						"schema-utils": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-							"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
-							"dev": true,
-							"requires": {
-								"@types/json-schema": "^7.0.9",
-								"ajv": "^8.9.0",
-								"ajv-formats": "^2.1.1",
-								"ajv-keywords": "^5.1.0"
-							}
-						}
-					}
-				},
 				"npm-run-path": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -70299,6 +70262,56 @@
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
 			"dev": true
+		},
+		"mini-css-extract-plugin": {
+			"version": "2.7.6",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
+			"integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
+			"dev": true,
+			"requires": {
+				"schema-utils": "^4.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.12.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ajv-keywords": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+					"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.3"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+					"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.9",
+						"ajv": "^8.9.0",
+						"ajv-formats": "^2.1.1",
+						"ajv-keywords": "^5.1.0"
+					}
+				}
+			}
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -140,19 +140,23 @@
 		"files": [
 			{
 				"path": "./js/build/*.js",
-				"maxSize": "1.74 kB"
+				"maxSize": "10 kB"
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "148.52 kB"
+				"maxSize": "18.05 kB"
+			},
+			{
+				"path": "./js/build/commons.js",
+				"maxSize": "54.14 kB"
+			},
+			{
+				"path": "./js/build/vendors.js",
+				"maxSize": "39.37 kB"
 			},
 			{
 				"path": "./js/build/*.css",
-				"maxSize": "364 B"
-			},
-			{
-				"path": "./js/build/index.css",
-				"maxSize": "12.55 kB"
+				"maxSize": "7.5 kB"
 			},
 			{
 				"path": "./google-listings-and-ads.zip",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"eslint-plugin-import": "^2.25.4",
 		"jest": "^29.6.2",
 		"jest-environment-jsdom": "^27.5.1",
+		"mini-css-extract-plugin": "^2.7.6",
 		"path-browserify": "^1.0.1",
 		"prettier": "npm:wp-prettier@2.6.2",
 		"react": "^17.0.2",

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -22,6 +22,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\Admin\PageController;
+
 /**
  * Class Admin
  *
@@ -75,7 +77,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 		add_action(
 			'admin_enqueue_scripts',
 			function() {
-				if ( wc_admin_is_registered_page() ) {
+				if ( PageController::is_admin_page() ) {
 					// Enqueue the required JavaScript scripts and CSS styles of the Media library.
 					wp_enqueue_media();
 				}
@@ -110,7 +112,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 	 */
 	protected function get_assets(): array {
 		$wc_admin_condition = function() {
-			return wc_admin_is_registered_page();
+			return PageController::is_admin_page();
 		};
 
 		$assets[] = ( new AdminScriptWithBuiltDependenciesAsset(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ const webpackConfig = {
 				test: /\.(svg|png|jpe?g|gif)$/i,
 				type: 'asset/resource',
 				generator: {
-					filename: 'images/[path]/[contenthash].[name][ext]',
+					filename: 'images/[path][contenthash].[name][ext]',
 				},
 			},
 			// Fix module not found problem for `process/browser`.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a pre-processing for supporting Product Block Editor.

With the current conditions for loading assets, navigating from a product editing page to a GL&A page will show “Sorry, you are not allowed to access this page.”

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/63c661fe-718a-4b89-bf12-d999ec44ee27

To fix this issue, this PR:
- Replace `wc_admin_is_registered_page` with `PageController::is_admin_page` to determine if loading the assets of React-powered pages.
- Furthermore, to reduce the loading file size while viewing other WC admin pages rather than loading all code bundled in a single JS/CSS file,
   - Set up lazy loading to the entry components for each React-powered page.
   - Set up code splitting for the external packages and internal shared codes.
   - Re-config the max sizes of bundlewatch for split files.
- Extra change: Remove a redundant slash in the path of the bundled image assets. For example:
   ```
   Before: https://wp.test/wp-content/plugins/google-listings-and-ads/js/build/images/js/src/components/account-card//25a37606f64ef10ff60e.wp-logo.svg
   After:  https://wp.test/wp-content/plugins/google-listings-and-ads/js/build/images/js/src/components/account-card/25a37606f64ef10ff60e.wp-logo.svg
   ```

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/74375d06-b815-4894-9d5f-4d85c0f837f3

### Detailed test instructions:

1. Set up [WooCommerce 8.1.1](https://github.com/woocommerce/woocommerce/releases/tag/8.1.1)
2. Go to WooCommerce > Settings > Advanced > Features. Enable the **New product editor**
   ![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/089066c0-2816-4ff6-a049-22d57fdc1ce6)
3. `npm install` and `npm start` to rebuild client-side files.
4. Go to edit a product, and then navigate to a GLA page.
5. Check if the GLA page is shown normally.
6. Navigate to other GLA pages to see if they are shown normally.
7. Navigate to GLA Settings page to view if the SVG icons are loaded.

### Additional details:

The issue mentioned above can be fixed by only having the commit c2841835da02f3589373380d9942053b3e74bc0f. However, while viewing other WC admin pages such as WC homepage, it would load all GLA JS and CSS codes as well but most of them may not required. For example:
- Get Started
- Extention Onboarding
- Google Ads Onboarding
- Reconntet Google/Jetpack
- All GLA admin pages

After setting up lazy loading and code splitting, it will still load the `index.js` and `index.css` files but they only include the minimum required codes that register GLA's React-powered pages via the client-side WP filter. The must-loaded index.js file size will be reduced from ~123 KB to ~15 KB. After navigating to a GLA page such as the Dashboard, it starts loading the JS and CSS files needed for that page.

### Changelog entry

> Dev - Adjust the conditions for loading JS and CSS assets, and configure them with lazy loading and code splitting.
