### PR TITLE
Update the `caniuse-lite` package to the latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21359,9 +21359,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001431",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
-			"integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
+			"version": "1.0.30001541",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+			"integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -21370,6 +21370,10 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			]
 		},
@@ -60138,9 +60142,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001431",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
-			"integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ=="
+			"version": "1.0.30001541",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+			"integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw=="
 		},
 		"capital-case": {
 			"version": "1.0.4",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The following warning shows when running `npm start` and `npm run test:js`. This PR updates the `caniuse-lite` package to the latest to avoid the warnings.

```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

### Detailed test instructions:

1. `npm install`
2. `npm start` and `npm run test:js` to check if the warning doesn't appear anymore.

### Changelog entry
