### PR TITLE
Product Block Editor: Declare feature compatibility

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -60,6 +60,7 @@ add_action(
 		if ( class_exists( FeaturesUtil::class ) ) {
 			FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__ );
 			FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__ );
+			FeaturesUtil::declare_compatibility( 'product_block_editor', __FILE__ );
 		}
 	}
 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The final step to make this extension fully compatible with the new product editor (Product Block Editor) is to declare the feature compatibility.

### Detailed test instructions:

1. Set up WooCommerce >= 8.6
1. Go to WooCommerce > Settings > Advanced > Features. Enable the **New product editor**.
1. Currently, [the `is_legacy` flag of the new product editor is set to true](https://github.com/woocommerce/woocommerce/blob/8.6.0/plugins/woocommerce/src/Internal/Features/FeaturesController.php#L182), so it won't show incompatible warnings. Adding the following code snippet can turn off the flag:
   ```php
   add_action(
   	'woocommerce_register_feature_definitions',
   	function( $features_controller ) {
   		$slug = 'product_block_editor';
   		$args = $features_controller->get_features( true )[ $slug ];
   
   		$args['is_legacy'] = false;
   		$features_controller->add_feature_definition( $slug, $args['name'], $args );
   	}
   );
   ```
1. Git checkout the dba7829e5cdcc95146654ba562c145d1e4daccbc revision that doesn't have the compatibility declaration.
1. Refresh the Settings page.
1. This extension should be listed as one of the incompatible plugins.
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/477b1426-d5db-44ef-a80a-7ddccb3d08c6)
1. Git checkout this PR's branch: `tweak/product-block-editor-compatibility`.
1. Refresh the Settings page.
1. Check if the incompatible list doesn't have this extension.
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/f9865f48-d294-43ef-8414-9d7db52b77ff)

### Changelog entry
