### PR TITLE
Product Block Editor: Add a custom block for prompting user to complete onboarding

### DIFF
--- a/js/src/blocks/index.js
+++ b/js/src/blocks/index.js
@@ -6,6 +6,8 @@ import { registerProductEditorBlockType } from '@woocommerce/product-editor';
 /**
  * Internal dependencies
  */
+import OnboardingPromptEdit from './product-onboarding-prompt/edit';
+import onboardingPromptMetadata from './product-onboarding-prompt/block.json';
 import ChannelVisibilityEdit from './product-channel-visibility/edit';
 import channelVisibilityMetadata from './product-channel-visibility/block.json';
 import DateTimeFieldEdit from './product-date-time-field/edit';
@@ -23,6 +25,7 @@ function registerProductEditorBlock( { name, ...metadata }, Edit ) {
 	} );
 }
 
+registerProductEditorBlock( onboardingPromptMetadata, OnboardingPromptEdit );
 registerProductEditorBlock( channelVisibilityMetadata, ChannelVisibilityEdit );
 registerProductEditorBlock( dateTimeFieldMetadata, DateTimeFieldEdit );
 registerProductEditorBlock( selectFieldMetadata, SelectFieldEdit );

--- a/js/src/blocks/product-onboarding-prompt/block.json
+++ b/js/src/blocks/product-onboarding-prompt/block.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "google-listings-and-ads/product-onboarding-prompt",
+	"title": "Product onboarding prompt",
+	"textdomain": "google-listings-and-ads",
+	"attributes": {
+		"startUrl": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"html": false,
+		"inserter": false,
+		"lock": false
+	}
+}

--- a/js/src/blocks/product-onboarding-prompt/edit.js
+++ b/js/src/blocks/product-onboarding-prompt/edit.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import styles from './editor.module.scss';
+
+/**
+ * @typedef {Object} ProductOnboardingPromptAttributes
+ * @property {string} startUrl The plugin start URL.
+ */
+
+/**
+ * Custom block for prompting the user to complete the onboarding.
+ *
+ * @param {Object} props React props.
+ * @param {ProductOnboardingPromptAttributes} props.attributes
+ */
+export default function Edit( { attributes } ) {
+	const blockProps = useWooBlockProps( attributes );
+
+	return (
+		<div { ...blockProps }>
+			<div className={ styles.wrapper }>
+				<p className={ styles.content }>
+					{ __(
+						'Complete setup to get your products listed on Google for free.',
+						'google-listings-and-ads'
+					) }
+				</p>
+				<Button isPrimary href={ attributes.startUrl }>
+					{ __( 'Get Started', 'google-listings-and-ads' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/js/src/blocks/product-onboarding-prompt/editor.module.scss
+++ b/js/src/blocks/product-onboarding-prompt/editor.module.scss
@@ -1,0 +1,8 @@
+.wrapper {
+	margin-top: $grid-unit-80;
+	text-align: center;
+}
+
+.content {
+	margin-bottom: $grid-unit-30;
+}

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -62,6 +62,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 	 * @var string[]
 	 */
 	protected const CUSTOM_BLOCKS = [
+		'product-onboarding-prompt',
 		'product-channel-visibility',
 		'product-date-time-field',
 		'product-select-field',
@@ -139,6 +140,16 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 				);
 
 				if ( ! $this->merchant_center->is_setup_complete() ) {
+					$group->add_block(
+						[
+							'id'         => 'google-listings-and-ads-product-onboarding-prompt',
+							'blockName'  => 'google-listings-and-ads/product-onboarding-prompt',
+							'attributes' => [
+								'startUrl' => $this->get_start_url(),
+							],
+						]
+					);
+
 					return;
 				}
 

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -197,7 +197,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 	 */
 	public function register_custom_blocks( string $build_path, string $uri, array $custom_blocks ): void {
 		foreach ( $custom_blocks as $custom_block ) {
-			$block_json_file = "${build_path}/${custom_block}/block.json";
+			$block_json_file = "{$build_path}/{$custom_block}/block.json";
 
 			if ( ! file_exists( $block_json_file ) ) {
 				continue;
@@ -209,11 +209,11 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 		$assets[] = new AdminScriptWithBuiltDependenciesAsset(
 			'google-listings-and-ads-product-blocks',
 			$uri,
-			"${build_path}/blocks.asset.php",
+			"{$build_path}/blocks.asset.php",
 			new BuiltScriptDependencyArray(
 				[
 					'dependencies' => [],
-					'version'      => (string) filemtime( "${build_path}/blocks.js" ),
+					'version'      => (string) filemtime( "{$build_path}/blocks.js" ),
 				]
 			)
 		);
@@ -222,7 +222,7 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 			'google-listings-and-ads-product-blocks-css',
 			$uri,
 			[],
-			(string) filemtime( "${build_path}/blocks.css" )
+			(string) filemtime( "{$build_path}/blocks.css" )
 		);
 
 		$this->assets_handler->register_many( $assets );

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -97,10 +97,6 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 	 * Register a service.
 	 */
 	public function register(): void {
-		if ( ! $this->merchant_center->is_setup_complete() ) {
-			return;
-		}
-
 		add_action(
 			'init',
 			function () {
@@ -141,6 +137,10 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 						],
 					]
 				);
+
+				if ( ! $this->merchant_center->is_setup_complete() ) {
+					return;
+				}
 
 				/** @var SectionInterface */
 				$channel_visibility_section = $group->add_section(

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -325,8 +325,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 
 		// Product Block Editor
-		$this->share_with_tags( ChannelVisibilityBlock::class, ProductHelper::class );
-		$this->share_with_tags( ProductBlocksService::class, AssetsHandlerInterface::class, ChannelVisibilityBlock::class, AttributeManager::class, MerchantCenterService::class );
+		$this->share_with_tags( ChannelVisibilityBlock::class, ProductHelper::class, MerchantCenterService::class );
+		$this->conditionally_share_with_tags( ProductBlocksService::class, AssetsHandlerInterface::class, ChannelVisibilityBlock::class, AttributeManager::class, MerchantCenterService::class );
 
 		$this->share_with_tags( MerchantAccountState::class );
 		$this->share_with_tags( MerchantStatuses::class );

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -112,8 +112,8 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 	}
 
 	private function setUpBlockMock( MockObject $anchor_group, string $template_id ) {
-		$template = $this->createStub( ProductFormTemplateInterface::class );
-		$group    = $this->createStub( GroupInterface::class );
+		$template = $this->createMock( ProductFormTemplateInterface::class );
+		$group    = $this->createMock( GroupInterface::class );
 
 		$visibility_section = $this->createMock( SectionInterface::class );
 		$attributes_section = $this->createMock( SectionInterface::class );
@@ -196,9 +196,31 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 			->expects( $this->exactly( 1 ) )
 			->method( 'add_group' );
 
+		$this->simple['group']
+			->expects( $this->exactly( 1 ) )
+			->method( 'add_block' )
+			->with(
+				[
+					'id'         => 'google-listings-and-ads-product-onboarding-prompt',
+					'blockName'  => 'google-listings-and-ads/product-onboarding-prompt',
+					'attributes' => [ 'startUrl' => 'http://example.org/wp-admin/admin.php?page=wc-admin&path=/google/start' ],
+				]
+			);
+
 		$this->variation_anchor_group->get_root_template()
 			->expects( $this->exactly( 1 ) )
 			->method( 'add_group' );
+
+		$this->variation['group']
+			->expects( $this->exactly( 1 ) )
+			->method( 'add_block' )
+			->with(
+				[
+					'id'         => 'google-listings-and-ads-product-onboarding-prompt',
+					'blockName'  => 'google-listings-and-ads/product-onboarding-prompt',
+					'attributes' => [ 'startUrl' => 'http://example.org/wp-admin/admin.php?page=wc-admin&path=/google/start' ],
+				]
+			);
 
 		$this->product_blocks_service->register();
 

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -193,11 +193,11 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 		$this->is_mc_setup_complete = false;
 
 		$this->simple_anchor_group->get_root_template()
-			->expects( $this->exactly( 0 ) )
+			->expects( $this->exactly( 1 ) )
 			->method( 'add_group' );
 
 		$this->variation_anchor_group->get_root_template()
-			->expects( $this->exactly( 0 ) )
+			->expects( $this->exactly( 1 ) )
 			->method( 'add_group' );
 
 		$this->product_blocks_service->register();

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -209,6 +209,8 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 	public function test_register_is_not_admin_page() {
 		unset( $_GET['page'] );
 
+		$this->assertFalse( ProductBlocksService::is_needed() );
+
 		$this->simple_anchor_group->get_root_template()
 			->expects( $this->exactly( 0 ) )
 			->method( 'add_group' );
@@ -217,7 +219,8 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 			->expects( $this->exactly( 0 ) )
 			->method( 'add_group' );
 
-		$this->product_blocks_service->register();
+		// Here it doesn't call `product_blocks_service->register()` because it will
+		// be processed by the conditional registration in `GoogleAdsCleanupServices`.
 
 		do_action( self::GENERAL_GROUP_HOOK, $this->simple_anchor_group );
 		do_action( self::GENERAL_GROUP_HOOK, $this->variation_anchor_group );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With the original product editor, this extension shows a prompt if the user has not yet completed onboarding.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/031a4c0b-a1e3-4d38-9145-493f586f4530)

To have a consistent prompt in the Product Block Editor, this PR:

- Change to let the `ChannelVisibilityBlock` handle its own registration as it has different conditions than `ProductBlocksService`.
- Change `ProductBlocksService` to still add a group for this extension and register custom blocks when the onboarding is not yet completed.
- Add a new custom block for prompting the user to complete the onboarding.
- Show the onboarding prompt in the Product Block Editor when it's not yet completed.
- Extra changes:
   - Fix the integrity checks for `woocommerce-grow-jsdoc` and `woocommerce-grow-storybook`.
   - Fix the deprecations of using `${var}` in a string for the `ProductBlocksService` class.

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/dc8d1530-aece-4b3b-96c1-8818babe7a55

### Detailed test instructions:

#### 📌 Prepare test environment

1. Please refer to [the test preparation in PR 2151](https://github.com/woocommerce/google-listings-and-ads/pull/2151#prepare-test-environment) with **Woo 8.5.1**.
   - 💡 Please note that the current implementation doesn't work with Woo >= 8.6 due to breaking changes. This will be fixed by another PR.
1. `npm install`
1. `npm start`
1. To control the onboarding status, locally changing this return value would be easier to test.
   https://github.com/woocommerce/google-listings-and-ads/blob/1ef20671a867ec921393c809e58f2e88e06cec9e/src/MerchantCenter/MerchantCenterService.php#L75-L77

#### 📌 Test the onboarding prompt

1. Set the onboarding status to not completed.
1. Go to edit a simple product, e.g. the **Beanie with Logo** imported from WC's sample products.
1. Switch to the **Google Listings & Ads** tab.
1. Check if it shows a prompt as in the following screenshot.
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/8b1eea7a-9f60-4611-a78c-32cad9a2d1d8)
1. Click the "Get Started" button to see if it brings you to this extension's Get Started page.
1. Repeat this test with variable and variation products.

### Changelog entry
