### PR TITLE
Fix the compatibility issue in starting E2E test environment due to the default charset change in MariaDB v11.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "google-listings-and-ads",
-			"version": "2.5.17",
+			"version": "2.5.18",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@woocommerce/components": "^10.3.0",
@@ -50,7 +50,7 @@
 				"@types/jest": "^27.5.2",
 				"@woocommerce/dependency-extraction-webpack-plugin": "^2.3.0",
 				"@woocommerce/eslint-plugin": "^1.2.0",
-				"@wordpress/env": "^8.4.0",
+				"@wordpress/env": "^9.4.0",
 				"@wordpress/jest-preset-default": "^11.9.0",
 				"@wordpress/prettier-config": "2.18.1",
 				"@wordpress/scripts": "^24.6.0",
@@ -7230,14 +7230,14 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.4.0.tgz",
-			"integrity": "sha512-3DnTW/WanvQpWqagCIMQYtSBYj9wXLQQqGgmKl8gVJ4MfxV3K5A9zE25Rv6iogdr7ydLcPSbmNJx6mYgQRaSog==",
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.4.0.tgz",
+			"integrity": "sha512-flF+WLAuf8j97OjFkJU7/l9bzvI7GEUm1MXYdo16kSqxBvOTwVkk2yf5s9nxREJ3gPYahgNYf8cA7uT9Rj2eDQ==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.22.2",
+				"docker-compose": "^0.24.3",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -13479,12 +13479,24 @@
 			}
 		},
 		"node_modules/docker-compose": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-			"integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
+			"version": "0.24.6",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.6.tgz",
+			"integrity": "sha512-VidlUyNzXMaVsuM79sjSvwC4nfojkP2VneL+Zfs538M2XFnffZDhx6veqnz/evCNIYGyz5O+1fgL6+g0NLWTBA==",
 			"dev": true,
+			"dependencies": {
+				"yaml": "^2.2.2"
+			},
 			"engines": {
 				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/docker-compose/node_modules/yaml": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+			"integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/doctrine": {
@@ -33865,14 +33877,14 @@
 			}
 		},
 		"@wordpress/env": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.4.0.tgz",
-			"integrity": "sha512-3DnTW/WanvQpWqagCIMQYtSBYj9wXLQQqGgmKl8gVJ4MfxV3K5A9zE25Rv6iogdr7ydLcPSbmNJx6mYgQRaSog==",
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.4.0.tgz",
+			"integrity": "sha512-flF+WLAuf8j97OjFkJU7/l9bzvI7GEUm1MXYdo16kSqxBvOTwVkk2yf5s9nxREJ3gPYahgNYf8cA7uT9Rj2eDQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.22.2",
+				"docker-compose": "^0.24.3",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -38555,10 +38567,21 @@
 			}
 		},
 		"docker-compose": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-			"integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
-			"dev": true
+			"version": "0.24.6",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.6.tgz",
+			"integrity": "sha512-VidlUyNzXMaVsuM79sjSvwC4nfojkP2VneL+Zfs538M2XFnffZDhx6veqnz/evCNIYGyz5O+1fgL6+g0NLWTBA==",
+			"dev": true,
+			"requires": {
+				"yaml": "^2.2.2"
+			},
+			"dependencies": {
+				"yaml": {
+					"version": "2.3.4",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+					"integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+					"dev": true
+				}
+			}
 		},
 		"doctrine": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@types/jest": "^27.5.2",
 		"@woocommerce/dependency-extraction-webpack-plugin": "^2.3.0",
 		"@woocommerce/eslint-plugin": "^1.2.0",
-		"@wordpress/env": "^8.4.0",
+		"@wordpress/env": "^9.4.0",
 		"@wordpress/jest-preset-default": "^11.9.0",
 		"@wordpress/prettier-config": "2.18.1",
 		"@wordpress/scripts": "^24.6.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

MariaDB v11.3.1 introduced [an issue](https://jira.mariadb.org/browse/MDEV-32975) that breaks backward compatibility for many PHP DB clients. It also affects the starting of E2E test env in this repo. 

To fix it, this PR updates `@wordpress/env` to [9.4.0](https://github.com/WordPress/gutenberg/blob/trunk/packages/env/CHANGELOG.md#940-2024-02-21) to use the LTS version of MariaDB rather than the (default) latest version.

### Screenshots:

#### 📷 Before

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/c3a5a83f-7ae9-45d9-9798-e01cd5f9938f)

#### 📷 After

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/2ac6ed15-4066-41a2-8b91-06cc89dfa83f)

### Detailed test instructions:

#### 📌 Check the results on GitHub Actions

1. View [the failed run](https://github.com/woocommerce/google-listings-and-ads/actions/runs/7986067115/job/21805717917) before this fix.
2. View [the successful run](https://github.com/woocommerce/google-listings-and-ads/actions/runs/7998968289/job/21846006175) after this fix.

#### 📌 Local test

1. It may need to run `npm run wp-env destroy` first to ensure the incompatible database will be recreated.
2. Run `npm run wp-env:up` to see if the E2E test env can be started without errors.
3. Run `npm run test:e2e` to see if E2E tests can be run normally.
4. Run `npm run wp-env:down` to see if E2E test env can be stopped correctly.

### Changelog entry

> Dev - Fix the compatibility issue in starting E2E test environment due to the default charset change in MariaDB v11.3.1.
