### PR TITLE
Add QIT workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_call:
   push:
     branches:
       - trunk
@@ -69,3 +70,12 @@ jobs:
         uses: woocommerce/grow/publish-extension-dev-build@actions-v1
         with:
           extension-asset-path: google-listings-and-ads.zip
+
+      - name: Publish build artifact
+        if: ${{ ! ( github.event_name == 'push' && github.ref_name == 'develop' ) }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: google-listings-and-ads.zip
+          path: ${{ github.workspace }}/google-listings-and-ads.zip
+          # Do not bloat the storage. Keep in only long enough for a caller workflow to pick it up and follow up with some manual debugging.
+          retention-days: 2

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -42,6 +42,7 @@ on:
   push:
     branches:
       - dev/qit-workflow
+      - dev/qit-workflow-alternative
 
 jobs:
   build:
@@ -50,17 +51,25 @@ jobs:
     secrets: inherit
   qit-tests:
     name: Run QIT Tests
-    # Update it with more stable path once merged.
-    uses: woocommerce/grow/.github/workflows/run-qit-extension.yml@add/qit-workflows
+    runs-on: ubuntu-20.04
     needs: build
-    secrets: inherit
-    with:
-      version: local
-      # Conditional statements are here to allow testing on push triggers, without manual input. To be removed before merging.
-      test-activation: ${{ inputs.test-activation || true }}
-      test-security: ${{ inputs.test-security || true }}
-      test-phpstan: ${{ inputs.test-phpstan || true }}
-      test-api: ${{ inputs.test-api || true }}
-      test-e2e: ${{ inputs.test-e2e || false }}
-      extension: 'google-listings-and-ads'
-      options: ${{ inputs.options }}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: google-listings-and-ads.zip
+      - name: Delegate QIT Tests
+        # Update it with more stable path once merged.
+        uses: woocommerce/grow/packages/github-actions/actions/run-qit-extension@add/qit-workflows-alternative
+        with:
+          qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
+          qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}
+          version: local
+          extension: 'google-listings-and-ads'
+          # Conditional statements are here to allow testing on push triggers, without manual input. To be removed before merging.
+          test-activation: ${{ inputs.test-activation || true }}
+          test-security: ${{ inputs.test-security || true }}
+          test-phpstan: ${{ inputs.test-phpstan || true }}
+          test-api: ${{ inputs.test-api || true }}
+          test-e2e: ${{ inputs.test-e2e || false }}
+          options: ${{ inputs.options }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -52,6 +52,7 @@ jobs:
     name: Run QIT Tests
     # Update it with more stable path once merged.
     uses: woocommerce/grow/.github/workflows/run-qit-extension.yml@add/qit-workflows
+    needs: build
     secrets: inherit
     with:
       version: local

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -60,7 +60,7 @@ jobs:
       test-activation: ${{ inputs.test-activation || true }}
       test-security: ${{ inputs.test-security || true }}
       test-phpstan: ${{ inputs.test-phpstan || true }}
-      test-api: ${{ inputs.test-api || false }}
+      test-api: ${{ inputs.test-api || true }}
       test-e2e: ${{ inputs.test-e2e || false }}
       extension: 'google-listings-and-ads'
       options: ${{ inputs.options }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -1,0 +1,65 @@
+name: Run QIT
+
+# **What it does**: Runs a suite of QIT tests for the extension.
+# **Why we have it**: To be able to check QIT compatibility at once. For example, to test a specific branch, or upcoming release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      # Configure which tests to run.
+      test-activation:
+        description: 'Should activation be tested?'
+        required: true
+        default: true
+        type: boolean
+      test-security:
+        description: 'Should security be tested?'
+        required: true
+        default: true
+        type: boolean
+      test-phpstan:
+        description: 'Should phpstan be tested?'
+        required: true
+        default: true
+        type: boolean
+      test-api:
+        description: 'Should API be tested?'
+        required: true
+        default: true
+        type: boolean
+      test-e2e:
+        description: 'Should E2E be tested? (takes a lot of time)'
+        required: true
+        default: false
+        type: boolean
+
+      # Advanced customization.
+      options:
+        description: 'Additional options for `qit` command, like `--optional_features=hpos`.'
+        required: false
+
+  # Used to test this PR, to be removed after before merging.
+  push:
+    branches:
+      - dev/qit-workflow
+
+jobs:
+  build:
+    name: Build extension
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+  qit-tests:
+    name: Run QIT Tests
+    # Update it with more stable path once merged.
+    uses: woocommerce/grow/.github/workflows/run-qit-extension.yml@add/qit-workflows
+    secrets: inherit
+    with:
+      version: local
+      # Conditional statements are here to allow testing on push triggers, without manual input. To be removed before merging.
+      test-activation: ${{ inputs.test-activation || true }}
+      test-security: ${{ inputs.test-security || true }}
+      test-phpstan: ${{ inputs.test-phpstan || true }}
+      test-api: ${{ inputs.test-api || false }}
+      test-e2e: ${{ inputs.test-e2e || false }}
+      extension: 'google-listings-and-ads'
+      options: ${{ inputs.options }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -47,11 +47,6 @@ on:
         description: 'Additional options for `qit` command, like `--optional_features=hpos`.'
         required: false
 
-  # Used to test this PR, to be removed after before merging.
-  push:
-    branches:
-      - dev/qit-workflow
-
 jobs:
   build:
     name: Build extension
@@ -68,18 +63,17 @@ jobs:
           name: google-listings-and-ads.zip
       - name: Run QIT Tests
         # Update it with more stable path once merged.
-        uses: woocommerce/grow/run-qit-extension@add/qit-workflows-test-build
+        uses: woocommerce/grow/run-qit-extension@actions-v1
         with:
           qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
           qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}
           version: local
-          # Conditional statements are here to allow testing on push trigger, without manual input. To be removed before merging.
-          wait: ${{ inputs.wait || true }}
+          wait: ${{ inputs.wait }}
           extension: 'google-listings-and-ads'
-          test-activation: ${{ inputs.test-activation || true }}
-          test-security: ${{ inputs.test-security || true }}
-          test-phpstan: ${{ inputs.test-phpstan || true }}
-          test-api: ${{ inputs.test-api || true }}
-          test-e2e: ${{ inputs.test-e2e || false }}
-          ignore-fail: ${{ inputs.ignore-fail || true }}
+          test-activation: ${{ inputs.test-activation }}
+          test-security: ${{ inputs.test-security }}
+          test-phpstan: ${{ inputs.test-phpstan }}
+          test-api: ${{ inputs.test-api }}
+          test-e2e: ${{ inputs.test-e2e }}
+          ignore-fail: ${{ inputs.ignore-fail }}
           options: ${{ inputs.options }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: google-listings-and-ads.zip
-      - name: Delegate QIT Tests
+      - name: Run QIT Tests
         # Update it with more stable path once merged.
         uses: woocommerce/grow/run-qit-extension@add/qit-workflows-test-build
         with:

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -6,6 +6,10 @@ name: Run QIT
 on:
   workflow_dispatch:
     inputs:
+      wait:
+        description: 'Should wait for results'
+        default: false
+        type: boolean
       # Configure which tests to run.
       test-activation:
         description: 'Should activation be tested?'
@@ -34,6 +38,11 @@ on:
         type: boolean
 
       # Advanced customization.
+      ignore-fail:
+        description: Should pass even if any awaited test fails.
+        required: false
+        default: false
+        type: boolean
       options:
         description: 'Additional options for `qit` command, like `--optional_features=hpos`.'
         required: false
@@ -42,7 +51,6 @@ on:
   push:
     branches:
       - dev/qit-workflow
-      - dev/qit-workflow-alternative
 
 jobs:
   build:
@@ -60,16 +68,18 @@ jobs:
           name: google-listings-and-ads.zip
       - name: Delegate QIT Tests
         # Update it with more stable path once merged.
-        uses: woocommerce/grow/packages/github-actions/actions/run-qit-extension@add/qit-workflows-alternative
+        uses: woocommerce/grow/run-qit-extension@add/qit-workflows-test-build
         with:
           qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
           qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}
           version: local
+          # Conditional statements are here to allow testing on push trigger, without manual input. To be removed before merging.
+          wait: ${{ inputs.wait || true }}
           extension: 'google-listings-and-ads'
-          # Conditional statements are here to allow testing on push triggers, without manual input. To be removed before merging.
           test-activation: ${{ inputs.test-activation || true }}
           test-security: ${{ inputs.test-security || true }}
           test-phpstan: ${{ inputs.test-phpstan || true }}
           test-api: ${{ inputs.test-api || true }}
           test-e2e: ${{ inputs.test-e2e || false }}
+          ignore-fail: ${{ inputs.ignore-fail || true }}
           options: ${{ inputs.options }}


### PR DESCRIPTION
:warning: depends on https://github.com/woocommerce/grow/pull/81

### Changes proposed in this Pull Request:

1. Change the `build` workflow so it publish an artifact and can be called by other workflows.
2. Add a manual workflow, that builds the extension and run selected QIT tests for that package.


### Screenshots:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17435/b6674b1c-32a6-4b71-b681-5b1b058b9b1e)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Fork the repo
2. Setup secrets. Links to secrets are at Pe98dy-Ir-p2 
3. Merge this branch to the main one /`trunk`
4. Run the manual workflow at  https://github.com/woocommerce/google-listings-and-ads/actions/workflows/run-qit.yml




### Additional details:

1. Before margin we need to remove those lines 
https://github.com/woocommerce/google-listings-and-ads/pull/2114/files#diff-0550f940c28a3fbd24937bad01914ede672b538aff10de709e999759ccf4f9dfR41-R44

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add manual QIT workflow
