### PR TITLE
Prevent Google API requests when disconnected

### DIFF
--- a/src/Notes/ReviewAfterConversions.php
+++ b/src/Notes/ReviewAfterConversions.php
@@ -4,10 +4,10 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Notes;
 
 use Automattic\WooCommerce\Admin\Notes\Note as NoteEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Exception;
@@ -21,10 +21,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
-class ReviewAfterConversions extends AbstractNote implements MerchantCenterAwareInterface {
+class ReviewAfterConversions extends AbstractNote implements AdsAwareInterface {
 
+	use AdsAwareTrait;
 	use LeaveReviewActionTrait;
-	use MerchantCenterAwareTrait;
 	use PluginHelper;
 	use Utilities;
 
@@ -111,6 +111,10 @@ class ReviewAfterConversions extends AbstractNote implements MerchantCenterAware
 	 */
 	public function should_be_added(): bool {
 		if ( $this->has_been_added() ) {
+			return false;
+		}
+
+		if ( ! $this->ads_service->is_connected() ) {
 			return false;
 		}
 

--- a/src/Notes/SetupCouponSharing.php
+++ b/src/Notes/SetupCouponSharing.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
+use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -97,8 +98,12 @@ class SetupCouponSharing extends AbstractNote implements MerchantCenterAwareInte
 		}
 
 		// Check if there are synced products.
-		$statuses = $this->merchant_statuses->get_product_statistics();
-		if ( $statuses['statistics']['active'] <= 0 ) {
+		try {
+			$statuses = $this->merchant_statuses->get_product_statistics();
+			if ( $statuses['statistics']['active'] <= 0 ) {
+				return false;
+			}
+		} catch ( Exception $e ) {
 			return false;
 		}
 

--- a/tests/Unit/Notes/ReviewAfterConversionsTest.php
+++ b/tests/Unit/Notes/ReviewAfterConversionsTest.php
@@ -1,0 +1,93 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReviewAfterConversions;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ReviewAfterConversionsTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes
+ */
+class ReviewAfterConversionsTest extends UnitTest {
+
+	/** @var MockObject|AdsService $ads_service */
+	protected $ads_service;
+
+	/** @var MockObject|MerchantMetrics $merchant_metrics */
+	protected $merchant_metrics;
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/** @var ReviewAfterConversions $note */
+	protected $note;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->ads_service      = $this->createMock( AdsService::class );
+		$this->merchant_metrics = $this->createMock( MerchantMetrics::class );
+		$this->wp               = $this->createMock( WP::class );
+
+		$this->note = new ReviewAfterConversions( $this->merchant_metrics, $this->wp );
+		$this->note->set_ads_object( $this->ads_service );
+	}
+
+	public function test_name() {
+		$this->assertEquals( 'gla-review-after-conversions', $this->note->get_name() );
+	}
+
+	public function test_note_entry() {
+		$note = $this->note->get_entry();
+
+		$this->assertEquals( 'gla-review-after-conversions', $note->get_name() );
+		$this->assertEquals( 'gla', $note->get_source() );
+		$this->assertEquals( 'leave-review', $note->get_actions()[0]->name );
+	}
+
+	public function test_should_not_add_already_added() {
+		$this->note->get_entry()->save();
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_not_connected() {
+		$this->ads_service->method( 'is_connected' )->willReturn( false );
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_low_merchant_metrics() {
+		$this->ads_service->method( 'is_connected' )->willReturn( true );
+		$this->merchant_metrics->expects( $this->once() )
+			->method( 'get_cached_ads_metrics' )
+			->willReturn(
+				[ 'conversions' => 5 ]
+			);
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_add() {
+		$this->ads_service->method( 'is_connected' )->willReturn( true );
+		$this->merchant_metrics->expects( $this->once() )
+			->method( 'get_cached_ads_metrics' )
+			->willReturn(
+				[ 'conversions' => 17 ]
+			);
+
+		$this->assertTrue( $this->note->should_be_added() );
+	}
+}

--- a/tests/Unit/Notes/SetupCouponSharingTest.php
+++ b/tests/Unit/Notes/SetupCouponSharingTest.php
@@ -1,0 +1,195 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCouponSharing;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SetupCouponSharingTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes
+ */
+class SetupCouponSharingTest extends UnitTest {
+
+	/** @var MockObject|AdsService $ads_service */
+	protected $ads_service;
+
+	/** @var MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
+
+	/** @var OptionsInterface $options */
+	protected $options;
+
+	/** @var ReviewAfterConversions $note */
+	protected $note;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->ads_service       = $this->createMock( AdsService::class );
+		$this->merchant_center   = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses = $this->createMock( MerchantStatuses::class );
+		$this->options           = $this->createMock( OptionsInterface::class );
+
+		$this->note = new SetupCouponSharing( $this->merchant_statuses );
+		$this->note->set_ads_object( $this->ads_service );
+		$this->note->set_merchant_center_object( $this->merchant_center );
+		$this->note->set_options_object( $this->options );
+	}
+
+	public function test_name() {
+		$this->assertEquals( 'gla-coupon-optin', $this->note->get_name() );
+	}
+
+	public function test_note_entry() {
+		$note = $this->note->get_entry();
+
+		$this->assertEquals( 'gla-coupon-optin', $note->get_name() );
+		$this->assertEquals( 'gla', $note->get_source() );
+		$this->assertEquals( 'coupon-views', $note->get_actions()[0]->name );
+	}
+
+	public function test_should_not_add_already_added() {
+		$this->note->get_entry()->save();
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_unsupported_promotion_country() {
+		$this->merchant_center->method( 'is_promotion_supported_country' )->willReturn( false );
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_not_connected() {
+		$this->merchant_center->method( 'is_promotion_supported_country' )->willReturn( true );
+		$this->merchant_statuses->method( 'get_product_statistics' )->willThrowException( new Exception( 'error' ) );
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_no_active_products() {
+		$this->merchant_center->method( 'is_promotion_supported_country' )->willReturn( true );
+		$this->mock_product_statistics( 0 );
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_no_coupons() {
+		$this->merchant_center->method( 'is_promotion_supported_country' )->willReturn( true );
+		$this->mock_product_statistics( 5 );
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_shared_coupons_found() {
+		$this->merchant_center->method( 'is_promotion_supported_country' )->willReturn( true );
+		$this->mock_product_statistics( 5 );
+		$this->create_coupon( true );
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_ads_setup_not_completed() {
+		$this->merchant_center->method( 'is_promotion_supported_country' )->willReturn( true );
+		$this->mock_product_statistics( 5 );
+		$this->create_coupon( false );
+
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
+		$this->mock_option_value(
+			OptionsInterface::MC_SETUP_COMPLETED_AT,
+			time() - ( 7 * DAY_IN_SECONDS )
+		);
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_ads_setup_completed() {
+		$this->merchant_center->method( 'is_promotion_supported_country' )->willReturn( true );
+		$this->mock_product_statistics( 5 );
+		$this->create_coupon( false );
+
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->mock_option_value(
+			OptionsInterface::MC_SETUP_COMPLETED_AT,
+			time() - ( 2 * DAY_IN_SECONDS )
+		);
+
+		$this->assertFalse( $this->note->should_be_added() );
+	}
+
+	public function test_should_add() {
+		$this->merchant_center->method( 'is_promotion_supported_country' )->willReturn( true );
+		$this->mock_product_statistics( 5 );
+		$this->create_coupon( false );
+
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->mock_option_value(
+			OptionsInterface::MC_SETUP_COMPLETED_AT,
+			time() - ( 7 * DAY_IN_SECONDS )
+		);
+
+		$this->assertTrue( $this->note->should_be_added() );
+	}
+
+	/**
+	 * Mock an option return value.
+	 *
+	 * @param string $key          Option name.
+	 * @param mixed  $return_value Value to mock.
+	 */
+	private function mock_option_value( string $key, $return_value ) {
+		$this->options->expects( $this->once() )->method( 'get' )->with( $key )->willReturn( $return_value );
+	}
+
+	/**
+	 * Mock the return value for product statistics.
+	 *
+	 * @param int $active_products Amount of active products to mock.
+	 */
+	private function mock_product_statistics( int $active_products ) {
+		$this->merchant_statuses->expects( $this->once() )->method( 'get_product_statistics' )->willReturn(
+			[
+				'statistics' => [
+					'active' => $active_products,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Creates a regular coupon (which is not set to sync and show)
+	 *
+	 * @param bool $shared Should this coupon be set to sync and show.
+	 */
+	private function create_coupon( bool $shared = true ) {
+		$visibility = $shared ? ChannelVisibility::SYNC_AND_SHOW : ChannelVisibility::DONT_SYNC_AND_SHOW;
+
+		wp_insert_post(
+			[
+				'post_type'   => 'shop_coupon',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					CouponMetaHandler::KEY_VISIBILITY => $visibility,
+				],
+			]
+		);
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR resolves the issue where the notification scheduler (which runs daily) still sends requests to the Google API even though it's marked as disconnected. The correct behaviour is to prevent any requests from being sent since a disconnected state means we are not able to retrieve the right tokens for the request.

For the ReviewAfterConversions notification it was only checking the presence of an Ads ID, I've expanded this to check if it's connected before retrieving conversions.

For the SetupCouponSharing notification I tweaked the behaviour since it throws an error when not connected. The exception was getting caught higher up in the NoteInitializer class, but I changed it so it would get caught directly when a connection is not established, which is the same way it's handled in SetupCampaign.

In addition to this I also checked all the other notifications to make sure none of them sent any requests, here is the overview of the status:
- CompleteSetup (does not send any requests to Google API)
- ContactInformation (checks `is_connected` before retrieving contact information)
- ReconnectWordPress (sends a request to WCS to check Google connection status, does not send request to Google API)
- ReviewAfterClicks (checks `is_connected` before retrieving clicks)
- SetupCampaign (catches an error when statuses are retrieved but google not connected)
- SetupCampaignTwoWeeks  (catches an error when statuses are retrieved but google not connected)

Closes #2224 

### Detailed test instructions:

##### Testing ReviewAfterConversions
1. If using an existing site, clear out any previously sent notifications`DROP FROM wp_wc_admin_notes WHERE name LIKE 'gla-%'`
2. Clear the Ads metrics transient: `_transient_gla_ads_metrics`
3. Complete MC onboarding, Complete Ads onboarding, disconnect Google
4. Go to WooCommerce > Status > Scheduled Actions and filter for pending
5. Run the task `wc_gla_cron_daily_notes`
6. If connected to a local WCS the requests to the API can be checked. There should only be one request sent by the notifications (from ReconnectWordPress) to `/google/connection/google-mc`. Before the changes in this PR we would have also seen a request to `/google/google-ads/v14/customers/123456789/googleAds:search` which would have been logged as a failure:
```
2024-01-31T09:00:05+00:00 ERROR Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider::handle_unauthorized_error Client error: `POST https://localhost:5000/google/google-ads/v14/customers/123456789/googleAds:search` resulted in a `401 Unauthorized` response:
{"statusCode":401,"error":{"message":"Site is not connected to Google account for google-ads"},"message":"Site is not co (truncated...)

2024-01-31T09:00:05+00:00 ERROR Automattic\WooCommerce\GoogleListingsAndAds\Notes\NoteInitializer::add_notes Please reconnect your Google account.
```

##### Testing SetupCouponSharing
1. If using an existing site, clear out any previously sent notifications`DROP FROM wp_wc_admin_notes WHERE name LIKE 'gla-%'`
2. Clear the statuses transient: `_transient_gla_mc_statuses`
3. Set the store country to a promotion supported country (like US)
4. Create a coupon (without setting it to Sync and Show)
5. Complete MC onboarding, disconnect Ads, disconnect Google
6. Go to WooCommerce > Status > Scheduled Actions and filter for pending
7. Run the task `wc_gla_cron_daily_notes`
8. Confirm that there are no more entries in WooCommerce > Status > Logs for the caught exception. Previously the disconnected error would be caught by the NoteInitializer and logged:
```
2024-01-31T09:00:05+00:00 ERROR Automattic\WooCommerce\GoogleListingsAndAds\Notes\NoteInitializer::add_notes Please reconnect your Google account.
```

### Additional details:
I've added two unit tests for the notifications ReviewAfterConversions and SetupCouponSharing.

### Changelog entry
* Fix - Prevent notifications from sending request to Google API when disconnected.
