### PR TITLE
Product Block Editor: Add a custom block for editing channel visibility

### DIFF
--- a/js/src/blocks/index.js
+++ b/js/src/blocks/index.js
@@ -6,6 +6,8 @@ import { registerProductEditorBlockType } from '@woocommerce/product-editor';
 /**
  * Internal dependencies
  */
+import ChannelVisibilityEdit from './product-channel-visibility/edit';
+import channelVisibilityMetadata from './product-channel-visibility/block.json';
 import DateTimeFieldEdit from './product-date-time-field/edit';
 import dateTimeFieldMetadata from './product-date-time-field/block.json';
 import SelectFieldEdit from './product-select-field/edit';
@@ -21,6 +23,7 @@ function registerProductEditorBlock( { name, ...metadata }, Edit ) {
 	} );
 }
 
+registerProductEditorBlock( channelVisibilityMetadata, ChannelVisibilityEdit );
 registerProductEditorBlock( dateTimeFieldMetadata, DateTimeFieldEdit );
 registerProductEditorBlock( selectFieldMetadata, SelectFieldEdit );
 registerProductEditorBlock(

--- a/js/src/blocks/product-channel-visibility/block.json
+++ b/js/src/blocks/product-channel-visibility/block.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "google-listings-and-ads/product-channel-visibility",
+	"title": "Product channel visibility",
+	"textdomain": "google-listings-and-ads",
+	"attributes": {
+		"property": {
+			"type": "string",
+			"__experimentalRole": "content"
+		},
+		"options": {
+			"type": "array",
+			"items": {
+				"type": "object"
+			},
+			"default": []
+		},
+		"valueOfSync": {
+			"type": "string"
+		},
+		"valueOfDontSync": {
+			"type": "string"
+		},
+		"statusOfSynced": {
+			"type": "string"
+		},
+		"statusOfHasErrors": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"html": false,
+		"inserter": false,
+		"lock": false
+	}
+}

--- a/js/src/blocks/product-channel-visibility/edit.js
+++ b/js/src/blocks/product-channel-visibility/edit.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { SelectControl, Notice } from '@wordpress/components';
+import { __experimentalUseProductEntityProp as useProductEntityProp } from '@woocommerce/product-editor';
+
+/**
+ * Internal dependencies
+ */
+import styles from './editor.module.scss';
+
+/**
+ * @typedef {import('../types.js').ProductEditorBlockContext} ProductEditorBlockContext
+ */
+
+/**
+ * @typedef {Object} ProductChannelVisibilityAttributes
+ * @property {string} property Property or metadata name in which the value is stored in the product data.
+ * @property {import('@wordpress/components').SelectControl.Option} [options=[]] The options to be shown in the select field.
+ * @property {string} valueOfSync The value of the "Sync and show" option to be used to determine the UI presentation.
+ * @property {string} valueOfDontSync The value of the "Don't Sync and show" option to be used to determine the UI presentation.
+ * @property {string} statusOfSynced The value of the "Synced" status to be used to determine the UI presentation.
+ * @property {string} statusOfHasErrors The value of the "HasErrors" status to be used to determine the UI presentation.
+ */
+
+/**
+ * Specific custom block for editing the channel visibility of the given product data.
+ *
+ * @param {Object} props React props.
+ * @param {ProductChannelVisibilityAttributes} props.attributes
+ * @param {ProductEditorBlockContext} props.context
+ */
+export default function Edit( { attributes, context } ) {
+	const {
+		valueOfSync: VALUE_SYNC,
+		valueOfDontSync: VALUE_DONT_SYNC,
+		statusOfSynced: STATUS_SYNCED,
+		statusOfHasErrors: STATUS_HAS_ERRORS,
+	} = attributes;
+
+	const blockProps = useWooBlockProps( attributes );
+	const [ value, setValue ] = useProductEntityProp( attributes.property, {
+		postType: context.postType,
+	} );
+
+	const setVisibility = ( nextVisibility ) => {
+		setValue( { ...value, channel_visibility: nextVisibility } );
+	};
+
+	const { is_visible: isVisible, sync_status: syncStatus, issues } = value;
+
+	// Force to select the "Don't Sync and show" option if the product is invisible.
+	const visibility = isVisible ? value.channel_visibility : VALUE_DONT_SYNC;
+
+	let syncStatusText = null;
+
+	if ( syncStatus === STATUS_HAS_ERRORS ) {
+		syncStatusText = __( 'Issues detected', 'google-listings-and-ads' );
+	} else if ( syncStatus ) {
+		syncStatusText = syncStatus.replace( '-', ' ' );
+	}
+
+	const help = isVisible
+		? ''
+		: __(
+				'This product cannot be shown on any channel because it is hidden from your store catalog. To enable this option, please change this product to be shown in the product catalog, and save the changes.',
+				'google-listings-and-ads'
+		  );
+
+	const shouldDisplayNotice =
+		isVisible &&
+		syncStatusText !== null &&
+		visibility === VALUE_SYNC &&
+		syncStatus !== STATUS_SYNCED;
+
+	const hasErrors = issues.length > 0;
+
+	return (
+		<div { ...blockProps }>
+			<SelectControl
+				disabled={ ! isVisible }
+				options={ attributes.options }
+				value={ visibility }
+				onChange={ setVisibility }
+				help={ help }
+			/>
+			{ shouldDisplayNotice && (
+				<Notice
+					className={ styles.notice }
+					status={ hasErrors ? 'warning' : 'info' }
+					isDismissible={ false }
+				>
+					<section>
+						<h2>
+							{ __(
+								'Google sync status',
+								'google-listings-and-ads'
+							) }
+						</h2>
+						<p className={ styles.uppercaseFirstLetter }>
+							{ syncStatusText }
+						</p>
+					</section>
+					{ hasErrors && (
+						<section>
+							<h2>
+								{ __( 'Issues', 'google-listings-and-ads' ) }
+							</h2>
+							<ul>
+								{ issues.map( ( issue, idx ) => (
+									<li key={ idx }>{ issue }</li>
+								) ) }
+							</ul>
+						</section>
+					) }
+				</Notice>
+			) }
+		</div>
+	);
+}

--- a/js/src/blocks/product-channel-visibility/editor.module.scss
+++ b/js/src/blocks/product-channel-visibility/editor.module.scss
@@ -1,0 +1,13 @@
+.notice {
+	margin: 1em 0 0;
+	padding-top: 0;
+	padding-bottom: 0;
+
+	h2 {
+		font-size: 1em;
+	}
+}
+
+.uppercaseFirstLetter::first-letter {
+	text-transform: uppercase;
+}

--- a/src/Admin/Product/ChannelVisibilityBlock.php
+++ b/src/Admin/Product/ChannelVisibilityBlock.php
@@ -1,0 +1,134 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ChannelVisibilityBlock
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product
+ */
+class ChannelVisibilityBlock {
+
+	public const PROPERTY = 'google_listings_and_ads__channel_visibility';
+
+	/**
+	 * @var ProductHelper
+	 */
+	protected $product_helper;
+
+	/**
+	 * ChannelVisibilityBlock constructor.
+	 *
+	 * @param ProductHelper $product_helper
+	 */
+	public function __construct( ProductHelper $product_helper ) {
+		$this->product_helper = $product_helper;
+	}
+
+	/**
+	 * Register hooks for querying and updating product via REST APIs.
+	 */
+	public function register_hooks(): void {
+		// https://github.com/woocommerce/woocommerce/blob/8.5.0/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php#L182-L192
+		add_filter( 'woocommerce_rest_prepare_product_object', [ $this, 'prepare_data' ], 10, 2 );
+
+		// https://github.com/woocommerce/woocommerce/blob/8.5.0/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php#L200-L207
+		// https://github.com/woocommerce/woocommerce/blob/8.5.0/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php#L247-L254
+		add_filter( 'woocommerce_rest_insert_product_object', [ $this, 'update_data' ], 10, 2 );
+	}
+
+	/**
+	 * Get channel visibility data from the given product and add it to the given response.
+	 *
+	 * @param Response   $response Response to be added channel visibility data.
+	 * @param WC_Product $product WooCommerce product to get data.
+	 *
+	 * @return Response
+	 */
+	public function prepare_data( Response $response, WC_Product $product ): Response {
+		$response->data[ self::PROPERTY ] = [
+			'is_visible'         => $product->is_visible(),
+			'channel_visibility' => $this->product_helper->get_channel_visibility( $product ),
+			'sync_status'        => $this->product_helper->get_sync_status( $product ),
+			'issues'             => $this->product_helper->get_validation_errors( $product ),
+		];
+
+		return $response;
+	}
+
+	/**
+	 * Get channel visibility data from the given request and update it to the given product.
+	 *
+	 * @param WC_Product $product WooCommerce product to be updated.
+	 * @param Request    $request Response to get the channel visibility data.
+	 */
+	public function update_data( WC_Product $product, Request $request ): void {
+		if ( ! in_array( $product->get_type(), $this->get_visible_product_types(), true ) ) {
+			return;
+		}
+
+		$params = $request->get_params();
+
+		if ( ! isset( $params[ self::PROPERTY ] ) ) {
+			return;
+		}
+
+		$channel_visibility = $params[ self::PROPERTY ]['channel_visibility'];
+
+		if ( $channel_visibility !== $this->product_helper->get_channel_visibility( $product ) ) {
+			$this->product_helper->update_channel_visibility( $product, $channel_visibility );
+		}
+	}
+
+	/**
+	 * Return the visible product types to control the hidden condition of the channel visibility block
+	 * in the Product Block Editor.
+	 *
+	 * @return array
+	 */
+	public function get_visible_product_types(): array {
+		return array_diff( ProductSyncer::get_supported_product_types(), [ 'variation' ] );
+	}
+
+	/**
+	 * Return the config used for the input's block within the Product Block Editor.
+	 *
+	 * @return array
+	 */
+	public function get_block_config(): array {
+		$options = [];
+
+		foreach ( ChannelVisibility::get_value_options() as $key => $value ) {
+			$options[] = [
+				'label' => $value,
+				'value' => $key,
+			];
+		}
+
+		$attributes = [
+			'property'          => self::PROPERTY,
+			'options'           => $options,
+			'valueOfSync'       => ChannelVisibility::SYNC_AND_SHOW,
+			'valueOfDontSync'   => ChannelVisibility::DONT_SYNC_AND_SHOW,
+			'statusOfSynced'    => SyncStatus::SYNCED,
+			'statusOfHasErrors' => SyncStatus::HAS_ERRORS,
+		];
+
+		return [
+			'id'         => 'google-listings-and-ads-product-channel-visibility',
+			'blockName'  => 'google-listings-and-ads/product-channel-visibility',
+			'attributes' => $attributes,
+		];
+	}
+}

--- a/src/Admin/Product/ChannelVisibilityBlock.php
+++ b/src/Admin/Product/ChannelVisibilityBlock.php
@@ -8,9 +8,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use WC_Data;
+use WC_Product;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
-use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -52,12 +53,16 @@ class ChannelVisibilityBlock implements Service {
 	/**
 	 * Get channel visibility data from the given product and add it to the given response.
 	 *
-	 * @param Response   $response Response to be added channel visibility data.
-	 * @param WC_Product $product WooCommerce product to get data.
+	 * @param Response           $response Response to be added channel visibility data.
+	 * @param WC_Product|WC_Data $product  WooCommerce product to get data.
 	 *
 	 * @return Response
 	 */
-	public function prepare_data( Response $response, WC_Product $product ): Response {
+	public function prepare_data( Response $response, WC_Data $product ): Response {
+		if ( ! $product instanceof WC_Product ) {
+			return $response;
+		}
+
 		$response->data[ self::PROPERTY ] = [
 			'is_visible'         => $product->is_visible(),
 			'channel_visibility' => $this->product_helper->get_channel_visibility( $product ),
@@ -71,11 +76,11 @@ class ChannelVisibilityBlock implements Service {
 	/**
 	 * Get channel visibility data from the given request and update it to the given product.
 	 *
-	 * @param WC_Product $product WooCommerce product to be updated.
-	 * @param Request    $request Response to get the channel visibility data.
+	 * @param WC_Product|WC_Data $product WooCommerce product to be updated.
+	 * @param Request            $request Response to get the channel visibility data.
 	 */
-	public function update_data( WC_Product $product, Request $request ): void {
-		if ( ! in_array( $product->get_type(), $this->get_visible_product_types(), true ) ) {
+	public function update_data( WC_Data $product, Request $request ): void {
+		if ( ! $product instanceof WC_Product || ! in_array( $product->get_type(), $this->get_visible_product_types(), true ) ) {
 			return;
 		}
 

--- a/src/Admin/Product/ChannelVisibilityBlock.php
+++ b/src/Admin/Product/ChannelVisibilityBlock.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
@@ -18,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product
  */
-class ChannelVisibilityBlock {
+class ChannelVisibilityBlock implements Service {
 
 	public const PROPERTY = 'google_listings_and_ads__channel_visibility';
 

--- a/src/Admin/Product/ChannelVisibilityBlock.php
+++ b/src/Admin/Product/ChannelVisibilityBlock.php
@@ -45,7 +45,7 @@ class ChannelVisibilityBlock {
 
 		// https://github.com/woocommerce/woocommerce/blob/8.5.0/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php#L200-L207
 		// https://github.com/woocommerce/woocommerce/blob/8.5.0/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php#L247-L254
-		add_filter( 'woocommerce_rest_insert_product_object', [ $this, 'update_data' ], 10, 2 );
+		add_action( 'woocommerce_rest_insert_product_object', [ $this, 'update_data' ], 10, 2 );
 	}
 
 	/**

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -14,7 +14,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\BuiltScriptDependencyArray;
 use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry;
@@ -72,16 +71,15 @@ class ProductBlocksService implements Service, Registerable {
 	 * ProductBlocksService constructor.
 	 *
 	 * @param AssetsHandlerInterface $assets_handler
-	 * @param ProductHelper          $product_helper
+	 * @param ChannelVisibilityBlock $channel_visibility_block
 	 * @param AttributeManager       $attribute_manager
 	 * @param MerchantCenterService  $merchant_center
 	 */
-	public function __construct( AssetsHandlerInterface $assets_handler, ProductHelper $product_helper, AttributeManager $attribute_manager, MerchantCenterService $merchant_center ) {
-		$this->assets_handler    = $assets_handler;
-		$this->attribute_manager = $attribute_manager;
-		$this->merchant_center   = $merchant_center;
-
-		$this->channel_visibility_block = new ChannelVisibilityBlock( $product_helper );
+	public function __construct( AssetsHandlerInterface $assets_handler, ChannelVisibilityBlock $channel_visibility_block, AttributeManager $attribute_manager, MerchantCenterService $merchant_center ) {
+		$this->assets_handler           = $assets_handler;
+		$this->attribute_manager        = $attribute_manager;
+		$this->merchant_center          = $merchant_center;
+		$this->channel_visibility_block = $channel_visibility_block;
 	}
 
 	/**

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -220,12 +220,14 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 					$section->add_block( $input->get_block_config() );
 				}
 			} else {
+				$visible_product_types = AttributesForm::get_attribute_product_types( $attribute_type )['visible'];
+
 				// When editing a simple or variable product, its product type on the frontend side can be
 				// changed dynamically. So, it needs to use the ProductTemplates API `add_hide_condition`
 				// to conditionally hide attributes.
 				/** @var BlockInterface */
 				$block = $section->add_block( $input->get_block_config() );
-				$block->add_hide_condition( $this->get_hide_condition( $attribute_type ) );
+				$block->add_hide_condition( $this->get_hide_condition( $visible_product_types ) );
 			}
 		}
 	}
@@ -264,24 +266,22 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 	}
 
 	/**
-	 * Get the expression of the hide condition to an attribute's block based on its applicable product types.
+	 * Get the expression of the hide condition to a block based on the visible product types.
 	 * e.g. "editedProduct.type !== 'simple' && ! editedProduct.parent_id > 0"
 	 *
 	 * The hide condition is a JavaScript-like expression that will be evaluated on the client to determine if the block should be hidden.
 	 * See [@woocommerce/expression-evaluation](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/expression-evaluation/README.md) for more details.
 	 *
-	 * @param string $attribute_type An attribute class extending AttributeInterface
+	 * @param array $visible_product_types The visible product types to be converted to a hidden condition
 	 *
 	 * @return string
 	 */
-	public function get_hide_condition( string $attribute_type ): string {
-		$attribute_product_types = AttributesForm::get_attribute_product_types( $attribute_type );
-
+	public function get_hide_condition( array $visible_product_types ): string {
 		$conditions = array_map(
 			function ( $type ) {
 				return "editedProduct.type !== '{$type}'";
 			},
-			$attribute_product_types['visible']
+			$visible_product_types
 		);
 
 		return implode( ' && ', $conditions ) ?: 'true';

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTab;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\VariationsAttributes;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\ChannelVisibilityBlock;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\ProductBlocksService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService as AdsAccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
@@ -321,7 +322,10 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( AttributeManager::class );
 		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
-		$this->share_with_tags( ProductBlocksService::class, AssetsHandlerInterface::class, ProductHelper::class, AttributeManager::class, MerchantCenterService::class );
+
+		// Product Block Editor
+		$this->share_with_tags( ChannelVisibilityBlock::class, ProductHelper::class );
+		$this->share_with_tags( ProductBlocksService::class, AssetsHandlerInterface::class, ChannelVisibilityBlock::class, AttributeManager::class, MerchantCenterService::class );
 
 		$this->share_with_tags( MerchantAccountState::class );
 		$this->share_with_tags( MerchantStatuses::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -321,7 +321,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( AttributeManager::class );
 		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
-		$this->conditionally_share_with_tags( ProductBlocksService::class, AssetsHandlerInterface::class, AttributeManager::class, MerchantCenterService::class );
+		$this->share_with_tags( ProductBlocksService::class, AssetsHandlerInterface::class, ProductHelper::class, AttributeManager::class, MerchantCenterService::class );
 
 		$this->share_with_tags( MerchantAccountState::class );
 		$this->share_with_tags( MerchantStatuses::class );

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -237,6 +237,30 @@ class ProductHelper implements Service {
 	}
 
 	/**
+	 * Update a product's channel visibility.
+	 *
+	 * @param WC_Product $product
+	 * @param string     $visibility
+	 */
+	public function update_channel_visibility( WC_Product $product, string $visibility ): void {
+		try {
+			$product = $this->maybe_swap_for_parent( $product );
+		} catch ( InvalidValue $exception ) {
+			// The error has been logged within the call of maybe_swap_for_parent
+			return;
+		}
+
+		try {
+			$visibility = ChannelVisibility::cast( $visibility )->get();
+		} catch ( InvalidValue $exception ) {
+			do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
+			return;
+		}
+
+		$this->meta_handler->update_visibility( $product, $visibility );
+	}
+
+	/**
 	 * @param WC_Product $product
 	 *
 	 * @return string[]|null An array of Google product IDs stored for each WooCommerce product

--- a/src/Value/ChannelVisibility.php
+++ b/src/Value/ChannelVisibility.php
@@ -65,6 +65,18 @@ class ChannelVisibility implements CastableValueInterface, ValueInterface {
 	}
 
 	/**
+	 * Return an array of the values with option labels.
+	 *
+	 * @return array
+	 */
+	public static function get_value_options(): array {
+		return [
+			self::SYNC_AND_SHOW      => __( 'Sync and show', 'google-listings-and-ads' ),
+			self::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
+		];
+	}
+
+	/**
 	 * @return string
 	 */
 	public function __toString(): string {

--- a/tests/Unit/Admin/Product/ChannelVisibilityBlockTest.php
+++ b/tests/Unit/Admin/Product/ChannelVisibilityBlockTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\ChannelVisibilityB
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use WC_Order_Item_Product;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
@@ -76,6 +77,15 @@ class ChannelVisibilityBlockTest extends UnitTest {
 		);
 	}
 
+	public function test_prepare_data_incoming_unexpected_wc_data() {
+		$product  = $this->createMock( WC_Order_Item_Product::class );
+		$response = $this->channel_visibility_block->prepare_data( new Response( [] ), $product );
+
+		$this->assertInstanceOf( Response::class, $response );
+		$this->assertArrayNotHasKey( ChannelVisibilityBlock::PROPERTY, $response->data );
+		$this->product_helper->expects( $this->exactly( 0 ) )->method( 'get_channel_visibility' );
+	}
+
 	public function test_update_data() {
 		$product = $this->generate_simple_product_mock();
 		$request = new Request( 'POST' );
@@ -101,6 +111,21 @@ class ChannelVisibilityBlockTest extends UnitTest {
 		$this->product_helper
 			->method( 'get_channel_visibility' )
 			->willReturn( $data['channel_visibility'] );
+
+		$this->product_helper
+			->expects( $this->exactly( 0 ) )
+			->method( 'update_channel_visibility' );
+
+		$this->channel_visibility_block->update_data( $product, $request );
+	}
+
+	public function test_update_data_incoming_unexpected_wc_data() {
+		$product = $this->createMock( WC_Order_Item_Product::class );
+		$request = $this->createMock( Request::class );
+
+		$request
+			->expects( $this->exactly( 0 ) )
+			->method( 'get_params' );
 
 		$this->product_helper
 			->expects( $this->exactly( 0 ) )

--- a/tests/Unit/Admin/Product/ChannelVisibilityBlockTest.php
+++ b/tests/Unit/Admin/Product/ChannelVisibilityBlockTest.php
@@ -1,0 +1,188 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\ChannelVisibilityBlock;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+/**
+ * Class ChannelVisibilityBlockTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin\Product
+ */
+class ChannelVisibilityBlockTest extends UnitTest {
+
+	use ProductTrait;
+
+	/** @var Stub|ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var ChannelVisibilityBlock $channel_visibility_block */
+	protected $channel_visibility_block;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->product_helper = $this->createStub( ProductHelper::class );
+
+		$this->channel_visibility_block = new ChannelVisibilityBlock( $this->product_helper );
+	}
+
+	public function test_register_hooks() {
+		$this->channel_visibility_block->register_hooks();
+
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_rest_prepare_product_object',
+				[ $this->channel_visibility_block, 'prepare_data' ]
+			)
+		);
+
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_rest_insert_product_object',
+				[ $this->channel_visibility_block, 'update_data' ]
+			)
+		);
+	}
+
+	public function test_prepare_data() {
+		$product = $this->generate_simple_product_mock();
+		$product->method( 'is_visible' )->willReturn( true );
+
+		$issues = [ 'Problem #1', 'Problem #2' ];
+		$this->product_helper->method( 'get_channel_visibility' )->willReturn( 'sync-and-show' );
+		$this->product_helper->method( 'get_sync_status' )->willReturn( 'has-errors' );
+		$this->product_helper->method( 'get_validation_errors' )->willReturn( $issues );
+
+		$response = $this->channel_visibility_block->prepare_data( new Response(), $product );
+
+		$this->assertInstanceOf( Response::class, $response );
+		$this->assertEquals(
+			[
+				'is_visible'         => true,
+				'channel_visibility' => 'sync-and-show',
+				'sync_status'        => 'has-errors',
+				'issues'             => $issues,
+			],
+			$response->data[ ChannelVisibilityBlock::PROPERTY ]
+		);
+	}
+
+	public function test_update_data() {
+		$product = $this->generate_simple_product_mock();
+		$request = new Request( 'POST' );
+		$data    = [ 'channel_visibility' => 'dont-sync-and-show' ];
+
+		$request->set_param( ChannelVisibilityBlock::PROPERTY, $data );
+
+		$this->product_helper
+			->expects( $this->exactly( 1 ) )
+			->method( 'update_channel_visibility' )
+			->with( $product, $data['channel_visibility'] );
+
+		$this->channel_visibility_block->update_data( $product, $request );
+	}
+
+	public function test_update_data_skip_update_if_same_value() {
+		$product = $this->generate_simple_product_mock();
+		$request = new Request( 'POST' );
+		$data    = [ 'channel_visibility' => 'sync-and-show' ];
+
+		$request->set_param( ChannelVisibilityBlock::PROPERTY, $data );
+
+		$this->product_helper
+			->method( 'get_channel_visibility' )
+			->willReturn( $data['channel_visibility'] );
+
+		$this->product_helper
+			->expects( $this->exactly( 0 ) )
+			->method( 'update_channel_visibility' );
+
+		$this->channel_visibility_block->update_data( $product, $request );
+	}
+
+	public function test_update_data_unsupported_product_type() {
+		$product = $this->generate_variation_product_mock();
+		$request = $this->createMock( Request::class );
+
+		$request
+			->expects( $this->exactly( 0 ) )
+			->method( 'get_params' );
+
+		$this->product_helper
+			->expects( $this->exactly( 0 ) )
+			->method( 'update_channel_visibility' );
+
+		$this->channel_visibility_block->update_data( $product, $request );
+	}
+
+	public function test_update_data_unrelated_request() {
+		$product = $this->generate_simple_product_mock();
+		$request = $this->createMock( Request::class );
+
+		$request
+			->expects( $this->exactly( 1 ) )
+			->method( 'get_params' );
+
+		$this->product_helper
+			->expects( $this->exactly( 0 ) )
+			->method( 'update_channel_visibility' );
+
+		$this->channel_visibility_block->update_data( $product, $request );
+	}
+
+	public function test_get_visible_product_types() {
+		$this->assertEqualsCanonicalizing(
+			[ 'simple', 'variable' ],
+			$this->channel_visibility_block->get_visible_product_types()
+		);
+
+		add_filter(
+			'woocommerce_gla_supported_product_types',
+			function ( array $product_types ) {
+				$product_types[] = 'bundle';
+				return $product_types;
+			}
+		);
+
+		$this->assertEqualsCanonicalizing(
+			[ 'simple', 'variable', 'bundle' ],
+			$this->channel_visibility_block->get_visible_product_types()
+		);
+	}
+
+	public function test_get_block_config() {
+		$this->assertEquals(
+			[
+				'id'         => 'google-listings-and-ads-product-channel-visibility',
+				'blockName'  => 'google-listings-and-ads/product-channel-visibility',
+				'attributes' => [
+					'property'          => ChannelVisibilityBlock::PROPERTY,
+					'options'           => [
+						[
+							'label' => 'Sync and show',
+							'value' => 'sync-and-show',
+						],
+						[
+							'label' => "Don't Sync and show",
+							'value' => 'dont-sync-and-show',
+						],
+					],
+					'valueOfSync'       => 'sync-and-show',
+					'valueOfDontSync'   => 'dont-sync-and-show',
+					'statusOfSynced'    => 'synced',
+					'statusOfHasErrors' => 'has-errors',
+				],
+			],
+			$this->channel_visibility_block->get_block_config()
+		);
+	}
+}

--- a/tests/Unit/Admin/Product/ChannelVisibilityBlockTest.php
+++ b/tests/Unit/Admin/Product/ChannelVisibilityBlockTest.php
@@ -46,7 +46,7 @@ class ChannelVisibilityBlockTest extends UnitTest {
 
 		$this->assertEquals(
 			10,
-			has_filter(
+			has_action(
 				'woocommerce_rest_insert_product_object',
 				[ $this->channel_visibility_block, 'update_data' ]
 			)

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\Pr
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\SectionInterface;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\ChannelVisibilityBlock;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\ProductBlocksService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminStyleAsset;
@@ -19,7 +20,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Adult;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Brand;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Gender;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\BuiltScriptDependencyArray;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -36,8 +36,8 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 	/** @var MockObject|AssetsHandlerInterface $assets_handler */
 	protected $assets_handler;
 
-	/** @var Stub|ProductHelper $product_helper */
-	protected $product_helper;
+	/** @var ChannelVisibilityBlock $channel_visibility_block */
+	protected $channel_visibility_block;
 
 	/** @var AttributeManager $attribute_manager */
 	protected $attribute_manager;
@@ -79,17 +79,17 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 
 		parent::setUp();
 
-		$this->assets_handler    = $this->createMock( AssetsHandlerInterface::class );
-		$this->product_helper    = $this->createStub( ProductHelper::class );
-		$this->attribute_manager = $this->container->get( AttributeManager::class );
-		$this->merchant_center   = $this->createStub( MerchantCenterService::class );
-		$this->block_registry    = $this->createMock( BlockRegistry::class );
+		$this->assets_handler           = $this->createMock( AssetsHandlerInterface::class );
+		$this->channel_visibility_block = $this->container->get( ChannelVisibilityBlock::class );
+		$this->attribute_manager        = $this->container->get( AttributeManager::class );
+		$this->merchant_center          = $this->createStub( MerchantCenterService::class );
+		$this->block_registry           = $this->createMock( BlockRegistry::class );
 
 		$this->simple_anchor_group    = $this->createMock( BlockInterface::class );
 		$this->variation_anchor_group = $this->createMock( BlockInterface::class );
 		$this->mismatching_group      = $this->createMock( BlockInterface::class );
 
-		$this->product_blocks_service = new ProductBlocksService( $this->assets_handler, $this->product_helper, $this->attribute_manager, $this->merchant_center );
+		$this->product_blocks_service = new ProductBlocksService( $this->assets_handler, $this->channel_visibility_block, $this->attribute_manager, $this->merchant_center );
 
 		$this->product_blocks_service->set_block_registry( $this->block_registry );
 

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -167,39 +167,21 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 	public function test_get_hide_condition() {
 		$this->assertEquals(
 			"editedProduct.type !== 'simple' && editedProduct.type !== 'variable' && editedProduct.type !== 'variation'",
-			$this->product_blocks_service->get_hide_condition( Adult::class )
+			$this->product_blocks_service->get_hide_condition( Adult::get_applicable_product_types() )
 		);
 
 		$this->assertEquals(
 			"editedProduct.type !== 'simple' && editedProduct.type !== 'variable'",
-			$this->product_blocks_service->get_hide_condition( Brand::class )
+			$this->product_blocks_service->get_hide_condition( Brand::get_applicable_product_types() )
 		);
 
 		$this->assertEquals(
 			"editedProduct.type !== 'simple' && editedProduct.type !== 'variation'",
-			$this->product_blocks_service->get_hide_condition( Gender::class )
+			$this->product_blocks_service->get_hide_condition( Gender::get_applicable_product_types() )
 		);
 
-		add_filter(
-			'woocommerce_gla_attribute_hidden_product_types_gender',
-			function ( array $applicable_types ) {
-				$applicable_types[] = 'simple';
-				return $applicable_types;
-			}
-		);
-
-		$this->assertEquals(
-			"editedProduct.type !== 'variation'",
-			$this->product_blocks_service->get_hide_condition( Gender::class )
-		);
-
-		// Hide all product types for Brand
-		add_filter(
-			'woocommerce_gla_attribute_hidden_product_types_brand',
-			[ Brand::class, 'get_applicable_product_types' ]
-		);
-
-		$this->assertEquals( 'true', $this->product_blocks_service->get_hide_condition( Brand::class ) );
+		// Hide all product types
+		$this->assertEquals( 'true', $this->product_blocks_service->get_hide_condition( [] ) );
 	}
 
 	public function test_register_merchant_center_setup_is_not_complete() {

--- a/tests/Unit/Value/ChannelVisibilityTest.php
+++ b/tests/Unit/Value/ChannelVisibilityTest.php
@@ -1,0 +1,68 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Value;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+
+/**
+ * Class ChannelVisibilityTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Value
+ */
+class ChannelVisibilityTest extends UnitTest {
+	public function test_constructor_and_get() {
+		$this->assertEquals(
+			'sync-and-show',
+			( new ChannelVisibility( 'sync-and-show' ) )->get()
+		);
+
+		$this->assertEquals(
+			'dont-sync-and-show',
+			( new ChannelVisibility( 'dont-sync-and-show' ) )->get()
+		);
+	}
+
+	public function test_constructor_invalid_value() {
+		$this->expectException( InvalidValue::class );
+
+		new ChannelVisibility( '123' );
+	}
+
+	public function test_cast() {
+		$this->assertEquals(
+			'sync-and-show',
+			ChannelVisibility::cast( 'sync-and-show' )->get()
+		);
+
+		$this->assertEquals(
+			'dont-sync-and-show',
+			ChannelVisibility::cast( 'dont-sync-and-show' )->get()
+		);
+	}
+
+	public function test_cast_invalid_value() {
+		$this->expectException( InvalidValue::class );
+
+		ChannelVisibility::cast( '123' );
+	}
+
+	public function test_get_value_options() {
+		$this->assertEquals(
+			[
+				'sync-and-show'      => 'Sync and show',
+				'dont-sync-and-show' => "Don't Sync and show",
+			],
+			ChannelVisibility::get_value_options(),
+		);
+	}
+
+	public function test_to_string() {
+		$this->assertEquals(
+			'sync-and-show',
+			(string) ( new ChannelVisibility( 'sync-and-show' ) )
+		);
+	}
+}

--- a/views/meta-box/channel_visibility.php
+++ b/views/meta-box/channel_visibility.php
@@ -63,10 +63,7 @@ if ( $input_disabled ) {
 				'label'             => __( 'Google Listing & Ads', 'google-listings-and-ads' ),
 				'description'       => $input_description,
 				'desc_tip'          => false,
-				'options'           => [
-					ChannelVisibility::SYNC_AND_SHOW      => __( 'Sync and show', 'google-listings-and-ads' ),
-					ChannelVisibility::DONT_SYNC_AND_SHOW => __( 'Don\'t Sync and show', 'google-listings-and-ads' ),
-				],
+				'options'           => ChannelVisibility::get_value_options(),
 				'custom_attributes' => $custom_attributes,
 				'wrapper_class'     => 'form-row form-row-full',
 			]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To be compatible with Product Block Editor, this PR adds a custom block for editing channel visibility.

### Screenshots:

#### 📷 Sync status is `synced` or `null`

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/747dd9ff-48b7-447d-aab4-7f833ab0c752)

#### 📷 Sync status is `pending`

![2](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/b2a5ccd1-9651-4405-be40-0c5d20a31751)

#### 📷 Sync status is `not-synced`

![3](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/2222aa6f-b7b6-4714-a9f8-89f13bfe1075)

#### 📷 Sync status is `has-errors`

![4](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/f87ade64-375e-40dd-a637-b7aeb6b374a8)

#### 📷 Variation product should not show the channel visibility

![5](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/db360523-4e55-4422-8f32-ad60de503e78)

#### 📹 Channel visibility is disabled when the product is hidden from the product catalog

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/38fe3f30-12ff-4329-b23e-fb9ef2dfe852

### Detailed test instructions:

#### 📌 Prepare test environment

1. Please refer to [the test preparation in PR 2151](https://github.com/woocommerce/google-listings-and-ads/pull/2151#prepare-test-environment) with **Woo 8.5.1**.
1. `npm install`
1. `npm start`

#### 📌 Test with simple product and disabled state

1. Go to edit a simple product, e.g. the **Beanie with Logo** imported from WC's sample products.
1. Switch to the **Google Listings & Ads** tab.
1. Change the selected channel visibility option and click the **Update** button at the top-right of the page.
1. Switch to the **Organization** tab.
1. Tick the "Hide in product catalog" option in the **Product catalog** section.
1. Click the **Update** button.
1. Switch to the **Google Listings & Ads** tab.
1. See if the channel visibility selection is disabled.
1. Switch to the **Organization** tab.
1. Uncheck the "Hide in product catalog" option.
1. Switch to the **Google Listings & Ads** tab.
1. Click the **Update** button.
1. See if the channel visibility selection is changed from disabled to enabled after updating.

💡 It must update the product data first because the `is_visible` value in the wp-data store won't be recalculated after changing the product's `catalog_visibility ` (the "Hide in product catalog" option) in the wp-data store. Instead, the `is_visible` value is only updated after the product update issues API request and syncs the response to the wp-data store.

#### 📌 Test with variable and variation products

1. Go to edit a variable product, e.g. the **Hoodie** imported from WC's sample products.
1. Switch to the **Google Listings & Ads** tab.
1. Change the selected channel visibility option and click the **Update** button.
1. Switch to the **Variations** tab.
1. Click one of the **Edit** links within the **Variations** section to edit a variation product.
1. Check if the channel visibility section is not shown.

#### 📌 Test the `has-errors` status

1. Go to edit a simple product.
1. Switch to the **Pricing** tab.
1. Clear the list price and sale price.
1. Switch to the **Google Listings & Ads** tab.
1. Enter an invalid GTIN such as `aaaa`.
1. Select "Sync and show" for the channel visibility.
1. Click the **Update** button.
1. Open the Connection Test: `/wp-admin/admin.php?page=connection-test-admin-page`.
1. Use the **Sync Product** to sync the above product
   - You might need to make the [MerchantCenterService::is_ready_for_syncing](https://github.com/woocommerce/google-listings-and-ads/blob/20169c47a3cfa2ef9c588ea69684688d4195c677/src/MerchantCenter/MerchantCenterService.php#L106) always return `true` if using a local test site.
1. Back to the product editor and refresh the webpage.
1. Check if it shows **Issues**.
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/4ef5ef1d-880b-4d31-b5e2-88518fd3e12e)

### Changelog entry
