### PR TITLE
Product Statuses - Handle failure of the Update Product Statuses Job

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ProductStatisticsController.php
@@ -176,6 +176,13 @@ class ProductStatisticsController extends BaseOptionsController {
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
+			'error'          => [
+				'type'        => 'string',
+				'description' => __( 'Error message in case of failure', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+				'default'     => null,
+			],
 		];
 	}
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -240,6 +240,7 @@ class MerchantStatusesTest extends UnitTest {
 						MCStatus::NOT_SYNCED         => 0,
 					],
 					'loading'    => false,
+					'error'      => null,
 				]
 			);
 
@@ -316,6 +317,7 @@ class MerchantStatusesTest extends UnitTest {
 						MCStatus::NOT_SYNCED         => 0,
 					],
 					'loading'    => false,
+					'error'      => null,
 				]
 			);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Follow-up of https://github.com/woocommerce/google-listings-and-ads/pull/2257.

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146 & https://github.com/woocommerce/google-listings-and-ads/issues/2250

Since we're calculating product statuses using AS jobs, there's a possibility that the job might fail when attempting to retrieve or update the data. Therefore, it's important to store this error so we can notify the client about any issues while updating the product statuses.

Action Scheduler will retry the job, and if it succeeds, the process will continue as usual and the error message will be overridden once all statuses are completed.

However, if the job fails permanently and the failure rate exceeds the threshold, AS will stop the job. In this case, when the client requests the data via `GET wc/gla/mc/product-statistics`, the response will contain the error message.

```
{
    "timestamp": 1708537779,
    "statistics": {},
    "scheduled_sync": 0,
    "loading": false,
    "error": "My fatal error"
}
```

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Produce an error in purpose, for example, add the following line `throw new \Error('My fatal error');`  in https://github.com/woocommerce/google-listings-and-ads/blob/b544a507e040cadc421b94391e0b9524639d1483/src/API/Google/MerchantReport.php#L67
2. Make a request to `GET wc/gla/mc/product-statistics/refresh`
3. Go to WooCommerce -> Statuses -> Scheduled Actions and search for `gla/jobs/update_merchant_product_statuses/process_item` and see that the jobs fails.
4. Call `wc/gla/mc/product-statistics` and see that the error is present in the transient. 


### Additional details:
- As discussed here https://github.com/woocommerce/google-listings-and-ads/pull/2257#issuecomment-1953823315  the idea is for the client to be able to view the error and have the choice to manually retry the statuses.
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
