### PR TITLE
Record tracking events for moving steps on the campaign creation and editing pages

### DIFF
--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -41,10 +41,21 @@ export const SHIPPING_RATE_METHOD = {
 };
 
 // Stepper key related
-export const CAMPAIGN_STEP = {
-	CAMPAIGN: 'campaign',
-	ASSET_GROUP: 'asset-group',
-};
+const campaignStepEntries = [
+	[ 'CAMPAIGN', 'campaign' ],
+	[ 'ASSET_GROUP', 'asset-group' ],
+];
+
+export const CAMPAIGN_STEP = Object.fromEntries( campaignStepEntries );
+
+export const CAMPAIGN_STEP_NUMBER_MAP = campaignStepEntries.reduce(
+	( acc, entry, index ) => {
+		const no = ( index + 1 ).toString();
+		acc[ entry[ 1 ] ] = no;
+		return acc;
+	},
+	{}
+);
 
 // MC Issues Related
 export const ISSUE_TYPE_PRODUCT = 'product';

--- a/js/src/pages/create-paid-ads-campaign/index.js
+++ b/js/src/pages/create-paid-ads-campaign/index.js
@@ -40,8 +40,8 @@ const dashboardURL = getDashboardUrl();
 /**
  * Renders the campaign creation page.
  *
- * @fires gla_paid_campaign_step with `{ conext: 'create-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
- * @fires gla_paid_campaign_step with `{ conext: 'create-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
+ * @fires gla_paid_campaign_step with `{ context: 'create-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
+ * @fires gla_paid_campaign_step with `{ context: 'create-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
  */
 const CreatePaidAdsCampaign = () => {
 	useLayout( 'full-content' );

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -23,10 +23,20 @@ import AppSpinner from '.~/components/app-spinner';
 import AssetGroup, {
 	ACTION_SUBMIT_CAMPAIGN_AND_ASSETS,
 } from '.~/components/paid-ads/asset-group';
-import { CAMPAIGN_STEP as STEP, CAMPAIGN_TYPE_PMAX } from '.~/constants';
+import {
+	CAMPAIGN_STEP as STEP,
+	CAMPAIGN_STEP_NUMBER_MAP as STEP_NUMBER_MAP,
+	CAMPAIGN_TYPE_PMAX,
+} from '.~/constants';
+import {
+	recordStepperChangeEvent,
+	recordStepContinueEvent,
+} from '.~/utils/recordEvent';
 
+const eventName = 'gla_paid_campaign_step';
+const eventContext = 'edit-ads';
 const dashboardURL = getDashboardUrl();
-const helpButton = <HelpIconButton eventContext="edit-ads" />;
+const helpButton = <HelpIconButton eventContext={ eventContext } />;
 
 function getCurrentStep() {
 	const { step } = getQuery();
@@ -38,6 +48,9 @@ function getCurrentStep() {
 
 /**
  * Renders the campaign editing page.
+ *
+ * @fires gla_paid_campaign_step with `{ conext: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
+ * @fires gla_paid_campaign_step with `{ conext: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
  */
 const EditPaidAdsCampaign = () => {
 	useLayout( 'full-content' );
@@ -64,8 +77,9 @@ const EditPaidAdsCampaign = () => {
 		}
 	}, [ campaign ] );
 
-	const setStep = ( step ) => {
-		const url = getNewPath( { ...getQuery(), step } );
+	const step = getCurrentStep();
+	const setStep = ( nextStep ) => {
+		const url = getNewPath( { ...getQuery(), step: nextStep } );
 		getHistory().push( url );
 	};
 
@@ -99,6 +113,25 @@ const EditPaidAdsCampaign = () => {
 			</>
 		);
 	}
+
+	const handleStepperClick = ( nextStep ) => {
+		recordStepperChangeEvent(
+			eventName,
+			STEP_NUMBER_MAP[ nextStep ],
+			eventContext
+		);
+		setStep( nextStep );
+	};
+
+	const handleContinueClick = ( nextStep ) => {
+		recordStepContinueEvent(
+			eventName,
+			STEP_NUMBER_MAP[ step ],
+			STEP_NUMBER_MAP[ nextStep ],
+			eventContext
+		);
+		setStep( nextStep );
+	};
 
 	const handleSubmit = async ( values, enhancer ) => {
 		const { action } = enhancer.submitter.dataset;
@@ -163,13 +196,13 @@ const EditPaidAdsCampaign = () => {
 							content: (
 								<AdsCampaign
 									campaign={ campaign }
-									trackingContext="edit-ads"
+									trackingContext={ eventContext }
 									onContinue={ () =>
-										setStep( STEP.ASSET_GROUP )
+										handleContinueClick( STEP.ASSET_GROUP )
 									}
 								/>
 							),
-							onClick: setStep,
+							onClick: handleStepperClick,
 						},
 						{
 							key: STEP.ASSET_GROUP,

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -49,8 +49,8 @@ function getCurrentStep() {
 /**
  * Renders the campaign editing page.
  *
- * @fires gla_paid_campaign_step with `{ conext: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
- * @fires gla_paid_campaign_step with `{ conext: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
+ * @fires gla_paid_campaign_step with `{ context: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
+ * @fires gla_paid_campaign_step with `{ context: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
  */
 const EditPaidAdsCampaign = () => {
 	useLayout( 'full-content' );

--- a/js/src/utils/recordEvent.js
+++ b/js/src/utils/recordEvent.js
@@ -120,6 +120,46 @@ export const recordTablePageEvent = ( context, page, direction ) => {
  */
 
 /**
+ * Triggered when moving to another step during creating/editing a campaign.
+ *
+ * @event gla_paid_campaign_step
+ * @property {string} triggered_by Indicates which button triggered this event
+ * @property {string} action User's action or/and objective (e.g. `go-to-step-2`)
+ * @property {string | undefined} context Indicates where this event happened
+ */
+
+/**
+ * Records the event tracking when calling back the "onClick" of <Stepper> to move to another step.
+ *
+ * @param {string} eventName The event name to record.
+ * @param {string} to The next step to go to, e.g. '2'.
+ * @param {string} [context] Indicates where this event happened.
+ */
+export function recordStepperChangeEvent( eventName, to, context ) {
+	recordEvent( eventName, {
+		triggered_by: `stepper-step${ to }-button`,
+		action: `go-to-step${ to }`,
+		context,
+	} );
+}
+
+/**
+ * Records the event tracking when clicking on the "Continue" button within a step content to move to another step.
+ *
+ * @param {string} eventName The event name to record.
+ * @param {string} from The current step to leave from, e.g. '1'.
+ * @param {string} to The next step to go to, e.g. '2'.
+ * @param {string} [context] Indicates where this event happened.
+ */
+export function recordStepContinueEvent( eventName, from, to, context ) {
+	recordEvent( eventName, {
+		triggered_by: `step${ from }-continue-button`,
+		action: `go-to-step${ to }`,
+		context,
+	} );
+}
+
+/**
  * A modal is closed.
  *
  * @event gla_modal_closed

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -537,7 +537,7 @@ Clicking on the Merchant Center phone number edit button.
 #### Emitters
 - [`PhoneNumberCard`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L127)
 
-### [`gla_modal_closed`](../../js/src/utils/recordEvent.js#L122)
+### [`gla_modal_closed`](../../js/src/utils/recordEvent.js#L162)
 A modal is closed.
 #### Properties
 | name | type | description |
@@ -560,7 +560,7 @@ Clicking on a text link within the modal content
 #### Emitters
 - [`ContentLink`](../../js/src/components/guide-page-content/index.js#L46) with given `context, href`
 
-### [`gla_modal_open`](../../js/src/utils/recordEvent.js#L135)
+### [`gla_modal_open`](../../js/src/utils/recordEvent.js#L175)
 A modal is open
 #### Properties
 | name | type | description |
@@ -596,6 +596,22 @@ Clicking on the "Complete setup" button to complete the onboarding flow with pai
 Clicking on the "Create a paid ad campaign" button to open the paid ads setup in the onboarding flow.
 #### Emitters
 - [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L67)
+
+### [`gla_paid_campaign_step`](../../js/src/utils/recordEvent.js#L122)
+Triggered when moving to another step during creating/editing a campaign.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`triggered_by` | `string` | Indicates which button triggered this event
+`action` | `string` | User's action or/and objective (e.g. `go-to-step-2`)
+`context` | `string \| undefined` | Indicates where this event happened
+#### Emitters
+- [`CreatePaidAdsCampaign`](../../js/src/pages/create-paid-ads-campaign/index.js#L46)
+	- with `{ conext: 'create-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
+	- with `{ conext: 'create-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
+- [`EditPaidAdsCampaign`](../../js/src/pages/edit-paid-ads-campaign/index.js#L55)
+	- with `{ conext: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
+	- with `{ conext: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
 
 ### [`gla_request_review`](../../js/src/product-feed/review-request/review-request-modal.js#L19)
 Triggered when request review button is clicked

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -607,11 +607,11 @@ Triggered when moving to another step during creating/editing a campaign.
 `context` | `string \| undefined` | Indicates where this event happened
 #### Emitters
 - [`CreatePaidAdsCampaign`](../../js/src/pages/create-paid-ads-campaign/index.js#L46)
-	- with `{ conext: 'create-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
-	- with `{ conext: 'create-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
+	- with `{ context: 'create-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
+	- with `{ context: 'create-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
 - [`EditPaidAdsCampaign`](../../js/src/pages/edit-paid-ads-campaign/index.js#L55)
-	- with `{ conext: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
-	- with `{ conext: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
+	- with `{ context: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
+	- with `{ context: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
 
 ### [`gla_request_review`](../../js/src/product-feed/review-request/review-request-modal.js#L19)
 Triggered when request review button is clicked


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up PR of https://github.com/woocommerce/google-listings-and-ads/pull/2111#issuecomment-1777130207 and relates to #2104 

PR #2111 added missing tracking to the onboarding flow when moving steps, but the campaign creation and editing pages with the same `<Stepper>` also missed the tracking events.

This RP:

- Add utility functions to record events for moving steps on a page that has `<Stepper>`.
- Record tracking events for moving steps on the campaign creation and editing pages.

### Screenshots:

#### 📷 Campaign creation

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/82af23da-6df1-42e6-a4ea-ae97236627fc)

#### 📷 Campaign editing

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/59952e26-83a4-4bae-af05-01475c69cbf8)

### Detailed test instructions:

1. Enable tracking debug tool
   - Open the Console tab of the browser DevTool.
   - Change the filter level to "All levels".
   - Run `localStorage.setItem( 'debug', 'wc-admin:*' )` and refresh the page to make it work.
   - It should be able to view tracking via the Console tab. Ref:
      ![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/698f85d8-e890-4ab6-939b-738acee6098f)
2. Go to the campaign creating page.
3. Click on the "Continue" button at the bottom to move to step 2.
4. Check the tracking event via the Console tab.
5. Click on the Stepper to move to step 1.
6. Check the tracking event via the Console tab.
7. Go to the campaign editing page.
8. Repeat steps 3-6 of this test instruction.

### Changelog entry

> Add - Record tracking events for moving steps on the campaign creation and editing pages.
