### PR TITLE
Include connected accounts in tracks from the backend.

### DIFF
--- a/src/Tracking/Tracks.php
+++ b/src/Tracking/Tracks.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tracking;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks as TracksProxy;
 
@@ -11,8 +13,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks as TracksProxy;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tracking
  */
-class Tracks implements TracksInterface {
+class Tracks implements TracksInterface, OptionsAwareInterface {
 
+	use OptionsAwareTrait;
 	use PluginHelper;
 
 	/**
@@ -40,6 +43,14 @@ class Tracks implements TracksInterface {
 		$base_properties = [
 			"{$this->get_slug()}_version" => $this->get_version(),
 		];
+
+		// Include connected accounts (if connected).
+		if ( $this->options->get_ads_id() ) {
+			$base_properties[ "{$this->get_slug()}_ads_id" ] = $this->options->get_ads_id();
+		}
+		if ( $this->options->get_merchant_id() ) {
+			$base_properties[ "{$this->get_slug()}_mc_id" ] = $this->options->get_merchant_id();
+		}
 
 		$properties      = array_merge( $base_properties, $properties );
 		$full_event_name = "{$this->get_slug()}_{$event_name}";


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds any connected accounts to tracks which we send from the backend. The accounts are only included if they are connected (non-zero).

### Detailed test instructions:

There aren't a lot of tracks being sent from the backend to test with, so I added the following line to `ConnectionTest::render_admin_page`:

```php
do_action( 'woocommerce_gla_url_switch_success', [] );
```

1. Make the change (suggested above) to add the manual track
2. Browse a site with both MC and Ads accounts connected
3. Turn on browser developer tools and browse to the hidden connection page:  `https://domain.test/wp-admin/admin.php?page=connection-test-admin-page`
4. In the browser developer tools filter network requests to `pixel.wp.com` 
5. Look for a request for `t.gif` and check the payload
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/0c2ff063-9bd4-4e08-954b-924fb59fee91)
6. Confirm that `gla_version`, `gla_ads_id`, `gla_merchant_id` all reflect the right values


### Changelog entry
* Add - Include connected accounts in tracks from the backend.
