### PR TITLE
Fix E2E gtag events for a blockified confirmation page.

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -121,6 +121,10 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		add_action(
 			'woocommerce_before_thankyou',
 			function ( $order_id ) use ( $ads_conversion_id, $ads_conversion_label ) {
+				// TODO: Remove this temporal workaround once this issue is fixed: https://github.com/woocommerce/woocommerce-blocks/issues/11851
+				if ( $order_id instanceof \WC_Order ) {
+					$order_id = $order_id->get_id();
+				}
 				$this->maybe_display_conversion_and_purchase_event_snippets( $ads_conversion_id, $ads_conversion_label, $order_id );
 			},
 		);

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -121,10 +121,6 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		add_action(
 			'woocommerce_before_thankyou',
 			function ( $order_id ) use ( $ads_conversion_id, $ads_conversion_label ) {
-				// TODO: Remove this temporal workaround once this issue is fixed: https://github.com/woocommerce/woocommerce-blocks/issues/11851
-				if ( $order_id instanceof \WC_Order ) {
-					$order_id = $order_id->get_id();
-				}
 				$this->maybe_display_conversion_and_purchase_event_snippets( $ads_conversion_id, $ads_conversion_label, $order_id );
 			},
 		);

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -100,6 +100,9 @@ export async function checkout( page ) {
 		await page.locator( '#billing-state input' ).fill( user.statename );
 	}
 
+	//TODO: See if there's an alternative method to click the button without relying on waitForTimeout.
+	await page.waitForTimeout( 3000 );
+
 	await page.locator( 'text=Place order' ).click();
 
 	await expect(

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -106,6 +106,6 @@ export async function checkout( page ) {
 	await page.locator( 'text=Place order' ).click();
 
 	await expect(
-		page.locator( '.woocommerce-thankyou-order-received' )
+		page.locator( '.wc-block-order-confirmation-status' )
 	).toContainText( 'order has been received' );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

~~Currently, there's a fatal error due to this issue: https://github.com/woocommerce/woocommerce-blocks/issues/11851 and a "blockified" confirmation page. This problem is caused because the hook `woocommerce_before_thankyou` is being called with incorrect parameters.~~

Additionally, our E2E tests are failing. Check here: https://github.com/woocommerce/google-listings-and-ads/actions/runs/6942346039/job/18885109983?pr=2160. The blockified confirmation page uses a different class for the order status.

This PR ~~introduces a temporary solution for the mentioned issue~~ and resolves the E2E test problem.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

~~Fatal Error in the confirmation page.~~ This has been fixed in WC 8.3.1 p1700588910958219-slack-C01DT6U03HC
~~1.  Use WC 8.3~~
~~2. Use a theme that supports blocks, for example twenty twenty-two.~~
~~3. Blockify your confirmation page. See instructions here: https://woo.com/document/cart-checkout-blocks-status/ (Search for "Replacing the order confirmation page" )~~
~~4. Buy a product and complete the order, you shouldn't get any fatal error.~~
~~5. Checkout develop and repeat the steps and you will get a fatal error.~~

### E2E Tests
1. Check that E2E are ✅ . 

### Additional details:
- I added `await page.waitForTimeout( 3000 );` because it was clicking the button too quickly making the tests fail.
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - E2E gtag evens tests.