### PR TITLE
API PULL - Check notification statuses on processing

### DIFF
--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -403,13 +403,17 @@ class ProductHelper implements Service {
 	 */
 	public function has_notified_creation( WC_Product $product ): bool {
 		$valid_has_notified_creation_statuses = [
-			NotificationStatus::NOTIFICATION_PENDING_CREATE,
 			NotificationStatus::NOTIFICATION_CREATED,
 			NotificationStatus::NOTIFICATION_UPDATED,
-			NotificationStatus::NOTIFICATION_PENDING_UPDATE
+			NotificationStatus::NOTIFICATION_PENDING_UPDATE,
+			NotificationStatus::NOTIFICATION_PENDING_DELETE,
 		];
 
-		return in_array( $this->meta_handler->get_notification_status( $product ), $valid_has_notified_creation_statuses, true ) || $this->is_product_synced( $product );
+		return in_array(
+			$this->meta_handler->get_notification_status( $product ),
+			$valid_has_notified_creation_statuses,
+			true
+		) || $this->is_product_synced( $product );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up for https://github.com/woocommerce/google-listings-and-ads/pull/2202 

See https://github.com/woocommerce/google-listings-and-ads/pull/2202#pullrequestreview-1850621965 and https://github.com/woocommerce/google-listings-and-ads/pull/2202#pullrequestreview-1849507552

When a product changes the user may change it again before the job gets processed. That might cause some undesired notifications. This PR checks again the statuses to be sure this doesn't happen. 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a product and see `gla/jobs/notifications/products/process_item` action with `product.create`.
2. Run it and see the Notification Create happened in the WooCommerce - GLA - Logs.
3. Trash the product and fast do "undo" to untrash the product. 
4. see 2 actions  `gla/jobs/notifications/products/process_item` with `product.delete` and `gla/jobs/notifications/products/process_item` action with `product.update`.
5. Run both
6. see ONLY Notification Updated happened in the WooCommerce - GLA - Logs.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
