### PR TITLE
Add instructions for running PHPUnit with wp-env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,37 @@ $ vendor/bin/phpunit
 
 The tests will execute and you'll be presented with a summary.
 
+### Running tests using `wp-env`
+
+To run PHPUnit from within the included `wp-env` environment, you will need to load the development version of the WooCommerce plugin in your environment.
+
+First, clone the WooCommerce repo, replacing `${WC_VERSION}` with the latest version of the plugin (e.g. 8.6.1):
+
+```bash
+$ git clone --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git ../woocommerce/`
+```
+
+Build the woocommerce plugin (see [this document](DEVELOPMENT.md) for additional instructions): 
+ - Go to the plugin directory: `cd ../woocommerce/plugins/woocommerce/`
+ - Install dependencies: `pnpm install`
+ - Build the plugin: `pnpm --filter=@woocommerce/plugin-woocommerce build`
+
+Go back to the Google Listings and Ads directory and create a `.wp-env.override.json` file containing the following:
+```json
+{
+	"plugins": [
+		"../woocommerce/plugins/woocommerce",
+		"."
+	]
+}
+```
+
+Restart your wp-env environment: `npm run wp-env start`
+
+You should now be able to run unit tests locally via the CLI: `npm run test:php`.
+
+To pass additional arguments to PHPUnit, make sure they are preceded by an additional `--`, like `npm run test:php -- --filter my_test_method`.
+
 ## E2E Testing
 
 E2E testing uses [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) which requires [Docker](https://www.docker.com/).

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
 		"test:e2e-dev": "npx playwright test --config=tests/e2e/config/playwright.config.js --debug",
 		"test:js": "wp-scripts test-unit-js --coverage",
 		"test:js:watch": "npm run test:js -- --watch",
+		"test:php": "wp-env run tests-wordpress --env-cwd=./wp-content/plugins/$(basename $(pwd)) ./vendor/bin/phpunit",
 		"test-proxy": "node ./tests/proxy",
 		"wp-env": "wp-env",
 		"wp-env:up": "npm run -- wp-env start --update",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This updates the README with the setup instructions for running PHPUnit tests with `wp-env`. This also adds a new `test:php` script to the `package.json` file to simplify running the tests locally.

### Detailed test instructions:
1. Try following the instructions to confirm that PHPUnit tests are running locally

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
