### PR TITLE
Update link for developer.woo.com

### DIFF
--- a/src/Menu/MenuFixesTrait.php
+++ b/src/Menu/MenuFixesTrait.php
@@ -28,9 +28,7 @@ trait MenuFixesTrait {
 	 *
 	 * There is a guide with a few examples showing how to add a page to WooCommerce Admin.
 	 *
-	 * TODO: rename to developer.woo.com when the migration is done
-	 *
-	 * @link https://developer.woocommerce.com/extension-developer-guide/working-with-woocommerce-admin-pages/
+	 * @link https://developer.woo.com/extension-developer-guide/working-with-woocommerce-admin-pages/
 	 *
 	 * Originally, a React-powered page is expected to be registered by WC core function
 	 * `wc_admin_register_page`, and the function also handles the registration of wp-admin


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a followup to the project for updating woocommerce.com links to woo.com: peeuvX-13n-p2

Now that developer.woocommerce.com has been fully migrated we can update the link.

### Changelog entry
* Dev - Update link for developer.woo.com