### PR TITLE
Support for `cart-add-item` hook in WC 8.5

### DIFF
--- a/js/src/gtag-events/index.js
+++ b/js/src/gtag-events/index.js
@@ -16,13 +16,21 @@ import {
 /* global jQuery */
 
 // Hook into cart add item events sent from Gutenberg blocks.
-addAction(
-	`${ ACTION_PREFIX }-cart-add-item`,
-	NAMESPACE,
-	( { product, quantity = 1 } ) => {
-		trackAddToCartEvent( product, quantity );
+// In WC >= 8.5 the product Proxy is the argument.
+// In WC < 8.5 the product and the quantity are sent as arguments.
+addAction( `${ ACTION_PREFIX }-cart-add-item`, NAMESPACE, ( data ) => {
+	if ( ! data ) {
+		return;
 	}
-);
+
+	if ( data?.product ) {
+		// WC < 8.5
+		trackAddToCartEvent( data.product, data.quantity );
+	} else {
+		// WC >= 8.5
+		trackAddToCartEvent( data, 1 );
+	}
+} );
 
 /**
  * Handle add to cart clicks on any buttons shown in an archive loop.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2191. 

This PR closes a bug in GLA when using WC8.5 and Product Blocks. In WC 8.5 we receive a Proxy Product as a parameter. Before we got 2, product and quantity


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install WC < 8.5
2. Setup a block shop page
3. Use GA Debugger extension to check the GA events.
4. Add an item to the cart and verify the add to cart event is triggered without errors
5. Install WC >= 8.5 
6. Add an item to the cart and verify the add to cart event is triggered without errors


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Add to cart produces an error
