### PR TITLE
Fix Issue with intermediate parents status

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -728,7 +728,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		// If the option is set, use it to sum the total quantity.
 		$product_statistics_intermediate_data = $this->options->get( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
 		if ( $product_statistics_intermediate_data ) {
-			$product_statistics = $product_statistics + ['parents' => []];
+			$product_statistics = $product_statistics + [ 'parents' => [] ];
 		}
 
 		$product_statistics_priority = [
@@ -761,13 +761,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		foreach ( $parent_statuses as $parent_id => $parent_status ) {
 			$current_parent_intermediate_data_status = $product_statistics_intermediate_data['parents'][ $parent_id ] ?? null;
 
-			if( $current_parent_intermediate_data_status && $product_statistics_priority[ $parent_status ] < $product_statistics_priority[ $current_parent_intermediate_data_status ] &&  $product_statistics[ $current_parent_intermediate_data_status ] > 0 ) {
+			// Check if the new parent status has higher priority than the previous one.
+			if ( $current_parent_intermediate_data_status && $product_statistics_priority[ $parent_status ] < $product_statistics_priority[ $current_parent_intermediate_data_status ] && $product_statistics[ $current_parent_intermediate_data_status ] > 0 ) {
 				$product_statistics[ $current_parent_intermediate_data_status ] -= 1;
-				$product_statistics[ $parent_status ] += 1;
 			}
-			else{
-				$product_statistics[ $parent_status ] += 1;
-			}
+
+			$product_statistics[ $parent_status ] += 1;
 
 			$product_statistics['parents'][ $parent_id ] = $parent_status;
 		}
@@ -805,6 +804,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$intermediate_data = $this->options->get( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
 
 		if ( $intermediate_data ) {
+
+			unset( $intermediate_data['parents'] );
 
 			$total_synced_products = $this->calculate_total_synced_product_statistics( $intermediate_data );
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -766,16 +766,27 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			}
 		}
 
-		foreach ( $parent_statuses as $parent_id => $parent_status ) {
+		foreach ( $parent_statuses as $parent_id => $new_parent_status ) {
 			$current_parent_intermediate_data_status = $product_statistics_intermediate_data['parents'][ $parent_id ] ?? null;
 
-			// Check if the new parent status has higher priority than the previous one.
-			if ( $current_parent_intermediate_data_status && $product_statistics_priority[ $parent_status ] < $product_statistics_priority[ $current_parent_intermediate_data_status ] && $product_statistics[ $current_parent_intermediate_data_status ] > 0 ) {
-				$product_statistics[ $current_parent_intermediate_data_status ] -= 1;
+			if ( $current_parent_intermediate_data_status === $new_parent_status ) {
+				continue;
 			}
 
-			$product_statistics[ $parent_status ]       += 1;
-			$product_statistics['parents'][ $parent_id ] = $parent_status;
+			if ( ! $current_parent_intermediate_data_status ) {
+				$product_statistics[ $new_parent_status ]   += 1;
+				$product_statistics['parents'][ $parent_id ] = $new_parent_status;
+				continue;
+			}
+
+			// Check if the new parent status has higher priority than the previous one.
+			if ( $product_statistics_priority[ $new_parent_status ] < $product_statistics_priority[ $current_parent_intermediate_data_status ] ) {
+				$product_statistics[ $current_parent_intermediate_data_status ] -= 1;
+				$product_statistics[ $new_parent_status ]                       += 1;
+				$product_statistics['parents'][ $parent_id ]                     = $new_parent_status;
+			} else {
+				$product_statistics['parents'][ $parent_id ] = $current_parent_intermediate_data_status;
+			}
 		}
 
 		$this->options->update( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $product_statistics );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -723,12 +723,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			MCStatus::PENDING            => 0,
 			MCStatus::DISAPPROVED        => 0,
 			MCStatus::NOT_SYNCED         => 0,
+			'parents'                    => [],
 		];
 
 		// If the option is set, use it to sum the total quantity.
 		$product_statistics_intermediate_data = $this->options->get( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
 		if ( $product_statistics_intermediate_data ) {
-			$product_statistics = $product_statistics + [ 'parents' => [] ];
+			$product_statistics = $product_statistics_intermediate_data;
 		}
 
 		$product_statistics_priority = [
@@ -766,8 +767,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 				$product_statistics[ $current_parent_intermediate_data_status ] -= 1;
 			}
 
-			$product_statistics[ $parent_status ] += 1;
-
+			$product_statistics[ $parent_status ]       += 1;
 			$product_statistics['parents'][ $parent_id ] = $parent_status;
 		}
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -407,16 +407,19 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'update' )->with(
 				OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA,
 				$this->callback(
-					function ( $value ) {
+					function ( $value ) use ( $variable_product ) {
 						$this->assertEquals(
 							[
 
-								MCStatus::APPROVED    => 2,
-								MCStatus::PARTIALLY_APPROVED => 1,
+								MCStatus::APPROVED    => 1,
+								MCStatus::PARTIALLY_APPROVED => 2,
 								MCStatus::EXPIRING    => 1,
 								MCStatus::DISAPPROVED => 0,
 								MCStatus::NOT_SYNCED  => 0,
 								MCStatus::PENDING     => 0,
+								'parents' => [
+									$variable_product->get_id() => MCStatus::PARTIALLY_APPROVED,
+								]
 							],
 							$value
 						);
@@ -450,7 +453,7 @@ class MerchantStatusesTest extends UnitTest {
 			],
 			[
 				'product_id'      => $variation_id_2,
-				'status'          => MCStatus::APPROVED,
+				'status'          => MCStatus::PARTIALLY_APPROVED,
 				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
 			],
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -23,6 +23,8 @@ use DateTime;
 use DateInterval;
 use Exception;
 use WC_Helper_Product;
+use WC_Product_Variation;
+use WC_Product_Variable;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -58,6 +60,7 @@ class MerchantStatusesTest extends UnitTest {
 	private $update_merchant_product_statuses_job;
 	private $options;
 	private $container;
+	private $initial_mc_statuses;
 
 	/**
 	 * Runs before each test is executed.
@@ -92,6 +95,22 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_statuses = new MerchantStatuses();
 		$this->merchant_statuses->set_container( $container );
 		$this->merchant_statuses->set_options_object( $this->options );
+
+		$this->initial_mc_statuses = [
+			MCStatus::APPROVED           => 0,
+			MCStatus::PARTIALLY_APPROVED => 0,
+			MCStatus::EXPIRING           => 0,
+			MCStatus::DISAPPROVED        => 0,
+			MCStatus::NOT_SYNCED         => 0,
+			MCStatus::PENDING            => 0,
+		];
+
+		add_filter(
+			'woocommerce_gla_mc_status_lifetime',
+			function () {
+				return self::MC_STATUS_LIFETIME;
+			}
+		);
 	}
 
 	public function test_refresh_account_issues() {
@@ -370,13 +389,6 @@ class MerchantStatusesTest extends UnitTest {
 		$variation_id_1 = $variations[0]['variation_id'];
 		$variation_id_2 = $variations[1]['variation_id'];
 
-		add_filter(
-			'woocommerce_gla_mc_status_lifetime',
-			function () {
-				return self::MC_STATUS_LIFETIME;
-			}
-		);
-
 		$matcher = $this->exactly( 2 );
 		$this->product_repository->expects( $matcher )->method( 'find_by_ids_as_associative_array' )->willReturnCallback(
 			function ( $args ) use ( $matcher, $product_1, $product_2, $product_3, $variable_product, $variation_id_1, $variation_id_2 ) {
@@ -464,13 +476,6 @@ class MerchantStatusesTest extends UnitTest {
 	}
 
 	public function test_handle_complete_mc_statuses_fetching() {
-		add_filter(
-			'woocommerce_gla_mc_status_lifetime',
-			function () {
-				return self::MC_STATUS_LIFETIME;
-			}
-		);
-
 		$this->options->expects( $this->once() )
 			->method( 'get' )->with( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA )->willReturn(
 				[
@@ -516,114 +521,15 @@ class MerchantStatusesTest extends UnitTest {
 			$this->merchant_statuses->handle_complete_mc_statuses_fetching();
 	}
 
-	public function test_update_product_multiple_variables_stats() {
+	public function test_update_product_with_multiple_variables_and_multiple_batches_with_different_statuses() {
 		$variable_product = WC_Helper_Product::create_variation_product();
-
-		$variations     = $variable_product->get_available_variations();
-		$variation_id_1 = $variations[0]['variation_id'];
-		$variation_id_2 = $variations[1]['variation_id'];
-
-		add_filter(
-			'woocommerce_gla_mc_status_lifetime',
-			function () {
-				return self::MC_STATUS_LIFETIME;
-			}
-		);
-
-		$matcher = $this->exactly( 4 );
-		$this->product_repository->expects( $matcher )->method( 'find_by_ids_as_associative_array' )->willReturnCallback(
-			function ( $args ) use ( $matcher, $variation_id_1, $variable_product, $variation_id_2 ) {
-				switch ( $matcher->getInvocationCount() ) {
-					case 1:
-						$this->assertEquals( [ $variation_id_1 ], $args );
-						return [
-							$variation_id_1 => wc_get_product( $variation_id_1 ) ,
-						];
-					case 2:
-						$this->assertEquals( [ $variable_product->get_id() ], $args );
-						return [ $variable_product->get_id() => $variable_product ];
-					case 3:
-						$this->assertEquals( [ $variation_id_2 ], $args );
-						return [
-							$variation_id_2 => wc_get_product( $variation_id_2 ) ,
-						];
-					case 4:
-						$this->assertEquals( [ $variable_product->get_id() ], $args );
-						return [ $variable_product->get_id() => $variable_product ];
-				}
-			}
-		);
-
-		$matcher = $this->exactly( 2 );
-		$this->options->expects( $matcher )
-			->method( 'get' )
-			->willReturnCallback(
-				function ( $args ) use ( $matcher, $variable_product ) {
-					switch ( $matcher->getInvocationCount() ) {
-						case 1:
-							$this->assertEquals( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $args );
-							return null;
-						case 2:
-							$this->assertEquals( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $args );
-							return [
-								MCStatus::APPROVED    => 1,
-								MCStatus::PARTIALLY_APPROVED => 0,
-								MCStatus::EXPIRING    => 0,
-								MCStatus::DISAPPROVED => 0,
-								MCStatus::NOT_SYNCED  => 0,
-								MCStatus::PENDING     => 0,
-								'parents'             => [ $variable_product->get_id() => MCStatus::APPROVED ],
-							];
-					}
-				}
-			);
-
-		$matcher = $this->exactly( 2 );
-		$this->options->expects( $matcher )
-			->method( 'update' )
-			->willReturnCallback(
-				function ( $option, $intermediate_data ) use ( $matcher, $variable_product ) {
-					$this->assertEquals( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $option );
-
-					switch ( $matcher->getInvocationCount() ) {
-						case 1:
-							$this->assertEquals(
-								[
-
-									MCStatus::APPROVED    => 1,
-									MCStatus::PARTIALLY_APPROVED => 0,
-									MCStatus::EXPIRING    => 0,
-									MCStatus::DISAPPROVED => 0,
-									MCStatus::NOT_SYNCED  => 0,
-									MCStatus::PENDING     => 0,
-									'parents'             => [ $variable_product->get_id() => MCStatus::APPROVED ],
-								],
-								$intermediate_data
-							);
-							return true;
-						case 2:
-							$this->assertEquals( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $option );
-							$this->assertEquals(
-								[
-
-									MCStatus::APPROVED    => 0,
-									MCStatus::PARTIALLY_APPROVED => 0,
-									MCStatus::EXPIRING    => 0,
-									MCStatus::DISAPPROVED => 1,
-									MCStatus::NOT_SYNCED  => 0,
-									MCStatus::PENDING     => 0,
-									'parents'             => [ $variable_product->get_id() => MCStatus::DISAPPROVED ],
-								],
-								$intermediate_data
-							);
-							return true;
-					}
-				}
-			);
+		$variations       = $variable_product->get_available_variations( 'objects' );
+		$variation_1      = $variations[0];
+		$variation_2      = $variations[1];
 
 		$product_statuses_1 = [
 			[
-				'product_id'      => $variation_id_1,
+				'product_id'      => $variation_1->get_id(),
 				'status'          => MCStatus::APPROVED,
 				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
 			],
@@ -632,12 +538,26 @@ class MerchantStatusesTest extends UnitTest {
 
 		$product_statuses_2 = [
 			[
-				'product_id'      => $variation_id_2,
+				'product_id'      => $variation_2->get_id(),
 				'status'          => MCStatus::DISAPPROVED,
 				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
 			],
 
 		];
+
+		$this->assert_find_by_ids_for_variations( $variable_product, $variation_1, $variation_2 );
+
+		$this->assert_update_intermediate_data(
+			[
+				MCStatus::APPROVED => 1,
+				'parents'          => [ $variable_product->get_id() => MCStatus::APPROVED ],
+			],
+			[
+				MCStatus::APPROVED    => 0,
+				MCStatus::DISAPPROVED => 1,
+				'parents'             => [ $variable_product->get_id() => MCStatus::DISAPPROVED ],
+			]
+		);
 
 		$this->merchant_statuses->update_product_stats(
 			$product_statuses_1
@@ -649,6 +569,192 @@ class MerchantStatusesTest extends UnitTest {
 
 		$merchant_statuses_2->update_product_stats(
 			$product_statuses_2
+		);
+	}
+
+
+	public function test_update_product_with_multiple_variables_and_multiple_batches_and_same_status() {
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variations       = $variable_product->get_available_variations( 'objects' );
+		$variation_1      = $variations[0];
+		$variation_2      = $variations[1];
+
+		$product_statuses_1 = [
+			[
+				'product_id'      => $variation_1->get_id(),
+				'status'          => MCStatus::APPROVED,
+				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+			],
+
+		];
+
+		$product_statuses_2 = [
+			[
+				'product_id'      => $variation_2->get_id(),
+				'status'          => MCStatus::APPROVED,
+				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+			],
+
+		];
+
+		$this->assert_find_by_ids_for_variations( $variable_product, $variation_1, $variation_2 );
+
+		$this->assert_update_intermediate_data(
+			[
+				MCStatus::APPROVED => 1,
+				'parents'          => [ $variable_product->get_id() => MCStatus::APPROVED ],
+			],
+			[
+				MCStatus::APPROVED => 1,
+				'parents'          => [ $variable_product->get_id() => MCStatus::APPROVED ],
+			]
+		);
+
+		$this->merchant_statuses->update_product_stats(
+			$product_statuses_1
+		);
+
+		$merchant_statuses_2 = new MerchantStatuses();
+		$merchant_statuses_2->set_container( $this->container );
+		$merchant_statuses_2->set_options_object( $this->options );
+
+		$merchant_statuses_2->update_product_stats(
+			$product_statuses_2
+		);
+	}
+
+
+	public function test_update_product_with_multiple_variables_and_multiple_batches_and_dont_override_previous_state() {
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variations       = $variable_product->get_available_variations( 'objects' );
+		$variation_1      = $variations[0];
+		$variation_2      = $variations[1];
+
+		$product_statuses_1 = [
+			[
+				'product_id'      => $variation_1->get_id(),
+				'status'          => MCStatus::DISAPPROVED,
+				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+			],
+
+		];
+
+		$product_statuses_2 = [
+			[
+				'product_id'      => $variation_2->get_id(),
+				'status'          => MCStatus::APPROVED,
+				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+			],
+
+		];
+
+		$this->assert_find_by_ids_for_variations( $variable_product, $variation_1, $variation_2 );
+
+		$this->assert_update_intermediate_data(
+			[
+				MCStatus::DISAPPROVED => 1,
+				'parents'             => [ $variable_product->get_id() => MCStatus::DISAPPROVED ],
+			],
+			[
+				MCStatus::DISAPPROVED => 1,
+				'parents'             => [ $variable_product->get_id() => MCStatus::DISAPPROVED ],
+			]
+		);
+
+		$this->merchant_statuses->update_product_stats(
+			$product_statuses_1
+		);
+
+		$merchant_statuses_2 = new MerchantStatuses();
+		$merchant_statuses_2->set_container( $this->container );
+		$merchant_statuses_2->set_options_object( $this->options );
+
+		$merchant_statuses_2->update_product_stats(
+			$product_statuses_2
+		);
+	}
+
+	/**
+	 *  Assert that the update_product_stats method updates the product stats in two batches.
+	 *
+	 * @param array $first_update_results
+	 * @param array $second_update_results
+	 */
+	protected function assert_update_intermediate_data( array $first_update_results, array $second_update_results ) {
+		$matcher = $this->exactly( 2 );
+		$this->options->expects( $matcher )
+			->method( 'get' )
+			->willReturnCallback(
+				function ( $args ) use ( $matcher, $first_update_results ) {
+					switch ( $matcher->getInvocationCount() ) {
+						case 1:
+							$this->assertEquals( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $args );
+							return null;
+						case 2:
+							$this->assertEquals( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $args );
+							return array_merge( $this->initial_mc_statuses, $first_update_results );
+					}
+				}
+			);
+
+		$matcher = $this->exactly( 2 );
+		$this->options->expects( $matcher )
+			->method( 'update' )
+			->willReturnCallback(
+				function ( $option, $intermediate_data ) use ( $matcher, $first_update_results, $second_update_results ) {
+					$this->assertEquals( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $option );
+
+					switch ( $matcher->getInvocationCount() ) {
+						case 1:
+							$this->assertEquals(
+								array_merge( $this->initial_mc_statuses, $first_update_results ),
+								$intermediate_data
+							);
+							return true;
+						case 2:
+							$this->assertEquals( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA, $option );
+							$this->assertEquals(
+								array_merge( $this->initial_mc_statuses, $second_update_results ),
+								$intermediate_data
+							);
+							return true;
+					}
+				}
+			);
+	}
+
+	/**
+	 *
+	 *  Assert that the find_by_ids_as_associative_array method is called with the expected arguments for variations when updating the product stats in two batches.
+	 *  Each batch calls find_by_ids_as_associative_array twice, once for the variation and once for the parent product.
+	 *
+	 * @param WC_Product_Variable  $variable_product
+	 * @param WC_Product_Variation $variation_1
+	 * @param WC_Product_Variation $variation_2
+	 */
+	protected function assert_find_by_ids_for_variations( WC_Product_Variable $variable_product, WC_Product_Variation $variation_1, WC_Product_Variation $variation_2 ) {
+		$matcher = $this->exactly( 4 );
+		$this->product_repository->expects( $matcher )->method( 'find_by_ids_as_associative_array' )->willReturnCallback(
+			function ( $args ) use ( $matcher, $variable_product, $variation_1, $variation_2 ) {
+				switch ( $matcher->getInvocationCount() ) {
+					case 1:
+						$this->assertEquals( [ $variation_1->get_id() ], $args );
+						return [
+							$variation_1->get_id() => $variation_1 ,
+						];
+					case 2:
+						$this->assertEquals( [ $variable_product->get_id() ], $args );
+						return [ $variable_product->get_id() => $variable_product ];
+					case 3:
+						$this->assertEquals( [ $variation_2->get_id() ], $args );
+						return [
+							$variation_2->get_id() => $variation_2,
+						];
+					case 4:
+						$this->assertEquals( [ $variable_product->get_id() ], $args );
+						return [ $variable_product->get_id() => $variable_product ];
+				}
+			}
 		);
 	}
 }

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -88,8 +88,7 @@ class MerchantStatusesTest extends UnitTest {
 		$container->share( MerchantIssueTable::class, $merchant_issue_table );
 		$container->share( UpdateMerchantProductStatuses::class, $this->update_merchant_product_statuses_job );
 
-		$this->container = $container;
-
+		$this->container         = $container;
 		$this->merchant_statuses = new MerchantStatuses();
 		$this->merchant_statuses->set_container( $container );
 		$this->merchant_statuses->set_options_object( $this->options );
@@ -417,9 +416,9 @@ class MerchantStatusesTest extends UnitTest {
 								MCStatus::DISAPPROVED => 0,
 								MCStatus::NOT_SYNCED  => 0,
 								MCStatus::PENDING     => 0,
-								'parents' => [
+								'parents'             => [
 									$variable_product->get_id() => MCStatus::PARTIALLY_APPROVED,
-								]
+								],
 							],
 							$value
 						);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Follow-up of https://github.com/woocommerce/google-listings-and-ads/pull/2257.

Now that we're calculating product statuses in batches, it's possible for variations from the same parents to come in different batches. For example:

Batch 1: Variable 1 - Parent ID 1 - DISAPPROVED
Batch 2: Variable 2 - Parent ID 1 - APPROVED

This could impact the total count because variable products are grouped by their parents. So, in the previous example, we should only count 1 DISAPPROVED product instead of 1 DISAPPROVED + 1 APPROVED.

This PR addresses the issue by storing the latest status from the parent product, ensuring it can be used for the total calculation.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. It's a bit of a tricky situation to test, so I mainly relied on the Unit Tests to simulate the scenario. However, you can create batches of 1, each with a parent product having different variables, and check if the total count is correct. To do so identify a variable product in your store, and get a couple of variable ids with the same parent id.
2. Check that those variables are available in your Merchant Center.
3. Go to https://github.com/woocommerce/google-listings-and-ads/blob/d7ecd99a5bb010ea371b62f2578dbf5c503ac4ea/src/API/Google/Query/MerchantProductViewReportQuery.php#L22-L28 and add the following line: `$this->where( 'product_view.offer_id', ['gla_VARIABLE_ID_1', 'gla_VARIABLE_ID_2'], 'IN' ); `
4. Change the batch size to `1` in this line: https://github.com/woocommerce/google-listings-and-ads/blob/d7ecd99a5bb010ea371b62f2578dbf5c503ac4ea/src/API/Google/MerchantReport.php#L68
5. Call the following endpoint `GET wc/gla/mc/product-statistics/refresh`
6. You should get only one status. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
