### PR TITLE
Update WordPress CS to 3.0

### DIFF
--- a/bin/GoogleAdsCleanupServices.php
+++ b/bin/GoogleAdsCleanupServices.php
@@ -160,36 +160,36 @@ class GoogleAdsCleanupServices {
 
 		foreach ( array_diff( $library_enums, $used_enums ) as $enum ) {
 			$this->remove_enum( $enum );
-		};
+		}
 	}
 
 	/**
 	 * Remove a specific enum.
 	 *
-	 * @param string $enum Enum name.
+	 * @param string $enum_name Enum name.
 	 */
-	protected function remove_enum( string $enum ) {
-		$this->output_text( "Removing enum {$enum}" );
+	protected function remove_enum( string $enum_name ) {
+		$this->output_text( "Removing enum {$enum_name}" );
 		$this->src_path = '/src/Google/Ads/GoogleAds';
 
-		$this->remove_file( "/{$this->version}/Enums/{$enum}Enum.php" );
-		$this->remove_file( "/{$this->version}/Enums/{$enum}Enum_{$enum}.php" );
-		$this->remove_file( "/{$this->version}/Enums/{$enum}Enum/{$enum}.php" );
-		$this->remove_directory( "/{$this->version}/Enums/{$enum}Enum" );
+		$this->remove_file( "/{$this->version}/Enums/{$enum_name}Enum.php" );
+		$this->remove_file( "/{$this->version}/Enums/{$enum_name}Enum_{$enum_name}.php" );
+		$this->remove_file( "/{$this->version}/Enums/{$enum_name}Enum/{$enum_name}.php" );
+		$this->remove_directory( "/{$this->version}/Enums/{$enum_name}Enum" );
 
 		// Remove metadata files.
 		$this->src_path = '/metadata/Google/Ads/GoogleAds';
-		$this->remove_file( "/{$this->version}/Enums/{$enum}.php" );
+		$this->remove_file( "/{$this->version}/Enums/{$enum_name}.php" );
 	}
 
 	/**
 	 * Find a list of files in a path, including subdirectories, matching a pattern.
 	 *
-	 * @param string $path Package path
-	 * @param string $match Regex pattern to match
+	 * @param string $path    Package path
+	 * @param string $pattern Regex pattern to match
 	 * @return array Matching files
 	 */
-	protected function get_dir_contents( $path, $match ) {
+	protected function get_dir_contents( $path, $pattern ) {
 		try {
 			$rdi = new RecursiveDirectoryIterator( $path );
 		} catch ( UnexpectedValueException $e ) {
@@ -203,7 +203,7 @@ class GoogleAdsCleanupServices {
 		}
 
 		$rii   = new RecursiveIteratorIterator( $rdi );
-		$rri   = new RegexIterator( $rii, $match );
+		$rri   = new RegexIterator( $rii, $pattern );
 		$files = [];
 		foreach ( $rri as $file ) {
 			$files[] = $file->getPathname();
@@ -255,7 +255,7 @@ class GoogleAdsCleanupServices {
 		}
 
 		return array_map(
-			function( $file ) use ( $suffix ) {
+			function ( $file ) use ( $suffix ) {
 				$name = pathinfo( $file, PATHINFO_FILENAME );
 				return $suffix ? $this->remove_suffix( $suffix, $name ) : $name;
 			},
@@ -317,10 +317,10 @@ class GoogleAdsCleanupServices {
 		// Parse until we encounter closing bracket.
 		for ( $end = $offset; $end < $length; $end++ ) {
 			if ( '{' === $contents[ $end ] ) {
-				$bracket++;
+				++$bracket;
 			}
 			if ( '}' === $contents[ $end ] ) {
-				$bracket--;
+				--$bracket;
 				if ( 1 > $bracket ) {
 					break;
 				}
@@ -334,7 +334,7 @@ class GoogleAdsCleanupServices {
 
 		// Include whitespaces before start.
 		while ( 0 < $start && ctype_space( $contents[ $start - 1 ] ) ) {
-			$start--;
+			--$start;
 		}
 
 		$new  = substr( $contents, 0, $start );
@@ -388,7 +388,7 @@ class GoogleAdsCleanupServices {
 			return;
 		}
 
-		unlink( $file );
+		unlink( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 	}
 
 	/**
@@ -403,7 +403,7 @@ class GoogleAdsCleanupServices {
 			return;
 		}
 
-		rmdir( $directory );
+		rmdir( $directory ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 	}
 
 	/**

--- a/bin/SymfonyPolyfillCleanup.php
+++ b/bin/SymfonyPolyfillCleanup.php
@@ -67,7 +67,6 @@ class SymfonyPolyfillCleanup {
 	public static function remove( Event $event = null ) {
 		$cleanup = new SymfonyPolyfillCleanup( $event );
 		$cleanup->remove_bootstraps80();
-
 	}
 
 	/**
@@ -131,10 +130,10 @@ class SymfonyPolyfillCleanup {
 		// Parse until we encounter closing bracket.
 		for ( $end = $offset; $end < $length; $end++ ) {
 			if ( '{' === $contents[ $end ] ) {
-				$bracket++;
+				++$bracket;
 			}
 			if ( '}' === $contents[ $end ] ) {
-				$bracket--;
+				--$bracket;
 				if ( 1 > $bracket ) {
 					break;
 				}
@@ -148,7 +147,7 @@ class SymfonyPolyfillCleanup {
 
 		// Include whitespaces before start.
 		while ( 0 < $start && ctype_space( $contents[ $start - 1 ] ) ) {
-			$start--;
+			--$start;
 		}
 
 		$new  = substr( $contents, 0, $start );
@@ -174,7 +173,7 @@ class SymfonyPolyfillCleanup {
 			return;
 		}
 
-		unlink( $file );
+		unlink( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 	}
 
 	/**

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -310,11 +310,11 @@ function prefix_string( &$contents, $search ) {
  *
  * @since 2.2.2
  *
- * @param string $path Package path
- * @param string $match Regex pattern to match
+ * @param string $path    Package path
+ * @param string $pattern Regex pattern to match
  * @return array Matching files
  */
-function get_dir_contents( $path, $match ) {
+function get_dir_contents( $path, $pattern ) {
 	try {
 		$rdi = new RecursiveDirectoryIterator( $path );
 	} catch ( UnexpectedValueException  $e ) {
@@ -326,7 +326,7 @@ function get_dir_contents( $path, $match ) {
 	}
 
 	$rii   = new RecursiveIteratorIterator( $rdi );
-	$rri   = new RegexIterator( $rii, $match );
+	$rri   = new RegexIterator( $rii, $pattern );
 	$files = [];
 	foreach ( $rri as $file ) {
 		$files[] = $file->getPathname();

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^v0.7",
 		"phpunit/phpunit": "^9.5",
 		"wp-cli/i18n-command": "^2.2",
-		"wp-coding-standards/wpcs": "^2.3",
+		"wp-coding-standards/wpcs": "^3.0",
 		"yoast/phpunit-polyfills": "^1.0"
 	},
 	"replace" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e11445388ffb41fd143162a17acf77b8",
+    "content-hash": "8b5dd0675461451b8f8df048aad22d1c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -3570,6 +3570,142 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2023-09-20T22:06:18+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-07-16T21:39:41+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "9.2.24",
             "source": {
@@ -5015,16 +5151,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -5060,14 +5196,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/finder",
@@ -5437,30 +5574,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -5477,6 +5622,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -5484,7 +5630,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -5561,5 +5713,5 @@
     "platform-overrides": {
         "php": "7.4.30"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -101,7 +101,7 @@ function woogle_get_container(): ContainerInterface {
  */
 add_action(
 	'plugins_loaded',
-	function() {
+	function () {
 		// Check requirements.
 		if ( ! PluginValidator::validate() ) {
 			return;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -106,6 +106,8 @@
 	<!-- Check the main PHP file and everything in src/ -->
 	<arg name="extensions" value="php"/>
 	<file>./src</file>
+	<file>./bin</file>
+	<file>./views</file>
 	<file>./google-listings-and-ads.php</file>
 
 	<!-- Show progress and sniff codes in all reports -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,8 +18,12 @@
 		<exclude name="Squiz.Commenting.LongConditionClosingComment"/>
 
 		<!-- No thanks -->
-		<exclude name="WordPress.PHP.DisallowShortTernary"/>
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder"/>
+		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+
+		<!-- Exceptions can be escaped before outputting not when thrown -->
+		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped"/>
 
 		<!-- These overrides are useful for code hinting -->
 		<exclude name="Generic.CodeAnalysis.UselessOverridingMethod.Found"/>
@@ -29,7 +33,7 @@
 		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching"/>
 
 		<!-- We like short array syntax -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
 
 		<!-- Multiple throws tags are fine -->
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
@@ -54,11 +58,6 @@
 		<properties>
 			<property name="text_domain" type="array" value="google-listings-and-ads"/>
 		</properties>
-	</rule>
-
-	<!-- This rule flags space indents in HTML tags, which are generally OK. -->
-	<rule ref="WordPress.WhiteSpace.PrecisionAlignment">
-		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found"/>
 	</rule>
 
 	<!-- We allow the use of / in hooks -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -60,6 +60,15 @@
 		</properties>
 	</rule>
 
+	<!-- Add manage_woocommerce to accepted user capabilities -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="manage_woocommerce"/>
+			</property>
+		</properties>
+	</rule>
+
 	<!-- We allow the use of / in hooks -->
 	<rule ref="WordPress.NamingConventions.ValidHookName">
 		<properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,7 +19,7 @@
 
 		<!-- No thanks -->
 		<exclude name="PSR12.Files.FileHeader.IncorrectOrder"/>
-		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
+		<exclude name="Universal.Operators.DisallowShortTernary"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 
 		<!-- Exceptions can be escaped before outputting not when thrown -->
@@ -33,7 +33,7 @@
 		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching"/>
 
 		<!-- We like short array syntax -->
-		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
 
 		<!-- Multiple throws tags are fine -->
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -323,5 +323,4 @@ class Ads implements OptionsAwareInterface {
 
 		throw new Exception( __( 'Merchant link is not available to accept', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -116,7 +116,6 @@ class AdsAsset implements OptionsAwareInterface {
 			default:
 				throw new Exception( 'Asset Field type not supported' );
 		}
-
 	}
 
 	/**
@@ -209,7 +208,6 @@ class AdsAsset implements OptionsAwareInterface {
 		}
 
 		return $arns;
-
 	}
 
 	/**
@@ -245,7 +243,6 @@ class AdsAsset implements OptionsAwareInterface {
 
 		$operation = ( new AssetOperation() )->setCreate( $asset );
 		return ( new MutateOperation() )->setAssetOperation( $operation );
-
 	}
 
 	/**

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -312,7 +312,6 @@ class AdsAssetGroup implements OptionsAwareInterface {
 				[ 'errors' => $errors ]
 			);
 		}
-
 	}
 
 	/**
@@ -473,5 +472,4 @@ class AdsAssetGroup implements OptionsAwareInterface {
 			throw new Exception( __( 'Invalid asset group ID', 'google-listings-and-ads' ) );
 		}
 	}
-
 }

--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -143,7 +143,6 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				[ 'errors' => $errors ]
 			);
 		}
-
 	}
 
 	/**
@@ -210,7 +209,6 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 				[ 'errors' => $errors ]
 			);
 		}
-
 	}
 
 	/**
@@ -224,7 +222,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		return array_values(
 			array_filter(
 				$assets,
-				function( $asset ) {
+				function ( $asset ) {
 					return ! empty( $asset['id'] );
 				}
 			)
@@ -242,7 +240,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		return array_values(
 			array_filter(
 				$assets,
-				function( $asset ) {
+				function ( $asset ) {
 					return ! empty( $asset['content'] );
 				}
 			)
@@ -293,7 +291,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	 */
 	protected function get_override_operations( int $asset_group_id, array $asset_field_types ): array {
 		return array_map(
-			function( $asset ) use ( $asset_group_id ) {
+			function ( $asset ) use ( $asset_group_id ) {
 				return $this->delete_operation( $asset_group_id, $asset['field_type'], $asset['id'] );
 			},
 			$this->get_specific_assets( $asset_group_id, $asset_field_types )
@@ -338,7 +336,6 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		// The delete operations must be executed first otherwise will cause a conflict with existing assets with identical content.
 		// See here: https://github.com/woocommerce/google-listings-and-ads/pull/1870
 		return array_merge( $delete_asset_group_assets_operations, $asset_group_assets_operations );
-
 	}
 
 
@@ -378,8 +375,4 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 		$operation                       = ( new AssetGroupAssetOperation() )->setRemove( $asset_group_asset_resource_name );
 		return ( new MutateOperation() )->setAssetGroupAssetOperation( $operation );
 	}
-
-
-
-
 }

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -117,7 +117,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			$converted_campaigns = [];
 
 			foreach ( $campaign_results->iterateAllElements() as $row ) {
-				$campaign_count++;
+				++$campaign_count;
 				$campaign                               = $this->convert_campaign( $row );
 				$converted_campaigns[ $campaign['id'] ] = $campaign;
 			}
@@ -386,9 +386,9 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				foreach ( $this->get_campaigns( false, false ) as $campaign ) {
 					if ( CampaignType::PERFORMANCE_MAX !== $campaign['type'] ) {
 						if ( CampaignStatus::REMOVED === $campaign['status'] ) {
-							$old_removed_campaigns++;
+							++$old_removed_campaigns;
 						} else {
-							$old_campaigns++;
+							++$old_campaigns;
 						}
 					}
 				}

--- a/src/API/Google/AdsConversionAction.php
+++ b/src/API/Google/AdsConversionAction.php
@@ -186,5 +186,4 @@ class AdsConversionAction implements OptionsAwareInterface {
 		}
 		return $return;
 	}
-
 }

--- a/src/API/Google/ExceptionTrait.php
+++ b/src/API/Google/ExceptionTrait.php
@@ -145,18 +145,18 @@ trait ExceptionTrait {
 	/**
 	 * Get an error message from a ClientException.
 	 *
-	 * @param ClientExceptionInterface $exception Exception to check.
-	 * @param string                   $default   Default error message.
+	 * @param ClientExceptionInterface $exception     Exception to check.
+	 * @param string                   $default_error Default error message.
 	 *
 	 * @return string
 	 */
-	protected function client_exception_message( ClientExceptionInterface $exception, string $default ): string {
+	protected function client_exception_message( ClientExceptionInterface $exception, string $default_error ): string {
 		if ( $exception instanceof BadResponseException ) {
 			$response = json_decode( $exception->getResponse()->getBody()->getContents(), true );
 			$message  = $response['message'] ?? false;
-			return $message ? $default . ': ' . $message : $default;
+			return $message ? $default_error . ': ' . $message : $default_error;
 		}
-		return $default;
+		return $default_error;
 	}
 
 	/**

--- a/src/API/Google/MerchantMetrics.php
+++ b/src/API/Google/MerchantMetrics.php
@@ -214,7 +214,7 @@ class MerchantMetrics implements OptionsAwareInterface {
 
 			// Iterate through all paged results (total results count is not set).
 			foreach ( $campaign_results->iterateAllElements() as $row ) {
-				$campaign_count++;
+				++$campaign_count;
 			}
 		} catch ( Exception $e ) {
 			$campaign_count = 0;
@@ -232,5 +232,4 @@ class MerchantMetrics implements OptionsAwareInterface {
 	protected function get_tomorrow(): string {
 		return ( new DateTime( 'tomorrow', $this->wp->wp_timezone() ) )->format( 'Y-m-d' );
 	}
-
 }

--- a/src/API/Google/Query/Query.php
+++ b/src/API/Google/Query/Query.php
@@ -67,16 +67,16 @@ abstract class Query implements QueryInterface {
 	/**
 	 * Query constructor.
 	 *
-	 * @param string $resource
+	 * @param string $resource_name
 	 *
 	 * @throws InvalidQuery When the resource name is not valid.
 	 */
-	public function __construct( string $resource ) {
-		if ( ! preg_match( '/^[a-zA-Z_]+$/', $resource ) ) {
+	public function __construct( string $resource_name ) {
+		if ( ! preg_match( '/^[a-zA-Z_]+$/', $resource_name ) ) {
 			throw InvalidQuery::resource_name();
 		}
 
-		$this->resource = $resource;
+		$this->resource = $resource_name;
 	}
 
 	/**
@@ -326,7 +326,7 @@ abstract class Query implements QueryInterface {
 					join(
 						"','",
 						array_map(
-							function( $value ) {
+							function ( $value ) {
 								return $this->escape( $value );
 							},
 							$where['value']

--- a/src/API/Google/SiteVerification.php
+++ b/src/API/Google/SiteVerification.php
@@ -172,5 +172,4 @@ class SiteVerification implements ContainerAwareInterface, OptionsAwareInterface
 			);
 		}
 	}
-
 }

--- a/src/API/PermissionsTrait.php
+++ b/src/API/PermissionsTrait.php
@@ -18,6 +18,6 @@ trait PermissionsTrait {
 	 * @return bool
 	 */
 	protected function can_manage(): bool {
-		return current_user_can( 'manage_woocommerce' );
+		return current_user_can( 'manage_woocommerce' ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
 	}
 }

--- a/src/API/PermissionsTrait.php
+++ b/src/API/PermissionsTrait.php
@@ -18,6 +18,6 @@ trait PermissionsTrait {
 	 * @return bool
 	 */
 	protected function can_manage(): bool {
-		return current_user_can( 'manage_woocommerce' ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
+		return current_user_can( 'manage_woocommerce' );
 	}
 }

--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -94,7 +94,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_accounts_callback(): callable {
-		return function() {
+		return function () {
 			try {
 				return new Response( $this->account->get_accounts() );
 			} catch ( Exception $e ) {
@@ -109,7 +109,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function create_or_link_account_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$link_id = absint( $request['id'] );
 				if ( $link_id ) {
@@ -130,7 +130,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_connected_ads_account_callback(): callable {
-		return function() {
+		return function () {
 			return $this->account->get_connected_account();
 		};
 	}
@@ -141,7 +141,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function disconnect_ads_account_callback(): callable {
-		return function() {
+		return function () {
 			$this->account->disconnect();
 
 			return [
@@ -157,7 +157,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_billing_status_callback(): callable {
-		return function() {
+		return function () {
 			return $this->account->get_billing_status();
 		};
 	}
@@ -195,5 +195,4 @@ class AccountController extends BaseController {
 	protected function get_schema_title(): string {
 		return 'account';
 	}
-
 }

--- a/src/API/Site/Controllers/Ads/AssetGroupController.php
+++ b/src/API/Site/Controllers/Ads/AssetGroupController.php
@@ -143,11 +143,11 @@ class AssetGroupController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_asset_groups_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$campaign_id = $request->get_param( 'campaign_id' );
 				return array_map(
-					function( $item ) use ( $request ) {
+					function ( $item ) use ( $request ) {
 						$data = $this->prepare_item_for_response( $item, $request );
 						return $this->prepare_response_for_collection( $data );
 					},
@@ -157,7 +157,6 @@ class AssetGroupController extends BaseController {
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}
-
 		};
 	}
 
@@ -167,7 +166,7 @@ class AssetGroupController extends BaseController {
 	 * @return callable
 	 */
 	public function create_asset_group_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$asset_group_id = $this->ads_asset_group->create_asset_group( $request->get_param( 'campaign_id' ) );
 				return [
@@ -187,7 +186,7 @@ class AssetGroupController extends BaseController {
 	 * @return callable
 	 */
 	public function edit_asset_group_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$asset_group_fields = array_intersect_key(
 					$request->get_params(),

--- a/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
+++ b/src/API/Site/Controllers/Ads/AssetSuggestionsController.php
@@ -132,7 +132,7 @@ class AssetSuggestionsController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_assets_suggestions_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$id   = $request->get_param( 'id' );
 				$type = $request->get_param( 'type' );
@@ -149,12 +149,12 @@ class AssetSuggestionsController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_final_url_suggestions_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$search   = $request->get_param( 'search' );
 			$per_page = $request->get_param( 'per_page' );
 			$order_by = $request->get_param( 'order_by' );
 			return array_map(
-				function( $item ) use ( $request ) {
+				function ( $item ) use ( $request ) {
 					$data = $this->prepare_item_for_response( $item, $request );
 					return $this->prepare_response_for_collection( $data );
 				},
@@ -198,7 +198,6 @@ class AssetSuggestionsController extends BaseController {
 			],
 
 		];
-
 	}
 
 
@@ -212,5 +211,4 @@ class AssetSuggestionsController extends BaseController {
 	protected function get_schema_title(): string {
 		return 'asset_final_url_suggestions';
 	}
-
 }

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -90,7 +90,7 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 	 * @return callable
 	 */
 	protected function get_budget_recommendation_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$country_codes = $request->get_param( 'country_codes' );
 			$currency      = $this->ads->get_ads_currency();
 

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -97,12 +97,12 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 	 * @return callable
 	 */
 	protected function get_campaigns_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$exclude_removed = $request->get_param( 'exclude_removed' );
 
 				return array_map(
-					function( $campaign ) use ( $request ) {
+					function ( $campaign ) use ( $request ) {
 						$data = $this->prepare_item_for_response( $campaign, $request );
 						return $this->prepare_response_for_collection( $data );
 					},
@@ -120,7 +120,7 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 	 * @return callable
 	 */
 	protected function create_campaign_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$fields = array_intersect_key( $request->get_json_params(), $this->get_schema_properties() );
 
@@ -149,7 +149,7 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 	 * @return callable
 	 */
 	protected function get_campaign_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$id       = absint( $request['id'] );
 				$campaign = $this->ads_campaign->get_campaign( $id );
@@ -177,7 +177,7 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 	 * @return callable
 	 */
 	protected function edit_campaign_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$fields = array_intersect_key( $request->get_json_params(), $this->get_edit_schema() );
 				if ( empty( $fields ) ) {
@@ -209,7 +209,7 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 	 * @return callable
 	 */
 	protected function delete_campaign_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$deleted_id = $this->ads_campaign->delete_campaign( absint( $request['id'] ) );
 
@@ -241,7 +241,7 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 		// Unset required to allow editing individual fields.
 		array_walk(
 			$fields,
-			function( &$value ) {
+			function ( &$value ) {
 				unset( $value['required'] );
 			}
 		);

--- a/src/API/Site/Controllers/Ads/ReportsController.php
+++ b/src/API/Site/Controllers/Ads/ReportsController.php
@@ -56,7 +56,7 @@ class ReportsController extends BaseReportsController {
 	 * @return callable
 	 */
 	protected function get_programs_report_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				/** @var AdsReport $ads */
 				$ads  = $this->container->get( AdsReport::class );
@@ -74,7 +74,7 @@ class ReportsController extends BaseReportsController {
 	 * @return callable
 	 */
 	protected function get_products_report_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				/** @var AdsReport $ads */
 				$ads  = $this->container->get( AdsReport::class );

--- a/src/API/Site/Controllers/Ads/SetupCompleteController.php
+++ b/src/API/Site/Controllers/Ads/SetupCompleteController.php
@@ -42,7 +42,7 @@ class SetupCompleteController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_setup_complete_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			do_action( 'woocommerce_gla_ads_setup_completed' );
 
 			return new Response(

--- a/src/API/Site/Controllers/AttributeMapping/AttributeMappingDataController.php
+++ b/src/API/Site/Controllers/AttributeMapping/AttributeMappingDataController.php
@@ -101,7 +101,7 @@ class AttributeMappingDataController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_mapping_sources_read_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$attribute = $request->get_param( 'attribute' );
 				return [

--- a/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php
+++ b/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php
@@ -94,7 +94,7 @@ class AttributeMappingRulesController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_rule_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$page     = $request->get_param( 'page' );
 				$per_page = $request->get_param( 'per_page' );
@@ -133,7 +133,7 @@ class AttributeMappingRulesController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function create_rule_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				if ( ! $this->attribute_mapping_rules_query->insert( $this->prepare_item_for_database( $request ) ) ) {
 					return $this->response_from_exception( new Exception( 'Unable to create the new rule.' ) );
@@ -154,7 +154,7 @@ class AttributeMappingRulesController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function update_rule_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$rule_id = $request->get_url_params()['id'];
 
@@ -177,7 +177,7 @@ class AttributeMappingRulesController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function delete_rule_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$rule_id = $request->get_url_params()['id'];
 
@@ -233,7 +233,7 @@ class AttributeMappingRulesController extends BaseOptionsController {
 				'description'       => __( 'List of category IDs, separated by commas.', 'google-listings-and-ads' ),
 				'type'              => 'string',
 				'required'          => false,
-				'validate_callback' => function( $param ) {
+				'validate_callback' => function ( $param ) {
 					return $this->validate_categories_param( $param );
 				},
 			],

--- a/src/API/Site/Controllers/AttributeMapping/AttributeMappingSyncerController.php
+++ b/src/API/Site/Controllers/AttributeMapping/AttributeMappingSyncerController.php
@@ -64,7 +64,7 @@ class AttributeMappingSyncerController extends BaseController implements Options
 	 * @return callable
 	 */
 	protected function get_sync_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$state = [
 					'is_scheduled' => (bool) $this->sync_stats->get_count(),

--- a/src/API/Site/Controllers/BaseController.php
+++ b/src/API/Site/Controllers/BaseController.php
@@ -18,7 +18,9 @@ use WP_REST_Response as Response;
  */
 abstract class BaseController extends WC_REST_Controller implements Registerable {
 
-	use PluginHelper, PermissionsTrait, ResponseFromExceptionTrait;
+	use PluginHelper;
+	use PermissionsTrait;
+	use ResponseFromExceptionTrait;
 
 	/**
 	 * @var RESTServer
@@ -67,7 +69,7 @@ abstract class BaseController extends WC_REST_Controller implements Registerable
 	 * @return callable
 	 */
 	protected function get_permission_callback(): callable {
-		return function() {
+		return function () {
 			return $this->can_manage();
 		};
 	}
@@ -107,7 +109,7 @@ abstract class BaseController extends WC_REST_Controller implements Registerable
 	 * @return callable
 	 */
 	protected function get_api_response_schema_callback(): callable {
-		return function() {
+		return function () {
 			return $this->get_item_schema();
 		};
 	}

--- a/src/API/Site/Controllers/CountryCodeTrait.php
+++ b/src/API/Site/Controllers/CountryCodeTrait.php
@@ -94,7 +94,7 @@ trait CountryCodeTrait {
 	 * @return callable
 	 */
 	protected function get_country_code_sanitize_callback(): callable {
-		return function( $value ) {
+		return function ( $value ) {
 			return is_array( $value )
 				? array_map( 'strtoupper', $value )
 				: strtoupper( $value );
@@ -108,7 +108,7 @@ trait CountryCodeTrait {
 	 * @return callable
 	 */
 	protected function get_country_code_validate_callback(): callable {
-		return function( ...$args ) {
+		return function ( ...$args ) {
 			return $this->validate_country_codes( false, ...$args );
 		};
 	}
@@ -120,7 +120,7 @@ trait CountryCodeTrait {
 	 * @return callable
 	 */
 	protected function get_supported_country_code_validate_callback(): callable {
-		return function( ...$args ) {
+		return function ( ...$args ) {
 			return $this->validate_country_codes( true, ...$args );
 		};
 	}

--- a/src/API/Site/Controllers/DisconnectController.php
+++ b/src/API/Site/Controllers/DisconnectController.php
@@ -40,7 +40,7 @@ class DisconnectController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_disconnect_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$endpoints = [
 				'ads/connection',
 				'mc/connection',

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -97,7 +97,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_connect_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$next       = $request->get_param( 'next_page_name' );
 				$login_hint = $request->get_param( 'login_hint' ) ?: '';
@@ -143,7 +143,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_disconnect_callback(): callable {
-		return function() {
+		return function () {
 			$this->connection->disconnect();
 
 			return [
@@ -161,7 +161,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_connected_callback(): callable {
-		return function() {
+		return function () {
 			try {
 				$status = $this->connection->get_status();
 				return [
@@ -181,7 +181,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_reconnected_callback(): callable {
-		return function() {
+		return function () {
 			try {
 				$status           = $this->connection->get_reconnect_status();
 				$status['active'] = array_key_exists( 'status', $status ) && ( 'connected' === $status['status'] ) ? 'yes' : 'no';

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -96,7 +96,7 @@ class AccountController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_connect_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			// Register the site to wp.com.
 			if ( ! $this->manager->is_connected() ) {
 				$result = $this->manager->register();
@@ -150,7 +150,7 @@ class AccountController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_disconnect_callback(): callable {
-		return function() {
+		return function () {
 			$this->manager->remove_connection();
 			$this->options->delete( OptionsInterface::WP_TOS_ACCEPTED );
 			$this->options->delete( OptionsInterface::JETPACK_CONNECTED );
@@ -168,7 +168,7 @@ class AccountController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_connected_callback(): callable {
-		return function() {
+		return function () {
 			if ( $this->is_jetpack_connected() && ! $this->options->get( OptionsInterface::WP_TOS_ACCEPTED ) ) {
 				$this->log_wp_tos_accepted();
 			}

--- a/src/API/Site/Controllers/MerchantCenter/AccountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AccountController.php
@@ -117,10 +117,10 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_accounts_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				return array_map(
-					function( $account ) use ( $request ) {
+					function ( $account ) use ( $request ) {
 						$data = $this->prepare_item_for_response( $account, $request );
 						return $this->prepare_response_for_collection( $data );
 					},
@@ -157,7 +157,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function setup_account_callback( string $action = 'setup_account' ): callable {
-		return function( Request $request ) use ( $action ) {
+		return function ( Request $request ) use ( $action ) {
 			try {
 				$account_id = absint( $request['id'] );
 
@@ -182,7 +182,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_connected_merchant_callback(): callable {
-		return function() {
+		return function () {
 			return $this->account->get_connected_status();
 		};
 	}
@@ -193,7 +193,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_setup_merchant_callback(): callable {
-		return function() {
+		return function () {
 			return $this->account->get_setup_status();
 		};
 	}
@@ -204,7 +204,7 @@ class AccountController extends BaseController {
 	 * @return callable
 	 */
 	protected function disconnect_merchant_callback(): callable {
-		return function() {
+		return function () {
 			$this->account->disconnect();
 
 			return [
@@ -278,5 +278,4 @@ class AccountController extends BaseController {
 			]
 		);
 	}
-
 }

--- a/src/API/Site/Controllers/MerchantCenter/AttributeMappingCategoriesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/AttributeMappingCategoriesController.php
@@ -52,7 +52,7 @@ class AttributeMappingCategoriesController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_categories_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$cats = $this->get_category_tree();
 				return array_map(
@@ -132,6 +132,4 @@ class AttributeMappingCategoriesController extends BaseController {
 			$categories
 		);
 	}
-
-
 }

--- a/src/API/Site/Controllers/MerchantCenter/BatchShippingTrait.php
+++ b/src/API/Site/Controllers/MerchantCenter/BatchShippingTrait.php
@@ -20,7 +20,7 @@ trait BatchShippingTrait {
 	 * @return callable
 	 */
 	protected function get_batch_delete_shipping_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$country_codes = $request->get_param( 'country_codes' );
 
 			$responses = [];

--- a/src/API/Site/Controllers/MerchantCenter/ConnectionController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ConnectionController.php
@@ -38,7 +38,7 @@ class ConnectionController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_connect_callback(): callable {
-		return function() {
+		return function () {
 			return [
 				'url' => 'example.com',
 			];

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -69,7 +69,7 @@ class IssuesController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_issues_read_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$type_filter = $request['type_filter'];
 			$per_page    = intval( $request['per_page'] );
 			$page        = max( 1, intval( $request['page'] ) );
@@ -208,7 +208,6 @@ class IssuesController extends BaseOptionsController {
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];
-
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PhoneVerificationController.php
@@ -116,7 +116,7 @@ class PhoneVerificationController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_request_phone_verification_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$verification_id = $this->phone_verification->request_phone_verification(
 					$request->get_param( 'phone_region_code' ),
@@ -138,7 +138,7 @@ class PhoneVerificationController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_verify_phone_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$this->phone_verification->verify_phone_number(
 					$request->get_param( 'verification_id' ),

--- a/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductFeedController.php
@@ -59,7 +59,7 @@ class ProductFeedController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_product_feed_read_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				return [
 					'products' => $this->query_helper->get( $request ),

--- a/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
@@ -83,7 +83,7 @@ class ProductStatisticsController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_product_statistics_read_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			return $this->get_product_status_stats( $request );
 		};
 	}
@@ -93,7 +93,7 @@ class ProductStatisticsController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_product_statistics_refresh_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			return $this->get_product_status_stats( $request, true );
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/ReportsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ReportsController.php
@@ -55,7 +55,7 @@ class ReportsController extends BaseReportsController {
 	 * @return callable
 	 */
 	protected function get_programs_report_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				/** @var MerchantReport $merchant */
 				$merchant = $this->container->get( MerchantReport::class );
@@ -73,7 +73,7 @@ class ReportsController extends BaseReportsController {
 	 * @return callable
 	 */
 	protected function get_products_report_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				/** @var MerchantReport $merchant */
 				$merchant = $this->container->get( MerchantReport::class );

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -260,6 +260,5 @@ class RequestReviewController extends BaseOptionsController {
 		}
 
 		return $review_status;
-
 	}
 }

--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -45,7 +45,7 @@ class SettingsController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_settings_endpoint_read_callback(): callable {
-		return function() {
+		return function () {
 			$data   = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
 			$schema = $this->get_schema_properties();
 			$items  = [];
@@ -63,7 +63,7 @@ class SettingsController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_settings_endpoint_edit_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$schema  = $this->get_schema_properties();
 			$options = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
 			if ( ! is_array( $options ) ) {

--- a/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
@@ -61,7 +61,7 @@ class SettingsSyncController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_sync_endpoint_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$this->settings->sync_taxes();
 				$this->settings->sync_shipping();

--- a/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingRateController.php
@@ -227,7 +227,7 @@ class ShippingRateController extends BaseController implements ISO3166AwareInter
 	 * @return callable
 	 */
 	protected function get_delete_rate_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$id = (string) $request->get_param( 'id' );
 

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeBatchController.php
@@ -50,7 +50,7 @@ class ShippingTimeBatchController extends ShippingTimeController {
 	 * @return callable
 	 */
 	protected function get_batch_create_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$country_codes = $request->get_param( 'country_codes' );
 			$time          = $request->get_param( 'time' );
 

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
@@ -92,7 +92,7 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 	 * @return callable
 	 */
 	protected function get_read_times_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$times = $this->get_all_shipping_times();
 			$items = [];
 			foreach ( $times as $time ) {
@@ -117,7 +117,7 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 	 * @return callable
 	 */
 	protected function get_read_time_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$country = $request->get_param( 'country_code' );
 			$time    = $this->get_shipping_time_for_country( $country );
 			if ( empty( $time ) ) {
@@ -146,7 +146,7 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 	 * @return callable
 	 */
 	protected function get_create_time_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$query        = $this->get_query_object();
 			$country_code = $request->get_param( 'country_code' );
 			$existing     = ! empty( $query->where( 'country', $country_code )->get_results() );
@@ -197,7 +197,7 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 	 * @return callable
 	 */
 	protected function get_delete_time_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$country_code = $request->get_param( 'country_code' );
 				$this->get_query_object()->delete( 'country', $country_code );
@@ -300,7 +300,7 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'get_callback' => function( $fields ) {
+			'get_callback' => function ( $fields ) {
 				return $this->iso3166_data_provider->alpha2( $fields['country_code'] )['name'];
 			},
 		];

--- a/src/API/Site/Controllers/MerchantCenter/SupportedCountriesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SupportedCountriesController.php
@@ -72,7 +72,7 @@ class SupportedCountriesController extends BaseController {
 	 * @return callable
 	 */
 	protected function get_countries_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$return = [
 				'countries' => $this->get_supported_countries( $request ),
 			];
@@ -108,7 +108,7 @@ class SupportedCountriesController extends BaseController {
 
 		uasort(
 			$supported,
-			function( $a, $b ) {
+			function ( $a, $b ) {
 				return $a['name'] <=> $b['name'];
 			}
 		);

--- a/src/API/Site/Controllers/MerchantCenter/SyncableProductsCountController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SyncableProductsCountController.php
@@ -65,7 +65,7 @@ class SyncableProductsCountController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_syncable_products_count_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$response = [
 				'count' => null,
 			];
@@ -86,7 +86,7 @@ class SyncableProductsCountController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function update_syncable_products_count_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$this->options->delete( OptionsInterface::SYNCABLE_PRODUCTS_COUNT );
 			$this->options->delete( OptionsInterface::SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA );
 

--- a/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php
+++ b/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php
@@ -108,7 +108,7 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 	 * @return callable
 	 */
 	protected function get_read_audience_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			return $this->prepare_item_for_response( $this->get_target_audience_option(), $request );
 		};
 	}
@@ -121,7 +121,7 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 	 * @since 1.9.0
 	 */
 	protected function get_suggest_audience_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			return $this->prepare_item_for_response( $this->get_target_audience_suggestion(), $request );
 		};
 	}
@@ -132,7 +132,7 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 	 * @return callable
 	 */
 	protected function get_update_audience_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			$data = $this->prepare_item_for_database( $request );
 			$this->update_target_audience_option( $data );
 			$this->prepare_item_for_response( $data, $request );
@@ -166,7 +166,7 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'get_callback' => function() {
+			'get_callback' => function () {
 				return $this->wp->get_locale();
 			},
 		];
@@ -276,12 +276,12 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 
 		// Default to using the Locale class if it is available.
 		if ( class_exists( Locale::class ) ) {
-			return function() use ( $locale ): string {
+			return function () use ( $locale ): string {
 				return Locale::getDisplayLanguage( $locale, $locale );
 			};
 		}
 
-		return function() use ( $locale ): string {
+		return function () use ( $locale ): string {
 			// en_US isn't provided by the translations API.
 			if ( 'en_US' === $locale ) {
 				return 'English';

--- a/src/API/Site/Controllers/TourController.php
+++ b/src/API/Site/Controllers/TourController.php
@@ -87,7 +87,7 @@ class TourController extends BaseOptionsController {
 	 * @return callable
 	 */
 	protected function get_tours_create_callback(): callable {
-		return function( Request $request ) {
+		return function ( Request $request ) {
 			try {
 				$tour_id           = $request->get_param( 'id' );
 				$tours             = $this->get_tours();

--- a/src/API/Site/RESTControllers.php
+++ b/src/API/Site/RESTControllers.php
@@ -40,7 +40,7 @@ class RESTControllers implements Service, Registerable {
 	public function register(): void {
 		add_action(
 			'rest_api_init',
-			function() {
+			function () {
 				$this->register_controllers();
 			}
 		);

--- a/src/ActionScheduler/ActionScheduler.php
+++ b/src/ActionScheduler/ActionScheduler.php
@@ -183,5 +183,4 @@ class ActionScheduler implements ActionSchedulerInterface, Service {
 	public function fetch_action( int $action_id ): ActionScheduler_Action {
 		return ActionSchedulerCore::store()->fetch_action( $action_id );
 	}
-
 }

--- a/src/ActionScheduler/ActionSchedulerInterface.php
+++ b/src/ActionScheduler/ActionSchedulerInterface.php
@@ -143,5 +143,4 @@ interface ActionSchedulerInterface {
 	 * @since 1.7.0
 	 */
 	public function fetch_action( int $action_id ): ActionScheduler_Action;
-
 }

--- a/src/ActionScheduler/AsyncActionRunner.php
+++ b/src/ActionScheduler/AsyncActionRunner.php
@@ -81,5 +81,4 @@ class AsyncActionRunner implements Service {
 		$this->locker->set( 'async-request-runner' );
 		$this->async_request->maybe_dispatch();
 	}
-
 }

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -76,7 +76,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 	public function register(): void {
 		add_action(
 			'admin_enqueue_scripts',
-			function() {
+			function () {
 				if ( PageController::is_admin_page() ) {
 					// Enqueue the required JavaScript scripts and CSS styles of the Media library.
 					wp_enqueue_media();
@@ -91,14 +91,14 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 
 		add_action(
 			"plugin_action_links_{$this->get_plugin_basename()}",
-			function( $links ) {
+			function ( $links ) {
 				return $this->add_plugin_links( $links );
 			}
 		);
 
 		add_action(
 			'wp_default_scripts',
-			function( $scripts ) {
+			function ( $scripts ) {
 				$this->inject_fast_refresh_for_dev( $scripts );
 			},
 			20
@@ -113,7 +113,7 @@ class Admin implements Service, Registerable, Conditional, OptionsAwareInterface
 	 * @return Asset[]
 	 */
 	protected function get_assets(): array {
-		$wc_admin_condition = function() {
+		$wc_admin_condition = function () {
 			return PageController::is_admin_page();
 		};
 

--- a/src/Admin/BulkEdit/CouponBulkEdit.php
+++ b/src/Admin/BulkEdit/CouponBulkEdit.php
@@ -118,7 +118,6 @@ class CouponBulkEdit implements BulkEditInterface, Registerable {
 		}
 
 		// Check nonce.
-	    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		if ( ! isset( $request_data['woocommerce_gla_bulk_edit'] ) || ! wp_verify_nonce( $request_data['woocommerce_gla_bulk_edit_nonce'], 'woocommerce_gla_bulk_edit_nonce' ) ) {
 			return $post_id;
 		}
@@ -146,7 +145,7 @@ class CouponBulkEdit implements BulkEditInterface, Registerable {
 	 */
 	protected function request_data(): array {
 		// Nonce must be verified manually.
-		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return $_REQUEST;
 	}
 }

--- a/src/Admin/Input/BooleanSelect.php
+++ b/src/Admin/Input/BooleanSelect.php
@@ -37,5 +37,4 @@ class BooleanSelect extends Select {
 
 		return $view_data;
 	}
-
 }

--- a/src/Admin/Input/DateTime.php
+++ b/src/Admin/Input/DateTime.php
@@ -94,5 +94,4 @@ class DateTime extends Input {
 	protected function get_local_tz_string(): string {
 		return wp_timezone_string();
 	}
-
 }

--- a/src/Admin/Input/SelectWithTextInput.php
+++ b/src/Admin/Input/SelectWithTextInput.php
@@ -24,8 +24,8 @@ class SelectWithTextInput extends Input {
 		$this->add( $select_input );
 
 		$custom_input = ( new Text() )->set_id( self::CUSTOM_INPUT_KEY )
-									  ->set_label( __( 'Enter your value', 'google-listings-and-ads' ) )
-									  ->set_name( self::CUSTOM_INPUT_KEY );
+			->set_label( __( 'Enter your value', 'google-listings-and-ads' ) )
+			->set_name( self::CUSTOM_INPUT_KEY );
 		$this->add( $custom_input );
 
 		parent::__construct( 'select-with-text-input' );

--- a/src/Admin/Product/Attributes/AttributesForm.php
+++ b/src/Admin/Product/Attributes/AttributesForm.php
@@ -99,7 +99,7 @@ class AttributesForm extends Form {
 	 */
 	protected function init_input( InputInterface $input, AttributeInterface $attribute ) {
 		$input->set_id( $attribute::get_id() )
-			  ->set_name( $attribute::get_id() );
+			->set_name( $attribute::get_id() );
 
 		$value_options = [];
 		if ( $attribute instanceof WithValueOptionsInterface ) {
@@ -111,7 +111,7 @@ class AttributesForm extends Form {
 			if ( ! $input instanceof Select && ! $input instanceof SelectWithTextInput ) {
 				$new_input = new SelectWithTextInput();
 				$new_input->set_label( $input->get_label() )
-						  ->set_description( $input->get_description() );
+					->set_description( $input->get_description() );
 
 				return $this->init_input( $new_input, $attribute );
 			}

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -187,5 +187,4 @@ class AttributesTab implements Service, Registerable, Conditional {
 			}
 		}
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/AdultInput.php
+++ b/src/Admin/Product/Attributes/Input/AdultInput.php
@@ -25,5 +25,4 @@ class AdultInput extends BooleanSelect {
 		$this->set_label( __( 'Adult content', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'Whether the product contains nudity or sexually suggestive content', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/AgeGroupInput.php
+++ b/src/Admin/Product/Attributes/Input/AgeGroupInput.php
@@ -25,5 +25,4 @@ class AgeGroupInput extends Select {
 		$this->set_label( __( 'Age Group', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'Target age group of the item.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/AttributeInputInterface.php
+++ b/src/Admin/Product/Attributes/Input/AttributeInputInterface.php
@@ -36,5 +36,4 @@ interface AttributeInputInterface {
 	 * @return string
 	 */
 	public static function get_input_type(): string;
-
 }

--- a/src/Admin/Product/Attributes/Input/AvailabilityDateInput.php
+++ b/src/Admin/Product/Attributes/Input/AvailabilityDateInput.php
@@ -25,5 +25,4 @@ class AvailabilityDateInput extends DateTime {
 		$this->set_label( __( 'Availability Date', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'The date a preordered or backordered product becomes available for delivery. Required if product availability is preorder or backorder', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/BrandInput.php
+++ b/src/Admin/Product/Attributes/Input/BrandInput.php
@@ -25,5 +25,4 @@ class BrandInput extends Text {
 		$this->set_label( __( 'Brand', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'Brand of the product.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/ColorInput.php
+++ b/src/Admin/Product/Attributes/Input/ColorInput.php
@@ -25,5 +25,4 @@ class ColorInput extends Text {
 		$this->set_label( __( 'Color', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'Color of the product.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/ConditionInput.php
+++ b/src/Admin/Product/Attributes/Input/ConditionInput.php
@@ -25,5 +25,4 @@ class ConditionInput extends Select {
 		$this->set_label( __( 'Condition', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'Condition or state of the item.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/GTINInput.php
+++ b/src/Admin/Product/Attributes/Input/GTINInput.php
@@ -25,5 +25,4 @@ class GTINInput extends Text {
 		$this->set_label( __( 'Global Trade Item Number (GTIN)', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'Global Trade Item Number (GTIN) for your item. These identifiers include UPC (in North America), EAN (in Europe), JAN (in Japan), and ISBN (for books)', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/GenderInput.php
+++ b/src/Admin/Product/Attributes/Input/GenderInput.php
@@ -25,5 +25,4 @@ class GenderInput extends Select {
 		$this->set_label( __( 'Gender', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'The gender for which your product is intended.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/IsBundleInput.php
+++ b/src/Admin/Product/Attributes/Input/IsBundleInput.php
@@ -25,5 +25,4 @@ class IsBundleInput extends BooleanSelect {
 		$this->set_label( __( 'Is Bundle?', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'Whether the item is a bundle of products. A bundle is a custom grouping of different products sold by a merchant for a single price.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/MPNInput.php
+++ b/src/Admin/Product/Attributes/Input/MPNInput.php
@@ -25,5 +25,4 @@ class MPNInput extends Text {
 		$this->set_label( __( 'Manufacturer Part Number (MPN)', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'This code uniquely identifies the product to its manufacturer.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/MaterialInput.php
+++ b/src/Admin/Product/Attributes/Input/MaterialInput.php
@@ -25,5 +25,4 @@ class MaterialInput extends Text {
 		$this->set_label( __( 'Material', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'The material of which the item is made.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/MultipackInput.php
+++ b/src/Admin/Product/Attributes/Input/MultipackInput.php
@@ -25,5 +25,4 @@ class MultipackInput extends Integer {
 		$this->set_label( __( 'Multipack', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/PatternInput.php
+++ b/src/Admin/Product/Attributes/Input/PatternInput.php
@@ -25,5 +25,4 @@ class PatternInput extends Text {
 		$this->set_label( __( 'Pattern', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'The item\'s pattern (e.g. polka dots).', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/SizeInput.php
+++ b/src/Admin/Product/Attributes/Input/SizeInput.php
@@ -25,5 +25,4 @@ class SizeInput extends Text {
 		$this->set_label( __( 'Size', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'Size of the product.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/SizeSystemInput.php
+++ b/src/Admin/Product/Attributes/Input/SizeSystemInput.php
@@ -25,5 +25,4 @@ class SizeSystemInput extends Select {
 		$this->set_label( __( 'Size system', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'System in which the size is specified. Recommended for apparel items.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/Input/SizeTypeInput.php
+++ b/src/Admin/Product/Attributes/Input/SizeTypeInput.php
@@ -25,5 +25,4 @@ class SizeTypeInput extends Select {
 		$this->set_label( __( 'Size type', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'The cut of the item. Recommended for apparel items.', 'google-listings-and-ads' ) );
 	}
-
 }

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -147,8 +147,8 @@ class VariationsAttributes implements Service, Registerable, Conditional {
 
 		$form = new Form();
 		$form->set_name( 'variation_attributes' )
-			 ->add( $attribute_form )
-			 ->set_data( [ (string) $variation_index => $this->attribute_manager->get_all_values( $variation ) ] );
+			->add( $attribute_form )
+			->set_data( [ (string) $variation_index => $this->attribute_manager->get_all_values( $variation ) ] );
 
 		return $form;
 	}
@@ -166,5 +166,4 @@ class VariationsAttributes implements Service, Registerable, Conditional {
 			}
 		}
 	}
-
 }

--- a/src/Admin/Redirect.php
+++ b/src/Admin/Redirect.php
@@ -171,5 +171,4 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 
 		return 2 === count( array_intersect_assoc( $_GET, $params ) ); // phpcs:disable WordPress.Security.NonceVerification.Recommended
 	}
-
 }

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -277,5 +277,4 @@ class AccountService implements OptionsAwareInterface, Service {
 		$action = $this->container->get( AdsConversionAction::class )->create_conversion_action();
 		$this->options->update( OptionsInterface::ADS_CONVERSION_ACTION, $action );
 	}
-
 }

--- a/src/Ads/AssetSuggestionsService.php
+++ b/src/Ads/AssetSuggestionsService.php
@@ -175,9 +175,7 @@ class AssetSuggestionsService implements Service {
 		}
 
 		return $url;
-
 	}
-
 
 
 	/**
@@ -197,7 +195,6 @@ class AssetSuggestionsService implements Service {
 		}
 
 		return array_merge( $this->get_suggestions_common_fields( [] ), [ 'final_url' => $final_url ], $asset_group_assets );
-
 	}
 
 	/**
@@ -217,7 +214,6 @@ class AssetSuggestionsService implements Service {
 		} else {
 			return $this->get_homepage_assets();
 		}
-
 	}
 
 	/**
@@ -251,7 +247,6 @@ class AssetSuggestionsService implements Service {
 			],
 			$this->get_suggestions_common_fields( $marketing_images )
 		);
-
 	}
 
 	/**
@@ -346,7 +341,6 @@ class AssetSuggestionsService implements Service {
 			],
 			$this->get_suggestions_common_fields( $marketing_images )
 		);
-
 	}
 
 	/**
@@ -395,7 +389,6 @@ class AssetSuggestionsService implements Service {
 		}
 
 		return $images_ids;
-
 	}
 
 	/**
@@ -671,7 +664,6 @@ class AssetSuggestionsService implements Service {
 		}
 
 		return $terms_suggestions;
-
 	}
 
 
@@ -686,7 +678,7 @@ class AssetSuggestionsService implements Service {
 	 */
 	public function get_final_url_suggestions( string $search = '', int $per_page = 30, string $order_by = 'title' ): array {
 		if ( empty( $search ) ) {
-			 return $this->get_defaults_final_url_suggestions();
+			return $this->get_defaults_final_url_suggestions();
 		}
 
 		$homepage = [];
@@ -694,7 +686,7 @@ class AssetSuggestionsService implements Service {
 		// If the search query contains the word "homepage" add the homepage to the results.
 		if ( strpos( 'homepage', strtolower( $search ) ) !== false ) {
 			$homepage[] = $this->get_homepage_final_url();
-			$per_page--;
+			--$per_page;
 		}
 
 		// Split possible results between posts and terms.
@@ -718,7 +710,6 @@ class AssetSuggestionsService implements Service {
 		$result = array_merge( $homepage, $posts, $terms, $more_results );
 
 		return $this->sort_results( $result, $order_by );
-
 	}
 
 	/**
@@ -749,21 +740,20 @@ class AssetSuggestionsService implements Service {
 	/**
 	 *  Order suggestions alphabetically
 	 *
-	 *  @param array  $array associative array
-	 *  @param string $field Sort by a specific field
+	 *  @param array  $results Results as an associative array
+	 *  @param string $field   Sort by a specific field
 	 *
 	 * @return array response sorted alphabetically
 	 */
-	protected function sort_results( array $array, string $field ): array {
+	protected function sort_results( array $results, string $field ): array {
 		usort(
-			$array,
+			$results,
 			function ( $a, $b ) use ( $field ) {
 				return strcmp( strtolower( (string) $a[ $field ] ), strtolower( (string) $b[ $field ] ) );
 			}
 		);
 
-		return $array;
-
+		return $results;
 	}
 
 	/**
@@ -783,7 +773,6 @@ class AssetSuggestionsService implements Service {
 			'title' => $title,
 			'url'   => $url,
 		];
-
 	}
 
 	/**
@@ -802,6 +791,5 @@ class AssetSuggestionsService implements Service {
 			AssetFieldType::PORTRAIT_MARKETING_IMAGE => $marketing_images [ self::PORTRAIT_MARKETING_IMAGE_KEY ] ?? [],
 			AssetFieldType::CALL_TO_ACTION_SELECTION => null,
 		];
-
 	}
 }

--- a/src/Assets/ScriptAsset.php
+++ b/src/Assets/ScriptAsset.php
@@ -62,13 +62,13 @@ class ScriptAsset extends BaseAsset {
 	/**
 	 * Add a localization to the script.
 	 *
-	 * @param string $object The object name.
-	 * @param array  $data   Array of data for the object.
+	 * @param string $object_name The object name.
+	 * @param array  $data        Array of data for the object.
 	 *
 	 * @return $this
 	 */
-	public function add_localization( string $object, array $data ): ScriptAsset {
-		$this->localizations[ $object ] = $data;
+	public function add_localization( string $object_name, array $data ): ScriptAsset {
+		$this->localizations[ $object_name ] = $data;
 
 		return $this;
 	}
@@ -93,7 +93,7 @@ class ScriptAsset extends BaseAsset {
 	 * @return callable
 	 */
 	protected function get_register_callback(): callable {
-		return function() {
+		return function () {
 			if ( wp_script_is( $this->handle, 'registered' ) ) {
 				return;
 			}
@@ -114,7 +114,7 @@ class ScriptAsset extends BaseAsset {
 	 * @return callable
 	 */
 	protected function get_enqueue_callback(): callable {
-		return function() {
+		return function () {
 			if ( ! wp_script_is( $this->handle, 'registered' ) ) {
 				throw InvalidAsset::asset_not_registered( $this->handle );
 			}
@@ -142,9 +142,8 @@ class ScriptAsset extends BaseAsset {
 	 * @return callable
 	 */
 	protected function get_dequeue_callback(): callable {
-		return function() {
+		return function () {
 			wp_dequeue_script( $this->handle );
 		};
 	}
-
 }

--- a/src/Assets/StyleAsset.php
+++ b/src/Assets/StyleAsset.php
@@ -51,7 +51,7 @@ class StyleAsset extends BaseAsset {
 	 * @return callable
 	 */
 	protected function get_register_callback(): callable {
-		return function() {
+		return function () {
 			if ( wp_style_is( $this->handle, 'registered' ) ) {
 				return;
 			}
@@ -72,7 +72,7 @@ class StyleAsset extends BaseAsset {
 	 * @return callable
 	 */
 	protected function get_enqueue_callback(): callable {
-		return function() {
+		return function () {
 			if ( ! wp_style_is( $this->handle, 'registered' ) ) {
 				throw InvalidAsset::asset_not_registered( $this->handle );
 			}
@@ -87,9 +87,8 @@ class StyleAsset extends BaseAsset {
 	 * @return callable
 	 */
 	protected function get_dequeue_callback(): callable {
-		return function() {
+		return function () {
 			wp_dequeue_style( $this->handle );
 		};
 	}
-
 }

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -53,7 +53,7 @@ class Autoloader {
 		}
 		add_action(
 			'admin_notices',
-			function() {
+			function () {
 				?>
 				<div class="notice notice-error">
 					<p>

--- a/src/Coupon/CouponHelper.php
+++ b/src/Coupon/CouponHelper.php
@@ -49,7 +49,8 @@ class CouponHelper implements Service {
 	public function __construct(
 		CouponMetaHandler $meta_handler,
 		WC $wc,
-		MerchantCenterService $merchant_center ) {
+		MerchantCenterService $merchant_center
+	) {
 		$this->meta_handler    = $meta_handler;
 		$this->wc              = $wc;
 		$this->merchant_center = $merchant_center;
@@ -66,7 +67,8 @@ class CouponHelper implements Service {
 	public function mark_as_synced(
 		WC_Coupon $coupon,
 		?string $google_id,
-		string $target_country ) {
+		string $target_country
+	) {
 		$this->meta_handler->update_synced_at( $coupon, time() );
 		$this->meta_handler->update_sync_status( $coupon, SyncStatus::SYNCED );
 		$this->update_empty_visibility( $coupon );

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -78,7 +78,8 @@ class CouponSyncer implements Service {
 		ValidatorInterface $validator,
 		MerchantCenterService $merchant_center,
 		TargetAudience $target_audience,
-		WC $wc ) {
+		WC $wc
+	) {
 		$this->google_service  = $google_service;
 		$this->coupon_helper   = $coupon_helper;
 		$this->validator       = $validator;

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -87,7 +87,8 @@ class SyncerHooks implements Service, Registerable {
 		CouponHelper $coupon_helper,
 		JobRepository $job_repository,
 		MerchantCenterService $merchant_center,
-		WC $wc ) {
+		WC $wc
+	) {
 		$this->update_coupon_job = $job_repository->get( UpdateCoupon::class );
 		$this->delete_coupon_job = $job_repository->get( DeleteCoupon::class );
 		$this->coupon_helper     = $coupon_helper;
@@ -256,7 +257,8 @@ class SyncerHooks implements Service, Registerable {
 	 */
 	protected function is_already_scheduled(
 		int $coupon_id,
-		string $schedule_type ): bool {
+		string $schedule_type
+	): bool {
 		return isset( $this->already_scheduled[ $coupon_id ] ) &&
 			$this->already_scheduled[ $coupon_id ] === $schedule_type;
 	}
@@ -296,7 +298,8 @@ class SyncerHooks implements Service, Registerable {
 	 */
 	protected function set_already_scheduled(
 		int $coupon_id,
-		string $schedule_type ): void {
+		string $schedule_type
+	): void {
 		$this->already_scheduled[ $coupon_id ] = $schedule_type;
 	}
 
@@ -320,4 +323,3 @@ class SyncerHooks implements Service, Registerable {
 		$this->set_already_scheduled( $coupon_id, self::SCHEDULE_TYPE_DELETE );
 	}
 }
-

--- a/src/Coupon/WCCouponAdapter.php
+++ b/src/Coupon/WCCouponAdapter.php
@@ -69,7 +69,7 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 	 */
 	public function mapTypes( $properties ) {
 		if ( empty( $properties['wc_coupon'] ) ||
-			! $array['wc_coupon'] instanceof WC_Coupon ) {
+			! $properties['wc_coupon'] instanceof WC_Coupon ) {
 				throw InvalidValue::not_instance_of( WC_Coupon::class, 'wc_coupon' );
 		}
 
@@ -78,7 +78,7 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 		$this->map_woocommerce_coupon( $wc_coupon, $this->get_coupon_destinations( $properties ) );
 
 		// Google doesn't expect extra fields, so it's best to remove them
-		unset( $propertiesarray['wc_coupon'] );
+		unset( $properties['wc_coupon'] );
 
 		parent::mapTypes( $properties );
 	}

--- a/src/Coupon/WCCouponAdapter.php
+++ b/src/Coupon/WCCouponAdapter.php
@@ -61,27 +61,26 @@ class WCCouponAdapter extends GooglePromotion implements Validatable {
 	/**
 	 * Initialize this object's properties from an array.
 	 *
-	 * @param array $array
-	 *            Used to seed this object's properties.
+	 * @param array $properties Used to seed this object's properties.
 	 *
 	 * @return void
 	 *
 	 * @throws InvalidValue When a WooCommerce coupon is not provided or it is invalid.
 	 */
-	public function mapTypes( $array ) {
-		if ( empty( $array['wc_coupon'] ) ||
+	public function mapTypes( $properties ) {
+		if ( empty( $properties['wc_coupon'] ) ||
 			! $array['wc_coupon'] instanceof WC_Coupon ) {
 				throw InvalidValue::not_instance_of( WC_Coupon::class, 'wc_coupon' );
 		}
 
-		$wc_coupon          = $array['wc_coupon'];
+		$wc_coupon          = $properties['wc_coupon'];
 		$this->wc_coupon_id = $wc_coupon->get_id();
-		$this->map_woocommerce_coupon( $wc_coupon, $this->get_coupon_destinations( $array ) );
+		$this->map_woocommerce_coupon( $wc_coupon, $this->get_coupon_destinations( $properties ) );
 
 		// Google doesn't expect extra fields, so it's best to remove them
-		unset( $array['wc_coupon'] );
+		unset( $propertiesarray['wc_coupon'] );
 
-		parent::mapTypes( $array );
+		parent::mapTypes( $properties );
 	}
 
 	/**

--- a/src/DB/Migration/MigrationVersion141.php
+++ b/src/DB/Migration/MigrationVersion141.php
@@ -50,10 +50,8 @@ class MigrationVersion141 extends AbstractMigration {
 	 */
 	public function apply(): void {
 		if ( $this->mc_issues_table->exists() && $this->mc_issues_table->has_index( 'product_issue' ) ) {
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$this->wpdb->query( "ALTER TABLE `{$this->wpdb->_escape( $this->mc_issues_table->get_name() )}` DROP INDEX `product_issue`" );
-			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		}
 	}
 }

--- a/src/DB/Migration/Migrator.php
+++ b/src/DB/Migration/Migrator.php
@@ -66,7 +66,7 @@ class Migrator implements Service {
 	 */
 	protected function can_apply( string $migration_version, string $old_version, string $new_version ): bool {
 		return version_compare( $old_version, $new_version, '<' ) &&
-			   version_compare( $old_version, $migration_version, '<' ) &&
-			   version_compare( $migration_version, $new_version, '<=' );
+			version_compare( $old_version, $migration_version, '<' ) &&
+			version_compare( $migration_version, $new_version, '<=' );
 	}
 }

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -232,4 +232,3 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 		return strtoupper( $this->request['order'] ?? '' ) === 'DESC' ? 'DESC' : 'ASC';
 	}
 }
-

--- a/src/DB/ProductMetaQueryHelper.php
+++ b/src/DB/ProductMetaQueryHelper.php
@@ -144,6 +144,4 @@ class ProductMetaQueryHelper implements Service {
 			throw InvalidMeta::invalid_key( $meta_key );
 		}
 	}
-
 }
-

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -359,7 +359,7 @@ abstract class Query implements QueryInterface {
 					join(
 						"','",
 						array_map(
-							function( $value ) {
+							function ( $value ) {
 								return $this->wpdb->_escape( $value );
 							},
 							$where['value']

--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -67,6 +67,4 @@ class ShippingRateQuery extends Query {
 			$this->results
 		);
 	}
-
-
 }

--- a/src/Event/ClearProductStatsCache.php
+++ b/src/Event/ClearProductStatsCache.php
@@ -38,13 +38,13 @@ class ClearProductStatsCache implements Registerable, Service {
 	public function register(): void {
 		add_action(
 			'woocommerce_gla_batch_updated_products',
-			function() {
+			function () {
 				$this->clear_stats_cache();
 			}
 		);
 		add_action(
 			'woocommerce_gla_batch_deleted_products',
-			function() {
+			function () {
 				$this->clear_stats_cache();
 			}
 		);

--- a/src/Event/StartProductSync.php
+++ b/src/Event/StartProductSync.php
@@ -37,14 +37,14 @@ class StartProductSync implements Registerable, Service {
 	public function register(): void {
 		add_action(
 			'woocommerce_gla_mc_settings_sync',
-			function() {
+			function () {
 				$this->on_settings_sync();
 			}
 		);
 
 		add_action(
 			'woocommerce_gla_mapping_rules_change',
-			function() {
+			function () {
 				$this->on_rules_change();
 			}
 		);

--- a/src/Exception/AccountReconnect.php
+++ b/src/Exception/AccountReconnect.php
@@ -50,5 +50,4 @@ class AccountReconnect extends ExceptionWithResponseData {
 			]
 		);
 	}
-
 }

--- a/src/Exception/ApiNotReady.php
+++ b/src/Exception/ApiNotReady.php
@@ -34,5 +34,4 @@ class ApiNotReady extends ExceptionWithResponseData {
 			]
 		);
 	}
-
 }

--- a/src/Exception/InvalidClass.php
+++ b/src/Exception/InvalidClass.php
@@ -15,17 +15,17 @@ class InvalidClass extends LogicException implements GoogleListingsAndAdsExcepti
 	/**
 	 * Create a new instance of the exception when a class should implement an interface but does not.
 	 *
-	 * @param string $class     The class name.
-	 * @param string $interface The interface name.
+	 * @param string $class_name     The class name.
+	 * @param string $interface_name The interface name.
 	 *
 	 * @return static
 	 */
-	public static function should_implement( string $class, string $interface ) {
+	public static function should_implement( string $class_name, string $interface_name ) {
 		return new static(
 			sprintf(
 				'The class "%s" must implement the "%s" interface.',
-				$class,
-				$interface
+				$class_name,
+				$interface_name
 			)
 		);
 	}
@@ -33,17 +33,17 @@ class InvalidClass extends LogicException implements GoogleListingsAndAdsExcepti
 	/**
 	 * Create a new instance of the exception when a class should NOT implement an interface but it does.
 	 *
-	 * @param string $class     The class name.
-	 * @param string $interface The interface name.
+	 * @param string $class_name     The class name.
+	 * @param string $interface_name The interface name.
 	 *
 	 * @return static
 	 */
-	public static function should_not_implement( string $class, string $interface ): InvalidClass {
+	public static function should_not_implement( string $class_name, string $interface_name ): InvalidClass {
 		return new static(
 			sprintf(
 				'The class "%s" must NOT implement the "%s" interface.',
-				$class,
-				$interface
+				$class_name,
+				$interface_name
 			)
 		);
 	}
@@ -51,17 +51,17 @@ class InvalidClass extends LogicException implements GoogleListingsAndAdsExcepti
 	/**
 	 * Create a new instance of the exception when a class should override a method but does not.
 	 *
-	 * @param string $class  The class name.
-	 * @param string $method The method name.
+	 * @param string $class_name  The class name.
+	 * @param string $method_name The method name.
 	 *
 	 * @return static
 	 */
-	public static function should_override( string $class, string $method ) {
+	public static function should_override( string $class_name, string $method_name ) {
 		return new static(
 			sprintf(
 				'The class "%s" must override the "%s()" method.',
-				$class,
-				$method
+				$class_name,
+				$method_name
 			)
 		);
 	}

--- a/src/Exception/InvalidProperty.php
+++ b/src/Exception/InvalidProperty.php
@@ -15,16 +15,16 @@ class InvalidProperty extends LogicException implements GoogleListingsAndAdsExce
 	/**
 	 * Create a new instance of the exception for a class property that should not be null.
 	 *
-	 * @param string $class    The class name.
-	 * @param string $property The class property name.
+	 * @param string $class_name The class name.
+	 * @param string $property   The class property name.
 	 *
 	 * @return static
 	 */
-	public static function not_null( string $class, string $property ) {
+	public static function not_null( string $class_name, string $property ) {
 		return new static(
 			sprintf(
 				'The class "%s" property "%s" must be set.',
-				$class,
+				$class_name,
 				$property
 			)
 		);

--- a/src/Exception/ValidateInterface.php
+++ b/src/Exception/ValidateInterface.php
@@ -13,53 +13,53 @@ trait ValidateInterface {
 	/**
 	 * Validate that a class implements a given interface.
 	 *
-	 * @param string $class     The class name.
-	 * @param string $interface The interface name.
+	 * @param string $class_name      The class name.
+	 * @param string $interface_name The interface name.
 	 *
 	 * @throws InvalidClass When the given class does not implement the interface.
 	 */
-	protected function validate_interface( string $class, string $interface ) {
-		$implements = class_implements( $class );
-		if ( ! array_key_exists( $interface, $implements ) ) {
-			throw InvalidClass::should_implement( $class, $interface );
+	protected function validate_interface( string $class_name, string $interface_name ) {
+		$implements = class_implements( $class_name );
+		if ( ! array_key_exists( $interface_name, $implements ) ) {
+			throw InvalidClass::should_implement( $class_name, $interface_name );
 		}
 	}
 
 	/**
 	 * Validate that an object is an instance of an interface.
 	 *
-	 * @param object $object    The object to validate.
-	 * @param string $interface The interface name.
+	 * @param object $object_instance The object to validate.
+	 * @param string $interface_name  The interface name.
 	 *
 	 * @throws InvalidClass When the given object does not implement the interface.
 	 */
-	protected function validate_instanceof( $object, string $interface ) {
-		$class = '';
-		if ( is_object( $object ) ) {
-			$class = get_class( $object );
+	protected function validate_instanceof( $object_instance, string $interface_name ) {
+		$class_name = '';
+		if ( is_object( $object_instance ) ) {
+			$class_name = get_class( $object_instance );
 		}
 
-		if ( ! $object instanceof $interface ) {
-			throw InvalidClass::should_implement( $class, $interface );
+		if ( ! $object_instance instanceof $interface_name ) {
+			throw InvalidClass::should_implement( $class_name, $interface_name );
 		}
 	}
 
 	/**
 	 * Validate that an object is NOT an instance of an interface.
 	 *
-	 * @param object $object    The object to validate.
-	 * @param string $interface The interface name.
+	 * @param object $object_instance The object to validate.
+	 * @param string $interface_name  The interface name.
 	 *
 	 * @throws InvalidClass When the given object implements the interface.
 	 */
-	protected function validate_not_instanceof( $object, string $interface ) {
-		$class = '';
-		if ( is_object( $object ) ) {
-			$class = get_class( $object );
+	protected function validate_not_instanceof( $object_instance, string $interface_name ) {
+		$class_name = '';
+		if ( is_object( $object_instance ) ) {
+			$class_name = get_class( $object_instance );
 		}
 
-		if ( $object instanceof $interface ) {
-			throw InvalidClass::should_not_implement( $class, $interface );
+		if ( $object_instance instanceof $interface_name ) {
+			throw InvalidClass::should_not_implement( $class_name, $interface_name );
 		}
 	}
 }

--- a/src/Google/Ads/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/ServiceClientFactoryTrait.php
@@ -208,5 +208,4 @@ trait ServiceClientFactoryTrait {
 	public function getMerchantCenterLinkServiceClient(): MerchantCenterLinkServiceClient {
 		return new MerchantCenterLinkServiceClient( $this->getGoogleAdsClientOptions() );
 	}
-
 }

--- a/src/Google/BatchInvalidProductEntry.php
+++ b/src/Google/BatchInvalidProductEntry.php
@@ -92,7 +92,7 @@ class BatchInvalidProductEntry implements JsonSerializable {
 	/**
 	 * @return array
 	 */
-	public function jsonSerialize(): array { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function jsonSerialize(): array {
 		$data = [
 			'woocommerce_id' => $this->get_wc_product_id(),
 			'errors'         => $this->get_errors(),

--- a/src/Google/BatchProductEntry.php
+++ b/src/Google/BatchProductEntry.php
@@ -53,7 +53,7 @@ class BatchProductEntry implements JsonSerializable {
 	/**
 	 * @return array
 	 */
-	public function jsonSerialize(): array { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function jsonSerialize(): array {
 		$data = [ 'woocommerce_id' => $this->get_wc_product_id() ];
 
 		if ( null !== $this->get_google_product() ) {

--- a/src/Google/DeleteCouponEntry.php
+++ b/src/Google/DeleteCouponEntry.php
@@ -40,7 +40,8 @@ class DeleteCouponEntry {
 	public function __construct(
 		int $wc_coupon_id,
 		GooglePromotion $google_promotion,
-		array $synced_google_ids ) {
+		array $synced_google_ids
+	) {
 		$this->wc_coupon_id      = $wc_coupon_id;
 		$this->google_promotion  = $google_promotion;
 		$this->synced_google_ids = $synced_google_ids;

--- a/src/Google/GoogleProductService.php
+++ b/src/Google/GoogleProductService.php
@@ -170,7 +170,7 @@ class GoogleProductService implements OptionsAwareInterface, Service {
 
 			$batch_id_product_map[ $batch_id ] = $product_entry;
 
-			$batch_id++;
+			++$batch_id;
 		}
 
 		$responses = $this->shopping_service->products->custombatch( new GoogleBatchRequest( [ 'entries' => $request_entries ] ) );

--- a/src/Google/InvalidCouponEntry.php
+++ b/src/Google/InvalidCouponEntry.php
@@ -129,7 +129,7 @@ class InvalidCouponEntry implements JsonSerializable {
 	 *
 	 * @return array
 	 */
-	public function jsonSerialize(): array { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function jsonSerialize(): array {
 		$data = [
 			'woocommerce_id' => $this->get_wc_coupon_id(),
 			'errors'         => $this->get_errors(),

--- a/src/Google/InvalidCouponEntry.php
+++ b/src/Google/InvalidCouponEntry.php
@@ -49,7 +49,8 @@ class InvalidCouponEntry implements JsonSerializable {
 		int $wc_coupon_id,
 		array $errors = [],
 		string $target_country = null,
-		string $google_promotion_id = null ) {
+		string $google_promotion_id = null
+	) {
 		$this->wc_coupon_id        = $wc_coupon_id;
 		$this->target_country      = $target_country;
 		$this->google_promotion_id = $google_promotion_id;
@@ -105,7 +106,8 @@ class InvalidCouponEntry implements JsonSerializable {
 	 * @return InvalidCouponEntry
 	 */
 	public function map_validation_violations(
-		ConstraintViolationListInterface $violations ): InvalidCouponEntry {
+		ConstraintViolationListInterface $violations
+	): InvalidCouponEntry {
 		$validation_errors = [];
 		foreach ( $violations as $violation ) {
 			array_push(

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -158,5 +158,4 @@ class RequestReviewStatuses implements Service {
 
 		return $cooldown;
 	}
-
 }

--- a/src/Google/SiteVerificationMeta.php
+++ b/src/Google/SiteVerificationMeta.php
@@ -26,7 +26,7 @@ class SiteVerificationMeta implements OptionsAwareInterface, Registerable, Servi
 	public function register(): void {
 		add_action(
 			'wp_head',
-			function() {
+			function () {
 				$this->display_meta_token();
 			}
 		);

--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -64,7 +64,6 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 		}
 
 		flush_rewrite_rules();
-
 	}
 
 	/**
@@ -92,7 +91,7 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 	public function register(): void {
 		add_action(
 			self::SERVICE_REGISTRATION_HOOK,
-			function() {
+			function () {
 				$this->maybe_register_services();
 			},
 			20
@@ -100,7 +99,7 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 
 		add_action(
 			'init',
-			function() {
+			function () {
 				// register the job initializer only if it is available. see JobInitializer::is_needed.
 				if ( $this->container->has( JobInitializer::class ) ) {
 					$this->container->get( JobInitializer::class )->register();
@@ -114,7 +113,6 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 				}
 			}
 		);
-
 	}
 
 	/**

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -62,7 +62,7 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	public function register(): void {
 		add_action(
 			'admin_init',
-			function() {
+			function () {
 				$this->admin_init();
 			}
 		);

--- a/src/Integration/WooCommerceProductBundles.php
+++ b/src/Integration/WooCommerceProductBundles.php
@@ -228,5 +228,4 @@ class WooCommerceProductBundles implements IntegrationInterface {
 			}
 		);
 	}
-
 }

--- a/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -51,27 +51,27 @@ abstract class AbstractServiceProvider extends LeagueProvider {
 	/**
 	 * Add an interface to the container.
 	 *
-	 * @param string      $interface The interface to add.
-	 * @param string|null $concrete  (Optional) The concrete class.
+	 * @param string      $interface_name The interface to add.
+	 * @param string|null $concrete       (Optional) The concrete class.
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function share_concrete( string $interface, $concrete = null ): DefinitionInterface {
-		return $this->getLeagueContainer()->share( $interface, $concrete );
+	protected function share_concrete( string $interface_name, $concrete = null ): DefinitionInterface {
+		return $this->getLeagueContainer()->share( $interface_name, $concrete );
 	}
 
 	/**
 	 * Share a class and add interfaces as tags.
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function share_with_tags( string $class, ...$arguments ): DefinitionInterface {
-		$definition = $this->share( $class, ...$arguments );
-		foreach ( class_implements( $class ) as $interface ) {
-			$definition->addTag( $interface );
+	protected function share_with_tags( string $class_name, ...$arguments ): DefinitionInterface {
+		$definition = $this->share( $class_name, ...$arguments );
+		foreach ( class_implements( $class_name ) as $interface_name ) {
+			$definition->addTag( $interface_name );
 		}
 
 		return $definition;
@@ -83,13 +83,13 @@ abstract class AbstractServiceProvider extends LeagueProvider {
 	 * Shared classes will always return the same instance of the class when the class is requested
 	 * from the container.
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function share( string $class, ...$arguments ): DefinitionInterface {
-		return $this->getLeagueContainer()->share( $class )->addArguments( $arguments );
+	protected function share( string $class_name, ...$arguments ): DefinitionInterface {
+		return $this->getLeagueContainer()->share( $class_name )->addArguments( $arguments );
 	}
 
 	/**
@@ -97,13 +97,13 @@ abstract class AbstractServiceProvider extends LeagueProvider {
 	 *
 	 * Classes will return a new instance of the class when the class is requested from the container.
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function add( string $class, ...$arguments ): DefinitionInterface {
-		return $this->getLeagueContainer()->add( $class )->addArguments( $arguments );
+	protected function add( string $class_name, ...$arguments ): DefinitionInterface {
+		return $this->getLeagueContainer()->add( $class_name )->addArguments( $arguments );
 	}
 
 	/**
@@ -112,19 +112,19 @@ abstract class AbstractServiceProvider extends LeagueProvider {
 	 * This will also check any classes that implement the Conditional interface and only add them if
 	 * they are needed.
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 */
-	protected function conditionally_share_with_tags( string $class, ...$arguments ) {
-		$implements = class_implements( $class );
+	protected function conditionally_share_with_tags( string $class_name, ...$arguments ) {
+		$implements = class_implements( $class_name );
 		if ( array_key_exists( Conditional::class, $implements ) ) {
 			/** @var Conditional $class */
-			if ( ! $class::is_needed() ) {
+			if ( ! $class_name::is_needed() ) {
 				return;
 			}
 		}
 
-		$this->provides[ $class ] = true;
-		$this->share_with_tags( $class, ...$arguments );
+		$this->provides[ $class_name ] = true;
+		$this->share_with_tags( $class_name, ...$arguments );
 	}
 }

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -231,14 +231,14 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Set up Options, and inflect classes that need options.
 		$this->share_concrete( OptionsInterface::class, Options::class );
 		$this->getLeagueContainer()
-			 ->inflector( OptionsAwareInterface::class )
-			 ->invokeMethod( 'set_options_object', [ OptionsInterface::class ] );
+			->inflector( OptionsAwareInterface::class )
+			->invokeMethod( 'set_options_object', [ OptionsInterface::class ] );
 
 		// Share helper classes, and inflect classes that need it.
 		$this->share_with_tags( GoogleHelper::class, WC::class );
 		$this->getLeagueContainer()
-			 ->inflector( GoogleHelperAwareInterface::class )
-			 ->invokeMethod( 'set_google_helper_object', [ GoogleHelper::class ] );
+			->inflector( GoogleHelperAwareInterface::class )
+			->invokeMethod( 'set_google_helper_object', [ GoogleHelper::class ] );
 
 		// Set up the TargetAudience service.
 		$this->share_with_tags( TargetAudience::class, WC::class, OptionsInterface::class, GoogleHelper::class );
@@ -246,15 +246,15 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Set up MerchantCenter service, and inflect classes that need it.
 		$this->share_with_tags( MerchantCenterService::class );
 		$this->getLeagueContainer()
-			 ->inflector( MerchantCenterAwareInterface::class )
-			 ->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );
+			->inflector( MerchantCenterAwareInterface::class )
+			->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );
 
 		// Set up Ads service, and inflect classes that need it.
 		$this->share_with_tags( AdsAccountState::class );
 		$this->share_with_tags( AdsService::class, AdsAccountState::class );
 		$this->getLeagueContainer()
-			 ->inflector( AdsAwareInterface::class )
-			 ->invokeMethod( 'set_ads_object', [ AdsService::class ] );
+			->inflector( AdsAwareInterface::class )
+			->invokeMethod( 'set_ads_object', [ AdsService::class ] );
 		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class, AdsAssetGroupAsset::class );
 
 		// Set up the installer.
@@ -370,8 +370,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Set up inflector for tracks classes.
 		$this->getLeagueContainer()
-			 ->inflector( TracksAwareInterface::class )
-			 ->invokeMethod( 'set_tracks', [ TracksInterface::class ] );
+			->inflector( TracksAwareInterface::class )
+			->invokeMethod( 'set_tracks', [ TracksInterface::class ] );
 
 		// Share admin meta boxes
 		$this->conditionally_share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class );

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -106,13 +106,13 @@ class DBServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Add a query class.
 	 *
-	 * @param string $class
+	 * @param string $class_name
 	 * @param mixed  ...$arguments
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function add_query_class( string $class, ...$arguments ): DefinitionInterface {
-		return $this->add( $class, wpdb::class, ...$arguments )->addTag( 'db_query' );
+	protected function add_query_class( string $class_name, ...$arguments ): DefinitionInterface {
+		return $this->add( $class_name, wpdb::class, ...$arguments )->addTag( 'db_query' );
 	}
 
 	/**
@@ -121,29 +121,29 @@ class DBServiceProvider extends AbstractServiceProvider {
 	 * Shared classes will always return the same instance of the class when the class is requested
 	 * from the container.
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function share_table_class( string $class, ...$arguments ): DefinitionInterface {
-		return parent::share( $class, WP::class, wpdb::class, ...$arguments )->addTag( 'db_table' );
+	protected function share_table_class( string $class_name, ...$arguments ): DefinitionInterface {
+		return parent::share( $class_name, WP::class, wpdb::class, ...$arguments )->addTag( 'db_table' );
 	}
 
 	/**
 	 * Share a migration class.
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @throws InvalidClass When the given class does not implement the MigrationInterface.
 	 *
 	 * @since 1.4.1
 	 */
-	protected function share_migration( string $class, ...$arguments ) {
-		$this->validate_interface( $class, MigrationInterface::class );
+	protected function share_migration( string $class_name, ...$arguments ) {
+		$this->validate_interface( $class_name, MigrationInterface::class );
 		$this->share_with_tags(
-			$class,
+			$class_name,
 			wpdb::class,
 			...$arguments
 		);

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -130,7 +130,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * Register guzzle with authorization middleware added.
 	 */
 	protected function register_guzzle() {
-		$callback = function() {
+		$callback = function () {
 			$handler_stack = HandlerStack::create();
 			$handler_stack->remove( 'http_errors' );
 			$handler_stack->push( $this->error_handler(), 'http_errors' );
@@ -153,7 +153,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * Register ads client.
 	 */
 	protected function register_ads_client() {
-		$callback = function() {
+		$callback = function () {
 			return new GoogleAdsClient( $this->get_connect_server_endpoint() );
 		};
 
@@ -188,8 +188,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @return callable
 	 */
 	protected function error_handler(): callable {
-		return function( callable $handler ) {
-			return function( RequestInterface $request, array $options ) use ( $handler ) {
+		return function ( callable $handler ) {
+			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				return $handler( $request, $options )->then(
 					function ( ResponseInterface $response ) use ( $request ) {
 						$code = $response->getStatusCode();
@@ -245,8 +245,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @return callable
 	 */
 	protected function add_auth_header(): callable {
-		return function( callable $handler ) {
-			return function( RequestInterface $request, array $options ) use ( $handler ) {
+		return function ( callable $handler ) {
+			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				try {
 					$request = $request->withHeader( 'Authorization', $this->generate_auth_header() );
 
@@ -272,10 +272,10 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @return callable
 	 */
 	public function add_plugin_version_header(): callable {
-		return function( callable $handler ) {
-			return function( RequestInterface $request, array $options ) use ( $handler ) {
+		return function ( callable $handler ) {
+			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				$request = $request->withHeader( 'x-client-name', $this->get_client_name() )
-								   ->withHeader( 'x-client-version', $this->get_version() );
+					->withHeader( 'x-client-version', $this->get_version() );
 				return $handler( $request, $options );
 			};
 		};
@@ -285,8 +285,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @return callable
 	 */
 	protected function override_http_url(): callable {
-		return function( callable $handler ) {
-			return function( RequestInterface $request, array $options ) use ( $handler ) {
+		return function ( callable $handler ) {
+			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				$request = $request->withUri( $request->getUri()->withScheme( 'http' ) );
 				return $handler( $request, $options );
 			};

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -204,7 +204,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 	 */
 	protected function share_coupon_syncer_job( string $class_name, ...$arguments ) {
 		// Coupon related jobs also should implement ProductSyncerJobInterface.
-		$this->validate_interface( $class, ProductSyncerJobInterface::class );
+		$this->validate_interface( $class_name, ProductSyncerJobInterface::class );
 		$this->share_action_scheduler_job(
 			$class_name,
 			CouponHelper::class,

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -149,15 +149,15 @@ class JobServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Share an ActionScheduler job class
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @throws InvalidClass When the given class does not implement the ActionSchedulerJobInterface.
 	 */
-	protected function share_action_scheduler_job( string $class, ...$arguments ) {
-		$this->validate_interface( $class, ActionSchedulerJobInterface::class );
+	protected function share_action_scheduler_job( string $class_name, ...$arguments ) {
+		$this->validate_interface( $class_name, ActionSchedulerJobInterface::class );
 		$this->share_with_tags(
-			$class,
+			$class_name,
 			ActionScheduler::class,
 			ActionSchedulerJobMonitor::class,
 			...$arguments
@@ -167,16 +167,16 @@ class JobServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Share a product syncer job class
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @throws InvalidClass When the given class does not implement the ProductSyncerJobInterface.
 	 */
-	protected function share_product_syncer_job( string $class, ...$arguments ) {
-		$this->validate_interface( $class, ProductSyncerJobInterface::class );
-		if ( is_subclass_of( $class, AbstractProductSyncerBatchedJob::class ) ) {
+	protected function share_product_syncer_job( string $class_name, ...$arguments ) {
+		$this->validate_interface( $class_name, ProductSyncerJobInterface::class );
+		if ( is_subclass_of( $class_name, AbstractProductSyncerBatchedJob::class ) ) {
 			$this->share_action_scheduler_job(
-				$class,
+				$class_name,
 				ProductSyncer::class,
 				ProductRepository::class,
 				BatchProductHelper::class,
@@ -185,7 +185,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 			);
 		} else {
 			$this->share_action_scheduler_job(
-				$class,
+				$class_name,
 				ProductSyncer::class,
 				ProductRepository::class,
 				MerchantCenterService::class,
@@ -197,16 +197,16 @@ class JobServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Share a coupon syncer job class
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @throws InvalidClass When the given class does not implement the ProductSyncerJobInterface.
 	 */
-	protected function share_coupon_syncer_job( string $class, ...$arguments ) {
+	protected function share_coupon_syncer_job( string $class_name, ...$arguments ) {
 		// Coupon related jobs also should implement ProductSyncerJobInterface.
 		$this->validate_interface( $class, ProductSyncerJobInterface::class );
 		$this->share_action_scheduler_job(
-			$class,
+			$class_name,
 			CouponHelper::class,
 			CouponSyncer::class,
 			WC::class,

--- a/src/Internal/DependencyManagement/ProxyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ProxyServiceProvider.php
@@ -58,7 +58,7 @@ class ProxyServiceProvider extends AbstractServiceProvider {
 			wpdb::class,
 			new Definition(
 				wpdb::class,
-				function() {
+				function () {
 					global $wpdb;
 					return $wpdb;
 				}

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -144,23 +144,23 @@ class RESTServiceProvider extends AbstractServiceProvider {
 	 *
 	 * Overridden to include the RESTServer proxy with all classes.
 	 *
-	 * @param string $class        The class name to add.
+	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function share( string $class, ...$arguments ): DefinitionInterface {
-		return parent::share( $class, RESTServer::class, ...$arguments )->addTag( 'rest_controller' );
+	protected function share( string $class_name, ...$arguments ): DefinitionInterface {
+		return parent::share( $class_name, RESTServer::class, ...$arguments )->addTag( 'rest_controller' );
 	}
 
 	/**
 	 * Share a class with only the container object provided.
 	 *
-	 * @param string $class The class name to add.
+	 * @param string $class_name The class name to add.
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function share_with_container( string $class ): DefinitionInterface {
-		return parent::share( $class, ContainerInterface::class )->addTag( 'rest_controller' );
+	protected function share_with_container( string $class_name ): DefinitionInterface {
+		return parent::share( $class_name, ContainerInterface::class )->addTag( 'rest_controller' );
 	}
 }

--- a/src/Internal/Requirements/GoogleProductFeedValidator.php
+++ b/src/Internal/Requirements/GoogleProductFeedValidator.php
@@ -33,7 +33,7 @@ class GoogleProductFeedValidator extends RequirementValidator {
 
 			add_filter(
 				'woocommerce_gla_custom_merchant_issues',
-				function( $issues, $current_time ) {
+				function ( $issues, $current_time ) {
 					return $this->add_conflict_issue( $issues, $current_time );
 				},
 				10,
@@ -42,7 +42,7 @@ class GoogleProductFeedValidator extends RequirementValidator {
 
 			add_action(
 				'deactivated_plugin',
-				function( $plugin ) {
+				function ( $plugin ) {
 					if ( 'woocommerce-product-feeds/woocommerce-gpf.php' === $plugin ) {
 						/** @var MerchantStatuses $merchant_statuses */
 						$merchant_statuses = woogle_get_container()->get( MerchantStatuses::class );

--- a/src/Internal/Requirements/PluginValidator.php
+++ b/src/Internal/Requirements/PluginValidator.php
@@ -49,5 +49,4 @@ class PluginValidator {
 		}
 		return self::$is_validated;
 	}
-
 }

--- a/src/Internal/Requirements/RequirementValidator.php
+++ b/src/Internal/Requirements/RequirementValidator.php
@@ -42,7 +42,7 @@ abstract class RequirementValidator implements RequirementValidatorInterface {
 		// Display notice error message.
 		add_action(
 			'admin_notices',
-			function() use ( $e ) {
+			function () use ( $e ) {
 				echo '<div class="notice notice-error">' . PHP_EOL;
 				echo '	<p>' . esc_html( $e->getMessage() ) . '</p>' . PHP_EOL;
 				echo '</div>' . PHP_EOL;

--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -185,5 +185,4 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
 	 */
 	abstract protected function get_batch( int $batch_number ): array;
-
 }

--- a/src/Jobs/ActionSchedulerJobInterface.php
+++ b/src/Jobs/ActionSchedulerJobInterface.php
@@ -36,5 +36,4 @@ interface ActionSchedulerJobInterface extends JobInterface {
 	 * @param array $args
 	 */
 	public function schedule( array $args = [] );
-
 }

--- a/src/Jobs/ActionSchedulerJobMonitor.php
+++ b/src/Jobs/ActionSchedulerJobMonitor.php
@@ -145,7 +145,7 @@ class ActionSchedulerJobMonitor implements Service {
 	 */
 	protected function is_timeout_error( array $error ): bool {
 		return isset( $error['type'] ) && $error['type'] === E_ERROR &&
-			   isset( $error['message'] ) && strpos( $error ['message'], 'Maximum execution time' ) !== false;
+			isset( $error['message'] ) && strpos( $error ['message'], 'Maximum execution time' ) !== false;
 	}
 
 	/**
@@ -222,5 +222,4 @@ class ActionSchedulerJobMonitor implements Service {
 	protected function is_monitored_for_timeout( string $hook, ?array $args = null ): bool {
 		return isset( $this->monitored_hooks[ self::get_job_hash( $hook, $args ) ] );
 	}
-
 }

--- a/src/Jobs/BatchedActionSchedulerJobInterface.php
+++ b/src/Jobs/BatchedActionSchedulerJobInterface.php
@@ -35,5 +35,4 @@ interface BatchedActionSchedulerJobInterface extends ActionSchedulerJobInterface
 	 * @throws Exception If an error occurs.
 	 */
 	public function handle_process_items_action( array $items );
-
 }

--- a/src/Jobs/JobException.php
+++ b/src/Jobs/JobException.php
@@ -74,5 +74,4 @@ class JobException extends RuntimeException implements GoogleListingsAndAdsExcep
 			)
 		);
 	}
-
 }

--- a/src/Jobs/JobInitializer.php
+++ b/src/Jobs/JobInitializer.php
@@ -58,9 +58,11 @@ class JobInitializer implements Registerable, Conditional {
 				);
 			}
 
-			if ( $job instanceof RecurringJobInterface &&
-				 ! $this->action_scheduler->has_scheduled_action( $job->get_start_hook()->get_hook() ) &&
-				 $job->can_schedule() ) {
+			if (
+				$job instanceof RecurringJobInterface &&
+				! $this->action_scheduler->has_scheduled_action( $job->get_start_hook()->get_hook() ) &&
+				$job->can_schedule()
+			) {
 
 				$recurring_date_time = new DateTime( 'tomorrow 3am', wp_timezone() );
 				$schedule            = '0 3 * * *'; // 3 am every day

--- a/src/Jobs/JobInterface.php
+++ b/src/Jobs/JobInterface.php
@@ -30,5 +30,4 @@ interface JobInterface extends Service {
 	 * Init the job.
 	 */
 	public function init(): void;
-
 }

--- a/src/Jobs/ProductSyncStats.php
+++ b/src/Jobs/ProductSyncStats.php
@@ -76,7 +76,7 @@ class ProductSyncStats {
 
 		foreach ( $scheduled as $action ) {
 			if ( $this->job_matches( $action->get_hook() ) ) {
-				$count++;
+				++$count;
 			}
 		}
 

--- a/src/Jobs/ProductSyncerJobInterface.php
+++ b/src/Jobs/ProductSyncerJobInterface.php
@@ -19,5 +19,4 @@ interface ProductSyncerJobInterface {
 	 * @return bool
 	 */
 	public function is_mc_ready_for_syncing(): bool;
-
 }

--- a/src/Jobs/RecurringJobInterface.php
+++ b/src/Jobs/RecurringJobInterface.php
@@ -18,5 +18,4 @@ interface RecurringJobInterface extends StartOnHookInterface {
 	 * @return int
 	 */
 	public function get_interval(): int;
-
 }

--- a/src/Jobs/StartHook.php
+++ b/src/Jobs/StartHook.php
@@ -46,5 +46,4 @@ class StartHook {
 	public function get_argument_count(): int {
 		return $this->argument_count;
 	}
-
 }

--- a/src/Jobs/StartOnHookInterface.php
+++ b/src/Jobs/StartOnHookInterface.php
@@ -20,5 +20,4 @@ interface StartOnHookInterface extends ActionSchedulerJobInterface {
 	 * @return StartHook
 	 */
 	public function get_start_hook(): StartHook;
-
 }

--- a/src/Jobs/Update/PluginUpdate.php
+++ b/src/Jobs/Update/PluginUpdate.php
@@ -76,5 +76,4 @@ class PluginUpdate implements Service, InstallableInterface {
 			}
 		}
 	}
-
 }

--- a/src/Menu/AttributeMapping.php
+++ b/src/Menu/AttributeMapping.php
@@ -19,7 +19,7 @@ class AttributeMapping implements Service, Registerable {
 	public function register(): void {
 		add_action(
 			'admin_menu',
-			function() {
+			function () {
 				wc_admin_register_page(
 					[
 						'title'    => __( 'Attribute Mapping', 'google-listings-and-ads' ),

--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -31,7 +31,7 @@ class Dashboard implements Service, Registerable, MerchantCenterAwareInterface {
 
 		add_action(
 			'admin_menu',
-			function() {
+			function () {
 				if ( $this->is_woo_nav_enabled() ) {
 					$this->register_navigation_pages();
 				} else {

--- a/src/Menu/GetStarted.php
+++ b/src/Menu/GetStarted.php
@@ -31,7 +31,7 @@ class GetStarted implements Service, Registerable, MerchantCenterAwareInterface 
 
 		add_action(
 			'admin_menu',
-			function() {
+			function () {
 				if ( $this->is_woo_nav_enabled() ) {
 					$this->register_navigation_pages();
 				} else {

--- a/src/Menu/ProductFeed.php
+++ b/src/Menu/ProductFeed.php
@@ -19,7 +19,7 @@ class ProductFeed implements Service, Registerable {
 	public function register(): void {
 		add_action(
 			'admin_menu',
-			function() {
+			function () {
 				wc_admin_register_page(
 					[
 						'title'    => __( 'Product Feed', 'google-listings-and-ads' ),

--- a/src/Menu/Reports.php
+++ b/src/Menu/Reports.php
@@ -19,7 +19,7 @@ class Reports implements Service, Registerable {
 	public function register(): void {
 		add_action(
 			'admin_menu',
-			function() {
+			function () {
 				wc_admin_register_page(
 					[
 						'title'    => __( 'Reports', 'google-listings-and-ads' ),

--- a/src/Menu/Settings.php
+++ b/src/Menu/Settings.php
@@ -19,7 +19,7 @@ class Settings implements Service, Registerable {
 	public function register(): void {
 		add_action(
 			'admin_menu',
-			function() {
+			function () {
 				wc_admin_register_page(
 					[
 						'title'    => __( 'Settings', 'google-listings-and-ads' ),

--- a/src/Menu/SetupAds.php
+++ b/src/Menu/SetupAds.php
@@ -19,7 +19,7 @@ class SetupAds implements Service, Registerable {
 	public function register(): void {
 		add_action(
 			'admin_menu',
-			function() {
+			function () {
 				wc_admin_register_page(
 					[
 						'title'  => __( 'Ads Setup Wizard', 'google-listings-and-ads' ),

--- a/src/Menu/SetupMerchantCenter.php
+++ b/src/Menu/SetupMerchantCenter.php
@@ -19,7 +19,7 @@ class SetupMerchantCenter implements Service, Registerable {
 	public function register(): void {
 		add_action(
 			'admin_menu',
-			function() {
+			function () {
 				wc_admin_register_page(
 					[
 						'title'  => __( 'MC Setup Wizard', 'google-listings-and-ads' ),

--- a/src/MerchantCenter/ContactInformation.php
+++ b/src/MerchantCenter/ContactInformation.php
@@ -84,5 +84,4 @@ class ContactInformation implements Service {
 		$account->setBusinessInformation( $business_information );
 		$this->merchant->update_account( $account );
 	}
-
 }

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -59,7 +59,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	public function __construct() {
 		add_filter(
 			'woocommerce_gla_custom_merchant_issues',
-			function( array $issues, DateTime $cache_created_time ) {
+			function ( array $issues, DateTime $cache_created_time ) {
 				return $this->maybe_add_contact_info_issue( $issues, $cache_created_time );
 			},
 			10,
@@ -383,7 +383,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 			// Check if all target countries have a shipping time.
 			$saved_shipping_time = count( $shipping_time_rows ) === count( $target_countries ) &&
-								   empty( array_diff( $target_countries, $saved_time_countries ) );
+				empty( array_diff( $target_countries, $saved_time_countries ) );
 		}
 
 		// Shipping rates saved if: 'manual', 'automatic', OR there are records for all countries
@@ -406,7 +406,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 			// Check if all target countries have a shipping rate.
 			$saved_shipping_rate = count( $shipping_rate_rows ) === count( $target_countries ) &&
-								   empty( array_diff( $target_countries, $saved_rates_countries ) );
+				empty( array_diff( $target_countries, $saved_rates_countries ) );
 		}
 
 		return $saved_shipping_rate && $saved_shipping_time;

--- a/src/MerchantCenter/TargetAudience.php
+++ b/src/MerchantCenter/TargetAudience.php
@@ -78,5 +78,4 @@ class TargetAudience implements Service {
 
 		return in_array( $shop_country, $target_countries, true ) ? $shop_country : $target_countries[0];
 	}
-
 }

--- a/src/Notes/AbstractNote.php
+++ b/src/Notes/AbstractNote.php
@@ -50,5 +50,4 @@ abstract class AbstractNote implements Note, OptionsAwareInterface {
 
 		return ! empty( $note_ids );
 	}
-
 }

--- a/src/Notes/ContactInformation.php
+++ b/src/Notes/ContactInformation.php
@@ -78,5 +78,4 @@ class ContactInformation extends AbstractNote implements MerchantCenterAwareInte
 
 		return true;
 	}
-
 }

--- a/src/Notes/LeaveReviewActionTrait.php
+++ b/src/Notes/LeaveReviewActionTrait.php
@@ -31,5 +31,4 @@ trait LeaveReviewActionTrait {
 			rand( 0, 1 ) ? $wp_link : $wc_link
 		);
 	}
-
 }

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -32,5 +32,4 @@ interface Note {
 	 * Get the note entry.
 	 */
 	public function get_entry(): NoteEntry;
-
 }

--- a/src/Notes/NoteInitializer.php
+++ b/src/Notes/NoteInitializer.php
@@ -127,5 +127,4 @@ class NoteInitializer implements Activateable, Deactivateable, InstallableInterf
 			Notes::delete_notes_with_name( $note_names );
 		}
 	}
-
 }

--- a/src/Notes/ReviewAfterClicks.php
+++ b/src/Notes/ReviewAfterClicks.php
@@ -125,5 +125,4 @@ class ReviewAfterClicks extends AbstractNote implements MerchantCenterAwareInter
 
 		return empty( $metrics ) ? 0 : $metrics['clicks'];
 	}
-
 }

--- a/src/Notes/ReviewAfterConversions.php
+++ b/src/Notes/ReviewAfterConversions.php
@@ -120,5 +120,4 @@ class ReviewAfterConversions extends AbstractNote implements MerchantCenterAware
 
 		return true;
 	}
-
 }

--- a/src/Notes/SetupCouponSharing.php
+++ b/src/Notes/SetupCouponSharing.php
@@ -119,10 +119,8 @@ class SetupCouponSharing extends AbstractNote implements MerchantCenterAwareInte
 			if ( ! $this->gla_setup_for( 3 * DAY_IN_SECONDS ) ) {
 				return false;
 			}
-		} else {
-			if ( ! $this->gla_setup_for( 17 * DAY_IN_SECONDS ) ) {
-				return false;
-			}
+		} elseif ( ! $this->gla_setup_for( 17 * DAY_IN_SECONDS ) ) {
+			return false;
 		}
 
 		return true;

--- a/src/Options/AdsSetupCompleted.php
+++ b/src/Options/AdsSetupCompleted.php
@@ -28,7 +28,7 @@ class AdsSetupCompleted implements OptionsAwareInterface, Registerable, Service 
 	public function register(): void {
 		add_action(
 			'woocommerce_gla_ads_setup_completed',
-			function() {
+			function () {
 				$this->set_completed_timestamp();
 			}
 		);

--- a/src/Options/MerchantSetupCompleted.php
+++ b/src/Options/MerchantSetupCompleted.php
@@ -25,7 +25,7 @@ class MerchantSetupCompleted implements OptionsAwareInterface, Registerable, Ser
 	public function register(): void {
 		add_action(
 			'woocommerce_gla_mc_settings_sync',
-			function() {
+			function () {
 				$this->set_contact_information_setup();
 				$this->set_completed_timestamp();
 			}

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -31,16 +31,16 @@ final class Options implements OptionsInterface, Service {
 	/**
 	 * Get an option.
 	 *
-	 * @param string $name    The option name.
-	 * @param mixed  $default A default value for the option.
+	 * @param string $name          The option name.
+	 * @param mixed  $default_value A default value for the option.
 	 *
 	 * @return mixed
 	 */
-	public function get( string $name, $default = null ) {
+	public function get( string $name, $default_value = null ) {
 		$this->validate_option_key( $name );
 
 		if ( ! array_key_exists( $name, $this->options ) ) {
-			$value                  = get_option( $this->prefix_name( $name ), $default );
+			$value                  = get_option( $this->prefix_name( $name ), $default_value );
 			$this->options[ $name ] = $this->maybe_cast_value( $name, $value );
 		}
 

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -82,12 +82,12 @@ interface OptionsInterface {
 	/**
 	 * Get an option.
 	 *
-	 * @param string $name    The option name.
-	 * @param mixed  $default A default value for the option.
+	 * @param string $name          The option name.
+	 * @param mixed  $default_value A default value for the option.
 	 *
 	 * @return mixed
 	 */
-	public function get( string $name, $default = null );
+	public function get( string $name, $default_value = null );
 
 	/**
 	 * Add an option.

--- a/src/Options/Transients.php
+++ b/src/Options/Transients.php
@@ -29,19 +29,19 @@ final class Transients implements TransientsInterface, Service {
 	/**
 	 * Get a transient.
 	 *
-	 * @param string $name    The transient name.
-	 * @param mixed  $default A default value for the transient.
+	 * @param string $name          The transient name.
+	 * @param mixed  $default_value A default value for the transient.
 	 *
 	 * @return mixed
 	 */
-	public function get( string $name, $default = null ) {
+	public function get( string $name, $default_value = null ) {
 		$this->validate_transient_key( $name );
 
 		if ( ! array_key_exists( $name, $this->transients ) ) {
 			$value = get_transient( $this->prefix_name( $name ) );
 
 			if ( false === $value ) {
-				$value = $default;
+				$value = $default_value;
 			}
 
 			$this->transients[ $name ] = $value;

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -31,12 +31,12 @@ interface TransientsInterface {
 	/**
 	 * Get a transient.
 	 *
-	 * @param string $name    The transient name.
-	 * @param mixed  $default A default value for the transient.
+	 * @param string $name          The transient name.
+	 * @param mixed  $default_value A default value for the transient.
 	 *
 	 * @return mixed
 	 */
-	public function get( string $name, $default = null );
+	public function get( string $name, $default_value = null );
 
 	/**
 	 * Add or update a transient.

--- a/src/Product/AttributeMapping/AttributeMappingHelper.php
+++ b/src/Product/AttributeMapping/AttributeMappingHelper.php
@@ -123,7 +123,6 @@ class AttributeMappingHelper implements Service {
 		}
 
 		return $attribute_sources;
-
 	}
 
 	/**
@@ -138,5 +137,4 @@ class AttributeMappingHelper implements Service {
 			self::CATEGORY_CONDITION_TYPE_ONLY,
 		];
 	}
-
 }

--- a/src/Product/Attributes/AbstractAttribute.php
+++ b/src/Product/Attributes/AbstractAttribute.php
@@ -98,5 +98,4 @@ abstract class AbstractAttribute implements AttributeInterface {
 	public function __toString() {
 		return (string) $this->get_value();
 	}
-
 }

--- a/src/Product/Attributes/AttributeInterface.php
+++ b/src/Product/Attributes/AttributeInterface.php
@@ -58,5 +58,4 @@ interface AttributeInterface {
 	 * @return mixed
 	 */
 	public function get_value();
-
 }

--- a/src/Product/Attributes/AvailabilityDate.php
+++ b/src/Product/Attributes/AvailabilityDate.php
@@ -66,5 +66,4 @@ class AvailabilityDate extends AbstractAttribute {
 	public static function get_input_type(): string {
 		return AvailabilityDateInput::class;
 	}
-
 }

--- a/src/Product/Attributes/Condition.php
+++ b/src/Product/Attributes/Condition.php
@@ -75,5 +75,4 @@ class Condition extends AbstractAttribute implements WithValueOptionsInterface, 
 	public static function get_name(): string {
 		return __( 'Condition', 'google-listings-and-ads' );
 	}
-
 }

--- a/src/Product/Attributes/IsBundle.php
+++ b/src/Product/Attributes/IsBundle.php
@@ -84,5 +84,4 @@ class IsBundle extends AbstractAttribute implements WithMappingInterface {
 			'no'  => __( 'No', 'google-listings-and-ads' ),
 		];
 	}
-
 }

--- a/src/Product/Attributes/Multipack.php
+++ b/src/Product/Attributes/Multipack.php
@@ -71,5 +71,4 @@ class Multipack extends AbstractAttribute implements WithMappingInterface {
 	public static function get_name(): string {
 		return __( 'Multipack', 'google-listings-and-ads' );
 	}
-
 }

--- a/src/Product/Attributes/Size.php
+++ b/src/Product/Attributes/Size.php
@@ -60,5 +60,4 @@ class Size extends AbstractAttribute implements WithMappingInterface {
 	public static function get_name(): string {
 		return __( 'Size', 'google-listings-and-ads' );
 	}
-
 }

--- a/src/Product/Attributes/SizeSystem.php
+++ b/src/Product/Attributes/SizeSystem.php
@@ -83,5 +83,4 @@ class SizeSystem extends AbstractAttribute implements WithValueOptionsInterface,
 	public static function get_name(): string {
 		return __( 'Size System', 'google-listings-and-ads' );
 	}
-
 }

--- a/src/Product/Attributes/SizeType.php
+++ b/src/Product/Attributes/SizeType.php
@@ -79,5 +79,4 @@ class SizeType extends AbstractAttribute implements WithValueOptionsInterface, W
 	public static function get_name(): string {
 		return __( 'Size Type', 'google-listings-and-ads' );
 	}
-
 }

--- a/src/Product/Attributes/WithMappingInterface.php
+++ b/src/Product/Attributes/WithMappingInterface.php
@@ -32,5 +32,4 @@ interface WithMappingInterface {
 	 * @return array
 	 */
 	public static function get_sources(): array;
-
 }

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -148,7 +148,6 @@ class ProductHelper implements Service {
 			// if there are no Google IDs left then this product is no longer considered "synced"
 			$this->mark_as_unsynced( $product );
 		}
-
 	}
 
 	/**
@@ -369,9 +368,9 @@ class ProductHelper implements Service {
 		}
 
 		return ( ChannelVisibility::DONT_SYNC_AND_SHOW !== $this->get_channel_visibility( $product ) ) &&
-			   ( in_array( $product->get_type(), ProductSyncer::get_supported_product_types(), true ) ) &&
-			   ( 'publish' === $product_status ) &&
-			   $product_visibility;
+			( in_array( $product->get_type(), ProductSyncer::get_supported_product_types(), true ) ) &&
+			( 'publish' === $product_status ) &&
+			$product_visibility;
 	}
 
 	/**
@@ -390,7 +389,7 @@ class ProductHelper implements Service {
 
 		// if it has failed more times than the specified threshold AND if syncing it has failed within the specified window
 		return $failed_attempts > ProductSyncer::FAILURE_THRESHOLD &&
-			   $failed_at > strtotime( sprintf( '-%s', ProductSyncer::FAILURE_THRESHOLD_WINDOW ) );
+			$failed_at > strtotime( sprintf( '-%s', ProductSyncer::FAILURE_THRESHOLD_WINDOW ) );
 	}
 
 	/**

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -71,41 +71,41 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	/**
 	 * Initialize this object's properties from an array.
 	 *
-	 * @param array $array Used to seed this object's properties.
+	 * @param array $properties Used to seed this object's properties.
 	 *
 	 * @return void
 	 *
 	 * @throws InvalidValue When a WooCommerce product is not provided or it is invalid.
 	 */
-	public function mapTypes( $array ) {
-		if ( empty( $array['wc_product'] ) || ! $array['wc_product'] instanceof WC_Product ) {
+	public function mapTypes( $properties ) {
+		if ( empty( $properties['wc_product'] ) || ! $properties['wc_product'] instanceof WC_Product ) {
 			throw InvalidValue::not_instance_of( WC_Product::class, 'wc_product' );
 		}
 
 		// throw an exception if the parent product isn't provided and this is a variation
-		if ( $array['wc_product'] instanceof WC_Product_Variation &&
-			 ( empty( $array['parent_wc_product'] ) || ! $array['parent_wc_product'] instanceof WC_Product_Variable )
+		if ( $properties['wc_product'] instanceof WC_Product_Variation &&
+			( empty( $properties['parent_wc_product'] ) || ! $properties['parent_wc_product'] instanceof WC_Product_Variable )
 		) {
 			throw InvalidValue::not_instance_of( WC_Product_Variable::class, 'parent_wc_product' );
 		}
 
-		if ( empty( $array['targetCountry'] ) ) {
+		if ( empty( $properties['targetCountry'] ) ) {
 			throw InvalidValue::is_empty( 'targetCountry' );
 		}
 
-		$this->wc_product        = $array['wc_product'];
-		$this->parent_wc_product = $array['parent_wc_product'] ?? null;
+		$this->wc_product        = $properties['wc_product'];
+		$this->parent_wc_product = $properties['parent_wc_product'] ?? null;
 
-		$mapping_rules  = $array['mapping_rules'] ?? [];
-		$gla_attributes = $array['gla_attributes'] ?? [];
+		$mapping_rules  = $properties['mapping_rules'] ?? [];
+		$gla_attributes = $properties['gla_attributes'] ?? [];
 
 		// Google doesn't expect extra fields, so it's best to remove them
-		unset( $array['wc_product'] );
-		unset( $array['parent_wc_product'] );
-		unset( $array['gla_attributes'] );
-		unset( $array['mapping_rules'] );
+		unset( $properties['wc_product'] );
+		unset( $properties['parent_wc_product'] );
+		unset( $properties['gla_attributes'] );
+		unset( $properties['mapping_rules'] );
 
-		parent::mapTypes( $array );
+		parent::mapTypes( $properties );
 		$this->map_woocommerce_product();
 		$this->map_attribute_mapping_rules( $mapping_rules );
 		$this->map_gla_attributes( $gla_attributes );
@@ -126,13 +126,12 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$this->setContentLanguage( $content_language );
 
 		$this->map_wc_product_id()
-			 ->map_wc_general_attributes()
-			 ->map_product_categories()
-			 ->map_wc_product_image( self::IMAGE_SIZE_FULL )
-			 ->map_wc_availability()
-			 ->map_wc_product_shipping()
-			 ->map_wc_prices();
-
+			->map_wc_general_attributes()
+			->map_product_categories()
+			->map_wc_product_image( self::IMAGE_SIZE_FULL )
+			->map_wc_availability()
+			->map_wc_product_shipping()
+			->map_wc_prices();
 	}
 
 	/**
@@ -428,7 +427,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			$weight_unit    = apply_filters( 'woocommerce_gla_weight_unit', get_option( 'woocommerce_weight_unit' ) );
 
 			$this->map_wc_shipping_dimensions( $dimension_unit )
-				 ->map_wc_shipping_weight( $weight_unit );
+				->map_wc_shipping_weight( $weight_unit );
 		}
 
 		// Set the product's shipping class slug as the shipping label.
@@ -659,8 +658,10 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$regular_price = $product->get_regular_price();
 		$sale_price    = $product->get_sale_price();
 		$active_price  = $product->get_price();
-		if ( ( empty( $sale_price ) && $active_price < $regular_price ) ||
-			 ( ! empty( $sale_price ) && $active_price < $sale_price ) ) {
+		if (
+			( empty( $sale_price ) && $active_price < $regular_price ) ||
+			( ! empty( $sale_price ) && $active_price < $sale_price )
+		) {
 			$sale_price = $active_price;
 		}
 
@@ -712,23 +713,26 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 
 		$now = new WC_DateTime();
 		// if we have a sale end date in the future, but no start date, set the start date to now()
-		if ( ! empty( $end_date ) &&
-			 $end_date > $now &&
-			 empty( $start_date )
+		if (
+			! empty( $end_date ) &&
+			$end_date > $now &&
+			empty( $start_date )
 		) {
 			$start_date = $now;
 		}
 		// if we have a sale start date in the past, but no end date, do not include the start date.
-		if ( ! empty( $start_date ) &&
-			 $start_date < $now &&
-			 empty( $end_date )
+		if (
+			! empty( $start_date ) &&
+			$start_date < $now &&
+			empty( $end_date )
 		) {
 			$start_date = null;
 		}
 		// if we have a start date in the future, but no end date, assume a one-day sale.
-		if ( ! empty( $start_date ) &&
-			 $start_date > $now &&
-			 empty( $end_date )
+		if (
+			! empty( $start_date ) &&
+			$start_date > $now &&
+			empty( $end_date )
 		) {
 			$end_date = clone $start_date;
 			$end_date->add( new DateInterval( 'P1D' ) );

--- a/src/Proxies/RESTServer.php
+++ b/src/Proxies/RESTServer.php
@@ -34,29 +34,29 @@ class RESTServer {
 	/**
 	 * Register a REST route.
 	 *
-	 * @param string $namespace The route namespace.
-	 * @param string $route     The route.
-	 * @param array  $args      Arguments for the route.
+	 * @param string $route_namespace The route namespace.
+	 * @param string $route           The route.
+	 * @param array  $args            Arguments for the route.
 	 */
-	public function register_route( string $namespace, string $route, array $args ): void {
+	public function register_route( string $route_namespace, string $route, array $args ): void {
 		// Clean up namespace and route.
-		$namespace  = trim( $namespace, '/' );
-		$route      = trim( $route, '/' );
-		$full_route = "/{$namespace}/{$route}";
-		$this->server->register_route( $namespace, $full_route, $this->prepare_route_args( $args ) );
+		$route_namespace = trim( $route_namespace, '/' );
+		$route           = trim( $route, '/' );
+		$full_route      = "/{$route_namespace}/{$route}";
+		$this->server->register_route( $route_namespace, $full_route, $this->prepare_route_args( $args ) );
 	}
 
 	/**
 	 * Get the registered REST routes.
 	 *
-	 * @param string $namespace Optionally, only return routes in the given namespace.
+	 * @param string $route_namespace Optionally, only return routes in the given namespace.
 	 * @return array `'/path/regex' => array( $callback, $bitmask )` or
 	 *               `'/path/regex' => array( array( $callback, $bitmask ), ...)`.
 	 *
 	 * @since 1.4.0
 	 */
-	public function get_routes( string $namespace = '' ): array {
-		return $this->server->get_routes( $namespace );
+	public function get_routes( string $route_namespace = '' ): array {
+		return $this->server->get_routes( $route_namespace );
 	}
 
 	/**

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -50,13 +50,13 @@ class WP {
 	/**
 	 * Retrieve values from the WP query_vars property.
 	 *
-	 * @param string $key     The key of the value to retrieve.
-	 * @param null   $default The default value to return if the key isn't found.
+	 * @param string $key           The key of the value to retrieve.
+	 * @param null   $default_value The default value to return if the key isn't found.
 	 *
 	 * @return mixed The query value if found, or the default value.
 	 */
-	public function get_query_vars( string $key, $default = null ) {
-		return $this->wp->query_vars[ $key ] ?? $default;
+	public function get_query_vars( string $key, $default_value = null ) {
+		return $this->wp->query_vars[ $key ] ?? $default_value;
 	}
 
 	/**
@@ -237,18 +237,14 @@ class WP {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param array|string $args       Optional. Array or string of arguments. See WP_Term_Query::__construct()
-	 *                                 for information on accepted arguments. Default empty array.
-	 * @param array|string $deprecated Optional. Argument array, when using the legacy function parameter format.
-	 *                                 If present, this parameter will be interpreted as `$args`, and the first
-	 *                                 function parameter will be parsed as a taxonomy or array of taxonomies.
-	 *                                 Default empty.
+	 * @param array|string $args Optional. Array or string of arguments. See WP_Term_Query::__construct()
+	 *                           for information on accepted arguments. Default empty array.
 	 * @return WP_Term[]|int[]|string[]|string|WP_Error Array of terms, a count thereof as a numeric string,
 	 *                                                  or WP_Error if any of the taxonomies do not exist.
 	 *                                                  See the function description for more information.
 	 */
-	public function get_terms( $args = [], $deprecated = '' ) {
-		return get_terms( $args, $deprecated );
+	public function get_terms( $args = [] ) {
+		return get_terms( $args );
 	}
 
 	/**
@@ -286,7 +282,6 @@ class WP {
 		}
 
 		return null;
-
 	}
 
 	/**
@@ -306,7 +301,6 @@ class WP {
 		}
 
 		return wp_update_image_subsizes( $attachment_id );
-
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/AbstractRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractRateGroupAdapter.php
@@ -22,25 +22,25 @@ abstract class AbstractRateGroupAdapter extends RateGroup {
 	/**
 	 * Initialize this object's properties from an array.
 	 *
-	 * @param array $array Used to seed this object's properties.
+	 * @param array $properties Used to seed this object's properties.
 	 *
 	 * @throws InvalidValue When the required parameters are not provided, or they are invalid.
 	 */
-	public function mapTypes( $array ) {
-		if ( empty( $array['currency'] ) || ! is_string( $array['currency'] ) ) {
+	public function mapTypes( $properties ) {
+		if ( empty( $properties['currency'] ) || ! is_string( $properties['currency'] ) ) {
 			throw new InvalidValue( 'The value of "currency" must be a non empty string.' );
 		}
-		if ( empty( $array['location_rates'] ) || ! is_array( $array['location_rates'] ) ) {
+		if ( empty( $properties['location_rates'] ) || ! is_array( $properties['location_rates'] ) ) {
 			throw new InvalidValue( 'The value of "location_rates" must be a non empty array.' );
 		}
 
-		$this->map_location_rates( $array['location_rates'], $array['currency'] );
+		$this->map_location_rates( $properties['location_rates'], $properties['currency'] );
 
 		// Remove the extra data before calling the parent method since it doesn't expect them.
-		unset( $array['currency'] );
-		unset( $array['location_rates'] );
+		unset( $properties['currency'] );
+		unset( $properties['location_rates'] );
 
-		parent::mapTypes( $array );
+		parent::mapTypes( $properties );
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
@@ -30,23 +30,23 @@ abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 	/**
 	 * Initialize this object's properties from an array.
 	 *
-	 * @param array $array Used to seed this object's properties.
+	 * @param array $properties Used to seed this object's properties.
 	 *
 	 * @return void
 	 *
 	 * @throws InvalidValue When the required parameters are not provided, or they are invalid.
 	 */
-	public function mapTypes( $array ) {
-		$this->validate_gla_data( $array );
+	public function mapTypes( $properties ) {
+		$this->validate_gla_data( $properties );
 
-		$this->currency       = $array['currency'];
-		$this->delivery_times = $array['delivery_times'];
+		$this->currency       = $properties['currency'];
+		$this->delivery_times = $properties['delivery_times'];
 
-		$this->map_gla_data( $array );
+		$this->map_gla_data( $properties );
 
-		$this->unset_gla_data( $array );
+		$this->unset_gla_data( $properties );
 
-		parent::mapTypes( $array );
+		parent::mapTypes( $properties );
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
@@ -185,5 +185,4 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 
 		return $service;
 	}
-
 }

--- a/src/Shipping/GoogleAdapter/StatesRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/StatesRateGroupAdapter.php
@@ -46,5 +46,4 @@ class StatesRateGroupAdapter extends AbstractRateGroupAdapter {
 
 		$this->setMainTable( $table );
 	}
-
 }

--- a/src/Shipping/LocationRatesProcessor.php
+++ b/src/Shipping/LocationRatesProcessor.php
@@ -60,7 +60,6 @@ class LocationRatesProcessor {
 	 */
 	protected function should_rate_be_replaced( ShippingRate $new_rate, ShippingRate $existing_rate ): bool {
 		return $new_rate->get_rate() > $existing_rate->get_rate() ||
-			   (float) $new_rate->get_min_order_amount() > (float) $existing_rate->get_min_order_amount();
+			(float) $new_rate->get_min_order_amount() > (float) $existing_rate->get_min_order_amount();
 	}
-
 }

--- a/src/Shipping/PostcodeRange.php
+++ b/src/Shipping/PostcodeRange.php
@@ -77,5 +77,4 @@ class PostcodeRange {
 
 		return $this->start_code;
 	}
-
 }

--- a/src/Shipping/ShippingLocation.php
+++ b/src/Shipping/ShippingLocation.php
@@ -115,5 +115,4 @@ class ShippingLocation {
 
 		return $code;
 	}
-
 }

--- a/src/Shipping/ShippingRate.php
+++ b/src/Shipping/ShippingRate.php
@@ -116,5 +116,4 @@ class ShippingRate implements JsonSerializable {
 			'rate' => $this->get_rate(),
 		];
 	}
-
 }

--- a/src/Shipping/ShippingRegion.php
+++ b/src/Shipping/ShippingRegion.php
@@ -86,5 +86,4 @@ class ShippingRegion {
 	public function __toString() {
 		return $this->get_country() . join( ',', $this->get_postcode_ranges() );
 	}
-
 }

--- a/src/Shipping/ShippingSuggestionService.php
+++ b/src/Shipping/ShippingSuggestionService.php
@@ -97,5 +97,4 @@ class ShippingSuggestionService implements Service {
 
 		return $suggestions;
 	}
-
 }

--- a/src/Shipping/ShippingZone.php
+++ b/src/Shipping/ShippingZone.php
@@ -177,5 +177,4 @@ class ShippingZone implements Service {
 			$this->location_rates[ $country_code ][ $location_key ] = $location_rates;
 		}
 	}
-
 }

--- a/src/Shipping/ZoneLocationsParser.php
+++ b/src/Shipping/ZoneLocationsParser.php
@@ -133,5 +133,4 @@ class ZoneLocationsParser implements Service {
 
 		return new ShippingRegion( $region_id, $country, $postcode_ranges );
 	}
-
 }

--- a/src/Shipping/ZoneMethodsParser.php
+++ b/src/Shipping/ZoneMethodsParser.php
@@ -167,5 +167,4 @@ class ZoneMethodsParser implements Service {
 
 		return array_values( $class_rates );
 	}
-
 }

--- a/src/TaskList/CompleteSetupTask.php
+++ b/src/TaskList/CompleteSetupTask.php
@@ -27,7 +27,7 @@ class CompleteSetupTask extends Task implements Service, Registerable, MerchantC
 	public function register(): void {
 		add_action(
 			'init',
-			function() {
+			function () {
 				$list_id = 'extended';
 
 				$this->task_list = TaskLists::get_list( $list_id );
@@ -105,5 +105,4 @@ class CompleteSetupTask extends Task implements Service, Registerable, MerchantC
 
 		return admin_url( 'admin.php?page=wc-admin&path=/google/dashboard' );
 	}
-
 }

--- a/src/Tracking/EventTracking.php
+++ b/src/Tracking/EventTracking.php
@@ -55,7 +55,7 @@ class EventTracking implements Service, Registerable {
 	public function register(): void {
 		add_action(
 			'init',
-			function() {
+			function () {
 				$this->register_events();
 			},
 			20 // After WC_Admin loads WC_Tracks class (init 10).

--- a/src/Tracking/Events/ActivatedEvents.php
+++ b/src/Tracking/Events/ActivatedEvents.php
@@ -76,7 +76,6 @@ class ActivatedEvents extends BaseEvent implements Activateable {
 		}
 
 		$this->record_event( 'activated_from_source', $available_source_params );
-
 	}
 
 	/**
@@ -87,5 +86,4 @@ class ActivatedEvents extends BaseEvent implements Activateable {
 	public function activate(): void {
 		$this->maybe_track_activation_source();
 	}
-
 }

--- a/src/Tracking/Events/BaseEvent.php
+++ b/src/Tracking/Events/BaseEvent.php
@@ -14,7 +14,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\TracksAwareTrait;
  */
 abstract class BaseEvent implements TracksEventInterface, TracksAwareInterface {
 
-	use TracksAwareTrait, PluginHelper;
+	use TracksAwareTrait;
+	use PluginHelper;
 
 	/**
 	 * Record an event using the Tracks instance.

--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -49,7 +49,7 @@ class TrackerSnapshot implements Conditional, ContainerAwareInterface, OptionsAw
 	public function register(): void {
 		add_filter(
 			'woocommerce_tracker_data',
-			function( $data ) {
+			function ( $data ) {
 				return $this->include_snapshot_data( $data );
 			}
 		);

--- a/src/Utility/ArrayUtil.php
+++ b/src/Utility/ArrayUtil.php
@@ -12,14 +12,11 @@ class ArrayUtil {
 	/**
 	 * Remove empty values from array.
 	 *
-	 * @param array $array A list of strings.
+	 * @param array $strings A list of strings.
 	 *
 	 * @return array A list of strings without empty strings.
 	 */
-	public static function remove_empty_values( array $array ): array {
-		return array_values( array_filter( $array ) );
+	public static function remove_empty_values( array $strings ): array {
+		return array_values( array_filter( $strings ) );
 	}
-
 }
-
-

--- a/src/Utility/DimensionUtility.php
+++ b/src/Utility/DimensionUtility.php
@@ -55,7 +55,4 @@ class DimensionUtility {
 	public function equals( DimensionUtility $target, $precision = 1 ): bool {
 		return wp_fuzzy_number_match( $this->x, $target->x, $precision ) && wp_fuzzy_number_match( $this->y, $target->y, $precision );
 	}
-
-
 }
-

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -80,10 +80,4 @@ class ImageUtility implements Service {
 
 		return new DimensionUtility( $x, $y );
 	}
-
-
-
-
 }
-
-

--- a/src/Value/ProductIDMap.php
+++ b/src/Value/ProductIDMap.php
@@ -22,16 +22,16 @@ class ProductIDMap extends ArrayObject implements ValueInterface {
 	/**
 	 * ProductIDMap constructor.
 	 *
-	 * @param int[]  $array         An array of WooCommerce product IDs mapped to Google product IDs as their key.
+	 * @param int[]  $product_ids   An array of WooCommerce product IDs mapped to Google product IDs as their key.
 	 * @param int    $flags         Flags to control the behaviour of the ArrayObject object.
 	 * @param string $iteratorClass Specify the class that will be used for iteration of the ArrayObject object. ArrayIterator is the default class used.
 	 *
 	 * @throws InvalidValue When an invalid WooCommerce product ID or Google product ID is provided in the map.
 	 */
-	public function __construct( $array = [], $flags = 0, $iteratorClass = 'ArrayIterator' ) {
-		$this->validate( $array );
+	public function __construct( $product_ids = [], $flags = 0, $iteratorClass = 'ArrayIterator' ) {
+		$this->validate( $product_ids );
 
-		parent::__construct( $array, $flags, $iteratorClass );
+		parent::__construct( $product_ids, $flags, $iteratorClass );
 	}
 
 	/**
@@ -44,12 +44,12 @@ class ProductIDMap extends ArrayObject implements ValueInterface {
 	}
 
 	/**
-	 * @param array $array
+	 * @param int[] $product_ids An array of WooCommerce product IDs mapped to Google product IDs as their key.
 	 *
 	 * @throws InvalidValue When an invalid WooCommerce product ID or Google product ID is provided in the map.
 	 */
-	protected function validate( array $array ) {
-		foreach ( $array as $google_id => $wc_product_id ) {
+	protected function validate( array $product_ids ) {
+		foreach ( $product_ids as $google_id => $wc_product_id ) {
 			$wc_product_id = filter_var( $wc_product_id, FILTER_VALIDATE_INT );
 			if ( false === $wc_product_id ) {
 				throw InvalidValue::not_integer( 'product_id' );

--- a/src/View/PHPView.php
+++ b/src/View/PHPView.php
@@ -220,13 +220,13 @@ class PHPView implements View {
 	}
 
 	/**
-	 * @param mixed $var
+	 * @param mixed $variable
 	 */
-	protected function sanitize_context_variable( $var ) {
-		if ( is_array( $var ) ) {
-			return array_map( [ $this, 'sanitize_context_variable' ], $var );
+	protected function sanitize_context_variable( $variable ) {
+		if ( is_array( $variable ) ) {
+			return array_map( [ $this, 'sanitize_context_variable' ], $variable );
 		} else {
-			return ! is_bool( $var ) && is_scalar( $var ) ? sanitize_text_field( $var ) : $var;
+			return ! is_bool( $variable ) && is_scalar( $variable ) ? sanitize_text_field( $variable ) : $variable;
 		}
 	}
 

--- a/tests/Framework/RESTControllerUnitTest.php
+++ b/tests/Framework/RESTControllerUnitTest.php
@@ -92,5 +92,4 @@ abstract class RESTControllerUnitTest extends UnitTest {
 
 		return $this->server->dispatch_request( $request );
 	}
-
 }

--- a/tests/Tools/HelperTrait/CouponTrait.php
+++ b/tests/Tools/HelperTrait/CouponTrait.php
@@ -103,7 +103,8 @@ trait CouponTrait {
 	 */
 	public function generate_google_promotion_mock(
 		$coupon_id = null,
-		$target_country = null ) {
+		$target_country = null
+	) {
 		$promotion = $this->createMock( GooglePromotion::class );
 
 		$target_country = $target_country ?: $this->get_sample_target_country();

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -130,7 +130,7 @@ trait GoogleAdsClientTrait {
 		$this->service_client->expects( $this->once() )
 			->method( 'mutate' )
 			->willReturnCallback(
-				function( int $ads_id, array $operations ) use ( $type, $response ) {
+				function ( int $ads_id, array $operations ) use ( $type, $response ) {
 					// Assert that the campaign operation is the right type.
 					foreach ( $operations as $operation ) {
 						if ( 'campaign_operation' === $operation->getOperation() ) {
@@ -390,11 +390,11 @@ trait GoogleAdsClientTrait {
 	/**
 	 * Generates a list of mocked customers resource names.
 	 *
-	 * @param array $list
+	 * @param array $mocked_list
 	 */
-	protected function generate_customer_list_mock( array $list ) {
+	protected function generate_customer_list_mock( array $mocked_list ) {
 		$customers = $this->createMock( ListAccessibleCustomersResponse::class );
-		$customers->method( 'getResourceNames' )->willReturn( $list );
+		$customers->method( 'getResourceNames' )->willReturn( $mocked_list );
 
 		$this->customer_service->method( 'listAccessibleCustomers' )->willReturn( $customers );
 	}
@@ -418,7 +418,7 @@ trait GoogleAdsClientTrait {
 		$this->client->method( 'getMerchantCenterLinkServiceClient' )->willReturn( $mc_link_service );
 
 		$links = array_map(
-			function( $link ) {
+			function ( $link ) {
 				return new MerchantCenterLink( $link );
 			},
 			$links
@@ -462,7 +462,7 @@ trait GoogleAdsClientTrait {
 		$this->conversion_action_service->expects( $this->once() )
 			->method( 'mutateConversionActions' )
 			->willReturnCallback(
-				function( int $ads_id, array $operations ) use ( $type, $response ) {
+				function ( int $ads_id, array $operations ) use ( $type, $response ) {
 					// Assert that the operation is the right type.
 					foreach ( $operations as $operation ) {
 						if ( 'conversion_action_operation' === $operation->getOperation() ) {
@@ -522,7 +522,7 @@ trait GoogleAdsClientTrait {
 		$page->method( 'getNextPageToken' )->willReturn( $next_page );
 		$page->method( 'getIterator' )->willReturn(
 			array_map(
-				function( $row ) use ( $args ) {
+				function ( $row ) use ( $args ) {
 					return $this->generate_report_row_mock( $row, $args );
 				},
 				$data
@@ -732,7 +732,7 @@ trait GoogleAdsClientTrait {
 		$this->service_client->expects( $this->once() )
 			->method( 'mutate' )
 			->willReturnCallback(
-				function( int $ads_id, array $operations ) use ( $type, $response, $include_assets ) {
+				function ( int $ads_id, array $operations ) use ( $type, $response, $include_assets ) {
 					$operations_names = [];
 
 					if ( $type === 'update' && count( $operations ) ) {
@@ -769,7 +769,6 @@ trait GoogleAdsClientTrait {
 					return $response;
 				}
 			);
-
 	}
 
 	/**
@@ -819,7 +818,6 @@ trait GoogleAdsClientTrait {
 			default:
 				return null;
 		}
-
 	}
 
 	/**
@@ -857,7 +855,7 @@ trait GoogleAdsClientTrait {
 		$this->service_client->expects( $this->once() )
 			->method( 'mutate' )
 			->willReturnCallback(
-				function( int $ads_id, array $operations ) use ( $type, $response, $asset ) {
+				function ( int $ads_id, array $operations ) use ( $type, $response, $asset ) {
 					// Assert that the asset group operation is the right type.
 					$operations_names = [];
 					foreach ( $operations as $operation ) {
@@ -874,14 +872,13 @@ trait GoogleAdsClientTrait {
 					return $response;
 				}
 			);
-
 	}
 
 	protected function generate_asset_batch_mutate_mock( $matcher, $asset_batches_callback ) {
 		$this->service_client->expects( $matcher )
 		->method( 'mutate' )
 		->willReturnCallback(
-			function( int $ads_id, array $operations ) use ( $matcher, $asset_batches_callback ) {
+			function ( int $ads_id, array $operations ) use ( $matcher, $asset_batches_callback ) {
 				$responses = [];
 
 				$asset_batches_callback( $matcher, $operations );
@@ -897,10 +894,8 @@ trait GoogleAdsClientTrait {
 				return ( new MutateGoogleAdsResponse() )->setMutateOperationResponses(
 					$responses
 				);
-
 			}
 		);
-
 	}
 
 	/**
@@ -958,7 +953,4 @@ trait GoogleAdsClientTrait {
 
 		return $asset_group_asset_operations;
 	}
-
-
-
 }

--- a/tests/Tools/HelperTrait/GuzzleClientTrait.php
+++ b/tests/Tools/HelperTrait/GuzzleClientTrait.php
@@ -184,6 +184,5 @@ trait GuzzleClientTrait {
 				$result,
 			)
 		);
-
 	}
 }

--- a/tests/Tools/HelperTrait/MerchantTrait.php
+++ b/tests/Tools/HelperTrait/MerchantTrait.php
@@ -97,5 +97,4 @@ trait MerchantTrait {
 
 		return $status;
 	}
-
 }

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -31,18 +31,18 @@ trait ProductTrait {
 		$id      = rand();
 
 		$children = [];
-		for ( $i = 0; $i < $number_of_variations; $i ++ ) {
+		for ( $i = 0; $i < $number_of_variations; $i++ ) {
 			$child = $this->createMock( WC_Product_Variation::class );
 
 			$child->expects( $this->any() )
-				  ->method( 'get_id' )
-				  ->willReturn( rand() );
+				->method( 'get_id' )
+				->willReturn( rand() );
 			$child->expects( $this->any() )
-				  ->method( 'get_parent_id' )
-				  ->willReturn( $id );
+				->method( 'get_parent_id' )
+				->willReturn( $id );
 			$child->expects( $this->any() )
-				  ->method( 'get_type' )
-				  ->willReturn( 'variation' );
+				->method( 'get_type' )
+				->willReturn( 'variation' );
 
 			$children[] = $child;
 		}
@@ -194,7 +194,7 @@ trait ProductTrait {
 	 */
 	public function create_simple_product_set( int $product_count ): array {
 		$products = [];
-		for ( $i = 1; $i <= $product_count; $i ++ ) {
+		for ( $i = 1; $i <= $product_count; $i++ ) {
 			$product                        = WC_Helper_Product::create_simple_product();
 			$products[ $product->get_id() ] = $product;
 		}

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -39,11 +39,10 @@ class ClientTest extends ContainerAwareUnitTest {
 		$request = new Request( 'GET', 'https://testing.local' );
 
 		$service->add_plugin_version_header()(
-			function( $request, $options ) {
+			function ( $request, $options ) {
 				$this->assertEquals( $this->get_client_name(), $request->getHeader( 'x-client-name' )[0] );
 				$this->assertEquals( $this->get_version(), $request->getHeader( 'x-client-version' )[0] );
 			}
 		)( $request, [] );
-
 	}
 }

--- a/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupAssetTest.php
@@ -105,7 +105,6 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );
 		$this->assertEquals( $expected, $this->asset_group_asset->get_assets_by_asset_group_ids( [ self::TEST_CAMPAIGN_ID ] ) );
-
 	}
 
 	public function test_asset_group_assets_without_asset_groups() {
@@ -162,7 +161,6 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );
 		$this->assertEquals( $expected, $this->asset_group_asset->get_assets_by_final_url( 'https://example.com' ) );
-
 	}
 
 	public function test_get_asset_groups_assets_by_final_url_firt_result() {
@@ -206,7 +204,6 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		$this->generate_ads_asset_group_asset_query_mock( $asset_group_asset_data );
 		$this->assertEquals( $expected, $this->asset_group_asset->get_assets_by_final_url( 'https://example.com', true ) );
-
 	}
 
 
@@ -256,7 +253,6 @@ class AdsAssetGroupAssetTest extends UnitTest {
 		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, self::TEST_ASSET_ID, AssetFieldType::name( AssetFieldType::LANDSCAPE_LOGO ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][0] )->getRemove() );
 		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[0]['id'], AssetFieldType::name( $assets[0]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][1] )->getRemove() );
 		$this->assertEquals( ResourceNames::forAssetGroupAsset( $this->options->get_ads_id(), self::TEST_ASSET_GROUP_ID, $assets[1]['id'], AssetFieldType::name( $assets[1]['field_type'] ) ), ( $grouped_operations['asset_group_asset_operation']['remove'][2] )->getRemove() );
-
 	}
 
 	public function test_edit_asset_group_assets_create_assets() {
@@ -294,7 +290,6 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		// We should not remove old assets.
 		$this->assertArrayNotHasKey( 'remove', $grouped_operations['asset_group_asset_operation'] );
-
 	}
 
 	public function test_edit_asset_group_assets_delete_assets() {
@@ -330,7 +325,6 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		// We should not create assets.
 		$this->assertArrayNotHasKey( 'create', $grouped_operations['asset_group_asset_operation'] );
-
 	}
 
 	protected function generate_overridable_asset(): void {
@@ -386,6 +380,4 @@ class AdsAssetGroupAssetTest extends UnitTest {
 
 		return $grouped_operations;
 	}
-
-
 }

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -124,7 +124,6 @@ class AdsAssetGroupTest extends UnitTest {
 
 		$this->generate_ads_asset_groups_query_mock( $asset_group_data );
 		$this->assertEquals( $asset_group_data, $this->asset_group->get_asset_groups_by_campaign_id( self::TEST_CAMPAIGN_ID ) );
-
 	}
 
 	public function test_get_asset_groups_by_campaign_id_without_assets() {
@@ -147,7 +146,6 @@ class AdsAssetGroupTest extends UnitTest {
 
 		$this->generate_ads_asset_groups_query_mock( $asset_group_data );
 		$this->assertEquals( $asset_group_data, $this->asset_group->get_asset_groups_by_campaign_id( self::TEST_CAMPAIGN_ID, $include_assets ) );
-
 	}
 
 	public function test_edit_asset_group_with_asset() {
@@ -269,7 +267,4 @@ class AdsAssetGroupTest extends UnitTest {
 			$this->assertEquals( 400, $e->getCode() );
 		}
 	}
-
-
-
 }

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -120,7 +120,6 @@ class AdsAssetTest extends UnitTest {
 
 		$this->generate_asset_mutate_mock( 'create', $data );
 		$this->assertEquals( $this->generate_asset_resource_name( $data['id'] ), $this->asset->create_assets( [ $data ] )[0] );
-
 	}
 
 	public function test_create_assets_image_asset() {
@@ -142,7 +141,6 @@ class AdsAssetTest extends UnitTest {
 
 			$this->generate_asset_mutate_mock( 'create', $data );
 			$this->assertEquals( $this->generate_asset_resource_name( $data['id'] ), $this->asset->create_assets( [ $data ] )[0] );
-
 	}
 
 	public function test_create_assets_image_asset_exception() {
@@ -173,7 +171,6 @@ class AdsAssetTest extends UnitTest {
 		$this->expectExceptionMessage( 'Asset Field type not supported' );
 
 		$this->asset->create_assets( [ $data ], self::TEMPORARY_ID );
-
 	}
 
 	public function test_create_one_batch() {
@@ -197,13 +194,11 @@ class AdsAssetTest extends UnitTest {
 			}
 
 			$this->assert_asset_content( $operations, $assets, $index );
-
 		};
 
 		$matcher = $this->exactly( 1 );
 		$this->generate_asset_batch_mutate_mock( $matcher, $assert_batches );
 		$this->asset->create_assets( $assets );
-
 	}
 
 	public function test_create_batches_multiple() {
@@ -236,13 +231,11 @@ class AdsAssetTest extends UnitTest {
 			}
 
 			$this->assert_asset_content( $operations, $assets, $index );
-
 		};
 
 		$matcher = $this->exactly( 3 );
 		$this->generate_asset_batch_mutate_mock( $matcher, $assert_batches );
 		$this->asset->create_assets( $assets, 5 * 1024 * 1024 );
-
 	}
 
 	/**
@@ -255,7 +248,7 @@ class AdsAssetTest extends UnitTest {
 	protected function assert_asset_content( $operations, $assets, $starting_index = 0 ) {
 		foreach ( $operations as $operation ) {
 			$this->assertEquals( $assets[ $starting_index ]['content'], $this->get_asset_content( $operation->getAssetOperation()->getCreate(), $assets[ $starting_index ]['field_type'] ) );
-			$starting_index++;
+			++$starting_index;
 		}
 	}
 
@@ -312,11 +305,10 @@ class AdsAssetTest extends UnitTest {
 				'headers' => new ArrayObject( [ 'content-length' => $size * 1024 * 1024 ] ),
 			];
 
-			$index++;
+			++$index;
 		}
 
 		return $responses;
-
 	}
 
 
@@ -340,8 +332,4 @@ class AdsAssetTest extends UnitTest {
 
 		return $assets;
 	}
-
-
-
-
 }

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -624,5 +624,4 @@ class AdsCampaignTest extends UnitTest {
 		$this->generate_ads_campaign_query_mock( $campaigns_data, [] );
 		$this->assertEquals( 'unconverted', $this->campaign->get_campaign_convert_status() );
 	}
-
 }

--- a/tests/Unit/API/Google/AdsConversionActionTest.php
+++ b/tests/Unit/API/Google/AdsConversionActionTest.php
@@ -157,5 +157,4 @@ class AdsConversionActionTest extends UnitTest {
 
 		$this->conversion_action->get_conversion_action( self::TEST_CONVERSION_ACTION_ID );
 	}
-
 }

--- a/tests/Unit/API/Google/AdsReportTest.php
+++ b/tests/Unit/API/Google/AdsReportTest.php
@@ -703,5 +703,4 @@ class AdsReportTest extends UnitTest {
 			$this->report->get_report_data( $report_type, $report_args )
 		);
 	}
-
 }

--- a/tests/Unit/API/Google/AdsTest.php
+++ b/tests/Unit/API/Google/AdsTest.php
@@ -282,5 +282,4 @@ class AdsTest extends UnitTest {
 			->willReturn( true );
 		$this->assertTrue( $this->ads->update_billing_url( self::TEST_BILLING_URL ) );
 	}
-
 }

--- a/tests/Unit/API/Google/MerchantMetricsTest.php
+++ b/tests/Unit/API/Google/MerchantMetricsTest.php
@@ -160,5 +160,4 @@ class MerchantMetricsTest extends UnitTest {
 
 		$this->assertSame( [], $this->metrics->get_ads_metrics() );
 	}
-
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -336,7 +336,7 @@ class MerchantTest extends UnitTest {
 			->method( 'custombatch' )
 			->with(
 				$this->callback(
-					function( ProductstatusesCustomBatchRequest $request ) {
+					function ( ProductstatusesCustomBatchRequest $request ) {
 						$this->assertEquals(
 							[
 								'batchId'    => 3,
@@ -408,7 +408,7 @@ class MerchantTest extends UnitTest {
 			->method( 'setAdsLinks' )
 			->with(
 				$this->callback(
-					function( array $links ) use ( $ads_id ) {
+					function ( array $links ) use ( $ads_id ) {
 						$this->assertEquals( $ads_id, $links[0]->getAdsId() );
 						$this->assertEquals( 'active', $links[0]->getStatus() );
 
@@ -519,5 +519,4 @@ class MerchantTest extends UnitTest {
 			->with( $this->merchant_id, $this->merchant_id )
 			->will( $this->throwException( $exception ) );
 	}
-
 }

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -450,5 +450,4 @@ class MiddlewareTest extends UnitTest {
 
 		$this->middleware->get_account_review_status();
 	}
-
 }

--- a/tests/Unit/API/Google/SiteVerificationTest.php
+++ b/tests/Unit/API/Google/SiteVerificationTest.php
@@ -140,5 +140,4 @@ class SiteVerificationTest extends UnitTest {
 		$this->verification_service->webResource->expects( $this->once() )
 			->method( 'insert' );
 	}
-
 }

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -214,5 +214,4 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( self::TEST_BILLING_STATUS_DATA, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
 	}
-
 }

--- a/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
@@ -169,7 +169,4 @@ class AssetGroupControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'error', $response->get_data()['message'] );
 		$this->assertEquals( 400, $response->get_status() );
 	}
-
-
-
 }

--- a/tests/Unit/API/Site/Controllers/Ads/AssetSuggestionsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetSuggestionsControllerTest.php
@@ -112,6 +112,4 @@ class AssetSuggestionsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'Invalid ID', $response->get_data()['message'] );
 		$this->assertEquals( 400, $response->get_status() );
 	}
-
-
 }

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -202,7 +202,7 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 		$this->ads_campaign->expects( $this->once() )
 			->method( 'create_campaign' )
 			->willReturnCallback(
-				function( array $data ) use ( $campaign_data, $expected ) {
+				function ( array $data ) use ( $campaign_data, $expected ) {
 					$name = $data['name'];
 					unset( $data['name'] );
 

--- a/tests/Unit/API/Site/Controllers/AttributeMapping/AttributeMappingDataControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/AttributeMapping/AttributeMappingDataControllerTest.php
@@ -83,5 +83,4 @@ class AttributeMappingDataControllerTest extends RESTControllerUnitTest {
 			$response->get_data()
 		);
 	}
-
 }

--- a/tests/Unit/API/Site/Controllers/AttributeMapping/AttributeMappingRulesControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/AttributeMapping/AttributeMappingRulesControllerTest.php
@@ -59,7 +59,6 @@ class AttributeMappingRulesControllerTest extends RESTControllerUnitTest {
 		$this->attribute_mapping_rules_query = $this->createMock( AttributeMappingRulesQuery::class );
 		$this->controller                    = new AttributeMappingRulesController( $this->server, $this->attribute_mapping_helper, $this->attribute_mapping_rules_query );
 		$this->controller->register();
-
 	}
 
 
@@ -160,7 +159,6 @@ class AttributeMappingRulesControllerTest extends RESTControllerUnitTest {
 			],
 			$response->get_headers()
 		);
-
 	}
 
 	public function test_create_rule_route() {
@@ -273,7 +271,6 @@ class AttributeMappingRulesControllerTest extends RESTControllerUnitTest {
 			]
 		);
 		$this->assertEquals( 400, $response->get_status() );
-
 	}
 
 	public function test_delete_rule_route() {

--- a/tests/Unit/API/Site/Controllers/AttributeMapping/AttributeMappingSyncerControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/AttributeMapping/AttributeMappingSyncerControllerTest.php
@@ -102,5 +102,4 @@ class AttributeMappingSyncerControllerTest extends RESTControllerUnitTest {
 			$response->get_data()
 		);
 	}
-
 }

--- a/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
+++ b/tests/Unit/API/Site/Controllers/CountryCodeTraitTest.php
@@ -40,7 +40,7 @@ class CountryCodeTraitTest extends TestCase {
 		$this->iso_provider  = $this->createMock( ISO3166DataProvider::class );
 		$this->google_helper = $this->createMock( GoogleHelper::class );
 
-		// phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
+		// phpcs:ignore Universal.Classes.RequireAnonClassParentheses.Missing
 		$this->trait = new class {
 			use CountryCodeTrait {
 				get_country_code_sanitize_callback as public;

--- a/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
@@ -180,5 +180,4 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		);
 		$this->assertEquals( 200, $response->get_status() );
 	}
-
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/AccountControllerTest.php
@@ -217,5 +217,4 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		);
 		$this->assertEquals( 200, $response->get_status() );
 	}
-
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
@@ -138,5 +138,4 @@ class PhoneVerificationControllerTest extends RESTControllerUnitTest {
 			$response->get_data()
 		);
 	}
-
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -454,7 +454,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_exception_in_request_route() {
-		 $this->middleware->expects( $this->once() )
+		$this->middleware->expects( $this->once() )
 			->method( 'get_account_review_status' )
 			->willReturn(
 				[
@@ -477,7 +477,6 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_post_request_review();
 		$this->assertEquals( 'error', $response->get_data()['message'] );
 		$this->assertEquals( 401, $response->get_status() );
-
 	}
 
 	private function do_post_request_review() {

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingRateControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingRateControllerTest.php
@@ -91,5 +91,4 @@ class ShippingRateControllerTest extends RESTControllerUnitTest {
 		// Confirm that the 'options' value is an object, not an array.
 		$this->assertIsObject( $data[0]['options'] );
 	}
-
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
@@ -46,7 +46,7 @@ class ShippingTimeBatchControllerTest extends RESTControllerUnitTest {
 			'/mc/shipping/times',
 			[
 				'methods'  => TransportMethods::CREATABLE,
-				'callback' => function( $request ) {
+				'callback' => function ( $request ) {
 					return new Response( $request->get_param( 'country_code' ), 201 );
 				},
 			]

--- a/tests/Unit/API/Site/Controllers/ToursControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/ToursControllerTest.php
@@ -44,7 +44,6 @@ class ToursControllerTest extends RESTControllerUnitTest {
 		$this->controller = new TourController( $this->server );
 		$this->controller->register();
 		$this->controller->set_options_object( $this->options );
-
 	}
 
 

--- a/tests/Unit/Admin/RedirectsTest.php
+++ b/tests/Unit/Admin/RedirectsTest.php
@@ -52,17 +52,17 @@ class RedirectsTest extends TestCase {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
 		$this->merchant_center->method( 'is_setup_complete' )
-							  ->willReturn( false );
+			->willReturn( false );
 
 		$this->assertFalse( $redirect_instance->maybe_redirect() );
 
 		$redirect_instance->method( 'is_current_wc_admin_page' )
-						  ->with( Dashboard::PATH )
-						  ->willReturn( true );
+			->with( Dashboard::PATH )
+			->willReturn( true );
 
 		$redirect_instance->expects( $this->once() )
-						  ->method( 'redirect_to' )
-						  ->with( GetStarted::PATH );
+			->method( 'redirect_to' )
+			->with( GetStarted::PATH );
 
 		$this->assertNull( $redirect_instance->maybe_redirect() );
 	}
@@ -78,17 +78,17 @@ class RedirectsTest extends TestCase {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
 		$this->merchant_center->method( 'is_setup_complete' )
-							  ->willReturn( true );
+			->willReturn( true );
 
 		$this->assertFalse( $redirect_instance->maybe_redirect() );
 
 		$redirect_instance->method( 'is_current_wc_admin_page' )
-						  ->with( GetStarted::PATH )
-						  ->willReturn( true );
+			->with( GetStarted::PATH )
+			->willReturn( true );
 
 		$redirect_instance->expects( $this->once() )
-						  ->method( 'redirect_to' )
-						  ->with( Dashboard::PATH );
+			->method( 'redirect_to' )
+			->with( Dashboard::PATH );
 
 		$this->assertNull( $redirect_instance->maybe_redirect() );
 	}
@@ -116,9 +116,9 @@ class RedirectsTest extends TestCase {
 	 */
 	private function get_redirect_instance( $only_methods = [] ): object {
 		$instance = $this->getMockBuilder( Redirect::class )
-						 ->setConstructorArgs( [ $this->wp ] )
-						 ->onlyMethods( $only_methods )
-						 ->getMock();
+			->setConstructorArgs( [ $this->wp ] )
+			->onlyMethods( $only_methods )
+			->getMock();
 
 		$instance->set_options_object( $this->options );
 		$instance->set_merchant_center_object( $this->merchant_center );

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -481,5 +481,4 @@ class AccountServiceTest extends UnitTest {
 
 		$this->account->disconnect();
 	}
-
 }

--- a/tests/Unit/Ads/AdsServiceTest.php
+++ b/tests/Unit/Ads/AdsServiceTest.php
@@ -37,7 +37,6 @@ class AdsServiceTest extends UnitTest {
 
 		$this->ads_service = new AdsService( $this->state );
 		$this->ads_service->set_options_object( $this->options );
-
 	}
 
 	public function test_is_setup_started() {
@@ -47,7 +46,6 @@ class AdsServiceTest extends UnitTest {
 			->willReturn( null );
 
 		$this->assertTrue( $this->ads_service->is_setup_started() );
-
 	}
 
 	public function test_is_setup_started_last_incomplete_step_is_empty() {
@@ -57,7 +55,6 @@ class AdsServiceTest extends UnitTest {
 			->willReturn( null );
 
 		$this->assertFalse( $this->ads_service->is_setup_started() );
-
 	}
 
 	public function test_is_setup_started_already_completed() {
@@ -67,7 +64,5 @@ class AdsServiceTest extends UnitTest {
 			->willReturn( 123 );
 
 		$this->assertFalse( $this->ads_service->is_setup_started() );
-
 	}
 }
-

--- a/tests/Unit/Ads/AssetSuggestionsServiceTest.php
+++ b/tests/Unit/Ads/AssetSuggestionsServiceTest.php
@@ -138,7 +138,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		// Disable logo image by default. There is a specific test for the logo asset.
 		add_filter( 'theme_mod_custom_logo', '__return_false' );
-
 	}
 
 	protected function format_url_post_item( $post ) {
@@ -183,7 +182,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			],
 			$this->get_suggestions_common_fields( $marketing_images )
 		);
-
 	}
 
 	protected function format_term_asset_response( $term, array $marketing_images = [] ): array {
@@ -197,7 +195,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			],
 			$this->get_suggestions_common_fields( $marketing_images )
 		);
-
 	}
 
 	protected function get_suggestions_common_fields( $marketing_images ) {
@@ -209,7 +206,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			AssetFieldType::PORTRAIT_MARKETING_IMAGE => $marketing_images[ self::PORTRAIT_MARKETING_IMAGE_KEY ] ?? [],
 			AssetFieldType::CALL_TO_ACTION_SELECTION => null,
 		];
-
 	}
 
 	protected function update_size_image( int $attachmend_id, DimensionUtility $size, array $size_types = [] ): void {
@@ -503,7 +499,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$images[ self::PORTRAIT_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_id, self::PORTRAIT_MARKETING_IMAGE_KEY ) ];
 
 		$this->assertEquals( $this->format_post_asset_response( $post, $images ), $this->asset_suggestions->get_assets_suggestions( $post->ID, 'post' ) );
-
 	}
 
 	public function test_get_shop_assets() {
@@ -637,7 +632,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$images[ self::PORTRAIT_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_post_2 ) ];
 
 		$this->assertEquals( $this->format_term_asset_response( $this->term, $images ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
-
 	}
 
 	public function test_get_term_without_product() {
@@ -652,7 +646,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->willReturnOnConsecutiveCalls( $posts_ids_assigned_to_term, [] );
 
 		$this->assertEquals( $this->format_term_asset_response( $this->term ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
-
 	}
 
 	public function test_get_term_without_assigned_posts() {
@@ -666,7 +659,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->willReturn( $posts_ids_assigned_to_term );
 
 		$this->assertEquals( $this->format_term_asset_response( $this->term, [] ), $this->asset_suggestions->get_assets_suggestions( $this->term->term_id, 'term' ) );
-
 	}
 
 	public function test_get_invalid_term_id() {
@@ -679,7 +671,7 @@ class AssetSuggestionsServiceTest extends UnitTest {
 
 		add_filter(
 			'theme_mod_custom_logo',
-			function() use ( $image_id ) {
+			function () use ( $image_id ) {
 				return $image_id; }
 		);
 
@@ -696,7 +688,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$images[ self::LOGO_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_id ) ];
 
 		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
 	}
 
 
@@ -722,7 +713,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$images[ self::PORTRAIT_MARKETING_IMAGE_KEY ] = [ wp_get_attachment_image_url( $image_id ) ];
 
 		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
 	}
 
 	public function tests_assets_image_too_small_size() {
@@ -747,7 +737,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 		$images[ self::PORTRAIT_MARKETING_IMAGE_KEY ] = [];
 
 		$this->assertEquals( $this->format_post_asset_response( $this->post, $images ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
 	}
 
 	public function test_get_asset_suggestions_with_empty_asset_group() {
@@ -757,7 +746,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			->willReturn( [] );
 
 			$this->assertEquals( $this->format_post_asset_response( $this->post ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
 	}
 
 	public function test_get_asset_suggestions_with_assets_from_asset_group() {
@@ -780,7 +768,6 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			];
 
 			$this->assertEquals( array_merge( $this->get_suggestions_common_fields( [] ), $expected ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
 	}
 
 	public function test_get_asset_suggestions_with_assets_from_asset_group_empty_call_to_action() {
@@ -802,7 +789,5 @@ class AssetSuggestionsServiceTest extends UnitTest {
 			];
 
 			$this->assertEquals( array_merge( $this->get_suggestions_common_fields( [] ), $expected ), $this->asset_suggestions->get_assets_suggestions( $this->post->ID, 'post' ) );
-
 	}
-
 }

--- a/tests/Unit/Coupon/CouponMetaHandlerTest.php
+++ b/tests/Unit/Coupon/CouponMetaHandlerTest.php
@@ -53,22 +53,22 @@ class CouponMetaHandlerTest extends WP_UnitTestCase {
 		$value  = 12345;
 
 		$coupon_meta_handler = $this->getMockBuilder( CouponMetaHandler::class )
-									 ->setMethodsExcept( [ '__call' ] )
-									 ->getMock();
+			->setMethodsExcept( [ '__call' ] )
+			->getMock();
 
 		$coupon_meta_handler->expects( $this->once() )
-							 ->method( 'update' )
-							 ->with( $this->equalTo( $coupon ), $this->equalTo( $key ), $this->equalTo( $value ) );
+			->method( 'update' )
+			->with( $this->equalTo( $coupon ), $this->equalTo( $key ), $this->equalTo( $value ) );
 		$coupon_meta_handler->update_synced_at( $coupon, $value );
 
 		$coupon_meta_handler->expects( $this->once() )
-							 ->method( 'get' )
-							 ->with( $this->equalTo( $coupon ), $this->equalTo( $key ) );
+			->method( 'get' )
+			->with( $this->equalTo( $coupon ), $this->equalTo( $key ) );
 		$coupon_meta_handler->get_synced_at( $coupon );
 
 		$coupon_meta_handler->expects( $this->once() )
-							 ->method( 'delete' )
-							 ->with( $this->equalTo( $coupon ), $this->equalTo( $key ) );
+			->method( 'delete' )
+			->with( $this->equalTo( $coupon ), $this->equalTo( $key ) );
 		$coupon_meta_handler->delete_synced_at( $coupon );
 	}
 

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -177,8 +177,8 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 
 		$this->target_audience = $this->createMock( TargetAudience::class );
 		$this->target_audience->expects( $this->any() )
-							  ->method( 'get_main_target_country' )
-							  ->willReturn( $this->get_sample_target_country() );
+			->method( 'get_main_target_country' )
+			->willReturn( $this->get_sample_target_country() );
 
 		$this->google_service = $this->createMock( GooglePromotionService::class );
 		$this->validator      = $this->createMock( ValidatorInterface::class );

--- a/tests/Unit/DB/Migration/MigratorTest.php
+++ b/tests/Unit/DB/Migration/MigratorTest.php
@@ -17,7 +17,7 @@ class MigratorTest extends UnitTest {
 	public function test_does_not_run_migrations_if_no_version_change() {
 		$mock_migration_1 = $this->createMock( MigrationInterface::class );
 		$mock_migration_1->expects( $this->never() )
-						 ->method( 'apply' );
+			->method( 'apply' );
 
 		$migrator = new Migrator( [ $mock_migration_1 ] );
 
@@ -27,38 +27,38 @@ class MigratorTest extends UnitTest {
 	public function test_runs_matching_migrations_if_version_increase() {
 		$mock_migration_0 = $this->createMock( MigrationInterface::class );
 		$mock_migration_0->expects( $this->any() )
-						 ->method( 'get_applicable_version' )
-						 ->willReturn( '1.2.0' );
+			->method( 'get_applicable_version' )
+			->willReturn( '1.2.0' );
 		$mock_migration_0->expects( $this->once() )
-						 ->method( 'apply' );
+			->method( 'apply' );
 
 		$mock_migration_1 = $this->createMock( MigrationInterface::class );
 		$mock_migration_1->expects( $this->any() )
-						 ->method( 'get_applicable_version' )
-						 ->willReturn( '1.1.5' );
+			->method( 'get_applicable_version' )
+			->willReturn( '1.1.5' );
 		$mock_migration_1->expects( $this->once() )
-						 ->method( 'apply' );
+			->method( 'apply' );
 
 		$mock_migration_2 = $this->createMock( MigrationInterface::class );
 		$mock_migration_2->expects( $this->any() )
-						 ->method( 'get_applicable_version' )
-						 ->willReturn( '1.1.0' );
+			->method( 'get_applicable_version' )
+			->willReturn( '1.1.0' );
 		$mock_migration_2->expects( $this->once() )
-						 ->method( 'apply' );
+			->method( 'apply' );
 
 		$mock_migration_3 = $this->createMock( MigrationInterface::class );
 		$mock_migration_3->expects( $this->any() )
-						 ->method( 'get_applicable_version' )
-						 ->willReturn( '1.0.0' );
+			->method( 'get_applicable_version' )
+			->willReturn( '1.0.0' );
 		$mock_migration_3->expects( $this->never() )
-						 ->method( 'apply' );
+			->method( 'apply' );
 
 		$mock_migration_4 = $this->createMock( MigrationInterface::class );
 		$mock_migration_4->expects( $this->any() )
-						 ->method( 'get_applicable_version' )
-						 ->willReturn( '0.9.0' );
+			->method( 'get_applicable_version' )
+			->willReturn( '0.9.0' );
 		$mock_migration_4->expects( $this->never() )
-						 ->method( 'apply' );
+			->method( 'apply' );
 
 		$migrator = new Migrator( [ $mock_migration_0, $mock_migration_1, $mock_migration_2, $mock_migration_3, $mock_migration_4 ] );
 

--- a/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
+++ b/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
@@ -33,12 +33,12 @@ class BudgetRecommendationTableTest extends UnitTest {
 
 		$this->wp   = $this->createMock( WP::class );
 		$this->wpdb = $this->getMockBuilder( wpdb::class )
-						 ->setMethods( [ 'query', 'prepare' ] )
-						 ->disableOriginalConstructor()
-						 ->disableOriginalClone()
-						 ->disableArgumentCloning()
-						 ->disallowMockingUnknownTypes()
-						 ->getMock();
+			->setMethods( [ 'query', 'prepare' ] )
+			->disableOriginalConstructor()
+			->disableOriginalClone()
+			->disableArgumentCloning()
+			->disallowMockingUnknownTypes()
+			->getMock();
 
 		$this->mock_budget_recommendation = $this->getMockBuilder( BudgetRecommendationTable::class )
 						->setMethods( [ 'exists', 'truncate', 'get_sql_safe_name' ] )
@@ -54,11 +54,11 @@ class BudgetRecommendationTableTest extends UnitTest {
 
 	public function test_reload_data_when_table_exists() {
 		$this->mock_budget_recommendation->expects( $this->once() )
-						 ->method( 'exists' )
-						 ->willReturn( true );
+			->method( 'exists' )
+			->willReturn( true );
 
 		$this->mock_budget_recommendation->expects( $this->once() )
-						 ->method( 'truncate' );
+			->method( 'truncate' );
 
 		$this->wpdb->expects( $this->atLeastOnce() )
 		->method( 'query' );
@@ -70,37 +70,34 @@ class BudgetRecommendationTableTest extends UnitTest {
 
 	public function test_reload_data_when_table_does_not_exist() {
 		$this->mock_budget_recommendation->expects( $this->once() )
-						 ->method( 'exists' )
-						 ->willReturn( false );
+			->method( 'exists' )
+			->willReturn( false );
 
 		$this->mock_budget_recommendation->expects( $this->exactly( 0 ) )
-						 ->method( 'truncate' );
+			->method( 'truncate' );
 
 		$this->wpdb->expects( $this->exactly( 0 ) )
-						 ->method( 'query' );
+			->method( 'query' );
 
 		$this->mock_budget_recommendation->reload_data();
 
 		$this->assertFalse( $this->mock_budget_recommendation->has_loaded_initial_data );
-
 	}
 
 	public function test_reload_data_when_table_exists_but_data_was_loaded_earlier() {
 		$this->mock_budget_recommendation->expects( $this->once() )
-						 ->method( 'exists' )
-						 ->willReturn( true );
+			->method( 'exists' )
+			->willReturn( true );
 
 		$this->mock_budget_recommendation->expects( $this->exactly( 0 ) )
-						 ->method( 'truncate' );
+			->method( 'truncate' );
 
 		$this->wpdb->expects( $this->exactly( 0 ) )
-						 ->method( 'query' );
+			->method( 'query' );
 
 		// If the table has been deleted or if it is a first installation, the BudgetRecommendationTable::install loads the data
 		$this->mock_budget_recommendation->has_loaded_initial_data = true;
 
 		$this->mock_budget_recommendation->reload_data();
-
 	}
-
 }

--- a/tests/Unit/Google/SiteVerificationMetaTest.php
+++ b/tests/Unit/Google/SiteVerificationMetaTest.php
@@ -62,5 +62,4 @@ class SiteVerificationMetaTest extends UnitTest {
 		do_action( 'wp_head' );
 		return ob_get_clean();
 	}
-
 }

--- a/tests/Unit/Integration/YoastWooCommerceSeoTest.php
+++ b/tests/Unit/Integration/YoastWooCommerceSeoTest.php
@@ -211,5 +211,4 @@ class YoastWooCommerceSeoTest extends UnitTest {
 		$this->assertEquals( self::TEST_GTIN, $adapted_one->getGtin() );
 		$this->assertEquals( '78901234', $adapted_two->getGtin() );
 	}
-
 }

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -36,73 +36,73 @@ class UpdateShippingSettingsTest extends UnitTest {
 
 	public function test_job_is_scheduled() {
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
-							  ->willReturn( true );
+			->method( 'is_connected' )
+			->willReturn( true );
 		$this->google_settings->expects( $this->any() )
-							  ->method( 'should_get_shipping_rates_from_woocommerce' )
-							  ->willReturn( true );
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( true );
 
 		$this->action_scheduler->expects( $this->once() )
-							   ->method( 'schedule_immediate' )
-							   ->with( $this->job->get_process_item_hook() );
+			->method( 'schedule_immediate' )
+			->with( $this->job->get_process_item_hook() );
 
 		$this->job->schedule();
 	}
 
 	public function test_job_is_not_scheduled_if_shipping_not_set_to_automatic_sync() {
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
-							  ->willReturn( true );
+			->method( 'is_connected' )
+			->willReturn( true );
 		$this->google_settings->expects( $this->any() )
-							  ->method( 'should_get_shipping_rates_from_woocommerce' )
-							  ->willReturn( false );
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( false );
 
 		$this->action_scheduler->expects( $this->never() )
-							   ->method( 'schedule_immediate' )
-							   ->with( $this->job->get_process_item_hook() );
+			->method( 'schedule_immediate' )
+			->with( $this->job->get_process_item_hook() );
 
 		$this->job->schedule();
 	}
 
 	public function test_job_is_not_scheduled_if_mc_not_connected() {
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
-							  ->willReturn( false );
+			->method( 'is_connected' )
+			->willReturn( false );
 		$this->google_settings->expects( $this->any() )
-							  ->method( 'should_get_shipping_rates_from_woocommerce' )
-							  ->willReturn( true );
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( true );
 
 		$this->action_scheduler->expects( $this->never() )
-							   ->method( 'schedule_immediate' )
-							   ->with( $this->job->get_process_item_hook() );
+			->method( 'schedule_immediate' )
+			->with( $this->job->get_process_item_hook() );
 
 		$this->job->schedule();
 	}
 
 	public function test_process_items() {
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
-							  ->willReturn( true );
+			->method( 'is_connected' )
+			->willReturn( true );
 		$this->google_settings->expects( $this->any() )
-							  ->method( 'should_get_shipping_rates_from_woocommerce' )
-							  ->willReturn( true );
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( true );
 
 		$this->google_settings->expects( $this->once() )
-							  ->method( 'sync_shipping' );
+			->method( 'sync_shipping' );
 
 		do_action( $this->job->get_process_item_hook(), [] );
 	}
 
 	public function test_process_items_fails_if_mc_not_connected() {
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
-							  ->willReturn( false );
+			->method( 'is_connected' )
+			->willReturn( false );
 		$this->google_settings->expects( $this->any() )
-							  ->method( 'should_get_shipping_rates_from_woocommerce' )
-							  ->willReturn( true );
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( true );
 
 		$this->google_settings->expects( $this->never() )
-							  ->method( 'sync_shipping' );
+			->method( 'sync_shipping' );
 
 		$this->expectException( JobException::class );
 
@@ -111,14 +111,14 @@ class UpdateShippingSettingsTest extends UnitTest {
 
 	public function test_process_items_fails_if_shipping_not_set_to_automatic_sync() {
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_connected' )
-							  ->willReturn( true );
+			->method( 'is_connected' )
+			->willReturn( true );
 		$this->google_settings->expects( $this->any() )
-							  ->method( 'should_get_shipping_rates_from_woocommerce' )
-							  ->willReturn( false );
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( false );
 
 		$this->google_settings->expects( $this->never() )
-							  ->method( 'sync_shipping' );
+			->method( 'sync_shipping' );
 
 		$this->expectException( JobException::class );
 
@@ -139,5 +139,4 @@ class UpdateShippingSettingsTest extends UnitTest {
 
 		$this->job->init();
 	}
-
 }

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -724,5 +724,4 @@ class AccountServiceTest extends UnitTest {
 
 		$this->account->disconnect();
 	}
-
 }

--- a/tests/Unit/MerchantCenter/ContactInformationTest.php
+++ b/tests/Unit/MerchantCenter/ContactInformationTest.php
@@ -42,16 +42,16 @@ class ContactInformationTest extends ContainerAwareUnitTest {
 
 	public function test_get_empty_contact_information() {
 		$this->merchant->expects( $this->any() )
-					   ->method( 'get_account' )
-					   ->willReturn( $this->get_empty_account() );
+			->method( 'get_account' )
+			->willReturn( $this->get_empty_account() );
 
 		$this->assertNull( $this->contact_information->get_contact_information() );
 	}
 
 	public function test_get_valid_contact_information() {
 		$this->merchant->expects( $this->any() )
-					   ->method( 'get_account' )
-					   ->willReturn( $this->get_valid_account() );
+			->method( 'get_account' )
+			->willReturn( $this->get_valid_account() );
 
 		$contact_information = $this->contact_information->get_contact_information();
 
@@ -84,12 +84,12 @@ class ContactInformationTest extends ContainerAwareUnitTest {
 
 	public function test_update_address() {
 		$this->merchant->expects( $this->any() )
-					   ->method( 'get_account' )
-					   ->willReturn( $this->get_valid_account() );
+			->method( 'get_account' )
+			->willReturn( $this->get_valid_account() );
 
 		$this->google_settings->expects( $this->any() )
-							  ->method( 'get_store_address' )
-							  ->willReturn( $this->get_sample_address() );
+			->method( 'get_store_address' )
+			->willReturn( $this->get_sample_address() );
 
 		$results = $this->contact_information->update_address_based_on_store_settings();
 
@@ -117,8 +117,8 @@ class ContactInformationTest extends ContainerAwareUnitTest {
 
 	public function test_get_account_exception() {
 		$this->merchant->expects( $this->any() )
-					   ->method( 'get_account' )
-					   ->willThrowException( $this->get_google_exception() );
+			->method( 'get_account' )
+			->willThrowException( $this->get_google_exception() );
 
 		$this->expectExceptionObject( $this->get_google_exception() );
 		$this->contact_information->get_contact_information();

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -624,5 +624,4 @@ class MerchantCenterServiceTest extends UnitTest {
 
 		$this->assertTrue( $this->mc_service->has_at_least_one_synced_product() );
 	}
-
 }

--- a/tests/Unit/MerchantCenter/PhoneVerificationTest.php
+++ b/tests/Unit/MerchantCenter/PhoneVerificationTest.php
@@ -35,15 +35,15 @@ class PhoneVerificationTest extends UnitTest {
 
 	public function test_request_phone_verification() {
 		$this->iso_utility->expects( $this->any() )
-						  ->method( 'wp_locale_to_bcp47' )
-						  ->willReturn( 'fr-CA' );
+			->method( 'wp_locale_to_bcp47' )
+			->willReturn( 'fr-CA' );
 		$this->merchant->expects( $this->any() )
-					   ->method( 'request_phone_verification' )
-					   ->with( $this->anything(), $this->anything(), $this->anything(), $this->equalTo( 'fr-CA' ) )
-					   ->willReturn( 'some_verification_id' );
+			->method( 'request_phone_verification' )
+			->with( $this->anything(), $this->anything(), $this->anything(), $this->equalTo( 'fr-CA' ) )
+			->willReturn( 'some_verification_id' );
 		$this->iso_utility->expects( $this->any() )
-						  ->method( 'is_iso3166_alpha2_country_code' )
-						  ->willReturn( true );
+			->method( 'is_iso3166_alpha2_country_code' )
+			->willReturn( true );
 
 		$this->assertEquals(
 			'some_verification_id',
@@ -53,8 +53,8 @@ class PhoneVerificationTest extends UnitTest {
 
 	public function test_request_phone_verification_invalid_verification_method() {
 		$this->iso_utility->expects( $this->any() )
-						  ->method( 'is_iso3166_alpha2_country_code' )
-						  ->willReturn( true );
+			->method( 'is_iso3166_alpha2_country_code' )
+			->willReturn( true );
 
 		$this->expectException( InvalidValue::class );
 
@@ -63,8 +63,8 @@ class PhoneVerificationTest extends UnitTest {
 
 	public function test_request_phone_verification_invalid_phone_region() {
 		$this->iso_utility->expects( $this->any() )
-						  ->method( 'is_iso3166_alpha2_country_code' )
-						  ->willReturn( false );
+			->method( 'is_iso3166_alpha2_country_code' )
+			->willReturn( false );
 
 		$this->expectException( InvalidValue::class );
 
@@ -73,8 +73,8 @@ class PhoneVerificationTest extends UnitTest {
 
 	public function test_map_google_exception() {
 		$this->iso_utility->expects( $this->any() )
-						  ->method( 'is_iso3166_alpha2_country_code' )
-						  ->willReturn( true );
+			->method( 'is_iso3166_alpha2_country_code' )
+			->willReturn( true );
 
 		$google_exception = new GoogleServiceException(
 			'Retries quota exceeded.',
@@ -89,8 +89,8 @@ class PhoneVerificationTest extends UnitTest {
 			]
 		);
 		$this->merchant->expects( $this->any() )
-					   ->method( 'request_phone_verification' )
-					   ->willThrowException( $google_exception );
+			->method( 'request_phone_verification' )
+			->willThrowException( $google_exception );
 
 		$this->expectException( PhoneVerificationException::class );
 		$this->expectExceptionMessage( 'Retries quota exceeded.' );

--- a/tests/Unit/MerchantCenter/ValidateAddressTest.php
+++ b/tests/Unit/MerchantCenter/ValidateAddressTest.php
@@ -117,6 +117,4 @@ class ValidateAddressTest extends ContainerAwareUnitTest {
 			count( $errors )
 		);
 	}
-
-
 }

--- a/tests/Unit/MultichannelMarketing/GLAChannelTest.php
+++ b/tests/Unit/MultichannelMarketing/GLAChannelTest.php
@@ -227,5 +227,4 @@ class GLAChannelTest extends UnitTest {
 			$this->product_sync_stats
 		);
 	}
-
 }

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -364,7 +364,6 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$this->assertEquals( '', $adapted_product->getBrand() );
 		$this->assertEquals( 'test', $adapted_product->getGtin() );
 		$this->assertEquals( '', $adapted_product->getMpn() );
-
 	}
 
 	/**

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -189,11 +189,11 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$products = $this->create_and_return_supported_test_products();
 
 		$this->target_audience->expects( $this->any() )
-							  ->method( 'get_main_target_country' )
-							  ->willReturn( 'US' );
+			->method( 'get_main_target_country' )
+			->willReturn( 'US' );
 		$this->validator->expects( $this->any() )
-						->method( 'validate' )
-						->willReturn( [] );
+			->method( 'validate' )
+			->willReturn( [] );
 
 		$this->rules_query->expects( $this->any() )
 			->method( 'get_results' )
@@ -233,28 +233,28 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$invalid_product = $products[0];
 
 		$this->validator->expects( $this->any() )
-						->method( 'validate' )
-						->willReturnCallback(
-							function ( WCProductAdapter $product ) use ( $invalid_product ) {
-								if ( $product->get_wc_product()->get_id() === $invalid_product->get_id() ) {
-									$violation_example = $this->createMock( ConstraintViolation::class );
-									$violations        = new ConstraintViolationList();
-									$violations->add( $violation_example );
+			->method( 'validate' )
+			->willReturnCallback(
+				function ( WCProductAdapter $product ) use ( $invalid_product ) {
+					if ( $product->get_wc_product()->get_id() === $invalid_product->get_id() ) {
+						$violation_example = $this->createMock( ConstraintViolation::class );
+						$violations        = new ConstraintViolationList();
+						$violations->add( $violation_example );
 
-									return $violations;
-								}
+						return $violations;
+					}
 
-								return [];
-							}
-						);
+					return [];
+				}
+			);
 
 		$this->rules_query->expects( $this->any() )
 			->method( 'get_results' )
 			->willReturn( [] );
 
 		$this->target_audience->expects( $this->any() )
-							  ->method( 'get_main_target_country' )
-							  ->willReturn( 'US' );
+			->method( 'get_main_target_country' )
+			->willReturn( 'US' );
 
 		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( $products );
 
@@ -280,11 +280,11 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		}
 
 		$this->target_audience->expects( $this->any() )
-							  ->method( 'get_main_target_country' )
-							  ->willReturn( 'US' );
+			->method( 'get_main_target_country' )
+			->willReturn( 'US' );
 		$this->validator->expects( $this->any() )
-						->method( 'validate' )
-						->willReturn( [] );
+			->method( 'validate' )
+			->willReturn( [] );
 		$this->rules_query->expects( $this->any() )
 			->method( 'get_results' )
 			->willReturn( [] );
@@ -316,11 +316,11 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$stale_product_id = $stale_product->get_id();
 
 		$this->target_audience->expects( $this->once() )
-							  ->method( 'get_target_countries' )
-							  ->willReturn( [ 'US' ] );
+			->method( 'get_target_countries' )
+			->willReturn( [ 'US' ] );
 		$this->target_audience->expects( $this->any() )
-							  ->method( 'get_main_target_country' )
-							  ->willReturn( 'US' );
+			->method( 'get_main_target_country' )
+			->willReturn( 'US' );
 
 		$stale_google_ids = [
 			'AU' => "online:en:AU:gla_{$stale_product_id}",
@@ -347,8 +347,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$stale_product_id = $stale_product->get_id();
 
 		$this->target_audience->expects( $this->once() )
-							  ->method( 'get_main_target_country' )
-							  ->willReturn( 'US' );
+			->method( 'get_main_target_country' )
+			->willReturn( 'US' );
 
 		$stale_google_ids = [
 			'AU' => "online:en:AU:gla_{$stale_product_id}",

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -102,8 +102,8 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$google_product = $this->generate_google_product_mock();
 
 		$this->target_audience->expects( $this->any() )
-							  ->method( 'get_target_countries' )
-							  ->willReturn( [ 'AU', $google_product->getTargetCountry() ] );
+			->method( 'get_target_countries' )
+			->willReturn( [ 'AU', $google_product->getTargetCountry() ] );
 
 		// add some random errors residue from previous sync attempts
 		$this->product_meta->update_errors( $product, [ 'Error 1', 'Error 2' ] );
@@ -131,8 +131,8 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$variation      = $this->wc->get_product( $parent->get_children()[0] );
 
 		$this->target_audience->expects( $this->any() )
-							  ->method( 'get_target_countries' )
-							  ->willReturn( [ $this->get_sample_target_country() ] );
+			->method( 'get_target_countries' )
+			->willReturn( [ $this->get_sample_target_country() ] );
 
 		// add some random errors residue from previous sync attempts
 		$this->product_meta->update_errors( $variation, [ 'Error 1', 'Error 2' ] );
@@ -170,8 +170,8 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$variation->save();
 
 		$this->target_audience->expects( $this->any() )
-							  ->method( 'get_target_countries' )
-							  ->willReturn( [ $this->get_sample_target_country() ] );
+			->method( 'get_target_countries' )
+			->willReturn( [ $this->get_sample_target_country() ] );
 
 		$this->product_helper->mark_as_synced( $variation, $google_product );
 
@@ -383,7 +383,6 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 			$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
 			$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
 		}
-
 	}
 
 	public function test_mark_as_invalid_does_not_update_parent_if_orphan_variation() {
@@ -499,7 +498,6 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertEquals( 1234567, $this->product_helper->get_wc_product_id( 'gla_1234567' ) );
 		// Invalid ID, not WC product or custom map
 		$this->assertEquals( 0, $this->product_helper->get_wc_product_id( 'online:en:US:not_gla_or_mapped' ) );
-
 	}
 
 	public function test_get_wc_product_title() {

--- a/tests/Unit/Product/ProductMetaHandlerTest.php
+++ b/tests/Unit/Product/ProductMetaHandlerTest.php
@@ -53,22 +53,22 @@ class ProductMetaHandlerTest extends WP_UnitTestCase {
 		$value   = 12345;
 
 		$product_meta_handler = $this->getMockBuilder( ProductMetaHandler::class )
-									 ->setMethodsExcept( [ '__call' ] )
-									 ->getMock();
+			->setMethodsExcept( [ '__call' ] )
+			->getMock();
 
 		$product_meta_handler->expects( $this->once() )
-							 ->method( 'update' )
-							 ->with( $this->equalTo( $product ), $this->equalTo( $key ), $this->equalTo( $value ) );
+			->method( 'update' )
+			->with( $this->equalTo( $product ), $this->equalTo( $key ), $this->equalTo( $value ) );
 		$product_meta_handler->update_synced_at( $product, $value );
 
 		$product_meta_handler->expects( $this->once() )
-							 ->method( 'get' )
-							 ->with( $this->equalTo( $product ), $this->equalTo( $key ) );
+			->method( 'get' )
+			->with( $this->equalTo( $product ), $this->equalTo( $key ) );
 		$product_meta_handler->get_synced_at( $product );
 
 		$product_meta_handler->expects( $this->once() )
-							 ->method( 'delete' )
-							 ->with( $this->equalTo( $product ), $this->equalTo( $key ) );
+			->method( 'delete' )
+			->with( $this->equalTo( $product ), $this->equalTo( $key ) );
 		$product_meta_handler->delete_synced_at( $product );
 	}
 

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -328,8 +328,8 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$product = WC_Helper_Product::create_simple_product();
 
 		$this->google_service->expects( $this->any() )
-							 ->method( 'insert_batch' )
-							 ->willThrowException( new GoogleException() );
+			->method( 'insert_batch' )
+			->willThrowException( new GoogleException() );
 
 		$this->expectException( ProductSyncerException::class );
 		$this->product_syncer->update_by_batch_requests( [ new BatchProductRequestEntry( $product->get_id(), $this->generate_adapted_product( $product ) ) ] );
@@ -339,8 +339,8 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$product = WC_Helper_Product::create_simple_product();
 
 		$this->google_service->expects( $this->any() )
-							 ->method( 'delete_batch' )
-							 ->willThrowException( new GoogleException() );
+			->method( 'delete_batch' )
+			->willThrowException( new GoogleException() );
 
 		$this->expectException( ProductSyncerException::class );
 		$this->product_syncer->delete_by_batch_requests( [ new BatchProductIDRequestEntry( $product->get_id(), $this->generate_google_id( $product ) ) ] );
@@ -540,12 +540,12 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		};
 
 		$this->google_service->expects( $this->any() )
-							 ->method( 'insert_batch' )
-							 ->willReturnCallback( $callback );
+			->method( 'insert_batch' )
+			->willReturnCallback( $callback );
 
 		$this->google_service->expects( $this->any() )
-							 ->method( 'delete_batch' )
-							 ->willReturnCallback( $callback );
+			->method( 'delete_batch' )
+			->willReturnCallback( $callback );
 	}
 
 	/**
@@ -579,8 +579,8 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->target_audience = $this->createMock( TargetAudience::class );
 		$this->merchant_center = $this->createMock( MerchantCenterService::class );
 		$this->merchant_center->expects( $this->any() )
-							  ->method( 'is_ready_for_syncing' )
-							  ->willReturn( true );
+			->method( 'is_ready_for_syncing' )
+			->willReturn( true );
 
 		$this->google_service = $this->createMock( GoogleProductService::class );
 		$this->rules_query    = $this->createMock( AttributeMappingRulesQuery::class );

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -225,7 +225,7 @@ class WCProductAdapterTest extends UnitTest {
 	public function test_get_google_product_offer_id_with_custom_mapping_filter() {
 		add_filter(
 			'woocommerce_gla_get_google_product_offer_id',
-			function( $mc_product_id, $woo_product_id ) {
+			function ( $mc_product_id, $woo_product_id ) {
 				if ( $woo_product_id === 25 ) {
 					$mc_product_id = 'custom_mapped_id';
 				}
@@ -377,7 +377,7 @@ class WCProductAdapterTest extends UnitTest {
 			false,
 			[
 				'description' => 'This product has a shortcode like [wc_gla_sample_test_shortcode] that will not get stripped out, ' .
-								 'along with an unregistered short code [some-test-short-code id=1] that will also remain intact.',
+					'along with an unregistered short code [some-test-short-code id=1] that will also remain intact.',
 			]
 		);
 		$adapted_product = new WCProductAdapter(

--- a/tests/Unit/Shipping/ShippingSuggestionServiceTest.php
+++ b/tests/Unit/Shipping/ShippingSuggestionServiceTest.php
@@ -119,8 +119,8 @@ class ShippingSuggestionServiceTest extends UnitTest {
 		parent::setUp();
 		$this->wc = $this->createMock( WC::class );
 		$this->wc->expects( $this->any() )
-				 ->method( 'get_woocommerce_currency' )
-				 ->willReturn( 'USD' );
+			->method( 'get_woocommerce_currency' )
+			->willReturn( 'USD' );
 
 		$this->shipping_zone = $this->createMock( ShippingZone::class );
 

--- a/tests/Unit/TaskList/CompleteSetupTaskTest.php
+++ b/tests/Unit/TaskList/CompleteSetupTaskTest.php
@@ -48,7 +48,6 @@ class CompleteSetupTaskTest extends UnitTest {
 	 */
 	public function test_register() {
 		$this->assertInstanceOf( CompleteSetupTask::class, TaskLists::get_list( 'extended' )->get_task( 'gla_complete_setup' ) );
-
 	}
 
 	public function test_id() {

--- a/tests/Unit/Utility/DimensionUtilityTest.php
+++ b/tests/Unit/Utility/DimensionUtilityTest.php
@@ -25,7 +25,6 @@ class DimensionUtilityTest extends UnitTest {
 		$image_2 = new DimensionUtility( 600, 300 );
 
 		$this->assertTrue( $image_1->is_minimum_size( $image_2 ) );
-
 	}
 
 	public function test_image_is_smaller_than_the_minimum_size() {
@@ -33,7 +32,6 @@ class DimensionUtilityTest extends UnitTest {
 		$image_2 = new DimensionUtility( 600, 300 );
 
 		$this->assertFalse( $image_1->is_minimum_size( $image_2 ) );
-
 	}
 
 	public function test_image_is_equal_with_default_precision() {
@@ -41,7 +39,6 @@ class DimensionUtilityTest extends UnitTest {
 		$image_2 = new DimensionUtility( 300, 400 );
 
 		$this->assertTrue( $image_1->equals( $image_2 ) );
-
 	}
 
 	public function test_image_is_equal_with_precision_of_2() {
@@ -49,7 +46,6 @@ class DimensionUtilityTest extends UnitTest {
 		$image_2 = new DimensionUtility( 302, 398 );
 
 		$this->assertTrue( $image_1->equals( $image_2, 2 ) );
-
 	}
 
 	public function test_image_is_not_equal() {
@@ -57,8 +53,5 @@ class DimensionUtilityTest extends UnitTest {
 		$image_2 = new DimensionUtility( 600, 300 );
 
 		$this->assertFalse( $image_1->equals( $image_2 ) );
-
 	}
-
-
 }

--- a/tests/Unit/Utility/ImageUtilityTest.php
+++ b/tests/Unit/Utility/ImageUtilityTest.php
@@ -55,7 +55,6 @@ class ImageUtilityTest extends UnitTest {
 		$metadata_updated = wp_get_attachment_metadata( $image_id );
 
 		$this->assertArrayHasKey( self::SUBSIZE_IMAGE_KEY, $metadata_updated['sizes'] );
-
 	}
 
 	public function test_real_size_bigger_than_suggested_square() {
@@ -69,7 +68,6 @@ class ImageUtilityTest extends UnitTest {
 		$this->assertEquals( 1200, $suggested_size->y );
 
 		$this->assert_aspect_rate_tolerance( $suggested_size, $recommended_size );
-
 	}
 
 	public function test_real_size_bigger_than_suggested_landscape() {
@@ -83,7 +81,6 @@ class ImageUtilityTest extends UnitTest {
 		$this->assertEquals( 525, $suggested_size->y );
 
 		$this->assert_aspect_rate_tolerance( $suggested_size, $recommended_size );
-
 	}
 
 	public function test_real_size_smaller_than_suggested_square() {
@@ -97,7 +94,6 @@ class ImageUtilityTest extends UnitTest {
 		$this->assertEquals( 350, $suggested_size->y );
 
 		$this->assert_aspect_rate_tolerance( $suggested_size, $recommended_size );
-
 	}
 
 	public function test_real_size_smaller_than_suggested_landscape() {
@@ -111,7 +107,6 @@ class ImageUtilityTest extends UnitTest {
 		$this->assertEquals( 225, $suggested_size->y );
 
 		$this->assert_aspect_rate_tolerance( $suggested_size, $recommended_size );
-
 	}
 
 	public function test_recommend_size_less_than_the_minimum() {
@@ -122,8 +117,5 @@ class ImageUtilityTest extends UnitTest {
 		$suggested_size = $this->image_utility->recommend_size( $real_size, $recommended_size, $minimum_size );
 
 		$this->assertFalse( $suggested_size );
-
 	}
-
-
 }

--- a/tests/Unit/View/PHPViewFactoryTest.php
+++ b/tests/Unit/View/PHPViewFactoryTest.php
@@ -39,5 +39,4 @@ class PHPViewFactoryTest extends UnitTest {
 		parent::setUp();
 		$this->view_factory = new PHPViewFactory();
 	}
-
 }

--- a/tests/Unit/View/PHPViewTest.php
+++ b/tests/Unit/View/PHPViewTest.php
@@ -69,5 +69,4 @@ VIEW;
 		parent::setUp();
 		$this->view_factory = new PHPViewFactory();
 	}
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,7 +18,7 @@ validate_file_exits( "{$wp_tests_dir}/includes/functions.php" );
 $wp_core_dir    = getenv( 'WP_CORE_DIR' ) ?: path_join( sys_get_temp_dir(), '/wordpress' );
 $wp_plugins_dir = path_join( $wp_core_dir, '/wp-content/plugins' );
 
-$gla_dir = dirname( __FILE__, 2 ); // ../../
+$gla_dir = dirname( __DIR__ ); // Parent directory
 
 $wc_dir = getenv( 'WC_DIR' );
 if ( ! $wc_dir ) {

--- a/tests/phpcs.xml.dist
+++ b/tests/phpcs.xml.dist
@@ -23,7 +23,7 @@
 
 		<!-- No thanks -->
 		<exclude name="PSR12.Files.FileHeader.IncorrectOrder"/>
-		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
+		<exclude name="Universal.Operators.DisallowShortTernary"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 
 		<!-- Exceptions can be escaped before outputting not when thrown -->

--- a/tests/phpcs.xml.dist
+++ b/tests/phpcs.xml.dist
@@ -64,6 +64,15 @@
 		</properties>
 	</rule>
 
+	<!-- Add manage_woocommerce to accepted user capabilities -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="manage_woocommerce"/>
+			</property>
+		</properties>
+	</rule>
+
 	<!-- We allow the use of / in hooks -->
 	<rule ref="WordPress.NamingConventions.ValidHookName">
 		<properties>

--- a/tests/phpcs.xml.dist
+++ b/tests/phpcs.xml.dist
@@ -22,8 +22,12 @@
 		<exclude name="Squiz.Commenting.ClassComment.Missing"/>
 
 		<!-- No thanks -->
-		<exclude name="WordPress.PHP.DisallowShortTernary"/>
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder"/>
+		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+
+		<!-- Exceptions can be escaped before outputting not when thrown -->
+		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped"/>
 
 		<!-- These overrides are useful for code hinting -->
 		<exclude name="Generic.CodeAnalysis.UselessOverridingMethod.Found"/>
@@ -33,7 +37,7 @@
 		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching"/>
 
 		<!-- We like short array syntax -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
 
 		<!-- Multiple throws tags are fine -->
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
@@ -58,11 +62,6 @@
 		<properties>
 			<property name="text_domain" type="array" value="google-listings-and-ads"/>
 		</properties>
-	</rule>
-
-	<!-- This rule flags space indents in HTML tags, which are generally OK. -->
-	<rule ref="WordPress.WhiteSpace.PrecisionAlignment">
-		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found"/>
 	</rule>
 
 	<!-- We allow the use of / in hooks -->

--- a/views/inputs/text.php
+++ b/views/inputs/text.php
@@ -13,4 +13,3 @@ defined( 'ABSPATH' ) || exit;
 $input = $this->input;
 
 woocommerce_wp_text_input( $input );
-


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates WordPress CS to version 3.0.1 and fixes CS issues across extension files.

The WordPress CS rules are slightly more sensitive about spacing so there were quite a few substitutions, but most of them could be fixed with `phpcbf` so I don't see any reason why we can't conform to the stricter rules.

I also added an exclusion for the check `WordPress.Security.EscapeOutput.ExceptionNotEscaped`. While it's a valid check, we don't output the content of exceptions directly, and at that point we don't know if the exception is going to be logged to a file or output(which makes it hard to escape). See additional details on this here: https://github.com/WordPress/WordPress-Coding-Standards/issues/2374

Files in the `bin` and `views` directories were not included when linting locally. In GitHub workflows we lint by using `vendor/bin/phpunit ./*` which includes all PHP files. So I went ahead and included those two folder so they lint locally as well.

### Upgraded packages
`composer update wp-coding-standards/wpcs --with-all-dependencies`
```
- Upgrading squizlabs/php_codesniffer (3.6.2 => 3.7.2)
- Upgrading wp-coding-standards/wpcs (2.3.0 => 3.0.1)
```


Closes #2066 

### Detailed test instructions:
1. Checkout `dev/updates-wpcs-3`
2. Run `composer install`
3. Lint PHP files `npm run lint:php && npm run lint:php-tests`
4. Confirm no errors are flagged
5. Run the unit tests locally to ensure that they don't flag any errors either

### Changelog entry
* Dev - Update WordPress CS to 3.0
