### PR TITLE
Add E2E tests for Setup Google Ads - Step 2

### DIFF
--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -302,10 +302,10 @@ test.describe( 'Set up Ads account', () => {
 					'.gla-campaign-preview-card__moving-button'
 				);
 
-				expect( await buttonsToChangeImage.count() ).toBe( 2 );
+				expect( buttonsToChangeImage ).toHaveCount( 2 );
 
 				for ( const button of await buttonsToChangeImage.all() ) {
-					expect( button ).toBeEnabled();
+					await expect( button ).toBeEnabled();
 				}
 			} );
 		} );

--- a/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js
@@ -8,7 +8,15 @@ import { expect, test } from '@playwright/test';
 import { clearOnboardedMerchant, setOnboardedMerchant } from '../../utils/api';
 import DashboardPage from '../../utils/pages/dashboard.js';
 import SetupAdsAccountsPage from '../../utils/pages/setup-ads/setup-ads-accounts.js';
+import SetupBudgetPage from '../../utils/pages/setup-ads/setup-budget';
 import { LOAD_STATE } from '../../utils/constants';
+import {
+	getCountryInputSearchBoxContainer,
+	getCountryTagsFromInputSearchBoxContainer,
+	getFAQPanelTitle,
+	getFAQPanelRow,
+	checkFAQExpandable,
+} from '../../utils/page';
 
 const ADS_ACCOUNTS = [
 	{
@@ -39,6 +47,11 @@ let setupAdsAccounts = null;
  * @type {import('@playwright/test').Locator} adsConnectionButton
  */
 let adsConnectionButton = null;
+
+/**
+ * @type {import('../../utils/pages/setup-ads/setup-budget.js').default} setupBudgetPage
+ */
+let setupBudgetPage = null;
 
 /**
  * @type {import('@playwright/test').Page} page
@@ -226,6 +239,22 @@ test.describe( 'Set up Ads account', () => {
 
 			await expect( setupAdsAccounts.getContinueButton() ).toBeEnabled();
 		} );
+	} );
+
+	test.describe( 'Create your paid campaign', () => {
+		test.beforeAll( async () => {
+			setupBudgetPage = new SetupBudgetPage( page );
+			await setupBudgetPage.fulfillBudgetRecommendation( {
+				currency: 'USD',
+				recommendations: [
+					{
+						country: 'US',
+						daily_budget_low: 5,
+						daily_budget_high: 15,
+					},
+				],
+			} );
+		} );
 
 		test( 'Continue to create paid campaign', async () => {
 			await setupAdsAccounts.clickContinue();
@@ -243,6 +272,89 @@ test.describe( 'Set up Ads account', () => {
 
 			await expect(
 				page.getByRole( 'heading', { name: 'Set your budget' } )
+			).toBeVisible();
+
+			await expect(
+				page.getByRole( 'button', { name: 'Continue' } )
+			).toBeDisabled();
+
+			await expect(
+				page.getByRole( 'link', {
+					name: 'See what your ads will look like.',
+				} )
+			).toBeVisible();
+		} );
+
+		test.describe( 'Preview product ad', () => {
+			test( 'Preview product ad should be visible', async () => {
+				await expect(
+					page.getByText( 'Preview product ad' )
+				).toBeVisible();
+				await expect(
+					page.getByText(
+						"Each of your product variants will have its own ad. Previews shown here are examples and don't include all possible formats."
+					)
+				).toBeVisible();
+			} );
+
+			test( 'Change image buttons should be enabled', async () => {
+				const buttonsToChangeImage = page.locator(
+					'.gla-campaign-preview-card__moving-button'
+				);
+
+				expect( await buttonsToChangeImage.count() ).toBe( 2 );
+
+				for ( const button of await buttonsToChangeImage.all() ) {
+					expect( button ).toBeEnabled();
+				}
+			} );
+		} );
+
+		test.describe( 'FAQ panels', () => {
+			test( 'should see five questions in FAQ', async () => {
+				const faqTitles = getFAQPanelTitle( page );
+				await expect( faqTitles ).toHaveCount( 5 );
+			} );
+
+			test( 'should not see FAQ rows when FAQ titles are not clicked', async () => {
+				const faqRows = getFAQPanelRow( page );
+				await expect( faqRows ).toHaveCount( 0 );
+			} );
+
+			// eslint-disable-next-line jest/expect-expect
+			test( 'should see FAQ rows when all FAQ titles are clicked', async () => {
+				await checkFAQExpandable( page );
+			} );
+		} );
+
+		test( 'Audience should be United States', async () => {
+			const countrySearchBoxContainer =
+				getCountryInputSearchBoxContainer( page );
+			const countryTags =
+				getCountryTagsFromInputSearchBoxContainer( page );
+			await expect( countryTags ).toHaveCount( 1 );
+			await expect( countrySearchBoxContainer ).toContainText(
+				'United States'
+			);
+		} );
+
+		test( 'Set the budget', async () => {
+			await setupBudgetPage.fillBudget( '1' );
+
+			await expect(
+				page.getByRole( 'button', { name: 'Continue' } )
+			).toBeEnabled();
+
+			await setupBudgetPage.fillBudget( '0' );
+
+			await expect(
+				page.getByRole( 'button', { name: 'Continue' } )
+			).toBeDisabled();
+		} );
+
+		test( 'Budget Recommendation', async () => {
+			await expect(
+				page.getByText( 'set a daily budget of 5 to 15 USD' )
 			).toBeVisible();
 		} );
 	} );

--- a/tests/e2e/specs/dashboard/edit-free-listings.test.js
+++ b/tests/e2e/specs/dashboard/edit-free-listings.test.js
@@ -64,9 +64,6 @@ test.describe( 'Edit Free Listings', () => {
 		const dontEditButton = await dashboardPage.getDontEditButton();
 		await expect( continueToEditButton ).toBeEnabled();
 		await expect( dontEditButton ).toBeEnabled();
-	} );
-
-	test( 'Continue to edit Free listings', async () => {
 		await dashboardPage.clickContinueToEditButton();
 		await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	} );

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -80,6 +80,7 @@ test.describe( 'Set up accounts', () => {
 			await expect( faqRows ).toHaveCount( 0 );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should see FAQ rows when all FAQ titles are clicked', async () => {
 			await checkFAQExpandable( page );
 		} );

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -120,6 +120,7 @@ test.describe( 'Complete your campaign', () => {
 			await expect( faqRows ).toHaveCount( 0 );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should see FAQ rows when all FAQ titles are clicked', async () => {
 			await checkFAQExpandable( page );
 		} );

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -223,6 +223,19 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the Budget Recommendation request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillBudgetRecommendation( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/ads\/campaigns\/budget-recommendation\b/,
+			payload
+		);
+	}
+
+	/**
 	 * Fulfill the Sync Settings Connection request.
 	 *
 	 * @param {Object} payload


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/2070, this PR adds E2E tests for https://github.com/woocommerce/google-listings-and-ads/issues/2070#gla-dashboard.



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow these steps to set up the e2e env: https://github.com/woocommerce/google-listings-and-ads#e2e-testing
2. Run `npm run test:e2e -- ./tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js`, the test should pass.
3. Or, run `npm run test:e2e-dev -- ./tests/e2e/specs/add-paid-campaigns/step-1-accounts.test.js`, check the test in the chromium step by step.
4. ~Run `npm run test:e2e` to make sure all tests are passed~. (It appears that one of the `gtags` tests is currently failing. I'll look into this in a separate PR.)


### Additional details:
- I didn't test the Audience tree selector in deep because this was already tested in https://github.com/woocommerce/google-listings-and-ads/pull/2105
- I'll update the current filename, which is `step-1-accounts.test.js` to something more generic. Initially, I thought of organizing the tests into steps, but it appears that currently, it's not feasible to skip directly to step 2 without completing step 1.
- I included `eslint-disable-next-line jest/expect-expect` for the `checkFAQExpandable` function since the tests are encompassed within that function. Also I grouped one of tests to avoid the warning `Test has no assertions  jest/expect-expect`. See https://github.com/woocommerce/google-listings-and-ads/pull/2121/commits/d90fb4ba4762a803920358eaa8ee1741e06ec19f
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>Dev - E2E - Setup Google Ads Step 2 - Create your paid campaign