### PR TITLE
Fix E2E tests - Track gtag event on specific page

### DIFF
--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -50,7 +50,7 @@ test.describe( 'GTag events', () => {
 	} );
 
 	test( 'Page view event is sent on a frontend page', async ( { page } ) => {
-		const event = trackGtagEvent( page, 'page_view', false );
+		const event = trackGtagEvent( page, 'page_view' );
 
 		await page.goto( 'shop' );
 		await expect( event ).resolves.toBeTruthy();
@@ -151,7 +151,7 @@ test.describe( 'GTag events', () => {
 	} ) => {
 		await singleProductAddToCart( page, simpleProductID );
 
-		const event = trackGtagEvent( page, 'page_view' );
+		const event = trackGtagEvent( page, 'page_view', 'cart' );
 		await page.goto( 'cart' );
 
 		await event.then( ( request ) => {
@@ -166,7 +166,7 @@ test.describe( 'GTag events', () => {
 	} ) => {
 		await singleProductAddToCart( page, simpleProductID );
 
-		const event = trackGtagEvent( page, 'conversion', false );
+		const event = trackGtagEvent( page, 'conversion', 'checkout' );
 		await checkout( page );
 
 		await event.then( ( request ) => {
@@ -181,7 +181,7 @@ test.describe( 'GTag events', () => {
 	} ) => {
 		await singleProductAddToCart( page, simpleProductID );
 
-		const event = trackGtagEvent( page, 'purchase' );
+		const event = trackGtagEvent( page, 'purchase', 'checkout' );
 		await checkout( page );
 
 		await event.then( ( request ) => {

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -50,7 +50,7 @@ test.describe( 'GTag events', () => {
 	} );
 
 	test( 'Page view event is sent on a frontend page', async ( { page } ) => {
-		const event = trackGtagEvent( page, 'page_view' );
+		const event = trackGtagEvent( page, 'page_view', false );
 
 		await page.goto( 'shop' );
 		await expect( event ).resolves.toBeTruthy();
@@ -166,7 +166,7 @@ test.describe( 'GTag events', () => {
 	} ) => {
 		await singleProductAddToCart( page, simpleProductID );
 
-		const event = trackGtagEvent( page, 'conversion' );
+		const event = trackGtagEvent( page, 'conversion', false );
 		await checkout( page );
 
 		await event.then( ( request ) => {

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -17,13 +17,13 @@ export function trackGtagEvent( page, eventName, urlPath = null ) {
 	const eventPath = '/pagead/';
 	return page.waitForRequest( ( request ) => {
 		const url = request.url();
-		const match = encodeURIComponent( 'event=' + eventName );
+		const match = 'event=' + eventName;
 		const origin = new URL( page.url() ).origin;
 		const params = new URL( url ).searchParams;
 
 		return (
 			url.includes( eventPath ) &&
-			url.includes( match ) &&
+			params.get( 'data' ).includes( match ) &&
 			( urlPath
 				? params
 						.get( 'url' )

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -10,18 +10,26 @@
  *
  * @param {Page} page
  * @param {string} eventName Event name to match.
- * @param  {boolean} ecommPagetype Whether to check for ecomm_pagetype in the URL.
+ * @param {string|null} URLpath The URL path where the event should be triggered.
  * @return {Promise<Request>} Matching request.
  */
-export function trackGtagEvent( page, eventName, ecommPagetype = true ) {
+export function trackGtagEvent( page, eventName, URLpath = null ) {
 	const eventPath = '/pagead/';
 	return page.waitForRequest( ( request ) => {
 		const url = request.url();
 		const match = encodeURIComponent( 'event=' + eventName );
+		const origin = new URL( page.url() ).origin;
+
 		return (
 			url.includes( eventPath ) &&
 			url.includes( match ) &&
-			( ecommPagetype ? url.includes( 'ecomm_pagetype' ) : true )
+			( URLpath
+				? url.includes(
+						`url=${ encodeURIComponent(
+							`${ origin }/${ URLpath }`
+						) }`
+				  )
+				: true )
 		);
 	} );
 }

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -10,25 +10,24 @@
  *
  * @param {Page} page
  * @param {string} eventName Event name to match.
- * @param {string|null} URLpath The URL path where the event should be triggered.
+ * @param {string|null} urlPath The starting path to match where the event should be triggered.
  * @return {Promise<Request>} Matching request.
  */
-export function trackGtagEvent( page, eventName, URLpath = null ) {
+export function trackGtagEvent( page, eventName, urlPath = null ) {
 	const eventPath = '/pagead/';
 	return page.waitForRequest( ( request ) => {
 		const url = request.url();
 		const match = encodeURIComponent( 'event=' + eventName );
 		const origin = new URL( page.url() ).origin;
+		const params = new URL( url ).searchParams;
 
 		return (
 			url.includes( eventPath ) &&
 			url.includes( match ) &&
-			( URLpath
-				? url.includes(
-						`url=${ encodeURIComponent(
-							`${ origin }/${ URLpath }`
-						) }`
-				  )
+			( urlPath
+				? params
+						.get( 'url' )
+						.includes( `${ `${ origin }/${ urlPath }` }` )
 				: true )
 		);
 	} );

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -10,14 +10,19 @@
  *
  * @param {Page} page
  * @param {string} eventName Event name to match.
+ * @param  {boolean} ecommPagetype Whether to check for ecomm_pagetype in the URL.
  * @return {Promise<Request>} Matching request.
  */
-export function trackGtagEvent( page, eventName ) {
+export function trackGtagEvent( page, eventName, ecommPagetype = true ) {
 	const eventPath = '/pagead/';
 	return page.waitForRequest( ( request ) => {
 		const url = request.url();
 		const match = encodeURIComponent( 'event=' + eventName );
-		return url.includes( eventPath ) && url.includes( match );
+		return (
+			url.includes( eventPath ) &&
+			url.includes( match ) &&
+			( ecommPagetype ? url.includes( 'ecomm_pagetype' ) : true )
+		);
 	} );
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

As of now, the `trackGtagEvent` function only checks for the event itself. Yet, there are scenarios where the same event may carry different properties, and within a brief timeframe, the same event can be triggered with varying properties. Since we don't perform an assertion to wait for a request with specific data, these tests could potentially fail.

https://github.com/woocommerce/google-listings-and-ads/blob/78582d6ffab31b5bf3dfcf97e69fcbf623f0b932/tests/e2e/utils/track-event.js#L15-L21

This PR tweaks the `trackGtagEvent` function. It will now wait for a specific event and also provides the capability to verify if the "ecomm_pagetype" data is sent.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow these steps to set up the e2e env: https://github.com/woocommerce/google-listings-and-ads#e2e-testing
2. Run `npm run test:e2e -- ./tests/e2e/specs/gtag-events/gtag-events.test.js` and see that all tests passes.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - E2E tests - Track gtag event on specific page
