### PR TITLE
Create product statuses jobs for each page token

### DIFF
--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -105,7 +105,7 @@ class MerchantReport implements OptionsAwareInterface {
 
 			}
 
-			$product_view_data['next_page'] = $response->getNextPageToken();
+			$product_view_data['next_page_token'] = $response->getNextPageToken();
 
 			return $product_view_data;
 		} catch ( GoogleException $e ) {

--- a/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use WP_REST_Response as Response;
 use WP_REST_Request as Request;
@@ -27,16 +28,25 @@ class ProductStatisticsController extends BaseOptionsController {
 	 */
 	protected $merchant_statuses;
 
+	/**
+	 * Helper class to count scheduled sync jobs.
+	 *
+	 * @var ProductSyncStats
+	 */
+	protected $sync_stats;
+
 
 	/**
 	 * ProductStatisticsController constructor.
 	 *
 	 * @param RESTServer       $server
 	 * @param MerchantStatuses $merchant_statuses
+	 * @param ProductSyncStats $sync_stats
 	 */
-	public function __construct( RESTServer $server, MerchantStatuses $merchant_statuses ) {
+	public function __construct( RESTServer $server, MerchantStatuses $merchant_statuses, ProductSyncStats $sync_stats ) {
 		parent::__construct( $server );
 		$this->merchant_statuses = $merchant_statuses;
+		$this->sync_stats        = $sync_stats;
 	}
 
 	/**
@@ -100,6 +110,8 @@ class ProductStatisticsController extends BaseOptionsController {
 		try {
 			$response = $this->merchant_statuses->get_product_statistics( $force_refresh );
 
+			$response['scheduled_sync'] = $this->sync_stats->get_count();
+
 			return $this->prepare_item_for_response( $response, $request );
 		} catch ( Exception $e ) {
 			return $this->response_from_exception( $e );
@@ -113,13 +125,13 @@ class ProductStatisticsController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'timestamp'  => [
+			'timestamp'      => [
 				'type'        => 'number',
 				'description' => __( 'Timestamp reflecting when the product status statistics were last generated.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'statistics' => [
+			'statistics'     => [
 				'type'        => 'object',
 				'description' => __( 'Merchant Center product status statistics.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
@@ -152,7 +164,13 @@ class ProductStatisticsController extends BaseOptionsController {
 					],
 				],
 			],
-			'loading'    => [
+			'scheduled_sync' => [
+				'type'        => 'number',
+				'description' => __( 'Amount of scheduled jobs which will sync products to Google.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+			'loading'        => [
 				'type'        => 'boolean',
 				'description' => __( 'Whether the product statistics are loading.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],

--- a/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use WP_REST_Response as Response;
 use WP_REST_Request as Request;
@@ -28,25 +27,16 @@ class ProductStatisticsController extends BaseOptionsController {
 	 */
 	protected $merchant_statuses;
 
-	/**
-	 * Helper class to count scheduled sync jobs.
-	 *
-	 * @var ProductSyncStats
-	 */
-	protected $sync_stats;
-
 
 	/**
 	 * ProductStatisticsController constructor.
 	 *
 	 * @param RESTServer       $server
 	 * @param MerchantStatuses $merchant_statuses
-	 * @param ProductSyncStats $sync_stats
 	 */
-	public function __construct( RESTServer $server, MerchantStatuses $merchant_statuses, ProductSyncStats $sync_stats ) {
+	public function __construct( RESTServer $server, MerchantStatuses $merchant_statuses ) {
 		parent::__construct( $server );
 		$this->merchant_statuses = $merchant_statuses;
-		$this->sync_stats        = $sync_stats;
 	}
 
 	/**
@@ -110,8 +100,6 @@ class ProductStatisticsController extends BaseOptionsController {
 		try {
 			$response = $this->merchant_statuses->get_product_statistics( $force_refresh );
 
-			$response['scheduled_sync'] = $this->sync_stats->get_count();
-
 			return $this->prepare_item_for_response( $response, $request );
 		} catch ( Exception $e ) {
 			return $this->response_from_exception( $e );
@@ -125,13 +113,13 @@ class ProductStatisticsController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'timestamp'      => [
+			'timestamp'  => [
 				'type'        => 'number',
 				'description' => __( 'Timestamp reflecting when the product status statistics were last generated.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'statistics'     => [
+			'statistics' => [
 				'type'        => 'object',
 				'description' => __( 'Merchant Center product status statistics.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
@@ -164,9 +152,9 @@ class ProductStatisticsController extends BaseOptionsController {
 					],
 				],
 			],
-			'scheduled_sync' => [
-				'type'        => 'number',
-				'description' => __( 'Amount of scheduled jobs which will sync products to Google.', 'google-listings-and-ads' ),
+			'loading'    => [
+				'type'        => 'boolean',
+				'description' => __( 'Whether the product statistics are loading.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -110,7 +110,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share_with_container( AdsReportsController::class );
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );
-		$this->share( MerchantCenterProductStatsController::class, MerchantStatuses::class, ProductSyncStats::class );
+		$this->share( MerchantCenterProductStatsController::class, MerchantStatuses::class );
 		$this->share( MerchantCenterIssuesController::class, MerchantStatuses::class, ProductHelper::class );
 		$this->share( MerchantCenterProductFeedController::class, ProductFeedQueryHelper::class );
 		$this->share( MerchantCenterProductVisibilityController::class, ProductHelper::class, MerchantIssueQuery::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -110,7 +110,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share_with_container( AdsReportsController::class );
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );
-		$this->share( MerchantCenterProductStatsController::class, MerchantStatuses::class );
+		$this->share( MerchantCenterProductStatsController::class, MerchantStatuses::class, ProductSyncStats::class );
 		$this->share( MerchantCenterIssuesController::class, MerchantStatuses::class, ProductHelper::class );
 		$this->share( MerchantCenterProductFeedController::class, ProductFeedQueryHelper::class );
 		$this->share( MerchantCenterProductVisibilityController::class, ProductHelper::class, MerchantIssueQuery::class );

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -90,7 +90,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 		}
 
 		$results         = $this->merchant_report->get_product_view_report( $next_page_token );
-		$next_page_token = $results['next_page'];
+		$next_page_token = $results['next_page_token'];
 
 		$this->merchant_statuses->update_product_stats( $results['statuses'] );
 
@@ -118,7 +118,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	 * @return bool
 	 */
 	public function is_scheduled(): bool {
-		// We set 'args' to null so that it matches any arguments. This is because it's possible to have multiple instances of the job running with different page tokens
+		// We set 'args' to null so it matches any arguments. This is because it's possible to have multiple instances of the job running with different page tokens
 		return $this->is_running( null );
 	}
 }

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -87,7 +87,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 		// Clear the cache if we're starting from the beginning.
 		if ( ! $next_page_token ) {
 			$this->merchant_statuses->clear_cache();
-			$this->merchant_statuses->delete_product_status_count_intermediate_data();
+			$this->merchant_statuses->delete_product_statuses_count_intermediate_data();
 		}
 
 		$results         = $this->merchant_report->get_product_view_report( $next_page_token );

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -87,6 +87,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 		// Clear the cache if we're starting from the beginning.
 		if ( ! $next_page_token ) {
 			$this->merchant_statuses->clear_cache();
+			$this->merchant_statuses->delete_product_status_count_intermediate_data();
 		}
 
 		$results         = $this->merchant_report->get_product_view_report( $next_page_token );

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -92,8 +92,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 		$results         = $this->merchant_report->get_product_view_report( $next_page_token );
 		$next_page_token = $results['next_page'];
 
-		$this->merchant_statuses->process_product_statuses( $results['statuses'] );
-		$this->merchant_statuses->update_product_stats();
+		$this->merchant_statuses->update_product_stats( $results['statuses'] );
 
 		if ( $next_page_token ) {
 			$this->schedule( [ [ 'next_page_token' => $next_page_token ] ] );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -179,6 +179,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * Check if the Merchant Center account is connected and throw an exception if it's not.
 	 *
+	 * @since x.x.x
+	 *
 	 * @throws Exception If the Merchant Center account is not connected.
 	 */
 	protected function check_mc_is_connected() {
@@ -601,7 +603,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	 * @param array[] $statuses statuses.
 	 * @see MerchantReport::get_product_view_report
 	 */
-	public function process_product_statuses( $statuses ): void {
+	public function process_product_statuses( array $statuses ): void {
 		$this->product_statuses = [
 			'products' => [],
 			'parents'  => [],
@@ -657,6 +659,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 	/**
 	 * Update the product status statistics for a list of products statuses.
+	 *
+	 * @since x.x.x
 	 *
 	 * @param array[] $statuses statuses. See statuses format in MerchantReport::get_product_view_report.
 	 */
@@ -776,6 +780,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	/**
 	 * Calculate the total count of products in the MC using the statistics.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param array $statistics
 	 *
 	 * @return int
@@ -792,6 +798,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 	/**
 	 * Handle the completion of the Merchant Center statuses fetching.
+	 *
+	 * @since x.x.x
 	 */
 	public function handle_complete_mc_statuses_fetching() {
 		$mc_statuses = $this->container->get( TransientsInterface::class )->get( Transients::MC_STATUSES );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -656,10 +656,15 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 	}
 
 	/**
-	 * Update the product status statistics.
+	 * Update the product status statistics for a list of products statuses.
+	 *
+	 * @param array[] $statuses statuses. See statuses format in MerchantReport::get_product_view_report.
 	 */
-	public function update_product_stats() {
+	public function update_product_stats( array $statuses ): void {
 		$this->mc_statuses = [];
+
+		$this->process_product_statuses( $statuses );
+
 		// Update each product's mc_status and then update the global statistics.
 		$this->update_products_meta_with_mc_status();
 		$this->update_mc_status_statistics();
@@ -856,8 +861,6 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 				$to_update[ $new_status ][] = intval( $product_id );
 			}
 		}
-
-		unset( $current_product_statuses, $new_product_statuses );
 
 		// Insert and update changed MC Status postmeta.
 		$product_meta_query_helper->batch_insert_values( ProductMetaHandler::KEY_MC_STATUS, $to_insert );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -185,7 +185,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 *
 	 * @since x.x.x
 	 */
-	public function delete_product_status_count_intermediate_data(): void {
+	public function delete_product_statuses_count_intermediate_data(): void {
 		$this->options->delete( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
 	}
 
@@ -725,7 +725,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			MCStatus::NOT_SYNCED         => 0,
 		];
 
-		// If the transient is set, use it to sum the total quantity.
+		// If the option is set, use it to sum the total quantity.
 		$product_statistics_intermediate_data = $this->options->get( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
 		if ( $product_statistics_intermediate_data ) {
 			$product_statistics = $product_statistics_intermediate_data;
@@ -816,7 +816,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 				$this->get_status_lifetime()
 			);
 
-			$this->delete_product_status_count_intermediate_data();
+			$this->delete_product_statuses_count_intermediate_data();
 		}
 	}
 

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -37,6 +37,7 @@ interface OptionsInterface {
 	public const SITE_VERIFICATION                         = 'site_verification';
 	public const SYNCABLE_PRODUCTS_COUNT                   = 'syncable_products_count';
 	public const SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA = 'syncable_products_count_intermediate_data';
+	public const PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA  = 'products_statuses_count_intermediate_data';
 	public const TARGET_AUDIENCE                           = 'target_audience';
 	public const TOURS                                     = 'tours';
 	public const UPDATE_ALL_PRODUCTS_LAST_SYNC             = 'update_all_products_last_sync';
@@ -68,6 +69,7 @@ interface OptionsInterface {
 		self::SITE_VERIFICATION                         => true,
 		self::SYNCABLE_PRODUCTS_COUNT                   => true,
 		self::SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA => true,
+		self::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA  => true,
 		self::TARGET_AUDIENCE                           => true,
 		self::TOURS                                     => true,
 		self::UPDATE_ALL_PRODUCTS_LAST_SYNC             => true,

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -37,7 +37,7 @@ interface OptionsInterface {
 	public const SITE_VERIFICATION                         = 'site_verification';
 	public const SYNCABLE_PRODUCTS_COUNT                   = 'syncable_products_count';
 	public const SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA = 'syncable_products_count_intermediate_data';
-	public const PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA  = 'products_statuses_count_intermediate_data';
+	public const PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA  = 'product_statuses_count_intermediate_data';
 	public const TARGET_AUDIENCE                           = 'target_audience';
 	public const TOURS                                     = 'tours';
 	public const UPDATE_ALL_PRODUCTS_LAST_SYNC             = 'update_all_products_last_sync';

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -250,33 +250,6 @@ class ProductRepository implements Service {
 		return $this->find_ids( $args, $limit, $offset );
 	}
 
-	/**
-	 * Find and return an array of WooCommerce product IDs that are marked as MC not_synced.
-	 * Excludes variations and variable products without variations.
-	 *
-	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
-	 * @param int $offset Amount to offset product results.
-	 *
-	 * @return int[] Array of WooCommerce product IDs
-	 */
-	public function find_mc_not_synced_product_ids( int $limit = -1, int $offset = 0 ): array {
-		$types = ProductSyncer::get_supported_product_types();
-		$types = array_diff( $types, [ 'variation' ] );
-		$args  = [
-			'status'     => 'publish',
-			'type'       => $types,
-			'meta_query' => [
-				[
-					'key'     => ProductMetaHandler::KEY_MC_STATUS,
-					'compare' => '=',
-					'value'   => MCStatus::NOT_SYNCED,
-				],
-			],
-		];
-
-		return $this->find_ids( $args, $limit, $offset );
-	}
-
 
 	/**
 	 * Find all simple and variable product IDs regardless of MC status or visibility.

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -277,6 +277,26 @@ class ProductRepository implements Service {
 		return $this->find_ids( $args, $limit, $offset );
 	}
 
+
+	/**
+	 * Find all simple and variable product IDs regardless of MC status or visibility.
+	 *
+	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
+	 * @param int $offset Amount to offset product results.
+	 *
+	 * @return int[] Array of WooCommerce product IDs
+	 */
+	public function find_all_product_ids( int $limit = -1, int $offset = 0 ): array {
+		$args['return'] = 'ids';
+
+		$args = [
+			'type'   => array_diff( ProductSyncer::get_supported_product_types(), [ 'variation' ] ),
+			'status' => 'publish',
+		];
+
+		return $this->find_ids( $args, $limit, $offset );
+	}
+
 	/**
 	 * Returns an array of Google Product IDs associated with all synced WooCommerce products.
 	 * Note: excludes variable parent products as only the child variation products are actually synced

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -250,7 +250,6 @@ class ProductRepository implements Service {
 		return $this->find_ids( $args, $limit, $offset );
 	}
 
-
 	/**
 	 * Find all simple and variable product IDs regardless of MC status or visibility.
 	 *

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -261,11 +261,10 @@ class ProductRepository implements Service {
 	 * @return int[] Array of WooCommerce product IDs
 	 */
 	public function find_all_product_ids( int $limit = -1, int $offset = 0 ): array {
-		$args['return'] = 'ids';
-
 		$args = [
-			'type'   => array_diff( ProductSyncer::get_supported_product_types(), [ 'variation' ] ),
 			'status' => 'publish',
+			'return' => 'ids',
+			'type'   => 'any',
 		];
 
 		return $this->find_ids( $args, $limit, $offset );
@@ -339,6 +338,11 @@ class ProductRepository implements Service {
 		// only include supported product types
 		if ( empty( $args['type'] ) ) {
 			$args['type'] = ProductSyncer::get_supported_product_types();
+		}
+
+		// It'll fetch all products with the post_type of 'product', excluding variations.
+		if ( $args['type'] === 'any' ) {
+			unset( $args['type'] );
 		}
 
 		// use no ordering unless specified in arguments. overrides the default WooCommerce query args

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -281,6 +281,8 @@ class ProductRepository implements Service {
 	/**
 	 * Find all simple and variable product IDs regardless of MC status or visibility.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
 	 * @param int $offset Amount to offset product results.
 	 *

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -1,0 +1,210 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateMerchantProductStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
+use PHPUnit\Framework\MockObject\MockObject;
+use Exception;
+
+/**
+ * Class UpdateMerchantProductStatusesTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+class UpdateMerchantProductStatusesTest extends UnitTest {
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|MerchantCenterService $merchant_center_service */
+	protected $merchant_center_service;
+
+	/** @var MockObject|MerchantReport $merchant_report */
+	protected $merchant_report;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
+
+	/** @var UpdateSyncableProductsCount $job */
+	protected $job;
+
+	protected const JOB_NAME          = 'update_merchant_product_statuses';
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler        = $this->createMock( ActionSchedulerInterface::class );
+		$this->monitor                 = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->merchant_center_service = $this->createMock( MerchantCenterService::class );
+		$this->merchant_report         = $this->createMock( MerchantReport::class );
+		$this->merchant_statuses       = $this->createMock( MerchantStatuses::class );
+		$this->job                     = new UpdateMerchantProductStatuses(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->merchant_center_service,
+			$this->merchant_report,
+			$this->merchant_statuses
+		);
+
+		$this->job->init();
+	}
+
+	public function test_update_merchant_product_statuses_not_connected() {
+		$this->merchant_center_service->method( 'is_connected' )
+			->willReturn( false );
+
+		$this->assertFalse( $this->job->can_schedule() );
+	}
+
+	public function test_update_merchant_product_statuses() {
+		$this->merchant_center_service->method( 'is_connected' )
+			->willReturn( true );
+
+		$matcher = $this->exactly( 3 );
+		$this->merchant_report->expects( $matcher )
+			->method( 'get_product_view_report' )
+			->will(
+				$this->returnCallback(
+					function ( $next_page_token ) use ( $matcher ) {
+						$invocation_count = $matcher->getInvocationCount();
+
+						if ( $invocation_count === 1 ) {
+
+							$this->assertNull( $next_page_token );
+							return [
+								'statuses'  => [
+									[
+										'product_id' => 1,
+										'status'     => MCStatus::APPROVED,
+									],
+								],
+								'next_page' => 'ABC=',
+							];
+						}
+
+						if ( $invocation_count === 2 ) {
+							$this->assertEquals( 'ABC=', $next_page_token );
+							return [
+								'statuses'  => [
+									[
+										'product_id' => 2,
+										'status'     => MCStatus::APPROVED,
+									],
+								],
+								'next_page' => 'DEF=',
+							];
+						}
+
+						if ( $invocation_count === 3 ) {
+							$this->assertEquals( 'DEF=', $next_page_token );
+							return [
+								'statuses'  => [
+									[
+										'product_id' => 3,
+										'status'     => MCStatus::APPROVED,
+									],
+								],
+								'next_page' => null,
+							];
+						}
+
+						throw new Exception( 'Invalid next page token' );
+					}
+				)
+			);
+
+		$matcher = $this->exactly( 3 );
+		$this->action_scheduler->expects( $matcher )
+			->method( 'schedule_immediate' )
+			->willReturnCallback(
+				function ( $hook_name, $args ) use ( $matcher ) {
+					$invocation_count = $matcher->getInvocationCount();
+
+					if ( $invocation_count === 1 ) {
+						$this->assertEquals( [], $args );
+					}
+
+					if ( $invocation_count === 2 ) {
+						$this->assertEquals( [ 'next_page_token' => 'ABC=' ], $args[0] );
+					}
+
+					if ( $invocation_count === 3 ) {
+						$this->assertEquals( [ 'next_page_token' => 'DEF=' ], $args[0] );
+					}
+
+					do_action( self::PROCESS_ITEM_HOOK, $args[0] ?? [] );
+
+					return $matcher->getInvocationCount();
+				}
+			);
+
+			$matcher = $this->exactly( 3 );
+			$this->merchant_statuses->expects( $matcher )
+				->method( 'process_product_statuses' )
+				->willReturnCallback(
+					function ( $statuses ) use ( $matcher ) {
+						$invocation_count = $matcher->getInvocationCount();
+
+						if ( $invocation_count === 1 ) {
+							$this->assertEquals(
+								[
+									[
+										'product_id' => 1,
+										'status'     => MCStatus::APPROVED,
+									],
+								],
+								$statuses
+							);
+						}
+
+						if ( $invocation_count === 2 ) {
+							$this->assertEquals(
+								[
+									[
+										'product_id' => 2,
+										'status'     => MCStatus::APPROVED,
+									],
+								],
+								$statuses
+							);
+						}
+
+						if ( $invocation_count === 3 ) {
+							$this->assertEquals(
+								[
+									[
+										'product_id' => 3,
+										'status'     => MCStatus::APPROVED,
+									],
+								],
+								$statuses
+							);
+						}
+					}
+				);
+
+		$this->merchant_statuses->expects( $this->exactly( 3 ) )
+			->method( 'update_product_stats' );
+
+		$this->merchant_statuses->expects( $this->exactly( 1 ) )
+			->method( 'handle_complete_mc_statuses_fetching' );
+
+		$this->job->schedule();
+	}
+}

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -88,39 +88,39 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 							$this->assertNull( $next_page_token );
 							return [
-								'statuses'  => [
+								'statuses'        => [
 									[
 										'product_id' => 1,
 										'status'     => MCStatus::APPROVED,
 									],
 								],
-								'next_page' => 'ABC=',
+								'next_page_token' => 'ABC=',
 							];
 						}
 
 						if ( $invocation_count === 2 ) {
 							$this->assertEquals( 'ABC=', $next_page_token );
 							return [
-								'statuses'  => [
+								'statuses'        => [
 									[
 										'product_id' => 2,
 										'status'     => MCStatus::APPROVED,
 									],
 								],
-								'next_page' => 'DEF=',
+								'next_page_token' => 'DEF=',
 							];
 						}
 
 						if ( $invocation_count === 3 ) {
 							$this->assertEquals( 'DEF=', $next_page_token );
 							return [
-								'statuses'  => [
+								'statuses'        => [
 									[
 										'product_id' => 3,
 										'status'     => MCStatus::APPROVED,
 									],
 								],
-								'next_page' => null,
+								'next_page_token' => null,
 							];
 						}
 

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -205,6 +205,9 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
 			->method( 'handle_complete_mc_statuses_fetching' );
 
+		$this->merchant_statuses->expects( $this->exactly( 1 ) )
+			->method( 'clear_cache' );
+
 		$this->job->schedule();
 	}
 }

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -205,6 +205,9 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
 			->method( 'clear_cache' );
 
+		$this->merchant_statuses->expects( $this->exactly( 1 ) )
+			->method( 'delete_product_status_count_intermediate_data' );
+
 		$this->job->schedule();
 	}
 }

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -156,7 +156,7 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 			$matcher = $this->exactly( 3 );
 			$this->merchant_statuses->expects( $matcher )
-				->method( 'process_product_statuses' )
+				->method( 'update_product_stats' )
 				->willReturnCallback(
 					function ( $statuses ) use ( $matcher ) {
 						$invocation_count = $matcher->getInvocationCount();
@@ -198,9 +198,6 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 						}
 					}
 				);
-
-		$this->merchant_statuses->expects( $this->exactly( 3 ) )
-			->method( 'update_product_stats' );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
 			->method( 'handle_complete_mc_statuses_fetching' );

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -206,7 +206,7 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 			->method( 'clear_cache' );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
-			->method( 'delete_product_status_count_intermediate_data' );
+			->method( 'delete_product_statuses_count_intermediate_data' );
 
 		$this->job->schedule();
 	}

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -30,7 +30,6 @@ defined( 'ABSPATH' ) || exit;
  * @property MerchantStatuses $merchant_statuses
  * @property ProductRepository $product_repository
  * @property ProductHelper $product_helper
- * @property ShoppingContent\ProductStatusDestinationStatus $product_status_destination_status
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
  * @group MerchantCenterStatuses
  */
@@ -52,16 +51,15 @@ class MerchantStatusesTest extends UnitTest {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->merchant                                     = $this->createMock( Merchant::class );
-		$this->merchant_issue_query                         = $this->createMock( MerchantIssueQuery::class );
-		$this->merchant_center_service                      = $this->createMock( MerchantCenterService::class );
-		$this->account_status                               = $this->createMock( ShoppingContent\AccountStatus::class );
-		$this->product_meta_query_helper                    = $this->createMock( ProductMetaQueryHelper::class );
-		$this->product_repository                           = $this->createMock( ProductRepository::class );
-		$this->product_helper                               = $this->createMock( ProductHelper::class );
-		$this->product_status_destination_status            = $this->createMock( ShoppingContent\ProductStatusDestinationStatus::class );
-		$this->transients                                   = $this->createMock( TransientsInterface::class );
-		$this->update_merchant_product_statuses_job         = $this->createMock( UpdateMerchantProductStatuses::class );
+		$this->merchant                             = $this->createMock( Merchant::class );
+		$this->merchant_issue_query                 = $this->createMock( MerchantIssueQuery::class );
+		$this->merchant_center_service              = $this->createMock( MerchantCenterService::class );
+		$this->account_status                       = $this->createMock( ShoppingContent\AccountStatus::class );
+		$this->product_meta_query_helper            = $this->createMock( ProductMetaQueryHelper::class );
+		$this->product_repository                   = $this->createMock( ProductRepository::class );
+		$this->product_helper                       = $this->createMock( ProductHelper::class );
+		$this->transients                           = $this->createMock( TransientsInterface::class );
+		$this->update_merchant_product_statuses_job = $this->createMock( UpdateMerchantProductStatuses::class );
 
 		$merchant_issue_table = $this->createMock( MerchantIssueTable::class );
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -30,9 +30,6 @@ defined( 'ABSPATH' ) || exit;
  * @property MerchantStatuses $merchant_statuses
  * @property ProductRepository $product_repository
  * @property ProductHelper $product_helper
- * @property ShoppingContent\ProductStatus $product_status
- * @property ShoppingContent\ProductStatusesCustomBatchResponse $product_statuses_custom_batch_response
- * @property ShoppingContent\ProductStatusesCustomBatchResponseEntry $product_statuses_custom_batch_response_entry
  * @property ShoppingContent\ProductStatusDestinationStatus $product_status_destination_status
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
  * @group MerchantCenterStatuses
@@ -62,9 +59,6 @@ class MerchantStatusesTest extends UnitTest {
 		$this->product_meta_query_helper                    = $this->createMock( ProductMetaQueryHelper::class );
 		$this->product_repository                           = $this->createMock( ProductRepository::class );
 		$this->product_helper                               = $this->createMock( ProductHelper::class );
-		$this->product_status                               = $this->createMock( ShoppingContent\ProductStatus::class );
-		$this->product_statuses_custom_batch_response       = $this->createMock( ShoppingContent\ProductstatusesCustomBatchResponse::class );
-		$this->product_statuses_custom_batch_response_entry = $this->createMock( ShoppingContent\ProductstatusesCustomBatchResponseEntry::class );
 		$this->product_status_destination_status            = $this->createMock( ShoppingContent\ProductStatusDestinationStatus::class );
 		$this->transients                                   = $this->createMock( TransientsInterface::class );
 		$this->update_merchant_product_statuses_job         = $this->createMock( UpdateMerchantProductStatuses::class );

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -259,39 +259,6 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 	}
 
-	public function test_find_mc_not_synced_product_ids() {
-		$product_1 = WC_Helper_Product::create_simple_product();
-		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
-		$this->product_meta->update_mc_status( $product_1, MCStatus::APPROVED );
-
-		$product_2 = WC_Helper_Product::create_simple_product();
-		$this->product_meta->update_sync_status( $product_2, SyncStatus::HAS_ERRORS );
-		$this->product_meta->update_visibility( $product_2, ChannelVisibility::SYNC_AND_SHOW );
-		$this->product_meta->update_mc_status( $product_2, MCStatus::NOT_SYNCED );
-
-		$product_3 = WC_Helper_Product::create_simple_product();
-		$this->product_meta->update_sync_status( $product_3, SyncStatus::HAS_ERRORS );
-		$this->product_meta->update_visibility( $product_3, ChannelVisibility::DONT_SYNC_AND_SHOW );
-		$this->product_meta->update_mc_status( $product_3, MCStatus::NOT_SYNCED );
-
-		WC_Helper_Product::create_simple_product();
-
-		$variable_product = WC_Helper_Product::create_variation_product();
-		$this->product_meta->update_sync_status( $variable_product, SyncStatus::NOT_SYNCED );
-		$this->product_meta->update_visibility( $variable_product, ChannelVisibility::SYNC_AND_SHOW );
-		$this->product_meta->update_mc_status( $variable_product, MCStatus::NOT_SYNCED );
-		foreach ( $variable_product->get_children() as $variation_id ) {
-			$this->product_meta->update_sync_status( wc_get_product( $variation_id ), SyncStatus::NOT_SYNCED );
-			$this->product_meta->update_visibility( wc_get_product( $variation_id ), ChannelVisibility::SYNC_AND_SHOW );
-			$this->product_meta->update_mc_status( wc_get_product( $variation_id ), MCStatus::NOT_SYNCED );
-		}
-
-		$this->assertEqualSets(
-			[ $product_2->get_id(), $variable_product->get_id() ],
-			$this->product_repository->find_mc_not_synced_product_ids()
-		);
-	}
-
 	public function test_find_all_synced_google_ids() {
 		$synced_google_ids = [];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146 & https://github.com/woocommerce/google-listings-and-ads/issues/2250

In https://github.com/woocommerce/google-listings-and-ads/pull/2229 we've added a background job that handles calculating product stats, bringing all products from MC and updating their status in WooCommerce.

This PR will allow the background job to generate multiple tasks based on the `$next_page_token`, helping us spread out resource usage more effectively.

While working on this  I noticed that we were changing the product status to "not synced" to calculate the unsynced products in MC. But, I think that's unnecessary. The actual count of unsynced products will simply be: NOT_SYNCED = WooCommerce Products ('simple', 'variable') - MC Products (with variants grouped).

In the case that we need to display the MC status, like in the Product Feed section, we can assume that if a WC product doesn't have an MC status, it's not synced in MC. I'm open to hearing other thoughts on this.

### Screenshots:

1. Change the batch size [here](https://github.com/woocommerce/google-listings-and-ads/blob/dd39acb2c1e877186678945dc5fe40936cafcb6b/src/API/Google/MerchantReport.php#L68) so you can create multiple batches depending on the number of products that you have or use the filter `woocommerce_gla_product_view_report_page_size`.
2. Make the following request to `GET gla/mc/product-statistics/refresh`
3. Go to WC -> Status -> Scheduled Actions -> Search for `gla/jobs/update_merchant_product_statuses`
4. See how multiple jobs are creating using a different page tokens.
5. Check the total stats in the Overview - Product Feed page makes sense. 


### Additional details:

- In another PR, I'll work with the WC_Product objects/CRUD classes and add the tests for MerchantStatuses.php and MerchantReport.php.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>