### PR TITLE
[R-1.1] Move useGoogleAccountCheck to its own file

### DIFF
--- a/js/src/components/google-ads-account-card/non-connected.js
+++ b/js/src/components/google-ads-account-card/non-connected.js
@@ -6,29 +6,23 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import SpinnerCard from '.~/components/spinner-card';
 import CreateAccount from './create-account';
-import useExistingGoogleAdsAccounts from '.~/hooks/useExistingGoogleAdsAccounts';
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
+import useGoogleAccountCheck from '.~/hooks/useGoogleAccountCheck';
 import ConnectAds from './connect-ads';
 
-const useGoogleAccountCheck = () => {
-	const { google } = useGoogleAccount();
-	const { existingAccounts } =
-		google && google.active !== 'no'
-			? // eslint-disable-next-line react-hooks/rules-of-hooks
-			  useExistingGoogleAdsAccounts()
-			: { existingAccounts: null };
-
-	return { google, existingAccounts };
-};
-
 const NonConnected = () => {
-	const { google, existingAccounts } = useGoogleAccountCheck();
+	const { google, existingAccounts, hasFinishedResolution } =
+		useGoogleAccountCheck();
 	const [ ignoreExisting, setIgnoreExisting ] = useState( false );
 
 	const handleShowExisting = () => {
 		setIgnoreExisting( false );
 	};
+
+	if ( ! hasFinishedResolution ) {
+		return <SpinnerCard />;
+	}
 
 	if (
 		! existingAccounts ||

--- a/js/src/hooks/useGoogleAccountCheck.js
+++ b/js/src/hooks/useGoogleAccountCheck.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { glaData } from '.~/constants';
+import { STORE_KEY } from '.~/data/constants';
+import toScopeState from '.~/utils/toScopeState';
+import useJetpackAccount from './useJetpackAccount';
+
+const useGoogleAccountCheck = () => {
+	const {
+		jetpack,
+		isResolving: isResolvingJetpack,
+		hasFinishedResolution: hasFinishedResolutionJetpack,
+	} = useJetpackAccount();
+
+	return useSelect(
+		( select ) => {
+			if ( ! jetpack || jetpack.active === 'no' ) {
+				return {
+					google: undefined,
+					scope: toScopeState( glaData.adsSetupComplete ),
+					isResolving: isResolvingJetpack,
+					hasFinishedResolution: hasFinishedResolutionJetpack,
+				};
+			}
+
+			const {
+				getGoogleAccount,
+				getExistingGoogleAdsAccounts,
+				isResolving,
+				hasFinishedResolution,
+			} = select( STORE_KEY );
+			const google = getGoogleAccount();
+
+			if ( google?.active === 'no' ) {
+				return {
+					google,
+					existingAccounts: null,
+					isResolving: isResolving( 'getGoogleAccount' ),
+					hasFinishedResolution:
+						hasFinishedResolution( 'getGoogleAccount' ),
+				};
+			}
+
+			const existingAccounts = getExistingGoogleAdsAccounts();
+			return {
+				google,
+				existingAccounts,
+				isResolving: isResolving( 'getExistingGoogleAdsAccounts' ),
+				hasFinishedResolution: hasFinishedResolution(
+					'getExistingGoogleAdsAccounts'
+				),
+			};
+		},
+		[ jetpack, isResolvingJetpack, hasFinishedResolutionJetpack ]
+	);
+};
+
+export default useGoogleAccountCheck;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Update the `useGoogleAccountCheck` hook to live in its own file and return additional properties. Remove the line from the original PR where the rule of hooks was disabled within the hook.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
