### PR TITLE
Update docs domain name to Woo.com

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please see [SECURITY.md](./SECURITY.md).
 
 ## Feature Requests
 
-Feature requests can be submitted to our [ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=403986). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+Feature requests can be submitted to our [feature requests page](https://woo.com/feature-requests/google-listings-and-ads/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A native integration with Google offering free listings and Performance Max ads 
 
 -   [WooCommerce.com product page](https://woocommerce.com/products/google-listings-and-ads/)
 -   [WordPress.org plugin page](https://wordpress.org/plugins/google-listings-and-ads/)
--   [User documentation](https://docs.woocommerce.com/document/google-listings-and-ads/)
+-   [User documentation](https://woo.com/document/google-listings-and-ads/)
 -   [Ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=403986)
 -   [Storybook](https://woocommerce.github.io/google-listings-and-ads/)
 
@@ -18,7 +18,7 @@ A native integration with Google offering free listings and Performance Max ads 
 
 This repository is not suitable for support. Please don't use our issue tracker for support requests.
 
-For self help, start with our [user documentation](https://docs.woocommerce.com/document/google-listings-and-ads/).
+For self help, start with our [user documentation](https://woo.com/document/google-listings-and-ads/).
 
 The best place to get support is the [WordPress.org Google Listings and Ads forum](https://wordpress.org/support/plugin/google-listings-and-ads/).
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 A native integration with Google offering free listings and Performance Max ads to WooCommerce merchants.
 
--   [WooCommerce.com product page](https://woocommerce.com/products/google-listings-and-ads/)
+-   [Woo.com product page](https://woo.com/products/google-listings-and-ads/)
 -   [WordPress.org plugin page](https://wordpress.org/plugins/google-listings-and-ads/)
 -   [User documentation](https://woo.com/document/google-listings-and-ads/)
--   [Ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=403986)
+-   [Feature requests](https://woo.com/feature-requests/google-listings-and-ads/)
 -   [Storybook](https://woocommerce.github.io/google-listings-and-ads/)
 
 ## Support
@@ -22,7 +22,7 @@ For self help, start with our [user documentation](https://woo.com/document/goog
 
 The best place to get support is the [WordPress.org Google Listings and Ads forum](https://wordpress.org/support/plugin/google-listings-and-ads/).
 
-If you have a WooCommerce.com account, you can [start a chat or open a ticket on WooCommerce.com](https://woocommerce.com/my-account/create-a-ticket/).
+If you have a Woo.com account, you can [start a chat or open a ticket on Woo.com](https://woo.com/my-account/contact-support/).
 
 ## Prerequisites
 
@@ -184,6 +184,6 @@ npm run -- wp-env run tests-cli -- wp wc update
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
-	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
+	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -5,7 +5,7 @@
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
  * Version: 2.5.10
  * Author: WooCommerce
- * Author URI: https://woocommerce.com/
+ * Author URI: https://woo.com/
  * Text Domain: google-listings-and-ads
  * Requires at least: 5.9
  * Tested up to: 6.3

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -20,7 +20,7 @@ import usePhoneNumberCheckTrackEventEffect from './usePhoneNumberCheckTrackEvent
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
-	'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information';
+	'https://woo.com/document/google-listings-and-ads/#contact-information';
 
 const description = (
 	<>
@@ -84,9 +84,9 @@ export function ContactInformationPreview() {
  *
  * @param {Object} props React props.
  * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified or has been verified.
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
- * @fires gla_documentation_link_click with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
- * @fires gla_documentation_link_click with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
  */
 const ContactInformation = ( { onPhoneNumberVerified } ) => {
 	const { adapter } = useAdaptiveFormContext();

--- a/js/src/components/google-account-card/connect-google-account-card.js
+++ b/js/src/components/google-account-card/connect-google-account-card.js
@@ -18,7 +18,7 @@ import useGoogleConnectFlow from './use-google-connect-flow';
  * @param {boolean} props.disabled
  * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'reconnect' }`
  * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'setup-mc' }`
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
 const ConnectGoogleAccountCard = ( { disabled } ) => {
 	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';

--- a/js/src/components/google-account-card/read-more-link.js
+++ b/js/src/components/google-account-card/read-more-link.js
@@ -7,7 +7,7 @@ const readMoreLink = (
 	<AppDocumentationLink
 		context="setup-mc-accounts"
 		linkId="required-google-permissions"
-		href="https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions"
+		href="https://woo.com/document/google-listings-and-ads/#required-google-permissions"
 	/>
 );
 

--- a/js/src/components/google-account-card/request-full-access-google-account-card.js
+++ b/js/src/components/google-account-card/request-full-access-google-account-card.js
@@ -21,7 +21,7 @@ import './request-full-access-google-account-card.scss';
  * @param {string} props.additionalScopeEmail Specify the email to be requested additional permission scopes to Google.
  * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'reconnect' }`
  * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'setup-mc' }`
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
 const RequestFullAccessGoogleAccountCard = ( { additionalScopeEmail } ) => {
 	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';

--- a/js/src/components/help-icon-button.js
+++ b/js/src/components/help-icon-button.js
@@ -34,7 +34,7 @@ const HelpIconButton = ( props ) => {
 		<AppIconButton
 			icon={ <GridiconHelpOutline /> }
 			text={ __( 'Help', 'google-listings-and-ads' ) }
-			href="https://docs.woocommerce.com/document/google-listings-and-ads/"
+			href="https://woo.com/document/google-listings-and-ads/"
 			target="_blank"
 			eventName="gla_help_click"
 			eventProps={ {

--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -30,7 +30,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="general-requirements"
-								href="https://woocommerce.com/document/google-listings-and-ads/#general-requirements"
+								href="https://woo.com/document/google-listings-and-ads/#general-requirements"
 							/>
 						),
 					}
@@ -96,7 +96,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="google-merchant-center-requirements"
-								href="https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements"
+								href="https://woo.com/document/google-listings-and-ads/#google-merchant-center-requirements"
 							/>
 						),
 					}
@@ -122,7 +122,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="performance-max"
-								href="https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns"
+								href="https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns"
 							/>
 						),
 					}
@@ -145,7 +145,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="free-listings"
-								href="https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google"
+								href="https://woo.com/document/google-listings-and-ads/#free-listings-on-google"
 							/>
 						),
 					}
@@ -172,7 +172,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="campaign-analytics"
-								href="https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics"
+								href="https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics"
 							/>
 						),
 					}
@@ -265,12 +265,12 @@ const faqItems = [
  * @fires gla_faq with `{ context: 'get-started', id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'collapse' }`.
  * @fires gla_faq with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'expand' }`.
  * @fires gla_faq with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'collapse' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woo.com/document/google-listings-and-ads/#general-requirements' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woo.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woo.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'terms-and-conditions-of-google-ads-coupons', href: 'https://www.google.com/ads/coupons/terms/' }`.
  */
 const Faqs = () => {

--- a/js/src/get-started-page/features-card/index.js
+++ b/js/src/get-started-page/features-card/index.js
@@ -38,9 +38,9 @@ const LearnMoreLink = ( { linkId, href } ) => {
 };
 
 /*
- * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-free-listing-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
- * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-google-ads-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
- * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-dashboard-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-free-listing-learn-more', href: 'https://woo.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-google-ads-learn-more', href: 'https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-dashboard-learn-more', href: 'https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
  */
 const FeaturesCard = () => {
 	return (
@@ -96,7 +96,7 @@ const FeaturesCard = () => {
 					</Text>
 					<LearnMoreLink
 						linkId="get-started-features-free-listing-learn-more"
-						href="https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google"
+						href="https://woo.com/document/google-listings-and-ads/#free-listings-on-google"
 					/>
 				</FlexBlock>
 				<FlexBlock>
@@ -129,7 +129,7 @@ const FeaturesCard = () => {
 					</Text>
 					<LearnMoreLink
 						linkId="get-started-features-google-ads-learn-more"
-						href="https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns"
+						href="https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns"
 					/>
 				</FlexBlock>
 				<FlexBlock>
@@ -162,7 +162,7 @@ const FeaturesCard = () => {
 					</Text>
 					<LearnMoreLink
 						linkId="get-started-features-dashboard-learn-more"
-						href="https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics"
+						href="https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics"
 					/>
 				</FlexBlock>
 			</Flex>

--- a/js/src/settings/edit-phone-number.js
+++ b/js/src/settings/edit-phone-number.js
@@ -18,13 +18,13 @@ import usePhoneNumberCheckTrackEventEffect from '.~/components/contact-informati
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
-	'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information';
+	'https://woo.com/document/google-listings-and-ads/#contact-information';
 
 /**
  * Renders the phone number settings page.
  *
  * @see PhoneNumberCard
- * @fires gla_documentation_link_click with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
+ * @fires gla_documentation_link_click with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
  */
 const EditPhoneNumber = () => {
 	const phone = useGoogleMCPhoneNumber();

--- a/js/src/settings/edit-store-address.js
+++ b/js/src/settings/edit-store-address.js
@@ -23,7 +23,7 @@ import StoreAddressCard from '.~/components/contact-information/store-address-ca
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
-	'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information';
+	'https://woo.com/document/google-listings-and-ads/#contact-information';
 
 /**
  * Triggered when the save button in contact information page is clicked.
@@ -36,7 +36,7 @@ const learnMoreUrl =
  *
  * @see StoreAddressCard
  * @fires gla_contact_information_save_button_click
- * @fires gla_documentation_link_click with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
+ * @fires gla_documentation_link_click with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
  */
 const EditStoreAddress = () => {
 	useLayout( 'full-content' );

--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
@@ -39,7 +39,7 @@ const PreLaunchChecklist = () => {
 							<AppDocumentationLink
 								context="setup-mc-checklist"
 								linkId="checklist-requirements"
-								href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy"
+								href="https://woo.com/document/google-listings-and-ads/compliance-policy"
 							>
 								{ __(
 									'Read Google Merchant Center requirements',
@@ -72,7 +72,7 @@ const PreLaunchChecklist = () => {
 									context="setup-mc-checklist"
 									linkId="check-website-is-live"
 									type="external"
-									href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#store-is-live"
+									href="https://woo.com/document/google-listings-and-ads/compliance-policy/#store-is-live"
 								>
 									{ __(
 										'Learn more about common landing page issues and how to fix them',
@@ -99,7 +99,7 @@ const PreLaunchChecklist = () => {
 									context="setup-mc-checklist"
 									linkId="check-payment-methods-visible"
 									type="external"
-									href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
+									href="https://woo.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
 								>
 									{ __(
 										"Learn more about Google's checkout requirements & best practices",
@@ -131,7 +131,7 @@ const PreLaunchChecklist = () => {
 									context="setup-mc-checklist"
 									linkId="check-checkout-process-secure"
 									type="external"
-									href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
+									href="https://woo.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
 								>
 									{ __(
 										'Learn to set up SSL on your website',
@@ -158,7 +158,7 @@ const PreLaunchChecklist = () => {
 									context="setup-mc-checklist"
 									linkId="check-refund-tos-visible"
 									type="external"
-									href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms"
+									href="https://woo.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms"
 								>
 									{ __(
 										"Learn more about Google's refund policy requirements",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"WooCommerce",
 		"Google"
 	],
-	"homepage": "https://woocommerce.com/products/google-listings-and-ads/",
+	"homepage": "https://woo.com/products/google-listings-and-ads/",
 	"repository": {
 		"type": "git",
 		"url": "git@github.com:woocommerce/google-listings-and-ads.git"

--- a/readme.txt
+++ b/readme.txt
@@ -60,7 +60,7 @@ Create a new Google Ads account through Google Listings & Ads and a promotional 
 * PHP Architecture 64 bits
 * MySQL version 5.6 or greater
 
-Visit the [WooCommerce server requirements documentation](https://docs.woocommerce.com/document/server-requirements/) for a detailed list of server requirements.
+Visit the [WooCommerce server requirements documentation](https://woo.com/document/server-requirements/) for a detailed list of server requirements.
 
 = Automatic installation =
 

--- a/src/Integration/WooCommercePreOrders.php
+++ b/src/Integration/WooCommercePreOrders.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Integration
  *
- * @link https://woocommerce.com/products/woocommerce-pre-orders/
+ * @link https://woo.com/products/woocommerce-pre-orders/
  *
  * @since 1.5.0
  */

--- a/src/Menu/MenuFixesTrait.php
+++ b/src/Menu/MenuFixesTrait.php
@@ -29,6 +29,7 @@ trait MenuFixesTrait {
 	 * There is a guide with a few examples showing how to add a page to WooCommerce Admin.
 	 *
 	 * TODO: rename to developer.woo.com when the migration is done
+	 *
 	 * @link https://developer.woocommerce.com/extension-developer-guide/working-with-woocommerce-admin-pages/
 	 *
 	 * Originally, a React-powered page is expected to be registered by WC core function

--- a/src/Menu/MenuFixesTrait.php
+++ b/src/Menu/MenuFixesTrait.php
@@ -28,6 +28,7 @@ trait MenuFixesTrait {
 	 *
 	 * There is a guide with a few examples showing how to add a page to WooCommerce Admin.
 	 *
+	 * TODO: rename to developer.woo.com when the migration is done
 	 * @link https://developer.woocommerce.com/extension-developer-guide/working-with-woocommerce-admin-pages/
 	 *
 	 * Originally, a React-powered page is expected to be registered by WC core function

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -883,7 +883,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 		 */
 		if ( 'home_page_issue' === $issue['code'] ) {
 			$issue['issue']      = 'Website claim is lost, need to re verify and claim your website. Please reference the support link';
-			$issue['action_url'] = 'https://woocommerce.com/document/google-listings-and-ads-faqs/#reverify-website';
+			$issue['action_url'] = 'https://woo.com/document/google-listings-and-ads-faqs/#reverify-website';
 		}
 
 		return $issue;

--- a/src/MultichannelMarketing/GLAChannel.php
+++ b/src/MultichannelMarketing/GLAChannel.php
@@ -110,7 +110,7 @@ class GLAChannel implements MarketingChannelInterface {
 	 * @return string
 	 */
 	public function get_icon_url(): string {
-		return 'https://woocommerce.com/wp-content/uploads/2021/06/woo-GoogleListingsAds-jworee.png';
+		return 'https://woo.com/wp-content/uploads/2021/06/woo-GoogleListingsAds-jworee.png';
 	}
 
 	/**

--- a/src/Notes/LeaveReviewActionTrait.php
+++ b/src/Notes/LeaveReviewActionTrait.php
@@ -23,7 +23,7 @@ trait LeaveReviewActionTrait {
 	 */
 	protected function add_leave_review_note_action( NoteEntry $note ) {
 		$wp_link = 'https://wordpress.org/support/plugin/google-listings-and-ads/reviews/#new-post';
-		$wc_link = 'https://woocommerce.com/products/google-listings-and-ads/#reviews';
+		$wc_link = 'https://woo.com/products/google-listings-and-ads/#reviews';
 
 		$note->add_action(
 			'leave-review',

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -79,7 +79,7 @@ class SetupCampaign extends AbstractSetupCampaign {
 		$note->add_action(
 			'setup-campaign-learn-more',
 			__( 'Learn more', 'google-listings-and-ads' ),
-			'https://docs.woocommerce.com/document/google-listings-and-ads/#get-500-in-free-ad-credits'
+			'https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns'
 		);
 	}
 }

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -152,7 +152,7 @@ trait PluginHelper {
 	 * @return string
 	 */
 	protected function get_documentation_url(): string {
-		return 'https://docs.woocommerce.com/document/google-listings-and-ads/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=google-listings-and-ads';
+		return 'https://woo.com/document/google-listings-and-ads/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=google-listings-and-ads';
 	}
 
 	/**

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -1,6 +1,6 @@
 # Usage Tracking
 
-_Google Listings & Ads_ implements usage tracking, based on the native [WooCommerce Usage Tracking](https://woocommerce.com/usage-tracking/), and is only enabled when WooCommerce Tracking is enabled.
+_Google Listings & Ads_ implements usage tracking, based on the native [WooCommerce Usage Tracking](https://woo.com/usage-tracking/), and is only enabled when WooCommerce Tracking is enabled.
 
 When a store opts in to WooCommerce usage tracking and uses _Google Listings & Ads_, they will also be opted in to the tracking added by _Google Listings & Ads_.
 
@@ -270,12 +270,12 @@ When a documentation link is clicked.
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
 - [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
-	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
+	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woo.com/document/google-listings-and-ads/#general-requirements' }`.
 	- with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
-	- with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
-	- with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
-	- with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
-	- with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+	- with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woo.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
+	- with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+	- with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woo.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+	- with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
 	- with `{ context: 'faqs', linkId: 'terms-and-conditions-of-google-ads-coupons', href: 'https://www.google.com/ads/coupons/terms/' }`.
 - [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L23) with `{ context: 'get-started', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
 - [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L23) with `{ context: 'get-started-with-video', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -244,9 +244,9 @@ When a documentation link is clicked.
 #### Emitters
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
 - [`ContactInformation`](../../js/src/components/contact-information/index.js#L91)
-	- with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
-	- with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
-	- with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+	- with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
+	- with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
+	- with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
 - [`DifferentCurrencyNotice`](../../js/src/components/different-currency-notice.js#L28)
 	- with `{ context: "dashboard", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-products", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
@@ -256,8 +256,8 @@ When a documentation link is clicked.
 - [`TaxRate`](../../js/src/components/free-listings/configure-product-listings/tax-rate.js#L22)
 	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-read-more', href: 'https://support.google.com/merchants/answer/160162' }`
 	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
-- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
-- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://docs.woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
 - [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L36) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
 - [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L32)
 	- with `{ context: 'setup-ads', link_id: 'shopping-ads-policies', href: 'https://support.google.com/merchants/answer/6149970' }`
@@ -283,8 +283,8 @@ When a documentation link is clicked.
 - [`UnsupportedCountry`](../../js/src/get-started-page/unsupported-notices/index.js#L73) with `{ context: "get-started", link_id: "supported-countries" }`
 - [`IssuesTableDataModal`](../../js/src/product-feed/issues-table-card/issues-table-data-modal.js#L21) with { context: 'issues-data-table-modal' }
 - [`ProductStatusHelpPopover`](../../js/src/product-feed/product-statistics/product-status-help-popover/index.js#L16) with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`
-- [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
-- [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information" }`
+- [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
+- [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
 - [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27) with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
 - [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L68) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
 - [`GoogleMCDisclaimer`](../../js/src/setup-mc/setup-stepper/setup-accounts/index.js#L33)

--- a/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
@@ -229,7 +229,7 @@ test.describe( 'Confirm store requirements', () => {
 			await expect( link ).toBeVisible();
 			await expect( link ).toHaveAttribute(
 				'href',
-				'https://woocommerce.com/document/google-listings-and-ads/compliance-policy'
+				'https://woo.com/document/google-listings-and-ads/compliance-policy'
 			);
 		} );
 
@@ -321,7 +321,7 @@ test.describe( 'Confirm store requirements', () => {
 					await expect( link1 ).toBeVisible();
 					await expect( link1 ).toHaveAttribute(
 						'href',
-						'https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#store-is-live'
+						'https://woo.com/document/google-listings-and-ads/compliance-policy/#store-is-live'
 					);
 
 					const panel2 = await panels.nth( 1 );
@@ -329,7 +329,7 @@ test.describe( 'Confirm store requirements', () => {
 					await expect( link2 ).toBeVisible();
 					await expect( link2 ).toHaveAttribute(
 						'href',
-						'https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout'
+						'https://woo.com/document/google-listings-and-ads/compliance-policy/#complete-checkout'
 					);
 
 					const panel3 = await panels.nth( 2 );
@@ -337,7 +337,7 @@ test.describe( 'Confirm store requirements', () => {
 					await expect( link3 ).toBeVisible();
 					await expect( link3 ).toHaveAttribute(
 						'href',
-						'https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout'
+						'https://woo.com/document/google-listings-and-ads/compliance-policy/#complete-checkout'
 					);
 
 					const panel4 = await panels.nth( 3 );
@@ -345,7 +345,7 @@ test.describe( 'Confirm store requirements', () => {
 					await expect( link4 ).toBeVisible();
 					await expect( link4 ).toHaveAttribute(
 						'href',
-						'https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms'
+						'https://woo.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms'
 					);
 				} );
 

--- a/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
@@ -219,7 +219,7 @@ test.describe( 'Confirm store requirements', () => {
 			await expect( link ).toBeVisible();
 			await expect( link ).toHaveAttribute(
 				'href',
-				'https://docs.woocommerce.com/document/google-listings-and-ads/#contact-information'
+				'https://woo.com/document/google-listings-and-ads/#contact-information'
 			);
 		} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the old WooCommerce.com → the new Woo.com in several places, especially for documentation links.

Project: peeuvX-13n-p2

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm all new URLs actually go to a page.

### Additional details:

- Did not change the `developer.woocommerce.com` and `api-vipgo.woocommerce.com` URLs
- Added a TODO (87e5872f28866c08d5d19e9123255a553822877d) for updating `developer.woocommerce.com` when the migration is done
- Also changed the anchor [#get-500-in-free-ad-credits](https://woo.com/document/google-listings-and-ads/#get-500-in-free-ad-credits) to [#google-performance-max-campaigns](https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns) because there is no anchor for the former, and the latter one is the parent section of it.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Doc - Use new Woo.com domain.
