### PR TITLE
Send the related tracking event with the account ID to be connected when connecting to an existing Google Merchant Center or Google Ads account

### DIFF
--- a/js/src/components/google-ads-account-card/connect-ads/index.js
+++ b/js/src/components/google-ads-account-card/connect-ads/index.js
@@ -25,6 +25,7 @@ import './index.scss';
  * Clicking on the button to connect an existing Google Ads account.
  *
  * @event gla_ads_account_connect_button_click
+ * @property {number} id The account ID to be connected.
  */
 
 /**
@@ -127,6 +128,7 @@ const ConnectAds = ( props ) => {
 							isSecondary
 							disabled={ ! value }
 							eventName="gla_ads_account_connect_button_click"
+							eventProps={ { id: Number( value ) } }
 							onClick={ handleConnectClick }
 						>
 							{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/js/src/components/google-mc-account-card/connect-mc/index.js
+++ b/js/src/components/google-mc-account-card/connect-mc/index.js
@@ -26,6 +26,7 @@ import './index.scss';
  * Clicking on the button to connect an existing Google Merchant Center account.
  *
  * @event gla_mc_account_connect_button_click
+ * @property {number} id The account ID to be connected.
  */
 
 /**
@@ -111,6 +112,7 @@ const ConnectMC = () => {
 						loading={ resultConnectMC.loading }
 						disabled={ ! value }
 						eventName="gla_mc_account_connect_button_click"
+						eventProps={ { id: Number( value ) } }
 						onClick={ handleConnectMC }
 					>
 						{ __( 'Connect', 'google-listings-and-ads' ) }

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -91,8 +91,12 @@ Do not edit it manually!
 
 ### [`gla_ads_account_connect_button_click`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L24)
 Clicking on the button to connect an existing Google Ads account.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`id` | `number` | The account ID to be connected.
 #### Emitters
-- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L36) when "Connect" button is clicked.
+- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L37) when "Connect" button is clicked.
 
 ### [`gla_ads_account_create_button_click`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L16)
 Clicking on the button to create a new Google Ads account, after agreeing to the terms and conditions.
@@ -259,7 +263,7 @@ When a documentation link is clicked.
 	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
 - [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
 - [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
-- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L36) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
+- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L37) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
 - [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L32)
 	- with `{ context: 'setup-ads', link_id: 'shopping-ads-policies', href: 'https://support.google.com/merchants/answer/6149970' }`
 	- with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
@@ -480,8 +484,12 @@ Triggered when the "Launch paid campaign" button is clicked to add a new paid ca
 
 ### [`gla_mc_account_connect_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L25)
 Clicking on the button to connect an existing Google Merchant Center account.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`id` | `number` | The account ID to be connected.
 #### Emitters
-- [`ConnectMC`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L41)
+- [`ConnectMC`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L42)
 
 ### [`gla_mc_account_connect_different_account_button_click`](../../js/src/components/google-mc-account-card/connected-google-mc-account-card.js#L21)
 Clicking on the "connect to a different Google Merchant Center account" button.
@@ -498,7 +506,7 @@ Clicking on the button to reclaim URL for a Google Merchant Center account.
 #### Emitters
 - [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L41)
 
-### [`gla_mc_account_switch_account_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L31)
+### [`gla_mc_account_switch_account_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L32)
 Clicking on the "Switch account" button to select a different Google Merchant Center account to connect.
 #### Properties
 | name | type | description |


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a follow-up PR for https://github.com/woocommerce/google-listings-and-ads/pull/2199#issuecomment-1895859258.

This PR adds the account ID to be connected to the properties of the `gla_mc_account_connect_button_click` and `gla_ads_account_connect_button_click ` events.

### Screenshots:

#### 📹 Connect Google Merchant Center account

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/ffb7cda6-411f-4aa5-9a76-9475e52b8d46

#### 📹 Connect Google Ads account

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/0ce40437-db4b-4022-ac13-898a28d144f4

### Detailed test instructions:

1. Enable tracking debug tool
   - Open the Console tab of the browser DevTool.
   - Change the filter level to "All levels".
   - Run `localStorage.setItem( 'debug', 'wc-admin:*' )` and refresh the page to make it work.
   - It should be able to view tracking via the Console tab. Ref:
      ![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/698f85d8-e890-4ab6-939b-738acee6098f)
2. Disconnect Google Merchant Center and Google Ads accounts if already connected.
3. Go to the first step of onboarding flow.
4. Connect to an existing Google Merchant Center account and check if the `gla_mc_account_connect_button_click` event properties have the `id` and if its value is correct.
5. Proceed to the last step of onboarding flow.
6. Connect to an existing Google Ads account and check if the `gla_ads_account_connect_button_click` event properties have the `id` and if its value is correct.

### Changelog entry

> Add - Send the related tracking event with the account ID to be connected when connecting to an existing Google Merchant Center or Google Ads account.
