### PR TITLE
Prevent Prefix Vendor to be added twice

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -296,8 +296,10 @@ function prefix_string( &$contents, $search ) {
 	global $namespace_prefix;
 
 	$quoted   = preg_quote( $search, '#' );
+	$namespace_quoted = preg_quote( "\\" . $namespace_prefix . "\\", '#' );
+
 	$contents = preg_replace(
-		"#({$quoted})#m",
+		"#((?<!{$namespace_quoted}){$quoted})#m", // prevent to add the namespace twice
 		"{$namespace_prefix}\\\\\$1",
 		$contents
 	);

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -296,7 +296,7 @@ function prefix_string( &$contents, $search ) {
 	global $namespace_prefix;
 
 	$quoted           = preg_quote( $search, '#' );
-	$namespace_quoted = preg_quote( '\\' . $namespace_prefix . '\\', '#' );
+	$namespace_quoted = preg_quote( $namespace_prefix . '\\', '#' );
 
 	$contents = preg_replace(
 		"#((?<!{$namespace_quoted}){$quoted})#m", // prevent to add the namespace twice

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -295,8 +295,8 @@ function prefix_uses( &$contents, $package ) {
 function prefix_string( &$contents, $search ) {
 	global $namespace_prefix;
 
-	$quoted   = preg_quote( $search, '#' );
-	$namespace_quoted = preg_quote( "\\" . $namespace_prefix . "\\", '#' );
+	$quoted           = preg_quote( $search, '#' );
+	$namespace_quoted = preg_quote( '\\' . $namespace_prefix . '\\', '#' );
 
 	$contents = preg_replace(
 		"#((?<!{$namespace_quoted}){$quoted})#m", // prevent to add the namespace twice


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug when running `prefix-vendor-namespace.php` script on `composer install` when running a second time.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Remove vendor folder
2. Run `composer install`
3. Go to `vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php` 
4. See `$options['sink'] = \Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Utils::tryFopen('php://temp', 'w+');` as been prefixed.
5. Run again `composer install` (without removing vendor)
6. See line in step 4 double prefixed
7. Checkout this PR
8. Repeat steps 1-5
9. Verify the mentioned line is not double prefixed
10. Search for "\Automattic\WooCommerce\GoogleListingsAndAds\Vendor" to verify everything is fine in terms of replacement.
11. Do a full onboarding to verify everything works

### Additional details:

This only impacts in `prefix_string` function, namespace and uses are not impacted by this bug. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Prevent Prefix Vendor to be added twice
