### PR TITLE
Change to require Google Ads connection during the onboarding

### DIFF
--- a/js/src/components/paid-ads/campaign-preview/mockup-search.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-search.js
@@ -48,7 +48,7 @@ export default function MockupSearch( { product } ) {
 					</ScaledText>
 					<Placeholder stroke="thinner" width="79" color="blue" />
 				</div>
-				<Flex justfy="space-between" align="stretch">
+				<Flex align="stretch">
 					<div className="gla-ads-mockup__search-card-placeholders">
 						<Placeholder width="100" />
 						<Placeholder width="97" />

--- a/js/src/hooks/useGoogleAdsAccount.js
+++ b/js/src/hooks/useGoogleAdsAccount.js
@@ -9,6 +9,7 @@ import { useCallback } from '@wordpress/element';
  */
 import { STORE_KEY } from '.~/data/constants';
 import { useAppDispatch } from '.~/data';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
 import useGoogleAccount from './useGoogleAccount';
 
 const googleAdsAccountSelector = 'getGoogleAdsAccount';
@@ -36,6 +37,15 @@ const useGoogleAdsAccount = () => {
 				googleAdsAccountSelector
 			);
 
+			// The "incomplete" status means there is a connected account but billing is not yet set
+			// so it's considered as `true`.
+			// The main reason for not using a naming like `isGoogleAdsConnected` here is to make
+			// a slight distinction from the "connected" status.
+			const hasGoogleAdsConnection = [
+				GOOGLE_ADS_ACCOUNT_STATUS.CONNECTED,
+				GOOGLE_ADS_ACCOUNT_STATUS.INCOMPLETE,
+			].includes( acc?.status );
+
 			return {
 				googleAdsAccount: acc,
 				isResolving: isResolvingGoogleAdsAccount,
@@ -43,6 +53,7 @@ const useGoogleAdsAccount = () => {
 				hasFinishedResolution: selector.hasFinishedResolution(
 					googleAdsAccountSelector
 				),
+				hasGoogleAdsConnection,
 			};
 		},
 		[ google, isResolving, refetchGoogleAdsAccount ]

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-features-section.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-features-section.js
@@ -15,7 +15,7 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import CampaignPreview from '.~/components/paid-ads/campaign-preview';
 import './paid-ads-features-section.scss';
 
-function FeatureList() {
+function FeatureList( { hideBudgetContent } ) {
 	const featuresItems = [
 		{
 			Icon: GridiconCheckmark,
@@ -24,21 +24,26 @@ function FeatureList() {
 				'google-listings-and-ads'
 			),
 		},
-		{
-			Icon: GridiconCheckmark,
-			content: __(
-				'Set a daily budget, and only pay when someone clicks.',
-				'google-listings-and-ads'
-			),
-		},
-		{
-			Icon: GridiconGift,
-			content: __(
-				'Claim $500 in ads credit when you spend your first $500 with Google Ads. Terms and conditions apply.',
-				'google-listings-and-ads'
-			),
-		},
 	];
+
+	if ( ! hideBudgetContent ) {
+		featuresItems.push(
+			{
+				Icon: GridiconCheckmark,
+				content: __(
+					'Set a daily budget, and only pay when someone clicks.',
+					'google-listings-and-ads'
+				),
+			},
+			{
+				Icon: GridiconGift,
+				content: __(
+					'Claim $500 in ads credit when you spend your first $500 with Google Ads. Terms and conditions apply.',
+					'google-listings-and-ads'
+				),
+			}
+		);
+	}
 
 	return (
 		<div className="gla-paid-ads-features-section__feature-list">
@@ -61,11 +66,13 @@ function FeatureList() {
  * for the next actions: skip or continue the paid ads setup.
  *
  * @param {Object} props React props.
+ * @param {boolean} props.hideBudgetContent Whether to hide the content about the ad budget.
  * @param {boolean} props.hideFooterButtons Whether to hide the buttons at the card footer.
  * @param {JSX.Element} props.skipButton Button to skip paid ads setup.
  * @param {JSX.Element} props.continueButton Button to continue paid ads setup.
  */
 export default function PaidAdsFeaturesSection( {
+	hideBudgetContent,
 	hideFooterButtons,
 	skipButton,
 	continueButton,
@@ -120,7 +127,9 @@ export default function PaidAdsFeaturesSection( {
 									'google-listings-and-ads'
 								) }
 							</div>
-							<FeatureList />
+							<FeatureList
+								hideBudgetContent={ hideBudgetContent }
+							/>
 							<cite className="gla-paid-ads-features-section__cite">
 								{ __(
 									'Source: Google Internal Data, July 2020',

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -11,16 +11,14 @@ import { Form } from '@woocommerce/components';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import useGoogleAdsAccountBillingStatus from '.~/hooks/useGoogleAdsAccountBillingStatus';
-import GoogleAdsAccountSection from './google-ads-account-section';
 import AudienceSection from '.~/components/paid-ads/audience-section';
 import BudgetSection from '.~/components/paid-ads/budget-section';
 import BillingCard from '.~/components/paid-ads/billing-card';
+import SpinnerCard from '.~/components/spinner-card';
+import Section from '.~/wcdl/section';
 import validateCampaign from '.~/components/paid-ads/validateCampaign';
 import clientSession from './clientSession';
-import {
-	GOOGLE_ADS_ACCOUNT_STATUS,
-	GOOGLE_ADS_BILLING_STATUS,
-} from '.~/constants';
+import { GOOGLE_ADS_BILLING_STATUS } from '.~/constants';
 
 /**
  * @typedef { import(".~/data/actions").CountryCode } CountryCode
@@ -77,7 +75,7 @@ function resolveInitialPaidAds( paidAds, targetAudience ) {
  * @param {(onStatesReceived: PaidAdsData)=>void} props.onStatesReceived Callback to receive the data for setting up paid ads when initial and also when the audience, budget, and billing are updated.
  */
 export default function PaidAdsSetupSections( { onStatesReceived } ) {
-	const { googleAdsAccount } = useGoogleAdsAccount();
+	const { hasGoogleAdsConnection } = useGoogleAdsAccount();
 	const { data: targetAudience } = useTargetAudienceFinalCountryCodes();
 	const { billingStatus } = useGoogleAdsAccountBillingStatus();
 
@@ -135,7 +133,11 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 	}, [ targetAudience ] );
 
 	if ( ! targetAudience || ! billingStatus ) {
-		return <GoogleAdsAccountSection />;
+		return (
+			<Section>
+				<SpinnerCard />
+			</Section>
+		);
 	}
 
 	const initialValues = {
@@ -153,16 +155,12 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 		>
 			{ ( formProps ) => {
 				const { countryCodes } = formProps.values;
-				const disabledAudience = ! [
-					GOOGLE_ADS_ACCOUNT_STATUS.CONNECTED,
-					GOOGLE_ADS_ACCOUNT_STATUS.INCOMPLETE,
-				].includes( googleAdsAccount?.status );
+				const disabledAudience = ! hasGoogleAdsConnection;
 				const disabledBudget =
 					disabledAudience || countryCodes.length === 0;
 
 				return (
 					<>
-						<GoogleAdsAccountSection />
 						<AudienceSection
 							formProps={ formProps }
 							disabled={ disabledAudience }

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -174,7 +174,10 @@ export default function SetupPaidAds() {
 			<ProductFeedStatusSection />
 			<GoogleAdsAccountSection />
 			<PaidAdsFeaturesSection
-				hideFooterButtons={ showPaidAdsSetup }
+				hideBudgetContent={ ! hasGoogleAdsConnection }
+				hideFooterButtons={
+					! hasGoogleAdsConnection || showPaidAdsSetup
+				}
 				skipButton={ createSkipButton(
 					__( 'Skip this step for now', 'google-listings-and-ads' )
 				) }

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -571,7 +571,7 @@ A modal is open
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
-### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L47)
+### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L49)
 Clicking on the skip paid ads button to complete the onboarding flow.
  The 'unknown' value of properties may means:
  - the paid ads setup is not opened
@@ -581,13 +581,13 @@ Clicking on the skip paid ads button to complete the onboarding flow.
 | name | type | description |
 | ---- | ---- | ----------- |
 `opened_paid_ads_setup` | `string` | Whether the paid ads setup is opened, e.g. 'yes', 'no'
-`google_ads_account_status` | `string` | The connection status of merchant's Google Ads addcount, e.g. 'unknown', 'connected', 'disconnected', 'incomplete'
+`google_ads_account_status` | `string` | The connection status of merchant's Google Ads addcount, e.g. 'connected', 'disconnected', 'incomplete'
 `billing_method_status` | `string` | aaa, The status of billing method of merchant's Google Ads addcount e.g. 'unknown', 'pending', 'approved', 'cancelled'
 `campaign_form_validation` | `string` | Whether the entered paid campaign form data are valid, e.g. 'unknown', 'valid', 'invalid'
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L69)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L71)
 
-### [`gla_onboarding_complete_with_paid_ads_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L39)
+### [`gla_onboarding_complete_with_paid_ads_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L41)
 Clicking on the "Complete setup" button to complete the onboarding flow with paid ads.
 #### Properties
 | name | type | description |
@@ -595,12 +595,12 @@ Clicking on the "Complete setup" button to complete the onboarding flow with pai
 `budget` | `number` | The budget for the campaign
 `audiences` | `string` | The targeted audiences for the campaign
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L69)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L71)
 
-### [`gla_onboarding_open_paid_ads_setup_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L33)
+### [`gla_onboarding_open_paid_ads_setup_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L35)
 Clicking on the "Create a paid ad campaign" button to open the paid ads setup in the onboarding flow.
 #### Emitters
-- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L69)
+- [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L71)
 
 ### [`gla_paid_campaign_step`](../../js/src/utils/recordEvent.js#L122)
 Triggered when moving to another step during creating/editing a campaign.

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -248,16 +248,6 @@ test.describe( 'Set up Ads account', () => {
 	test.describe( 'Create your paid campaign', () => {
 		test.beforeAll( async () => {
 			setupBudgetPage = new SetupBudgetPage( page );
-			await setupBudgetPage.fulfillBudgetRecommendation( {
-				currency: 'USD',
-				recommendations: [
-					{
-						country: 'US',
-						daily_budget_low: 5,
-						daily_budget_high: 15,
-					},
-				],
-			} );
 		} );
 
 		test( 'Continue to create paid campaign', async () => {

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -360,7 +360,7 @@ test.describe( 'Set up Ads account', () => {
 
 		test( 'Budget Recommendation', async () => {
 			await expect(
-				page.getByText( 'set a daily budget of 5 to 15 USD' )
+				page.getByText( 'set a daily budget of 15 USD' )
 			).toBeVisible();
 		} );
 	} );

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -423,13 +423,13 @@ test.describe( 'Complete your campaign', () => {
 					await expect( treeSelectMenu ).not.toBeVisible();
 				} );
 
-				test( 'should see the budget recommendation range changed, and see the budget recommendation request is triggered  when changing the ads audience', async () => {
+				test( 'should see the budget recommendation value changed, and see the budget recommendation request is triggered when changing the ads audience', async () => {
 					let textContent = await setupBudgetPage
 						.getBudgetRecommendationTextRow()
 						.textContent();
 
 					const textBeforeRemoveCountry =
-						setupBudgetPage.extractBudgetRecommendationRange(
+						setupBudgetPage.extractBudgetRecommendationValue(
 							textContent
 						);
 
@@ -438,7 +438,7 @@ test.describe( 'Complete your campaign', () => {
 
 					await removeCountryFromSearchBox(
 						page,
-						'United States (US)'
+						'United Kingdom (UK)'
 					);
 
 					await responsePromise;
@@ -448,7 +448,7 @@ test.describe( 'Complete your campaign', () => {
 						.textContent();
 
 					const textAfterRemoveCountry =
-						setupBudgetPage.extractBudgetRecommendationRange(
+						setupBudgetPage.extractBudgetRecommendationValue(
 							textContent
 						);
 

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -223,19 +223,6 @@ export default class MockRequests {
 	}
 
 	/**
-	 * Fulfill the Budget Recommendation request.
-	 *
-	 * @param {Object} payload
-	 * @return {Promise<void>}
-	 */
-	async fulfillBudgetRecommendation( payload ) {
-		await this.fulfillRequest(
-			/\/wc\/gla\/ads\/campaigns\/budget-recommendation\b/,
-			payload
-		);
-	}
-
-	/**
 	 * Fulfill the Sync Settings Connection request.
 	 *
 	 * @param {Object} payload

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -297,6 +297,42 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the MC account issues request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillAccountIssuesRequest( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/issues\/account\b/,
+			payload
+		);
+	}
+
+	/**
+	 * Fulfill the MC product issues request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillProductIssuesRequest( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/issues\/product\b/,
+			payload
+		);
+	}
+
+	/**
+	 * Fulfill the MC review request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillMCReview( payload ) {
+		await this.fulfillRequest( /\/wc\/gla\/mc\/review\b/, payload );
+	}
+
+	/**
 	 * Fulfill product statistics request.
 	 *
 	 * @param {Object} payload

--- a/tests/e2e/utils/page.js
+++ b/tests/e2e/utils/page.js
@@ -178,6 +178,7 @@ export async function selectCountryFromSearchBox(
  */
 export async function checkFAQExpandable( page ) {
 	const faqTitles = getFAQPanelTitle( page );
+	await expect.poll( () => faqTitles.count() ).toBeGreaterThan( 0 );
 	const count = await faqTitles.count();
 
 	if ( count === 1 ) {

--- a/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-ads-accounts.js
@@ -118,6 +118,49 @@ export default class SetupAdsAccount extends MockRequests {
 	}
 
 	/**
+	 * Mock Google Ads account as not yet connected.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockAdsAccountDisconnected() {
+		await this.fulfillAdsConnection( {
+			id: 0,
+			currency: null,
+			symbol: 'NT$',
+			status: 'disconnected',
+		} );
+	}
+
+	/**
+	 * Mock Google Ads account as connected but its billing setup is incomplete.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockAdsAccountIncomplete() {
+		await this.fulfillAdsConnection( {
+			id: 12345,
+			currency: 'TWD',
+			symbol: 'NT$',
+			status: 'incomplete',
+		} );
+	}
+
+	/**
+	 * Mock Google Ads account as connected.
+	 *
+	 * @param {number} [id=12345]
+	 * @return {Promise<void>}
+	 */
+	async mockAdsAccountConnected( id = 12345 ) {
+		await this.fulfillAdsConnection( {
+			id,
+			currency: 'TWD',
+			symbol: 'NT$',
+			status: 'connected',
+		} );
+	}
+
+	/**
 	 * Mock the Ads accounts response.
 	 *
 	 * @param {Object} payload

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -85,13 +85,13 @@ export default class SetupBudget extends MockRequests {
 	}
 
 	/**
-	 * Extract budget recommendation range.
+	 * Extract budget recommendation value.
 	 *
 	 * @param {string} text
 	 *
-	 * @return {string} The budget recommendation range.
+	 * @return {string} The budget recommendation value.
 	 */
-	extractBudgetRecommendationRange( text ) {
+	extractBudgetRecommendationValue( text ) {
 		const match = text.match( /set a daily budget of (\d+)/ );
 		if ( match ) {
 			return match[ 1 ];

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -92,7 +92,7 @@ export default class SetupBudget extends MockRequests {
 	 * @return {string} The budget recommendation range.
 	 */
 	extractBudgetRecommendationRange( text ) {
-		const match = text.match( /set a daily budget of (\d+ to \d+)/ );
+		const match = text.match( /set a daily budget of (\d+)/ );
 		if ( match ) {
 			return match[ 1 ];
 		}

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -56,20 +56,20 @@ export default class CompleteCampaign extends MockRequests {
 	}
 
 	/**
-	 * Get paid ads features section.
-	 *
-	 * @return {import('@playwright/test').Locator} Get paid ads features section.
-	 */
-	getPaidAdsFeaturesSection() {
-		return this.getSections().nth( 1 );
-	}
-
-	/**
 	 * Get ads account section.
 	 *
 	 * @return {import('@playwright/test').Locator} Get ads account section.
 	 */
 	getAdsAccountSection() {
+		return this.getSections().nth( 1 );
+	}
+
+	/**
+	 * Get paid ads features section.
+	 *
+	 * @return {import('@playwright/test').Locator} Get paid ads features section.
+	 */
+	getPaidAdsFeaturesSection() {
 		return this.getSections().nth( 2 );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-1YY-p2

This PR changes the step 4 of the onboarding:

- Change it to require a connected Google Ads account and make its setup card always visible.
- Hide the content about the ad budget in the Boost card before a Google Ads account is connected.
- Adjust E2E tests to reflect the above changes.
- Extra fix: The E2E util `checkFAQExpandable` doesn't wait for the page to load to proceed with assertions.

It also fixes #2172 as a few related E2E tests failed.

- Cherry-pick ab228ba476f78d15be661086c35410cef5ebc49c
- Fix the budget recommendation test cases in ea809f5597e8a5a6b06c8ec41360e006e283d6d9

Closes #2172 

### Screenshots:

#### 📹 Connect and disconnect Google Ads, complete onboarding without creating a campaign

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/b39f489c-9994-46fb-adc9-b15bd7b0f3c7

#### 📹 Complete onboarding along with creating a campaign

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/6d1e7ca0-ac2a-4985-997c-0f92eb985e40

### Detailed test instructions:

#### 📌 Event tracking

💡 Testing this with the UI part together would save some time.

1. Enable event tracking logging by running `localStorage.setItem( 'debug', 'wc-admin:*' )` in the Console tab of DevTool, and refresh page to make it effective.
1. Go to step 4 of the onboarding flow.
1. Test the four buttons that are marked as **A**, **B**, **C**, **D** in the following screenshot.
1. Check if the event names and their properties are the same as the description.

![2022-09-21 15 35 55](https://user-images.githubusercontent.com/17420811/191444603-805eddd5-566c-47ee-8a64-6769e31597c5.png)
![2022-09-21 15 36 36](https://user-images.githubusercontent.com/17420811/191444621-330a8009-5684-4c90-9196-4ef2424e2f73.png)

- `gla_onboarding_complete_button_click` for **A** and **C** with these properties:
   - `opened_paid_ads_setup`: yes | no
   - `google_ads_account_status`: connected | disconnected | incomplete
   - `billing_method_status`: unknown | pending | approved | cancelled
   - `campaign_form_validation`: unknown | valid | invalid
   - The unknown status is used when the paid ads setup is not opened.
- `gla_onboarding_open_paid_ads_setup_button_click` for **B**
- `gla_onboarding_complete_with_paid_ads_button_click` for **D**
   - `budget`: should be the same as the entered value
   -  `audiences`: country codes of the campaign audience countries, e.g. `'US,JP,AU'`

#### 📌 UI

1. Go to step 4 of the onboarding flow.
1. During any operations in this onboarding step, the "Google Ads" section should always be shown and it should be above the "Boost product listings with paid ads" section.
1. Before a Google Ads account is connected:
   - The Boost card should only have one feature item and no footer buttons.
      ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/f530651d-680a-43cd-ac66-da9ff137f7a3)
   - Check if there is no way to complete the onboarding.
1. After a Google Ads account is created:
   - The Boost card should only have three feature items and footer buttons.
      ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/e9fc371c-ddc7-4629-88af-12e6080ee5fe)
   - Check if the onboarding can be completed without setting up billing.
1. Click the "Create a paid ad campaign" button:
   - Check if the audience and budget UIs are shown and enabled.
1. Disconnect the Google Ads account:
   - Check if the audience and budget UIs are disabled.
   - Check if the "Skip paid ads creation" and "Complete setup" buttons at the bottom of the page are disabled.
1. Connect a Google Ads account.
1. Complete the onboarding with "Skip paid ads creation".
1. Set up audience, budget, and billing. Complete the onboarding with "Complete setup".
1. View the result of E2E tests: https://github.com/woocommerce/google-listings-and-ads/actions/runs/7207930857/job/19635800443


### Changelog entry

> Update - Change to require Google Ads connection during the onboarding.
