### PR TITLE
Ignore the directory of E2E test results to avoid eslint getting stuck

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@ languages
 node_modules
 vendor
 legacy
+tests/e2e/test-results


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While running `npm run lint:js` locally, it got stuck for over 20 minutes. It's because the .js files in the `tests/e2e/test-results` directory for storing E2E test results are included.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/0f75b279-807e-4095-8bf4-b7d817d5bc33)

This PR excludes the `tests/e2e/test-results` directory to avoid eslint getting stuck.

### Detailed test instructions:

1. Follow the [e2e-testing](https://github.com/woocommerce/google-listings-and-ads/tree/16d44683fc4f1b402031e165188cdfd4035c1cce#e2e-testing) to run it locally. It should generate some .js files in the `tests/e2e/test-results` directory.
2. Run `npm run lint:js` to see if eslint can be completed within 3 minutes.

### Changelog entry
