### PR TITLE
Include PHP 8.3 in tested versions for PHPunit

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
 
-      - if: matrix.wc-versions == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.0
+      - if: matrix.wc-versions == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.2
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -50,19 +50,16 @@ jobs:
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
     strategy:
       matrix:
-        php: [ 8.0 ]
+        php: [ 8.2 ]
         wp-version: [ latest ]
         wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions) }}
         include:
-          - php: 8.2
+          - php: 8.3
             wp-version: latest
             wc-versions: latest
           - php: 7.4
             wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[2] }} # L-2 WP Version support
             wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions)[2] }} # L-2 WC Version support
-          - php: 8.1
-            wp-version: latest
-            wc-versions: latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the tested versions for PHPunit.

I switched it to running the default unit tests on PHP 8.2 and then included an additional test for the lowest (7.4) supported and highest (8.3) supported versions.

> [!Note]
> Although the unit tests run successfully with PHP 8.3 we are still waiting on #2182 to be resolved before we can mark the extension as fully compatible.

### Detailed test instructions:
1. Check the workflow runs in this PR and confirm it has a successful unit test for PHP versions 7.4, 8.2, 8.3

### Changelog entry
* Dev - Include PHP 8.3 in tested versions for PHPunit.