### PR TITLE
Fix a few E2E tests that may fail due to network time lag or no fallback requests

### DIFF
--- a/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
@@ -284,25 +284,25 @@ test.describe( 'Confirm store requirements', () => {
 				} );
 
 				test( 'should see all checkboxes are not checked', async () => {
-					const prelaunchChecklistCheckboxes =
+					const checkboxes =
 						storeRequirements.getPrelaunchChecklistCheckboxes();
 
-					for ( const checkbox of await prelaunchChecklistCheckboxes.all() ) {
+					await expect( checkboxes ).toHaveCount( 5 );
+
+					for ( const checkbox of await checkboxes.all() ) {
 						await expect( checkbox ).not.toBeChecked();
 					}
 				} );
 
 				test( 'should toggle all checklists and see the "Confirm" button in each checklist', async () => {
-					const prelaunchChecklistToggles =
-						storeRequirements.getPrelaunchChecklistToggles();
-					const count = await prelaunchChecklistToggles.count();
+					const panels =
+						storeRequirements.getPrelaunchChecklistPanels();
 
-					for ( let i = 0; i < count; i++ ) {
-						const toggle = await prelaunchChecklistToggles.nth( i );
-						await toggle.click();
-						const panel = await storeRequirements
-							.getPrelaunchChecklistPanels()
-							.nth( i );
+					await expect( panels ).toHaveCount( 5 );
+
+					for ( const panel of await panels.all() ) {
+						await panel.click();
+
 						const confirmButton = panel.getByRole( 'button', {
 							name: 'Confirm',
 							exact: true,
@@ -494,9 +494,12 @@ test.describe( 'Confirm store requirements', () => {
 				} );
 
 				test( 'should see all checkboxes are checked', async () => {
-					const prelaunchChecklistCheckboxes =
+					const checkboxes =
 						storeRequirements.getPrelaunchChecklistCheckboxes();
-					for ( const checkbox of await prelaunchChecklistCheckboxes.all() ) {
+
+					await expect( checkboxes ).toHaveCount( 5 );
+
+					for ( const checkbox of await checkboxes.all() ) {
 						await expect( checkbox ).toBeChecked();
 						await expect( checkbox ).toBeDisabled();
 					}

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -33,7 +33,7 @@ export default class MockRequests {
 					body: JSON.stringify( payload ),
 				} );
 			} else {
-				route.continue();
+				route.fallback();
 			}
 		} );
 	}
@@ -98,13 +98,15 @@ export default class MockRequests {
 	 *
 	 * @param {Object} payload
 	 * @param {number} status
+	 * @param {string[]} [methods]
 	 * @return {Promise<void>}
 	 */
-	async fulfillMCAccounts( payload, status = 200 ) {
+	async fulfillMCAccounts( payload, status = 200, methods ) {
 		await this.fulfillRequest(
 			/\/wc\/gla\/mc\/accounts\b/,
 			payload,
-			status
+			status,
+			methods
 		);
 	}
 
@@ -402,12 +404,16 @@ export default class MockRequests {
 	 * @param {number} id
 	 */
 	async mockMCCreateAccountWebsiteNotClaimed( id = 12345 ) {
-		await this.fulfillMCAccounts( {
-			id,
-			subaccount: null,
-			name: null,
-			domain: null,
-		} );
+		await this.fulfillMCAccounts(
+			{
+				id,
+				subaccount: null,
+				name: null,
+				domain: null,
+			},
+			200,
+			[ 'POST' ]
+		);
 	}
 
 	/**
@@ -427,7 +433,8 @@ export default class MockRequests {
 				id,
 				website_url: websiteUrl,
 			},
-			403
+			403,
+			[ 'POST' ]
 		);
 	}
 

--- a/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
+++ b/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
@@ -195,17 +195,6 @@ export default class StoreRequirements extends MockRequests {
 	}
 
 	/**
-	 * Get pre-launch checklist toggles.
-	 *
-	 * @return {import('@playwright/test').Locator} Get pre-launch checklist toggles.
-	 */
-	getPrelaunchChecklistToggles() {
-		return this.getPrelaunchChecklistPanels().locator(
-			'.components-button.components-panel__body-toggle'
-		);
-	}
-
-	/**
 	 * Get Continue button.
 	 *
 	 * @return {import('@playwright/test').Locator} Get Continue button.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a few E2E tests.
- Fix the tests of pre-launch checklist
   - It may fail due to the network time lag.
- Fix the test of claimed GMC account.
   - The multiple routes of the same pattern didn't fall back.

#### Context

While working on #2108 and #2115, there were a few tests that always failed or failed very easily.

Especially with the change to lazy loading in #2108, `page.goto( url, { waitUntil: 'domcontentloaded' } )` may lead to skipping or failing tests because the lazy loading page is not fully loaded and the target elements are not yet available.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/29ca8994-13d7-4fcc-988a-f8660e8727f7)

(Ref: https://github.com/woocommerce/google-listings-and-ads/actions/runs/6337008219/job/17211193354#step:10:397)

### Detailed test instructions:

1. View the E2E test results of this PR on GHA: https://github.com/woocommerce/google-listings-and-ads/actions/runs/6337174014/job/17211701721
2. Set up local E2E test env.
3. Run `npm run test:e2e -- ./tests/e2e/specs/setup-mc/step-1-accounts.test.js`, all tests should pass.
4. Run `npm run test:e2e -- ./tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js`, all tests should pass.
5. Run `npm run test:e2e` to make sure all tests are passed.

### Additional details:

#### 📌 Test case of claimed GMC account:

In the following code, the last registered `setUpAccountsPage.mockMCCreateAccountWebsiteClaimed` will override `setUpAccountsPage.mockMCHasNoAccounts` as they share the same route pattern. It caused the page to crash because the first request expected an empty array of GMC accounts but it returned a claimed account data as an object structure. Therefore, the test always resulted in a timeout failure.

https://github.com/woocommerce/google-listings-and-ads/blob/47bbbdfe93beba9482d87197681f0dd8ea9de9e3/tests/e2e/specs/setup-mc/step-1-accounts.test.js#L301-L315

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/94253f4a-26e9-44c7-99c3-c6cb73a6ccb1)

#### 📌 Test cases of pre-launch checklist:

The [result of `prelaunchChecklistCheckboxes.all()`](https://github.com/woocommerce/google-listings-and-ads/blob/47bbbdfe93beba9482d87197681f0dd8ea9de9e3/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js#L290-L292) has a very high chance of being an empty array, and it happens on the subsequent tests.

![2](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/40973917-6075-4586-becb-a8b527d56f81)

### Changelog entry
