### PR TITLE
[R-1.2] Update step 4 of the onboarding flow

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-features-section.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-features-section.js
@@ -84,14 +84,14 @@ export default function PaidAdsFeaturesSection( {
 				<Pill>{ __( 'Recommended', 'google-listings-and-ads' ) }</Pill>
 			}
 			title={ __(
-				'Boost product listings with paid ads',
+				'Performance Max campaign',
 				'google-listings-and-ads'
 			) }
 			description={
 				<>
 					<p>
 						{ __(
-							'Get the most out of your paid ads with Performance Max campaigns. With Google’s machine learning technology, your Performance Max campaigns will be automated to show the most impactful ads at the right time and place.',
+							'Performance Max uses the best of Google’s AI to show the most impactful ads for your products at the right time and place. Google will use your product data to create ads for this campaign. ',
 							'google-listings-and-ads'
 						) }
 					</p>
@@ -101,7 +101,10 @@ export default function PaidAdsFeaturesSection( {
 							linkId="paid-ads-with-performance-max-campaigns-learn-more"
 							href="https://support.google.com/google-ads/answer/10724817"
 						>
-							{ __( 'Learn more', 'google-listings-and-ads' ) }
+							{ __(
+								'Learn more about Performance Max',
+								'google-listings-and-ads'
+							) }
 						</AppDocumentationLink>
 					</p>
 				</>

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -20,7 +20,6 @@ import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
 import FaqsSection from '.~/components/paid-ads/faqs-section';
 import AppButton from '.~/components/app-button';
-import ProductFeedStatusSection from './product-feed-status-section';
 import PaidAdsFeaturesSection from './paid-ads-features-section';
 import PaidAdsSetupSections from './paid-ads-setup-sections';
 import { getProductFeedUrl } from '.~/utils/urls';
@@ -162,15 +161,14 @@ export default function SetupPaidAds() {
 		<StepContent>
 			<StepContentHeader
 				title={ __(
-					'Complete your campaign with paid ads',
+					'Create a campaign to advertise your products',
 					'google-listings-and-ads'
 				) }
 				description={ __(
-					'As soon as your products are approved, your listings and ads will be live. In the meantime, let’s set up your ads.',
+					'You’re ready to set up a Performance Max campaign to drive more sales with ads. Your products will be included in the campaign after they’re approved.',
 					'google-listings-and-ads'
 				) }
 			/>
-			<ProductFeedStatusSection />
 			<PaidAdsFeaturesSection
 				hideBudgetContent={ ! hasGoogleAdsConnection }
 				hideFooterButtons={


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Related #2215.

This updates the copy on step 4 and removes the `ProductFeedStatusSection` to align with the new designs.

### Screenshots:

<img width="943" alt="Screenshot 2024-02-08 at 12 51 34 AM" src="https://github.com/woocommerce/google-listings-and-ads/assets/1442637/d4e6b117-3c93-4784-a58e-2f5eb8a7bc78">

### Changelog entry
