### PR TITLE
Fix the auto-refresh processing of billing status in the ads onboarding flow

### DIFF
--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -209,7 +209,7 @@ function AdaptiveForm( { onSubmit, extendAdapter, children, ...props }, ref ) {
 				// Keep the target element for identifying which one triggered the submission when
 				// there are multiple submit buttons.
 				formContext.handleSubmit = function ( event ) {
-					adapterRef.current.submitter = event.currentTarget;
+					adapterRef.current.submitter = event?.currentTarget || null;
 					return handleSubmit.call( this, event );
 				};
 

--- a/js/src/components/adaptive-form/adaptive-form.test.js
+++ b/js/src/components/adaptive-form/adaptive-form.test.js
@@ -116,16 +116,25 @@ describe( 'AdaptiveForm', () => {
 							<button onClick={ formContext.handleSubmit }>
 								B
 							</button>
+							<button
+								onClick={ () => {
+									// To simulate that `handleSubmit` is called without passing an `event`.
+									formContext.handleSubmit();
+								} }
+							>
+								C
+							</button>
 						</>
 					);
 				} }
 			</AdaptiveForm>
 		);
 
-		const [ buttonA, buttonB ] = screen.getAllByRole( 'button' );
+		const [ buttonA, buttonB, buttonC ] = screen.getAllByRole( 'button' );
 
 		expect( inspectOnSubmit ).toHaveBeenCalledTimes( 0 );
 
+		// Click button A to test if the form indicates that button A triggered a submission.
 		await act( async () => {
 			return userEvent.click( buttonA );
 		} );
@@ -138,6 +147,7 @@ describe( 'AdaptiveForm', () => {
 			expect.objectContaining( { submitter: buttonA } )
 		);
 
+		// Click button B to test if the form indicates that button B triggered another submission.
 		inspectSubmitter.mockClear();
 
 		await act( async () => {
@@ -150,6 +160,24 @@ describe( 'AdaptiveForm', () => {
 		expect( inspectOnSubmit ).toHaveBeenLastCalledWith(
 			{},
 			expect.objectContaining( { submitter: buttonB } )
+		);
+
+		// Click button C to test if the form stays `submitter` as `null` if `handleSubmit`
+		// is triggered without a corresponding event.
+		inspectSubmitter.mockClear();
+
+		await act( async () => {
+			return userEvent.click( buttonC );
+		} );
+
+		expect( inspectSubmitter ).toHaveBeenCalled();
+		inspectSubmitter.mock.calls.forEach( ( args ) => {
+			expect( args ).toEqual( [ null ] );
+		} );
+		expect( inspectOnSubmit ).toHaveBeenCalledTimes( 3 );
+		expect( inspectOnSubmit ).toHaveBeenLastCalledWith(
+			{},
+			expect.objectContaining( { submitter: null } )
 		);
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2124 

To fix the issue, the wrapped `handleSubmit` in `AdaptiveForm` component is changed to allow it to be called without a corresponding event. As the `submitter` is unknown in this case, the value is kept as `null` to align with [its type in JSDoc](https://github.com/woocommerce/google-listings-and-ads/blob/60e1782084eb74ff6d7613ea3341136ea8ac3aae/js/src/components/adaptive-form/adaptive-form-context.js#L25).

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/f61a2b3d-3e84-4223-a6cd-99d0f2ab3f2c

### Detailed test instructions:

Follow the reproduction steps in #2124 to see if the ads onboarding flow can be completed.

### Additional details:

In the demo video, there is another issue that it may create two campaigns after completing ads onboarding. I will fix it by a subsequence PR.

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/45901eaf-6e01-4a54-a293-160a01b6506b)

### Changelog entry

> Fix - The auto-refresh processing of billing status in the Google Ads onboarding flow.
