### PR TITLE
Remove unused flush_rewrite_rules

### DIFF
--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -62,8 +62,6 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 				$service->activate();
 			}
 		}
-
-		flush_rewrite_rules();
 	}
 
 	/**
@@ -79,8 +77,6 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 				$service->deactivate();
 			}
 		}
-
-		flush_rewrite_rules();
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the `flush_rewrite_rules` as we are not registering any custom pages/endpoints that require the rules to be flushed. See details in #2154 on why it's problematic.

Closes #2154 

### Detailed test instructions:
1. Install a plugin like https://wordpress.org/plugins/rewrite-rules-inspector/ to inspect the registered rewrite rules
2. Activate and deactivate GLA (before testing this branch) and compare the rewrite rules to make sure there are no changes when flushing upon activation/deactivation (copy output from Tools > Rewrite Rules to a file and use a `diff` tool to compare changes)
3. Install this PR and test activating / deactivating the extension
4. Ensure there are no errors / warnings (rewrite rules should again remain the same)

### Changelog entry
* Tweak - Remove rewrite rules flush.
