### PR TITLE
Upload coverage report for JS unit tests to codecov

### DIFF
--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run JavaScript unit tests
         run: npm run test:js
 
-      - name: JS unit coverage report
+      - name: Upload JS unit coverage report
         uses: codecov/codecov-action@v3
         with:
           files: coverage/clover.xml

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -38,3 +38,10 @@ jobs:
 
       - name: Run JavaScript unit tests
         run: npm run test:js
+
+      - name: JS unit coverage report
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/clover.xml
+          flags: js-unit-tests
+          name: js-coverage-report

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -90,7 +90,7 @@ jobs:
         run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover=tests/php-coverage/report.xml
 
       - if: env.generate_coverage == 'true'
-        name: PHP unit coverage report
+        name: Upload PHP unit coverage report
         uses: codecov/codecov-action@v3
         with:
           files: tests/php-coverage/report.xml


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When running the unit tests for JS, coverage reports are already being generated in various formats. This PR uploads the clover format to codecov.io so they can be included in the coverage report comment.

The coverage comment is currently only showing the status for PHP coverage, since there is no base to compare with yet for the JS coverage reports. Over time we'll have to monitor how accurate this is, since JS / PHP coverage reports are run conditionally depending on which files are changed. So not every PR / head commit has both to compare the differences.

Closes #864

### Detailed test instructions:
1. Confirm that the JS code coverage results are available: https://app.codecov.io/github/woocommerce/google-listings-and-ads/pull/2238/tree/js/src
2. Confirm that the PHP code coverage results are available: https://app.codecov.io/github/woocommerce/google-listings-and-ads/pull/2238/tree/src

### Changelog entry
* Dev - Upload coverage report for JS unit tests to codecov.
