### PR TITLE
API PULL - Fix PHPCS and remove wrong obsolete code 

### DIFF
--- a/src/Google/NotificationsService.php
+++ b/src/Google/NotificationsService.php
@@ -116,7 +116,7 @@ class NotificationsService implements Service {
 	 * @param array $args
 	 * @return array|\WP_Error
 	 */
-	protected function do_request( array $args ): \WP_Error|array {
+	protected function do_request( array $args ) {
 		return Client::remote_request( $args, wp_json_encode( $args['body'] ) );
 	}
 

--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -33,13 +33,6 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 	private $registered_services;
 
 	/**
-	 * The client ID.
-	 *
-	 * @var string
-	 */
-	private $client_id;
-
-	/**
 	 * GoogleListingsAndAdsPlugin constructor.
 	 *
 	 * @param ContainerInterface $container
@@ -116,15 +109,6 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 				}
 			}
 		);
-
-		add_action( 'login_form_jetpack_json_api_authorization', [ $this, 'login_form_json_api_authorization' ] );
-
-		add_filter(
-			'jetpack_xmlrpc_test_connection_response',
-			function () {
-				return '1.40';
-			}
-		);
 	}
 
 	/**
@@ -152,101 +136,5 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 		}
 
 		$registered = true;
-	}
-
-	/**
-	 * Handles the login action for Authorizing the JSON API
-	 */
-	public function login_form_json_api_authorization() {
-		add_action( 'wp_login', [ $this, 'store_json_api_authorization_token' ], 10, 2 );
-		add_action( 'login_form', [ $this, 'preserve_action_in_login_form_for_json_api_authorization' ] );
-		add_filter( 'site_url', [ $this, 'post_login_form_to_signed_url' ], 10, 3 );
-	}
-
-	/**
-	 * If someone logs in to approve API access, store the Access Code in usermeta.
-	 *
-	 * @param string  $user_login Unused.
-	 * @param WP_User $user User logged in.
-	 */
-	public function store_json_api_authorization_token( $user_login, $user ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized after via sanitize_text_field
-		$data = isset( $_REQUEST['data'] ) ? json_decode( base64_decode( wp_unslash( $_REQUEST['data'] ) ) ) : null;
-
-		if ( is_null( $data ) ) {
-			return;
-		}
-
-		$this->client_id = sanitize_text_field( $data->client_id );
-		add_filter( 'login_redirect', [ $this, 'add_token_to_login_redirect_json_api_authorization' ], 10, 3 );
-		add_filter( 'allowed_redirect_hosts', [ $this, 'allow_wpcom_public_api_domain' ] );
-		$token = wp_generate_password( 32, false );
-		update_user_meta( $user->ID, 'jetpack_json_api_' . $this->client_id, $token );
-	}
-
-	/**
-	 * Make sure the POSTed request is handled by the same action.
-	 */
-	public function preserve_action_in_login_form_for_json_api_authorization() {
-		$http_host   = isset( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- escaped with esc_url below.
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- escaped with esc_url below.
-		echo "<input type='hidden' name='action' value='jetpack_json_api_authorization' />\n";
-		echo "<input type='hidden' name='jetpack_json_api_original_query' value='" . esc_url( set_url_scheme( $http_host . $request_uri ) ) . "' />\n";
-	}
-
-	/**
-	 * Make sure the login form is POSTed to the signed URL so we can reverify the request.
-	 *
-	 * @param string $url Redirect URL.
-	 * @param string $path Path.
-	 * @param string $scheme URL Scheme.
-	 */
-	public function post_login_form_to_signed_url( $url, $path, $scheme ) {
-		if ( 'wp-login.php' !== $path || ( 'login_post' !== $scheme && 'login' !== $scheme ) ) {
-			return $url;
-		}
-		$query_string = isset( $_SERVER['QUERY_STRING'] ) ? wp_unslash( $_SERVER['QUERY_STRING'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$parsed_url   = wp_parse_url( $url );
-		$url          = strtok( $url, '?' );
-		$url          = "$url?{$query_string}";
-		if ( ! empty( $parsed_url['query'] ) ) {
-			$url .= "&{$parsed_url['query']}";
-		}
-
-		return $url;
-	}
-
-	/**
-	 * Add the Access Code details to the public-api.wordpress.com redirect.
-	 *
-	 * @param string  $redirect_to URL.
-	 * @param string  $original_redirect_to URL.
-	 * @param WP_User $user WP_User for the redirect.
-	 *
-	 * @return string
-	 */
-	public function add_token_to_login_redirect_json_api_authorization( $redirect_to, $original_redirect_to, $user ) {
-		return add_query_arg(
-			urlencode_deep(
-				[
-					'jetpack-code'    => get_user_meta( $user->ID, 'jetpack_json_api_' . $this->client_id, true ),
-					'jetpack-user-id' => (int) $user->ID,
-					'jetpack-state'   => '',
-				]
-			),
-			$redirect_to
-		);
-	}
-
-	/**
-	 * Add public-api.wordpress.com to the safe redirect allowed list - only added when someone allows API access.
-	 *
-	 * To be used with a filter of allowed domains for a redirect.
-	 *
-	 * @param array $domains Allowed WP.com Environments.
-	 */
-	public function allow_wpcom_public_api_domain( $domains ) {
-		$domains[] = 'public-api.wordpress.com';
-		return $domains;
 	}
 }

--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -170,7 +170,7 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 	 * @param WP_User $user User logged in.
 	 */
 	public function store_json_api_authorization_token( $user_login, $user ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized after via sanitize_text_field
 		$data = isset( $_REQUEST['data'] ) ? json_decode( base64_decode( wp_unslash( $_REQUEST['data'] ) ) ) : null;
 
 		if ( is_null( $data ) ) {

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -406,7 +406,7 @@ class ProductHelper implements Service {
 			NotificationStatus::NOTIFICATION_PENDING_CREATE,
 			NotificationStatus::NOTIFICATION_CREATED,
 			NotificationStatus::NOTIFICATION_UPDATED,
-			NotificationStatus::NOTIFICATION_PENDING_UPDATE
+			NotificationStatus::NOTIFICATION_PENDING_UPDATE,
 		];
 
 		return in_array( $this->meta_handler->get_notification_status( $product ), $valid_has_notified_creation_statuses, true ) || $this->is_product_synced( $product );

--- a/tests/Unit/Google/NotificationsServiceTest.php
+++ b/tests/Unit/Google/NotificationsServiceTest.php
@@ -10,107 +10,114 @@
 
 	/**
 	 * Class NotificationsServiceTest
+	 *
 	 * @group Notifications
 	 * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google
 	 */
-	class NotificationsServiceTest extends UnitTest {
+class NotificationsServiceTest extends UnitTest {
 
-		/**
-		 * @var NotificationsService
-		 */
-		public $service;
+	/**
+	 * @var NotificationsService
+	 */
+	public $service;
 
-		const DUMMY_BLOG_ID = "123";
+	public const DUMMY_BLOG_ID = '123';
 
-		/**
-		 * Runs before each test is executed.
-		 */
-		public function setUp(): void {
-			parent::setUp();
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-			// Mock the Blog ID from Jetpack
-			add_filter('jetpack_options', function ( $value, $name ) {
+		// Mock the Blog ID from Jetpack
+		add_filter(
+			'jetpack_options',
+			function ( $value, $name ) {
 				if ( $name === 'id' ) {
 					return self::DUMMY_BLOG_ID;
 				}
 
 				return $value;
-			}, 10, 2 );
-
-		}
-
-		/**
-		 * Test if the route is correct
-		 */
-		public function test_route() {
-			$this->service = $this->get_mock( [] );
-
-
-			$blog_id = self::DUMMY_BLOG_ID;
-			$this->assertEquals( $this->service->get_notification_url(), "https://public-api.wordpress.com/wpcom/v2/sites/{$blog_id}/partners/google/notifications" );
-		}
-
-
-		/**
-		 * Test notify() function with a call with success response.
-		 */
-		public function test_notify() {
-			$this->service = $this->get_mock();
-
-
-			$topic   = 'product.create';
-			$item_id = 1;
-
-			$args = [
-				'method'  => 'POST',
-				'timeout' => 30,
-				'headers' => [
-					'x-woocommerce-topic' => $topic
-				],
-				'body' => [
-					'item_id' => $item_id,
-				],
-				'url' =>  $this->service->get_notification_url(),
-			];
-
-			$this->service->expects( $this->once() )->method( 'do_request' )->with( $args )->willReturn( [ 'code' => 200 ] );
-			$this->assertTrue( $this->service->notify( $item_id , $topic ) );
-
-		}
-
-
-		/**
-		 * Test notify() function with a call with wp_error response.
-		 */
-		public function test_notify_wp_error() {
-			$this->service = $this->get_mock();
-
-
-			$this->service->expects( $this->once() )->method( 'do_request' )->willReturn( new \WP_Error( 'error', 'error message' ) );
-			$this->assertFalse( $this->service->notify( 1 , 'topic') );
-			$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
-		}
-
-		/**
-		 * Test notify() function with a call with an error response.
-		 */
-		public function test_notify_response_error() {
-
-			$this->service = $this->get_mock();
-
-			$this->service->expects( $this->once() )->method( 'do_request' )->willReturn(  [ 'response' => [ 'code' => 400, 'body' => 'Bad request' ] ] );
-			$this->assertFalse( $this->service->notify( 1 , 'topic') );
-			$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
-		}
-
-		/**
-		 * Mocks the service
-		 * @return NotificationsService
-		 */
-		public function get_mock() {
-			return $this->getMockBuilder( NotificationsService::class)
-				->onlyMethods( [ 'do_request' ] )
-				->getMock();
-		}
-
+			},
+			10,
+			2
+		);
 	}
+
+	/**
+	 * Test if the route is correct
+	 */
+	public function test_route() {
+		$this->service = $this->get_mock( [] );
+
+		$blog_id = self::DUMMY_BLOG_ID;
+		$this->assertEquals( $this->service->get_notification_url(), "https://public-api.wordpress.com/wpcom/v2/sites/{$blog_id}/partners/google/notifications" );
+	}
+
+
+	/**
+	 * Test notify() function with a call with success response.
+	 */
+	public function test_notify() {
+		$this->service = $this->get_mock();
+
+		$topic   = 'product.create';
+		$item_id = 1;
+
+		$args = [
+			'method'  => 'POST',
+			'timeout' => 30,
+			'headers' => [
+				'x-woocommerce-topic' => $topic,
+			],
+			'body'    => [
+				'item_id' => $item_id,
+			],
+			'url'     => $this->service->get_notification_url(),
+		];
+
+		$this->service->expects( $this->once() )->method( 'do_request' )->with( $args )->willReturn( [ 'code' => 200 ] );
+		$this->assertTrue( $this->service->notify( $item_id, $topic ) );
+	}
+
+
+	/**
+	 * Test notify() function with a call with wp_error response.
+	 */
+	public function test_notify_wp_error() {
+		$this->service = $this->get_mock();
+
+		$this->service->expects( $this->once() )->method( 'do_request' )->willReturn( new \WP_Error( 'error', 'error message' ) );
+		$this->assertFalse( $this->service->notify( 1, 'topic' ) );
+		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
+	}
+
+	/**
+	 * Test notify() function with a call with an error response.
+	 */
+	public function test_notify_response_error() {
+		$this->service = $this->get_mock();
+
+		$this->service->expects( $this->once() )->method( 'do_request' )->willReturn(
+			[
+				'response' => [
+					'code' => 400,
+					'body' => 'Bad request',
+				],
+			]
+		);
+		$this->assertFalse( $this->service->notify( 1, 'topic' ) );
+		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
+	}
+
+	/**
+	 * Mocks the service
+	 *
+	 * @return NotificationsService
+	 */
+	public function get_mock() {
+		return $this->getMockBuilder( NotificationsService::class )
+			->onlyMethods( [ 'do_request' ] )
+			->getMock();
+	}
+}

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -15,6 +15,7 @@ use WC_Helper_Product;
 
 /**
  * Class ProductNotificationJobTest
+ *
  * @group Notifications
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
@@ -65,7 +66,7 @@ class ProductNotificationJobTest extends UnitTest {
 
 	public function test_schedule_schedules_immediate_job() {
 		$topic = 'product.create';
-		$id = 1;
+		$id    = 1;
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
@@ -83,7 +84,7 @@ class ProductNotificationJobTest extends UnitTest {
 	}
 
 	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
-		$id = 1;
+		$id    = 1;
 		$topic = 'product.create';
 
 		$this->action_scheduler->expects( $this->once() )
@@ -94,11 +95,10 @@ class ProductNotificationJobTest extends UnitTest {
 		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
 
 		$this->job->schedule( [ $id, $topic ] );
-
 	}
 
 	public function test_schedule_doesnt_schedules_immediate_job_if_filtered() {
-		$id = 1;
+		$id    = 1;
 		$topic = 'product.create';
 
 		add_filter( 'woocommerce_gla_product_notification_job_can_schedule', '__return_false' );
@@ -111,14 +111,13 @@ class ProductNotificationJobTest extends UnitTest {
 		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
 
 		$this->job->schedule( [ $id, $topic ] );
-
 	}
 
 	public function test_process_items_calls_notify_and_set_status_on_success() {
 		/** @var \WC_Product $product */
 		$product = WC_Helper_Product::create_simple_product();
-		$id = $product->get_id();
-		$topic = 'product.create';
+		$id      = $product->get_id();
+		$topic   = 'product.create';
 
 		$this->notification_service->expects( $this->once() )
 			->method( 'notify' )
@@ -135,7 +134,6 @@ class ProductNotificationJobTest extends UnitTest {
 			->with( $product, NotificationStatus::NOTIFICATION_CREATED );
 
 		$this->job->handle_process_items_action( [ $id, $topic ] );
-
 	}
 
 	public function test_process_items_doesnt_calls_notify_when_no_args() {
@@ -149,8 +147,8 @@ class ProductNotificationJobTest extends UnitTest {
 	public function test_process_items_doesnt_calls_set_status_on_failure() {
 		/** @var \WC_Product $product */
 		$product = WC_Helper_Product::create_simple_product();
-		$id = $product->get_id();
-		$topic = 'product.create';
+		$id      = $product->get_id();
+		$topic   = 'product.create';
 
 		$this->notification_service->expects( $this->once() )
 			->method( 'notify' )
@@ -164,13 +162,12 @@ class ProductNotificationJobTest extends UnitTest {
 			->method( 'set_notification_status' );
 
 		$this->job->handle_process_items_action( [ $id, $topic ] );
-
 	}
 
 	public function test_get_after_notification_status() {
 		/** @var \WC_Product $product */
 		$product = WC_Helper_Product::create_simple_product();
-		$id = $product->get_id();
+		$id      = $product->get_id();
 
 		$this->notification_service->expects( $this->exactly( 3 ) )
 			->method( 'notify' )
@@ -182,20 +179,20 @@ class ProductNotificationJobTest extends UnitTest {
 
 		$this->product_helper->expects( $this->exactly( 3 ) )
 			->method( 'set_notification_status' )
-			->willReturnCallback( function( $id, $topic ) {
-				if ( $topic === 'product.create' ) {
-					return NotificationStatus::NOTIFICATION_CREATED;
-				} else if ( $topic === 'product.delete' ) {
-					return  NotificationStatus::NOTIFICATION_DELETED;
-				} else {
-					return  NotificationStatus::NOTIFICATION_UPDATED;
+			->willReturnCallback(
+				function ( $id, $topic ) {
+					if ( $topic === 'product.create' ) {
+							return NotificationStatus::NOTIFICATION_CREATED;
+					} elseif ( $topic === 'product.delete' ) {
+						return NotificationStatus::NOTIFICATION_DELETED;
+					} else {
+						return NotificationStatus::NOTIFICATION_UPDATED;
+					}
 				}
-			});
-
+			);
 
 		$this->job->handle_process_items_action( [ $id, 'product.create' ] );
 		$this->job->handle_process_items_action( [ $id, 'product.delete' ] );
 		$this->job->handle_process_items_action( [ $id, 'product.update' ] );
 	}
-
 }

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -24,6 +24,7 @@ use WC_Product;
 
 /**
  * Class ProductHelperTest
+ *
  * @group Helpers
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
  */
@@ -1130,12 +1131,13 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 
 	/**
 	 * Set and save product to make it Notification Ready
+	 *
 	 * @param WC_Product $product
 	 * @return WC_Product
 	 */
 	public function get_notification_ready_product( $product ) {
 		$product->set_status( 'publish' );
-		$product->add_meta_data( '_wc_gla_visibility', ChannelVisibility::SYNC_AND_SHOW , true );
+		$product->add_meta_data( '_wc_gla_visibility', ChannelVisibility::SYNC_AND_SHOW, true );
 		$product->save();
 		return $product;
 	}

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -77,7 +77,6 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 			->method( 'schedule' )
 			->with( $this->equalTo( [ [ $product->get_id() ] ] ) );
 
-
 		$product->set_status( 'publish' );
 		$product->save();
 	}
@@ -281,7 +280,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 	public function test_create_product_triggers_notification_created() {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
-		$this->notification_service->expects( $this->once() )->method('is_enabled')->willReturn( true );
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->product_notification_job->expects( $this->once() )
 			->method( 'schedule' )->with( $this->equalTo( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_CREATED ] ) );
 		$product->set_status( 'publish' );
@@ -290,7 +289,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 	public function test_create_product_triggers_notification_updated() {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
-		$this->notification_service->expects( $this->once() )->method('is_enabled')->willReturn( true );
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->product_notification_job->expects( $this->once() )
 			->method( 'schedule' )->with( $this->equalTo( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_UPDATED ] ) );
 		$product->set_status( 'publish' );
@@ -300,11 +299,11 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 	public function test_create_product_triggers_notification_delete() {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
-		$this->notification_service->expects( $this->once() )->method('is_enabled')->willReturn( true );
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->product_notification_job->expects( $this->once() )
 			->method( 'schedule' )->with( $this->equalTo( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_DELETED ] ) );
 		$product->set_status( 'publish' );
-		$product->add_meta_data( '_wc_gla_visibility', ChannelVisibility::DONT_SYNC_AND_SHOW , true );
+		$product->add_meta_data( '_wc_gla_visibility', ChannelVisibility::DONT_SYNC_AND_SHOW, true );
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_CREATED );
 		$product->save();
 	}
@@ -323,11 +322,11 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 			->method( 'is_ready_for_syncing' )
 			->willReturn( true );
 
-		$this->update_products_job              = $this->createMock( UpdateProducts::class );
-		$this->delete_products_job              = $this->createMock( DeleteProducts::class );
-		$this->product_notification_job 		= $this->createMock( ProductNotificationJob::class );
-		$this->job_repository                   = $this->createMock( JobRepository::class );
-		$this->notification_service             = $this->createMock( NotificationsService::class );
+		$this->update_products_job      = $this->createMock( UpdateProducts::class );
+		$this->delete_products_job      = $this->createMock( DeleteProducts::class );
+		$this->product_notification_job = $this->createMock( ProductNotificationJob::class );
+		$this->job_repository           = $this->createMock( JobRepository::class );
+		$this->notification_service     = $this->createMock( NotificationsService::class );
 
 		$this->job_repository->expects( $this->any() )
 			->method( 'get' )
@@ -339,12 +338,12 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 				]
 			);
 
-		$this->batch_helper          = $this->container->get( BatchProductHelper::class );
-		$this->product_helper        = $this->container->get( ProductHelper::class );
-		$this->wc                    = $this->container->get( WC::class );
+		$this->batch_helper   = $this->container->get( BatchProductHelper::class );
+		$this->product_helper = $this->container->get( ProductHelper::class );
+		$this->wc             = $this->container->get( WC::class );
 		$this->syncer_hooks   = new SyncerHooks( $this->batch_helper, $this->product_helper, $this->job_repository, $this->merchant_center, $this->notification_service, $this->wc );
 
-		add_filter( 'woocommerce_gla_notifications_enabled', '__return_false');
+		add_filter( 'woocommerce_gla_notifications_enabled', '__return_false' );
 		$this->syncer_hooks->register();
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes some PHPCS warnings created in GoogleListingAndAds.php 

This was due to some old wrong code that got into the feature branch.

1. Observe this WIP commit adding some functions in GoogleListingAndAds.php -- https://github.com/woocommerce/google-listings-and-ads/commit/25db8192d7029b6a89b0bbd4b508c467495f3d22
2. Observe this PR when we add the Jetpack functions in their own file -- https://github.com/woocommerce/google-listings-and-ads/pull/2145
3. Observe this commit when we remove the functions from GoogleListingAndAds.php -- https://github.com/woocommerce/google-listings-and-ads/commit/6975f776364f38c754cf038942244f4430e5fcb5

At some point the code in point 1. Was not removed. This PR removes it.

Additionally, this PR solves PHPCS errors undetected in test files. 

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow the testing guide defined in https://github.com/woocommerce/google-listings-and-ads/pull/2145
2. See there are no more PHPCS errors


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
