### PR TITLE
Product Block Editor: Preprocessing for adding the channel visibility

### DIFF
--- a/js/src/blocks/README.md
+++ b/js/src/blocks/README.md
@@ -77,14 +77,14 @@ With the adjusted setup:
 
 #### Registration on the PHP side
 
-By default, when each block is registered via PHP in the [AttributesBlock](../../../src/Admin/Product/Attributes/AttributesBlock.php) class, the `register_block_type` function will also register and enqueue the related scripts and styles such as the built edit.js.
+By default, when each block is registered via PHP in the [ProductBlocksService](../../../src/Admin/ProductBlocksService.php) class, the `register_block_type` function will also register and enqueue the related scripts and styles such as the built edit.js.
 
-The same part is the separate registration for each block, therefore all blocks should be listed in the `CUSTOM_BLOCKS` array of the `AttributesBlock` class.
+The same part is the separate registration for each block, therefore all blocks should be listed in the `CUSTOM_BLOCKS` array of the `ProductBlocksService` class.
 
 With the adjusted setup:
 
 - The scripts and styles of blocks are not specified in block.json files, so they won't be registered or enqueued via the `register_block_type` function.
-- Instead, the blocks.js script is registered and enqueued by `AttributesBlock`.
+- Instead, the blocks.js script is registered and enqueued by `ProductBlocksService`.
 
 ## Related documentation
 

--- a/src/Admin/Input/Input.php
+++ b/src/Admin/Input/Input.php
@@ -57,8 +57,7 @@ class Input extends Form implements InputInterface {
 	 * @param string $type
 	 * @param string $block_name The name of a generic product block in WooCommerce core or a custom block in this extension.
 	 */
-	public function __construct( string $type, string $block_name = '' ) {
-		// TODO: Remove the default value of $block_name after all attribute inputs have specified a block name
+	public function __construct( string $type, string $block_name ) {
 		$this->type       = $type;
 		$this->block_name = $block_name;
 		parent::__construct();

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -100,6 +100,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 		add_action(
 			"woocommerce_block_template_area_{$template_area}_after_add_block_{$block_id}",
 			function ( BlockInterface $general_group ) {
+				/** @var Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\ProductFormTemplateInterface */
 				$template = $general_group->get_root_template();
 
 				// Please note that the simple and variable product types use the same product block template 'simple-product'.
@@ -107,6 +108,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					return;
 				}
 
+				/** @var Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\Group */
 				$group = $template->add_group(
 					[
 						'id'         => 'google-listings-and-ads-group',
@@ -117,6 +119,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					]
 				);
 
+				/** @var Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\Section */
 				$channel_visibility_section = $group->add_section(
 					[
 						'id'         => 'google-listings-and-ads-channel-visibility-section',
@@ -127,6 +130,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					]
 				);
 
+				/** @var Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\Section */
 				$product_attributes_section = $group->add_section(
 					[
 						'id'         => 'google-listings-and-ads-product-attributes-section',
@@ -203,6 +207,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 				// When editing a simple or variable product, its product type on the frontend side can be
 				// changed dynamically. So, it needs to use the ProductTemplates API `add_hide_condition`
 				// to conditionally hide attributes.
+				/** @var BlockInterface */
 				$block = $section->add_block( $input->get_block_config() );
 				$block->add_hide_condition( $this->get_hide_condition( $attribute_type ) );
 			}

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -191,11 +191,6 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 			$input_type = call_user_func( [ $attribute_type, 'get_input_type' ] );
 			$input      = AttributesForm::init_input( new $input_type(), new $attribute_type() );
 
-			// TODO: Remove this check after all attribute inputs have specified a block name
-			if ( '' === $input->get_block_config()['blockName'] ) {
-				continue;
-			}
-
 			if ( $is_variation_template ) {
 				// When editing a variation, its product type on the frontend side won't be changed dynamically.
 				// In addition, the property of `editedProduct.type` doesn't exist in the variation product.

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -17,6 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\BuiltScriptDependencyArray;
 use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
+use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\SectionInterface;
 use Automattic\WooCommerce\Admin\PageController;
 
 defined( 'ABSPATH' ) || exit;
@@ -120,7 +121,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					]
 				);
 
-				/** @var Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\SectionInterface */
+				/** @var SectionInterface */
 				$channel_visibility_section = $group->add_section(
 					[
 						'id'         => 'google-listings-and-ads-channel-visibility-section',
@@ -131,7 +132,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					]
 				);
 
-				/** @var Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\SectionInterface */
+				/** @var SectionInterface */
 				$product_attributes_section = $group->add_section(
 					[
 						'id'         => 'google-listings-and-ads-product-attributes-section',
@@ -191,9 +192,9 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 	/**
 	 * Add product attribute blocks to the given section block.
 	 *
-	 * @param BlockInterface $section The section block to add product attribute blocks
+	 * @param SectionInterface $section The section block to add product attribute blocks
 	 */
-	private function add_product_attribute_blocks( BlockInterface $section ): void {
+	private function add_product_attribute_blocks( SectionInterface $section ): void {
 		$is_variation_template = $this->is_variation_template( $section );
 
 		$product_types   = $is_variation_template ? [ 'variation' ] : $this->get_applicable_product_types();

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -117,6 +117,16 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					]
 				);
 
+				$channel_visibility_section = $group->add_section(
+					[
+						'id'         => 'google-listings-and-ads-channel-visibility-section',
+						'order'      => 1,
+						'attributes' => [
+							'title' => __( 'Channel visibility', 'google-listings-and-ads' ),
+						],
+					]
+				);
+
 				$product_attributes_section = $group->add_section(
 					[
 						'id'         => 'google-listings-and-ads-product-attributes-section',

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -1,8 +1,10 @@
 <?php
 declare( strict_types=1 );
 
-namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesForm;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
@@ -19,11 +21,11 @@ use Automattic\WooCommerce\Admin\PageController;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class AttributesBlock
+ * Class ProductBlocksService
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
  */
-class AttributesBlock implements Service, Registerable, Conditional {
+class ProductBlocksService implements Service, Registerable, Conditional {
 
 	use AdminConditional;
 	use AttributesTrait;
@@ -54,7 +56,7 @@ class AttributesBlock implements Service, Registerable, Conditional {
 	];
 
 	/**
-	 * AttributesBlock constructor.
+	 * ProductBlocksService constructor.
 	 *
 	 * @param AssetsHandlerInterface $assets_handler
 	 * @param AttributeManager       $attribute_manager

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -109,7 +109,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					return;
 				}
 
-				/** @var Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\Group */
+				/** @var Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\GroupInterface */
 				$group = $template->add_group(
 					[
 						'id'         => 'google-listings-and-ads-group',
@@ -120,7 +120,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					]
 				);
 
-				/** @var Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\Section */
+				/** @var Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\SectionInterface */
 				$channel_visibility_section = $group->add_section(
 					[
 						'id'         => 'google-listings-and-ads-channel-visibility-section',
@@ -131,7 +131,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					]
 				);
 
-				/** @var Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\Section */
+				/** @var Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\SectionInterface */
 				$product_attributes_section = $group->add_section(
 					[
 						'id'         => 'google-listings-and-ads-product-attributes-section',

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -12,9 +12,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityM
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\CouponChannelVisibilityMetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesBlock;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTab;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\VariationsAttributes;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\ProductBlocksService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService as AdsAccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
@@ -321,7 +321,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( AttributeManager::class );
 		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
-		$this->conditionally_share_with_tags( AttributesBlock::class, AssetsHandlerInterface::class, AttributeManager::class, MerchantCenterService::class );
+		$this->conditionally_share_with_tags( ProductBlocksService::class, AssetsHandlerInterface::class, AttributeManager::class, MerchantCenterService::class );
 
 		$this->share_with_tags( MerchantAccountState::class );
 		$this->share_with_tags( MerchantStatuses::class );

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -102,11 +102,16 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 		$template = $this->createStub( ProductFormTemplateInterface::class );
 		$group    = $this->createStub( GroupInterface::class );
 
+		$visibility_section = $this->createMock( SectionInterface::class );
 		$attributes_section = $this->createMock( SectionInterface::class );
+		$visibility_block   = $this->createMock( BlockInterface::class );
 		$attributes_block   = $this->createMock( BlockInterface::class );
 
 		$template->method( 'get_id' )->willReturn( $template_id );
 		$template->method( 'add_group' )->willReturn( $group );
+
+		$visibility_section->method( 'get_root_template' )->willReturn( $template );
+		$visibility_section->method( 'add_block' )->willReturn( $visibility_block );
 
 		$attributes_section->method( 'get_root_template' )->willReturn( $template );
 		$attributes_section->method( 'add_block' )->willReturn( $attributes_block );
@@ -116,7 +121,11 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 		$group
 			->method( 'add_section' )
 			->willReturnCallback(
-				function ( array $config ) use ( $attributes_section ) {
+				function ( array $config ) use ( $visibility_section, $attributes_section ) {
+					if ( 'google-listings-and-ads-channel-visibility-section' === $config['id'] ) {
+						return $visibility_section;
+					}
+
 					if ( 'google-listings-and-ads-product-attributes-section' === $config['id'] ) {
 						return $attributes_section;
 					}
@@ -126,7 +135,9 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 		return [
 			'template'           => $template,
 			'group'              => $group,
+			'visibility_section' => $visibility_section,
 			'attributes_section' => $attributes_section,
+			'visibility_block'   => $visibility_block,
 			'attributes_block'   => $attributes_block,
 		];
 	}
@@ -289,9 +300,18 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 			);
 
 		$this->simple['group']
-			->expects( $this->exactly( 1 ) )
+			->expects( $this->exactly( 2 ) )
 			->method( 'add_section' )
 			->withConsecutive(
+				[
+					[
+						'id'         => 'google-listings-and-ads-channel-visibility-section',
+						'order'      => 1,
+						'attributes' => [
+							'title' => __( 'Channel visibility', 'google-listings-and-ads' ),
+						],
+					],
+				],
 				[
 					[
 						'id'         => 'google-listings-and-ads-product-attributes-section',
@@ -316,9 +336,18 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 			);
 
 		$this->variation['group']
-			->expects( $this->exactly( 1 ) )
+			->expects( $this->exactly( 2 ) )
 			->method( 'add_section' )
 			->withConsecutive(
+				[
+					[
+						'id'         => 'google-listings-and-ads-channel-visibility-section',
+						'order'      => 1,
+						'attributes' => [
+							'title' => __( 'Channel visibility', 'google-listings-and-ads' ),
+						],
+					],
+				],
 				[
 					[
 						'id'         => 'google-listings-and-ads-product-attributes-section',

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -1,15 +1,15 @@
 <?php
 declare( strict_types=1 );
 
-namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin\Product\Attributes;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin;
 
 use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
 use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\GroupInterface;
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\SectionInterface;
 use Automattic\WooCommerce\Admin\PageController;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesBlock;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\ProductBlocksService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
@@ -22,11 +22,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\BuiltScriptDependencyArray
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * Class AttributesBlockTest
+ * Class ProductBlocksServiceTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin\Product\Attributes
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin
  */
-class AttributesBlockTest extends ContainerAwareUnitTest {
+class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 
 	use AttributesTrait;
 
@@ -51,8 +51,8 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 	/** @var MockObject|SectionInterface $variation_gla_section */
 	protected $variation_gla_section;
 
-	/** @var AttributesBlock $attributes_block */
-	protected $attributes_block;
+	/** @var ProductBlocksService $product_blocks_service */
+	protected $product_blocks_service;
 
 	/** @var bool $is_mc_setup_complete */
 	protected $is_mc_setup_complete;
@@ -75,7 +75,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 		$this->simple_anchor_block    = $this->createMock( BlockInterface::class );
 		$this->variation_anchor_block = $this->createMock( BlockInterface::class );
 
-		$this->attributes_block = new AttributesBlock( $this->assets_handler, $this->attribute_manager, $this->merchant_center );
+		$this->product_blocks_service = new ProductBlocksService( $this->assets_handler, $this->attribute_manager, $this->merchant_center );
 
 		// Set up stubs and mocks
 		$this->is_mc_setup_complete = true;
@@ -130,17 +130,17 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 	public function test_get_hide_condition() {
 		$this->assertEquals(
 			"editedProduct.type !== 'simple' && editedProduct.type !== 'variable' && editedProduct.type !== 'variation'",
-			$this->attributes_block->get_hide_condition( Adult::class )
+			$this->product_blocks_service->get_hide_condition( Adult::class )
 		);
 
 		$this->assertEquals(
 			"editedProduct.type !== 'simple' && editedProduct.type !== 'variable'",
-			$this->attributes_block->get_hide_condition( Brand::class )
+			$this->product_blocks_service->get_hide_condition( Brand::class )
 		);
 
 		$this->assertEquals(
 			"editedProduct.type !== 'simple' && editedProduct.type !== 'variation'",
-			$this->attributes_block->get_hide_condition( Gender::class )
+			$this->product_blocks_service->get_hide_condition( Gender::class )
 		);
 
 		add_filter(
@@ -153,7 +153,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 
 		$this->assertEquals(
 			"editedProduct.type !== 'variation'",
-			$this->attributes_block->get_hide_condition( Gender::class )
+			$this->product_blocks_service->get_hide_condition( Gender::class )
 		);
 	}
 
@@ -168,7 +168,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 			->expects( $this->exactly( 0 ) )
 			->method( 'get_root_template' );
 
-		$this->attributes_block->register();
+		$this->product_blocks_service->register();
 
 		do_action( self::SIMPLE_ATTRIBUTES_SECTION_HOOK, $this->simple_anchor_block );
 		do_action( self::VARIATION_IMAGES_SECTION_HOOK, $this->variation_anchor_block );
@@ -185,7 +185,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 			->expects( $this->exactly( 0 ) )
 			->method( 'get_root_template' );
 
-		$this->attributes_block->register();
+		$this->product_blocks_service->register();
 
 		do_action( self::SIMPLE_ATTRIBUTES_SECTION_HOOK, $this->simple_anchor_block );
 		do_action( self::VARIATION_IMAGES_SECTION_HOOK, $this->variation_anchor_block );
@@ -200,7 +200,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 			->expects( $this->exactly( 1 ) )
 			->method( 'get_root_template' );
 
-		$this->attributes_block->register();
+		$this->product_blocks_service->register();
 
 		do_action( self::SIMPLE_ATTRIBUTES_SECTION_HOOK, $this->simple_anchor_block );
 		do_action( self::VARIATION_IMAGES_SECTION_HOOK, $this->variation_anchor_block );
@@ -230,7 +230,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 			->method( 'enqueue' )
 			->with( $expected_asset );
 
-		$this->attributes_block->register_custom_blocks( GLA_TESTS_DATA_DIR, 'tests/data/blocks', $custom_blocks );
+		$this->product_blocks_service->register_custom_blocks( GLA_TESTS_DATA_DIR, 'tests/data/blocks', $custom_blocks );
 	}
 
 	public function test_register_not_add_section() {
@@ -242,7 +242,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 			->expects( $this->exactly( 0 ) )
 			->method( 'add_section' );
 
-		$this->attributes_block->register();
+		$this->product_blocks_service->register();
 
 		// Here it intentionally calls with a mismatched template for each
 		do_action( self::SIMPLE_ATTRIBUTES_SECTION_HOOK, $this->variation_anchor_block );
@@ -276,7 +276,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 				]
 			);
 
-		$this->attributes_block->register();
+		$this->product_blocks_service->register();
 
 		do_action( self::SIMPLE_ATTRIBUTES_SECTION_HOOK, $this->simple_anchor_block );
 		do_action( self::VARIATION_IMAGES_SECTION_HOOK, $this->variation_anchor_block );
@@ -305,7 +305,7 @@ class AttributesBlockTest extends ContainerAwareUnitTest {
 			->expects( $this->exactly( 0 ) )
 			->method( 'add_hide_condition' );
 
-		$this->attributes_block->register();
+		$this->product_blocks_service->register();
 
 		do_action( self::SIMPLE_ATTRIBUTES_SECTION_HOOK, $this->simple_anchor_block );
 		do_action( self::VARIATION_IMAGES_SECTION_HOOK, $this->variation_anchor_block );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To be compatible with Product Block Editor, it also needs to add the channel visibility block.

Since product attributes and channel visibility are different groupings in terms of code and UI presentation, it would be better to separate them into different sections in the Product Block Editor as well. Therefore, before adding the block, it requires some preprocessing:

- Move and rename `Admin\Product\Attributes\AttributesBlock` class to `Admin\ProductBlocksService` class.
   - This way, when the block corresponding to `ChannelVisibilityMetaBox` is added to it afterward, the code structure should make more sense.
- Change to create a dedicated group in the Product Block Editor for this extension.
- Add a new section to this extension's group in the Product Block Editor for channel visibility setup.
- Clean up the temporary codes that prevent unmapped inputs from being added to the Product Block Editor.

### Screenshots:

#### 📷 Simple product

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/6431f6ad-2ebe-4432-b2fb-272d818c5599)

#### 📷 Variable product

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/ffdf13d7-aeef-4a7e-8acd-f51442001bd7)

#### 📷 Variation product

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/5b2ae69e-1f19-48e4-b8f4-f8a945aa494f)

### Detailed test instructions:

#### 📌 Prepare test environment

1. Please refer to [the test preparation in PR 2151](https://github.com/woocommerce/google-listings-and-ads/pull/2151#prepare-test-environment) with **Woo 8.4.0**.
   - Currently, it can be tested with [8.4.0-rc.1](https://github.com/woocommerce/woocommerce/releases/tag/8.4.0-rc.1)
1. `npm install`
1. `npm start`

#### 📌 Test the dedicated group for GL&A

1. Go to edit a simple product, e.g. the **Beanie with Logo** imported from WC's sample products.
1. Check if there is a **Google Listings & Ads** tab, which is that dedicated group.
1. Switch to the **Google Listings & Ads** tab.
1. Check if there are **Channel visibility** and **Product attributes** sections.
   - Currently, the Channel visibility section is empty.
   - The Product attributes section should have attribute fields that correspond to the current product's type.
1. Repeat the above test steps with variable product and variation product types.

### Changelog entry
