### PR TITLE
Scheduled batched Notifications

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -333,7 +333,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( PolicyComplianceCheck::class, WC::class, GoogleHelper::class, TargetAudience::class );
 		$this->share_with_tags( ContactInformation::class, Merchant::class, GoogleSettings::class );
 		$this->share_with_tags( ProductMetaHandler::class );
-		$this->share( ProductHelper::class, ProductMetaHandler::class, WC::class, TargetAudience::class );
+		$this->share( ProductHelper::class, ProductMetaHandler::class, WC::class, TargetAudience::class, NotificationsService::class );
 		$this->share_with_tags( ProductFilter::class, ProductHelper::class );
 		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class, ProductFilter::class );
 		$this->share_with_tags( ProductFactory::class, AttributeManager::class, WC::class );

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -19,6 +19,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupSyncedProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
@@ -101,6 +102,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		$this->share_product_syncer_job( ResubmitExpiringProducts::class );
 		$this->share_product_syncer_job( CleanupProductsJob::class );
 		$this->share_product_syncer_job( CleanupSyncedProducts::class );
+		$this->share_product_syncer_job( Notification::class );
 
 		// share coupon syncer jobs.
 		$this->share_coupon_syncer_job( UpdateCoupon::class );
@@ -183,6 +185,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 				ProductRepository::class,
 				BatchProductHelper::class,
 				MerchantCenterService::class,
+				NotificationsService::class,
 				...$arguments
 			);
 		} else {
@@ -191,6 +194,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 				ProductSyncer::class,
 				ProductRepository::class,
 				MerchantCenterService::class,
+				NotificationsService::class,
 				...$arguments
 			);
 		}

--- a/src/Jobs/AbstractActionSchedulerJob.php
+++ b/src/Jobs/AbstractActionSchedulerJob.php
@@ -74,6 +74,7 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	 * @hooked gla/jobs/{$job_name}/process_item
 	 *
 	 * @param array $items The job items from the current batch.
+	 * @param array $args Action args.
 	 *
 	 * @throws Exception If an error occurs.
 	 */
@@ -136,6 +137,7 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	 * Process batch items.
 	 *
 	 * @param array $items A single batch from the get_batch() method.
+	 * @param array $args Action args.
 	 *
 	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/AbstractActionSchedulerJob.php
+++ b/src/Jobs/AbstractActionSchedulerJob.php
@@ -50,11 +50,11 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 
 	/**
 	 * Init the batch schedule for the job.
-	 *
+	 * º
 	 * The job name is used to generate the schedule event name.
 	 */
 	public function init(): void {
-		add_action( $this->get_process_item_hook(), [ $this, 'handle_process_items_action' ] );
+		add_action( $this->get_process_item_hook(), [ $this, 'handle_process_items_action' ], 10, 2 );
 	}
 
 	/**
@@ -77,7 +77,7 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	 *
 	 * @throws Exception If an error occurs.
 	 */
-	public function handle_process_items_action( array $items = [] ) {
+	public function handle_process_items_action( array $items = [], array $args = [] ) {
 		$process_hook = $this->get_process_item_hook();
 		$process_args = [ $items ];
 
@@ -87,7 +87,7 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 		}
 
 		try {
-			$this->process_items( $items );
+			$this->process_items( $items, $args );
 		} catch ( Exception $exception ) {
 			// reschedule on failure
 			$this->action_scheduler->schedule_immediate( $process_hook, $process_args );
@@ -139,5 +139,5 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	 *
 	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	abstract protected function process_items( array $items );
+	abstract protected function process_items( array $items, array $args = [] );
 }

--- a/src/Jobs/AbstractProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractProductSyncerBatchedJob.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -39,6 +40,11 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	protected $merchant_center;
 
 	/**
+	 * @var NotificationsService
+	 */
+	protected $notifications_service;
+
+	/**
 	 * SyncProducts constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
@@ -47,6 +53,7 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	 * @param ProductRepository         $product_repository
 	 * @param BatchProductHelper        $batch_product_helper
 	 * @param MerchantCenterService     $merchant_center
+	 * @param NotificationsService      $notifications_service
 	 */
 	public function __construct(
 		ActionSchedulerInterface $action_scheduler,
@@ -54,12 +61,14 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 		ProductSyncer $product_syncer,
 		ProductRepository $product_repository,
 		BatchProductHelper $batch_product_helper,
-		MerchantCenterService $merchant_center
+		MerchantCenterService $merchant_center,
+		NotificationsService $notifications_service
 	) {
-		$this->batch_product_helper = $batch_product_helper;
-		$this->product_syncer       = $product_syncer;
-		$this->product_repository   = $product_repository;
-		$this->merchant_center      = $merchant_center;
+		$this->batch_product_helper  = $batch_product_helper;
+		$this->product_syncer        = $product_syncer;
+		$this->product_repository    = $product_repository;
+		$this->merchant_center       = $merchant_center;
+		$this->notifications_service = $notifications_service;
 		parent::__construct( $action_scheduler, $monitor );
 	}
 

--- a/src/Jobs/AbstractProductSyncerJob.php
+++ b/src/Jobs/AbstractProductSyncerJob.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -33,6 +34,11 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob imple
 	protected $merchant_center;
 
 	/**
+	 * @var NotificationsService
+	 */
+	protected $notifications_service;
+
+	/**
 	 * SyncProducts constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
@@ -46,11 +52,13 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob imple
 		ActionSchedulerJobMonitor $monitor,
 		ProductSyncer $product_syncer,
 		ProductRepository $product_repository,
-		MerchantCenterService $merchant_center
+		MerchantCenterService $merchant_center,
+		NotificationsService $notifications_service,
 	) {
-		$this->product_syncer     = $product_syncer;
-		$this->product_repository = $product_repository;
-		$this->merchant_center    = $merchant_center;
+		$this->product_syncer        = $product_syncer;
+		$this->product_repository    = $product_repository;
+		$this->merchant_center       = $merchant_center;
+		$this->notifications_service = $notifications_service;
 		parent::__construct( $action_scheduler, $monitor );
 	}
 

--- a/src/Jobs/AbstractProductSyncerJob.php
+++ b/src/Jobs/AbstractProductSyncerJob.php
@@ -46,6 +46,7 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob imple
 	 * @param ProductSyncer             $product_syncer
 	 * @param ProductRepository         $product_repository
 	 * @param MerchantCenterService     $merchant_center
+	 * @param NotificationsService      $notifications_service
 	 */
 	public function __construct(
 		ActionSchedulerInterface $action_scheduler,

--- a/src/Jobs/BatchedActionSchedulerJobInterface.php
+++ b/src/Jobs/BatchedActionSchedulerJobInterface.php
@@ -23,7 +23,7 @@ interface BatchedActionSchedulerJobInterface extends ActionSchedulerJobInterface
 	 *
 	 * @throws Exception If an error occurs.
 	 */
-	public function handle_create_batch_action( int $batch_number );
+	public function handle_create_batch_action( int $batch_number, array $args = [] );
 
 	/**
 	 * Handles processing a single batch action hook.
@@ -34,5 +34,5 @@ interface BatchedActionSchedulerJobInterface extends ActionSchedulerJobInterface
 	 *
 	 * @throws Exception If an error occurs.
 	 */
-	public function handle_process_items_action( array $items );
+	public function handle_process_items_action( array $items, array $args = [] );
 }

--- a/src/Jobs/BatchedActionSchedulerJobInterface.php
+++ b/src/Jobs/BatchedActionSchedulerJobInterface.php
@@ -19,7 +19,8 @@ interface BatchedActionSchedulerJobInterface extends ActionSchedulerJobInterface
 	 *
 	 * @hooked gla/jobs/{$job_name}/create_batch
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $args Action args.
 	 *
 	 * @throws Exception If an error occurs.
 	 */
@@ -31,6 +32,7 @@ interface BatchedActionSchedulerJobInterface extends ActionSchedulerJobInterface
 	 * @hooked gla/jobs/{$job_name}/process_item
 	 *
 	 * @param array $items The job items from the current batch.
+	 * @param array $args Action args.
 	 *
 	 * @throws Exception If an error occurs.
 	 */

--- a/src/Jobs/CleanupProductsJob.php
+++ b/src/Jobs/CleanupProductsJob.php
@@ -32,10 +32,11 @@ class CleanupProductsJob extends AbstractProductSyncerBatchedJob {
 	 * If no items are returned the job will stop.
 	 *
 	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $args The action args.
 	 *
 	 * @return array
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $args = [] ): array {
 		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -43,10 +44,11 @@ class CleanupProductsJob extends AbstractProductSyncerBatchedJob {
 	 * Process batch items.
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $args The action args.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $args = [] ) {
 		$products      = $this->product_repository->find_by_ids( $items );
 		$stale_entries = $this->batch_product_helper->generate_stale_products_request_entries( $products );
 		$this->product_syncer->delete_by_batch_requests( $stale_entries );

--- a/src/Jobs/CleanupProductsJob.php
+++ b/src/Jobs/CleanupProductsJob.php
@@ -31,7 +31,7 @@ class CleanupProductsJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
 	 * @param array $args The action args.
 	 *
 	 * @return array

--- a/src/Jobs/CleanupSyncedProducts.php
+++ b/src/Jobs/CleanupSyncedProducts.php
@@ -54,11 +54,12 @@ class CleanupSyncedProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $args The action args.
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $args = [] ): array {
 		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -67,8 +68,9 @@ class CleanupSyncedProducts extends AbstractProductSyncerBatchedJob {
 	 * Skips processing if the Merchant Center has been connected again.
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $args The action args.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $args = [] ) {
 		if ( $this->is_mc_connected() ) {
 			do_action(
 				'woocommerce_gla_debug_message',

--- a/src/Jobs/DeleteAllProducts.php
+++ b/src/Jobs/DeleteAllProducts.php
@@ -34,7 +34,7 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @return int[]
 	 */
-	protected function get_batch( int $batch_number ): array {
+	protected function get_batch( int $batch_number, array $args = [] ): array {
 		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -45,7 +45,7 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $args = [] ) {
 		$products        = $this->product_repository->find_by_ids( $items );
 		$product_entries = $this->batch_product_helper->generate_delete_request_entries( $products );
 		$this->product_syncer->delete_by_batch_requests( $product_entries );

--- a/src/Jobs/DeleteAllProducts.php
+++ b/src/Jobs/DeleteAllProducts.php
@@ -30,7 +30,8 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $args Action args.
 	 *
 	 * @return int[]
 	 */
@@ -42,6 +43,7 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	 * Process batch items.
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $args Action args.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/DeleteCoupon.php
+++ b/src/Jobs/DeleteCoupon.php
@@ -33,11 +33,12 @@ class DeleteCoupon extends AbstractCouponSyncerJob implements
 	 * Process an item.
 	 *
 	 * @param array[] $coupon_entries
+	 * @param array   $args
 	 *
 	 * @throws JobException If no valid coupon data is provided as argument. The exception will be logged by ActionScheduler.
 	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	public function process_items( array $coupon_entries ) {
+	public function process_items( array $coupon_entries, array $args = [] ) {
 		$wc_coupon_id     = $coupon_entries[0] ?? null;
 		$google_promotion = $coupon_entries[1] ?? null;
 		$google_ids       = $coupon_entries[2] ?? null;

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -33,6 +33,7 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * Process an item.
 	 *
 	 * @param string[] $product_id_map An array of Google product IDs mapped to WooCommerce product IDs as their key.
+	 * @param array    $args Action args.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -36,7 +36,7 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	public function process_items( array $product_id_map ) {
+	public function process_items( array $product_id_map, array $args = [] ) {
 		$product_entries = BatchProductIDRequestEntry::create_from_id_map( new ProductIDMap( $product_id_map ) );
 		$this->product_syncer->delete_by_batch_requests( $product_entries );
 	}

--- a/src/Jobs/JobException.php
+++ b/src/Jobs/JobException.php
@@ -42,6 +42,20 @@ class JobException extends RuntimeException implements GoogleListingsAndAdsExcep
 	}
 
 	/**
+	 * Create a new exception instance for when the provided items are not WC_Product instances.
+	 *
+	 * @param string $type The expected type.
+	 *
+	 * @return static
+	 */
+	public static function item_is_not_expected_type( string $type ): JobException {
+		return new static(
+			/* translators: %s: the type */
+			sprintf( __( 'Some provided items were not instances of %s.', 'google-listings-and-ads' ), $type )
+		);
+	}
+
+	/**
 	 * Create a new exception instance for when a job is stopped due to a high failure rate.
 	 *
 	 * @param string $job_name

--- a/src/Jobs/Notification.php
+++ b/src/Jobs/Notification.php
@@ -1,0 +1,99 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Notification
+ *
+ * Notifies Google about changes in the customer data.
+ *
+ * Note: The job will not start if it is already running.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
+ */
+class Notification extends AbstractProductSyncerBatchedJob {
+
+
+	public const TOPIC_KEY = 'topic';
+	public const ITEMS_KEY = 'items';
+
+	/**
+	 * Get the name of the job.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'notifications';
+	}
+
+	/**
+	 * Schedules a notification action.
+	 *
+	 * @param array  $items The items to send notifications about.
+	 * @param string $topic A topic to send notifications about.
+	 */
+	public function schedule_notifications( $items, $topic ) {
+		$args = [
+			1,
+			[
+				self::ITEMS_KEY => $items,
+				self::TOPIC_KEY => $topic,
+			],
+		];
+		if ( ! $this->is_running( $args ) ) {
+			$this->action_scheduler->schedule_immediate( $this->get_create_batch_hook(), $args );
+		}
+	}
+
+
+	/**
+	 * Get the batch for the job.
+	 *
+	 * @param int   $batch_number
+	 * @param array $args
+	 *
+	 * @return array
+	 */
+	protected function get_batch( int $batch_number, array $args = [] ): array {
+		if ( isset( $args[ self::ITEMS_KEY ] ) ) {
+			return array_slice( $args[ self::ITEMS_KEY ], $batch_number - 1, $this->get_batch_size() );
+		}
+
+		return [];
+	}
+
+	/**
+	 * Get the batch size for this job
+	 *
+	 * @return int
+	 */
+	protected function get_batch_size(): int {
+		return 1;
+	}
+
+	/**
+	 * Process an item.
+	 *
+	 * @param array $ids an array of item ids.
+	 * @param array $args The action arguments.
+	 */
+	public function process_items( array $ids, array $args = [] ) {
+		if ( ! isset( $args[ self::TOPIC_KEY ] ) ) {
+			return;
+		}
+
+		$topic = $args[ self::TOPIC_KEY ];
+		if ( $this->notifications_service->is_product_topic( $topic ) ) {
+			$item_ids = $this->product_repository->find_notification_ready_products( [ 'include' => $ids ] );
+		} else {
+			$item_ids = $ids;
+		}
+
+		foreach ( $item_ids as $id ) {
+			$this->notifications_service->notify( $id, $topic );
+		}
+	}
+}

--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -30,7 +30,8 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $args Action args.
 	 *
 	 * @return array
 	 */
@@ -42,6 +43,7 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 * Process batch items.
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $args Action args.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -34,7 +34,7 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 *
 	 * @return array
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $args = [] ): array {
 		return $this->product_repository->find_expiring_product_ids( $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -45,7 +45,7 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $args = [] ) {
 		$products = $this->product_repository->find_by_ids( $items );
 
 		$this->product_syncer->update( $products );

--- a/src/Jobs/SyncableProductsBatchedActionSchedulerJobTrait.php
+++ b/src/Jobs/SyncableProductsBatchedActionSchedulerJobTrait.php
@@ -20,11 +20,11 @@ trait SyncableProductsBatchedActionSchedulerJobTrait {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
-	 *
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $args The action arguments.
 	 * @return WC_Product[]
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $args = [] ): array {
 		return $this->get_filtered_batch( $batch_number )->get();
 	}
 
@@ -53,12 +53,13 @@ trait SyncableProductsBatchedActionSchedulerJobTrait {
 	 *
 	 * @since 1.4.0
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $args The action arguments.
 	 *
 	 * @throws Exception If an error occurs.
 	 * @throws JobException If the job failure rate is too high.
 	 */
-	public function handle_create_batch_action( int $batch_number ) {
+	public function handle_create_batch_action( int $batch_number, array $args = [] ) {
 		$create_batch_hook = $this->get_create_batch_hook();
 		$create_batch_args = [ $batch_number ];
 

--- a/src/Jobs/Update/CleanupProductTargetCountriesJob.php
+++ b/src/Jobs/Update/CleanupProductTargetCountriesJob.php
@@ -37,7 +37,7 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @return array
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $args = [] ): array {
 		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -48,7 +48,7 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $args = [] ) {
 		$products      = $this->product_repository->find_by_ids( $items );
 		$stale_entries = $this->batch_product_helper->generate_stale_countries_request_entries( $products );
 		$this->product_syncer->delete_by_batch_requests( $stale_entries );

--- a/src/Jobs/Update/CleanupProductTargetCountriesJob.php
+++ b/src/Jobs/Update/CleanupProductTargetCountriesJob.php
@@ -33,7 +33,8 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $args Action args.
 	 *
 	 * @return array
 	 */
@@ -45,6 +46,7 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	 * Process batch items.
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $args Action args.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -37,7 +37,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob implements Optio
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $args = [] ) {
 		$products = $this->product_repository->find_by_ids( $items );
 		$this->product_syncer->update( $products );
 	}

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -34,6 +34,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob implements Optio
 	 * Process batch items.
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $args Action args.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/UpdateCoupon.php
+++ b/src/Jobs/UpdateCoupon.php
@@ -32,6 +32,7 @@ class UpdateCoupon extends AbstractCouponSyncerJob implements
 	 * Process an item.
 	 *
 	 * @param int[] $coupon_ids
+	 * @param array $args Action args.
 	 *
 	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/UpdateCoupon.php
+++ b/src/Jobs/UpdateCoupon.php
@@ -35,7 +35,7 @@ class UpdateCoupon extends AbstractCouponSyncerJob implements
 	 *
 	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	public function process_items( $coupon_ids ) {
+	public function process_items( $coupon_ids, array $args = [] ) {
 		foreach ( $coupon_ids as $coupon_id ) {
 			$coupon = $this->wc->maybe_get_coupon( $coupon_id );
 			if ( $coupon instanceof WC_Coupon &&

--- a/src/Jobs/UpdateProducts.php
+++ b/src/Jobs/UpdateProducts.php
@@ -31,6 +31,7 @@ class UpdateProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * Process an item.
 	 *
 	 * @param int[] $product_ids An array of WooCommerce product ids.
+	 * @param array $args Action args
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.

--- a/src/Jobs/UpdateProducts.php
+++ b/src/Jobs/UpdateProducts.php
@@ -35,7 +35,7 @@ class UpdateProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
 	 */
-	public function process_items( array $product_ids ) {
+	public function process_items( array $product_ids, array $args = [] ) {
 		$args     = [ 'include' => $product_ids ];
 		$products = $this->product_repository->find_sync_ready_products( $args )->get();
 

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -69,6 +69,7 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob {
 	 * Process the job.
 	 *
 	 * @param int[] $items An array of job arguments.
+	 * @param array $args Action args.
 	 *
 	 * @throws JobException If the shipping settings cannot be synced.
 	 */

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -72,7 +72,7 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob {
 	 *
 	 * @throws JobException If the shipping settings cannot be synced.
 	 */
-	public function process_items( array $items ) {
+	public function process_items( array $items, array $args = [] ) {
 		if ( ! $this->can_sync_shipping() ) {
 			throw new JobException( 'Cannot sync shipping settings. Confirm that the merchant center account is connected and the option to automatically sync the shipping settings is selected.' );
 		}

--- a/src/Jobs/UpdateSyncableProductsCount.php
+++ b/src/Jobs/UpdateSyncableProductsCount.php
@@ -78,6 +78,7 @@ class UpdateSyncableProductsCount extends AbstractBatchedActionSchedulerJob impl
 	 * Process batch items.
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $args Action args.
 	 */
 	protected function process_items( array $items, array $args = [] ) {
 		$product_ids = $this->options->get( OptionsInterface::SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA );

--- a/src/Jobs/UpdateSyncableProductsCount.php
+++ b/src/Jobs/UpdateSyncableProductsCount.php
@@ -79,7 +79,7 @@ class UpdateSyncableProductsCount extends AbstractBatchedActionSchedulerJob impl
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $args = [] ) {
 		$product_ids = $this->options->get( OptionsInterface::SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA );
 
 		if ( ! is_array( $product_ids ) ) {

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -44,6 +44,9 @@ defined( 'ABSPATH' ) || exit;
  * @method update_mc_status( WC_Product $product, string $value )
  * @method delete_mc_status( WC_Product $product )
  * @method get_mc_status( WC_Product $product ): string|null
+ * @method get_notification_status( WC_Product $product ): string|null
+ * @method delete_notification_status( WC_Product $product ):
+ * @method update_notification_status( WC_Product $product, string $value )
  */
 class ProductMetaHandler implements Service, Registerable {
 
@@ -58,6 +61,7 @@ class ProductMetaHandler implements Service, Registerable {
 	public const KEY_SYNC_FAILED_AT         = 'sync_failed_at';
 	public const KEY_SYNC_STATUS            = 'sync_status';
 	public const KEY_MC_STATUS              = 'mc_status';
+	public const KEY_NOTIFICATION_STATUS    = 'notification_status';
 
 	protected const TYPES = [
 		self::KEY_SYNCED_AT              => 'int',
@@ -69,6 +73,7 @@ class ProductMetaHandler implements Service, Registerable {
 		self::KEY_SYNC_FAILED_AT         => 'int',
 		self::KEY_SYNC_STATUS            => 'string',
 		self::KEY_MC_STATUS              => 'string',
+		self::KEY_NOTIFICATION_STATUS    => 'string',
 	];
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -153,6 +153,21 @@ class ProductRepository implements Service {
 	}
 
 	/**
+	 * Find and return an array of WooCommerce product objects ready to be notified to Google.
+	 *
+	 * @param array $args   Array of WooCommerce args (except 'return'), and product metadata.
+	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
+	 * @param int   $offset Amount to offset product results.
+	 *
+	 * @return int[] List of WooCommerce product objects after filtering.
+	 */
+	public function find_notification_ready_products( array $args = [], int $limit = - 1, int $offset = 0 ): array {
+		$args['post_status'] = [ 'publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash' ];
+
+		return $this->find_ids( $args, $limit, $offset );
+	}
+
+	/**
 	 * Find and return an array of WooCommerce product ID's ready to be deleted from the Google Merchant Center.
 	 *
 	 * @since 1.12.0
@@ -203,6 +218,23 @@ class ProductRepository implements Service {
 		if ( empty( $args['status'] ) ) {
 			$args['status'] = [ 'publish' ];
 		}
+
+		return $args;
+	}
+
+	/**
+	 * @param array $args Array of WooCommerce args (except 'return'), and product metadata.
+	 *
+	 * @return array
+	 */
+	protected function get_notification_ready_products_query_args( array $args = [] ): array {
+		$args['meta_query'] = [
+			[
+				'key'     => ProductMetaHandler::KEY_VISIBILITY,
+				'compare' => '!=',
+				'value'   => ChannelVisibility::DONT_SYNC_AND_SHOW,
+			],
+		];
 
 		return $args;
 	}

--- a/src/Value/NotificationStatus.php
+++ b/src/Value/NotificationStatus.php
@@ -1,0 +1,58 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Value;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class NotificationStatus
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Value
+ */
+class NotificationStatus implements ValueInterface {
+
+	public const CREATED = 'created';
+
+	public const ALLOWED_VALUES = [
+		self::CREATED,
+	];
+
+	/**
+	 * @var string
+	 */
+	protected $status;
+
+	/**
+	 * SyncStatus constructor.
+	 *
+	 * @param string $status The value.
+	 *
+	 * @throws InvalidValue When an invalid status type is provided.
+	 */
+	public function __construct( string $status ) {
+		if ( ! in_array( $status, self::ALLOWED_VALUES, true ) ) {
+			throw InvalidValue::not_in_allowed_list( $status, self::ALLOWED_VALUES );
+		}
+
+		$this->status = $status;
+	}
+
+	/**
+	 * Get the value of the object.
+	 *
+	 * @return string
+	 */
+	public function get(): string {
+		return $this->status;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function __toString(): string {
+		return $this->get();
+	}
+}

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
@@ -21,7 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class UpdateProductsTest
- *
+ * @group Jobs
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
 class UpdateAllProductsTest extends UnitTest {
@@ -50,6 +51,9 @@ class UpdateAllProductsTest extends UnitTest {
 	/** @var MockObject|MerchantCenterService $merchant_center */
 	protected $merchant_center;
 
+	/** @var MockObject|NotificationsService $notifications */
+	protected $notifications;
+
 	/** @var UpdateAllProducts $job */
 	protected $job;
 
@@ -70,13 +74,15 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->product_repository = $this->createMock( ProductRepository::class );
 		$this->product_helper     = $this->createMock( BatchProductHelper::class );
 		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
+		$this->notifications      = $this->createMock( NotificationsService::class );
 		$this->job                = new UpdateAllProducts(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->product_syncer,
 			$this->product_repository,
 			$this->product_helper,
-			$this->merchant_center
+			$this->merchant_center,
+			$this->notifications
 		);
 
 		$this->merchant_center
@@ -127,11 +133,11 @@ class UpdateAllProductsTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( self::CREATE_BATCH_HOOK, [ 1 ] );
+			->with( self::CREATE_BATCH_HOOK, [ 1, [] ] );
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
 	}
 
 	/**
@@ -149,13 +155,13 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 3 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $filtered_product_list->get_product_ids() ] ]
+				[ self::CREATE_BATCH_HOOK, [ 1, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $filtered_product_list->get_product_ids(), [] ] ]
 			);
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
 	}
 
 	/**
@@ -169,11 +175,11 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 5 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3 ] ],
+				[ self::CREATE_BATCH_HOOK, [ 1, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, [] ] ],
 			);
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
@@ -187,9 +193,9 @@ class UpdateAllProductsTest extends UnitTest {
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
-		do_action( self::CREATE_BATCH_HOOK, 2 );
-		do_action( self::CREATE_BATCH_HOOK, 3 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
+		do_action( self::CREATE_BATCH_HOOK, 2, [] );
+		do_action( self::CREATE_BATCH_HOOK, 3, [] );
 	}
 
 	/**
@@ -203,11 +209,11 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 5 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3 ] ],
+				[ self::CREATE_BATCH_HOOK, [ 1, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, [] ] ],
 			);
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
@@ -221,9 +227,9 @@ class UpdateAllProductsTest extends UnitTest {
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
-		do_action( self::CREATE_BATCH_HOOK, 2 );
-		do_action( self::CREATE_BATCH_HOOK, 3 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
+		do_action( self::CREATE_BATCH_HOOK, 2, [] );
+		do_action( self::CREATE_BATCH_HOOK, 3, [] );
 	}
 
 	/**
@@ -242,10 +248,10 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 4 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1 ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3 ] ],
+				[ self::CREATE_BATCH_HOOK, [ 1, [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, [] ] ],
 			);
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
@@ -255,9 +261,9 @@ class UpdateAllProductsTest extends UnitTest {
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
-		do_action( self::CREATE_BATCH_HOOK, 2 );
-		do_action( self::CREATE_BATCH_HOOK, 3 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
+		do_action( self::CREATE_BATCH_HOOK, 2, [] );
+		do_action( self::CREATE_BATCH_HOOK, 3, [] );
 	}
 
 	public function test_process_item() {

--- a/tests/Unit/Jobs/UpdateProductsTest.php
+++ b/tests/Unit/Jobs/UpdateProductsTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateProducts;
@@ -17,7 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class UpdateProductsTest
- *
+ * @group Jobs
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
 class UpdateProductsTest extends UnitTest {
@@ -40,6 +41,9 @@ class UpdateProductsTest extends UnitTest {
 	/** @var MockObject|MerchantCenterService $merchant_center */
 	protected $merchant_center;
 
+	/** @var MockObject|NotificationsService $notifications */
+	protected $notifications;
+
 	/** @var UpdateProducts $job */
 	protected $job;
 
@@ -57,12 +61,14 @@ class UpdateProductsTest extends UnitTest {
 		$this->product_syncer     = $this->createMock( ProductSyncer::class );
 		$this->product_repository = $this->createMock( ProductRepository::class );
 		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
+		$this->notifications      = $this->createMock( NotificationsService::class );
 		$this->job                = new UpdateProducts(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->product_syncer,
 			$this->product_repository,
-			$this->merchant_center
+			$this->merchant_center,
+			$this->notifications
 		);
 
 		$this->job->init();

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class UpdateShippingSettingsTest
- *
+ * @group Jobs
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
 class UpdateShippingSettingsTest extends UnitTest {

--- a/tests/Unit/Jobs/UpdateSyncableProductsCountTest.php
+++ b/tests/Unit/Jobs/UpdateSyncableProductsCountTest.php
@@ -18,7 +18,7 @@ use WC_Helper_Product;
 
 /**
  * Class UpdateSyncableProductsCountTest
- *
+ * @group Jobs
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
 class UpdateSyncableProductsCountTest extends UnitTest {
@@ -98,11 +98,11 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 5 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3 ] ],
+				[ self::CREATE_BATCH_HOOK, [ 1, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, [] ] ],
 			);
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
@@ -134,11 +134,11 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
-		do_action( self::PROCESS_ITEM_HOOK, $batch_a->get_product_ids() );
-		do_action( self::CREATE_BATCH_HOOK, 2 );
-		do_action( self::PROCESS_ITEM_HOOK, $batch_b->get_product_ids() );
-		do_action( self::CREATE_BATCH_HOOK, 3 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
+		do_action( self::PROCESS_ITEM_HOOK, $batch_a->get_product_ids(), [] );
+		do_action( self::CREATE_BATCH_HOOK, 2, [] );
+		do_action( self::PROCESS_ITEM_HOOK, $batch_b->get_product_ids(), [] );
+		do_action( self::CREATE_BATCH_HOOK, 3, [] );
 	}
 
 	public function test_update_syncable_products_count_duplicate_product_ids() {
@@ -166,11 +166,11 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 5 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3 ] ],
+				[ self::CREATE_BATCH_HOOK, [ 1, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, [] ] ],
 			);
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
@@ -202,11 +202,11 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
-		do_action( self::PROCESS_ITEM_HOOK, $batch_a->get_product_ids() );
-		do_action( self::CREATE_BATCH_HOOK, 2 );
-		do_action( self::PROCESS_ITEM_HOOK, $batch_b->get_product_ids() );
-		do_action( self::CREATE_BATCH_HOOK, 3 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
+		do_action( self::PROCESS_ITEM_HOOK, $batch_a->get_product_ids(), [] );
+		do_action( self::CREATE_BATCH_HOOK, 2, [] );
+		do_action( self::PROCESS_ITEM_HOOK, $batch_b->get_product_ids(), [] );
+		do_action( self::CREATE_BATCH_HOOK, 3, [] );
 	}
 
 	public function test_update_syncable_products_count_no_syncable_products_single_batch() {
@@ -215,7 +215,7 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( self::CREATE_BATCH_HOOK, [ 1 ] );
+			->with( self::CREATE_BATCH_HOOK, [ 1, [] ] );
 
 		$this->product_repository->expects( $this->once() )
 			->method( 'find_sync_ready_products' )
@@ -233,7 +233,7 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
 	}
 
 	public function test_update_syncable_products_count_no_syncable_products_multiple_batches() {
@@ -249,9 +249,9 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 3 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1 ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2 ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3 ] ]
+				[ self::CREATE_BATCH_HOOK, [ 1, [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, [] ] ]
 			);
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
@@ -274,9 +274,9 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 
 		$this->job->schedule();
 
-		do_action( self::CREATE_BATCH_HOOK, 1 );
-		do_action( self::CREATE_BATCH_HOOK, 2 );
-		do_action( self::CREATE_BATCH_HOOK, 3 );
+		do_action( self::CREATE_BATCH_HOOK, 1, [] );
+		do_action( self::CREATE_BATCH_HOOK, 2, [] );
+		do_action( self::CREATE_BATCH_HOOK, 3, [] );
 	}
 
 	public function test_update_syncable_products_count_product_gets_deleted_after_batches_get_created() {
@@ -307,11 +307,11 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 5 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2 ] ],
-				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids() ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3 ] ],
+				[ self::CREATE_BATCH_HOOK, [ 1, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_a->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, [] ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $batch_b->get_product_ids(), [] ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, [] ] ],
 			);
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
@@ -352,9 +352,9 @@ class UpdateSyncableProductsCountTest extends UnitTest {
 		wp_trash_post( $product_to_be_deleted->get_id() );
 		$product_to_be_deleted->set_status( 'trash' );
 		$product_to_be_deleted->save();
-		do_action( self::PROCESS_ITEM_HOOK, $batch_a->get_product_ids() );
-		do_action( self::CREATE_BATCH_HOOK, 2 );
-		do_action( self::PROCESS_ITEM_HOOK, $batch_b->get_product_ids() );
-		do_action( self::CREATE_BATCH_HOOK, 3 );
+		do_action( self::PROCESS_ITEM_HOOK, $batch_a->get_product_ids(), [] );
+		do_action( self::CREATE_BATCH_HOOK, 2, [] );
+		do_action( self::PROCESS_ITEM_HOOK, $batch_b->get_product_ids(), [] );
+		do_action( self::CREATE_BATCH_HOOK, 3, [] );
 	}
 }

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
@@ -31,7 +32,7 @@ use WC_Product_Variation;
 
 /**
  * Class BatchProductHelperTest
- *
+ * @group Jobs
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
  */
 class BatchProductHelperTest extends ContainerAwareUnitTest {
@@ -53,6 +54,9 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 
 	/** @var MockObject|TargetAudience $target_audience */
 	protected $target_audience;
+
+	/** @var MockObject|NotificationsService $notifications */
+	protected $notifications;
 
 	/** @var BatchProductHelper $batch_product_helper */
 	protected $batch_product_helper;
@@ -388,10 +392,11 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->target_audience      = $this->createMock( TargetAudience::class );
 		$this->validator            = $this->createMock( ValidatorInterface::class );
 		$this->rules_query          = $this->createMock( AttributeMappingRulesQuery::class );
+		$this->notifications        = $this->createMock( NotificationsService::class );
 		$this->product_meta         = $this->container->get( ProductMetaHandler::class );
 		$this->product_factory      = $this->container->get( ProductFactory::class );
 		$this->wc                   = $this->container->get( WC::class );
-		$this->product_helper       = new ProductHelper( $this->product_meta, $this->wc, $this->target_audience );
+		$this->product_helper       = new ProductHelper( $this->product_meta, $this->wc, $this->target_audience, $this->notifications );
 		$this->batch_product_helper = new BatchProductHelper( $this->product_meta, $this->product_helper, $this->validator, $this->product_factory, $this->target_audience, $this->rules_query );
 	}
 }

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
@@ -37,6 +38,9 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 
 	/** @var MockObject|TargetAudience $target_audience */
 	protected $target_audience;
+
+	/** @var MockObject|NotificationsService $notifications */
+	protected $notifications;
 
 	/** @var ProductHelper $product_helper */
 	protected $product_helper;
@@ -1087,6 +1091,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$this->product_meta    = $this->container->get( ProductMetaHandler::class );
 		$this->wc              = $this->container->get( WC::class );
 		$this->target_audience = $this->createMock( TargetAudience::class );
-		$this->product_helper  = new ProductHelper( $this->product_meta, $this->wc, $this->target_audience );
+		$this->notifications   = $this->createMock( NotificationsService::class );
+		$this->product_helper  = new ProductHelper( $this->product_meta, $this->wc, $this->target_audience, $this->notifications );
 	}
 }

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -3,11 +3,14 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\FilteredProductList;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
@@ -17,7 +20,7 @@ use WC_Product;
 
 /**
  * Class ProductRepositoryTest
- *
+ * @group Jobs
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
  */
 class ProductRepositoryTest extends ContainerAwareUnitTest {
@@ -348,5 +351,7 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		$this->product_meta       = $this->container->get( ProductMetaHandler::class );
 		$this->product_helper     = $this->container->get( ProductHelper::class );
 		$this->product_repository = $this->container->get( ProductRepository::class );
+		add_filter('woocommerce_gla_notifications_enabled', '__return_false' );
+
 	}
 }

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -32,7 +32,7 @@ use WC_Product;
 
 /**
  * Class ProductSyncerTest
- *
+ * @group Jobs
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
  */
 class ProductSyncerTest extends ContainerAwareUnitTest {
@@ -591,5 +591,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->wc                 = $this->container->get( WC::class );
 		$this->product_repository = $this->container->get( ProductRepository::class );
 		$this->product_syncer     = $this->get_product_syncer();
+
+		add_filter('woocommerce_gla_notifications_enabled', '__return_false' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is another strategy alternative to https://github.com/woocommerce/google-listings-and-ads/pull/2202

With this one, we updated the Abstract Job internal classes to support args. IN this args we send the items in the batch, and we query them. There is a single Notification Job doing this.

For that this PR:

- Modified AbstractActionSchedulerJob.php, AbstractProductSyncerBatchedJob.php and  src/Jobs/AbstractBatchedActionSchedulerJob.php to support $args.
- Adapt all the Jobs signature
- Create  Job in `Notification.php`
- Adapt `ProductHelper`, `ProductRepository` and `ProductMetaHandler` to use the new strategy
- Adapt `SynceHooks` for triggering the Job

The way it works is that on Product Changes we load all the items in the batched scheduled action.

Advantages:

- Potentially one single Job can do all the topics as we support args.

Disadvantages:

- Needs to tweak all the structure of ScheduledJobs 
- May have more collisions in the AS queue

### Detailed test instructions:

No need to do a detailed test here. Follow kinda the same steps as here https://github.com/woocommerce/google-listings-and-ads/pull/2202 or just offer some feedback for this strategy.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
