### PR TITLE
Fix item price in purchase event

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -302,7 +302,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			$product_id   = $item->get_product_id();
 			$product_name = $item->get_name();
 			$quantity     = $item->get_quantity();
-			$price        = $item->get_subtotal();
+			$price        = $order->get_item_total( $item );
 			$item_info [] = sprintf(
 				'{
 				id: "gla_%s",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://github.com/woocommerce/google-listings-and-ads/issues/2181 .

The purchase event on the Order confirmation page was displaying the wrong price for each item. Instead of showing the individual item's price, it was reflecting the total amount for that line.

For example, if we have an item priced at 3€ and we purchase 2 units:

#### Before:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/263e5500-0efe-4515-8cf4-1ab94175839d)

#### After:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/12dad09a-cee7-485b-9664-c9eef5c8ddfc)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open an incognito window.
1. Purchase a product and add more than 1 unit to the cart.
2. Finish the order.
3. Use the Google Analytics debugger extension, GA4 Debug View, or inspect the code on the Order confirmation page.
4. Check that the purchase event -> items -> price aligns with the product price.


### Additional details:

@mikkamp suggested that a nice way to test these scenarios by including `wp_print_inline_script_tag` into the [WP Proxy](https://github.com/woocommerce/google-listings-and-ads/blob/develop/src/Proxies/WP.php) class, enabling us to test various outcomes. I'll create a follow-up issue to focus on this.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - item price in purchase event.
