### PR TITLE
Add - Product View Report Test

### DIFF
--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -70,7 +70,7 @@ class MerchantReport implements OptionsAwareInterface {
 		try {
 			$product_view_data = [
 				'statuses'  => [],
-				'next_page' => null,
+				'next_page_token' => null,
 			];
 
 			$query = new MerchantProductViewReportQuery(

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -69,7 +69,7 @@ class MerchantReport implements OptionsAwareInterface {
 
 		try {
 			$product_view_data = [
-				'statuses'  => [],
+				'statuses'        => [],
 				'next_page_token' => null,
 			];
 

--- a/src/API/Google/Query/MerchantProductViewReportQuery.php
+++ b/src/API/Google/Query/MerchantProductViewReportQuery.php
@@ -45,7 +45,6 @@ class MerchantProductViewReportQuery extends MerchantQuery {
 		$this->columns(
 			[
 				'id'              => 'product_view.id',
-				'offer_id'        => 'product_view.offer_id',
 				'expiration_date' => 'product_view.expiration_date',
 				'status'          => 'product_view.aggregated_destination_status',
 			]

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -88,6 +88,11 @@ class ProductRepository implements Service {
 	 * @return WC_Product[] Array of WooCommerce product objects
 	 */
 	public function find_by_ids( array $ids, array $args = [], int $limit = -1, int $offset = 0 ): array {
+		// If no product IDs are supplied then return early to avoid querying and loading every product.
+		if ( empty( $ids ) ) {
+			return [];
+		}
+
 		$args['include'] = $ids;
 
 		return $this->find( $args, $limit, $offset );

--- a/tests/Unit/API/Google/MerchantReportTest.php
+++ b/tests/Unit/API/Google/MerchantReportTest.php
@@ -15,8 +15,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingCo
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\SearchRequest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\SearchResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Resource\Reports;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Exception as GoogleException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ShoppingContentDateTrait;
 use DateTime;
+use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
 defined( 'ABSPATH' ) || exit;
@@ -79,7 +81,7 @@ class MerchantReportTest extends UnitTest {
 		return $product_view;
 	}
 
-	public function test_get_free_listing_metrics() {
+	public function test_get_product_view_report() {
 		$test_merchant_id = 432;
 		$wc_product_id_1  = 882;
 		$wc_product_id_2  = 883;
@@ -166,5 +168,19 @@ class MerchantReportTest extends UnitTest {
 			],
 			$this->merchant_report->get_product_view_report()
 		);
+	}
+
+	public function test_get_product_view_report_with_exception() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 432 );
+
+		$this->shopping_client->reports->expects( $this->once() )
+			->method( 'search' )
+			->will(
+				$this->throwException( new GoogleException( 'Test exception' ) )
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unable to retrieve Product View Report.' );
+		$this->merchant_report->get_product_view_report();
 	}
 }

--- a/tests/Unit/API/Google/MerchantReportTest.php
+++ b/tests/Unit/API/Google/MerchantReportTest.php
@@ -1,0 +1,170 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Date as GoogleDate;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductView;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ReportRow;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\SearchRequest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\SearchResponse;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Resource\Reports;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ShoppingContentDateTrait;
+use DateTime;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MerchantReportTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class MerchantReportTest extends UnitTest {
+
+	use ShoppingContentDateTrait;
+
+	/** @var MockObject|ShoppingContent $shopping_client */
+	protected $shopping_client;
+
+	/** @var MockObject|ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MerchantReport $merchant_report */
+	protected $merchant_report;
+
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->shopping_client          = $this->createMock( ShoppingContent::class );
+		$this->product_helper           = $this->createMock( ProductHelper::class );
+		$this->shopping_client->reports = $this->createMock( Reports::class );
+
+		$this->options         = $this->createMock( OptionsInterface::class );
+		$this->merchant_report = new MerchantReport( $this->shopping_client, $this->product_helper );
+		$this->merchant_report->set_options_object( $this->options );
+	}
+
+	/**
+	 * Creates a product view with the given id, status and expiration date.
+	 *
+	 * @param string        $mc_id The MC center id.
+	 * @param string        $status The status of the product.
+	 * @param DateTime|null $expiration_date The expiration date of the product.
+	 *
+	 * @return ProductView
+	 */
+	protected function create_product_view_product_status( string $mc_id, string $status = 'ELIGIBLE', $expiration_date = null ): ProductView {
+		$expiration_date = $expiration_date ?? new DateTime( 'tomorrow', wp_timezone() );
+		$product_view    = new ProductView();
+		$google_date     = new GoogleDate();
+		$google_date->setYear( $expiration_date->format( 'Y' ) );
+		$google_date->setMonth( $expiration_date->format( 'm' ) );
+		$google_date->setDay( $expiration_date->format( 'd' ) );
+		$product_view->setExpirationDate( $google_date );
+		$product_view->setAggregatedDestinationStatus( $status );
+		$product_view->setId( $mc_id );
+		return $product_view;
+	}
+
+	public function test_get_free_listing_metrics() {
+		$test_merchant_id = 432;
+		$wc_product_id_1  = 882;
+		$wc_product_id_2  = 883;
+		$wc_product_id_3  = 884;
+
+		add_filter(
+			'woocommerce_gla_product_view_report_page_size',
+			function () {
+				return 500;
+			}
+		);
+
+		$this->options->method( 'get_merchant_id' )->willReturn( $test_merchant_id );
+
+		$this->product_helper->method( 'get_wc_product_id' )->will(
+			$this->returnCallback(
+				function ( $mc_id ) use ( $wc_product_id_1, $wc_product_id_2, $wc_product_id_3 ) {
+					if ( $mc_id === 'online:en:ES:gla_' . $wc_product_id_1 ) {
+							return $wc_product_id_1;
+					}
+
+					if ( $mc_id === 'online:en:ES:gla_' . $wc_product_id_2 ) {
+						return $wc_product_id_2;
+					}
+
+					if ( $mc_id === 'online:en:ES:gla_' . $wc_product_id_3 ) {
+						return $wc_product_id_3;
+					}
+
+					return 0;
+				}
+			)
+		);
+
+		$product_view_1 = $this->create_product_view_product_status( 'online:en:ES:gla_' . $wc_product_id_1 );
+		$product_view_2 = $this->create_product_view_product_status( 'online:en:ES:gla_' . $wc_product_id_2, 'NOT_ELIGIBLE_OR_DISAPPROVED' );
+		$product_view_3 = $this->create_product_view_product_status( 'online:en:ES:external' . $wc_product_id_3 );
+
+		$report_row_1 = new ReportRow();
+		$report_row_1->setProductView( $product_view_1 );
+
+		$report_row_2 = new ReportRow();
+		$report_row_2->setProductView( $product_view_2 );
+
+		$report_row_3 = new ReportRow();
+		$report_row_3->setProductView( $product_view_3 );
+
+		$response = $this->createMock( SearchResponse::class );
+		$response->expects( $this->once() )
+			->method( 'getResults' )
+			->willReturn( [ $report_row_1, $report_row_2, $report_row_3 ] );
+
+		$response->expects( $this->once() )
+			->method( 'getNextPageToken' )
+			->willReturn( null );
+
+		$search_request = new SearchRequest();
+		$search_request->setQuery(
+			'SELECT product_view.id,product_view.expiration_date,product_view.aggregated_destination_status FROM ProductView'
+		);
+
+		$search_request->setPageSize( 500 );
+
+		$this->shopping_client->reports->expects( $this->once() )
+			->method( 'search' )
+			->with( $test_merchant_id, $search_request )
+			->willReturn( $response );
+
+		$this->assertEquals(
+			[
+				'statuses'        => [
+					$wc_product_id_1 => [
+						'product_id'      => $wc_product_id_1,
+						'status'          => MCStatus::APPROVED,
+						'expiration_date' => $this->convert_shopping_content_date( $product_view_1->getExpirationDate() ),
+					],
+					$wc_product_id_2 => [
+						'product_id'      => $wc_product_id_2,
+						'status'          => MCStatus::DISAPPROVED,
+						'expiration_date' => $this->convert_shopping_content_date( $product_view_2->getExpirationDate() ),
+					],
+				],
+				'next_page_token' => null,
+			],
+			$this->merchant_report->get_product_view_report()
+		);
+	}
+}

--- a/tests/Unit/API/Google/MerchantReportTest.php
+++ b/tests/Unit/API/Google/MerchantReportTest.php
@@ -85,12 +85,12 @@ class MerchantReportTest extends UnitTest {
 		$test_merchant_id = 432;
 		$wc_product_id_1  = 882;
 		$wc_product_id_2  = 883;
-		$wc_product_id_3  = 884;
+		$page_size        = 800;
 
 		add_filter(
 			'woocommerce_gla_product_view_report_page_size',
-			function () {
-				return 500;
+			function () use ( $page_size ) {
+				return $page_size;
 			}
 		);
 
@@ -98,17 +98,13 @@ class MerchantReportTest extends UnitTest {
 
 		$this->product_helper->method( 'get_wc_product_id' )->will(
 			$this->returnCallback(
-				function ( $mc_id ) use ( $wc_product_id_1, $wc_product_id_2, $wc_product_id_3 ) {
+				function ( $mc_id ) use ( $wc_product_id_1, $wc_product_id_2 ) {
 					if ( $mc_id === 'online:en:ES:gla_' . $wc_product_id_1 ) {
 							return $wc_product_id_1;
 					}
 
 					if ( $mc_id === 'online:en:ES:gla_' . $wc_product_id_2 ) {
 						return $wc_product_id_2;
-					}
-
-					if ( $mc_id === 'online:en:ES:gla_' . $wc_product_id_3 ) {
-						return $wc_product_id_3;
 					}
 
 					return 0;
@@ -118,7 +114,7 @@ class MerchantReportTest extends UnitTest {
 
 		$product_view_1 = $this->create_product_view_product_status( 'online:en:ES:gla_' . $wc_product_id_1 );
 		$product_view_2 = $this->create_product_view_product_status( 'online:en:ES:gla_' . $wc_product_id_2, 'NOT_ELIGIBLE_OR_DISAPPROVED' );
-		$product_view_3 = $this->create_product_view_product_status( 'online:en:ES:external' . $wc_product_id_3 );
+		$product_view_3 = $this->create_product_view_product_status( 'online:en:ES:external' );
 
 		$report_row_1 = new ReportRow();
 		$report_row_1->setProductView( $product_view_1 );
@@ -143,7 +139,7 @@ class MerchantReportTest extends UnitTest {
 			'SELECT product_view.id,product_view.expiration_date,product_view.aggregated_destination_status FROM ProductView'
 		);
 
-		$search_request->setPageSize( 500 );
+		$search_request->setPageSize( $page_size );
 
 		$this->shopping_client->reports->expects( $this->once() )
 			->method( 'search' )

--- a/tests/Unit/API/Google/MerchantReportTest.php
+++ b/tests/Unit/API/Google/MerchantReportTest.php
@@ -44,6 +44,9 @@ class MerchantReportTest extends UnitTest {
 	/** @var MerchantReport $merchant_report */
 	protected $merchant_report;
 
+	/** Merchant ID */
+	protected const MERCHANT_ID = 432;
+
 
 	/**
 	 * Runs before each test is executed.
@@ -57,6 +60,8 @@ class MerchantReportTest extends UnitTest {
 		$this->options         = $this->createMock( OptionsInterface::class );
 		$this->merchant_report = new MerchantReport( $this->shopping_client, $this->product_helper );
 		$this->merchant_report->set_options_object( $this->options );
+
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
 	}
 
 	/**
@@ -82,10 +87,9 @@ class MerchantReportTest extends UnitTest {
 	}
 
 	public function test_get_product_view_report() {
-		$test_merchant_id = 432;
-		$wc_product_id_1  = 882;
-		$wc_product_id_2  = 883;
-		$page_size        = 800;
+		$wc_product_id_1 = 882;
+		$wc_product_id_2 = 883;
+		$page_size       = 800;
 
 		add_filter(
 			'woocommerce_gla_product_view_report_page_size',
@@ -93,8 +97,6 @@ class MerchantReportTest extends UnitTest {
 				return $page_size;
 			}
 		);
-
-		$this->options->method( 'get_merchant_id' )->willReturn( $test_merchant_id );
 
 		$this->product_helper->method( 'get_wc_product_id' )->will(
 			$this->returnCallback(
@@ -143,7 +145,7 @@ class MerchantReportTest extends UnitTest {
 
 		$this->shopping_client->reports->expects( $this->once() )
 			->method( 'search' )
-			->with( $test_merchant_id, $search_request )
+			->with( self::MERCHANT_ID, $search_request )
 			->willReturn( $response );
 
 		$this->assertEquals(
@@ -167,8 +169,6 @@ class MerchantReportTest extends UnitTest {
 	}
 
 	public function test_get_product_view_report_with_exception() {
-		$this->options->method( 'get_merchant_id' )->willReturn( 432 );
-
 		$this->shopping_client->reports->expects( $this->once() )
 			->method( 'search' )
 			->will(

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -145,6 +145,8 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 			array_map( 'wc_get_product', $ids ),
 			$this->product_repository->find_by_ids( $ids )
 		);
+
+		$this->assertEquals( [], $this->product_repository->find_by_ids( [] ) );
 	}
 
 	public function test_find_synced_products() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146 & https://github.com/woocommerce/google-listings-and-ads/issues/2250

This PR introduces:

- Tests for the Product View Report.
- Removed the `product_view.offer_id` from the MerchantQuery, as we're using the MC-ID to extract the `offerID`. The product_view.id is necessary in the query and cannot be removed.
- I've updated the default placeholder for `$product_view_data` from `next_page` to `next_page_token` to maintain consistency with the rest of the code.

It looks like the report for free listings isn't covered by tests, so I'll create a follow-up issue to add tests for that section.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Run the tests `./vendor/bin/phpunit`


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
