### PR TITLE
Product Block Editor: Map `SelectWithTextInput` and `DateTime` inputs to the custom product blocks

### DIFF
--- a/js/src/blocks/README.md
+++ b/js/src/blocks/README.md
@@ -45,7 +45,7 @@ The `useProductEntityProp` hook imported from `@woocommerce/product-editor` offe
 
 #### Derived value for initialization
 
-At the time of starting rendering a block, the product data has already been loaded to a data store of `@wordpress/data` in Woo's Product Block Editor, so the value returned from `useProductEntityProp` can be considered as an already fetched data for directly initializing derived values, because they all eventually use the same selector `getEntityRecord` from `@wordpress/core-data` to get product data.
+The "derived value" refers to the computation of a value based on another state or props in a component. At the time of starting rendering a block, the product data has already been loaded to a data store of `@wordpress/data` in Woo's Product Block Editor, so the value returned from `useProductEntityProp` can be considered as an already fetched data for directly initializing derived values, because they all eventually use the same selector `getEntityRecord` from `@wordpress/core-data` to get product data.
 
 References:
 

--- a/js/src/blocks/README.md
+++ b/js/src/blocks/README.md
@@ -36,6 +36,24 @@ Since this extension requires a few custom blocks, and considering these custom 
 └── blocks.asset.php       # The dependencies of blocks.js to be used when registering blocks.js via PHP
 ```
 
+### Accessing product data
+
+The `useProductEntityProp` hook imported from `@woocommerce/product-editor` offers a convenient way to get and set product data and metadata.
+
+- In block.json, it needs to list `"postType"` in the `usesContext` array to ask for the current post type ('product' or 'product_variation') from the context provider.
+- Forwarding the `context.postType` to `useProductEntityProp` hook is required in order to be compatible with both simple and variation product block templates.
+
+#### Derived value for initialization
+
+At the time of starting rendering a block, the product data has already been loaded to a data store of `@wordpress/data` in Woo's Product Block Editor, so the value returned from `useProductEntityProp` can be considered as an already fetched data for directly initializing derived values, because they all eventually use the same selector `getEntityRecord` from `@wordpress/core-data` to get product data.
+
+References:
+
+- At [ProductPage](https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce-admin/client/products/product-page.tsx#L77-L79) and [ProductVariationPage](https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce-admin/client/products/product-variation-page.tsx#L83-L85) layers, they won't render the actual blocks before the product data is fetched
+- The above product data is obtained from [useProductEntityRecord](https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts#L19-L23) or [useProductVariationEntityRecord](https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce-admin/client/products/hooks/use-product-variation-entity-record.ts#L16-L22) hook, and both hooks use the `getEntityRecord` selector.
+- This extension obtains product data from [useProductEntityProp](https://github.com/woocommerce/woocommerce/blob/8.3.0/packages/js/product-editor/src/hooks/use-product-entity-prop.ts#L24-L33), which uses the `useEntityProp` hook internally.
+- The [useEntityProp](https://github.com/WordPress/gutenberg/blob/wp/6.0/packages/core-data/src/entity-provider.js#L102-L133) hook also uses the `getEntityRecord` selector.
+
 ### Infrastructure adjustments
 
 #### block.json and edit.js

--- a/js/src/blocks/index.js
+++ b/js/src/blocks/index.js
@@ -8,6 +8,8 @@ import { registerProductEditorBlockType } from '@woocommerce/product-editor';
  */
 import SelectFieldEdit from './product-select-field/edit';
 import selectFieldMetadata from './product-select-field/block.json';
+import SelectWithTextFieldEdit from './product-select-with-text-field/edit';
+import selectWithTextFieldMetadata from './product-select-with-text-field/block.json';
 
 function registerProductEditorBlock( { name, ...metadata }, Edit ) {
 	registerProductEditorBlockType( {
@@ -18,3 +20,7 @@ function registerProductEditorBlock( { name, ...metadata }, Edit ) {
 }
 
 registerProductEditorBlock( selectFieldMetadata, SelectFieldEdit );
+registerProductEditorBlock(
+	selectWithTextFieldMetadata,
+	SelectWithTextFieldEdit
+);

--- a/js/src/blocks/index.js
+++ b/js/src/blocks/index.js
@@ -6,8 +6,8 @@ import { registerProductEditorBlockType } from '@woocommerce/product-editor';
 /**
  * Internal dependencies
  */
-import DatetimeFieldEdit from './product-date-time-field/edit';
-import datetimeFieldMetadata from './product-date-time-field/block.json';
+import DateTimeFieldEdit from './product-date-time-field/edit';
+import dateTimeFieldMetadata from './product-date-time-field/block.json';
 import SelectFieldEdit from './product-select-field/edit';
 import selectFieldMetadata from './product-select-field/block.json';
 import SelectWithTextFieldEdit from './product-select-with-text-field/edit';
@@ -21,7 +21,7 @@ function registerProductEditorBlock( { name, ...metadata }, Edit ) {
 	} );
 }
 
-registerProductEditorBlock( datetimeFieldMetadata, DatetimeFieldEdit );
+registerProductEditorBlock( dateTimeFieldMetadata, DateTimeFieldEdit );
 registerProductEditorBlock( selectFieldMetadata, SelectFieldEdit );
 registerProductEditorBlock(
 	selectWithTextFieldMetadata,

--- a/js/src/blocks/index.js
+++ b/js/src/blocks/index.js
@@ -6,6 +6,8 @@ import { registerProductEditorBlockType } from '@woocommerce/product-editor';
 /**
  * Internal dependencies
  */
+import DatetimeFieldEdit from './product-date-time-field/edit';
+import datetimeFieldMetadata from './product-date-time-field/block.json';
 import SelectFieldEdit from './product-select-field/edit';
 import selectFieldMetadata from './product-select-field/block.json';
 import SelectWithTextFieldEdit from './product-select-with-text-field/edit';
@@ -19,6 +21,7 @@ function registerProductEditorBlock( { name, ...metadata }, Edit ) {
 	} );
 }
 
+registerProductEditorBlock( datetimeFieldMetadata, DatetimeFieldEdit );
 registerProductEditorBlock( selectFieldMetadata, SelectFieldEdit );
 registerProductEditorBlock(
 	selectWithTextFieldMetadata,

--- a/js/src/blocks/product-date-time-field/block.json
+++ b/js/src/blocks/product-date-time-field/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "google-listings-and-ads/product-date-time-field",
-	"title": "Product datetime control",
+	"title": "Product date and time fields",
 	"textdomain": "google-listings-and-ads",
 	"attributes": {
 		"_templateBlockHideConditions": {

--- a/js/src/blocks/product-date-time-field/block.json
+++ b/js/src/blocks/product-date-time-field/block.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "google-listings-and-ads/product-date-time-field",
+	"title": "Product datetime control",
+	"textdomain": "google-listings-and-ads",
+	"attributes": {
+		"_templateBlockHideConditions": {
+			"type": "array"
+		},
+		"label": {
+			"type": "string"
+		},
+		"tooltip": {
+			"type": "string"
+		},
+		"property": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"html": false,
+		"inserter": false,
+		"lock": false
+	},
+	"usesContext": [
+		"postType"
+	]
+}

--- a/js/src/blocks/product-date-time-field/edit.js
+++ b/js/src/blocks/product-date-time-field/edit.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { date as formatDate, getDate } from '@wordpress/date';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { useState } from '@wordpress/element';
+import {
+	__experimentalUseProductEntityProp as useProductEntityProp,
+	__experimentalTextControl as TextControl,
+} from '@woocommerce/product-editor';
+import { Flex, FlexBlock } from '@wordpress/components';
+
+export default function Edit( { attributes, context } ) {
+	const blockProps = useWooBlockProps( attributes );
+	const [ value, setValue ] = useProductEntityProp( attributes.property, {
+		postType: context.postType,
+		fallbackValue: '',
+	} );
+
+	// Refer to the "Derived value for initialization" in README for why these `useState`
+	// can initialize directly.
+	const [ date, setDate ] = useState( () =>
+		value ? formatDate( 'Y-m-d', value ) : ''
+	);
+	const [ time, setTime ] = useState( () =>
+		value ? formatDate( 'H:i', value ) : ''
+	);
+
+	const setNextValue = ( nextDate, nextTime ) => {
+		let nextValue = '';
+
+		if ( nextDate && nextTime ) {
+			// The date and time values are strings presented in the site timezone.
+			// Normalize them to date string in UTC timezone in ISO 8601 format.
+			const dateInSiteTimezone = getDate( `${ nextDate }T${ nextTime }` );
+			nextValue = formatDate( 'c', dateInSiteTimezone, 'UTC' );
+		}
+
+		setDate( nextDate );
+		setTime( nextTime );
+
+		if ( value !== nextValue ) {
+			setValue( nextValue );
+		}
+	};
+
+	return (
+		<div { ...blockProps }>
+			<Flex align="flex-end">
+				<FlexBlock>
+					<TextControl
+						type="date"
+						pattern="\d{4}-\d{2}-\d{2}"
+						label={ attributes.label }
+						tooltip={ attributes.tooltip }
+						value={ date }
+						onChange={ ( nextDate ) =>
+							setNextValue( nextDate, time )
+						}
+					/>
+				</FlexBlock>
+				<FlexBlock>
+					<TextControl
+						type="time"
+						pattern="[0-9]{2}:[0-9]{2}"
+						value={ time }
+						onChange={ ( nextTime ) =>
+							setNextValue( date, nextTime )
+						}
+					/>
+				</FlexBlock>
+			</Flex>
+		</div>
+	);
+}

--- a/js/src/blocks/product-date-time-field/edit.js
+++ b/js/src/blocks/product-date-time-field/edit.js
@@ -3,17 +3,31 @@
  */
 import { date as formatDate, getDate } from '@wordpress/date';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import { useState } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import {
 	__experimentalUseProductEntityProp as useProductEntityProp,
 	__experimentalTextControl as TextControl,
+	useValidation,
 } from '@woocommerce/product-editor';
 import { Flex, FlexBlock } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import styles from './editor.module.scss';
 
 /**
  * @typedef {import('../types.js').ProductEditorBlockContext} ProductEditorBlockContext
  * @typedef {import('../types.js').ProductBasicAttributes} ProductBasicAttributes
  */
+
+async function resolveValidationMessage( inputRef ) {
+	const input = inputRef.current;
+
+	if ( ! input.validity.valid ) {
+		return input.validationMessage;
+	}
+}
 
 /**
  * Custom block for editing a given product data with date and time fields.
@@ -23,11 +37,14 @@ import { Flex, FlexBlock } from '@wordpress/components';
  * @param {ProductEditorBlockContext} props.context
  */
 export default function Edit( { attributes, context } ) {
+	const { property } = attributes;
 	const blockProps = useWooBlockProps( attributes );
-	const [ value, setValue ] = useProductEntityProp( attributes.property, {
+	const [ value, setValue ] = useProductEntityProp( property, {
 		postType: context.postType,
 		fallbackValue: '',
 	} );
+	const dateInputRef = useRef( null );
+	const timeInputRef = useRef( null );
 
 	// Refer to the "Derived value for initialization" in README for why these `useState`
 	// can initialize directly.
@@ -41,10 +58,12 @@ export default function Edit( { attributes, context } ) {
 	const setNextValue = ( nextDate, nextTime ) => {
 		let nextValue = '';
 
-		if ( nextDate && nextTime ) {
+		// It allows `nextTime` to be an empty string and fall back to '00:00:00'.
+		if ( nextDate ) {
 			// The date and time values are strings presented in the site timezone.
 			// Normalize them to date string in UTC timezone in ISO 8601 format.
-			const dateInSiteTimezone = getDate( `${ nextDate }T${ nextTime }` );
+			const isoDateString = `${ nextDate }T${ nextTime || '00:00:00' }`;
+			const dateInSiteTimezone = getDate( isoDateString );
 			nextValue = formatDate( 'c', dateInSiteTimezone, 'UTC' );
 		}
 
@@ -56,29 +75,49 @@ export default function Edit( { attributes, context } ) {
 		}
 	};
 
+	const dateValidation = useValidation( `${ property }-date`, () =>
+		resolveValidationMessage( dateInputRef )
+	);
+
+	const timeValidation = useValidation( `${ property }-time`, () =>
+		resolveValidationMessage( timeInputRef )
+	);
+
 	return (
 		<div { ...blockProps }>
-			<Flex align="flex-end">
+			<Flex align="flex-start">
 				<FlexBlock>
 					<TextControl
+						ref={ dateInputRef }
 						type="date"
 						pattern="\d{4}-\d{2}-\d{2}"
 						label={ attributes.label }
 						tooltip={ attributes.tooltip }
 						value={ date }
+						error={ dateValidation.error }
 						onChange={ ( nextDate ) =>
 							setNextValue( nextDate, time )
 						}
+						onBlur={ dateValidation.validate }
 					/>
 				</FlexBlock>
 				<FlexBlock>
 					<TextControl
+						// The invisible chars in the label and tooltip are to maintain the space between
+						// the <label> and <input> as the same in the sibling <TextControl>. Also, it uses
+						// CSS to keep its space but is invisible.
+						className={ styles.invisibleLabelAndTooltip }
+						label=" "
+						tooltip="‎ "
+						ref={ timeInputRef }
 						type="time"
 						pattern="[0-9]{2}:[0-9]{2}"
 						value={ time }
+						error={ timeValidation.error }
 						onChange={ ( nextTime ) =>
 							setNextValue( date, nextTime )
 						}
+						onBlur={ timeValidation.validate }
 					/>
 				</FlexBlock>
 			</Flex>

--- a/js/src/blocks/product-date-time-field/edit.js
+++ b/js/src/blocks/product-date-time-field/edit.js
@@ -10,6 +10,18 @@ import {
 } from '@woocommerce/product-editor';
 import { Flex, FlexBlock } from '@wordpress/components';
 
+/**
+ * @typedef {import('../types.js').ProductEditorBlockContext} ProductEditorBlockContext
+ * @typedef {import('../types.js').ProductBasicAttributes} ProductBasicAttributes
+ */
+
+/**
+ * Custom block for editing a given product data with date and time fields.
+ *
+ * @param {Object} props React props.
+ * @param {ProductBasicAttributes} props.attributes
+ * @param {ProductEditorBlockContext} props.context
+ */
 export default function Edit( { attributes, context } ) {
 	const blockProps = useWooBlockProps( attributes );
 	const [ value, setValue ] = useProductEntityProp( attributes.property, {

--- a/js/src/blocks/product-date-time-field/editor.module.scss
+++ b/js/src/blocks/product-date-time-field/editor.module.scss
@@ -1,0 +1,5 @@
+.invisibleLabelAndTooltip {
+	label {
+		visibility: hidden;
+	}
+}

--- a/js/src/blocks/product-select-field/block.json
+++ b/js/src/blocks/product-select-field/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "google-listings-and-ads/product-select-field",
-	"title": "Product select control",
+	"title": "Product select field",
 	"textdomain": "google-listings-and-ads",
 	"attributes": {
 		"_templateBlockHideConditions": {

--- a/js/src/blocks/product-select-field/edit.js
+++ b/js/src/blocks/product-select-field/edit.js
@@ -10,6 +10,25 @@ import { __experimentalUseProductEntityProp as useProductEntityProp } from '@woo
  */
 import { Label } from '../components';
 
+/**
+ * @typedef {import('../types.js').ProductEditorBlockContext} ProductEditorBlockContext
+ * @typedef {import('../types.js').ProductBasicAttributes} ProductBasicAttributes
+ */
+
+/**
+ * @typedef {Object} SpecificAttributes
+ * @property {import('@wordpress/components').SelectControl.Option} [options=[]] The options to be shown in the select field.
+ *
+ * @typedef {ProductBasicAttributes & SpecificAttributes} ProductSelectFieldAttributes
+ */
+
+/**
+ * Custom block for editing a given product data with a select field.
+ *
+ * @param {Object} props React props.
+ * @param {ProductSelectFieldAttributes} props.attributes
+ * @param {ProductEditorBlockContext} props.context
+ */
 export default function Edit( { attributes, context } ) {
 	const blockProps = useWooBlockProps( attributes );
 	const [ value, setValue ] = useProductEntityProp( attributes.property, {

--- a/js/src/blocks/product-select-with-text-field/block.json
+++ b/js/src/blocks/product-select-with-text-field/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "google-listings-and-ads/product-select-with-text-field",
-	"title": "Product select control with text control",
+	"title": "Product select with text field",
 	"textdomain": "google-listings-and-ads",
 	"attributes": {
 		"_templateBlockHideConditions": {

--- a/js/src/blocks/product-select-with-text-field/block.json
+++ b/js/src/blocks/product-select-with-text-field/block.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "google-listings-and-ads/product-select-with-text-field",
+	"title": "Product select control with text control",
+	"textdomain": "google-listings-and-ads",
+	"attributes": {
+		"_templateBlockHideConditions": {
+			"type": "array"
+		},
+		"label": {
+			"type": "string"
+		},
+		"tooltip": {
+			"type": "string"
+		},
+		"property": {
+			"type": "string",
+			"__experimentalRole": "content"
+		},
+		"options": {
+			"type": "array",
+			"items": {
+				"type": "object"
+			},
+			"default": []
+		},
+		"customInputValue": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"html": false,
+		"inserter": false,
+		"lock": false
+	},
+	"usesContext": [
+		"postType"
+	]
+}

--- a/js/src/blocks/product-select-with-text-field/edit.js
+++ b/js/src/blocks/product-select-with-text-field/edit.js
@@ -14,8 +14,30 @@ import {
  */
 import { Label } from '../components';
 
+/**
+ * @typedef {import('../types.js').ProductEditorBlockContext} ProductEditorBlockContext
+ * @typedef {import('../types.js').ProductBasicAttributes} ProductBasicAttributes
+ */
+
+/**
+ * @typedef {Object} SpecificAttributes
+ * @property {string} customInputValue The value to be used in the selection option that shows the text field.
+ * @property {import('@wordpress/components').SelectControl.Option} [options=[]] The options to be shown in the select field.
+ *
+ * @typedef {ProductBasicAttributes & SpecificAttributes} ProductSelectWithTextFieldAttributes
+ */
+
 const FALLBACK_VALUE = '';
 
+/**
+ * Custom block for editing a given product data with a select field or a text field.
+ * The text field is used to enter a custom value and is shown when selecting the option
+ * that has the same value as the given `customInputValue`.
+ *
+ * @param {Object} props React props.
+ * @param {ProductSelectWithTextFieldAttributes} props.attributes
+ * @param {ProductEditorBlockContext} props.context
+ */
 export default function Edit( { attributes, context } ) {
 	const { options, customInputValue } = attributes;
 

--- a/js/src/blocks/product-select-with-text-field/edit.js
+++ b/js/src/blocks/product-select-with-text-field/edit.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { SelectControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import {
+	__experimentalUseProductEntityProp as useProductEntityProp,
+	__experimentalTextControl as TextControl,
+} from '@woocommerce/product-editor';
+
+/**
+ * Internal dependencies
+ */
+import { Label } from '../components';
+
+const FALLBACK_VALUE = '';
+
+export default function Edit( { attributes, context } ) {
+	const { options, customInputValue } = attributes;
+
+	const blockProps = useWooBlockProps( attributes );
+	const [ value, setValue ] = useProductEntityProp( attributes.property, {
+		postType: context.postType,
+		fallbackValue: FALLBACK_VALUE,
+	} );
+
+	// Refer to the "Derived value for initialization" in README for why this `useState`
+	// can initialize directly.
+	const [ optionValue, setOptionValue ] = useState( () => {
+		// Empty string is a valid option value.
+		const initValue = value ?? FALLBACK_VALUE;
+		const selectedOption = options.find(
+			( option ) => option.value === initValue
+		);
+
+		return selectedOption?.value ?? customInputValue;
+	} );
+
+	const isSelectedCustomInput = optionValue === customInputValue;
+
+	const [ text, setText ] = useState( isSelectedCustomInput ? value : '' );
+
+	const handleSelectionChange = ( nextOptionValue ) => {
+		setOptionValue( nextOptionValue );
+
+		if ( nextOptionValue === customInputValue ) {
+			setValue( text );
+		} else {
+			setValue( nextOptionValue );
+		}
+	};
+
+	const handleTextChange = ( nextText ) => {
+		setText( nextText );
+		setValue( nextText );
+	};
+
+	return (
+		<div { ...blockProps }>
+			<SelectControl
+				label={
+					<Label
+						label={ attributes.label }
+						tooltip={ attributes.tooltip }
+					/>
+				}
+				options={ options }
+				value={ optionValue }
+				onChange={ handleSelectionChange }
+			/>
+			{ isSelectedCustomInput && (
+				<TextControl
+					type="text"
+					value={ text }
+					onChange={ handleTextChange }
+				/>
+			) }
+		</div>
+	);
+}

--- a/js/src/blocks/types.js
+++ b/js/src/blocks/types.js
@@ -1,0 +1,14 @@
+/**
+ * @typedef {Object} ProductEditorBlockContext
+ * @property {string} postType The current post type ('product' or 'product_variation') got from the context provider.
+ */
+
+/**
+ * @typedef {Object} ProductBasicAttributes
+ * @property {string} property Property or metadata name in which the value is stored in the product data.
+ * @property {string} [label] Label that appears on top of the field.
+ * @property {string} [tooltip] Tooltip next to the label with additional information.
+ */
+
+// This export is required for JSDoc in other files to import the type definitions from this file.
+export default {};

--- a/src/Admin/Input/DateTime.php
+++ b/src/Admin/Input/DateTime.php
@@ -21,7 +21,7 @@ class DateTime extends Input {
 	 * DateTime constructor.
 	 */
 	public function __construct() {
-		parent::__construct( 'datetime' );
+		parent::__construct( 'datetime', 'google-listings-and-ads/product-date-time-field' );
 	}
 
 	/**

--- a/src/Admin/Input/SelectWithTextInput.php
+++ b/src/Admin/Input/SelectWithTextInput.php
@@ -28,7 +28,7 @@ class SelectWithTextInput extends Input {
 			->set_name( self::CUSTOM_INPUT_KEY );
 		$this->add( $custom_input );
 
-		parent::__construct( 'select-with-text-input' );
+		parent::__construct( 'select-with-text-input', 'google-listings-and-ads/product-select-with-text-field' );
 	}
 
 	/**
@@ -135,5 +135,31 @@ class SelectWithTextInput extends Input {
 			$this->get_select_input()->set_data( $select_value );
 			$this->data = $select_value;
 		}
+	}
+
+	/**
+	 * Return the attributes of block config used for the input's view within the Product Block Editor.
+	 *
+	 * @return array
+	 */
+	public function get_block_attributes(): array {
+		$options = [];
+
+		foreach ( $this->get_options() as $key => $value ) {
+			$options[] = [
+				'label' => $value,
+				'value' => $key,
+			];
+		}
+
+		$options[] = [
+			'label' => __( 'Enter a custom value', 'google-listings-and-ads' ),
+			'value' => self::CUSTOM_INPUT_KEY,
+		];
+
+		$this->set_block_attribute( 'options', $options );
+		$this->set_block_attribute( 'customInputValue', self::CUSTOM_INPUT_KEY );
+
+		return parent::get_block_attributes();
 	}
 }

--- a/src/Admin/Product/Attributes/AttributesBlock.php
+++ b/src/Admin/Product/Attributes/AttributesBlock.php
@@ -49,6 +49,7 @@ class AttributesBlock implements Service, Registerable, Conditional {
 	 */
 	protected const CUSTOM_BLOCKS = [
 		'product-select-field',
+		'product-select-with-text-field',
 	];
 
 	/**

--- a/src/Admin/Product/Attributes/AttributesBlock.php
+++ b/src/Admin/Product/Attributes/AttributesBlock.php
@@ -68,8 +68,8 @@ class AttributesBlock implements Service, Registerable, Conditional {
 	 * Register a service.
 	 */
 	public function register(): void {
-		// compatibility-code "WC >= 8.3" -- The Block Template API used requires at least WooCommerce 8.3
-		if ( ! version_compare( WC_VERSION, '8.3', '>=' ) ) {
+		// compatibility-code "WC >= 8.4" -- The Block Template API used requires at least WooCommerce 8.4
+		if ( ! version_compare( WC_VERSION, '8.4', '>=' ) ) {
 			return;
 		}
 

--- a/src/Admin/Product/Attributes/AttributesBlock.php
+++ b/src/Admin/Product/Attributes/AttributesBlock.php
@@ -48,6 +48,7 @@ class AttributesBlock implements Service, Registerable, Conditional {
 	 * @var string[]
 	 */
 	protected const CUSTOM_BLOCKS = [
+		'product-date-time-field',
 		'product-select-field',
 		'product-select-with-text-field',
 	];

--- a/src/Admin/Product/Attributes/AttributesBlock.php
+++ b/src/Admin/Product/Attributes/AttributesBlock.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminStyleAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
@@ -141,7 +142,7 @@ class AttributesBlock implements Service, Registerable, Conditional {
 			register_block_type( $block_json_file );
 		}
 
-		$asset = new AdminScriptWithBuiltDependenciesAsset(
+		$assets[] = new AdminScriptWithBuiltDependenciesAsset(
 			'google-listings-and-ads-product-blocks',
 			$uri,
 			"${build_path}/blocks.asset.php",
@@ -153,8 +154,15 @@ class AttributesBlock implements Service, Registerable, Conditional {
 			)
 		);
 
-		$this->assets_handler->register( $asset );
-		$this->assets_handler->enqueue( $asset );
+		$assets[] = new AdminStyleAsset(
+			'google-listings-and-ads-product-blocks-css',
+			$uri,
+			[],
+			(string) filemtime( "${build_path}/blocks.css" )
+		);
+
+		$this->assets_handler->register_many( $assets );
+		$this->assets_handler->enqueue_many( $assets );
 	}
 
 	/**

--- a/tests/Unit/Admin/Input/InputCollectionTest.php
+++ b/tests/Unit/Admin/Input/InputCollectionTest.php
@@ -71,6 +71,7 @@ class InputCollectionTest extends UnitTest {
 		$input = new DateTime();
 
 		$this->assertEquals( 'datetime', $input->get_type() );
+		$this->assertEquals( 'google-listings-and-ads/product-date-time-field', $input->get_block_name() );
 
 		// Null by default
 		$view_data = $input->get_view_data();

--- a/tests/Unit/Admin/Input/InputCollectionTest.php
+++ b/tests/Unit/Admin/Input/InputCollectionTest.php
@@ -148,8 +148,10 @@ class InputCollectionTest extends UnitTest {
 	public function test_select_with_text_input() {
 		$input = new SelectWithTextInput();
 		$input->set_name( 'name' );
+		$input->set_id( 'test-select-with-text-input' );
 
 		$this->assertEquals( 'select-with-text-input', $input->get_type() );
+		$this->assertEquals( 'google-listings-and-ads/product-select-with-text-field', $input->get_block_name() );
 
 		// Default view data
 		$this->assertEquals(
@@ -194,6 +196,17 @@ class InputCollectionTest extends UnitTest {
 				'gla_wrapper_class' => ' select-with-text-input',
 			],
 			$input->get_view_data()
+		);
+
+		$this->assertEquals( '_gla_custom_value', $input->get_block_attributes()['customInputValue'] );
+		$this->assertEquals(
+			[
+				[
+					'label' => 'Enter a custom value',
+					'value' => '_gla_custom_value',
+				],
+			],
+			$input->get_block_attributes()['options']
 		);
 
 		// After calling setters
@@ -251,6 +264,24 @@ class InputCollectionTest extends UnitTest {
 				'gla_wrapper_class' => ' select-with-text-input',
 			],
 			$input->get_view_data()
+		);
+
+		$this->assertEquals(
+			[
+				[
+					'label' => 'Default name',
+					'value' => '',
+				],
+				[
+					'label' => 'Use admin name',
+					'value' => 'use_admin_name',
+				],
+				[
+					'label' => 'Enter a custom value',
+					'value' => '_gla_custom_value',
+				],
+			],
+			$input->get_block_attributes()['options']
 		);
 
 		// Selected an option other than value from the custom text input

--- a/tests/Unit/Admin/Product/Attributes/AttributesBlockTest.php
+++ b/tests/Unit/Admin/Product/Attributes/AttributesBlockTest.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesBlock;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminStyleAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Adult;
@@ -207,8 +208,8 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_register_custom_blocks() {
-		$custom_blocks  = [ 'existing-block', 'non-existent-block' ];
-		$expected_asset = new AdminScriptWithBuiltDependenciesAsset(
+		$custom_blocks         = [ 'existing-block', 'non-existent-block' ];
+		$expected_script_asset = new AdminScriptWithBuiltDependenciesAsset(
 			'google-listings-and-ads-product-blocks',
 			'tests/data/blocks',
 			GLA_TESTS_DATA_DIR . '/blocks.asset.php',
@@ -219,16 +220,22 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 				]
 			)
 		);
+		$expected_style_asset  = new AdminStyleAsset(
+			'google-listings-and-ads-product-blocks-css',
+			'tests/data/blocks',
+			[],
+			(string) filemtime( GLA_TESTS_DATA_DIR . '/blocks.css' )
+		);
 
 		$this->assets_handler
 			->expects( $this->exactly( 1 ) )
-			->method( 'register' )
-			->with( $expected_asset );
+			->method( 'register_many' )
+			->with( [ $expected_script_asset, $expected_style_asset ] );
 
 		$this->assets_handler
 			->expects( $this->exactly( 1 ) )
-			->method( 'enqueue' )
-			->with( $expected_asset );
+			->method( 'enqueue_many' )
+			->with( [ $expected_script_asset, $expected_style_asset ] );
 
 		$this->attributes_block->register_custom_blocks( GLA_TESTS_DATA_DIR, 'tests/data/blocks', $custom_blocks );
 	}

--- a/tests/Unit/Admin/Product/Attributes/AttributesBlockTest.php
+++ b/tests/Unit/Admin/Product/Attributes/AttributesBlockTest.php
@@ -61,9 +61,9 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 	protected const VARIATION_IMAGES_SECTION_HOOK  = 'woocommerce_block_template_area_product-form_after_add_block_product-variation-images-section';
 
 	public function setUp(): void {
-		// compatibility-code "WC >= 8.3" -- The Block Template API used requires at least WooCommerce 8.3
-		if ( ! version_compare( WC_VERSION, '8.3', '>=' ) ) {
-			$this->markTestSkipped( 'This test suite requires WooCommerce version >= 8.3' );
+		// compatibility-code "WC >= 8.4" -- The Block Template API used requires at least WooCommerce 8.4
+		if ( ! version_compare( WC_VERSION, '8.4', '>=' ) ) {
+			$this->markTestSkipped( 'This test suite requires WooCommerce version >= 8.4' );
 		}
 
 		parent::setUp();

--- a/tests/Unit/Admin/Product/Attributes/AttributesBlockTest.php
+++ b/tests/Unit/Admin/Product/Attributes/AttributesBlockTest.php
@@ -287,20 +287,18 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 	 * `InputTest` and `AttributeInputCollectionTest`.
 	 */
 	public function test_register_add_blocks() {
-		// The total number of blocks to be added to the simple product template is 16,
-		// and the converted number so far is 15
+		// The total number of blocks to be added to the simple product template is 16
 		$this->simple_gla_section
-			->expects( $this->exactly( 15 ) )
+			->expects( $this->exactly( 16 ) )
 			->method( 'add_block' );
 
 		$this->simple_gla_section->get_block( 'mocked-singleton' )
-			->expects( $this->exactly( 15 ) )
+			->expects( $this->exactly( 16 ) )
 			->method( 'add_hide_condition' );
 
-		// The total number of visible blocks to be added to the variation product template is 15,
-		// and the converted number so far is 14
+		// The total number of visible blocks to be added to the variation product template is 15
 		$this->variation_gla_section
-			->expects( $this->exactly( 14 ) )
+			->expects( $this->exactly( 15 ) )
 			->method( 'add_block' );
 
 		$this->variation_gla_section->get_block( 'mocked-singleton' )

--- a/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
+++ b/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
@@ -146,6 +146,19 @@ class AttributeInputCollectionTest extends UnitTest {
 			],
 			$input->get_view_data()
 		);
+
+		$this->assertEquals(
+			[
+				'id'         => 'google-listings-and-ads-product-attributes-availabilityDate',
+				'blockName'  => 'google-listings-and-ads/product-date-time-field',
+				'attributes' => [
+					'property' => 'meta_data._wc_gla_availabilityDate',
+					'label'    => 'Availability Date',
+					'tooltip'  => 'The date a preordered or backordered product becomes available for delivery. Required if product availability is preorder or backorder',
+				],
+			],
+			$input->get_block_config()
+		);
 	}
 
 	public function test_brand_input() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To be compatible with Product Block Editor, this PR makes the conversions for the last two attribute inputs:

- Implement the custom blocks for the product select-with-text field and product date-time field.
- Map `SelectWithTextInput` and `DateTime` inputs to the above custom product blocks.
- Set the minimum required Woo version of `AttributesBlock` class to 8.4 as it's the minimum version that the `__experimentalTextControl` component is exported from `@woocommerce/product-editor`.

### Screenshots:

#### 📷 Field is converted from text block to select-with-text block

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/c7295f35-294d-4df4-bf7a-edfbeb382561)

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/7f90e834-7e9f-4589-8931-4bd79e35510e)

#### 📷 Date-time block

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/4f96517a-bb89-4bbb-84f7-3a8e4810fc5a)

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/687873e2-16ce-420c-b0b9-dbacb6ee0d67)

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/7253359c-8054-404f-b74b-83ed4cca4604)

### Detailed test instructions:

#### 📌 Prepare test environment

1. Please refer to [the test preparation in PR 2151](https://github.com/woocommerce/google-listings-and-ads/pull/2151#prepare-test-environment) with **Woo 8.4.0**.
   - Currently, it can be tested with [8.4.0-rc.1](https://github.com/woocommerce/woocommerce/releases/tag/8.4.0-rc.1)
1. `npm install`
1. `npm start`

#### 📌 Test the select-with-text block

1. Install [WooCommerce Brands](https://github.com/woocommerce/woocommerce-brands) but don't activate it.
1. Go to edit a simple product, e.g. the **Beanie with Logo** imported from WC's sample products.
1. Switch to the **Organization** tab and find the **Google Listings & Ads** section.
1. The brand field should be shown in a text block.
1. Activate WooCommerce Brands and refresh the product editor page.
1. Check if the brand field is shown in a select-with-text block with three options:
   1. "Default"
   1. "From WooCommerce Brands"
   1. "Enter a custom value"
1. Change the selected option to see if the UI works well.
1. After selecting the "Enter a custom value" option, a text field should be shown below the selection.
1. Operate the selection and text fields.
1. Click on the **Update** button at the top-right of the page.
1. Refresh the page or switch back to the classical product editor to see if the changed option or text is saved.
1. The GTIN and MPN will be converted to use the select-with-text block when Yoast WooCommerce SEO is installed and activated.
   - If want to also test this part without actually getting the extension, an alternative way is to locally make the following function `return true;`
      https://github.com/woocommerce/google-listings-and-ads/blob/abd3492ab9db2350bfa7c215bdf452cb12b299ed/src/Integration/YoastWooCommerceSeo.php#L32-L34

#### 📌 Test the date-time block

1. Go to Settings > General. Set the site's timezone to another one different from your machine's system time, which is also the local timezone of browsers.
1. Go to edit a simple product that has not yet set an availability date.
1. Switch to the **Organization** tab and find the **Google Listings & Ads** section.
1. Check if there is an Availability Date field shown in a date-time block.
1. Operate the date-time block to set a date.
1. Click on the **Update** button at the top-right of the page.
1. Refresh the page to see if the availability date is saved.
1. Switch back to the classical product editor to see if the values on the availability date field are the same.
1. Set the site's timezone to another or the same as your machine.
1. Refresh and check both classical and blockified product editors to see if the date values are shifted as per the delta of the two timezones.

### Additional details:

TODOs will be cleaned up in a separate PR.

- https://github.com/woocommerce/google-listings-and-ads/blob/abd3492ab9db2350bfa7c215bdf452cb12b299ed/src/Admin/Input/Input.php#L60-L61
- https://github.com/woocommerce/google-listings-and-ads/blob/abd3492ab9db2350bfa7c215bdf452cb12b299ed/src/Admin/Product/Attributes/AttributesBlock.php#L194-L197

### Changelog entry
