### PR TITLE
Update budget recommendation text for e2e tests

### DIFF
--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -360,7 +360,7 @@ test.describe( 'Set up Ads account', () => {
 
 		test( 'Budget Recommendation', async () => {
 			await expect(
-				page.getByText( 'set a daily budget of 5 to 15 USD' )
+				page.getByText( 'set a daily budget of 15 USD' )
 			).toBeVisible();
 		} );
 	} );

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -92,7 +92,7 @@ export default class SetupBudget extends MockRequests {
 	 * @return {string} The budget recommendation range.
 	 */
 	extractBudgetRecommendationRange( text ) {
-		const match = text.match( /set a daily budget of (\d+ to \d+)/ );
+		const match = text.match( /set a daily budget of (\d+)/ );
 		if ( match ) {
 			return match[ 1 ];
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2172 

Updates the budget recommendation text in E2E tests to match the recent changes (#2153)

### Screenshots:

<img width="944" alt="Screenshot 2023-12-05 at 18 12 40" src="https://github.com/woocommerce/google-listings-and-ads/assets/40762232/536b1163-1d90-4ecb-be11-3c7c0ae925f5">

### Detailed test instructions:
1. Checkout `fix/2172-failing-e2e-tests`
2. Run [E2E tests](https://github.com/woocommerce/google-listings-and-ads#e2e-testing)
3. Confirm all tests pass

### Changelog entry

> Fix - Budget recommendation text in e2e tests