### PR TITLE
Product Block Editor: Validate integer input for the Multipack attribute

### DIFF
--- a/src/Admin/Input/Integer.php
+++ b/src/Admin/Input/Integer.php
@@ -15,6 +15,11 @@ class Integer extends Input {
 	 * Integer constructor.
 	 */
 	public function __construct() {
-		parent::__construct( 'integer', 'woocommerce/product-number-field' );
+		// Ideally, it should use the 'woocommerce/product-number-field' block
+		// but the block doesn't support integer validation. Therefore, it uses
+		// the text field block to work around it.
+		parent::__construct( 'integer', 'woocommerce/product-text-field' );
+
+		$this->set_block_attribute( 'type', [ 'value' => 'number' ] );
 	}
 }

--- a/src/Admin/Product/Attributes/Input/MultipackInput.php
+++ b/src/Admin/Product/Attributes/Input/MultipackInput.php
@@ -24,6 +24,6 @@ class MultipackInput extends Integer {
 
 		$this->set_label( __( 'Multipack', 'google-listings-and-ads' ) );
 		$this->set_description( __( 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.', 'google-listings-and-ads' ) );
-		$this->set_block_attribute( 'min', 0 );
+		$this->set_block_attribute( 'min', [ 'value' => 0 ] );
 	}
 }

--- a/tests/Unit/Admin/Input/InputCollectionTest.php
+++ b/tests/Unit/Admin/Input/InputCollectionTest.php
@@ -104,9 +104,11 @@ class InputCollectionTest extends UnitTest {
 
 	public function test_integer() {
 		$input = new Integer();
+		$input->set_id( 'test-integer' );
 
 		$this->assertEquals( 'integer', $input->get_type() );
-		$this->assertEquals( 'woocommerce/product-number-field', $input->get_block_name() );
+		$this->assertEquals( 'woocommerce/product-text-field', $input->get_block_name() );
+		$this->assertEquals( [ 'value' => 'number' ], $input->get_block_attributes()['type'] );
 	}
 
 	public function test_select() {

--- a/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
+++ b/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
@@ -480,12 +480,13 @@ class AttributeInputCollectionTest extends UnitTest {
 		$this->assertEquals(
 			[
 				'id'         => 'google-listings-and-ads-product-attributes-multipack',
-				'blockName'  => 'woocommerce/product-number-field',
+				'blockName'  => 'woocommerce/product-text-field',
 				'attributes' => [
 					'property' => 'meta_data._wc_gla_multipack',
 					'label'    => 'Multipack',
 					'tooltip'  => 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.',
-					'min'      => 0,
+					'type'     => [ 'value' => 'number' ],
+					'min'      => [ 'value' => 0 ],
 				],
 			],
 			$input->get_block_config()


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the previous work to be compatible with Product Block Editor, the **Multipack** attribute was using the Woo generic number field block. However, the number block doesn't support integer validation. This PR uses the Woo generic text field block to work around it.

### Screenshots:

#### 📹 Validation error after entering a non-integer

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/dff08eee-df95-4d68-9cad-ae0fc6546f41

💡 The validation error message "**請輸入有效值。最接近的兩個有效值分別是 20 和 21。**" in the video means "**Please enter a valid value. The two nearest valid values are 20 and 21.**" It's a localized message from the native [HTMLObjectElement validationMessage](https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/validationMessage).

#### 📷 Validation error after entering a negative number

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/5cb63491-6a11-4c66-9a83-c8a4d31cae73)

### Detailed test instructions:

#### 📌 Prepare test environment

1. Please refer to [the test preparation in PR 2151](https://github.com/woocommerce/google-listings-and-ads/pull/2151#prepare-test-environment) with **Woo 8.5.1**.
1. `npm install`
1. `npm start`

#### 📌 Test the integer validation for the Multipack attribute

1. Go to edit a product.
2. Switch to the **Google Listings & Ads** tab.
3. Find the **Multipack** attribute.
4. Enter a negative number to see if it shows a validation error message.
5. Click the "Update" to check if a notification pops up the validation error message.
6. Enter a non-integer to see if it shows a validation error message.
7. Click the "Update" to check if a notification pops up the validation error message.
8. Enter a valid integer to view if there is no error message and it's able to update product data.

### Changelog entry
