### PR TITLE
Fix the issue that may create two campaigns after completing ads onboarding

### DIFF
--- a/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
+++ b/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { render, act } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import BillingSetupCard from './billing-setup-card';
+import useWindowFocus from '.~/hooks/useWindowFocus';
+
+jest.mock( '.~/hooks/useGoogleAdsAccount', () =>
+	jest.fn().mockName( 'useGoogleAdsAccount' ).mockReturnValue( {} )
+);
+
+jest.mock( '.~/hooks/useDispatchCoreNotices', () =>
+	jest
+		.fn()
+		.mockName( 'useDispatchCoreNotices' )
+		.mockReturnValue( { createNotice: () => {} } )
+);
+
+jest.mock( '.~/hooks/useWindowFocus', () =>
+	jest.fn().mockName( 'useWindowFocus' ).mockReturnValue( true )
+);
+
+jest.mock( '@wordpress/api-fetch', () => {
+	const impl = jest.fn().mockName( '@wordpress/api-fetch' );
+	impl.use = jest.fn().mockName( 'apiFetch.use' );
+	return impl;
+} );
+
+describe( 'BillingSetupCard', () => {
+	let fetchBillingStatus;
+
+	beforeEach( () => {
+		fetchBillingStatus = jest
+			.fn()
+			.mockResolvedValue( { status: 'approved' } );
+
+		apiFetch.mockImplementation( ( { path } ) => {
+			switch ( path ) {
+				case '/wc/gla/ads/accounts':
+					return Promise.resolve( {} );
+
+				case '/wc/gla/ads/billing-status':
+					return fetchBillingStatus();
+
+				default:
+					throw new Error( `No mocked apiFetch for path: ${ path }` );
+			}
+		} );
+	} );
+
+	it( 'Should only call back `onSetupComplete` once regardless of its reference change', async () => {
+		const inspect = jest.fn();
+
+		let onSetupComplete = () => inspect();
+		let rerender;
+
+		// Initial with a not yet set up billing.
+		fetchBillingStatus.mockResolvedValueOnce( { status: 'unknown' } );
+		await act( async () => {
+			const result = render(
+				<BillingSetupCard onSetupComplete={ onSetupComplete } />
+			);
+			rerender = result.rerender;
+		} );
+
+		expect( fetchBillingStatus ).toHaveBeenCalledTimes( 1 );
+		expect( inspect ).toHaveBeenCalledTimes( 0 );
+
+		// Simulate document regains focus to trigger billing status check again.
+		useWindowFocus.mockReturnValueOnce( false );
+		rerender( <BillingSetupCard onSetupComplete={ onSetupComplete } /> );
+		await act( async () => {
+			rerender(
+				<BillingSetupCard onSetupComplete={ onSetupComplete } />
+			);
+		} );
+
+		expect( fetchBillingStatus ).toHaveBeenCalledTimes( 2 );
+		expect( inspect ).toHaveBeenCalledTimes( 1 );
+
+		// Change the reference of callback.
+		onSetupComplete = () => inspect();
+		await act( async () => {
+			rerender(
+				<BillingSetupCard onSetupComplete={ onSetupComplete } />
+			);
+		} );
+
+		expect( inspect ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
+++ b/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
@@ -108,7 +108,6 @@ describe( 'BillingSetupCard', () => {
 			jest.runOnlyPendingTimers();
 		} );
 
-		expect( fetchBillingStatus ).toHaveBeenCalledTimes( 2 );
 		expect( onSetupComplete ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
+++ b/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
@@ -93,4 +93,22 @@ describe( 'BillingSetupCard', () => {
 
 		expect( inspect ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'Should not call back `onSetupComplete` again by the next interval after billing is already approved', async () => {
+		const onSetupComplete = jest.fn();
+
+		await act( async () => {
+			render( <BillingSetupCard onSetupComplete={ onSetupComplete } /> );
+		} );
+
+		expect( fetchBillingStatus ).toHaveBeenCalledTimes( 1 );
+		expect( onSetupComplete ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => {
+			jest.runOnlyPendingTimers();
+		} );
+
+		expect( fetchBillingStatus ).toHaveBeenCalledTimes( 2 );
+		expect( onSetupComplete ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js
+++ b/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { noop } from 'lodash';
 
@@ -28,6 +28,9 @@ const useAutoCheckBillingStatusEffect = ( onStatusApproved = noop ) => {
 	const { createNotice } = useDispatchCoreNotices();
 	const { receiveGoogleAdsAccountBillingStatus } = useAppDispatch();
 
+	const onStatusApprovedRef = useRef();
+	onStatusApprovedRef.current = onStatusApproved;
+
 	const checkStatusAndCompleteSetup = useCallback( async () => {
 		const billingStatus = await apiFetch( {
 			path: '/wc/gla/ads/billing-status',
@@ -39,7 +42,7 @@ const useAutoCheckBillingStatusEffect = ( onStatusApproved = noop ) => {
 
 		try {
 			await completeGoogleAdsAccountSetup();
-			await onStatusApproved();
+			await onStatusApprovedRef.current();
 			receiveGoogleAdsAccountBillingStatus( billingStatus );
 		} catch ( e ) {
 			createNotice(
@@ -50,11 +53,7 @@ const useAutoCheckBillingStatusEffect = ( onStatusApproved = noop ) => {
 				)
 			);
 		}
-	}, [
-		createNotice,
-		onStatusApproved,
-		receiveGoogleAdsAccountBillingStatus,
-	] );
+	}, [ createNotice, receiveGoogleAdsAccountBillingStatus ] );
 
 	useWindowFocusCallbackIntervalEffect( checkStatusAndCompleteSetup, 30 );
 };

--- a/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js
+++ b/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js
@@ -40,6 +40,8 @@ const useAutoCheckBillingStatusEffect = ( onStatusApproved = noop ) => {
 
 		prevStatusRef.current = billingStatus.status;
 
+		// Prevent the completion API and callback from being called unwanted times due to
+		// the regain focus or interval timer after the status is approved.
 		if (
 			prevStatus === billingStatus.status ||
 			billingStatus.status !== GOOGLE_ADS_BILLING_STATUS.APPROVED

--- a/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js
+++ b/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js
@@ -27,16 +27,23 @@ const completeGoogleAdsAccountSetup = () => {
 const useAutoCheckBillingStatusEffect = ( onStatusApproved = noop ) => {
 	const { createNotice } = useDispatchCoreNotices();
 	const { receiveGoogleAdsAccountBillingStatus } = useAppDispatch();
+	const prevStatusRef = useRef();
 
 	const onStatusApprovedRef = useRef();
 	onStatusApprovedRef.current = onStatusApproved;
 
 	const checkStatusAndCompleteSetup = useCallback( async () => {
+		const prevStatus = prevStatusRef.current;
 		const billingStatus = await apiFetch( {
 			path: '/wc/gla/ads/billing-status',
 		} );
 
-		if ( billingStatus.status !== GOOGLE_ADS_BILLING_STATUS.APPROVED ) {
+		prevStatusRef.current = billingStatus.status;
+
+		if (
+			prevStatus === billingStatus.status ||
+			billingStatus.status !== GOOGLE_ADS_BILLING_STATUS.APPROVED
+		) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While working on #2126, found another issue that may create two campaigns after completing ads onboarding. The root cause is [the reference changes of `onStatusApproved`](https://github.com/woocommerce/google-listings-and-ads/blob/60e1782084eb74ff6d7613ea3341136ea8ac3aae/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js#L55) in `useAutoCheckBillingStatusEffect` hook, and it leads to calling `onStatusApproved` multiple times before redirecting out of the ads onboarding page.

This PR fixes it by ensuring the `onSetupComplete` callback of `BillingSetupCard` is only called once after getting an approved status for billing.

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/45901eaf-6e01-4a54-a293-160a01b6506b)

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/037ca89b-1f95-4f12-966c-5068e2e661c9

### Detailed test instructions:

1. `git checkout 3dd7efe8b8da3ed7d00b9ff17a559a5a43e0fb16`
2. `npm run env -- wp-scripts test-unit-js billing-setup-card` to see the failure of this test.
3. `git checkout ee841eba98df32ebc50d3661df529f06f3ea0d3c`
4. Rerun the above test to check if the test can pass.
5. `git checkout 3235e1496fc9a0bfd4ff7dc8ebd6506384935f9b`
6. Rerun the above test to see the failure of the second test case.
7. `git checkout fix/finish-onboarding-ads-duplicate-campaigns`
8. Rerun the above test to check if the second test case can pass.
9. Follow the reproduction steps in #2124 to see if it creates only a new campaign after finishing the ads onboarding flow 

### Changelog entry

> Fix - Avoid creating two campaigns after completing the Google Ads onboarding.
