### PR TITLE
Add tracking for campaign count

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Google\Ads\GoogleAds\Util\FieldMasks;
 use Google\Ads\GoogleAds\Util\V14\ResourceNames;
@@ -35,6 +36,7 @@ use Exception;
  *
  * ContainerAware used for:
  * - AdsAssetGroup
+ * - TransientsInterface
  * - WC
  *
  * @since 1.12.2 Refactored to support PMax and (legacy) SSC.
@@ -219,6 +221,9 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			);
 
 			$campaign_id = $this->mutate( $operations );
+
+			// Clear cached campaign count.
+			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_CAMPAIGN_COUNT );
 
 			return [
 				'id'      => $campaign_id,

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -112,12 +112,23 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				$query->where( 'campaign.status', 'REMOVED', '!=' );
 			}
 
+			$campaign_count      = 0;
 			$campaign_results    = $query->get_results();
 			$converted_campaigns = [];
 
 			foreach ( $campaign_results->iterateAllElements() as $row ) {
+				$campaign_count++;
 				$campaign                               = $this->convert_campaign( $row );
 				$converted_campaigns[ $campaign['id'] ] = $campaign;
+			}
+
+			if ( $exclude_removed ) {
+				// Cache campaign count.
+				$this->container->get( TransientsInterface::class )->set(
+					TransientsInterface::ADS_CAMPAIGN_COUNT,
+					$campaign_count,
+					HOUR_IN_SECONDS * 12
+				);
 			}
 
 			if ( $fetch_criterion ) {

--- a/src/API/Google/MerchantMetrics.php
+++ b/src/API/Google/MerchantMetrics.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCampaignReportQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCampaignQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantFreeListingReportQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -185,6 +186,37 @@ class MerchantMetrics implements OptionsAwareInterface {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Return amount of active campaigns for the connected Ads account.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return int
+	 */
+	public function get_campaign_count(): int {
+		if ( ! $this->options->get_ads_id() ) {
+			return 0;
+		}
+
+		$campaign_count = 0;
+
+		try {
+			$query = ( new AdsCampaignQuery() )->set_client( $this->ads_client, $this->options->get_ads_id() );
+			$query->where( 'campaign.status', 'REMOVED', '!=' );
+
+			$campaign_results = $query->get_results();
+
+			// Iterate through all paged results (total results count is not set).
+			foreach ( $campaign_results->iterateAllElements() as $row ) {
+				$campaign_count++;
+			}
+		} catch ( Exception $e ) {
+			$campaign_count = 0;
+		}
+
+		return $campaign_count;
 	}
 
 	/**

--- a/src/API/Google/MerchantMetrics.php
+++ b/src/API/Google/MerchantMetrics.php
@@ -201,6 +201,10 @@ class MerchantMetrics implements OptionsAwareInterface {
 		}
 
 		$campaign_count = 0;
+		$cached_count   = $this->transients->get( TransientsInterface::ADS_CAMPAIGN_COUNT );
+		if ( null !== $cached_count ) {
+			return (int) $cached_count;
+		}
 
 		try {
 			$query = ( new AdsCampaignQuery() )->set_client( $this->ads_client, $this->options->get_ads_id() );
@@ -216,6 +220,7 @@ class MerchantMetrics implements OptionsAwareInterface {
 			$campaign_count = 0;
 		}
 
+		$this->transients->set( TransientsInterface::ADS_CAMPAIGN_COUNT, $campaign_count, HOUR_IN_SECONDS * 12 );
 		return $campaign_count;
 	}
 

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Exception;
 
@@ -28,6 +29,7 @@ defined( 'ABSPATH' ) || exit;
  * - AdsConversionAction
  * - Merchant
  * - Middleware
+ * - TransientsInterface
  *
  * @since 1.11.0
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Ads
@@ -216,6 +218,7 @@ class AccountService implements OptionsAwareInterface, Service {
 		$this->options->delete( OptionsInterface::ADS_ID );
 		$this->options->delete( OptionsInterface::ADS_SETUP_COMPLETED_AT );
 		$this->options->delete( OptionsInterface::CAMPAIGN_CONVERT_STATUS );
+		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_CAMPAIGN_COUNT );
 	}
 
 	/**

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
  */
 interface TransientsInterface {
 
+	public const ADS_CAMPAIGN_COUNT   = 'ads_campaign_count';
 	public const ADS_METRICS          = 'ads_metrics';
 	public const FREE_LISTING_METRICS = 'free_listing_metrics';
 	public const MC_ACCOUNT_REVIEW    = 'mc_account_review';
@@ -18,6 +19,7 @@ interface TransientsInterface {
 	public const URL_MATCHES          = 'url_matches';
 
 	public const VALID_OPTIONS = [
+		self::ADS_CAMPAIGN_COUNT   => true,
 		self::ADS_METRICS          => true,
 		self::FREE_LISTING_METRICS => true,
 		self::MC_ACCOUNT_REVIEW    => true,

--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tracking;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -20,7 +21,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
  * Include Google Listings and Ads data in the WC Tracker snapshot.
  *
  * ContainerAware used to access:
- * - MerchantStatuses
+ * - AdsService
+ * - MerchantCenterService
+ * - MerchantMetrics
+ * - TargetAudience
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tracking
  */
@@ -83,6 +87,8 @@ class TrackerSnapshot implements Conditional, ContainerAwareInterface, OptionsAw
 		$ads_service = $this->container->get( AdsService::class );
 		/** @var MerchantCenterService $mc_service */
 		$mc_service = $this->container->get( MerchantCenterService::class );
+		/** @var MerchantMetrics $merchant_metrics */
+		$merchant_metrics = $this->container->get( MerchantMetrics::class );
 
 		return [
 			'version'                         => $this->get_version(),
@@ -98,6 +104,8 @@ class TrackerSnapshot implements Conditional, ContainerAwareInterface, OptionsAw
 			'has_account_issue'               => $mc_service->is_connected() && $mc_service->has_account_issues() ? 'yes' : 'no',
 			'has_at_least_one_synced_product' => $mc_service->is_connected() && $mc_service->has_at_least_one_synced_product() ? 'yes' : 'no',
 			'ads_setup_started'               => $ads_service->is_setup_started() ? 'yes' : 'no',
+			'ads_customer_id'                 => $this->options->get_ads_id(),
+			'ads_campaign_count'              => $merchant_metrics->get_campaign_count(),
 		];
 	}
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
@@ -42,6 +43,9 @@ class AdsCampaignTest extends UnitTest {
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
+	/** @var MockObject|TransientsInterface $transients */
+	protected $transients;
+
 	/** @var AdsCampaign $campaign */
 	protected $campaign;
 
@@ -69,12 +73,14 @@ class AdsCampaignTest extends UnitTest {
 		$this->budget      = $this->createMock( AdsCampaignBudget::class );
 		$this->criterion   = new AdsCampaignCriterion();
 		$this->options     = $this->createMock( OptionsInterface::class );
+		$this->transients  = $this->createMock( TransientsInterface::class );
 
 		$this->wc            = $this->createMock( WC::class );
 		$this->google_helper = new GoogleHelper( $this->wc );
 
 		$this->container = new Container();
 		$this->container->share( AdsAssetGroup::class, $this->asset_group );
+		$this->container->share( TransientsInterface::class, $this->transients );
 		$this->container->share( WC::class, $this->wc );
 
 		$this->campaign = new AdsCampaign( $this->client, $this->budget, $this->criterion, $this->google_helper );

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Exception;
@@ -40,6 +41,9 @@ class AccountServiceTest extends UnitTest {
 
 	/** @var MockObject|AdsAccountState $state */
 	protected $state;
+
+	/** @var MockObject|TransientsInterface $transients */
+	protected $transients;
 
 	/** @var AccountService $account */
 	protected $account;
@@ -104,6 +108,7 @@ class AccountServiceTest extends UnitTest {
 		$this->middleware        = $this->createMock( Middleware::class );
 		$this->state             = $this->createMock( AdsAccountState::class );
 		$this->options           = $this->createMock( OptionsInterface::class );
+		$this->transients        = $this->createMock( TransientsInterface::class );
 
 		$this->container = new Container();
 		$this->container->share( Ads::class, $this->ads );
@@ -111,6 +116,7 @@ class AccountServiceTest extends UnitTest {
 		$this->container->share( Merchant::class, $this->merchant );
 		$this->container->share( Middleware::class, $this->middleware );
 		$this->container->share( AdsAccountState::class, $this->state );
+		$this->container->share( TransientsInterface::class, $this->transients );
 
 		$this->account = new AccountService( $this->container );
 		$this->account->set_options_object( $this->options );
@@ -465,6 +471,12 @@ class AccountServiceTest extends UnitTest {
 				[ OptionsInterface::ADS_ID ],
 				[ OptionsInterface::ADS_SETUP_COMPLETED_AT ],
 				[ OptionsInterface::CAMPAIGN_CONVERT_STATUS ]
+			);
+
+		$this->transients->expects( $this->exactly( 1 ) )
+			->method( 'delete' )
+			->withConsecutive(
+				[ TransientsInterface::ADS_CAMPAIGN_COUNT ],
 			);
 
 		$this->account->disconnect();


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR adds tracking for campaign count and the ads customer ID.

Since the campaign count is retrieved from the Ads API the result is cached for 12 hours to reduce any delays. Since we also fetch a list of campaigns when viewing the dashboard, we use this opportunity to cache the count so when the tracker snapshot is sent it can use a cached value.

The cached values are cleared upon a disconnect, when a campaign is created, or if the transient expires.

Closes #2130 

### Detailed test instructions:
1. Test on a site with MC and Ads accounts onboarded 
2. Use a code snippet to output a tracking snapshot to a page:
```php
add_action(
	'admin_init',
	function() {
		if ( ! empty( $_GET['wctracker'] ) ) {
			$tracks = apply_filters( 'woocommerce_tracker_data', [] );
			echo '<pre>' . json_encode( $tracks, JSON_PRETTY_PRINT ) . '</pre>';
			exit;
		}
	}
);
```
3. Visit the page: `https://domain.test/wp-admin/?wctracker=1` (swap for your admin domain)
4. Confirm the snapshot data has the correct values for `ads_customer_id` and `ads_campaign_count`
5. Disconnect the ads account and recheck the snapshot data
6. Confirm the values are both 0
7. Confirm that the transient `_transient_gla_ads_campaign_count` is cleared up (after the disconnect)
8. Reconnect and view the list of campaigns on the dashboard page
9. Check the DB (or transient manager) to confirm that the transient `_transient_gla_ads_campaign_count` has been populated

### Changelog entry
* Tweak - Add tracking for campaign count.
