### PR TITLE
Fix Setup Ads Faqs context

### DIFF
--- a/js/src/components/paid-ads/faqs-section.js
+++ b/js/src/components/paid-ads/faqs-section.js
@@ -89,7 +89,11 @@ const faqItems = [
 const FaqsSection = () => {
 	return (
 		<Section>
-			<FaqsPanel trackName="gla_setup_ads_faq" faqItems={ faqItems } />
+			<FaqsPanel
+				trackName="gla_setup_ads_faq"
+				context="setup-ads"
+				faqItems={ faqItems }
+			/>
 		</Section>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2211 

Fixes Undefined context in `wcadmin_gla_setup_ads_faq `

### Screenshots:

<img width="371" alt="Screenshot 2024-01-22 at 16 45 21" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/a3d86cb2-0a32-4500-967d-40aec06b6242">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open the Console tab of the browser DevTool.
2. Change the filter level to "All levels".
3. Run localStorage.setItem( 'debug', 'wc-admin:*' ) and refresh the page to make it work.
4. In the last step. Campaign Creation. Expand the faqs. The context is `setup-ads`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Context not tracked in Create Campaign FAQs
