### PR TITLE
API PULL - Add Settings Notification

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -651,6 +651,7 @@ class ConnectionTest implements Service, Registerable {
 											<option value="coupon.delete" <?php echo $_GET['topic'] === 'coupon.delete' ? "selected" : ""?>>coupon.delete</option>
 											<option value="coupon.update" <?php echo $_GET['topic'] === 'coupon.update' ? "selected" : ""?>>coupon.update</option>
 											<option value="shipping.update" <?php echo $_GET['topic'] === 'shipping.update' ? "selected" : ""?>>shipping.update</option>
+											<option value="settings.update" <?php echo $_GET['topic'] === 'settings.update' ? "selected" : ""?>>settings.update</option>
 										</select>
 									</label>
 									<button class="button">Send Notification</button>

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -737,12 +737,12 @@ class ConnectionTest implements Service, Registerable {
 		}
 
 		if ( 'partner-notification' === $_GET['action'] && check_admin_referer( 'partner-notification' ) ) {
-			if ( ! isset( $_GET['topic'], $_GET['item_id'] ) ) {
-				$this->response .= "\n Topic and Item ID are required.";
+			if ( ! isset( $_GET['topic'] ) ) {
+				$this->response .= "\n Topic is required.";
 				return;
 			}
 
-			$item  = $_GET['item_id'];
+			$item  = $_GET['item_id'] ?? null;
 			$topic = $_GET['topic'];
 
 			$service = new NotificationsService();

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -645,13 +645,13 @@ class ConnectionTest implements Service, Registerable {
 										Topic
 										<select name="topic">
 											<option value="product.create" <?php echo (! isset( $_GET['topic'] ) || $_GET['topic'] === 'product.create') ? "selected" : "" ?>>product.create</option>
-											<option value="product.delete" <?php echo $_GET['topic'] === 'product.delete' ? "selected" : ""?>>product.delete</option>
-											<option value="product.update" <?php echo $_GET['topic'] === 'product.update' ? "selected" : ""?>>product.update</option>
-											<option value="coupon.create" <?php echo $_GET['topic'] === 'coupon.create' ? "selected" : ""?>>coupon.create</option>
-											<option value="coupon.delete" <?php echo $_GET['topic'] === 'coupon.delete' ? "selected" : ""?>>coupon.delete</option>
-											<option value="coupon.update" <?php echo $_GET['topic'] === 'coupon.update' ? "selected" : ""?>>coupon.update</option>
-											<option value="shipping.update" <?php echo $_GET['topic'] === 'shipping.update' ? "selected" : ""?>>shipping.update</option>
-											<option value="settings.update" <?php echo $_GET['topic'] === 'settings.update' ? "selected" : ""?>>settings.update</option>
+											<option value="product.delete" <?php echo isset( $_GET['topic'] ) && $_GET['topic'] === 'product.delete' ? "selected" : ""?>>product.delete</option>
+											<option value="product.update" <?php echo isset( $_GET['topic'] ) && $_GET['topic'] === 'product.update' ? "selected" : ""?>>product.update</option>
+											<option value="coupon.create" <?php echo isset( $_GET['topic'] ) && $_GET['topic'] === 'coupon.create' ? "selected" : ""?>>coupon.create</option>
+											<option value="coupon.delete" <?php echo isset( $_GET['topic'] ) && $_GET['topic'] === 'coupon.delete' ? "selected" : ""?>>coupon.delete</option>
+											<option value="coupon.update" <?php echo isset( $_GET['topic'] ) && $_GET['topic'] === 'coupon.update' ? "selected" : ""?>>coupon.update</option>
+											<option value="shipping.update" <?php echo isset( $_GET['topic'] ) && $_GET['topic'] === 'shipping.update' ? "selected" : ""?>>shipping.update</option>
+											<option value="settings.update" <?php echo isset( $_GET['topic'] ) && $_GET['topic'] === 'settings.update' ? "selected" : ""?>>settings.update</option>
 										</select>
 									</label>
 									<button class="button">Send Notification</button>

--- a/src/Google/NotificationsService.php
+++ b/src/Google/NotificationsService.php
@@ -26,6 +26,7 @@ class NotificationsService implements Service {
 	public const TOPIC_COUPON_DELETED   = 'coupon.delete';
 	public const TOPIC_COUPON_UPDATED   = 'coupon.update';
 	public const TOPIC_SHIPPING_UPDATED = 'shipping.update';
+	public const TOPIC_SETTINGS_UPDATED = 'settings.update';
 
 	/**
 	 * The url to send the notification

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ProductNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ShippingNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncerJobInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
@@ -48,6 +49,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
+use Automattic\WooCommerce\GoogleListingsAndAds\Settings;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -151,6 +153,15 @@ class JobServiceProvider extends AbstractServiceProvider {
 			ShippingNotificationJob::class,
 			NotificationsService::class
 		);
+
+		// Share settings notifications job
+		$this->share_action_scheduler_job(
+			SettingsNotificationJob::class,
+			NotificationsService::class
+		);
+
+		// Share settings syncer hooks
+		$this->share_with_tags( Settings\SyncerHooks::class, JobRepository::class, NotificationsService::class );
 
 		// Share shipping settings syncer job and hooks.
 		$this->share_action_scheduler_job( UpdateShippingSettings::class, MerchantCenterService::class, GoogleSettings::class );

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -86,7 +86,7 @@ class ProductNotificationJob extends AbstractActionSchedulerJob implements JobIn
 	 * @param array $args
 	 */
 	public function schedule( array $args = [] ): void {
-		if ( $this->can_schedule( $args ) ) {
+		if ( $this->can_schedule( [ $args ] ) ) {
 			$this->action_scheduler->schedule_immediate(
 				$this->get_process_item_hook(),
 				[ $args ]

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -86,7 +86,7 @@ class ProductNotificationJob extends AbstractActionSchedulerJob implements JobIn
 	 * @param array $args
 	 */
 	public function schedule( array $args = [] ): void {
-		if ( $this->can_schedule( [ $args ] ) ) {
+		if ( $this->can_schedule( $args ) ) {
 			$this->action_scheduler->schedule_immediate(
 				$this->get_process_item_hook(),
 				[ $args ]

--- a/src/Jobs/Notifications/SettingsNotificationJob.php
+++ b/src/Jobs/Notifications/SettingsNotificationJob.php
@@ -72,7 +72,7 @@ class SettingsNotificationJob extends AbstractActionSchedulerJob implements JobI
 	 * @param array $args
 	 */
 	public function schedule( array $args = [] ): void {
-		if ( $this->can_schedule( $args ) ) {
+		if ( $this->can_schedule( [ $args ] ) ) {
 			$this->action_scheduler->schedule_immediate(
 				$this->get_process_item_hook(),
 				[ $args ]

--- a/src/Jobs/Notifications/SettingsNotificationJob.php
+++ b/src/Jobs/Notifications/SettingsNotificationJob.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractActionSchedulerJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SettingsNotificationJob
+ * Class for the Settings Notifications
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
+ */
+class SettingsNotificationJob extends AbstractActionSchedulerJob implements JobInterface {
+
+	/**
+	 * @var NotificationsService $notifications_service
+	 */
+	protected $notifications_service;
+
+	/**
+	 * @var string $topic
+	 */
+	protected $topic;
+
+	/**
+	 * Notifications Jobs constructor.
+	 *
+	 * @param ActionSchedulerInterface  $action_scheduler
+	 * @param ActionSchedulerJobMonitor $monitor
+	 * @param NotificationsService      $notifications_service
+	 */
+	public function __construct(
+		ActionSchedulerInterface $action_scheduler,
+		ActionSchedulerJobMonitor $monitor,
+		NotificationsService $notifications_service
+	) {
+		$this->notifications_service = $notifications_service;
+		$this->topic                 = NotificationsService::TOPIC_SETTINGS_UPDATED;
+		parent::__construct( $action_scheduler, $monitor );
+	}
+
+	/**
+	 * Get the job name
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'notifications/settings';
+	}
+
+
+	/**
+	 * Logic when processing the items
+	 *
+	 * @param array $args Arguments for the notification
+	 */
+	protected function process_items( array $args ): void {
+		$this->notifications_service->notify( $this->topic );
+	}
+
+	/**
+	 * Schedule the Job
+	 *
+	 * @param array $args
+	 */
+	public function schedule( array $args = [] ): void {
+		if ( $this->can_schedule( $args ) ) {
+			$this->action_scheduler->schedule_immediate(
+				$this->get_process_item_hook(),
+				[ $args ]
+			);
+		}
+	}
+
+	/**
+	 * Can the job be scheduled.
+	 *
+	 * @param array|null $args
+	 *
+	 * @return bool Returns true if the job can be scheduled.
+	 */
+	public function can_schedule( $args = [] ): bool {
+		/**
+		 * Allow users to disable the notification job schedule.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
+		 * @param array $args The arguments for the schedule function with the item id and the topic.
+		 */
+		return apply_filters( 'woocommerce_gla_settings_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $args );
+	}
+}

--- a/src/Jobs/Notifications/ShippingNotificationJob.php
+++ b/src/Jobs/Notifications/ShippingNotificationJob.php
@@ -72,7 +72,7 @@ class ShippingNotificationJob extends AbstractActionSchedulerJob implements JobI
 	 * @param array $args
 	 */
 	public function schedule( array $args = [] ): void {
-		if ( $this->can_schedule( [ $args ] ) ) {
+		if ( $this->can_schedule( $args ) ) {
 			$this->action_scheduler->schedule_immediate(
 				$this->get_process_item_hook(),
 				[ $args ]

--- a/src/Jobs/Notifications/ShippingNotificationJob.php
+++ b/src/Jobs/Notifications/ShippingNotificationJob.php
@@ -72,7 +72,7 @@ class ShippingNotificationJob extends AbstractActionSchedulerJob implements JobI
 	 * @param array $args
 	 */
 	public function schedule( array $args = [] ): void {
-		if ( $this->can_schedule( $args ) ) {
+		if ( $this->can_schedule( [ $args ] ) ) {
 			$this->action_scheduler->schedule_immediate(
 				$this->get_process_item_hook(),
 				[ $args ]

--- a/src/Jobs/Notifications/ShippingNotificationJob.php
+++ b/src/Jobs/Notifications/ShippingNotificationJob.php
@@ -60,14 +60,14 @@ class ShippingNotificationJob extends AbstractActionSchedulerJob implements JobI
 	/**
 	 * Logic when processing the items
 	 *
-	 * @param array $args Arguments with the item id and the topic
+	 * @param array $args Arguments for the notification
 	 */
 	protected function process_items( array $args ): void {
 		$this->notifications_service->notify( $this->topic );
 	}
 
 	/**
-	 * Schedule the Product Notification Job
+	 * Schedule the Job
 	 *
 	 * @param array $args
 	 */

--- a/src/Settings/SyncerHooks.php
+++ b/src/Settings/SyncerHooks.php
@@ -60,25 +60,10 @@ class SyncerHooks implements Service, Registerable {
 
 		$update_rest = function ( $option ) {
 			if ( strpos( $option, 'woocommerce_' ) === 0 ) {
-				$this->handle_update_shipping_settings();
+				$this->settings_notification_job->schedule();
 			}
 		};
 
 		add_action( 'update_option', $update_rest, 90, 1 );
-	}
-
-	/**
-	 * Handle updating of Merchant Center shipping settings.
-	 *
-	 * @return void
-	 */
-	protected function handle_update_shipping_settings() {
-		// Bail if an event is already scheduled in the current request
-		if ( $this->already_scheduled ) {
-			return;
-		}
-
-		$this->settings_notification_job->schedule();
-		$this->already_scheduled = true;
 	}
 }

--- a/src/Settings/SyncerHooks.php
+++ b/src/Settings/SyncerHooks.php
@@ -23,13 +23,6 @@ defined( 'ABSPATH' ) || exit;
 class SyncerHooks implements Service, Registerable {
 
 	/**
-	 * This property is used to avoid scheduling duplicate jobs in the same request.
-	 *
-	 * @var bool
-	 */
-	protected $already_scheduled = false;
-
-	/**
 	 * @var NotificationsService $notifications_service
 	 */
 	protected $notifications_service;
@@ -38,6 +31,39 @@ class SyncerHooks implements Service, Registerable {
 	 * @var SettingsNotificationJob $settings_notification_job
 	 */
 	protected $settings_notification_job;
+
+	/**
+	 * WooCommerce General Settings IDs
+	 * Copied from https://github.com/woocommerce/woocommerce/blob/af03815134385c72feb7a70abc597eca57442820/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php#L34
+	 */
+	protected const ALLOWED_SETTINGS = [
+		'store_address',
+		'woocommerce_store_address',
+		'woocommerce_store_address_2',
+		'woocommerce_store_city',
+		'woocommerce_default_country',
+		'woocommerce_store_postcode',
+		'store_address',
+		'general_options',
+		'woocommerce_allowed_countries',
+		'woocommerce_all_except_countries',
+		'woocommerce_specific_allowed_countries',
+		'woocommerce_ship_to_countries',
+		'woocommerce_specific_ship_to_countries',
+		'woocommerce_default_customer_address',
+		'woocommerce_calc_taxes',
+		'woocommerce_enable_coupons',
+		'woocommerce_calc_discounts_sequentially',
+		'general_options',
+		'pricing_options',
+		'woocommerce_currency',
+		'woocommerce_currency_pos',
+		'woocommerce_price_thousand_sep',
+		'woocommerce_price_decimal_sep',
+		'woocommerce_price_num_decimals',
+		'pricing_options',
+	];
+
 
 	/**
 	 * SyncerHooks constructor.
@@ -59,7 +85,7 @@ class SyncerHooks implements Service, Registerable {
 		}
 
 		$update_rest = function ( $option ) {
-			if ( strpos( $option, 'woocommerce_' ) === 0 ) {
+			if ( in_array( $option, self::ALLOWED_SETTINGS, true ) ) {
 				$this->settings_notification_job->schedule();
 			}
 		};

--- a/src/Settings/SyncerHooks.php
+++ b/src/Settings/SyncerHooks.php
@@ -1,0 +1,84 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Settings;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SyncerHooks
+ *
+ * Hooks to various WooCommerce and WordPress actions to automatically sync WooCommerce General Settings.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Settings
+ *
+ * @since x.x.x
+ */
+class SyncerHooks implements Service, Registerable {
+
+	/**
+	 * This property is used to avoid scheduling duplicate jobs in the same request.
+	 *
+	 * @var bool
+	 */
+	protected $already_scheduled = false;
+
+	/**
+	 * @var NotificationsService $notifications_service
+	 */
+	protected $notifications_service;
+
+	/**
+	 * @var SettingsNotificationJob $settings_notification_job
+	 */
+	protected $settings_notification_job;
+
+	/**
+	 * SyncerHooks constructor.
+	 *
+	 * @param JobRepository        $job_repository
+	 * @param NotificationsService $notifications_service
+	 */
+	public function __construct( JobRepository $job_repository, NotificationsService $notifications_service ) {
+		$this->settings_notification_job = $job_repository->get( SettingsNotificationJob::class );
+		$this->notifications_service     = $notifications_service;
+	}
+
+	/**
+	 * Register the service.
+	 */
+	public function register(): void {
+		if ( ! $this->notifications_service->is_enabled() ) {
+			return;
+		}
+
+		$update_rest = function ( $option ) {
+			if ( strpos( $option, 'woocommerce_' ) === 0 ) {
+				$this->handle_update_shipping_settings();
+			}
+		};
+
+		add_action( 'update_option', $update_rest, 90, 1 );
+	}
+
+	/**
+	 * Handle updating of Merchant Center shipping settings.
+	 *
+	 * @return void
+	 */
+	protected function handle_update_shipping_settings() {
+		// Bail if an event is already scheduled in the current request
+		if ( $this->already_scheduled ) {
+			return;
+		}
+
+		$this->settings_notification_job->schedule();
+		$this->already_scheduled = true;
+	}
+}

--- a/tests/Unit/Jobs/SettingsNotificationJobTest.php
+++ b/tests/Unit/Jobs/SettingsNotificationJobTest.php
@@ -59,7 +59,7 @@ class SettingsNotificationJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [] )
+			->with( self::PROCESS_ITEM_HOOK )
 			->willReturn( false );
 
 		$this->action_scheduler->expects( $this->once() )
@@ -74,7 +74,7 @@ class SettingsNotificationJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [] )
+			->with( self::PROCESS_ITEM_HOOK )
 			->willReturn( true );
 
 		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );

--- a/tests/Unit/Jobs/SettingsNotificationJobTest.php
+++ b/tests/Unit/Jobs/SettingsNotificationJobTest.php
@@ -9,8 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
-use WC_Helper_Product;
-
 /**
  * Class SettingsNotificationJobTest
  *

--- a/tests/Unit/Jobs/SettingsNotificationJobTest.php
+++ b/tests/Unit/Jobs/SettingsNotificationJobTest.php
@@ -1,0 +1,106 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Helper_Product;
+
+/**
+ * Class SettingsNotificationJobTest
+ *
+ * @group Notifications
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+class SettingsNotificationJobTest extends UnitTest {
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|NotificationsService $notification_service */
+	protected $notification_service;
+
+	/** @var SettingsNotificationJob $job */
+	protected $job;
+
+	protected const JOB_NAME          = 'notifications/settings';
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->notification_service = $this->createMock( NotificationsService::class );
+		$this->job                  = new SettingsNotificationJob(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->notification_service
+		);
+
+		$this->job->init();
+	}
+
+	public function test_job_name() {
+		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
+	}
+
+	public function test_schedule_schedules_immediate_job() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( self::PROCESS_ITEM_HOOK, [] )
+			->willReturn( false );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( self::PROCESS_ITEM_HOOK );
+
+		$this->job->schedule();
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( self::PROCESS_ITEM_HOOK, [] )
+			->willReturn( true );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule();
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
+
+		$this->action_scheduler->expects( $this->never() )
+			->method( 'has_scheduled_action' );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule();
+	}
+
+	public function test_process_items_calls_notify() {
+		$this->notification_service->expects( $this->once() )
+			->method( 'notify' )
+			->with( NotificationsService::TOPIC_SETTINGS_UPDATED )
+			->willReturn( true );
+
+		$this->job->handle_process_items_action();
+	}
+}

--- a/tests/Unit/Settings/SyncerHooksTest.php
+++ b/tests/Unit/Settings/SyncerHooksTest.php
@@ -66,12 +66,13 @@ class SyncerHooksTest extends UnitTest {
 		'woocommerce_price_num_decimals',
 		'pricing_options',
 	];
+
 	public function test_saving_woocommerce_general_settings_schedules_notification_job() {
 		$this->notification_service->expects( $this->once() )
 			->method( 'is_enabled' )
 			->willReturn( true );
 
-		$this->settings_notification_job->expects( $this->exactly ( count( self::ALLOWED_SETTINGS ) ) )
+		$this->settings_notification_job->expects( $this->exactly( count( self::ALLOWED_SETTINGS ) ) )
 			->method( 'schedule' );
 
 		$this->syncer_hooks->register();

--- a/tests/Unit/Settings/SyncerHooksTest.php
+++ b/tests/Unit/Settings/SyncerHooksTest.php
@@ -35,17 +35,49 @@ class SyncerHooksTest extends UnitTest {
 	 */
 	protected $sample_class_id;
 
-
-	public function test_saving_woocommerce_settings_schedules_notification_job() {
+	/**
+	 * WooCommerce General Settings IDs
+	 * Copied from https://github.com/woocommerce/woocommerce/blob/af03815134385c72feb7a70abc597eca57442820/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php#L34
+	 */
+	protected const ALLOWED_SETTINGS = [
+		'store_address',
+		'woocommerce_store_address',
+		'woocommerce_store_address_2',
+		'woocommerce_store_city',
+		'woocommerce_default_country',
+		'woocommerce_store_postcode',
+		'store_address',
+		'general_options',
+		'woocommerce_allowed_countries',
+		'woocommerce_all_except_countries',
+		'woocommerce_specific_allowed_countries',
+		'woocommerce_ship_to_countries',
+		'woocommerce_specific_ship_to_countries',
+		'woocommerce_default_customer_address',
+		'woocommerce_calc_taxes',
+		'woocommerce_enable_coupons',
+		'woocommerce_calc_discounts_sequentially',
+		'general_options',
+		'pricing_options',
+		'woocommerce_currency',
+		'woocommerce_currency_pos',
+		'woocommerce_price_thousand_sep',
+		'woocommerce_price_decimal_sep',
+		'woocommerce_price_num_decimals',
+		'pricing_options',
+	];
+	public function test_saving_woocommerce_general_settings_schedules_notification_job() {
 		$this->notification_service->expects( $this->once() )
 			->method( 'is_enabled' )
 			->willReturn( true );
 
-		$this->settings_notification_job->expects( $this->once() )
+		$this->settings_notification_job->expects( $this->exactly ( count( self::ALLOWED_SETTINGS ) ) )
 			->method( 'schedule' );
 
 		$this->syncer_hooks->register();
-		do_action( 'update_option', 'woocommerce_sample_option' );
+		foreach ( self::ALLOWED_SETTINGS as $setting ) {
+			do_action( 'update_option', $setting );
+		}
 	}
 
 	public function test_saving_other_settings_dont_schedules_notification_job() {
@@ -69,7 +101,7 @@ class SyncerHooksTest extends UnitTest {
 			->method( 'schedule' );
 
 		$this->syncer_hooks->register();
-		do_action( 'update_option', 'woocommerce_sample_option' );
+		do_action( 'update_option', 'store_address' );
 	}
 
 	/**

--- a/tests/Unit/Settings/SyncerHooksTest.php
+++ b/tests/Unit/Settings/SyncerHooksTest.php
@@ -1,0 +1,96 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Settings;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Settings\SyncerHooks;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class SyncerHooksTest
+ *
+ * @group SyncerHooks
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Settings
+ */
+class SyncerHooksTest extends UnitTest {
+
+	/** @var MockObject|NotificationsService $notification_service */
+	protected $notification_service;
+
+	/** @var MockObject|SettingsNotificationJob $settings_notification_job */
+	protected $settings_notification_job;
+
+	/** @var MockObject|JobRepository $job_repository */
+	protected $job_repository;
+
+	/** @var SyncerHooks $syncer_hooks */
+	protected $syncer_hooks;
+
+	/**
+	 * @var int The ID of an example shipping class stored in DB.
+	 */
+	protected $sample_class_id;
+
+
+	public function test_saving_woocommerce_settings_schedules_notification_job() {
+		$this->notification_service->expects( $this->once() )
+			->method( 'is_enabled' )
+			->willReturn( true );
+
+		$this->settings_notification_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->syncer_hooks->register();
+		do_action( 'update_option', 'woocommerce_sample_option' );
+	}
+
+	public function test_saving_other_settings_dont_schedules_notification_job() {
+		$this->notification_service->expects( $this->once() )
+			->method( 'is_enabled' )
+			->willReturn( true );
+
+		$this->settings_notification_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->syncer_hooks->register();
+		do_action( 'update_option', 'other_option' );
+	}
+
+	public function test_dont_register_if_notifications_disabled() {
+		$this->notification_service->expects( $this->once() )
+			->method( 'is_enabled' )
+			->willReturn( false );
+
+		$this->settings_notification_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->syncer_hooks->register();
+		do_action( 'update_option', 'woocommerce_sample_option' );
+	}
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->login_as_administrator();
+
+		$this->notification_service      = $this->createMock( NotificationsService::class );
+		$this->settings_notification_job = $this->createMock( SettingsNotificationJob::class );
+		$this->job_repository            = $this->createMock( JobRepository::class );
+		$this->job_repository->expects( $this->any() )
+			->method( 'get' )
+			->willReturnMap(
+				[
+					[ SettingsNotificationJob::class, $this->settings_notification_job ],
+				]
+			);
+
+		$this->syncer_hooks = new SyncerHooks( $this->job_repository, $this->notification_service );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds Notifications for Settings.

⚠️  Notice there are some pending PRs and Diffs to merge so the Notification won't be successful. Only it needs to check if it's triggered.

⚠️  Ideally the notifications only trigger when WooCommerce General settings are updated. However, the only method found that supports UI + REST + Programatically updating options was `update_option` hook. So, I added a check `woocommerce_` prefix to reduce the number of times the notifications are done. But it still triggers non-general Woocommerce Notifications.  If programmatically way is not needed yes there are some other hooks to filter only General settings.

### Screenshots:

<img width="1609" alt="Screenshot 2024-02-20 at 18 46 48" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/327d6acd-a434-4cd5-9da7-0ac08aa13003">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this PR
2. Update Settings via WP Admin - Woocommerce - Settings 
3. See the action `notifications/settings` is scheduled. Run it.
4. Update Settings via[ Rest API ](https://woocommerce.github.io/woocommerce-rest-api-docs/#settings)
5. See the action `notifications/settings` is scheduled. Run it.
6. Update Settings programmatically via `update_option`
7. See the action `notifications/settings` is scheduled. Run it.


