### PR TITLE
Generate coverage report with xdebug

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,13 @@ coverage:
     precision: 1
     round: nearest
     range: '50...80'
+    status:
+        project:
+            default:
+                informational: true
+        patch:
+            default:
+                informational: true
 
 ignore:
     - 'bin/*'

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: woocommerce/grow/get-plugin-releases@actions-v1
         with:
           slug: woocommerce
-          
+
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     needs: GetMatrix
@@ -64,23 +64,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        
+
       - if: matrix.wc-versions == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.2
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 
-      - name: Prepare PHP  
+      - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@actions-v1
         with:
           php-version: "${{ matrix.php }}"
           coverage: "${{ env.generate_coverage == 'true' && 'xdebug' || 'none' }}"
 
-      - name: Prepare MySQL    
+      - name: Prepare MySQL
         uses: woocommerce/grow/prepare-mysql@actions-v1
 
-      - name: Install WP tests  
+      - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
-  
+
       - if: env.generate_coverage != 'true'
         name: Run PHP unit tests
         run: composer test-unit

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -87,7 +87,7 @@ jobs:
 
       - if: env.generate_coverage == 'true'
         name: Run PHP unit tests (with code coverage)
-        run: phpdbg -qrr vendor/bin/phpunit --coverage-clover=tests/php-coverage/report.xml
+        run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover=tests/php-coverage/report.xml
 
       - if: env.generate_coverage == 'true'
         name: PHP unit coverage report

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -64,22 +64,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
-        with:
-          php-version: "${{ matrix.php }}"
-
-      - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v1
-
-      - name: Install WP tests
-        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
-
+        
       - if: matrix.wc-versions == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.2
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 
+      - name: Prepare PHP  
+        uses: woocommerce/grow/prepare-php@actions-v1
+        with:
+          php-version: "${{ matrix.php }}"
+          coverage: "${{ env.generate_coverage == 'true' && 'xdebug' || 'none' }}"
+
+      - name: Prepare MySQL    
+        uses: woocommerce/grow/prepare-mysql@actions-v1
+
+      - name: Install WP tests  
+        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
+  
       - if: env.generate_coverage != 'true'
         name: Run PHP unit tests
         run: composer test-unit


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR runs the coverage report using xdebug instead of phpdbg. Two changes were required to make this work:
- Setup PHP passing the coverage mode
- Run the unit tests with xdebug mode set

In addition to this change I've also set the codecov status checks to be informational only. This prevents the tests from being marked as failures when we don't reach the target coverage amount. Even though target is set to `auto` it still happens quite often that the checks on the PR fail because we don't submit enough unit tests. This will allow us to use the report as a guide instead of a requirement.

> [!Note]
To calculate the threshold / target it compares with the last submitted codecov report for the develop branch. We use an anonymous method (without token) to upload the codecov report since our repo is public. Unfortunately that means it sometimes hits API limits and prevents the codecov report from uploading. So it doesn't always have the latest to compare with, causing the status check to fail more often then expected. Setting it to informational prevents it from being a blocker. The other alternative would be to submit with a token so we have a more flexible limit.

Closes #2208 

### Detailed test instructions:
1. View the report for the ProductVisibilityController and see that the contents of the anonymous function is now marked red as not covered: https://app.codecov.io/gh/woocommerce/google-listings-and-ads/pull/2217/blob/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L75
2. Similar to a controller that is covered, we can now see that all the lines in the anonymous function are covered: https://app.codecov.io/gh/woocommerce/google-listings-and-ads/pull/2217/blob/src/API/Site/Controllers/Ads/CampaignController.php#L122
3. Confirm the codecov checks on the PR now pass even though the target has not been reached:
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/5a8b07d4-0dfc-470f-9ce5-1713a2869c5e)


### Changelog entry
* Dev - Generate coverage report with xdebug.
