### PR TITLE
Add plugin version, Google Merchant Center account ID, and Google Ads account ID to frontend pageview tracking events

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -39,7 +39,7 @@ module.exports = {
 	],
 	globals: {
 		wcAdminFeatures: {
-			navigation: true,
+			navigation: false,
 		},
 		glaData: {
 			slug: 'gla',

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -15,6 +15,7 @@ import './css/index.scss';
 import withAdminPageShell from '.~/components/withAdminPageShell';
 import './data';
 import isWCNavigationEnabled from './utils/isWCNavigationEnabled';
+import { addBaseEventProperties } from '.~/utils/tracks';
 
 const Dashboard = lazy( () =>
 	import( /* webpackChunkName: "dashboard" */ './dashboard' )
@@ -47,6 +48,8 @@ const AttributeMapping = lazy( () =>
 const Settings = lazy( () =>
 	import( /* webpackChunkName: "settings" */ './settings' )
 );
+
+export const pagePaths = new Set();
 
 const woocommerceTranslation =
 	getSetting( 'admin' )?.woocommerceTranslation ||
@@ -165,8 +168,28 @@ addFilter(
 
 		pluginAdminPages.forEach( ( page ) => {
 			page.container = withAdminPageShell( page.container );
+
+			// Do the same thing as https://github.com/woocommerce/woocommerce/blob/6.9.0/plugins/woocommerce-admin/client/layout/index.js#L178
+			const path = page.path.substring( 1 ).replace( /\//g, '_' );
+			pagePaths.add( path );
 		} );
 
 		return pages.concat( pluginAdminPages );
+	}
+);
+
+// Ref: https://github.com/woocommerce/woocommerce/blob/6.9.0/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php#L92
+addFilter(
+	'woocommerce_tracks_client_event_properties',
+	'woocommerce/google-listings-and-ads/add-base-event-properties-to-page-view',
+	( eventProperties, eventName ) => {
+		if (
+			eventName === 'wcadmin_page_view' &&
+			pagePaths.has( eventProperties.path )
+		) {
+			return addBaseEventProperties( eventProperties );
+		}
+
+		return eventProperties;
 	}
 );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -57,7 +57,7 @@ const woocommerceTranslation =
 
 addFilter(
 	'woocommerce_admin_pages_list',
-	'woocommerce-marketing',
+	'woocommerce/google-listings-and-ads/add-page-routes',
 	( pages ) => {
 		const navigationEnabled = isWCNavigationEnabled();
 		const initialBreadcrumbs = [ [ '', woocommerceTranslation ] ];

--- a/js/src/index.test.js
+++ b/js/src/index.test.js
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { pagePaths } from './';
+import { STORE_KEY } from '.~/data';
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getSetting: jest.fn().mockName( 'getSetting' ),
+} ) );
+
+describe( 'index', () => {
+	describe( 'Filter woocommerce_admin_pages_list', () => {
+		const filter = 'woocommerce_admin_pages_list';
+
+		it( 'should initialize `pagePaths`', () => {
+			expect( pagePaths.size ).toBe( 0 );
+
+			const pages = applyFilters( filter, [] );
+
+			expect( pages.length ).toBeGreaterThan( 0 );
+			expect( pagePaths.size ).toBe( pages.length );
+
+			pages.forEach( ( page ) => {
+				const path = page.path.replace( /./, '' ).replace( /\//g, '_' );
+
+				expect( pagePaths ).toContain( path );
+			} );
+		} );
+
+		it( 'should keep the pages that already exist before applying the filter', () => {
+			const page = {};
+			const pages = applyFilters( filter, [ page ] );
+
+			expect( pages ).toContain( page );
+		} );
+
+		it( "should add this plugin's pages", () => {
+			const pages = applyFilters( filter, [] );
+
+			expect( pages.length ).toBeGreaterThan( 0 );
+
+			pages.forEach( ( page ) => {
+				expect( page ).toMatchObject( {
+					breadcrumbs: expect.arrayContaining( [
+						[ '', 'WooCommerce' ],
+						[ '/marketing', 'Marketing' ],
+						'Google Listings & Ads',
+						expect.any( String ),
+					] ),
+					container: expect.any( Function ),
+					path: expect.stringMatching( /^\/google\/[a-z\-]+/ ),
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'Filter woocommerce_tracks_client_event_properties', () => {
+		function getProperties( path, eventName = 'wcadmin_page_view' ) {
+			return applyFilters(
+				'woocommerce_tracks_client_event_properties',
+				{ path },
+				eventName
+			);
+		}
+
+		function updateAccountIds( mcId, adsId ) {
+			dispatch( STORE_KEY ).hydratePrefetchedData( { mcId, adsId } );
+		}
+
+		beforeEach( () => {
+			// To initialize `pagePaths`.
+			applyFilters( 'woocommerce_admin_pages_list', [] );
+		} );
+
+		afterEach( () => {
+			updateAccountIds( null, null );
+		} );
+
+		it( "When the `path` of `wcadmin_page_view` tracking event is one of this plugin's route paths, it should add base properties", () => {
+			expect( pagePaths.size ).toBeGreaterThan( 0 );
+
+			pagePaths.forEach( ( path ) => {
+				const properties = getProperties( path );
+
+				expect( properties ).toEqual( { path, gla_version: '1.2.3' } );
+			} );
+
+			updateAccountIds( 123, 456 );
+
+			pagePaths.forEach( ( path ) => {
+				const properties = getProperties( path );
+
+				expect( properties ).toEqual( {
+					path,
+					gla_version: '1.2.3',
+					gla_mc_id: 123,
+					gla_ads_id: 456,
+				} );
+			} );
+		} );
+
+		it( "When the `path` of `wcadmin_page_view` tracking event is not one of this plugin's route paths, it should not add base properties", () => {
+			const path = 'google_other_plugin_page';
+
+			expect( pagePaths.size ).toBeGreaterThan( 0 );
+			expect( getProperties( path ) ).toEqual( { path } );
+		} );
+
+		it( 'When the tracking event is not `wcadmin_page_view`, it should not add base properties', () => {
+			expect( pagePaths.size ).toBeGreaterThan( 0 );
+
+			pagePaths.forEach( ( path ) => {
+				const properties = getProperties(
+					path,
+					'wcadmin_marketplace_view'
+				);
+
+				expect( properties ).toEqual( { path } );
+			} );
+		} );
+	} );
+} );

--- a/js/src/tests/jest-unit.setup.js
+++ b/js/src/tests/jest-unit.setup.js
@@ -18,3 +18,5 @@ global.ResizeObserver = jest
 		unobserve: jest.fn().mockName( 'resizeObserver.unobserve' ),
 		disconnect: jest.fn().mockName( 'resizeObserver.disconnect' ),
 	} ) );
+
+global.wpNavMenuClassChange = jest.fn().mockName( 'wpNavMenuClassChange' );

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -30,7 +30,16 @@ import { STORE_KEY } from '.~/data';
  * @property {string} direction Direction of page to be changed. `("next" | "previous")`
  */
 
-function prepareEventProperties( eventProperties ) {
+/**
+ * Returns an event properties with base properties.
+ * - gla_version: Plugin version
+ * - gla_mc_id: Google Merchant Center account ID if connected
+ * - gla_ads_id: Google Ads account ID if connected
+ *
+ * @param {Object} [eventProperties] The event properties to be included base properties.
+ * @return {Object} Event properties with base event properties.
+ */
+export function addBaseEventProperties( eventProperties ) {
 	const { slug } = glaData;
 	const { version, adsId, mcId } = select( STORE_KEY ).getGeneral();
 
@@ -57,7 +66,7 @@ function prepareEventProperties( eventProperties ) {
  * @param {Object} [eventProperties] The event properties to include in the event.
  */
 export function recordGlaEvent( eventName, eventProperties ) {
-	recordEvent( eventName, prepareEventProperties( eventProperties ) );
+	recordEvent( eventName, addBaseEventProperties( eventProperties ) );
 }
 
 /**
@@ -69,7 +78,7 @@ export function recordGlaEvent( eventName, eventProperties ) {
  * @param {Object} [eventProperties] The event properties to include in the event.
  */
 export function queueRecordGlaEvent( eventName, eventProperties ) {
-	queueRecordEvent( eventName, prepareEventProperties( eventProperties ) );
+	queueRecordEvent( eventName, addBaseEventProperties( eventProperties ) );
 }
 
 /**

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -211,7 +211,7 @@ Triggered when "continue" to edit program button is clicked.
 #### Emitters
 - [`EditProgramPromptModal`](../../js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js#L32) when "Continue to edit" is clicked.
 
-### [`gla_datepicker_update`](../../js/src/utils/tracks.js#L101)
+### [`gla_datepicker_update`](../../js/src/utils/tracks.js#L110)
 Triggered when datepicker (date ranger picker) is updated,
  with report name and data that comes from `DateRangeFilterPicker`'s `onRangeSelect` callback
 #### Properties
@@ -379,7 +379,7 @@ Clicking on faq item to collapse or expand it.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'expand' }`.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'collapse' }`.
 
-### [`gla_filter`](../../js/src/utils/tracks.js#L113)
+### [`gla_filter`](../../js/src/utils/tracks.js#L122)
 Triggered when changing products & variations filter,
  with data that comes from
  `FilterPicker`'s `onFilterSelect` callback.
@@ -407,7 +407,7 @@ Saving changes to the free campaign.
 #### Emitters
 - [`EditFreeCampaign`](../../js/src/edit-free-campaign/index.js#L46)
 
-### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L143)
+### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L152)
 Clicking on the button to connect Google account.
 #### Properties
 | name | type | description |
@@ -439,7 +439,7 @@ Clicking on a Google Ads account text link.
 #### Emitters
 - [`BillingSavedCard`](../../js/src/setup-ads/ads-stepper/setup-billing/billing-saved-card/index.js#L31) with `{ context: 'setup-ads', link_id: 'google-ads-account' }`
 
-### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L153)
+### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L162)
 Clicking on a Google Merchant Center link.
 #### Properties
 | name | type | description |
@@ -468,7 +468,7 @@ Clicking on the "Scan for assets" button.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/assets-loader.js#L96)
 
-### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L135)
+### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L144)
 Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign in the Google Ads setup flow.
 #### Properties
 | name | type | description |
@@ -538,7 +538,7 @@ Clicking on the Merchant Center phone number edit button.
 #### Emitters
 - [`PhoneNumberCard`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L127)
 
-### [`gla_modal_closed`](../../js/src/utils/tracks.js#L211)
+### [`gla_modal_closed`](../../js/src/utils/tracks.js#L220)
 A modal is closed.
 #### Properties
 | name | type | description |
@@ -561,7 +561,7 @@ Clicking on a text link within the modal content
 #### Emitters
 - [`ContentLink`](../../js/src/components/guide-page-content/index.js#L46) with given `context, href`
 
-### [`gla_modal_open`](../../js/src/utils/tracks.js#L224)
+### [`gla_modal_open`](../../js/src/utils/tracks.js#L233)
 A modal is open
 #### Properties
 | name | type | description |
@@ -603,7 +603,7 @@ Clicking on the "Create a paid ad campaign" button to open the paid ads setup in
 #### Emitters
 - [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L71)
 
-### [`gla_paid_campaign_step`](../../js/src/utils/tracks.js#L171)
+### [`gla_paid_campaign_step`](../../js/src/utils/tracks.js#L180)
 Triggered when moving to another step during creating/editing a campaign.
 #### Properties
 | name | type | description |
@@ -648,7 +648,7 @@ Clicking on the "Or, select another page" button.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/final-url-card.js#L39)
 
-### [`gla_setup_ads`](../../js/src/utils/tracks.js#L161)
+### [`gla_setup_ads`](../../js/src/utils/tracks.js#L170)
 Triggered on events during ads onboarding
 #### Properties
 | name | type | description |
@@ -673,7 +673,7 @@ Clicking on faq items to collapse or expand it in the Onboarding Flow or creatin
 #### Emitters
 - [`FaqsSection`](../../js/src/components/paid-ads/faqs-section.js#L89)
 
-### [`gla_setup_mc`](../../js/src/utils/tracks.js#L124)
+### [`gla_setup_mc`](../../js/src/utils/tracks.js#L133)
 Setup Merchant Center
 #### Properties
 | name | type | description |
@@ -725,7 +725,7 @@ When table pagination is changed by entering page via "Go to page" input.
 `page` | `string` | Page number (starting at 1)
 #### Emitters
 - [`ProductFeedTableCard`](../../js/src/product-feed/product-feed-table-card/index.js#L65) with `context: 'product-feed'`
-- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L87) with the given `{ context, page }`.
+- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L96) with the given `{ context, page }`.
 
 ### [`gla_table_header_toggle`](../../js/src/components/app-table-card/index.js#L12)
 Toggling display of table columns
@@ -748,7 +748,7 @@ When table pagination is clicked
 `direction` | `string` | Direction of page to be changed. `("next" \| "previous")`
 #### Emitters
 - [`ProductFeedTableCard`](../../js/src/product-feed/product-feed-table-card/index.js#L65) with `context: 'product-feed'`
-- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L87) with the given `{ context, direction }`.
+- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L96) with the given `{ context, direction }`.
 
 ### [`gla_table_sort`](../../js/src/components/app-table-card/index.js#L38)
 Sorting table


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-20H-p2

This PR implements another JS part of the project. The target is to attach the following properties when Woo core sends pageview tracking events related to this plugin's pages:

- Plugin Version
- Google Merchant Center account ID if connected
- Google Ads account ID if connected

To achieve the above target, this PR:

- Rename the `prepareEventProperties` in tracks.js to `prepareEventProperties` and export it.
- Add base properties to the plugin's page view tracking events via the `woocommerce_tracks_client_event_properties` filter.
- Extra change: Set the mocked `globals.wcAdminFeatures.navigation` to `false` for jest as the **new WooCommerce navigation experience** is currently on hold and disabled forcibly.
- Extra change: In **js/src/index.js**, adjust the namespace string that calls `addFilter` to match its uniquely identified convention.
   - Quoted from [`@wordpress/hooks` doc](https://github.com/WordPress/gutenberg/tree/%40wordpress/hooks%403.22.0/packages/hooks#the-global-instance):
      > One notable difference between the JS and PHP hooks API is that in the JS version, `addAction()` and `addFilter()` also need to include a namespace as the second argument. Namespace uniquely identifies a callback in the form `vendor/plugin/function`.

### Screenshots:

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/acbc3083-bb43-495c-9a10-7a3ad90c75d4)

### Detailed test instructions:

1. Go to **WooCommerce > Settings > Advanced > Woo.com**. Tick off the **Enable tracking** option.
   - This tracking event can't be tested via the Console tab and `localStorage.setItem( 'debug', 'wc-admin:*' )`.
2. Open the Network tab of the browser DevTool. Filter **All** requests and keyword `t.gif`.
3. Go to this plugin's admin pages and inspect the requests in the Network tab to check if all `wcadmin_page_view` tracking events have the base properties.
   https://github.com/woocommerce/google-listings-and-ads/blob/61ef165a2e5119f8e2c9e1f565961a154b81535a/js/src/utils/tracks.js#L35-L37
4. Go to other admin pages such as **Marketing > Overview**. Check if the `wcadmin_page_view` tracking events sent from other pages don't have the base properties.

### Changelog entry
