### PR TITLE
API PULL - Fix Notifications Body Encoding

### DIFF
--- a/src/Google/NotificationsService.php
+++ b/src/Google/NotificationsService.php
@@ -116,7 +116,7 @@ class NotificationsService implements Service {
 	 * @return array|\WP_Error
 	 */
 	protected function do_request( array $args ) {
-		return Client::remote_request( $args, wp_json_encode( $args['body'] ) );
+		return Client::remote_request( $args, $args['body'] );
 	}
 
 	/**

--- a/src/Google/NotificationsService.php
+++ b/src/Google/NotificationsService.php
@@ -70,6 +70,7 @@ class NotificationsService implements Service {
 			'timeout' => 30,
 			'headers' => [
 				'x-woocommerce-topic' => $topic,
+				'Content-Type'        => 'application/json',
 			],
 			'body'    => [
 				'item_id' => $item_id,
@@ -116,7 +117,7 @@ class NotificationsService implements Service {
 	 * @return array|\WP_Error
 	 */
 	protected function do_request( array $args ) {
-		return Client::remote_request( $args, $args['body'] );
+		return Client::remote_request( $args, wp_json_encode( $args['body'] ) );
 	}
 
 	/**

--- a/tests/Unit/Google/NotificationsServiceTest.php
+++ b/tests/Unit/Google/NotificationsServiceTest.php
@@ -69,7 +69,7 @@ class NotificationsServiceTest extends UnitTest {
 			'timeout' => 30,
 			'headers' => [
 				'x-woocommerce-topic' => $topic,
-				'Content-Type' => 'application/json'
+				'Content-Type'        => 'application/json',
 			],
 			'body'    => [
 				'item_id' => $item_id,

--- a/tests/Unit/Google/NotificationsServiceTest.php
+++ b/tests/Unit/Google/NotificationsServiceTest.php
@@ -69,6 +69,7 @@ class NotificationsServiceTest extends UnitTest {
 			'timeout' => 30,
 			'headers' => [
 				'x-woocommerce-topic' => $topic,
+				'Content-Type' => 'application/json'
 			],
 			'body'    => [
 				'item_id' => $item_id,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There is an issue when sending notifications. We are getting `invalid_body_hash`. This seems to happen on `is_jetpack_authorized_for_site` in WPCOM when trying to compare the body hash.

Seems like its failing due the encoding. This PR fix that.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Connection test page
2. Send a notification request
3. See you get a failing error
4. Go to WooCommerce Status - Logs and get the last logs for GLA
5. See the request failed because  `invalid_body_hash`
6. Checkout this PR
7. Repeat steps 1-2
8.  See the request is successfull


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->