### PR TITLE
401 handling for connected Ads accounts

### DIFF
--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -278,7 +278,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 *
 	 * @return callable
 	 */
-	public function add_plugin_version_header(): callable {
+	protected function add_plugin_version_header(): callable {
 		return function ( callable $handler ) {
 			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				$request = $request->withHeader( 'x-client-name', $this->get_client_name() )

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -134,12 +134,12 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			$handler_stack = HandlerStack::create();
 			$handler_stack->remove( 'http_errors' );
 			$handler_stack->push( $this->error_handler(), 'http_errors' );
-			$handler_stack->push( $this->add_auth_header() );
+			$handler_stack->push( $this->add_auth_header(), 'auth_header' );
 			$handler_stack->push( $this->add_plugin_version_header(), 'plugin_version_header' );
 
 			// Override endpoint URL if we are using http locally.
 			if ( 0 === strpos( $this->get_connect_server_url_root()->getValue(), 'http://' ) ) {
-				$handler_stack->push( $this->override_http_url() );
+				$handler_stack->push( $this->override_http_url(), 'override_http_url' );
 			}
 
 			return new GuzzleClient( [ 'handler' => $handler_stack ] );

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -91,6 +91,21 @@ class ClientTest extends ContainerAwareUnitTest {
 	}
 
 	/**
+	 * Confirm that a request to listAccessibleCustomers does not return a redirect error.
+	 */
+	public function test_error_handler_list_accessible_customers() {
+		$mocked_responses = [
+			new Response( 401, [], 'error' ),
+		];
+
+		$this->expectException( RequestException::class );
+		$this->expectExceptionMessage( 'error' );
+
+		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$response = $client->request( 'GET', 'https://testing.local/google/google-ads/customers:listAccessibleCustomers' );
+	}
+
+	/**
 	 * Confirm that the error handler throws a generic error when the status code is higher than 400 except a 401.
 	 */
 	public function test_error_handler_generic_error_response() {

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider;
@@ -84,6 +85,21 @@ class ClientTest extends ContainerAwareUnitTest {
 
 		$this->expectException( AccountReconnect::class );
 		$this->expectExceptionMessage( AccountReconnect::google_disconnected()->getMessage() );
+
+		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$response = $client->request( 'GET', 'https://testing.local' );
+	}
+
+	/**
+	 * Confirm that the error handler throws a generic error when the status code is higher than 400 except a 401.
+	 */
+	public function test_error_handler_generic_error_response() {
+		$mocked_responses = [
+			new Response( 404, [], 'not found' ),
+		];
+
+		$this->expectException( RequestException::class );
+		$this->expectExceptionMessage( 'not found' );
 
 		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -269,7 +269,7 @@ class ClientTest extends UnitTest {
 	protected function mock_client_with_handler( string $handler_function, array $mocked_responses ) {
 		$mock     = new MockHandler( $mocked_responses );
 		$handlers = HandlerStack::create( $mock );
-		$handlers->push( $this->invoke_handler( 'error_handler' ) );
+		$handlers->push( $this->invoke_handler( $handler_function ) );
 		return new Client( [ 'handler' => $handlers ] );
 	}
 }

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReconnectWordPress;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -66,7 +67,6 @@ class ClientTest extends UnitTest {
 
 		$this->provider = new GoogleServiceProvider();
 		$this->provider->setLeagueContainer( $this->container );
-		$this->provider->register();
 	}
 
 	/**
@@ -76,7 +76,7 @@ class ClientTest extends UnitTest {
 	 * - `plugin_version_header`
 	 */
 	public function test_handlers_in_stack(): void {
-		// Get string representation of the handler stack.
+		// Get string representation of the handler stack (fetches handlers from main container).
 		$handlers = (string) woogle_get_container()->get( Client::class )->getConfig( 'handler' );
 
 		$this->assertStringContainsString( 'http_errors', $handlers );
@@ -85,6 +85,15 @@ class ClientTest extends UnitTest {
 
 		// By default we should not have a http URL.
 		$this->assertStringNotContainsString( 'override_http_url', $handlers );
+	}
+
+	/**
+	 * Confirm that service classes are available from the container after registering.
+	 */
+	public function test_registering_provided_services() {
+		$this->provider->register();
+
+		$this->assertNotNull( $this->container->get( GoogleAdsClient::class ) );
 	}
 
 	/**

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -26,13 +26,21 @@ class ClientTest extends ContainerAwareUnitTest {
 	use PluginHelper;
 
 	/**
-	 * Confirm that the client handler stack includes the `plugin_version_header`
-	 *
-	 * @return void
+	 * Confirm that the client handler stack includes the following handlers:
+	 * - `http_errors`
+	 * - `auth_header`
+	 * - `plugin_version_header`
 	 */
-	public function test_plugin_version_header_in_handler_stack(): void {
-		// Get string representation of the handler stack and confirm if `plugin_version_header` is contained within it.
-		$this->assertStringContainsString( 'plugin_version_header', (string) $this->container->get( Client::class )->getConfig( 'handler' ) );
+	public function test_handlers_in_stack(): void {
+		// Get string representation of the handler stack.
+		$handlers = (string) $this->container->get( Client::class )->getConfig( 'handler' );
+
+		$this->assertStringContainsString( 'http_errors', $handlers );
+		$this->assertStringContainsString( 'auth_header', $handlers );
+		$this->assertStringContainsString( 'plugin_version_header', $handlers );
+
+		// By default we should not have a http URL.
+		$this->assertStringNotContainsString( 'override_http_url', $handlers );
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Exception;
@@ -213,5 +214,19 @@ class AccountControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( self::TEST_BILLING_STATUS_DATA, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test a Google disconnected error since it's a dependency for a connected Ads account.
+	 */
+	public function test_connected_with_google_disconnected() {
+		$this->account->expects( $this->once() )
+			->method( 'get_accounts' )
+			->willThrowException( AccountReconnect::google_disconnected() );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
+		$this->assertEquals( 'GOOGLE_DISCONNECTED', $response->get_data()['code'] );
+		$this->assertEquals( 401, $response->get_data()['status'] );
+		$this->assertEquals( 401, $response->get_status() );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We have a universal handler for any response with a 401 status code. This handler determines if it's either the Jetpack or the Google connection that no longer has the required permission and then handles it with a ReconnectAccount response.

Unfortunately though there is a scenario when listing Ads accounts that also throws a 401 error if the user has never signed up to Ads yet. Which is indicated by the following error message:
```json
"errorCode": {
    "authenticationError": "NOT_ADS_USER"
},
"message": "The Google account (@gmail.com user) that generated the OAuth access tokens is not associated with any Ads accounts. Create a new account, or add the Google account to an existing Ads account."
```

We previously handled this scenario by returning an empty list of existing accounts. However that is no longer possible since the error handler catches it earlier. So this PR prevents the error handler from catching the error so it can be handled correctly by the call to fetch a list of Ad accounts.

I originally wanted to set a flag in the Client class that when the flag is set we shouldn't handle 401's, however with the way the handler stack is being built, I didn't find a good way to do this. I also considered setting a header in the request, but this seemed like it would be similar to just checking the request path.

I've also added a small test to the site controller to expect the reconnect Google account exception. We are already testing for an empty list to be returned when a `NOT_ADS_USER` response is returned. ~~But unfortunately we don't have a full test that makes use of all the Guzzle handlers, so it won't catch our custom error handler preventing the error. We'd need a better integration test for that, which would be out of scope of a unit test.~~
Edit: I've found a way to mock the handlers and test them individually with various mocked requests. This PR includes unit tests to confirm the various scenarios in the `error_handler` are handled as intended.

### Detailed test instructions:
1. Start with a site with all accounts disconnected
2. Connect a WP.com account
3. Connect a Google account (make sure it's an account that never had an Ads account connected)
4. Use the connection test page to fetch a list of customers "Get Customers from Google Ads"
5. Expect it to return an empty list "Total accounts: 0"
6. Confirm that the full exception is logged in WooCommerce > Status > Logs:
```json
{
    "message": "Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https:\/\/developers.google.com\/identity\/sign-in\/web\/devconsole-project.",
    "code": 16,
    "status": "UNAUTHENTICATED",
    "details": [
        {
            "@type": "type.googleapis.com\/google.ads.googleads.v14.errors.GoogleAdsFailure",
            "errors": [
                {
                    "errorCode": {
                        "authenticationError": "NOT_ADS_USER"
                    },
                    "message": "The Google account (@gmail.com user) that generated the OAuth access tokens is not associated with any Ads accounts. Create a new account, or add the Google account to an existing Ads account."
                }
            ],
            "requestId": "duBXnLB1SNjhc5DM3tB10w"
        }
    ]
}
```


### Changelog entry
* Fix - 401 handling for connected Ads accounts.
