### PR TITLE
Add tracking for completed events

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -330,6 +330,9 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				$this->delete_operation( $campaign_resource_name ),
 			];
 
+			// Clear cached campaign count.
+			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_CAMPAIGN_COUNT );
+
 			return $this->mutate( $operations );
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -43,6 +43,26 @@ class Settings {
 	}
 
 	/**
+	 * Return a set of formatted settings which can be used in tracking.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array
+	 */
+	public function get_tracked_settings() {
+		$settings = $this->get_settings();
+
+		return [
+			'shipping_rate'           => $settings['shipping_rate'] ?? '',
+			'offers_free_shipping'    => (bool) $settings['offers_free_shipping'] ?? false,
+			'free_shipping_threshold' => (float) $settings['free_shipping_threshold'] ?? 0,
+			'shipping_time'           => $settings['shipping_time'] ?? '',
+			'tax_rate'                => $settings['tax_rate'] ?? '',
+			'target_countries'        => join( ',', $this->get_target_countries() ),
+		];
+	}
+
+	/**
 	 * Sync the shipping settings with Google.
 	 */
 	public function sync_shipping() {
@@ -392,5 +412,20 @@ class Settings {
 	protected function get_settings(): array {
 		$settings = $this->get_options_object()->get( OptionsInterface::MERCHANT_CENTER );
 		return is_array( $settings ) ? $settings : [];
+	}
+
+	/**
+	 * Return a list of target countries or all.
+	 *
+	 * @return array
+	 */
+	protected function get_target_countries(): array {
+		$target_audience = $this->get_options_object()->get( OptionsInterface::TARGET_AUDIENCE );
+
+		if ( isset( $target_audience['location'] ) && 'all' === $target_audience['location'] ) {
+			return [ 'all' ];
+		}
+
+		return $target_audience['countries'] ?? [];
 	}
 }

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -49,7 +49,7 @@ class Settings {
 	 *
 	 * @return array
 	 */
-	public function get_tracked_settings() {
+	public function get_settings_for_tracking() {
 		$settings = $this->get_settings();
 
 		return [

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -228,10 +228,12 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 				do_action(
 					'woocommerce_gla_track_event',
 					'edited_campaign',
-					[
-						'id' => $campaign_id,
-						...$fields,
-					]
+					array_merge(
+						[
+							'id' => $campaign_id,
+						],
+						$fields,
+					)
 				);
 
 				return [

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -136,6 +136,30 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 
 				$campaign = $this->ads_campaign->create_campaign( $fields );
 
+				/**
+				 * When a campaign has been successfully created.
+				 *
+				 * @event gla_created_campaign
+				 * @property int    id                 Campaign ID.
+				 * @property string status             Campaign status, `enabled` or `paused`.
+				 * @property string name               Campaign name, generated based on date.
+				 * @property float  amount             Campaign budget.
+				 * @property string country            Base target country code.
+				 * @property string targeted_locations Additional target country codes.
+				 */
+				do_action(
+					'woocommerce_gla_track_event',
+					'created_campaign',
+					[
+						'id'                 => $campaign['id'],
+						'status'             => $campaign['status'],
+						'name'               => $campaign['name'],
+						'amount'             => $campaign['amount'],
+						'country'            => $campaign['country'],
+						'targeted_locations' => join( ',', $campaign['targeted_locations'] ),
+					]
+				);
+
 				return $this->prepare_item_for_response( $campaign, $request );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
@@ -192,6 +216,24 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 
 				$campaign_id = $this->ads_campaign->edit_campaign( absint( $request['id'] ), $fields );
 
+				/**
+				 * When a campaign has been successfully edited.
+				 *
+				 * @event gla_edited_campaign
+				 * @property int    id     Campaign ID.
+				 * @property string status Campaign status, `enabled` or `paused`.
+				 * @property string name   Campaign name, generated based on date.
+				 * @property float  amount Campaign budget.
+				 */
+				do_action(
+					'woocommerce_gla_track_event',
+					'edited_campaign',
+					[
+						'id' => $campaign_id,
+						...$fields,
+					]
+				);
+
 				return [
 					'status'  => 'success',
 					'message' => __( 'Successfully edited campaign.', 'google-listings-and-ads' ),
@@ -212,6 +254,20 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 		return function ( Request $request ) {
 			try {
 				$deleted_id = $this->ads_campaign->delete_campaign( absint( $request['id'] ) );
+
+				/**
+				 * When a campaign has been successfully deleted.
+				 *
+				 * @event gla_deleted_campaign
+				 * @property int id Campaign ID.
+				 */
+				do_action(
+					'woocommerce_gla_track_event',
+					'deleted_campaign',
+					[
+						'id' => $deleted_id,
+					]
+				);
 
 				return [
 					'status'  => 'success',

--- a/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
@@ -68,6 +68,23 @@ class SettingsSyncController extends BaseController {
 
 				do_action( 'woocommerce_gla_mc_settings_sync' );
 
+				/**
+				 * MerchantCenter onboarding has been successfully completed.
+				 *
+				 * @event gla_mc_setup_completed
+				 * @property string shipping_rate           Shipping rate setup `automatic`, `manual`, `flat`.
+				 * @property bool   offers_free_shipping    Free Shipping is available.
+				 * @property float  free_shipping_threshold Minimum amount to avail of free shipping.
+				 * @property string shipping_time           Shipping time setup `flat`, `manual`.
+				 * @property string tax_rate                Tax rate setup `destination`, `manual`.
+				 * @property string target_countries        List of target countries or `all`.
+				 */
+				do_action(
+					'woocommerce_gla_track_event',
+					'mc_setup_completed',
+					$this->settings->get_tracked_settings()
+				);
+
 				return new Response(
 					[
 						'status'  => 'success',

--- a/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
@@ -82,7 +82,7 @@ class SettingsSyncController extends BaseController {
 				do_action(
 					'woocommerce_gla_track_event',
 					'mc_setup_completed',
-					$this->settings->get_tracked_settings()
+					$this->settings->get_settings_for_tracking()
 				);
 
 				return new Response(

--- a/src/Exception/WPErrorTrait.php
+++ b/src/Exception/WPErrorTrait.php
@@ -41,7 +41,7 @@ trait WPErrorTrait {
 	 * @return WP_Error
 	 */
 	protected function error_from_exception( Throwable $e, string $code, array $data = [] ): WP_Error {
-		return new WP_Error( $code, $e->getMessage(), $data );
+		return new WP_Error( $code, $data['message'] ?? $e->getMessage(), $data );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -109,6 +109,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneLocationsParser;
 use Automattic\WooCommerce\GoogleListingsAndAds\TaskList\CompleteSetupTask;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\ActivatedEvents;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\GenericEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteClaimEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteVerificationEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\EventTracking;
@@ -386,8 +387,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Share other classes.
 		$this->share_with_tags( ActivatedEvents::class, $_SERVER );
-		$this->share_with_tags( SiteVerificationEvents::class );
+		$this->share_with_tags( GenericEvents::class );
 		$this->share_with_tags( SiteClaimEvents::class );
+		$this->share_with_tags( SiteVerificationEvents::class );
 
 		$this->conditionally_share_with_tags( InstallTimestamp::class );
 		$this->conditionally_share_with_tags( ClearProductStatsCache::class, MerchantStatuses::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AssetSuggestionsService as A
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
@@ -128,7 +129,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( SupportedCountriesController::class, WC::class, GoogleHelper::class );
 		$this->share( SettingsSyncController::class, Settings::class );
 		$this->share( DisconnectController::class );
-		$this->share( SetupCompleteController::class );
+		$this->share( SetupCompleteController::class, MerchantMetrics::class );
 		$this->share( AssetSuggestionsController::class, AdsAssetSuggestionsService::class );
 		$this->share( SyncableProductsCountController::class, JobRepository::class );
 		$this->share( PolicyComplianceCheckController::class, PolicyComplianceCheck::class );

--- a/src/Tracking/EventTracking.php
+++ b/src/Tracking/EventTracking.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\ActivatedEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\BaseEvent;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\GenericEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteClaimEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events\SiteVerificationEvents;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
@@ -35,9 +36,10 @@ class EventTracking implements Service, Registerable {
 	 * @var string[]
 	 */
 	protected $events = [
-		SiteVerificationEvents::class,
-		SiteClaimEvents::class,
 		ActivatedEvents::class,
+		GenericEvents::class,
+		SiteClaimEvents::class,
+		SiteVerificationEvents::class,
 	];
 
 	/**

--- a/src/Tracking/Events/GenericEvents.php
+++ b/src/Tracking/Events/GenericEvents.php
@@ -1,0 +1,32 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tracking\Events;
+
+/**
+ * This class adds an action to track a generic event, which can be triggered by:
+ * `do_action( 'woocommerce_gla_track_event', 'event_name', $properties )`
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tracking
+ */
+class GenericEvents extends BaseEvent {
+
+	/**
+	 * Register the tracking class.
+	 */
+	public function register(): void {
+		add_action( 'woocommerce_gla_track_event', [ $this, 'track_event' ], 10, 2 );
+	}
+
+	/**
+	 * Track a generic event providing event name and optional list of properties.
+	 *
+	 * @param string $event_name Event name to record.
+	 * @param array  $properties Optional additional properties to pass with the event.
+	 */
+	public function track_event( string $event_name, array $properties = [] ) {
+		$this->record_event( $event_name, $properties );
+	}
+}

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -58,6 +58,35 @@ When a site verification with Google fails
 ### `gla_site_verify_success`
 When a site is successfully verified with Google
 
+### `gla_created_campaign`
+When a campaign has been successfully created.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`id` | `int` | Campaign ID.
+`status` | `string` | Campaign status, `enabled` or `paused`.
+`name` | `string` | Campaign name, generated based on date.
+`amount` | `float` | Campaign budget.
+`country` | `string` | Base target country code.
+`targeted_locations` | `string` | Additional target country codes.
+
+### `gla_edited_campaign`
+When a campaign has been successfully edited.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`id` | `int` | Campaign ID.
+`status` | `string` | Campaign status, `enabled` or `paused`.
+`name` | `string` | Campaign name.
+`amount` | `float` | Campaign budget.
+
+### `gla_deleted_campaign`
+When a campaign has been successfully deleted.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`id` | `int` | Campaign ID.
+
 <!-- -- >
 ## Developer Info
 All new tracking info should be updated in this readme.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -94,6 +94,18 @@ Ads onboarding has been successfully completed.
 | ---- | ---- | ----------- |
 `campaign_count` | `int` | Number of campaigns for the connected Ads account.
 
+### `gla_mc_setup_completed`
+Merchant Center onboarding has been successfully completed.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`shipping_rate` | `string` | Shipping rate setup `automatic`, `manual`, `flat`.
+`offers_free_shipping` | `bool` | Free Shipping is available.
+`free_shipping_threshold` | `float` | Minimum amount to avail of free shipping.
+`shipping_time` | `string` | Shipping time setup `flat`, `manual`.
+`tax_rate` | `string` | Tax rate setup `destination`, `manual`.
+`target_countries` | `string` | List of target countries or `all`.
+
 <!-- -- >
 ## Developer Info
 All new tracking info should be updated in this readme.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -87,6 +87,13 @@ When a campaign has been successfully deleted.
 | ---- | ---- | ----------- |
 `id` | `int` | Campaign ID.
 
+### `gla_ads_setup_completed`
+Ads onboarding has been successfully completed.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`campaign_count` | `int` | Number of campaigns for the connected Ads account.
+
 <!-- -- >
 ## Developer Info
 All new tracking info should be updated in this readme.

--- a/tests/Tools/HelperTrait/TrackingTrait.php
+++ b/tests/Tools/HelperTrait/TrackingTrait.php
@@ -1,0 +1,30 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
+
+/**
+ * Trait for confirming tracking events are triggered.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait
+ */
+trait TrackingTrait {
+
+	use WPHookTrait;
+
+	/**
+	 * Expect a track event to be triggered through a hook with specific event name and properties.
+	 *
+	 * @param string $event_name Event name to expect.
+	 * @param array  $properties Properties to expect.
+	 */
+	protected function expect_track_event( string $event_name, array $properties = [] ) {
+		$this->expect_do_action_once(
+			'woocommerce_gla_track_event',
+			[
+				$event_name,
+				$properties,
+			]
+		);
+	}
+}

--- a/tests/Tools/HelperTrait/WPHookTrait.php
+++ b/tests/Tools/HelperTrait/WPHookTrait.php
@@ -1,0 +1,45 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\WPHookMock;
+
+/**
+ * Trait for mocking calls to WP hooks.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait
+ */
+trait WPHookTrait {
+
+	/**
+	 * Expect a single call to do_action() with specific hook and args.
+	 *
+	 * @param string $hook
+	 * @param array  $args
+	 */
+	protected function expect_do_action_once( string $hook, $args ) {
+		global $wp_filter;
+
+		$mock = $this->createMock( WPHookMock::class );
+		$mock->expects( $this->once() )
+			->method( 'do_action' )
+			->with( $args );
+
+		$wp_filter[ $hook ] = $mock; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+	}
+
+	/**
+	 * Expect no calls to do_action() with a specific hook.
+	 *
+	 * @param string $hook
+	 */
+	protected function expect_do_action_never( string $hook ) {
+		global $wp_filter;
+
+		$mock = $this->createMock( WPHookMock::class );
+		$mock->expects( $this->never() )->method( 'do_action' );
+
+		$wp_filter[ $hook ] = $mock; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+	}
+}

--- a/tests/Tools/WPHookMock.php
+++ b/tests/Tools/WPHookMock.php
@@ -1,0 +1,15 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools;
+
+/**
+ * Mockable version of WP_Hook
+ *
+ * @see \WP_Hook
+ */
+class WPHookMock {
+	public function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {}
+	public function do_action( $args ) {}
+	public function has_filter( $hook, $callback ) {}
+}

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -297,6 +297,8 @@ class AdsCampaignTest extends UnitTest {
 			'country' => self::BASE_COUNTRY,
 		] + $campaign_data;
 
+		$this->transients->expects( $this->once() )->method( 'delete' )->with( TransientsInterface::ADS_CAMPAIGN_COUNT );
+
 		$this->assertEquals(
 			$expected,
 			$this->campaign->create_campaign( $campaign_data )
@@ -445,6 +447,8 @@ class AdsCampaignTest extends UnitTest {
 
 	public function test_delete_campaign() {
 		$this->generate_campaign_mutate_mock( 'remove', self::TEST_CAMPAIGN_ID );
+
+		$this->transients->expects( $this->once() )->method( 'delete' )->with( TransientsInterface::ADS_CAMPAIGN_COUNT );
 
 		$this->assertEquals(
 			self::TEST_CAMPAIGN_ID,

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\CampaignController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -16,6 +17,8 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
  */
 class CampaignControllerTest extends RESTControllerUnitTest {
+
+	use TrackingTrait;
 
 	/** @var MockObject|AdsCampaign $ads_campaign */
 	protected $ads_campaign;
@@ -178,6 +181,18 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 			->method( 'create_campaign' )
 			->with( $campaign_data )
 			->willReturn( $expected );
+
+		$this->expect_track_event(
+			'created_campaign',
+			[
+				'id'                 => self::TEST_CAMPAIGN_ID,
+				'status'             => 'enabled',
+				'name'               => 'New Campaign',
+				'amount'             => 20,
+				'country'            => self::BASE_COUNTRY,
+				'targeted_locations' => 'US,GB,TW',
+			]
+		);
 
 		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
 
@@ -351,6 +366,14 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 			->with( self::TEST_CAMPAIGN_ID, $campaign_data )
 			->willReturn( self::TEST_CAMPAIGN_ID );
 
+		$this->expect_track_event(
+			'edited_campaign',
+			[
+				'id'     => self::TEST_CAMPAIGN_ID,
+				'amount' => 44.55,
+			]
+		);
+
 		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'POST', $campaign_data );
 
 		$this->assertEquals(
@@ -402,6 +425,13 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 			->method( 'delete_campaign' )
 			->with( self::TEST_CAMPAIGN_ID )
 			->willReturn( self::TEST_CAMPAIGN_ID );
+
+		$this->expect_track_event(
+			'deleted_campaign',
+			[
+				'id' => self::TEST_CAMPAIGN_ID,
+			]
+		);
 
 		$response = $this->do_request( self::ROUTE_CAMPAIGN, 'DELETE' );
 

--- a/tests/Unit/API/Site/Controllers/Ads/SetupCompleteControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/SetupCompleteControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\SetupCompleteController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class SetupCompleteControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ */
+class SetupCompleteControllerTest extends RESTControllerUnitTest {
+
+	use TrackingTrait;
+
+	/** @var MockObject|MerchantMetrics $metrics */
+	protected $metrics;
+
+	/** @var SetupCompleteController $controller */
+	protected $controller;
+
+	protected const ROUTE = '/wc/gla/ads/setup/complete';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->metrics    = $this->createMock( MerchantMetrics::class );
+		$this->controller = new SetupCompleteController( $this->server, $this->metrics );
+		$this->controller->register();
+	}
+
+	public function test_setup_complete() {
+		$this->metrics->expects( $this->once() )
+			->method( 'get_campaign_count' )
+			->willReturn( 1 );
+
+		$this->expect_track_event(
+			'ads_setup_completed',
+			[
+				'campaign_count' => 1,
+			]
+		);
+
+		$response = $this->do_request( self::ROUTE, 'POST' );
+
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_ads_setup_completed' ) );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsSyncControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsSyncControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsSyncController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class SettingsSyncControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ */
+class SettingsSyncControllerTest extends RESTControllerUnitTest {
+
+	use TrackingTrait;
+
+	/** @var MockObject|Settings $settings */
+	protected $settings;
+
+	/** @var SettingsSyncController $controller */
+	protected $controller;
+
+	protected const ROUTE = '/wc/gla/mc/settings/sync';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->settings   = $this->createMock( Settings::class );
+		$this->controller = new SettingsSyncController( $this->server, $this->settings );
+		$this->controller->register();
+	}
+
+	public function test_settings_sync() {
+		$this->settings->expects( $this->once() )->method( 'sync_taxes' );
+		$this->settings->expects( $this->once() )->method( 'sync_shipping' );
+
+		$settings = [
+			'shipping_rate'           => 'flat',
+			'offers_free_shipping'    => true,
+			'free_shipping_threshold' => 100,
+			'shipping_time'           => 'manual',
+			'tax_rate'                => 'manual',
+			'target_countries'        => 'US,CA',
+		];
+
+		$this->settings->expects( $this->once() )
+			->method( 'get_tracked_settings' )
+			->willReturn( $settings );
+
+		$this->expect_track_event( 'mc_setup_completed', $settings );
+
+		$response = $this->do_request( self::ROUTE, 'POST' );
+
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_mc_settings_sync' ) );
+	}
+
+	public function test_settings_sync_with_non_json_exception() {
+		$this->settings->expects( $this->once() )
+			->method( 'sync_taxes' )
+			->willThrowException(
+				new Exception( 'error' )
+			);
+
+		$response = $this->do_request( self::ROUTE, 'POST' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 500, $response->get_status() );
+	}
+
+	public function test_settings_sync_with_json_exception() {
+		$this->settings->expects( $this->once() )
+			->method( 'sync_taxes' )
+			->willThrowException(
+				new Exception(
+					json_encode(
+						[
+							'code'    => 400,
+							'message' => 'error',
+						]
+					)
+				)
+			);
+
+		$response = $this->do_request( self::ROUTE, 'POST' );
+
+		$this->assertEquals( 'error', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsSyncControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsSyncControllerTest.php
@@ -48,7 +48,7 @@ class SettingsSyncControllerTest extends RESTControllerUnitTest {
 		];
 
 		$this->settings->expects( $this->once() )
-			->method( 'get_tracked_settings' )
+			->method( 'get_settings_for_tracking' )
 			->willReturn( $settings );
 
 		$this->expect_track_event( 'mc_setup_completed', $settings );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project Thread: pcTzPl-20H-p2

This PR adds tracking from the backend for the following events:
- Merchant Center onboarding completed
- Ads onboarding completed
- Campaign created
- Campaign edited
- Campaign deleted

Sending these events from the backend allows us to track when the event was successful (as opposed to when the button is clicked to submit the data), as well as return relevant properties.

### Detailed test instructions:
1. Connect a new site and confirm tracking is allowed in WooCommerce > Settings > Advanced > Woo.com
2. Go through the onboarding, while skipping the campaign creation
3. Go through the ads onboarding by adding a campaign on the dashboard
4. Create a campaign
5. Update a campaign
6. Delete a campaign
7. Go to tracks > history and filter for your username to confirm all tracks are received (make sure to set the date range to include today and might need to wait a while for them to show up)
8. Alternatively I used a snippet like this to add the track properties to a debug log file:
```php
// Log tracks.
add_filter(
	'pre_http_request',
	function ( $pre, $args, $url ) {
		if ( str_starts_with( $url, 'https://pixel.wp.com' ) ) {
			wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_vars );
			error_log( json_encode( $query_vars, JSON_PRETTY_PRINT ) );
		}
		return $pre;
	},
	10,
	3
);
```

> [!Note]
This snippet will only work for tracks that are sent through `wp_remote_get` (for example while doing REST API requests), tracks that are injected into the page footer will not be logged through this snippet.

### Changelog entry
* Add - Tracking for completed events.
