### PR TITLE
Prevent find_by_ids executing if no arguments are supplied

### DIFF
--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -88,6 +88,11 @@ class ProductRepository implements Service {
 	 * @return WC_Product[] Array of WooCommerce product objects
 	 */
 	public function find_by_ids( array $ids, array $args = [], int $limit = -1, int $offset = 0 ): array {
+		// If no product IDs are supplied then return early to avoid querying and loading every product.
+		if ( empty( $ids ) ) {
+			return [];
+		}
+
 		$args['include'] = $ids;
 
 		return $this->find( $args, $limit, $offset );

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -144,6 +144,8 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 			array_map( 'wc_get_product', $ids ),
 			$this->product_repository->find_by_ids( $ids )
 		);
+
+		$this->assertEquals( [], $this->product_repository->find_by_ids( [] ) );
 	}
 
 	public function test_find_synced_products() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1959 

We've previously had reports of `gla/jobs/delete_products/process_item` being slow to execute and recently encountered a report of memory exhaustion issues for these scheduled actions.

During the action, when we `handle_delete_errors`, we track any failed deletions in the `$internal_error_ids` array which is then used to [query products on the store](https://github.com/woocommerce/google-listings-and-ads/blob/f7b639b3336ea137ed61c46a30e857eafde4d006/src/Product/ProductSyncer.php#L338).

The issue with the slow action and potential memory exhaustion appears to come from the possibility that `$internal_error_ids` is empty at the point we run the query in `find_by_ids`. As no IDs are supplied, we instead run a query that will return every product in the store which in turn spawns an instance of `WC_Product_{ product_type }` for [each product](https://github.com/woocommerce/google-listings-and-ads/blob/f7b639b3336ea137ed61c46a30e857eafde4d006/src/Product/ProductRepository.php#L331).

For a store has a small number of products that doesn't cause any problems, although it's still unnecessary, but when a store has thousands of products it's creating thousands of objects and queries which is where the problem is.

This PR adds a check in `find_by_ids` so that if no `$ids` are supplied then we return an empty array instead of executing the query.

### Detailed test instructions:

1. Checkout `fix/1959-prevent-find-by-ids-executing-without-ids-supplied`
2. Sync products with Google
3. Delete products from Google
4. Confirm actions complete

### Additional details:

I've looked through other calls to `find_by_ids` in the extension and it doesn't look like there is any point where we would expect to be able to use the function without supplying IDs but would appreciate if someone could take a second look at that to confirm this change won't cause any other problems.

### Changelog entry

> Fix - Prevent product queries by IDs if no arguments are supplied