### PR TITLE
Add Shipping notifications

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -744,7 +744,7 @@ class ConnectionTest implements Service, Registerable {
 			$topic = $_GET['topic'];
 
 			$service = new NotificationsService();
-			if ( $service->notify( $item, $topic ) ) {
+			if ( $service->notify( $topic, $item ) ) {
 				$this->response .= "\n Notification success. Item: " . $item . " - Topic: " . $topic;
 			} else {
 				$this->response .= "\n Notification failed. Item: " . $item . " - Topic: " . $topic;

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -637,7 +637,7 @@ class ConnectionTest implements Service, Registerable {
 							<td>
 								<p>
 									<label>
-										Product/Coupon/Shipping ID <input name="item_id" type="text" value="<?php echo ! empty( $_GET['item_id'] ) ? intval( $_GET['item_id'] ) : ''; ?>" />
+										Product/Coupon ID <input name="item_id" type="text" value="<?php echo ! empty( $_GET['item_id'] ) ? intval( $_GET['item_id'] ) : ''; ?>" />
 									</label>
 									<br />
 									<br />
@@ -650,6 +650,7 @@ class ConnectionTest implements Service, Registerable {
 											<option value="coupon.create" <?php echo $_GET['topic'] === 'coupon.create' ? "selected" : ""?>>coupon.create</option>
 											<option value="coupon.delete" <?php echo $_GET['topic'] === 'coupon.delete' ? "selected" : ""?>>coupon.delete</option>
 											<option value="coupon.update" <?php echo $_GET['topic'] === 'coupon.update' ? "selected" : ""?>>coupon.update</option>
+											<option value="shipping.update" <?php echo $_GET['topic'] === 'shipping.update' ? "selected" : ""?>>shipping.update</option>
 										</select>
 									</label>
 									<button class="button">Send Notification</button>

--- a/src/Google/NotificationsService.php
+++ b/src/Google/NotificationsService.php
@@ -48,7 +48,7 @@ class NotificationsService implements Service {
 	 * https://public-api.wordpress.com/wpcom/v2/sites/{site}/partners/google/notifications
 	 *
 	 * @param string   $topic The topic to use in the notification.
-	 * @param int|null $item_id Tme item ID to notify. It can be null for topics that doesn't need Item ID
+	 * @param int|null $item_id The item ID to notify. It can be null for topics that doesn't need Item ID
 	 * @return bool True is the notification is successful. False otherwise.
 	 */
 	public function notify( string $topic, $item_id = null ): bool {

--- a/src/Google/NotificationsService.php
+++ b/src/Google/NotificationsService.php
@@ -25,8 +25,7 @@ class NotificationsService implements Service {
 	public const TOPIC_COUPON_CREATED   = 'coupon.create';
 	public const TOPIC_COUPON_DELETED   = 'coupon.delete';
 	public const TOPIC_COUPON_UPDATED   = 'coupon.update';
-	public const TOPIC_SHIPPING_SAVED   = 'action.woocommerce_after_shipping_zone_object_save';
-	public const TOPIC_SHIPPING_DELETED = 'action.woocommerce_delete_shipping_zone';
+	public const TOPIC_SHIPPING_UPDATED = 'shipping.update';
 
 	/**
 	 * The url to send the notification
@@ -48,11 +47,11 @@ class NotificationsService implements Service {
 	 * Calls the Notification endpoint in WPCOM.
 	 * https://public-api.wordpress.com/wpcom/v2/sites/{site}/partners/google/notifications
 	 *
-	 * @param int    $item_id
-	 * @param string $topic
+	 * @param string   $topic The topic to use in the notification.
+	 * @param int|null $item_id Tme item ID to notify. It can be null for topics that doesn't need Item ID
 	 * @return bool True is the notification is successful. False otherwise.
 	 */
-	public function notify( int $item_id, string $topic ): bool {
+	public function notify( string $topic, $item_id = null ): bool {
 		/**
 		 * Allow users to disable the notification request.
 		 *
@@ -65,12 +64,6 @@ class NotificationsService implements Service {
 		if ( ! apply_filters( 'woocommerce_gla_notify', true, $item_id, $topic ) ) {
 			return false;
 		}
-
-		do_action(
-			'woocommerce_gla_debug_message',
-			sprintf( 'Notification - Item ID: %d - Topic: %s', $item_id, $topic ),
-			__METHOD__
-		);
 
 		$remote_args = [
 			'method'  => 'POST',
@@ -88,9 +81,15 @@ class NotificationsService implements Service {
 
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) >= 400 ) {
 			$error = is_wp_error( $response ) ? $response->get_error_message() : wp_remote_retrieve_body( $response );
-			$this->notification_error( $item_id, $topic, $error );
+			$this->notification_error( $topic, $error, $item_id );
 			return false;
 		}
+
+		do_action(
+			'woocommerce_gla_debug_message',
+			sprintf( 'Notification - Item ID: %s - Topic: %s', $item_id, $topic ),
+			__METHOD__
+		);
 
 		return true;
 	}
@@ -98,14 +97,14 @@ class NotificationsService implements Service {
 	/**
 	 * Logs an error.
 	 *
-	 * @param int    $item_id
-	 * @param string $topic
-	 * @param string $error
+	 * @param string   $topic
+	 * @param string   $error
+	 * @param int|null $item_id
 	 */
-	private function notification_error( int $item_id, string $topic, string $error ): void {
+	private function notification_error( string $topic, string $error, $item_id = null ): void {
 		do_action(
 			'woocommerce_gla_error',
-			sprintf( 'Error sending notification for Item ID %d with topic %s. %s', $item_id, $topic, $error ),
+			sprintf( 'Error sending notification for Item ID %s with topic %s. %s', $item_id, $topic, $error ),
 			__METHOD__
 		);
 	}

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ProductNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ShippingNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncerJobInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ResubmitExpiringProducts;
@@ -145,9 +146,15 @@ class JobServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( StartProductSync::class, JobRepository::class );
 		$this->share_with_tags( PluginUpdate::class, JobRepository::class );
 
+		// Share shipping notifications job
+		$this->share_action_scheduler_job(
+			ShippingNotificationJob::class,
+			NotificationsService::class
+		);
+
 		// Share shipping settings syncer job and hooks.
 		$this->share_action_scheduler_job( UpdateShippingSettings::class, MerchantCenterService::class, GoogleSettings::class );
-		$this->share_with_tags( Shipping\SyncerHooks::class, MerchantCenterService::class, GoogleSettings::class, JobRepository::class );
+		$this->share_with_tags( Shipping\SyncerHooks::class, MerchantCenterService::class, GoogleSettings::class, JobRepository::class, NotificationsService::class );
 
 		// Share plugin update jobs
 		$this->share_product_syncer_job( CleanupProductTargetCountriesJob::class );

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -86,17 +86,7 @@ class ProductNotificationJob extends AbstractActionSchedulerJob implements JobIn
 	 * @param array $args
 	 */
 	public function schedule( array $args = [] ): void {
-		/**
-		 * Allow users to disable the notification job schedule.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
-		 * @param array $args The arguments for the schedule function with the item id and the topic.
-		 */
-		$can_schedule = apply_filters( 'woocommerce_gla_product_notification_job_can_schedule', $this->can_schedule( [ $args ] ), $args );
-
-		if ( $can_schedule ) {
+		if ( $this->can_schedule( $args ) ) {
 			$this->action_scheduler->schedule_immediate(
 				$this->get_process_item_hook(),
 				[ $args ]
@@ -149,5 +139,24 @@ class ProductNotificationJob extends AbstractActionSchedulerJob implements JobIn
 		} else {
 			return $this->product_helper->should_trigger_update_notification( $product );
 		}
+	}
+
+	/**
+	 * Can the job be scheduled.
+	 *
+	 * @param array|null $args
+	 *
+	 * @return bool Returns true if the job can be scheduled.
+	 */
+	public function can_schedule( $args = [] ): bool {
+		/**
+		 * Allow users to disable the notification job schedule.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
+		 * @param array $args The arguments for the schedule function with the item id and the topic.
+		 */
+		return apply_filters( 'woocommerce_gla_product_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $args );
 	}
 }

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -75,7 +75,7 @@ class ProductNotificationJob extends AbstractActionSchedulerJob implements JobIn
 		$item  = $args[0];
 		$topic = $args[1];
 
-		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $item, $topic ) ) {
+		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
 			$this->set_status( $item, $this->get_after_notification_status( $topic ) );
 		}
 	}

--- a/src/Jobs/Notifications/ShippingNotificationJob.php
+++ b/src/Jobs/Notifications/ShippingNotificationJob.php
@@ -40,7 +40,7 @@ class ShippingNotificationJob extends AbstractActionSchedulerJob implements JobI
 	public function __construct(
 		ActionSchedulerInterface $action_scheduler,
 		ActionSchedulerJobMonitor $monitor,
-		NotificationsService $notifications_service,
+		NotificationsService $notifications_service
 	) {
 		$this->notifications_service = $notifications_service;
 		$this->topic                 = NotificationsService::TOPIC_SHIPPING_UPDATED;

--- a/src/Jobs/Notifications/ShippingNotificationJob.php
+++ b/src/Jobs/Notifications/ShippingNotificationJob.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractActionSchedulerJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ShippingNotificationJob
+ * Class for the Shipping Notifications
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
+ */
+class ShippingNotificationJob extends AbstractActionSchedulerJob implements JobInterface {
+
+	/**
+	 * @var NotificationsService $notifications_service
+	 */
+	protected $notifications_service;
+
+	/**
+	 * @var string $topic
+	 */
+	protected $topic;
+
+	/**
+	 * Notifications Jobs constructor.
+	 *
+	 * @param ActionSchedulerInterface  $action_scheduler
+	 * @param ActionSchedulerJobMonitor $monitor
+	 * @param NotificationsService      $notifications_service
+	 */
+	public function __construct(
+		ActionSchedulerInterface $action_scheduler,
+		ActionSchedulerJobMonitor $monitor,
+		NotificationsService $notifications_service,
+	) {
+		$this->notifications_service = $notifications_service;
+		$this->topic                 = NotificationsService::TOPIC_SHIPPING_UPDATED;
+		parent::__construct( $action_scheduler, $monitor );
+	}
+
+	/**
+	 * Get the job name
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'notifications/shipping';
+	}
+
+
+	/**
+	 * Logic when processing the items
+	 *
+	 * @param array $args Arguments with the item id and the topic
+	 */
+	protected function process_items( array $args ): void {
+		$this->notifications_service->notify( $this->topic );
+	}
+
+	/**
+	 * Schedule the Product Notification Job
+	 *
+	 * @param array $args
+	 */
+	public function schedule( array $args = [] ): void {
+		/**
+		 * Allow users to disable the notification job schedule.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
+		 * @param array $args The arguments for the schedule function.
+		 */
+		$can_schedule = apply_filters( 'woocommerce_gla_shipping_notification_job_can_schedule', $this->can_schedule( [ $args ] ), $args );
+
+		if ( $can_schedule ) {
+			$this->action_scheduler->schedule_immediate(
+				$this->get_process_item_hook(),
+				[ $args ]
+			);
+		}
+	}
+}

--- a/src/Jobs/Notifications/ShippingNotificationJob.php
+++ b/src/Jobs/Notifications/ShippingNotificationJob.php
@@ -72,21 +72,30 @@ class ShippingNotificationJob extends AbstractActionSchedulerJob implements JobI
 	 * @param array $args
 	 */
 	public function schedule( array $args = [] ): void {
+		if ( $this->can_schedule( $args ) ) {
+			$this->action_scheduler->schedule_immediate(
+				$this->get_process_item_hook(),
+				[ $args ]
+			);
+		}
+	}
+
+	/**
+	 * Can the job be scheduled.
+	 *
+	 * @param array|null $args
+	 *
+	 * @return bool Returns true if the job can be scheduled.
+	 */
+	public function can_schedule( $args = [] ): bool {
 		/**
 		 * Allow users to disable the notification job schedule.
 		 *
 		 * @since x.x.x
 		 *
 		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
-		 * @param array $args The arguments for the schedule function.
+		 * @param array $args The arguments for the schedule function with the item id and the topic.
 		 */
-		$can_schedule = apply_filters( 'woocommerce_gla_shipping_notification_job_can_schedule', $this->can_schedule( [ $args ] ), $args );
-
-		if ( $can_schedule ) {
-			$this->action_scheduler->schedule_immediate(
-				$this->get_process_item_hook(),
-				[ $args ]
-			);
-		}
+		return apply_filters( 'woocommerce_gla_shipping_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $args );
 	}
 }

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -4,9 +4,11 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ShippingNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 
@@ -46,16 +48,29 @@ class SyncerHooks implements Service, Registerable {
 	protected $update_shipping_job;
 
 	/**
+	 * @var NotificationsService $notifications_service
+	 */
+	protected $notifiations_service;
+
+	/**
+	 * @var ShippingNotificationJob $shipping_notification_job
+	 */
+	protected $shipping_notification_job;
+
+	/**
 	 * SyncerHooks constructor.
 	 *
 	 * @param MerchantCenterService $merchant_center
 	 * @param GoogleSettings        $google_settings
 	 * @param JobRepository         $job_repository
+	 * @param NotificationsService  $notifications_service
 	 */
-	public function __construct( MerchantCenterService $merchant_center, GoogleSettings $google_settings, JobRepository $job_repository ) {
-		$this->google_settings     = $google_settings;
-		$this->merchant_center     = $merchant_center;
-		$this->update_shipping_job = $job_repository->get( UpdateShippingSettings::class );
+	public function __construct( MerchantCenterService $merchant_center, GoogleSettings $google_settings, JobRepository $job_repository, NotificationsService $notifications_service ) {
+		$this->google_settings           = $google_settings;
+		$this->merchant_center           = $merchant_center;
+		$this->update_shipping_job       = $job_repository->get( UpdateShippingSettings::class );
+		$this->shipping_notification_job = $job_repository->get( ShippingNotificationJob::class );
+		$this->notifiations_service      = $notifications_service;
 	}
 
 	/**
@@ -128,7 +143,13 @@ class SyncerHooks implements Service, Registerable {
 		if ( $this->already_scheduled ) {
 			return;
 		}
-		$this->update_shipping_job->schedule();
+
+		if ( $this->notifiations_service->is_enabled() ) {
+			$this->shipping_notification_job->schedule();
+		} else {
+			$this->update_shipping_job->schedule();
+		}
+
 		$this->already_scheduled = true;
 	}
 }

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -50,7 +50,7 @@ class SyncerHooks implements Service, Registerable {
 	/**
 	 * @var NotificationsService $notifications_service
 	 */
-	protected $notifiations_service;
+	protected $notifications_service;
 
 	/**
 	 * @var ShippingNotificationJob $shipping_notification_job
@@ -70,7 +70,7 @@ class SyncerHooks implements Service, Registerable {
 		$this->merchant_center           = $merchant_center;
 		$this->update_shipping_job       = $job_repository->get( UpdateShippingSettings::class );
 		$this->shipping_notification_job = $job_repository->get( ShippingNotificationJob::class );
-		$this->notifiations_service      = $notifications_service;
+		$this->notifications_service     = $notifications_service;
 	}
 
 	/**
@@ -144,7 +144,7 @@ class SyncerHooks implements Service, Registerable {
 			return;
 		}
 
-		if ( $this->notifiations_service->is_enabled() ) {
+		if ( $this->notifications_service->is_enabled() ) {
 			$this->shipping_notification_job->schedule();
 		} else {
 			$this->update_shipping_job->schedule();

--- a/tests/Unit/Google/NotificationsServiceTest.php
+++ b/tests/Unit/Google/NotificationsServiceTest.php
@@ -77,7 +77,7 @@ class NotificationsServiceTest extends UnitTest {
 		];
 
 		$this->service->expects( $this->once() )->method( 'do_request' )->with( $args )->willReturn( [ 'code' => 200 ] );
-		$this->assertTrue( $this->service->notify( $item_id, $topic ) );
+		$this->assertTrue( $this->service->notify( $topic, $item_id ) );
 	}
 
 
@@ -88,7 +88,7 @@ class NotificationsServiceTest extends UnitTest {
 		$this->service = $this->get_mock();
 
 		$this->service->expects( $this->once() )->method( 'do_request' )->willReturn( new \WP_Error( 'error', 'error message' ) );
-		$this->assertFalse( $this->service->notify( 1, 'topic' ) );
+		$this->assertFalse( $this->service->notify( 'topic', 1 ) );
 		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
 	}
 
@@ -106,7 +106,7 @@ class NotificationsServiceTest extends UnitTest {
 				],
 			]
 		);
-		$this->assertFalse( $this->service->notify( 1, 'topic' ) );
+		$this->assertFalse( $this->service->notify( 'topic', 1 ) );
 		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
 	}
 

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -121,7 +121,7 @@ class ProductNotificationJobTest extends UnitTest {
 
 		$this->notification_service->expects( $this->once() )
 			->method( 'notify' )
-			->with( $id, $topic )
+			->with( $topic, $id )
 			->willReturn( true );
 
 		$this->product_helper->expects( $this->exactly( 2 ) )
@@ -157,7 +157,7 @@ class ProductNotificationJobTest extends UnitTest {
 
 		$this->notification_service->expects( $this->once() )
 			->method( 'notify' )
-			->with( $id, $topic )
+			->with( $topic, $id )
 			->willReturn( false );
 
 		$this->product_helper->expects( $this->once() )

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -68,9 +68,11 @@ class ProductNotificationJobTest extends UnitTest {
 		$topic = 'product.create';
 		$id    = 1;
 
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
+			->with( self::PROCESS_ITEM_HOOK, [ $id, $topic ] )
 			->willReturn( false );
 
 		$this->action_scheduler->expects( $this->once() )
@@ -87,9 +89,11 @@ class ProductNotificationJobTest extends UnitTest {
 		$id    = 1;
 		$topic = 'product.create';
 
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
+			->with( self::PROCESS_ITEM_HOOK, [ $id, $topic ] )
 			->willReturn( true );
 
 		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
@@ -97,16 +101,14 @@ class ProductNotificationJobTest extends UnitTest {
 		$this->job->schedule( [ $id, $topic ] );
 	}
 
-	public function test_schedule_doesnt_schedules_immediate_job_if_filtered() {
+	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
 		$id    = 1;
 		$topic = 'product.create';
 
-		add_filter( 'woocommerce_gla_product_notification_job_can_schedule', '__return_false' );
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
 
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
-			->willReturn( false );
+		$this->action_scheduler->expects( $this->never() )
+			->method( 'has_scheduled_action' );
 
 		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
 

--- a/tests/Unit/Jobs/ShippingNotificationJobTest.php
+++ b/tests/Unit/Jobs/ShippingNotificationJobTest.php
@@ -1,0 +1,107 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ProductNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ShippingNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Helper_Product;
+
+/**
+ * Class ShippingNotificationJobTest
+ *
+ * @group Notifications
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+class ShippingNotificationJobTest extends UnitTest {
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|NotificationsService $notification_service */
+	protected $notification_service;
+
+	/** @var ProductNotificationJob $job */
+	protected $job;
+
+	protected const JOB_NAME          = 'notifications/shipping';
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->notification_service = $this->createMock( NotificationsService::class );
+		$this->job                  = new ShippingNotificationJob(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->notification_service
+		);
+
+		$this->job->init();
+	}
+
+	public function test_job_name() {
+		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
+	}
+
+	public function test_schedule_schedules_immediate_job() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( self::PROCESS_ITEM_HOOK, [] )
+			->willReturn( false );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( self::PROCESS_ITEM_HOOK );
+
+		$this->job->schedule();
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( self::PROCESS_ITEM_HOOK, [] )
+			->willReturn( true );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule();
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
+
+		$this->action_scheduler->expects( $this->never() )
+			->method( 'has_scheduled_action' );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule();
+	}
+
+	public function test_process_items_calls_notify() {
+		$this->notification_service->expects( $this->once() )
+			->method( 'notify' )
+			->with( NotificationsService::TOPIC_SHIPPING_UPDATED )
+			->willReturn( true );
+
+		$this->job->handle_process_items_action();
+	}
+}

--- a/tests/Unit/Shipping/SyncerHooksTest.php
+++ b/tests/Unit/Shipping/SyncerHooksTest.php
@@ -4,7 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ShippingNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\SyncerHooks;
@@ -27,8 +29,14 @@ class SyncerHooksTest extends UnitTest {
 	/** @var MockObject|GoogleSettings $google_settings */
 	protected $google_settings;
 
+	/** @var MockObject|NotificationsService $notification_service */
+	protected $notification_service;
+
 	/** @var MockObject|UpdateShippingSettings $update_shipping_job */
 	protected $update_shipping_job;
+
+	/** @var MockObject|ShippingNotificationJob $shipping_notification_job */
+	protected $shipping_notification_job;
 
 	/** @var MockObject|JobRepository $job_repository */
 	protected $job_repository;
@@ -185,6 +193,39 @@ class SyncerHooksTest extends UnitTest {
 		$zone->save();
 	}
 
+	public function test_saving_shipping_zone_doesnt_schedule_notifications_when_disabled() {
+		$this->mock_sync_ready_flags_and_register_hooks( true, true );
+
+		$this->notification_service->expects( $this->once() )
+			->method( 'is_enabled' );
+
+		$this->shipping_notification_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( 'GB' );
+		$zone->add_location( 'GB', 'country' );
+		$zone->save();
+	}
+
+	public function test_saving_shipping_zone_doesnt_schedule_notifications_when_enabled() {
+		$this->mock_sync_ready_flags_and_register_hooks( true, true );
+
+		$this->notification_service->expects( $this->once() )
+			->method( 'is_enabled' )->willReturn( true );
+
+		$this->shipping_notification_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->update_shipping_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( 'GB' );
+		$zone->add_location( 'GB', 'country' );
+		$zone->save();
+	}
+
 	/**
 	 * Mocks the validation methods that allow/disallow the shipping settings to be synced.
 	 *
@@ -226,18 +267,23 @@ class SyncerHooksTest extends UnitTest {
 			]
 		);
 
-		$this->merchant_center     = $this->createMock( MerchantCenterService::class );
-		$this->google_settings     = $this->createMock( GoogleSettings::class );
-		$this->update_shipping_job = $this->createMock( UpdateShippingSettings::class );
-		$this->job_repository      = $this->createMock( JobRepository::class );
+		$this->notification_service      = $this->createMock( NotificationsService::class );
+		$this->merchant_center           = $this->createMock( MerchantCenterService::class );
+		$this->google_settings           = $this->createMock( GoogleSettings::class );
+		$this->update_shipping_job       = $this->createMock( UpdateShippingSettings::class );
+		$this->shipping_notification_job = $this->createMock( ShippingNotificationJob::class );
+		$this->job_repository            = $this->createMock( JobRepository::class );
 		$this->job_repository->expects( $this->any() )
 			->method( 'get' )
 			->willReturnMap(
 				[
+					[ ShippingNotificationJob::class, $this->shipping_notification_job ],
 					[ UpdateShippingSettings::class, $this->update_shipping_job ],
 				]
 			);
 
-		$this->syncer_hooks = new SyncerHooks( $this->merchant_center, $this->google_settings, $this->job_repository );
+		add_filter( 'woocommerce_gla_notifications_enabled', '__return_false' );
+
+		$this->syncer_hooks = new SyncerHooks( $this->merchant_center, $this->google_settings, $this->job_repository, $this->notification_service );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implement Notifications for Shipping Updates.
As discussed for now we don't send Item IDs and just send a generic "shipping.update" method with no Item ID



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
 
1. Checkout this PR, complete onboarding and select "Shipping Rates --> Automatically sync my store’s shipping settings to Google."
2. Go to WooCommerce -- Settings -- Shipping and update something 
3. See the Job `gla/jobs/notifications/shipping/process_item` appearing
4. Run it and see the notification `shipping.update` happening 


### Additional details:

⚠️  The topic needs to be enabled in the Proxy, so all the notifications will fail 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
