### PR TITLE
MC Product Statuses: Replace WP functions with WC functions

### DIFF
--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -97,7 +97,7 @@ class MerchantReport implements OptionsAwareInterface {
 					continue;
 				}
 
-				$product_view_data['statuses'][ (int) $wc_product_id ] = [
+				$product_view_data['statuses'][ $wc_product_id ] = [
 					'product_id'      => $wc_product_id,
 					'status'          => $mc_product_status,
 					'expiration_date' => $this->convert_shopping_content_date( $product_view->getExpirationDate() ),

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -65,7 +65,7 @@ class MerchantReport implements OptionsAwareInterface {
 	 * @throws Exception If the product view report data can't be retrieved.
 	 */
 	public function get_product_view_report( $next_page_token = null ): array {
-		$batch_size = apply_filters( 'woocommerce_gla_product_view_report_page_size', 1000 );
+		$batch_size = apply_filters( 'woocommerce_gla_product_view_report_page_size', 500 );
 
 		try {
 			$product_view_data = [

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -97,7 +97,7 @@ class MerchantReport implements OptionsAwareInterface {
 					continue;
 				}
 
-				$product_view_data['statuses'][] = [
+				$product_view_data['statuses'][ (int) $wc_product_id ] = [
 					'product_id'      => $wc_product_id,
 					'status'          => $mc_product_status,
 					'expiration_date' => $this->convert_shopping_content_date( $product_view->getExpirationDate() ),

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -611,47 +611,27 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
-	 * Get the WC Products from the Product View statuses report.
-	 *
-	 * @param array $statuses statuses.
-	 * @see MerchantReport::get_product_view_report
-	 *
-	 * @return WC_Product[] Associative array with the key as the product ID and the value the WooCommerce Product object.
-	 */
-	protected function get_wc_products_from_product_view_statuses( array $statuses ): array {
-		$product_repository = $this->container->get( ProductRepository::class );
-		$products           = $product_repository->find_by_ids( array_column( $statuses, 'product_id' ) );
-		$map                = [];
-
-		foreach ( $products as $product ) {
-			$map[ $product->get_id() ] = $product;
-		}
-
-		return $map;
-	}
-
-	/**
 	 * Process product status statistics.
 	 *
 	 * @param array[] $statuses statuses.
 	 * @see MerchantReport::get_product_view_report
 	 */
 	public function process_product_statuses( array $statuses ): void {
+		$product_repository = $this->container->get( ProductRepository::class );
+		$products           = $product_repository->find_by_ids_as_associative_array( array_column( $statuses, 'product_id' ) );
+
 		$this->product_statuses = [
 			'products' => [],
 			'parents'  => [],
 		];
-
-		$visibility_meta_key = $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY );
-		$products            = $this->get_wc_products_from_product_view_statuses( $statuses );
 
 		foreach ( $statuses as $product_status ) {
 
 			$wc_product_id     = $product_status['product_id'];
 			$mc_product_status = $product_status['status'];
 
-			// Skip if the product does not exist or if the product previously found/validated.
-			if ( ! $wc_product_id || ! empty( $this->product_data_lookup[ $wc_product_id ] ) ) {
+			// Skip if the product does not exist in WooCommerce.
+			if ( ! $wc_product_id ) {
 				continue;
 			}
 
@@ -667,12 +647,6 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 				continue;
 			}
 
-			$this->product_data_lookup[ $wc_product_id ] = [
-				'name'       => $wc_product->get_name(),
-				'visibility' => $wc_product->get_meta( $visibility_meta_key ),
-				'parent_id'  => $wc_product->get_parent_id(),
-			];
-
 			if ( $this->product_is_expiring( $product_status['expiration_date'] ) ) {
 				$mc_product_status = MCStatus::EXPIRING;
 			}
@@ -681,13 +655,21 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			$this->product_statuses['products'][ $wc_product_id ][ $mc_product_status ] = 1 + ( $this->product_statuses['products'][ $wc_product_id ][ $mc_product_status ] ?? 0 );
 
 			// Aggregate parent statuses for mc_status postmeta.
-			$wc_parent_id = $this->product_data_lookup[ $wc_product_id ]['parent_id'];
+			$wc_parent_id = $wc_product->get_parent_id();
 			if ( ! $wc_parent_id ) {
 				continue;
 			}
 			$this->product_statuses['parents'][ $wc_parent_id ][ $mc_product_status ] = 1 + ( $this->product_statuses['parents'][ $wc_parent_id ][ $mc_product_status ] ?? 0 );
 
 		}
+
+		$parent_keys     = array_values( array_keys( $this->product_statuses['parents'] ) );
+		$parent_products = $product_repository->find_by_ids_as_associative_array( $parent_keys );
+		$products        = $products + $parent_products;
+
+		// Update each product's mc_status and then update the global statistics.
+		$this->update_products_meta_with_mc_status( $products );
+		$this->update_intermediate_product_statistics( $products );
 	}
 
 	/**
@@ -701,10 +683,6 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$this->mc_statuses = [];
 
 		$this->process_product_statuses( $statuses );
-
-		// Update each product's mc_status and then update the global statistics.
-		$this->update_products_meta_with_mc_status();
-		$this->update_intermediate_product_statistics();
 	}
 
 	/**
@@ -733,9 +711,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * 3. Compare if a higher priority status is found for that variable product.
 	 * 4. Loop through the `$parent_statuses` array at the end to add the final status counts.
 	 *
+	 * @param WC_Product[] $products The products to update. (passed by reference).
+	 *
 	 * @return array Product status statistics.
 	 */
-	protected function update_intermediate_product_statistics(): array {
+	protected function update_intermediate_product_statistics( &$products ): array {
 		$product_statistics = [
 			MCStatus::APPROVED           => 0,
 			MCStatus::PARTIALLY_APPROVED => 0,
@@ -764,7 +744,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 		foreach ( $this->product_statuses['products'] as $product_id => $statuses ) {
 			foreach ( $statuses as $status => $num_products ) {
-				$parent_id = $this->product_data_lookup[ $product_id ]['parent_id'];
+				$parent_id = $products[ $product_id ]->get_parent_id();
 				if ( ! $parent_id ) {
 					$product_statistics[ $status ] += $num_products;
 				} elseif ( ! isset( $parent_statuses[ $parent_id ] ) ) {
@@ -843,8 +823,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 	/**
 	 * Update the Merchant Center status for each product.
+	 *
+	 * @param WC_Product[] $products The products to update. (passed by reference).
 	 */
-	protected function update_products_meta_with_mc_status() {
+	protected function update_products_meta_with_mc_status( &$products ) {
 		// Generate a product_id=>mc_status array.
 		$new_product_statuses = [];
 		foreach ( $this->product_statuses as $types ) {
@@ -866,8 +848,18 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		}
 
 		foreach ( $new_product_statuses as $product_id => $new_status ) {
-			// wc_get_product should return the cached product because it was fetched in the process_product_statuses method.
-			$product = wc_get_product( $product_id );
+			$product = $products[ $product_id ] ?? null;
+
+			// At this point, the product should exist in WooCommerce but in the case that product is not found, log it.
+			if ( ! $product ) {
+				do_action(
+					'woocommerce_gla_debug_message',
+					sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $product_id ),
+					__METHOD__,
+				);
+				continue;
+			}
+
 			$product->add_meta_data( $this->prefix_meta_key( ProductMetaHandler::KEY_MC_STATUS ), $new_status, true );
 			// We use save_meta_data so we don't trigger the woocommerce_update_product hook and the Syncer Hooks.
 			$product->save_meta_data();

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -744,7 +744,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 		foreach ( $this->product_statuses['products'] as $product_id => $statuses ) {
 			foreach ( $statuses as $status => $num_products ) {
-				$parent_id = $products[ $product_id ]->get_parent_id();
+				$product = $products[ $product_id ] ?? null;
+
+				if ( ! $product ) {
+					continue;
+				}
+
+				$parent_id = $product->get_parent_id();
+
 				if ( ! $parent_id ) {
 					$product_statistics[ $status ] += $num_products;
 				} elseif ( ! isset( $parent_statuses[ $parent_id ] ) ) {

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -865,7 +865,6 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			}
 		}
 
-		ksort( $new_product_statuses );
 		foreach ( $new_product_statuses as $product_id => $new_status ) {
 			// wc_get_product should return the cached product because it was fetched in the process_product_statuses method.
 			$product = wc_get_product( $product_id );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -869,9 +869,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface {
 
 		ksort( $new_product_statuses );
 		foreach ( $new_product_statuses as $product_id => $new_status ) {
-			// Here the product should be already cached because it was fetched in the process_product_statuses method.
+			// wc_get_product should return the cached product because it was fetched in the process_product_statuses method.
 			$product = wc_get_product( $product_id );
 			$product->add_meta_data( $this->prefix_meta_key( ProductMetaHandler::KEY_MC_STATUS ), $new_status, true );
+			// We use save_meta_data so we don't trigger the woocommerce_update_product hook and the Syncer Hooks.
 			$product->save_meta_data();
 		}
 	}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -861,7 +861,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			if ( ! $product ) {
 				do_action(
 					'woocommerce_gla_debug_message',
-					sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $product_id ),
+					sprintf( 'Merchant Center product with WooCommerce ID %d is not found in this store.', $product_id ),
 					__METHOD__,
 				);
 				continue;

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -621,12 +621,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	protected function get_wc_products_from_product_view_statuses( array $statuses ): array {
 		$product_repository = $this->container->get( ProductRepository::class );
 		$products           = $product_repository->find_by_ids( array_column( $statuses, 'product_id' ) );
+		$map                = [];
 
 		foreach ( $products as $product ) {
-			$mapped_products[ $product->get_id() ] = $product;
+			$map[ $product->get_id() ] = $product;
 		}
 
-		return $mapped_products;
+		return $map;
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -611,7 +611,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
-	 * Get the WC Products from the Merchant Center statuses.
+	 * Get the WC Products from the Product View statuses report.
 	 *
 	 * @param array $statuses statuses.
 	 * @see MerchantReport::get_product_view_report

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -94,6 +94,25 @@ class ProductRepository implements Service {
 	}
 
 	/**
+	 * Find and return an associative array of products with the product ID as the key.
+	 *
+	 * @param int[] $ids    Array of WooCommerce product IDs
+	 * @param array $args   Array of WooCommerce args (except 'return'), and product metadata.
+	 * @param int   $limit  Maximum number of results to retrieve or -1 for unlimited.
+	 * @param int   $offset Amount to offset product results.
+	 *
+	 * @return WC_Product[] Array of WooCommerce product objects
+	 */
+	public function find_by_ids_as_associative_array( array $ids, array $args = [], int $limit = -1, int $offset = 0 ) {
+		$products = $this->find_by_ids( $ids, $args, $limit, $offset );
+		$map      = [];
+		foreach ( $products as $product ) {
+			$map[ $product->get_id() ] = $product;
+		}
+		return $map;
+	}
+
+	/**
 	 * Find and return an array of WooCommerce product objects already submitted to Google Merchant Center.
 	 *
 	 * @param array $args   Array of WooCommerce args (except 'return' and 'meta_query').

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -108,7 +108,7 @@ class ProductRepository implements Service {
 	 *
 	 * @return WC_Product[] Array of WooCommerce product objects
 	 */
-	public function find_by_ids_as_associative_array( array $ids, array $args = [], int $limit = -1, int $offset = 0 ) {
+	public function find_by_ids_as_associative_array( array $ids, array $args = [], int $limit = -1, int $offset = 0 ): array {
 		$products = $this->find_by_ids( $ids, $args, $limit, $offset );
 		$map      = [];
 		foreach ( $products as $product ) {

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -378,15 +378,19 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
-		$this->product_repository->expects( $this->once() )->method( 'find_by_ids' )->with(
-			[
-				$product_1->get_id(),
-				$product_2->get_id(),
-				$product_3->get_id(),
-				$variation_id_1,
-				$variation_id_2,
-			]
-		)->willReturn( [ $product_1, $product_2, $product_3, wc_get_product( $variation_id_1 ) , wc_get_product( $variation_id_2 ) ] );
+		$matcher = $this->exactly(2);
+		$this->product_repository->expects( $matcher )->method( 'find_by_ids_as_associative_array' )->willReturnCallback(function ($args) use ( $matcher, $product_1, $product_2, $product_3, $variable_product, $variation_id_1, $variation_id_2){
+
+			switch ($matcher->getInvocationCount()) {
+				case 1:
+					$this->assertEquals([$product_1->get_id(), $product_2->get_id(), $product_3->get_id(),  $variation_id_1, $variation_id_2 ], $args);
+					return [ $product_1->get_id() => $product_1, $product_2->get_id() => $product_2, $product_3->get_id() => $product_3, $variation_id_1 => wc_get_product( $variation_id_1 ) , $variation_id_2 => wc_get_product( $variation_id_2 ) ];
+				case 2:
+					$this->assertEquals([$variable_product->get_id() ], $args);
+					return [ $variable_product->get_id() => $variable_product ];
+			}
+
+		});
 
 		$this->options->expects( $this->exactly( 1 ) )
 			->method( 'get' )

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -378,19 +378,25 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
-		$matcher = $this->exactly(2);
-		$this->product_repository->expects( $matcher )->method( 'find_by_ids_as_associative_array' )->willReturnCallback(function ($args) use ( $matcher, $product_1, $product_2, $product_3, $variable_product, $variation_id_1, $variation_id_2){
-
-			switch ($matcher->getInvocationCount()) {
-				case 1:
-					$this->assertEquals([$product_1->get_id(), $product_2->get_id(), $product_3->get_id(),  $variation_id_1, $variation_id_2 ], $args);
-					return [ $product_1->get_id() => $product_1, $product_2->get_id() => $product_2, $product_3->get_id() => $product_3, $variation_id_1 => wc_get_product( $variation_id_1 ) , $variation_id_2 => wc_get_product( $variation_id_2 ) ];
-				case 2:
-					$this->assertEquals([$variable_product->get_id() ], $args);
-					return [ $variable_product->get_id() => $variable_product ];
+		$matcher = $this->exactly( 2 );
+		$this->product_repository->expects( $matcher )->method( 'find_by_ids_as_associative_array' )->willReturnCallback(
+			function ( $args ) use ( $matcher, $product_1, $product_2, $product_3, $variable_product, $variation_id_1, $variation_id_2 ) {
+				switch ( $matcher->getInvocationCount() ) {
+					case 1:
+						$this->assertEquals( [ $product_1->get_id(), $product_2->get_id(), $product_3->get_id(),  $variation_id_1, $variation_id_2 ], $args );
+						return [
+							$product_1->get_id() => $product_1,
+							$product_2->get_id() => $product_2,
+							$product_3->get_id() => $product_3,
+							$variation_id_1      => wc_get_product( $variation_id_1 ) ,
+							$variation_id_2      => wc_get_product( $variation_id_2 ),
+						];
+					case 2:
+						$this->assertEquals( [ $variable_product->get_id() ], $args );
+						return [ $variable_product->get_id() => $variable_product ];
+				}
 			}
-
-		});
+		);
 
 		$this->options->expects( $this->exactly( 1 ) )
 			->method( 'get' )

--- a/tests/proxy/handler.js
+++ b/tests/proxy/handler.js
@@ -16,6 +16,11 @@ module.exports.checkRequest = ( request ) => {
 	}
 	if ( request.params.path.includes( 'reports/search' ) ) {
 		const body = JSON.parse( request.payload );
+
+		if ( body.query.includes( 'ProductView' ) ) {
+			return false;
+		}
+
 		const file = body.query.includes( 'segments.offer_id' )
 			? 'products'
 			: 'programs';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146 & https://github.com/woocommerce/google-listings-and-ads/issues/2250

In https://github.com/woocommerce/google-listings-and-ads/pull/2255, we've divided the background job for fetching product statuses into multiple tasks to distribute resource usage. Until now, we've been relying on `WP_Post` and bulk updates via raw queries to handle updating numerous products in a single request. While it sped things up, it could became less reliable as WC might change how product data is stored. For better future-proofing, it's more convenient to use WooCommerce objects to retrieve and update their data.

This PR replaces the bulk queries and the use of get_post with `wc_get_products`.  I've also updated metadata using methods available in their class. The metadata is saved using the `save_meta_data` method, so this way, we bypass calling the `woocommerce_update_product` hook and avoid triggering the syncer hooks.

At first, I experimented with batches of 1,000 products. However, in some instances, it was hitting the maximum execution time of 30 seconds. So, I opted to decrease it to 500 products. I did these tests with a memory limit of 128MB.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Create a bunch of products ( I did the test using more than 3k products)
2. Reduce the PHP memory limit to 128MB
3. Delete any existing `mc_statuses` so you can check that the` mc_status` is added. You can run a query like this one: 
`DELETE FROM wp_postmeta WHERE meta_key = '_wc_gla_mc_status';`
4. Watch your server error log.
4. Call this endpoint `GET /gla/mc/product-statistics/refresh`
5. Go to WC -> Status -> Scheduled actions and see that `update_merchant_product_statuses` runs.
6. When all the jobs are completed, you should see the total results in Product View - Overview section.
7. Check that the product's metadata `_wc_gla_mc_status` is set.
8. Check that the syncer hooks have not been called. (No pending jobs trying to sync the product)


### Additional details:

- The UI will be updated in a different PR to indicate that the stats are loading while the jobs are running. 
- With these changes, the methods `ProductMetaQueryHelper::batch_update_values` and `ProductMetaQueryHelper::batch_insert_values` are not longer used in our codebase, so they could be deleted however they are public, so not sure if it is better just to deprecate them for now. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
