### PR TITLE
Product Block Editor: Make it compatible with WooCommerce 8.6

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -40,9 +40,6 @@ jobs:
         uses: woocommerce/grow/get-plugin-releases@actions-v1
         with:
           slug: woocommerce
-          # Temporarily use the RC version as version 8.6.0 has not been released yet.
-          # Will be reverted before merging PR.
-          includeRC: true
 
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -40,6 +40,9 @@ jobs:
         uses: woocommerce/grow/get-plugin-releases@actions-v1
         with:
           slug: woocommerce
+          # Temporarily use the RC version as version 8.6.0 has not been released yet.
+          # Will be reverted before merging PR.
+          includeRC: true
 
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}

--- a/js/src/blocks/README.md
+++ b/js/src/blocks/README.md
@@ -53,9 +53,9 @@ The "derived value" refers to the computation of a value based on another state 
 
 References:
 
-- At [ProductPage](https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce-admin/client/products/product-page.tsx#L77-L79) and [ProductVariationPage](https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce-admin/client/products/product-variation-page.tsx#L83-L85) layers, they won't render the actual blocks before the product data is fetched
-- The above product data is obtained from [useProductEntityRecord](https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts#L19-L23) or [useProductVariationEntityRecord](https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce-admin/client/products/hooks/use-product-variation-entity-record.ts#L16-L22) hook, and both hooks use the `getEntityRecord` selector.
-- This extension obtains product data from [useProductEntityProp](https://github.com/woocommerce/woocommerce/blob/8.3.0/packages/js/product-editor/src/hooks/use-product-entity-prop.ts#L24-L33), which uses the `useEntityProp` hook internally.
+- At [ProductPage](https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce-admin/client/products/product-page.tsx#L77-L79) and [ProductVariationPage](https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce-admin/client/products/product-variation-page.tsx#L83-L85) layers, they won't render the actual blocks before the product data is fetched
+- The above product data is obtained from [useProductEntityRecord](https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts#L19-L23) or [useProductVariationEntityRecord](https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce-admin/client/products/hooks/use-product-variation-entity-record.ts#L16-L22) hook, and both hooks use the `getEntityRecord` selector.
+- This extension obtains product data from [useProductEntityProp](https://github.com/woocommerce/woocommerce/blob/8.6.0/packages/js/product-editor/src/hooks/use-product-entity-prop.ts#L24-L34), which uses the `useEntityProp` hook internally.
 - The [useEntityProp](https://github.com/WordPress/gutenberg/blob/wp/6.0/packages/core-data/src/entity-provider.js#L102-L133) hook also uses the `getEntityRecord` selector.
 
 ### Infrastructure adjustments

--- a/src/Admin/Product/ChannelVisibilityBlock.php
+++ b/src/Admin/Product/ChannelVisibilityBlock.php
@@ -55,11 +55,11 @@ class ChannelVisibilityBlock implements Service, Registerable {
 			return;
 		}
 
-		// https://github.com/woocommerce/woocommerce/blob/8.5.0/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php#L182-L192
+		// https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php#L182-L192
 		add_filter( 'woocommerce_rest_prepare_product_object', [ $this, 'prepare_data' ], 10, 2 );
 
-		// https://github.com/woocommerce/woocommerce/blob/8.5.0/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php#L200-L207
-		// https://github.com/woocommerce/woocommerce/blob/8.5.0/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php#L247-L254
+		// https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php#L200-L207
+		// https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php#L247-L254
 		add_action( 'woocommerce_rest_insert_product_object', [ $this, 'update_data' ], 10, 2 );
 	}
 

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -85,8 +85,8 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 	 * @return bool Whether this service is needed to be registered.
 	 */
 	public static function is_needed(): bool {
-		// compatibility-code "WC >= 8.5" -- The Block Template API used requires at least WooCommerce 8.5
-		return version_compare( WC_VERSION, '8.5', '>=' ) && PageController::is_admin_page();
+		// compatibility-code "WC >= 8.6" -- The Block Template API used requires at least WooCommerce 8.6
+		return version_compare( WC_VERSION, '8.6', '>=' );
 	}
 
 	/**
@@ -97,11 +97,11 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 			add_action( 'init', [ $this, 'hook_init' ] );
 		}
 
-		// https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/AbstractProductFormTemplate.php#L16
+		// https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/AbstractProductFormTemplate.php#L19
 		$template_area = 'product-form';
 
-		// https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php#L18
-		// https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php#L18
+		// https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php#L19
+		// https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php#L19
 		$block_id = 'general';
 
 		add_action(

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -286,6 +286,42 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 		$this->product_blocks_service->hook_block_template( $this->variation_anchor_group );
 	}
 
+	public function test_hook_block_template_group_hidden_condition() {
+		$this->simple['group']
+			->expects( $this->exactly( 1 ) )
+			->method( 'add_hide_condition' )
+			->with( "editedProduct.type !== 'simple' && editedProduct.type !== 'variable' && editedProduct.type !== 'variation'" );
+
+		$this->variation['group']
+			->expects( $this->exactly( 0 ) )
+			->method( 'add_hide_condition' );
+
+		$this->product_blocks_service->hook_block_template( $this->simple_anchor_group );
+		$this->product_blocks_service->hook_block_template( $this->variation_anchor_group );
+	}
+
+	public function test_hook_block_template_group_hidden_condition_with_applying_filter() {
+		$this->simple['group']
+			->expects( $this->exactly( 1 ) )
+			->method( 'add_hide_condition' )
+			->with( "editedProduct.type !== 'simple'" );
+
+		$this->variation['group']
+			->expects( $this->exactly( 1 ) )
+			->method( 'add_hide_condition' )
+			->with( 'true' );
+
+		add_filter(
+			'woocommerce_gla_supported_product_types',
+			function () {
+				return [ 'simple' ];
+			}
+		);
+
+		$this->product_blocks_service->hook_block_template( $this->simple_anchor_group );
+		$this->product_blocks_service->hook_block_template( $this->variation_anchor_group );
+	}
+
 	public function test_hook_block_template_merchant_center_setup_is_not_complete() {
 		$this->is_mc_setup_complete = false;
 

--- a/tests/Unit/Admin/ProductBlocksServiceTest.php
+++ b/tests/Unit/Admin/ProductBlocksServiceTest.php
@@ -69,9 +69,9 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 	protected const GENERAL_GROUP_HOOK = 'woocommerce_block_template_area_product-form_after_add_block_general';
 
 	public function setUp(): void {
-		// compatibility-code "WC >= 8.5" -- The Block Template API used requires at least WooCommerce 8.5
-		if ( ! version_compare( WC_VERSION, '8.5', '>=' ) ) {
-			$this->markTestSkipped( 'This test suite requires WooCommerce version >= 8.5' );
+		// compatibility-code "WC >= 8.6" -- The Block Template API used requires at least WooCommerce 8.6
+		if ( ! ProductBlocksService::is_needed() ) {
+			$this->markTestSkipped( 'This test suite requires WooCommerce version >= 8.6' );
 		}
 
 		parent::setUp();
@@ -97,7 +97,7 @@ class ProductBlocksServiceTest extends ContainerAwareUnitTest {
 				}
 			);
 
-		// Ref: https://github.com/woocommerce/woocommerce/blob/8.3.0/plugins/woocommerce/src/Admin/PageController.php#L555-L562
+		// Ref: https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce/src/Admin/PageController.php#L555-L562
 		$_GET['page'] = PageController::PAGE_ROOT;
 
 		$this->simple    = $this->setUpBlockMock( $this->simple_anchor_group, 'simple-product' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In WooCommerce 8.6, the Product Block Editor has some breaking changes:
- The template of Product Block Editor is changed to be fetched via the `/wc/v3/layout-templates` REST API.
   - Ref: https://github.com/woocommerce/woocommerce/pull/43589
- Product Block Editor starts supporting the **grouped** and **external** product types but they share the same template "simple-product".
   - Ref: https://github.com/woocommerce/woocommerce/pull/41823

Before adjusting, some preprocessing makes the `ProductBlocksService` class easier to test:

- 355f61ded45dbfc45657100291277984343d42aa: Change to use a dedicated method as the `'init'` action handler.
- 175d53cc6295cfdc86437aa075ea22526dbe614e: Change to use a dedicated method as the `"woocommerce_block_template_area_{$template_area}_after_add_block_{$block_id}"` action handler.

To be compatible with the above, it requires a few adjustments:
- f0544940a6f3a022c6781d2fd1bca999c1ba9300: Remove the is_admin_page check from the conditional registration of `ProductBlocksService` and set the minimum support WC version to 8.6.
- 8bbf6713346883125d8c831536da1bcede70ef91: Hide this extension's group from Product Block Editor for the unsupported product types.

### 📌 Checklist for @eason9487

- [x] Check if all links starting with `https://github.com/woocommerce/woocommerce/blob/8.6.0/[...]` point to the correct lines of code.
- [x] Revert 955a9a6a79968e653d7500fe80e04c9ef970c88b before merging

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/4bbf7b04-f944-446a-a777-61a18d7cd8f7

### Detailed test instructions:

#### 📌 Prepare test environment

1. Please refer to [the test preparation in PR 2151](https://github.com/woocommerce/google-listings-and-ads/pull/2151#prepare-test-environment) with **Woo 8.6.0**.
   - 💡 Currently, it can be tested with [8.6.0-rc.1](https://github.com/woocommerce/woocommerce/releases/tag/8.6.0-rc.1)
1. `npm install`
1. `npm start`

#### 📌 Test the visibility of this extension's tab and blocks

💡 By default, the supported product types of this extension are [simple, variable, and variation](https://github.com/woocommerce/google-listings-and-ads/blob/8bbf6713346883125d8c831536da1bcede70ef91/src/Product/ProductSyncer.php#L258-L265).

1. Start creating a new product.
1. The **Google Listings & Ads** tab should be visible.
1. Enter product name.
1. In the **General** tab, change to other product types back and forth.
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/bb3152b3-61be-41b7-9996-95b8e4deb285)
1. Check if the **Google Listings & Ads** tab is only visible when selecting the **Standard product** type.
1. Go to edit a variable product, e.g. the **Hoodie** imported from WC's sample products.
1. The **Google Listings & Ads** tab should be visible.
1. Switch to the **Variations** tab.
1. Click one of the **Edit** links within the **Variations** section to edit a variation product.
1. The **Google Listings & Ads** tab should be visible.

### Changelog entry
