### PR TITLE
API PULL - Refactor Notification Jobs

### DIFF
--- a/src/Google/NotificationsService.php
+++ b/src/Google/NotificationsService.php
@@ -28,6 +28,18 @@ class NotificationsService implements Service {
 	public const TOPIC_SHIPPING_UPDATED = 'shipping.update';
 	public const TOPIC_SETTINGS_UPDATED = 'settings.update';
 
+	// Constant used to get all the allowed topics
+	public const ALLOWED_TOPICS = [
+		self::TOPIC_PRODUCT_CREATED,
+		self::TOPIC_PRODUCT_DELETED,
+		self::TOPIC_PRODUCT_UPDATED,
+		self::TOPIC_COUPON_CREATED,
+		self::TOPIC_COUPON_DELETED,
+		self::TOPIC_COUPON_UPDATED,
+		self::TOPIC_SHIPPING_UPDATED,
+		self::TOPIC_SETTINGS_UPDATED,
+	];
+
 	/**
 	 * The url to send the notification
 	 *
@@ -62,7 +74,7 @@ class NotificationsService implements Service {
 		 * @param int $item_id The item_id for the notification.
 		 * @param string $topic The topic for the notification.
 		 */
-		if ( ! apply_filters( 'woocommerce_gla_notify', true, $item_id, $topic ) ) {
+		if ( ! apply_filters( 'woocommerce_gla_notify', in_array( $topic, self::ALLOWED_TOPICS, true ), $item_id, $topic ) ) {
 			return false;
 		}
 

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -24,7 +24,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 * @param array $args Arguments with the item id and the topic
 	 */
 	protected function process_items( array $args ): void {
-		if ( ! isset( $args[0] ) || ! isset( $args[1] ) ) {
+		if ( ! isset( $args['item_id'] ) || ! isset( $args['topic'] ) ) {
 			do_action(
 				'woocommerce_gla_error',
 				'Error sending the Notification. Topic and Item ID are mandatory',
@@ -33,8 +33,8 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 			return;
 		}
 
-		$item  = $args[0];
-		$topic = $args[1];
+		$item  = $args['item_id'];
+		$topic = $args['topic'];
 
 		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
 			$this->set_status( $item, $this->get_after_notification_status( $topic ) );

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AbstractItemNotificationJob
+ * Generic class for the Notification Jobs containing items
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
+ */
+abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
+
+	/**
+	 * Logic when processing the items
+	 *
+	 * @param array $args Arguments with the item id and the topic
+	 */
+	protected function process_items( array $args ): void {
+		if ( ! isset( $args[0] ) || ! isset( $args[1] ) ) {
+			do_action(
+				'woocommerce_gla_error',
+				'Error sending the Notification. Topic and Item ID are mandatory',
+				__METHOD__
+			);
+			return;
+		}
+
+		$item  = $args[0];
+		$topic = $args[1];
+
+		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
+			$this->set_status( $item, $this->get_after_notification_status( $topic ) );
+			$this->maybe_mark_as_unsynced( $topic, $item );
+		}
+	}
+
+	/**
+	 * Set the notification status for the item.
+	 *
+	 * @param int    $item_id
+	 * @param string $status
+	 */
+	protected function set_status( int $item_id, string $status ): void {
+		$item = $this->get_item( $item_id );
+		$this->get_helper()->set_notification_status( $item, $status );
+	}
+
+	/**
+	 * Get the Notification Status after the notification happens
+	 *
+	 * @param string $topic
+	 * @return string
+	 */
+	protected function get_after_notification_status( string $topic ): string {
+		if ( str_contains( $topic, '.create' ) ) {
+			return NotificationStatus::NOTIFICATION_CREATED;
+		} elseif ( str_contains( $topic, '.delete' ) ) {
+			return NotificationStatus::NOTIFICATION_DELETED;
+		} else {
+			return NotificationStatus::NOTIFICATION_UPDATED;
+		}
+	}
+
+	/**
+	 * Checks if the item can be processed based on the topic.
+	 * This is needed because the item can change the Notification Status before
+	 * the Job process the item.
+	 *
+	 * @param int    $item_id
+	 * @param string $topic
+	 * @return bool
+	 */
+	protected function can_process( int $item_id, string $topic ): bool {
+		$item = $this->get_item( $item_id );
+
+		if ( str_contains( $topic, '.create' ) ) {
+			return $this->get_helper()->should_trigger_create_notification( $item );
+		} elseif ( str_contains( $topic, '.delete' ) ) {
+			return $this->get_helper()->should_trigger_delete_notification( $item );
+		} else {
+			return $this->get_helper()->should_trigger_update_notification( $item );
+		}
+	}
+
+	/**
+	 * If there is a valid Item ID and topic is a deletion topic. Mark the item as unsynced.
+	 *
+	 * @param string $topic
+	 * @param int    $item
+	 */
+	protected function maybe_mark_as_unsynced( string $topic, int $item ): void {
+		if ( ! str_contains( $topic, '.delete' ) ) {
+			return;
+		}
+
+		$item = $this->get_item( $item );
+		$this->get_helper()->mark_as_unsynced( $item );
+	}
+
+	/**
+	 * Get the item
+	 *
+	 * @param int $item_id
+	 * @return \WC_Product|\WC_Coupon
+	 */
+	abstract protected function get_item( int $item_id );
+
+	/**
+	 * Get the helper
+	 *
+	 * @return CouponHelper|ProductHelper
+	 */
+	abstract public function get_helper();
+}

--- a/src/Jobs/Notifications/AbstractNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractNotificationJob.php
@@ -38,7 +38,7 @@ abstract class AbstractNotificationJob extends AbstractActionSchedulerJob implem
 	public function __construct(
 		ActionSchedulerInterface $action_scheduler,
 		ActionSchedulerJobMonitor $monitor,
-		NotificationsService $notifications_service,
+		NotificationsService $notifications_service
 	) {
 		$this->notifications_service = $notifications_service;
 		parent::__construct( $action_scheduler, $monitor );

--- a/src/Jobs/Notifications/AbstractNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractNotificationJob.php
@@ -8,7 +8,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractActionSchedulerJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
 
 
 defined( 'ABSPATH' ) || exit;
@@ -65,23 +64,6 @@ abstract class AbstractNotificationJob extends AbstractActionSchedulerJob implem
 				$this->get_process_item_hook(),
 				[ $args ]
 			);
-		}
-	}
-
-
-	/**
-	 * Get the Notification Status after the notification happens
-	 *
-	 * @param string $topic
-	 * @return string
-	 */
-	protected function get_after_notification_status( string $topic ): string {
-		if ( str_contains( $topic, '.create' ) ) {
-			return NotificationStatus::NOTIFICATION_CREATED;
-		} elseif ( str_contains( $topic, '.delete' ) ) {
-			return NotificationStatus::NOTIFICATION_DELETED;
-		} else {
-			return NotificationStatus::NOTIFICATION_UPDATED;
 		}
 	}
 

--- a/src/Jobs/Notifications/AbstractNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractNotificationJob.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractActionSchedulerJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
+
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AbstractNotificationJob
+ * Generic class for the Notifications Jobs
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
+ */
+abstract class AbstractNotificationJob extends AbstractActionSchedulerJob implements JobInterface {
+
+	/**
+	 * @var NotificationsService $notifications_service
+	 */
+	protected $notifications_service;
+
+
+	/**
+	 * Notifications Jobs constructor.
+	 *
+	 * @param ActionSchedulerInterface  $action_scheduler
+	 * @param ActionSchedulerJobMonitor $monitor
+	 * @param NotificationsService      $notifications_service
+	 */
+	public function __construct(
+		ActionSchedulerInterface $action_scheduler,
+		ActionSchedulerJobMonitor $monitor,
+		NotificationsService $notifications_service,
+	) {
+		$this->notifications_service = $notifications_service;
+		parent::__construct( $action_scheduler, $monitor );
+	}
+
+	/**
+	 * Get the parent job name
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'notifications/' . $this->get_job_name();
+	}
+
+
+	/**
+	 * Schedule the Job
+	 *
+	 * @param array $args
+	 */
+	public function schedule( array $args = [] ): void {
+		if ( $this->can_schedule( [ $args ] ) ) {
+			$this->action_scheduler->schedule_immediate(
+				$this->get_process_item_hook(),
+				[ $args ]
+			);
+		}
+	}
+
+
+	/**
+	 * Get the Notification Status after the notification happens
+	 *
+	 * @param string $topic
+	 * @return string
+	 */
+	protected function get_after_notification_status( string $topic ): string {
+		if ( str_contains( $topic, '.create' ) ) {
+			return NotificationStatus::NOTIFICATION_CREATED;
+		} elseif ( str_contains( $topic, '.delete' ) ) {
+			return NotificationStatus::NOTIFICATION_DELETED;
+		} else {
+			return NotificationStatus::NOTIFICATION_UPDATED;
+		}
+	}
+
+
+	/**
+	 * Can the job be scheduled.
+	 *
+	 * @param array|null $args
+	 *
+	 * @return bool Returns true if the job can be scheduled.
+	 */
+	public function can_schedule( $args = [] ): bool {
+		/**
+		 * Allow users to disable the notification job schedule.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
+		 * @param string $job_name The current Job name.
+		 * @param array $args The arguments for the schedule function with the item id and the topic.
+		 */
+		return apply_filters( 'woocommerce_gla_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $this->get_job_name(), $args );
+	}
+
+	/**
+	 * Get the child job name
+	 *
+	 * @return string
+	 */
+	abstract public function get_job_name(): string;
+
+	/**
+	 * Logic when processing the items
+	 *
+	 * @param array $args
+	 */
+	abstract protected function process_items( array $args ): void;
+}

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -5,34 +5,24 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractActionSchedulerJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
-
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class CouponNotificationJob
- * Class for all the Coupons Notifications Jobs
+ * Class for the Coupons Notifications Jobs
  *
  * @since x.x.x
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
  */
-class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInterface {
+class CouponNotificationJob extends AbstractItemNotificationJob {
 
 	/**
-	 * @var NotificationsService $notifications_service
+	 * @var CouponHelper $helper
 	 */
-	protected $notifications_service;
-
-	/**
-	 * @var CouponHelper $coupon_helper
-	 */
-	protected $coupon_helper;
+	protected $helper;
 
 	/**
 	 * Notifications Jobs constructor.
@@ -49,8 +39,27 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 		CouponHelper $coupon_helper
 	) {
 		$this->notifications_service = $notifications_service;
-		$this->coupon_helper         = $coupon_helper;
-		parent::__construct( $action_scheduler, $monitor );
+		$this->helper                = $coupon_helper;
+		parent::__construct( $action_scheduler, $monitor, $notifications_service );
+	}
+
+	/**
+	 * Get the coupon
+	 *
+	 * @param int $item_id
+	 * @return \WC_Coupon
+	 */
+	protected function get_item( int $item_id ) {
+		return $this->helper->get_wc_coupon( $item_id );
+	}
+
+	/**
+	 * Get the Coupon Helper
+	 *
+	 * @return CouponHelper
+	 */
+	public function get_helper() {
+		return $this->helper;
 	}
 
 	/**
@@ -58,127 +67,7 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 	 *
 	 * @return string
 	 */
-	public function get_name(): string {
-		return 'notifications/coupons';
-	}
-
-
-	/**
-	 * Logic when processing the items
-	 *
-	 * @param array $args Arguments with the item id and the topic
-	 */
-	protected function process_items( array $args ): void {
-		if ( ! isset( $args[0] ) || ! isset( $args[1] ) ) {
-			do_action(
-				'woocommerce_gla_error',
-				'Error sending Coupon Notification. Topic and Coupon ID are mandatory',
-				__METHOD__
-			);
-			return;
-		}
-
-		$item  = $args[0];
-		$topic = $args[1];
-
-		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
-			$this->set_status( $item, $this->get_after_notification_status( $topic ) );
-			$this->maybe_mark_as_unsynced( $topic, $item );
-		}
-	}
-
-	/**
-	 * Schedule the Coupon Notification Job
-	 *
-	 * @param array $args
-	 */
-	public function schedule( array $args = [] ): void {
-		if ( $this->can_schedule( [ $args ] ) ) {
-			$this->action_scheduler->schedule_immediate(
-				$this->get_process_item_hook(),
-				[ $args ]
-			);
-		}
-	}
-
-	/**
-	 * Set the notification status for a coupon.
-	 *
-	 * @param int    $coupon_id
-	 * @param string $status
-	 */
-	protected function set_status( int $coupon_id, string $status ): void {
-		$coupon = $this->coupon_helper->get_wc_coupon( $coupon_id );
-		$this->coupon_helper->set_notification_status( $coupon, $status );
-	}
-
-	/**
-	 * Get the Notification Status after the notification happens
-	 *
-	 * @param string $topic
-	 * @return string
-	 */
-	protected function get_after_notification_status( string $topic ): string {
-		if ( str_contains( $topic, '.create' ) ) {
-			return NotificationStatus::NOTIFICATION_CREATED;
-		} elseif ( str_contains( $topic, '.delete' ) ) {
-			return NotificationStatus::NOTIFICATION_DELETED;
-		} else {
-			return NotificationStatus::NOTIFICATION_UPDATED;
-		}
-	}
-
-	/**
-	 * Checks if the item can be processed based on the topic.
-	 * This is needed because the coupon can change the Notification Status before
-	 * the Job process the item.
-	 *
-	 * @param int    $coupon_id
-	 * @param string $topic
-	 * @return bool
-	 */
-	protected function can_process( int $coupon_id, string $topic ): bool {
-		$coupon = $this->coupon_helper->get_wc_coupon( $coupon_id );
-		if ( str_contains( $topic, '.create' ) ) {
-			return $this->coupon_helper->should_trigger_create_notification( $coupon );
-		} elseif ( str_contains( $topic, '.delete' ) ) {
-			return $this->coupon_helper->should_trigger_delete_notification( $coupon );
-		} else {
-			return $this->coupon_helper->should_trigger_update_notification( $coupon );
-		}
-	}
-
-	/**
-	 * If there is a valid Item ID and topic is a deletion topic. Mark the coupon as unsynced.
-	 *
-	 * @param string $topic
-	 * @param int    $item
-	 */
-	protected function maybe_mark_as_unsynced( string $topic, int $item ): void {
-		if ( ! str_contains( $topic, '.delete' ) ) {
-			return;
-		}
-
-		$coupon = $this->coupon_helper->get_wc_coupon( $item );
-		$this->coupon_helper->mark_as_unsynced( $coupon );
-	}
-
-	/**
-	 * Can the job be scheduled.
-	 *
-	 * @param array|null $args
-	 *
-	 * @return bool Returns true if the job can be scheduled.
-	 */
-	public function can_schedule( $args = [] ): bool {
-		/**
-		 * Allow users to disable the notification job schedule.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
-		 * @param array $args The arguments for the schedule function with the item id and the topic.
-		 */
-		return apply_filters( 'woocommerce_gla_coupon_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $args );
+	public function get_job_name(): string {
+		return 'coupons';
 	}
 }

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -7,29 +7,22 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
-
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class ProductNotificationJob
- * Class for all the Product Notifications Jobs
+ * Class for the Product Notifications Jobs
  *
  * @since x.x.x
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
  */
-class ProductNotificationJob extends AbstractNotificationJob {
+class ProductNotificationJob extends AbstractItemNotificationJob {
 
 	/**
-	 * @var NotificationsService $notifications_service
+	 * @var ProductHelper $helper
 	 */
-	protected $notifications_service;
-
-	/**
-	 * @var ProductHelper $product_helper
-	 */
-	protected $product_helper;
+	protected $helper;
 
 	/**
 	 * Notifications Jobs constructor.
@@ -37,17 +30,36 @@ class ProductNotificationJob extends AbstractNotificationJob {
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param NotificationsService      $notifications_service
-	 * @param ProductHelper             $product_helper
+	 * @param ProductHelper             $helper
 	 */
 	public function __construct(
 		ActionSchedulerInterface $action_scheduler,
 		ActionSchedulerJobMonitor $monitor,
 		NotificationsService $notifications_service,
-		ProductHelper $product_helper
+		ProductHelper $helper
 	) {
 		$this->notifications_service = $notifications_service;
-		$this->product_helper        = $product_helper;
+		$this->helper                = $helper;
 		parent::__construct( $action_scheduler, $monitor, $notifications_service );
+	}
+
+	/**
+	 * Get the product
+	 *
+	 * @param int $item_id
+	 * @return \WC_Product
+	 */
+	protected function get_item( int $item_id ) {
+		return $this->helper->get_wc_product( $item_id );
+	}
+
+	/**
+	 * Get the Product Helper
+	 *
+	 * @return ProductHelper
+	 */
+	public function get_helper() {
+		return $this->helper;
 	}
 
 	/**
@@ -57,76 +69,5 @@ class ProductNotificationJob extends AbstractNotificationJob {
 	 */
 	public function get_job_name(): string {
 		return 'products';
-	}
-
-
-	/**
-	 * Logic when processing the items
-	 *
-	 * @param array $args Arguments with the item id and the topic
-	 */
-	protected function process_items( array $args ): void {
-		if ( ! isset( $args[0] ) || ! isset( $args[1] ) ) {
-			do_action(
-				'woocommerce_gla_error',
-				'Error processing Product Notification Job. Item ID and Topic are mandatory.',
-				__METHOD__
-			);
-			return;
-		}
-
-		$item  = $args[0];
-		$topic = $args[1];
-
-		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
-			$this->set_status( $item, $this->get_after_notification_status( $topic ) );
-		}
-	}
-
-	/**
-	 * Set the notification status for a product.
-	 *
-	 * @param int    $product_id
-	 * @param string $status
-	 */
-	protected function set_status( int $product_id, string $status ): void {
-		$product = $this->product_helper->get_wc_product( $product_id );
-		$this->product_helper->set_notification_status( $product, $status );
-	}
-
-	/**
-	 * Get the Notification Status after the notification happens
-	 *
-	 * @param string $topic
-	 * @return string
-	 */
-	protected function get_after_notification_status( string $topic ): string {
-		if ( str_contains( $topic, '.create' ) ) {
-			return NotificationStatus::NOTIFICATION_CREATED;
-		} elseif ( str_contains( $topic, '.delete' ) ) {
-			return NotificationStatus::NOTIFICATION_DELETED;
-		} else {
-			return NotificationStatus::NOTIFICATION_UPDATED;
-		}
-	}
-
-	/**
-	 * Checks if the item can be processed based on the topic.
-	 * This is needed because the product can change the Notification Status before
-	 * the Job process the item.
-	 *
-	 * @param int    $product_id
-	 * @param string $topic
-	 * @return bool
-	 */
-	protected function can_process( int $product_id, string $topic ): bool {
-		$product = $this->product_helper->get_wc_product( $product_id );
-		if ( str_contains( $topic, '.create' ) ) {
-			return $this->product_helper->should_trigger_create_notification( $product );
-		} elseif ( str_contains( $topic, '.delete' ) ) {
-			return $this->product_helper->should_trigger_delete_notification( $product );
-		} else {
-			return $this->product_helper->should_trigger_update_notification( $product );
-		}
 	}
 }

--- a/src/Jobs/Notifications/SettingsNotificationJob.php
+++ b/src/Jobs/Notifications/SettingsNotificationJob.php
@@ -3,12 +3,6 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractActionSchedulerJob;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -18,44 +12,7 @@ defined( 'ABSPATH' ) || exit;
  * @since x.x.x
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
  */
-class SettingsNotificationJob extends AbstractActionSchedulerJob implements JobInterface {
-
-	/**
-	 * @var NotificationsService $notifications_service
-	 */
-	protected $notifications_service;
-
-	/**
-	 * @var string $topic
-	 */
-	protected $topic;
-
-	/**
-	 * Notifications Jobs constructor.
-	 *
-	 * @param ActionSchedulerInterface  $action_scheduler
-	 * @param ActionSchedulerJobMonitor $monitor
-	 * @param NotificationsService      $notifications_service
-	 */
-	public function __construct(
-		ActionSchedulerInterface $action_scheduler,
-		ActionSchedulerJobMonitor $monitor,
-		NotificationsService $notifications_service
-	) {
-		$this->notifications_service = $notifications_service;
-		$this->topic                 = NotificationsService::TOPIC_SETTINGS_UPDATED;
-		parent::__construct( $action_scheduler, $monitor );
-	}
-
-	/**
-	 * Get the job name
-	 *
-	 * @return string
-	 */
-	public function get_name(): string {
-		return 'notifications/settings';
-	}
-
+class SettingsNotificationJob extends AbstractNotificationJob {
 
 	/**
 	 * Logic when processing the items
@@ -63,39 +20,16 @@ class SettingsNotificationJob extends AbstractActionSchedulerJob implements JobI
 	 * @param array $args Arguments for the notification
 	 */
 	protected function process_items( array $args ): void {
-		$this->notifications_service->notify( $this->topic );
+		$this->notifications_service->notify( $this->notifications_service::TOPIC_SETTINGS_UPDATED );
 	}
 
-	/**
-	 * Schedule the Job
-	 *
-	 * @param array $args
-	 */
-	public function schedule( array $args = [] ): void {
-		if ( $this->can_schedule( [ $args ] ) ) {
-			$this->action_scheduler->schedule_immediate(
-				$this->get_process_item_hook(),
-				[ $args ]
-			);
-		}
-	}
 
 	/**
-	 * Can the job be scheduled.
+	 * Get the job name
 	 *
-	 * @param array|null $args
-	 *
-	 * @return bool Returns true if the job can be scheduled.
+	 * @return string
 	 */
-	public function can_schedule( $args = [] ): bool {
-		/**
-		 * Allow users to disable the notification job schedule.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
-		 * @param array $args The arguments for the schedule function with the item id and the topic.
-		 */
-		return apply_filters( 'woocommerce_gla_settings_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $args );
+	public function get_job_name(): string {
+		return 'settings';
 	}
 }

--- a/src/Jobs/Notifications/ShippingNotificationJob.php
+++ b/src/Jobs/Notifications/ShippingNotificationJob.php
@@ -3,12 +3,6 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractActionSchedulerJob;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -18,42 +12,15 @@ defined( 'ABSPATH' ) || exit;
  * @since x.x.x
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
  */
-class ShippingNotificationJob extends AbstractActionSchedulerJob implements JobInterface {
-
-	/**
-	 * @var NotificationsService $notifications_service
-	 */
-	protected $notifications_service;
-
-	/**
-	 * @var string $topic
-	 */
-	protected $topic;
-
-	/**
-	 * Notifications Jobs constructor.
-	 *
-	 * @param ActionSchedulerInterface  $action_scheduler
-	 * @param ActionSchedulerJobMonitor $monitor
-	 * @param NotificationsService      $notifications_service
-	 */
-	public function __construct(
-		ActionSchedulerInterface $action_scheduler,
-		ActionSchedulerJobMonitor $monitor,
-		NotificationsService $notifications_service
-	) {
-		$this->notifications_service = $notifications_service;
-		$this->topic                 = NotificationsService::TOPIC_SHIPPING_UPDATED;
-		parent::__construct( $action_scheduler, $monitor );
-	}
+class ShippingNotificationJob extends AbstractNotificationJob {
 
 	/**
 	 * Get the job name
 	 *
 	 * @return string
 	 */
-	public function get_name(): string {
-		return 'notifications/shipping';
+	public function get_job_name(): string {
+		return 'shipping';
 	}
 
 
@@ -63,39 +30,6 @@ class ShippingNotificationJob extends AbstractActionSchedulerJob implements JobI
 	 * @param array $args Arguments for the notification
 	 */
 	protected function process_items( array $args ): void {
-		$this->notifications_service->notify( $this->topic );
-	}
-
-	/**
-	 * Schedule the Job
-	 *
-	 * @param array $args
-	 */
-	public function schedule( array $args = [] ): void {
-		if ( $this->can_schedule( $args ) ) {
-			$this->action_scheduler->schedule_immediate(
-				$this->get_process_item_hook(),
-				[ $args ]
-			);
-		}
-	}
-
-	/**
-	 * Can the job be scheduled.
-	 *
-	 * @param array|null $args
-	 *
-	 * @return bool Returns true if the job can be scheduled.
-	 */
-	public function can_schedule( $args = [] ): bool {
-		/**
-		 * Allow users to disable the notification job schedule.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
-		 * @param array $args The arguments for the schedule function with the item id and the topic.
-		 */
-		return apply_filters( 'woocommerce_gla_shipping_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $args );
+		$this->notifications_service->notify( $this->notifications_service::TOPIC_SHIPPING_UPDATED );
 	}
 }

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -242,13 +242,28 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_update_product_notification( WC_Product $product ) {
 		if ( $this->product_helper->should_trigger_create_notification( $product ) ) {
 			$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_PENDING_CREATE );
-			$this->product_notification_job->schedule( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_CREATED ] );
+			$this->product_notification_job->schedule(
+				[
+					'item_id' => $product->get_id(),
+					'topic'   => NotificationsService::TOPIC_PRODUCT_CREATED,
+				]
+			);
 		} elseif ( $this->product_helper->should_trigger_update_notification( $product ) ) {
 			$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_PENDING_UPDATE );
-			$this->product_notification_job->schedule( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_UPDATED ] );
+			$this->product_notification_job->schedule(
+				[
+					'item_id' => $product->get_id(),
+					'topic'   => NotificationsService::TOPIC_PRODUCT_UPDATED,
+				]
+			);
 		} elseif ( $this->product_helper->should_trigger_delete_notification( $product ) ) {
 			$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_PENDING_DELETE );
-			$this->product_notification_job->schedule( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_DELETED ] );
+			$this->product_notification_job->schedule(
+				[
+					'item_id' => $product->get_id(),
+					'topic'   => NotificationsService::TOPIC_PRODUCT_DELETED,
+				]
+			);
 		}
 	}
 
@@ -261,7 +276,12 @@ class SyncerHooks implements Service, Registerable {
 		$product = wc_get_product( $product_id );
 		if ( $product instanceof WC_Product && $this->notifications_service->is_enabled() && $this->product_helper->should_trigger_delete_notification( $product ) ) {
 			$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_PENDING_DELETE );
-			$this->product_notification_job->schedule( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_DELETED ] );
+			$this->product_notification_job->schedule(
+				[
+					'item_id' => $product->get_id(),
+					'topic'   => NotificationsService::TOPIC_PRODUCT_DELETED,
+				]
+			);
 			return;
 		}
 

--- a/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
@@ -1,0 +1,258 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\AbstractItemNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Generic Class for AbstractItemNotificationJobTest
+ *
+ * @group Notifications
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+abstract class AbstractItemNotificationJobTest extends UnitTest {
+
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|NotificationsService $notification_service */
+	protected $notification_service;
+
+	/** @var MockObject|AbstractItemNotificationJob $job */
+	protected $job;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->notification_service = $this->createMock( NotificationsService::class );
+		$this->job                  = $this->get_job();
+		$this->job->init();
+	}
+
+	public function test_job_name() {
+		$this->assertEquals( $this->get_name(), $this->job->get_name() );
+	}
+
+	public function test_schedule_schedules_immediate_job() {
+		$topic = $this->get_topic_name() . '.create';
+		$id    = 1;
+
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( $this->get_process_item_hook(), [ [ $id, $topic ] ] )
+			->willReturn( false );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with(
+				$this->get_process_item_hook(),
+				[ [ $id, $topic ] ]
+			);
+
+		$this->job->schedule( [ $id, $topic ] );
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
+		$topic = $this->get_topic_name() . '.create';
+		$id    = 1;
+
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( $this->get_process_item_hook(), [ [ $id, $topic ] ] )
+			->willReturn( true );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule( [ $id, $topic ] );
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
+		$topic = $this->get_topic_name() . '.create';
+		$id    = 1;
+
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
+
+		$this->action_scheduler->expects( $this->never() )
+			->method( 'has_scheduled_action' );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule( [ $id, $topic ] );
+	}
+
+	public function test_process_items_calls_notify_and_set_status_on_success() {
+		/** @var \WC_Product|\WC_Coupon $item */
+		$item  = $this->create_item();
+		$id    = $item->get_id();
+		$topic = $this->get_topic_name() . '.create';
+
+		$this->notification_service->expects( $this->once() )
+			->method( 'notify' )
+			->with( $topic, $id )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->exactly( 2 ) )
+			->method( 'get_wc_' . $this->get_topic_name() )
+			->with( $id )
+			->willReturn( $item );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $item )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'set_notification_status' )
+			->with( $item, NotificationStatus::NOTIFICATION_CREATED );
+
+		$this->job->handle_process_items_action( [ $id, $topic ] );
+	}
+
+	public function test_process_items_doesnt_calls_notify_when_no_args() {
+		$this->notification_service->expects( $this->never() )
+			->method( 'notify' );
+
+		$this->job->handle_process_items_action( [] );
+		$this->job->handle_process_items_action( [ 1 ] );
+	}
+
+	public function test_process_items_doesnt_calls_set_status_on_failure() {
+		/** @var \WC_Product|\WC_Coupon $item */
+		$item  = $this->create_item();
+		$id    = $item->get_id();
+		$topic = $this->get_topic_name() . '.create';
+
+		$this->notification_service->expects( $this->once() )
+			->method( 'notify' )
+			->with( $topic, $id )
+			->willReturn( false );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'get_wc_' . $this->get_topic_name() )
+			->with( $id )
+			->willReturn( $item );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $item )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->never() )
+			->method( 'set_notification_status' );
+
+		$this->job->handle_process_items_action( [ $id, $topic ] );
+	}
+
+	public function test_get_after_notification_status() {
+		/** @var \WC_Product|\WC_Coupon $item */
+		$item = $this->create_item();
+		$id   = $item->get_id();
+
+		$this->notification_service->expects( $this->exactly( 3 ) )
+			->method( 'notify' )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->exactly( 7 ) )
+			->method( 'get_wc_' . $this->get_topic_name() )
+			->willReturn( $item );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $item )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_update_notification' )
+			->with( $item )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_delete_notification' )
+			->with( $item )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->exactly( 3 ) )
+			->method( 'set_notification_status' )
+			->willReturnCallback(
+				function ( $id, $topic ) {
+					if ( $topic === 'product.create' ) {
+							return NotificationStatus::NOTIFICATION_CREATED;
+					} elseif ( $topic === 'product.delete' ) {
+						return NotificationStatus::NOTIFICATION_DELETED;
+					} else {
+						return NotificationStatus::NOTIFICATION_UPDATED;
+					}
+				}
+			);
+
+		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.create' ] );
+		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.delete' ] );
+		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.update' ] );
+	}
+
+	public function test_dont_process_item_if_status_changed() {
+		/** @var \WC_Product|\WC_Coupon $item */
+		$item = $this->create_item();
+		$id   = $item->get_id();
+
+		$this->notification_service->expects( $this->never() )->method( 'notify' );
+
+		$this->job->get_helper()->expects( $this->exactly( 3 ) )
+			->method( 'get_wc_' . $this->get_topic_name() )
+			->willReturn( $item );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $item )
+			->willReturn( false );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_update_notification' )
+			->with( $item )
+			->willReturn( false );
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_delete_notification' )
+			->with( $item )
+			->willReturn( false );
+
+		$this->job->get_helper()->expects( $this->never() )->method( 'set_notification_status' );
+
+		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.create' ] );
+		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.delete' ] );
+		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.update' ] );
+	}
+
+	public function get_name() {
+		return 'notifications/' . $this->get_job_name();
+	}
+
+	public function get_process_item_hook() {
+		return 'gla/jobs/' . $this->get_name() . '/process_item';
+	}
+
+	abstract public function get_job_name();
+	abstract public function get_topic_name();
+	abstract public function get_job();
+	abstract public function create_item();
+}

--- a/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
@@ -57,17 +57,35 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
-			->with( $this->get_process_item_hook(), [ [ $id, $topic ] ] )
+			->with(
+				$this->get_process_item_hook(),
+				[
+					[
+						'item_id' => $id,
+						'topic'   => $topic,
+					],
+				]
+			)
 			->willReturn( false );
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
 			->with(
 				$this->get_process_item_hook(),
-				[ [ $id, $topic ] ]
+				[
+					[
+						'item_id' => $id,
+						'topic'   => $topic,
+					],
+				]
 			);
 
-		$this->job->schedule( [ $id, $topic ] );
+		$this->job->schedule(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
 	}
 
 	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
@@ -78,12 +96,25 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
-			->with( $this->get_process_item_hook(), [ [ $id, $topic ] ] )
+			->with(
+				$this->get_process_item_hook(),
+				[
+					[
+						'item_id' => $id,
+						'topic'   => $topic,
+					],
+				]
+			)
 			->willReturn( true );
 
 		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
 
-		$this->job->schedule( [ $id, $topic ] );
+		$this->job->schedule(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
 	}
 
 	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
@@ -97,7 +128,12 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
 
-		$this->job->schedule( [ $id, $topic ] );
+		$this->job->schedule(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
 	}
 
 	public function test_process_items_calls_notify_and_set_status_on_success() {
@@ -125,7 +161,12 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 			->method( 'set_notification_status' )
 			->with( $item, NotificationStatus::NOTIFICATION_CREATED );
 
-		$this->job->handle_process_items_action( [ $id, $topic ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
 	}
 
 	public function test_process_items_doesnt_calls_notify_when_no_args() {
@@ -160,7 +201,12 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 		$this->job->get_helper()->expects( $this->never() )
 			->method( 'set_notification_status' );
 
-		$this->job->handle_process_items_action( [ $id, $topic ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
 	}
 
 	public function test_get_after_notification_status() {
@@ -195,9 +241,9 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 			->method( 'set_notification_status' )
 			->willReturnCallback(
 				function ( $id, $topic ) {
-					if ( $topic === 'product.create' ) {
+					if ( $topic === $this->get_topic_name() . '.create' ) {
 							return NotificationStatus::NOTIFICATION_CREATED;
-					} elseif ( $topic === 'product.delete' ) {
+					} elseif ( $topic === $this->get_topic_name() . '.delete' ) {
 						return NotificationStatus::NOTIFICATION_DELETED;
 					} else {
 						return NotificationStatus::NOTIFICATION_UPDATED;
@@ -205,9 +251,24 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 				}
 			);
 
-		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.create' ] );
-		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.delete' ] );
-		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.update' ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $this->get_topic_name() . '.create',
+			]
+		);
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $this->get_topic_name() . '.delete',
+			]
+		);
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $this->get_topic_name() . '.update',
+			]
+		);
 	}
 
 	public function test_dont_process_item_if_status_changed() {
@@ -238,9 +299,50 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 
 		$this->job->get_helper()->expects( $this->never() )->method( 'set_notification_status' );
 
-		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.create' ] );
-		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.delete' ] );
-		$this->job->handle_process_items_action( [ $id, $this->get_topic_name() . '.update' ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $this->get_topic_name() . '.create',
+			]
+		);
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $this->get_topic_name() . '.delete',
+			]
+		);
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $this->get_topic_name() . '.update',
+			]
+		);
+	}
+
+	public function test_mark_as_unsynced_when_delete() {
+		$item = $this->create_item();
+		$id   = $item->get_id();
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_delete_notification' )
+			->with( $item )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->exactly( 3 ) )
+			->method( 'get_wc_' . $this->get_topic_name() )
+			->with( $id )
+			->willReturn( $item );
+
+		$this->notification_service->expects( $this->once() )->method( 'notify' )->willReturn( true );
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'mark_as_unsynced' );
+
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $this->get_topic_name() . '.delete',
+			]
+		);
 	}
 
 	public function get_name() {

--- a/tests/Unit/Jobs/AbstractNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractNotificationJobTest.php
@@ -1,0 +1,109 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Generic Class for NotificationJobTests
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+abstract class AbstractNotificationJobTest extends UnitTest {
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|NotificationsService $notification_service */
+	protected $notification_service;
+
+	/** @var SettingsNotificationJob $job */
+	protected $job;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->notification_service = $this->createMock( NotificationsService::class );
+		$this->job                  = $this->get_job();
+
+		$this->job->init();
+	}
+
+	public function test_job_name() {
+		$this->assertEquals( $this->get_name(), $this->job->get_name() );
+	}
+
+	public function test_schedule_schedules_immediate_job() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( $this->get_process_item_hook() )
+			->willReturn( false );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( $this->get_process_item_hook() );
+
+		$this->job->schedule();
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( $this->get_process_item_hook() )
+			->willReturn( true );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule();
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
+
+		$this->action_scheduler->expects( $this->never() )
+			->method( 'has_scheduled_action' );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule();
+	}
+
+	public function test_process_items_calls_notify() {
+		$this->notification_service->expects( $this->once() )
+			->method( 'notify' )
+			->with( $this->get_topic() )
+			->willReturn( true );
+
+		$this->job->handle_process_items_action();
+	}
+
+	public function get_name() {
+		return 'notifications/' . $this->get_job_name();
+	}
+
+	public function get_process_item_hook() {
+		return 'gla/jobs/' . $this->get_name() . '/process_item';
+	}
+
+	abstract public function get_topic();
+	abstract public function get_job_name();
+	abstract public function get_job();
+}

--- a/tests/Unit/Jobs/AbstractNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractNotificationJobTest.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\AbstractNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -26,7 +26,7 @@ abstract class AbstractNotificationJobTest extends UnitTest {
 	/** @var MockObject|NotificationsService $notification_service */
 	protected $notification_service;
 
-	/** @var SettingsNotificationJob $job */
+	/** @var AbstractNotificationJob $job */
 	protected $job;
 
 	/**

--- a/tests/Unit/Jobs/CouponNotificationJobTest.php
+++ b/tests/Unit/Jobs/CouponNotificationJobTest.php
@@ -3,14 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\CouponNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
-use PHPUnit\Framework\MockObject\MockObject;
 use WC_Helper_Coupon;
 
 /**
@@ -19,264 +13,26 @@ use WC_Helper_Coupon;
  * @group Notifications
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
-class CouponNotificationJobTest extends UnitTest {
+class CouponNotificationJobTest extends AbstractItemNotificationJobTest {
 
+	public function get_job_name() {
+		return 'coupons';
+	}
 
-	/** @var MockObject|ActionScheduler $action_scheduler */
-	protected $action_scheduler;
+	public function get_topic_name() {
+		return 'coupon';
+	}
 
-	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
-	protected $monitor;
-
-	/** @var MockObject|NotificationsService $notification_service */
-	protected $notification_service;
-
-	/** @var MockObject|CouponHelper $coupon_helper */
-	protected $coupon_helper;
-
-	/** @var CouponNotificationJob $job */
-	protected $job;
-
-	protected const JOB_NAME          = 'notifications/coupons';
-	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
-
-	/**
-	 * Runs before each test is executed.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
-		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->notification_service = $this->createMock( NotificationsService::class );
-		$this->coupon_helper        = $this->createMock( CouponHelper::class );
-		$this->job                  = new CouponNotificationJob(
+	public function get_job() {
+		return new CouponNotificationJob(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->notification_service,
-			$this->coupon_helper
+			$this->createMock( CouponHelper::class )
 		);
-
-		$this->job->init();
 	}
 
-	public function test_job_name() {
-		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
-	}
-
-	public function test_schedule_schedules_immediate_job() {
-		$topic = 'coupon.create';
-		$id    = 1;
-
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
-			->willReturn( false );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with(
-				self::PROCESS_ITEM_HOOK,
-				[ [ $id, $topic ] ]
-			);
-
-		$this->job->schedule( [ $id, $topic ] );
-	}
-
-	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
-		$id    = 1;
-		$topic = 'coupon.create';
-
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
-			->willReturn( true );
-
-		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
-
-		$this->job->schedule( [ $id, $topic ] );
-	}
-
-	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
-		$id    = 1;
-		$topic = 'coupon.create';
-
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
-
-		$this->action_scheduler->expects( $this->never() )
-			->method( 'has_scheduled_action' );
-
-		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
-
-		$this->job->schedule( [ $id, $topic ] );
-	}
-
-	public function test_process_items_calls_notify_and_set_status_on_success() {
-		/** @var \WC_Coupon $coupon */
-		$coupon = WC_Helper_Coupon::create_coupon();
-		$id     = $coupon->get_id();
-		$topic  = 'coupon.create';
-
-		$this->notification_service->expects( $this->once() )
-			->method( 'notify' )
-			->with( $topic, $id )
-			->willReturn( true );
-
-		$this->coupon_helper->expects( $this->exactly( 2 ) )
-		->method( 'get_wc_coupon' )
-		->with( $id )
-		->willReturn( $coupon );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_create_notification' )
-			->with( $coupon )
-			->willReturn( true );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'set_notification_status' )
-			->with( $coupon, NotificationStatus::NOTIFICATION_CREATED );
-
-		$this->job->handle_process_items_action( [ $id, $topic ] );
-	}
-
-	public function test_process_items_doesnt_calls_notify_when_no_args() {
-		$this->notification_service->expects( $this->never() )
-			->method( 'notify' );
-
-		$this->job->handle_process_items_action( [] );
-		$this->job->handle_process_items_action( [ 1 ] );
-	}
-
-	public function test_process_items_doesnt_calls_set_status_on_failure() {
-		/** @var \WC_Coupon $coupon */
-		$coupon = WC_Helper_Coupon::create_coupon();
-		$id     = $coupon->get_id();
-		$topic  = 'coupon.create';
-
-		$this->notification_service->expects( $this->once() )
-			->method( 'notify' )
-			->with( $topic, $id )
-			->willReturn( false );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'get_wc_coupon' )
-			->with( $id )
-			->willReturn( $coupon );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_create_notification' )
-			->with( $coupon )
-			->willReturn( true );
-
-		$this->coupon_helper->expects( $this->never() )
-			->method( 'set_notification_status' );
-
-		$this->job->handle_process_items_action( [ $id, $topic ] );
-	}
-
-	public function test_get_after_notification_status() {
-		/** @var \WC_Coupon $coupon */
-		$coupon = WC_Helper_Coupon::create_coupon();
-		$id     = $coupon->get_id();
-
-		$this->notification_service->expects( $this->exactly( 3 ) )
-			->method( 'notify' )
-			->willReturn( true );
-
-		$this->coupon_helper->expects( $this->exactly( 7 ) )
-			->method( 'get_wc_coupon' )
-			->willReturn( $coupon );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_create_notification' )
-			->with( $coupon )
-			->willReturn( true );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_update_notification' )
-			->with( $coupon )
-			->willReturn( true );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_delete_notification' )
-			->with( $coupon )
-			->willReturn( true );
-
-		$this->coupon_helper->expects( $this->exactly( 3 ) )
-			->method( 'set_notification_status' )
-			->willReturnCallback(
-				function ( $id, $topic ) {
-					if ( $topic === 'coupon.create' ) {
-							return NotificationStatus::NOTIFICATION_CREATED;
-					} elseif ( $topic === 'coupon.delete' ) {
-						return NotificationStatus::NOTIFICATION_DELETED;
-					} else {
-						return NotificationStatus::NOTIFICATION_UPDATED;
-					}
-				}
-			);
-
-		$this->job->handle_process_items_action( [ $id, 'coupon.create' ] );
-		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
-		$this->job->handle_process_items_action( [ $id, 'coupon.update' ] );
-	}
-
-	public function test_dont_process_item_if_status_changed() {
-		/** @var \WC_Coupon $coupon */
-		$coupon = WC_Helper_Coupon::create_coupon();
-		$id     = $coupon->get_id();
-
-		$this->notification_service->expects( $this->never() )->method( 'notify' );
-
-		$this->coupon_helper->expects( $this->exactly( 3 ) )
-			->method( 'get_wc_coupon' )
-			->willReturn( $coupon );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_create_notification' )
-			->with( $coupon )
-			->willReturn( false );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_update_notification' )
-			->with( $coupon )
-			->willReturn( false );
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_delete_notification' )
-			->with( $coupon )
-			->willReturn( false );
-
-		$this->coupon_helper->expects( $this->never() )->method( 'set_notification_status' );
-
-		$this->job->handle_process_items_action( [ $id, 'coupon.create' ] );
-		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
-		$this->job->handle_process_items_action( [ $id, 'coupon.update' ] );
-	}
-
-	public function test_mark_as_unsynced_when_delete() {
-		/** @var \WC_Coupon $coupon */
-		$coupon = WC_Helper_Coupon::create_coupon();
-		$id     = $coupon->get_id();
-
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'should_trigger_delete_notification' )
-			->with( $coupon )
-			->willReturn( true );
-
-		$this->coupon_helper->expects( $this->exactly( 3 ) )
-			->method( 'get_wc_coupon' )
-			->with( $id )
-			->willReturn( $coupon );
-
-		$this->notification_service->expects( $this->once() )->method( 'notify' )->willReturn( true );
-		$this->coupon_helper->expects( $this->once() )
-			->method( 'mark_as_unsynced' );
-
-		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
+	public function create_item() {
+		return WC_Helper_Coupon::create_coupon();
 	}
 }

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -3,14 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ProductNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
-use PHPUnit\Framework\MockObject\MockObject;
 use WC_Helper_Product;
 
 /**
@@ -19,242 +13,27 @@ use WC_Helper_Product;
  * @group Notifications
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
-class ProductNotificationJobTest extends UnitTest {
+class ProductNotificationJobTest extends AbstractItemNotificationJobTest {
 
+	public function get_job_name() {
+		return 'products';
+	}
 
-	/** @var MockObject|ActionScheduler $action_scheduler */
-	protected $action_scheduler;
+	public function get_topic_name() {
+		return 'product';
+	}
 
-	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
-	protected $monitor;
-
-	/** @var MockObject|NotificationsService $notification_service */
-	protected $notification_service;
-
-	/** @var MockObject|ProductHelper $product_helper */
-	protected $product_helper;
-
-	/** @var ProductNotificationJob $job */
-	protected $job;
-
-	protected const JOB_NAME          = 'notifications/products';
-	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
-
-	/**
-	 * Runs before each test is executed.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
-		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->notification_service = $this->createMock( NotificationsService::class );
-		$this->product_helper       = $this->createMock( ProductHelper::class );
-		$this->job                  = new ProductNotificationJob(
+	public function get_job() {
+		return new ProductNotificationJob(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->notification_service,
-			$this->product_helper
+			$this->createMock( ProductHelper::class )
 		);
-
-		$this->job->init();
 	}
 
-	public function test_job_name() {
-		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
-	}
 
-	public function test_schedule_schedules_immediate_job() {
-		$topic = 'product.create';
-		$id    = 1;
-
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
-			->willReturn( false );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with(
-				self::PROCESS_ITEM_HOOK,
-				[ [ $id, $topic ] ]
-			);
-
-		$this->job->schedule( [ $id, $topic ] );
-	}
-
-	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
-		$id    = 1;
-		$topic = 'product.create';
-
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
-			->willReturn( true );
-
-		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
-
-		$this->job->schedule( [ $id, $topic ] );
-	}
-
-	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
-		$id    = 1;
-		$topic = 'product.create';
-
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
-
-		$this->action_scheduler->expects( $this->never() )
-			->method( 'has_scheduled_action' );
-
-		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
-
-		$this->job->schedule( [ $id, $topic ] );
-	}
-
-	public function test_process_items_calls_notify_and_set_status_on_success() {
-		/** @var \WC_Product $product */
-		$product = WC_Helper_Product::create_simple_product();
-		$id      = $product->get_id();
-		$topic   = 'product.create';
-
-		$this->notification_service->expects( $this->once() )
-			->method( 'notify' )
-			->with( $topic, $id )
-			->willReturn( true );
-
-		$this->product_helper->expects( $this->exactly( 2 ) )
-		->method( 'get_wc_product' )
-		->with( $id )
-		->willReturn( $product );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_create_notification' )
-			->with( $product )
-			->willReturn( true );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'set_notification_status' )
-			->with( $product, NotificationStatus::NOTIFICATION_CREATED );
-
-		$this->job->handle_process_items_action( [ $id, $topic ] );
-	}
-
-	public function test_process_items_doesnt_calls_notify_when_no_args() {
-		$this->notification_service->expects( $this->never() )
-			->method( 'notify' );
-
-		$this->job->handle_process_items_action( [] );
-		$this->job->handle_process_items_action( [ 1 ] );
-	}
-
-	public function test_process_items_doesnt_calls_set_status_on_failure() {
-		/** @var \WC_Product $product */
-		$product = WC_Helper_Product::create_simple_product();
-		$id      = $product->get_id();
-		$topic   = 'product.create';
-
-		$this->notification_service->expects( $this->once() )
-			->method( 'notify' )
-			->with( $topic, $id )
-			->willReturn( false );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'get_wc_product' )
-			->with( $id )
-			->willReturn( $product );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_create_notification' )
-			->with( $product )
-			->willReturn( true );
-
-		$this->product_helper->expects( $this->never() )
-			->method( 'set_notification_status' );
-
-		$this->job->handle_process_items_action( [ $id, $topic ] );
-	}
-
-	public function test_get_after_notification_status() {
-		/** @var \WC_Product $product */
-		$product = WC_Helper_Product::create_simple_product();
-		$id      = $product->get_id();
-
-		$this->notification_service->expects( $this->exactly( 3 ) )
-			->method( 'notify' )
-			->willReturn( true );
-
-		$this->product_helper->expects( $this->exactly( 6 ) )
-			->method( 'get_wc_product' )
-			->willReturn( $product );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_create_notification' )
-			->with( $product )
-			->willReturn( true );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_update_notification' )
-			->with( $product )
-			->willReturn( true );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_delete_notification' )
-			->with( $product )
-			->willReturn( true );
-
-		$this->product_helper->expects( $this->exactly( 3 ) )
-			->method( 'set_notification_status' )
-			->willReturnCallback(
-				function ( $id, $topic ) {
-					if ( $topic === 'product.create' ) {
-							return NotificationStatus::NOTIFICATION_CREATED;
-					} elseif ( $topic === 'product.delete' ) {
-						return NotificationStatus::NOTIFICATION_DELETED;
-					} else {
-						return NotificationStatus::NOTIFICATION_UPDATED;
-					}
-				}
-			);
-
-		$this->job->handle_process_items_action( [ $id, 'product.create' ] );
-		$this->job->handle_process_items_action( [ $id, 'product.delete' ] );
-		$this->job->handle_process_items_action( [ $id, 'product.update' ] );
-	}
-
-	public function test_dont_process_item_if_status_changed() {
-		/** @var \WC_Product $product */
-		$product = WC_Helper_Product::create_simple_product();
-		$id      = $product->get_id();
-
-		$this->notification_service->expects( $this->never() )->method( 'notify' );
-
-		$this->product_helper->expects( $this->exactly( 3 ) )
-			->method( 'get_wc_product' )
-			->willReturn( $product );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_create_notification' )
-			->with( $product )
-			->willReturn( false );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_update_notification' )
-			->with( $product )
-			->willReturn( false );
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_delete_notification' )
-			->with( $product )
-			->willReturn( false );
-
-		$this->product_helper->expects( $this->never() )->method( 'set_notification_status' );
-
-		$this->job->handle_process_items_action( [ $id, 'product.create' ] );
-		$this->job->handle_process_items_action( [ $id, 'product.delete' ] );
-		$this->job->handle_process_items_action( [ $id, 'product.update' ] );
+	public function create_item() {
+		return WC_Helper_Product::create_simple_product();
 	}
 }

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -36,26 +36,4 @@ class ProductNotificationJobTest extends AbstractItemNotificationJobTest {
 	public function create_item() {
 		return WC_Helper_Product::create_simple_product();
 	}
-
-	public function test_mark_as_unsynced_when_delete() {
-		/** @var \WC_Product $product */
-		$product = WC_Helper_Product::create_simple_product();
-		$id      = $product->get_id();
-
-		$this->product_helper->expects( $this->once() )
-			->method( 'should_trigger_delete_notification' )
-			->with( $product )
-			->willReturn( true );
-
-		$this->product_helper->expects( $this->exactly( 3 ) )
-			->method( 'get_wc_product' )
-			->with( $id )
-			->willReturn( $product );
-
-		$this->notification_service->expects( $this->once() )->method( 'notify' )->willReturn( true );
-		$this->product_helper->expects( $this->once() )
-			->method( 'mark_as_unsynced' );
-
-		$this->job->handle_process_items_action( [ $id, 'product.delete' ] );
-	}
 }

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -72,7 +72,7 @@ class ProductNotificationJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ $id, $topic ] )
+			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
 			->willReturn( false );
 
 		$this->action_scheduler->expects( $this->once() )
@@ -93,7 +93,7 @@ class ProductNotificationJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [ $id, $topic ] )
+			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
 			->willReturn( true );
 
 		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );

--- a/tests/Unit/Jobs/SettingsNotificationJobTest.php
+++ b/tests/Unit/Jobs/SettingsNotificationJobTest.php
@@ -3,102 +3,30 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use PHPUnit\Framework\MockObject\MockObject;
+
 /**
  * Class SettingsNotificationJobTest
  *
  * @group Notifications
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
-class SettingsNotificationJobTest extends UnitTest {
+class SettingsNotificationJobTest extends AbstractNotificationJobTest {
 
-	/** @var MockObject|ActionScheduler $action_scheduler */
-	protected $action_scheduler;
 
-	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
-	protected $monitor;
+	public function get_topic() {
+		return $this->notification_service::TOPIC_SETTINGS_UPDATED;
+	}
 
-	/** @var MockObject|NotificationsService $notification_service */
-	protected $notification_service;
+	public function get_job_name() {
+		return 'settings';
+	}
 
-	/** @var SettingsNotificationJob $job */
-	protected $job;
-
-	protected const JOB_NAME          = 'notifications/settings';
-	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
-
-	/**
-	 * Runs before each test is executed.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
-		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->notification_service = $this->createMock( NotificationsService::class );
-		$this->job                  = new SettingsNotificationJob(
+	public function get_job() {
+		return new SettingsNotificationJob(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->notification_service
 		);
-
-		$this->job->init();
-	}
-
-	public function test_job_name() {
-		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
-	}
-
-	public function test_schedule_schedules_immediate_job() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK )
-			->willReturn( false );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with( self::PROCESS_ITEM_HOOK );
-
-		$this->job->schedule();
-	}
-
-	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK )
-			->willReturn( true );
-
-		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
-
-		$this->job->schedule();
-	}
-
-	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
-
-		$this->action_scheduler->expects( $this->never() )
-			->method( 'has_scheduled_action' );
-
-		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
-
-		$this->job->schedule();
-	}
-
-	public function test_process_items_calls_notify() {
-		$this->notification_service->expects( $this->once() )
-			->method( 'notify' )
-			->with( NotificationsService::TOPIC_SETTINGS_UPDATED )
-			->willReturn( true );
-
-		$this->job->handle_process_items_action();
 	}
 }

--- a/tests/Unit/Jobs/SettingsNotificationJobTest.php
+++ b/tests/Unit/Jobs/SettingsNotificationJobTest.php
@@ -15,7 +15,7 @@ class SettingsNotificationJobTest extends AbstractNotificationJobTest {
 
 
 	public function get_topic() {
-		return $this->notification_service::TOPIC_SETTINGS_UPDATED;
+		return 'settings.update';
 	}
 
 	public function get_job_name() {

--- a/tests/Unit/Jobs/ShippingNotificationJobTest.php
+++ b/tests/Unit/Jobs/ShippingNotificationJobTest.php
@@ -15,7 +15,7 @@ class ShippingNotificationJobTest extends AbstractNotificationJobTest {
 
 
 	public function get_topic() {
-		return $this->notification_service::TOPIC_SHIPPING_UPDATED;
+		return 'shipping.update';
 	}
 
 	public function get_job_name() {

--- a/tests/Unit/Jobs/ShippingNotificationJobTest.php
+++ b/tests/Unit/Jobs/ShippingNotificationJobTest.php
@@ -3,14 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ProductNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ShippingNotificationJob;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use PHPUnit\Framework\MockObject\MockObject;
-use WC_Helper_Product;
 
 /**
  * Class ShippingNotificationJobTest
@@ -18,90 +11,22 @@ use WC_Helper_Product;
  * @group Notifications
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */
-class ShippingNotificationJobTest extends UnitTest {
+class ShippingNotificationJobTest extends AbstractNotificationJobTest {
 
-	/** @var MockObject|ActionScheduler $action_scheduler */
-	protected $action_scheduler;
 
-	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
-	protected $monitor;
+	public function get_topic() {
+		return $this->notification_service::TOPIC_SHIPPING_UPDATED;
+	}
 
-	/** @var MockObject|NotificationsService $notification_service */
-	protected $notification_service;
+	public function get_job_name() {
+		return 'shipping';
+	}
 
-	/** @var ProductNotificationJob $job */
-	protected $job;
-
-	protected const JOB_NAME          = 'notifications/shipping';
-	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
-
-	/**
-	 * Runs before each test is executed.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
-		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->notification_service = $this->createMock( NotificationsService::class );
-		$this->job                  = new ShippingNotificationJob(
+	public function get_job() {
+		return new ShippingNotificationJob(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->notification_service
 		);
-
-		$this->job->init();
-	}
-
-	public function test_job_name() {
-		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
-	}
-
-	public function test_schedule_schedules_immediate_job() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [] )
-			->willReturn( false );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with( self::PROCESS_ITEM_HOOK );
-
-		$this->job->schedule();
-	}
-
-	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'has_scheduled_action' )
-			->with( self::PROCESS_ITEM_HOOK, [] )
-			->willReturn( true );
-
-		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
-
-		$this->job->schedule();
-	}
-
-	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
-
-		$this->action_scheduler->expects( $this->never() )
-			->method( 'has_scheduled_action' );
-
-		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
-
-		$this->job->schedule();
-	}
-
-	public function test_process_items_calls_notify() {
-		$this->notification_service->expects( $this->once() )
-			->method( 'notify' )
-			->with( NotificationsService::TOPIC_SHIPPING_UPDATED )
-			->willReturn( true );
-
-		$this->job->handle_process_items_action();
 	}
 }

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -282,7 +282,14 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
 		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->product_notification_job->expects( $this->once() )
-			->method( 'schedule' )->with( $this->equalTo( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_CREATED ] ) );
+			->method( 'schedule' )->with(
+				$this->equalTo(
+					[
+						'item_id' => $product->get_id(),
+						'topic'   => NotificationsService::TOPIC_PRODUCT_CREATED,
+					]
+				)
+			);
 		$product->set_status( 'publish' );
 		$product->save();
 	}
@@ -291,7 +298,14 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
 		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->product_notification_job->expects( $this->once() )
-			->method( 'schedule' )->with( $this->equalTo( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_UPDATED ] ) );
+			->method( 'schedule' )->with(
+				$this->equalTo(
+					[
+						'item_id' => $product->get_id(),
+						'topic'   => NotificationsService::TOPIC_PRODUCT_UPDATED,
+					]
+				)
+			);
 		$product->set_status( 'publish' );
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_CREATED );
 		$product->save();
@@ -301,7 +315,14 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
 		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->product_notification_job->expects( $this->once() )
-			->method( 'schedule' )->with( $this->equalTo( [ $product->get_id(), NotificationsService::TOPIC_PRODUCT_DELETED ] ) );
+			->method( 'schedule' )->with(
+				$this->equalTo(
+					[
+						'item_id' => $product->get_id(),
+						'topic'   => NotificationsService::TOPIC_PRODUCT_DELETED,
+					]
+				)
+			);
 		$product->set_status( 'publish' );
 		$product->add_meta_data( '_wc_gla_visibility', ChannelVisibility::DONT_SYNC_AND_SHOW, true );
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_CREATED );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Refactor Notifications Jobs and Tests for reducing duplications.

After emerging the work related to coupons notifications this PR does:

- Reactor all the generic methods shared between `SettingsNotificationsJob`, `ShippingNotificationsJob`, `CouponNotificationJob`,  `ProductNotificationJob`, into an abstract `AbstractNotificatioJob` class.
- Refactor `CouponNotificationJob` and `ProductNotificationJob` (Job using Item IDs)  into an abstract `AbstractNotificatioItemJob` 
- Refactor the tests (also using abstract tests)

⚠️  Some methods and classes (mostly regarding SyncerHooks, Helpers and MetaHandlers) can be refactored too. But are out scope of the Project. This might be done after adopting the new API PULL strategy and deprecating the current MC methods completely.

⚠️  IF your domain is not authorized for using the sandbox, this PR wont work as a successful notification it's needed to update the statuses. So one option is to hardcode the next line so the notification is always successful.

`NotificationsService.php`
```php
public function notify( string $topic, $item_id = null ): bool {
     return true;
}
```

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a product -- See `gla/jobs/notifications/products/process_item with the product and the `product.create `topic. Run it
2. Update the product -- See `gla/jobs/notifications/products/process_item with the product and the `product.update `topic. Run it
3. Delete the product -- See `gla/jobs/notifications/products/process_item with the product and the `product.delete `topic. Run it
4. Restore the product. See `gla/jobs/notifications/products/process_item with the product and the `product.create `topic
5. Create a coupon -- See `gla/jobs/notifications/coupons/process_item with the coupon and the `coupon.create `topic. Run it
6. Update the coupon -- See `gla/jobs/notifications/coupons/process_item with the coupon and the `coupon.update `topic. Run it
7. Delete the coupon -- See `gla/jobs/notifications/coupons/process_item with the coupon and the `coupon.delete `topic. Run it
8. Update the WooCommerce general Settings -- See `gla/jobs/notifications/settings/process_item without ID and the `settings.update` topic.
9.  Update/Delete/Create any WooCommerce Shipping -- See `gla/jobs/notifications/shipping/process_item without ID and the `settings.update` topic.

