### PR TITLE
Add correct Destinations for Supported Countries in Coupons

### DIFF
--- a/src/Coupon/WCCouponAdapter.php
+++ b/src/Coupon/WCCouponAdapter.php
@@ -50,6 +50,8 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 
 	protected const DATE_TIME_FORMAT = 'Y-m-d h:i:sa';
 
+	private const COUNTRIES_WITH_FREE_SHIPPING_DESTINATION = [ 'BR', 'IT', 'JP', 'NL', 'KR', 'US' ];
+
 	/**
 	 *
 	 * @var int wc_coupon_id
@@ -74,7 +76,7 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 
 		$wc_coupon          = $array['wc_coupon'];
 		$this->wc_coupon_id = $wc_coupon->get_id();
-			$this->map_woocommerce_coupon( $wc_coupon );
+		$this->map_woocommerce_coupon( $wc_coupon, $this->get_coupon_destinations_per_country( $array['targetCountry'] ) );
 
 		// Google doesn't expect extra fields, so it's best to remove them
 		unset( $array['wc_coupon'] );
@@ -86,14 +88,13 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 	 * Map the WooCommerce coupon attributes to the current class.
 	 *
 	 * @param WC_Coupon $wc_coupon
+	 * @param string[] $destinations The destination ID's for the coupon
 	 *
 	 * @return void
 	 */
-	protected function map_woocommerce_coupon( WC_Coupon $wc_coupon ) {
+	protected function map_woocommerce_coupon( WC_Coupon $wc_coupon, array $destinations ) {
 		$this->setRedemptionChannel( self::CHANNEL_ONLINE );
-		$this->setPromotionDestinationIds(
-			[ self::PROMOTION_DESTINATION_ADS, self::PROMOTION_DESTINATION_FREE_LISTING ]
-		);
+		$this->setPromotionDestinationIds( $destinations );
 
 		$content_language = empty( get_locale() ) ? 'en' : strtolower(
 			substr( get_locale(), 0, 2 )
@@ -374,5 +375,20 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 	public function setTargetCountry( $targetCountry ) {
 		// set the new target country
 		parent::setTargetCountry( $targetCountry );
+	}
+
+	/**
+	 * Get the destinations allowed per specific country.
+	 *
+	 * @param string $target_country The country to get the allowed destinations in ISO 3166-1 alpha-2 format (ie 'US')
+	 * @return string[] The destinations country based.
+	 */
+	private function get_coupon_destinations_per_country( string $target_country ) : array {
+		$destinations = [ self::PROMOTION_DESTINATION_ADS ];
+		if ( in_array( $target_country, self::COUNTRIES_WITH_FREE_SHIPPING_DESTINATION ) ) {
+			$destinations[] = self::PROMOTION_DESTINATION_FREE_LISTING;
+		}
+
+		return apply_filters( 'woocommerce_gla_coupon_destinations', $destinations, [ $target_country, $this->wc_coupon_id ] );
 	}
 }

--- a/src/Coupon/WCCouponAdapter.php
+++ b/src/Coupon/WCCouponAdapter.php
@@ -88,7 +88,7 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 	 * Map the WooCommerce coupon attributes to the current class.
 	 *
 	 * @param WC_Coupon $wc_coupon
-	 * @param string[] $destinations The destination ID's for the coupon
+	 * @param string[]  $destinations The destination ID's for the coupon
 	 *
 	 * @return void
 	 */
@@ -383,9 +383,9 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 	 * @param string $target_country The country to get the allowed destinations in ISO 3166-1 alpha-2 format (ie 'US')
 	 * @return string[] The destinations country based.
 	 */
-	private function get_coupon_destinations_per_country( string $target_country ) : array {
+	private function get_coupon_destinations_per_country( string $target_country ): array {
 		$destinations = [ self::PROMOTION_DESTINATION_ADS ];
-		if ( in_array( $target_country, self::COUNTRIES_WITH_FREE_SHIPPING_DESTINATION ) ) {
+		if ( in_array( $target_country, self::COUNTRIES_WITH_FREE_SHIPPING_DESTINATION, true ) ) {
 			$destinations[] = self::PROMOTION_DESTINATION_FREE_LISTING;
 		}
 

--- a/src/Coupon/WCCouponAdapter.php
+++ b/src/Coupon/WCCouponAdapter.php
@@ -50,7 +50,7 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 
 	protected const DATE_TIME_FORMAT = 'Y-m-d h:i:sa';
 
-	private const COUNTRIES_WITH_FREE_SHIPPING_DESTINATION = [ 'BR', 'IT', 'JP', 'NL', 'KR', 'US' ];
+	public const COUNTRIES_WITH_FREE_SHIPPING_DESTINATION = [ 'BR', 'IT', 'ES', 'JP', 'NL', 'KR', 'US' ];
 
 	/**
 	 *
@@ -389,6 +389,6 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 			$destinations[] = self::PROMOTION_DESTINATION_FREE_LISTING;
 		}
 
-		return apply_filters( 'woocommerce_gla_coupon_destinations', $destinations, [ $target_country, $this->wc_coupon_id ] );
+		return apply_filters( 'woocommerce_gla_coupon_destinations', $destinations, $target_country, $this->wc_coupon_id );
 	}
 }

--- a/src/Coupon/WCCouponAdapter.php
+++ b/src/Coupon/WCCouponAdapter.php
@@ -76,7 +76,7 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 
 		$wc_coupon          = $array['wc_coupon'];
 		$this->wc_coupon_id = $wc_coupon->get_id();
-		$this->map_woocommerce_coupon( $wc_coupon, $this->get_coupon_destinations_per_country( $array['targetCountry'] ) );
+		$this->map_woocommerce_coupon( $wc_coupon, $this->get_coupon_destinations( $array ) );
 
 		// Google doesn't expect extra fields, so it's best to remove them
 		unset( $array['wc_coupon'] );
@@ -380,15 +380,15 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 	/**
 	 * Get the destinations allowed per specific country.
 	 *
-	 * @param string $target_country The country to get the allowed destinations in ISO 3166-1 alpha-2 format (ie 'US')
+	 * @param array $coupon_data The coupon data to get the allowed destinations.
 	 * @return string[] The destinations country based.
 	 */
-	private function get_coupon_destinations_per_country( string $target_country ): array {
+	private function get_coupon_destinations( array $coupon_data ): array {
 		$destinations = [ self::PROMOTION_DESTINATION_ADS ];
-		if ( in_array( $target_country, self::COUNTRIES_WITH_FREE_SHIPPING_DESTINATION, true ) ) {
+		if ( isset( $coupon_data['targetCountry'] ) && in_array( $coupon_data['targetCountry'], self::COUNTRIES_WITH_FREE_SHIPPING_DESTINATION, true ) ) {
 			$destinations[] = self::PROMOTION_DESTINATION_FREE_LISTING;
 		}
 
-		return apply_filters( 'woocommerce_gla_coupon_destinations', $destinations, $target_country, $this->wc_coupon_id );
+		return apply_filters( 'woocommerce_gla_coupon_destinations', $destinations, $coupon_data );
 	}
 }

--- a/src/Google/GoogleHelper.php
+++ b/src/Google/GoogleHelper.php
@@ -1204,11 +1204,17 @@ class GoogleHelper implements Service {
 	protected function get_mc_promotion_supported_countries_currencies(): array {
 		return [
 			'AU' => 'AUD', // Australia
+			'BR' => 'BRL', // Brazil
 			'CA' => 'CAD', // Canada
 			'DE' => 'EUR', // Germany
+			'ES' => 'EUR', // Spain
 			'FR' => 'EUR', // France
 			'GB' => 'GBP', // United Kingdom
 			'IN' => 'INR', // India
+			'IT' => 'EUR', // Italy
+			'JP' => 'JPY', // Japan
+			'NL' => 'EUR', // The Netherlands
+			'KR' => 'KRW', // South Korea
 			'US' => 'USD', // United States
 		];
 	}

--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
  * Class WCProductAdapterTest
+ *
  * @group Coupons
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon
  */
@@ -86,7 +87,7 @@ class WCCouponAdapterTest extends UnitTest {
 	}
 
 	public function test_destination_ids_are_set() {
-		$coupon         = $this->create_ready_to_sync_coupon();
+		$coupon = $this->create_ready_to_sync_coupon();
 
 		foreach ( WCCouponAdapter::COUNTRIES_WITH_FREE_SHIPPING_DESTINATION as $free_shipping_destination ) {
 			$adapted_coupon = new WCCouponAdapter(
@@ -95,6 +96,7 @@ class WCCouponAdapterTest extends UnitTest {
 					'targetCountry' => $free_shipping_destination,
 				]
 			);
+
 			$this->assertEquals(
 				[ 'Shopping_ads', 'Free_listings' ],
 				$adapted_coupon->getPromotionDestinationIds()
@@ -104,7 +106,7 @@ class WCCouponAdapterTest extends UnitTest {
 		$adapted_coupon = new WCCouponAdapter(
 			[
 				'wc_coupon'     => $coupon,
-				'targetCountry' => 'BR',
+				'targetCountry' => 'IN',
 			]
 		);
 

--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
  * Class WCProductAdapterTest
- *
+ * @group Coupons
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon
  */
 class WCCouponAdapterTest extends UnitTest {
@@ -87,18 +87,34 @@ class WCCouponAdapterTest extends UnitTest {
 
 	public function test_destination_ids_are_set() {
 		$coupon         = $this->create_ready_to_sync_coupon();
+
+		foreach ( WCCouponAdapter::COUNTRIES_WITH_FREE_SHIPPING_DESTINATION as $free_shipping_destination ) {
+			$adapted_coupon = new WCCouponAdapter(
+				[
+					'wc_coupon'     => $coupon,
+					'targetCountry' => $free_shipping_destination,
+				]
+			);
+			$this->assertEquals(
+				[ 'Shopping_ads', 'Free_listings' ],
+				$adapted_coupon->getPromotionDestinationIds()
+			);
+		}
+
 		$adapted_coupon = new WCCouponAdapter(
 			[
 				'wc_coupon'     => $coupon,
-				'targetCountry' => 'US',
+				'targetCountry' => 'BR',
 			]
 		);
 
 		$this->assertEquals(
-			[ 'Shopping_ads', 'Free_listings' ],
+			[ 'Shopping_ads' ],
 			$adapted_coupon->getPromotionDestinationIds()
 		);
 	}
+
+
 
 	public function test_promotion_id_is_set() {
 		$coupon         = $this->create_ready_to_sync_coupon();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2113 

This PR implements Destination for the Coupons country based.

### Screenshots:

<img width="1792" alt="Screenshot 2023-10-11 at 11 53 27" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/fa62533f-fc21-4567-b8a0-e5b9e2a375c9">
<img width="1528" alt="Screenshot 2023-10-11 at 12 32 36" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/ad54b4fd-c1e6-49f1-8666-c294b0203d1e">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a Coupon with the Country India as Target country
2. Refresh and see that is Sent to Google Merchant Center with Only Shopping ads
 as destination
3. Create a Coupon with the Country Brazil as Target country
4. Refresh and see that is Sent to Google Merchant Center with Shopping ads and Free Listings
 as destination
5. Add a filter like this
```php
add_filter( 'woocommerce_gla_coupon_destinations', function ( $destinations, $coupon_data ) {
	if ( $coupon_data['targetCountry'] === 'IN' ) {
		return ['Shopping_ads', 'Free_listings'];  // force bad destinations to show the filter working
	}
    return $destinations;
}, 10, 2 );
```
6. Create a coupon with India as Target country.
7. See the coupon shows an error when syncing.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Add correct Destinations for Supported Countries in Coupons
