### PR TITLE
Add (budget and audiences) tracking for Onboarding completed with Ads

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -7,7 +7,6 @@ import { select } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { Flex } from '@wordpress/components';
 import { noop, merge } from 'lodash';
-import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -41,14 +40,8 @@ const ACTION_SKIP = 'skip-ads';
  * Clicking on the "Complete setup" button to complete the onboarding flow with paid ads.
  *
  * @event gla_onboarding_complete_with_paid_ads_button_click
- */
-
-/**
- * When the Onboarding is completed with Ads Setup.
- *
- * @event gla_onboarding_complete_ads_setup
  * @property {number} budget The budget for the campaign
- * @property {number} audiences The targeted audiences for the campaign
+ * @property {string} audiences The targeted audiences for the campaign
  */
 
 /**
@@ -72,7 +65,6 @@ const ACTION_SKIP = 'skip-ads';
  * @fires gla_onboarding_open_paid_ads_setup_button_click
  * @fires gla_onboarding_complete_with_paid_ads_button_click
  * @fires gla_onboarding_complete_button_click
- * @fires gla_onboarding_complete_ads_setup
  */
 export default function SetupPaidAds() {
 	const adminUrl = useAdminUrl();
@@ -109,11 +101,6 @@ export default function SetupPaidAds() {
 				)
 			);
 		}
-
-		recordEvent( 'gla_onboarding_complete_ads_setup', {
-			budget: paidAds.amount,
-			audiences: paidAds.countryCodes.join( ',' ),
-		} );
 
 		// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
 		const query = { guide: GUIDE_NAMES.SUBMISSION_SUCCESS };
@@ -222,6 +209,10 @@ export default function SetupPaidAds() {
 						disabled={ disabledComplete }
 						onClick={ handleCompleteClick }
 						eventName="gla_onboarding_complete_with_paid_ads_button_click"
+						eventProps={ {
+							budget: paidAds.amount,
+							audiences: paidAds.countryCodes.join( ',' ),
+						} }
 					/>
 				</Flex>
 			</StepContentFooter>

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -7,6 +7,7 @@ import { select } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { Flex } from '@wordpress/components';
 import { noop, merge } from 'lodash';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -43,6 +44,14 @@ const ACTION_SKIP = 'skip-ads';
  */
 
 /**
+ * When the Onboarding is completed with Ads Setup.
+ *
+ * @event gla_onboarding_complete_ads_setup
+ * @property {number} budget The budget for the campaign
+ * @property {number} audiences The targeted audiences for the campaign
+ */
+
+/**
  * Clicking on the skip paid ads button to complete the onboarding flow.
  * The 'unknown' value of properties may means:
  * - the paid ads setup is not opened
@@ -63,6 +72,7 @@ const ACTION_SKIP = 'skip-ads';
  * @fires gla_onboarding_open_paid_ads_setup_button_click
  * @fires gla_onboarding_complete_with_paid_ads_button_click
  * @fires gla_onboarding_complete_button_click
+ * @fires gla_onboarding_complete_ads_setup
  */
 export default function SetupPaidAds() {
 	const adminUrl = useAdminUrl();
@@ -99,6 +109,11 @@ export default function SetupPaidAds() {
 				)
 			);
 		}
+
+		recordEvent( 'gla_onboarding_complete_ads_setup', {
+			budget: paidAds.amount,
+			audiences: paidAds.countryCodes.join( ',' ),
+		} );
 
 		// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
 		const query = { guide: GUIDE_NAMES.SUBMISSION_SUCCESS };

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -211,7 +211,7 @@ export default function SetupPaidAds() {
 						eventName="gla_onboarding_complete_with_paid_ads_button_click"
 						eventProps={ {
 							budget: paidAds.amount,
-							audiences: paidAds.countryCodes.join( ',' ),
+							audiences: paidAds.countryCodes?.join( ',' ),
 						} }
 					/>
 				</Flex>

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -571,7 +571,17 @@ A modal is open
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
-### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L45)
+### [`gla_onboarding_complete_ads_setup`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L46)
+When the Onboarding is completed with Ads Setup.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`budget` | `number` | The budget for the campaign
+`audiences` | `number` | The targeted audiences for the campaign
+#### Emitters
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L77)
+
+### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L54)
 Clicking on the skip paid ads button to complete the onboarding flow.
  The 'unknown' value of properties may means:
  - the paid ads setup is not opened
@@ -585,17 +595,17 @@ Clicking on the skip paid ads button to complete the onboarding flow.
 `billing_method_status` | `string` | aaa, The status of billing method of merchant's Google Ads addcount e.g. 'unknown', 'pending', 'approved', 'cancelled'
 `campaign_form_validation` | `string` | Whether the entered paid campaign form data are valid, e.g. 'unknown', 'valid', 'invalid'
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L67)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L77)
 
-### [`gla_onboarding_complete_with_paid_ads_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L39)
+### [`gla_onboarding_complete_with_paid_ads_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L40)
 Clicking on the "Complete setup" button to complete the onboarding flow with paid ads.
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L67)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L77)
 
-### [`gla_onboarding_open_paid_ads_setup_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L33)
+### [`gla_onboarding_open_paid_ads_setup_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L34)
 Clicking on the "Create a paid ad campaign" button to open the paid ads setup in the onboarding flow.
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L67)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L77)
 
 ### [`gla_paid_campaign_step`](../../js/src/utils/recordEvent.js#L122)
 Triggered when moving to another step during creating/editing a campaign.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -571,17 +571,7 @@ A modal is open
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
-### [`gla_onboarding_complete_ads_setup`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L46)
-When the Onboarding is completed with Ads Setup.
-#### Properties
-| name | type | description |
-| ---- | ---- | ----------- |
-`budget` | `number` | The budget for the campaign
-`audiences` | `number` | The targeted audiences for the campaign
-#### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L77)
-
-### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L54)
+### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L47)
 Clicking on the skip paid ads button to complete the onboarding flow.
  The 'unknown' value of properties may means:
  - the paid ads setup is not opened
@@ -595,17 +585,22 @@ Clicking on the skip paid ads button to complete the onboarding flow.
 `billing_method_status` | `string` | aaa, The status of billing method of merchant's Google Ads addcount e.g. 'unknown', 'pending', 'approved', 'cancelled'
 `campaign_form_validation` | `string` | Whether the entered paid campaign form data are valid, e.g. 'unknown', 'valid', 'invalid'
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L77)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L69)
 
-### [`gla_onboarding_complete_with_paid_ads_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L40)
+### [`gla_onboarding_complete_with_paid_ads_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L39)
 Clicking on the "Complete setup" button to complete the onboarding flow with paid ads.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`budget` | `number` | The budget for the campaign
+`audiences` | `string` | The targeted audiences for the campaign
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L77)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L69)
 
-### [`gla_onboarding_open_paid_ads_setup_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L34)
+### [`gla_onboarding_open_paid_ads_setup_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L33)
 Clicking on the "Create a paid ad campaign" button to open the paid ads setup in the onboarding flow.
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L77)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L69)
 
 ### [`gla_paid_campaign_step`](../../js/src/utils/recordEvent.js#L122)
 Triggered when moving to another step during creating/editing a campaign.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a continuation for https://github.com/woocommerce/google-listings-and-ads/pull/2153

This PR adds the Tracking events with the budget and the audience when the onboarding is completed adding Ads.

- It only adds Budget and Audiences

### Screenshots:

<img width="419" alt="Screenshot 2023-11-30 at 20 07 40" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/44de89e4-6275-4d94-8e42-45ceb090f76c">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Enable tracks debugger --> Add this to yourBrowser console --> `localStorage.setItem( 'debug', 'wc-admin:*' )`
2. Start a fresh Onboarding
3. In the final step connect Ads and create a campaign
4. Set a budget 
5. Complete the setup
6. See the track event with the budget and the audiences.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak -  Track Budgets and Audience in Onboarding  
