### PR TITLE
Only sync selected categories as product type

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -194,8 +194,11 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 */
 	protected function map_product_categories() {
 		// set product type using merchants defined product categories
-		$base_product_id            = $this->is_variation() ? $this->parent_wc_product->get_id() : $this->wc_product->get_id();
-		$this->product_category_ids = wc_get_product_cat_ids( $base_product_id );
+		$base_product_id = $this->is_variation() ? $this->parent_wc_product->get_id() : $this->wc_product->get_id();
+
+		// Fetch only selected term ids without parents.
+		$this->product_category_ids = wc_get_product_term_ids( $base_product_id, 'product_cat' );
+
 		if ( ! empty( $this->product_category_ids ) ) {
 			$google_product_types = self::convert_product_types( $this->product_category_ids );
 			do_action(
@@ -234,6 +237,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	}
 
 	/**
+	 * Return category names including ancestors, separated by ">"
 	 *
 	 * @param int $category_id
 	 *

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -536,7 +536,20 @@ DESCRIPTION;
 			'product_cat',
 			[ 'parent' => $category_2['term_id'] ]
 		);
-		$product->set_category_ids( [ $category_1['term_id'], $category_3['term_id'] ] );
+		$category_4 = wp_insert_term(
+			'Charlie Category',
+			'product_cat',
+			[ 'parent' => $category_3['term_id'] ]
+		);
+		$category_5 = wp_insert_term( 'Delta Category', 'product_cat' );
+
+		$product->set_category_ids(
+			[
+				$category_1['term_id'], // Zulu
+				$category_3['term_id'], // Beta
+				$category_4['term_id'], // Charlie
+			]
+		);
 		$product->save();
 
 		$adapted_product = new WCProductAdapter(
@@ -545,9 +558,17 @@ DESCRIPTION;
 				'targetCountry' => 'US',
 			]
 		);
+
+		// Confirm the selected categories Zulu, Beta and Charlie are included (with their parent types).
 		$this->assertContains( 'Alpha Category > Beta Category', $adapted_product->getProductTypes() );
+		$this->assertContains( 'Alpha Category > Beta Category > Charlie Category', $adapted_product->getProductTypes() );
 		$this->assertContains( 'Zulu Category', $adapted_product->getProductTypes() );
-		$this->assertContains( 'Alpha Category', $adapted_product->getProductTypes() );
+
+		// Confirm Alpha is not included as it should only be included as a parent of Beta and Charlie.
+		$this->assertNotContains( 'Alpha Category', $adapted_product->getProductTypes() );
+
+		// Confirm unrelated category is not included.
+		$this->assertNotContains( 'Delta Category', $adapted_product->getProductTypes() );
 	}
 
 	public function test_images_are_set() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the behaviour to only sync the selected categories as product type. Previously it would sync parent categories, both included as the parent of a child category as well as the parent individually even if the parent wasn't selected directly.

This change switches from using `wc_get_product_cat_ids` to using `wc_get_product_term_ids` as the first function will include a list of ancestors (regardless of whether they are selected or not). The latter function will return a list of all the selected categories. Which means we can influence which parent categories get synced individually by selecting them or not.

I altered the unit test to match the expected behaviour as well as testing some more edge cases to ensure they are synced correctly:
- test for unselected parent not included
- test 2 levels of ancestors
- test parent and child are included individually when both are selected
- test unrelated category is not included

Closes #2230

### Detailed test instructions:
1. Setup a site with the extension and onboarded to Merchant Center 
2. Create some categories with hierarchy
3. Create a test product where only the child category is selected
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/e95d091a-02f6-4809-a190-313f6ee8e890)
4. Save the product and wait for it to sync, and then confirm the final attributes in MC, the parent category should not be included as an individual line
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/68e895fe-5953-40b0-af43-97328d096c1d)
5. Create a test product where both the parent and child categories are selected
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/9441a884-da39-4531-8d67-3728b6fee995)
6. Save the product and wait for it to sync, and then confirm the final attributes in MC, the parent category should be included as an individual line and also as part of the child line
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/188d9835-6aa1-4a8b-a410-805e9239d03f)

### Changelog entry
* Fix - Only sync selected categories as product type.
