### PR TITLE
Add E2E tests for Setup Google Ads - Step 3

### DIFF
--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -209,7 +209,7 @@ function AdaptiveForm( { onSubmit, extendAdapter, children, ...props }, ref ) {
 				// Keep the target element for identifying which one triggered the submission when
 				// there are multiple submit buttons.
 				formContext.handleSubmit = function ( event ) {
-					adapterRef.current.submitter = event.currentTarget;
+					adapterRef.current.submitter = event?.currentTarget || null;
 					return handleSubmit.call( this, event );
 				};
 

--- a/js/src/components/adaptive-form/adaptive-form.test.js
+++ b/js/src/components/adaptive-form/adaptive-form.test.js
@@ -116,16 +116,25 @@ describe( 'AdaptiveForm', () => {
 							<button onClick={ formContext.handleSubmit }>
 								B
 							</button>
+							<button
+								onClick={ () => {
+									// To simulate that `handleSubmit` is called without passing an `event`.
+									formContext.handleSubmit();
+								} }
+							>
+								C
+							</button>
 						</>
 					);
 				} }
 			</AdaptiveForm>
 		);
 
-		const [ buttonA, buttonB ] = screen.getAllByRole( 'button' );
+		const [ buttonA, buttonB, buttonC ] = screen.getAllByRole( 'button' );
 
 		expect( inspectOnSubmit ).toHaveBeenCalledTimes( 0 );
 
+		// Click button A to test if the form indicates that button A triggered a submission.
 		await act( async () => {
 			return userEvent.click( buttonA );
 		} );
@@ -138,6 +147,7 @@ describe( 'AdaptiveForm', () => {
 			expect.objectContaining( { submitter: buttonA } )
 		);
 
+		// Click button B to test if the form indicates that button B triggered another submission.
 		inspectSubmitter.mockClear();
 
 		await act( async () => {
@@ -150,6 +160,24 @@ describe( 'AdaptiveForm', () => {
 		expect( inspectOnSubmit ).toHaveBeenLastCalledWith(
 			{},
 			expect.objectContaining( { submitter: buttonB } )
+		);
+
+		// Click button C to test if the form stays `submitter` as `null` if `handleSubmit`
+		// is triggered without a corresponding event.
+		inspectSubmitter.mockClear();
+
+		await act( async () => {
+			return userEvent.click( buttonC );
+		} );
+
+		expect( inspectSubmitter ).toHaveBeenCalled();
+		inspectSubmitter.mock.calls.forEach( ( args ) => {
+			expect( args ).toEqual( [ null ] );
+		} );
+		expect( inspectOnSubmit ).toHaveBeenCalledTimes( 3 );
+		expect( inspectOnSubmit ).toHaveBeenLastCalledWith(
+			{},
+			expect.objectContaining( { submitter: null } )
 		);
 	} );
 

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -16,7 +16,7 @@ import {
 	getFAQPanelTitle,
 	getFAQPanelRow,
 	checkFAQExpandable,
-	checkAdsPopup,
+	checkBillingAdsPopup,
 } from '../../utils/page';
 
 const ADS_ACCOUNTS = [
@@ -388,7 +388,7 @@ test.describe( 'Set up Ads account', () => {
 
 			// eslint-disable-next-line jest/expect-expect
 			test( 'should open a popup when clicking set up billing button', async () => {
-				await checkAdsPopup( page );
+				await checkBillingAdsPopup( page );
 			} );
 		} );
 		test.describe( 'Billing status is approved', () => {

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -16,6 +16,7 @@ import {
 	getFAQPanelTitle,
 	getFAQPanelRow,
 	checkFAQExpandable,
+	checkAdsPopup,
 } from '../../utils/page';
 
 const ADS_ACCOUNTS = [
@@ -339,23 +340,56 @@ test.describe( 'Set up Ads account', () => {
 		} );
 
 		test( 'Set the budget', async () => {
-			await setupBudgetPage.fillBudget( '1' );
-
-			await expect(
-				page.getByRole( 'button', { name: 'Continue' } )
-			).toBeEnabled();
-
 			await setupBudgetPage.fillBudget( '0' );
 
 			await expect(
 				page.getByRole( 'button', { name: 'Continue' } )
 			).toBeDisabled();
+
+			await setupBudgetPage.fillBudget( '1' );
+
+			await expect(
+				page.getByRole( 'button', { name: 'Continue' } )
+			).toBeEnabled();
 		} );
 
 		test( 'Budget Recommendation', async () => {
 			await expect(
 				page.getByText( 'set a daily budget of 5 to 15 USD' )
 			).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Set up billing', () => {
+		test.describe( 'Billing status is not approved', () => {
+			test( 'It should say that the billing is not setup', async () => {
+				await page.getByRole( 'button', { name: 'Continue' } ).click();
+				await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+
+				await expect(
+					page.getByRole( 'button', {
+						name: 'Set up billing',
+						exact: true,
+					} )
+				).toBeEnabled();
+
+				await expect(
+					page.getByText(
+						'In order to launch your paid campaign, your billing information is required. You will be billed directly by Google and only pay when someone clicks on your ad.'
+					)
+				).toBeVisible();
+
+				await expect(
+					page.getByRole( 'link', {
+						name: 'click here instead',
+					} )
+				).toBeVisible();
+			} );
+
+			// eslint-disable-next-line jest/expect-expect
+			test( 'should open a popup when clicking set up billing button', async () => {
+				await checkAdsPopup( page );
+			} );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -419,7 +419,10 @@ test.describe( 'Set up Ads account', () => {
 			test( 'It should say that the billing is setup', async () => {
 				//Every 30s the page will check if the billing status is approved and it will trigger the campaign creation.
 				await setupBudgetPage.awaitForBillingStatusRequest();
-				await setupBudgetPage.mockCampaignCreation( budget, [ 'US' ] );
+				await setupBudgetPage.mockCampaignCreationAndAdsSetupCompletion(
+					budget,
+					[ 'US' ]
+				);
 
 				await expect(
 					page.getByText(
@@ -491,10 +494,11 @@ test.describe( 'Set up Ads account', () => {
 				page.getByRole( 'button', { name: 'Launch paid campaign' } )
 			).toBeEnabled();
 
-			const campaignCreation = setupBudgetPage.mockCampaignCreation(
-				'1',
-				[ 'US' ]
-			);
+			const campaignCreation =
+				setupBudgetPage.mockCampaignCreationAndAdsSetupCompletion(
+					'1',
+					[ 'US' ]
+				);
 			await page
 				.getByRole( 'button', { name: 'Launch paid campaign' } )
 				.click();

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -391,5 +391,40 @@ test.describe( 'Set up Ads account', () => {
 				await checkAdsPopup( page );
 			} );
 		} );
+		test.describe( 'Billing status is approved', () => {
+			test.beforeAll( async () => {
+				await setupBudgetPage.fulfillBillingStatusRequest( {
+					status: 'approved',
+				} );
+
+				await setupAdsAccounts.mockAdsAccountsResponse( {
+					id: ADS_ACCOUNTS[ 1 ],
+					billing_url: null,
+				} );
+			} );
+			test( 'It should say that the billing is setup', async () => {
+				await page
+					.getByRole( 'button', {
+						name: 'Create your paid campaign',
+					} )
+					.click();
+				await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+
+				await page.getByRole( 'button', { name: 'Continue' } ).click();
+				await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+
+				await expect(
+					page.getByText(
+						'Great! You already have billing information saved for this'
+					)
+				).toBeVisible();
+
+				await expect(
+					page.getByRole( 'link', {
+						name: 'Google Ads account',
+					} )
+				).toBeVisible();
+			} );
+		} );
 	} );
 } );

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -60,6 +60,9 @@ let setupBudgetPage = null;
 let page = null;
 
 test.describe( 'Set up Ads account', () => {
+	// The campaign budget
+	let budget = null;
+
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
 		dashboardPage = new DashboardPage( page );
@@ -340,13 +343,15 @@ test.describe( 'Set up Ads account', () => {
 		} );
 
 		test( 'Set the budget', async () => {
-			await setupBudgetPage.fillBudget( '0' );
+			budget = '0';
+			await setupBudgetPage.fillBudget( budget );
 
 			await expect(
 				page.getByRole( 'button', { name: 'Continue' } )
 			).toBeDisabled();
 
-			await setupBudgetPage.fillBudget( '1' );
+			budget = '1';
+			await setupBudgetPage.fillBudget( budget );
 
 			await expect(
 				page.getByRole( 'button', { name: 'Continue' } )
@@ -403,15 +408,11 @@ test.describe( 'Set up Ads account', () => {
 				} );
 			} );
 			test( 'It should say that the billing is setup', async () => {
-				await page
-					.getByRole( 'button', {
-						name: 'Create your paid campaign',
-					} )
-					.click();
-				await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
-
-				await page.getByRole( 'button', { name: 'Continue' } ).click();
-				await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+				//Every 30s the page will check if the billing status is approved and it will trigger the campaign creation.
+				await setupBudgetPage.awaitForBillingStatusRequest();
+				await setupBudgetPage.awaitForCampaignCreationRequest( budget, [
+					'US',
+				] );
 
 				await expect(
 					page.getByText(

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -396,7 +396,7 @@ test.describe( 'Set up Ads account', () => {
 				await checkBillingAdsPopup( page );
 			} );
 		} );
-		test.describe( 'Billing status is approved', () => {
+		test.describe( 'Billing status is approved', async () => {
 			test.beforeAll( async () => {
 				await setupBudgetPage.fulfillBillingStatusRequest( {
 					status: 'approved',
@@ -425,6 +425,28 @@ test.describe( 'Set up Ads account', () => {
 						name: 'Google Ads account',
 					} )
 				).toBeVisible();
+
+				//This step is necessary; otherwise, it will set the ADS_SETUP_COMPLETED_AT option in the database, which could potentially impact other tests.
+				await setupBudgetPage.fulfillRequest(
+					/\/wc\/gla\/ads\/setup\/complete\b/,
+					null,
+					200,
+					[ 'POST' ]
+				);
+
+				await setupBudgetPage.fulfillAdsCampaignsRequest(
+					{
+						id: 111111111,
+						name: 'Test Campaign',
+						status: 'enabled',
+						type: 'performance_max',
+						amount: budget,
+						country: 'US',
+						targeted_locations: [ 'US' ],
+					},
+					200,
+					[ 'POST' ]
+				);
 			} );
 		} );
 	} );

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -18,7 +18,7 @@ import {
 	getFAQPanelRow,
 	getTreeSelectMenu,
 	removeCountryFromSearchBox,
-	checkAdsPopup,
+	checkBillingAdsPopup,
 } from '../../utils/page';
 
 test.use( { storageState: process.env.ADMINSTATE } );
@@ -492,7 +492,7 @@ test.describe( 'Complete your campaign', () => {
 
 				// eslint-disable-next-line jest/expect-expect
 				test( 'should open a popup when clicking set up billing button', async () => {
-					await checkAdsPopup( page );
+					await checkBillingAdsPopup( page );
 				} );
 
 				test( 'should open a new page when clicking set up billing link', async () => {

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -18,6 +18,7 @@ import {
 	getFAQPanelRow,
 	getTreeSelectMenu,
 	removeCountryFromSearchBox,
+	checkAdsPopup,
 } from '../../utils/page';
 
 test.use( { storageState: process.env.ADMINSTATE } );
@@ -489,20 +490,9 @@ test.describe( 'Complete your campaign', () => {
 					);
 				} );
 
+				// eslint-disable-next-line jest/expect-expect
 				test( 'should open a popup when clicking set up billing button', async () => {
-					const popupPromise = page.waitForEvent( 'popup' );
-					await setupBudgetPage.clickSetUpBillingButton();
-					const popup = await popupPromise;
-					await popup.waitForLoadState();
-					const popupTitle = await popup.title();
-					const popupURL = popup.url();
-					expect( popupTitle ).toBe(
-						'Add a new payment method in Google Ads - Google Ads Help'
-					);
-					expect( popupURL ).toBe(
-						'https://support.google.com/google-ads/answer/2375375'
-					);
-					await popup.close();
+					await checkAdsPopup( page );
 				} );
 
 				test( 'should open a new page when clicking set up billing link', async () => {

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -339,10 +339,17 @@ export default class MockRequests {
 	 * Fulfill ads campaigns request.
 	 *
 	 * @param {Object} payload
+	 * @param {number} status The HTTP status in the response.
+	 * @param {Array} methods The HTTP methods in the request to be fulfill.
 	 * @return {Promise<void>}
 	 */
-	async fulfillAdsCampaignsRequest( payload ) {
-		await this.fulfillRequest( /\/wc\/gla\/ads\/campaigns\b/, payload );
+	async fulfillAdsCampaignsRequest( payload, status = 200, methods = [] ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/ads\/campaigns\b/,
+			payload,
+			status,
+			methods
+		);
 	}
 
 	/**

--- a/tests/e2e/utils/page.js
+++ b/tests/e2e/utils/page.js
@@ -4,6 +4,11 @@
 const { expect } = require( '@playwright/test' );
 
 /**
+ * Internal dependencies
+ */
+import SetupBudgetPage from '../utils/pages/setup-ads/setup-budget';
+
+/**
  * Get FAQ panel.
  *
  * @param {import('@playwright/test').Page} page The current page.
@@ -189,6 +194,23 @@ export async function checkFAQExpandable( page ) {
 			await expect( faqRow ).toBeVisible();
 		}
 	}
+}
+
+export async function checkAdsPopup( page ) {
+	const popupPromise = page.waitForEvent( 'popup' );
+	const setupBudgetPage = new SetupBudgetPage( page );
+	await setupBudgetPage.clickSetUpBillingButton();
+	const popup = await popupPromise;
+	await popup.waitForLoadState();
+	const popupTitle = await popup.title();
+	const popupURL = popup.url();
+	expect( popupTitle ).toBe(
+		'Add a new payment method in Google Ads - Google Ads Help'
+	);
+	expect( popupURL ).toBe(
+		'https://support.google.com/google-ads/answer/2375375'
+	);
+	await popup.close();
 }
 
 /**

--- a/tests/e2e/utils/page.js
+++ b/tests/e2e/utils/page.js
@@ -197,7 +197,7 @@ export async function checkFAQExpandable( page ) {
 }
 
 /**
- * Test if the Billing pop opens.
+ * Test if the billing ads pop up opens.
  *
  * @param {import('@playwright/test').Page} page The current page.
  */

--- a/tests/e2e/utils/page.js
+++ b/tests/e2e/utils/page.js
@@ -196,7 +196,12 @@ export async function checkFAQExpandable( page ) {
 	}
 }
 
-export async function checkAdsPopup( page ) {
+/**
+ * Test if the Billing pop opens.
+ *
+ * @param {import('@playwright/test').Page} page The current page.
+ */
+export async function checkBillingAdsPopup( page ) {
 	const popupPromise = page.waitForEvent( 'popup' );
 	const setupBudgetPage = new SetupBudgetPage( page );
 	await setupBudgetPage.clickSetUpBillingButton();

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -188,13 +188,13 @@ export default class SetupBudget extends MockRequests {
 	}
 
 	/**
-	 * Mock the campaign creation process.
+	 * Mock the campaign creation process and the Ads setup completion.
 	 *
 	 * @param {string} budget The campaign budget.
 	 * @param {Array}  targetLocations The targeted locations.
 	 * @return {Promise<void>}
 	 */
-	async mockCampaignCreation( budget, targetLocations ) {
+	async mockCampaignCreationAndAdsSetupCompletion( budget, targetLocations ) {
 		//This step is necessary; otherwise, it will set the ADS_SETUP_COMPLETED_AT option in the database, which could potentially impact other tests.
 		await this.fulfillRequest(
 			/\/wc\/gla\/ads\/setup\/complete\b/,

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -145,4 +145,38 @@ export default class SetupBudget extends MockRequests {
 		const link = this.getSetUpBillingLink();
 		await link.click();
 	}
+
+	/**
+	 * Await for billing status request.
+	 *
+	 * @return {Promise<Request>} The request.
+	 */
+	async awaitForBillingStatusRequest() {
+		return this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/ads/billing-status' ) &&
+				request.method() === 'GET',
+			{ timeout: 35000 }
+		);
+	}
+
+	/**
+	 * Await for the campaign creation request.
+	 *
+	 * @param {string} budget The campaign budget.
+	 * @param {Array}  targetLocations The targeted locations.
+	 * @return {Promise<Request>} The request.
+	 */
+	async awaitForCampaignCreationRequest( budget, targetLocations ) {
+		return this.page.waitForRequest( ( request ) => {
+			return (
+				request.url().includes( '/gla/ads/campaigns' ) &&
+				request.method() === 'POST' &&
+				request.postDataJSON().amount === parseInt( budget, 10 ) &&
+				targetLocations.every( ( item ) =>
+					request.postDataJSON().targeted_locations.includes( item )
+				)
+			);
+		} );
+	}
 }

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -168,15 +168,55 @@ export default class SetupBudget extends MockRequests {
 	 * @return {Promise<Request>} The request.
 	 */
 	async awaitForCampaignCreationRequest( budget, targetLocations ) {
-		return this.page.waitForRequest( ( request ) => {
-			return (
-				request.url().includes( '/gla/ads/campaigns' ) &&
-				request.method() === 'POST' &&
-				request.postDataJSON().amount === parseInt( budget, 10 ) &&
-				targetLocations.every( ( item ) =>
-					request.postDataJSON().targeted_locations.includes( item )
-				)
-			);
-		} );
+		return this.page.waitForRequest(
+			( request ) => {
+				return (
+					request.url().includes( '/gla/ads/campaigns' ) &&
+					request.method() === 'POST' &&
+					request.postDataJSON().amount === parseInt( budget, 10 ) &&
+					targetLocations.every( ( item ) =>
+						request
+							.postDataJSON()
+							.targeted_locations.includes( item )
+					)
+				);
+			},
+			{
+				timeout: 35000,
+			}
+		);
+	}
+
+	/**
+	 * Mock the campaign creation process.
+	 *
+	 * @param {string} budget The campaign budget.
+	 * @param {Array}  targetLocations The targeted locations.
+	 * @return {Promise<void>}
+	 */
+	async mockCampaignCreation( budget, targetLocations ) {
+		//This step is necessary; otherwise, it will set the ADS_SETUP_COMPLETED_AT option in the database, which could potentially impact other tests.
+		await this.fulfillRequest(
+			/\/wc\/gla\/ads\/setup\/complete\b/,
+			null,
+			200,
+			[ 'POST' ]
+		);
+
+		await this.fulfillAdsCampaignsRequest(
+			{
+				id: 111111111,
+				name: 'Test Campaign',
+				status: 'enabled',
+				type: 'performance_max',
+				amount: budget,
+				country: 'US',
+				targeted_locations: targetLocations,
+			},
+			200,
+			[ 'POST' ]
+		);
+
+		await this.awaitForCampaignCreationRequest( budget, targetLocations );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/2070, this PR adds E2E tests for https://github.com/woocommerce/google-listings-and-ads/issues/2070#gla-dashboard.

### Detailed test instructions:
- Follow these steps to set up the e2e env: https://github.com/woocommerce/google-listings-and-ads#e2e-testing
- Run `npm run test:e2e -- ./tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js`, the test should pass.
- Or, run `npm run test:e2e-dev -- ./tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js`, check the test in the chromium step by step.
- Run `npm run test:e2e` to make sure all tests are passed.

### Additional details:
- I cherry-pick a commit https://github.com/woocommerce/google-listings-and-ads/pull/2123/commits/65d7479cc5e87105ae783ef76d840268ca506ba0 from https://github.com/woocommerce/google-listings-and-ads/pull/2126 which fixes an issue with the auto-refresh of billing status.
- The auto-refresh occurs every 30 seconds, which means that when we're testing if the billing is set up, the E2E tests might take a bit longer. An alternative approach would be to return to step 2 and then proceed to step 3 to trigger the auto-refresh. However, I believe this wouldn't accurately simulate the real-world scenario.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - E2E - Setup Google Ads Step 3 - Setup billing data.