### PR TITLE
Refactor product issues

### DIFF
--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -98,6 +98,7 @@ class MerchantReport implements OptionsAwareInterface {
 				}
 
 				$product_view_data['statuses'][ $wc_product_id ] = [
+					'mc_id'           => $product_view->getId(),
 					'product_id'      => $wc_product_id,
 					'status'          => $mc_product_status,
 					'expiration_date' => $this->convert_shopping_content_date( $product_view->getExpirationDate() ),

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -55,10 +55,9 @@ SQL;
 	 * Delete stale issue records.
 	 *
 	 * @param DateTime $created_before Delete all records created before this.
-	 * @param string   $compare        Comparison operator to use. Default is '<'.
 	 */
-	public function delete_stale( DateTime $created_before, string $compare = '<' ) {
-		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` {$compare} '%s'";
+	public function delete_stale( DateTime $created_before ) {
+		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` < '%s'";
 		$this->wpdb->query( $this->wpdb->prepare( $query, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
 

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -56,10 +56,11 @@ SQL;
 	 *
 	 * @param DateTime $created_before Delete all records created before this.
 	 */
-	public function delete_stale( DateTime $created_before ) {
-		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` < '%s'";
-		$this->wpdb->query( $this->wpdb->prepare( $query, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
-	}
+	public function delete_stale( DateTime $created_before, string $comparison = '<') {
+		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` %s '%s'";
+		error_log( '========>'.$query );
+		$this->wpdb->query( $this->wpdb->prepare( $query, $comparison, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
+	}	
 
 	/**
 	 * Get the columns for the table.

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -56,7 +56,7 @@ SQL;
 	 *
 	 * @param DateTime $created_before Delete all records created before this.
 	 */
-	public function delete_stale( DateTime $created_before ) {
+	public function delete_stale( DateTime $created_before ): void {
 		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` < '%s'";
 		$this->wpdb->query( $this->wpdb->prepare( $query, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}
@@ -67,7 +67,7 @@ SQL;
 	 * @param array  $products_ids Array of product IDs to delete issues for.
 	 * @param string $source       The source of the issues. Default is 'mc'.
 	 */
-	public function delete_specific_product_issues( array $products_ids, string $source = 'mc' ) {
+	public function delete_specific_product_issues( array $products_ids, string $source = 'mc' ): void {
 		$placeholder = '(' . implode( ',', array_fill( 0, count( $products_ids ), '%d' ) ) . ')';
 		$this->wpdb->query( $this->wpdb->prepare( "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `product_id` IN {$placeholder} AND `source` = %s", array_merge( $products_ids, [ $source ] ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -55,6 +55,7 @@ SQL;
 	 * Delete stale issue records.
 	 *
 	 * @param DateTime $created_before Delete all records created before this.
+	 * @param string   $compare         Comparison operator to use. Default is '<'.
 	 */
 	public function delete_stale( DateTime $created_before, string $compare = '<') {
 		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` {$compare} '%s'";

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -57,10 +57,10 @@ SQL;
 	 * @param DateTime $created_before Delete all records created before this.
 	 * @param string   $compare         Comparison operator to use. Default is '<'.
 	 */
-	public function delete_stale( DateTime $created_before, string $compare = '<') {
+	public function delete_stale( DateTime $created_before, string $compare = '<' ) {
 		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` {$compare} '%s'";
 		$this->wpdb->query( $this->wpdb->prepare( $query, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
-	}	
+	}
 
 	/**
 	 * Get the columns for the table.

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -56,10 +56,9 @@ SQL;
 	 *
 	 * @param DateTime $created_before Delete all records created before this.
 	 */
-	public function delete_stale( DateTime $created_before, string $comparison = '<') {
-		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` %s '%s'";
-		error_log( '========>'.$query );
-		$this->wpdb->query( $this->wpdb->prepare( $query, $comparison, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
+	public function delete_stale( DateTime $created_before, string $compare = '<') {
+		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` {$compare} '%s'";
+		$this->wpdb->query( $this->wpdb->prepare( $query, $created_before->format( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
 	}	
 
 	/**

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -62,6 +62,17 @@ SQL;
 	}
 
 	/**
+	 * Delete product issues for specific products and source.
+	 *
+	 * @param array  $products_ids Array of product IDs to delete issues for.
+	 * @param string $source       The source of the issues. Default is 'mc'.
+	 */
+	public function delete_specific_product_issues( array $products_ids, string $source = 'mc' ) {
+		$placeholder = '(' . implode( ',', array_fill( 0, count( $products_ids ), '%d' ) ) . ')';
+		$this->wpdb->query( $this->wpdb->prepare( "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `product_id` IN {$placeholder} AND `source` = %s", array_merge( $products_ids, [ $source ] ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL
+	}
+
+	/**
 	 * Get the columns for the table.
 	 *
 	 * @return array

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -55,7 +55,7 @@ SQL;
 	 * Delete stale issue records.
 	 *
 	 * @param DateTime $created_before Delete all records created before this.
-	 * @param string   $compare         Comparison operator to use. Default is '<'.
+	 * @param string   $compare        Comparison operator to use. Default is '<'.
 	 */
 	public function delete_stale( DateTime $created_before, string $compare = '<' ) {
 		$query = "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `created_at` {$compare} '%s'";

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -88,7 +88,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 
 			// Clear the cache if we're starting from the beginning.
 			if ( ! $next_page_token ) {
-				$this->merchant_statuses->clear_product_statuses_cache();
+				$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 			}
 
 			$results         = $this->merchant_report->get_product_view_report( $next_page_token );

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -88,8 +88,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 
 			// Clear the cache if we're starting from the beginning.
 			if ( ! $next_page_token ) {
-				$this->merchant_statuses->clear_cache();
-				$this->merchant_statuses->delete_product_statuses_count_intermediate_data();
+				$this->merchant_statuses->clear_product_statuses_cache();
 			}
 
 			$results         = $this->merchant_report->get_product_view_report( $next_page_token );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -386,6 +386,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$product_issues = [];
 		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
 		foreach ( $merchant->get_productstatuses_batch( $google_ids )->getEntries() as $response_entry ) {
+			/** @var GoogleProductStatus $mc_product_status */
 			$mc_product_status = $response_entry->getProductStatus();
 			$mc_product_id     = $mc_product_status->getProductId();
 			$wc_product_id     = $product_helper->get_wc_product_id( $mc_product_id );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -198,10 +198,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * Delete the stale issues from the database.
 	 * 
+	 * @param srting $comparison The comparison operator to use for the created_at field.
+	 * 
 	 * @since x.x.x
 	 */
-	protected function delete_stale_issues() {
-		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
+	protected function delete_stale_issues( string $comparison = '<') {
+		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time, $comparison );
 	}
 
 	/**
@@ -209,7 +211,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 *
 	 * @since x.x.x
 	 */
-	public function clear_product_statuses_cache(): void {
+	public function clear_product_statuses_cache_and_issues(): void {
 		$this->clear_cache();
 		$this->delete_stale_issues();
 		$this->delete_product_statuses_count_intermediate_data();		
@@ -797,6 +799,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 */
 	public function handle_failed_mc_statuses_fetching( string $error_message = '' ) {
 		$this->delete_product_statuses_count_intermediate_data();
+		// Let's remove any issue created during the failed fetch.
+		$this->delete_stale_issues( '=' );
 
 		$mc_statuses = [
 			'timestamp'  => $this->cache_created_time->getTimestamp(),

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -360,8 +360,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$product_helper      = $this->container->get( ProductHelper::class );
 		$visibility_meta_key = $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY );
 
-		$google_ids = array_column( $statuses, 'mc_id' );
-
+		$google_ids     = array_column( $statuses, 'mc_id' );
 		$product_issues = [];
 		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
 		foreach ( $merchant->get_productstatuses_batch( $google_ids )->getEntries() as $response_entry ) {
@@ -513,6 +512,9 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 		$issue_query->update_or_insert( array_values( $product_issues ) );
+
+		// TODO: Before deleting we should fetch the account and pre-sync issues.
+		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -803,11 +803,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @since x.x.x
 	 *
 	 * @param string $error_message The error message.
+	 *
+	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
+	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
 	public function handle_failed_mc_statuses_fetching( string $error_message = '' ): void {
 		$this->delete_product_statuses_count_intermediate_data();
 		// Let's remove any issue created during the failed fetch.
-		$this->delete_stale_issues( '=' );
+		$this->container->get( MerchantIssueTable::class )->delete_specific_product_issues( array_keys( $this->product_data_lookup ) );
 
 		$mc_statuses = [
 			'timestamp'  => $this->cache_created_time->getTimestamp(),

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -239,7 +239,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
-	 * Update stale status-related data - account issues, product issues, products status stats.
+	 * Update stale status-related data - account issues.
 	 *
 	 * @param bool $force_refresh Force refresh of all status-related data.
 	 *

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -198,12 +198,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * Delete the stale issues from the database.
 	 *
-	 * @param string $compare The comparison operator to use for the created_at field.
-	 *
 	 * @since x.x.x
 	 */
-	protected function delete_stale_issues( string $compare = '<' ) {
-		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time, $compare );
+	protected function delete_stale_issues() {
+		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -198,12 +198,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * Delete the stale issues from the database.
 	 * 
-	 * @param srting $comparison The comparison operator to use for the created_at field.
+	 * @param srting $compare The comparison operator to use for the created_at field.
 	 * 
 	 * @since x.x.x
 	 */
-	protected function delete_stale_issues( string $comparison = '<') {
-		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time, $comparison );
+	protected function delete_stale_issues( string $compare = '<') {
+		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time, $compare );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -191,9 +191,29 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 *
 	 * @since x.x.x
 	 */
-	public function delete_product_statuses_count_intermediate_data(): void {
+	protected function delete_product_statuses_count_intermediate_data(): void {
 		$this->options->delete( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
 	}
+
+	/**
+	 * Delete the stale issues from the database.
+	 * 
+	 * @since x.x.x
+	 */
+	protected function delete_stale_issues() {
+		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
+	}
+
+	/**
+	 * Clear the product statuses cache and delete stale issues.
+	 *
+	 * @since x.x.x
+	 */
+	public function clear_product_statuses_cache(): void {
+		$this->clear_cache();
+		$this->delete_stale_issues();
+		$this->delete_product_statuses_count_intermediate_data();		
+	}	
 
 	/**
 	 * Check if the Merchant Center account is connected and throw an exception if it's not.
@@ -512,9 +532,6 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 		$issue_query->update_or_insert( array_values( $product_issues ) );
-
-		// TODO: Before deleting we should fetch the account and pre-sync issues.
-		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -200,7 +200,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 *
 	 * @since x.x.x
 	 */
-	protected function delete_stale_issues() {
+	protected function delete_stale_issues(): void {
 		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
 	}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -197,12 +197,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 	/**
 	 * Delete the stale issues from the database.
-	 * 
-	 * @param srting $compare The comparison operator to use for the created_at field.
-	 * 
+	 *
+	 * @param string $compare The comparison operator to use for the created_at field.
+	 *
 	 * @since x.x.x
 	 */
-	protected function delete_stale_issues( string $compare = '<') {
+	protected function delete_stale_issues( string $compare = '<' ) {
 		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time, $compare );
 	}
 
@@ -214,8 +214,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	public function clear_product_statuses_cache_and_issues(): void {
 		$this->clear_cache();
 		$this->delete_stale_issues();
-		$this->delete_product_statuses_count_intermediate_data();		
-	}	
+		$this->delete_product_statuses_count_intermediate_data();
+	}
 
 	/**
 	 * Check if the Merchant Center account is connected and throw an exception if it's not.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -371,7 +371,9 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * Get MC product issues from a list of Product View statuses.
 	 *
-	 * @param [] $statuses The list of Product View statuses.
+	 * @param array $statuses The list of Product View statuses.
+	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
+	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 *
 	 * @return array The list of product issues.
 	 */
@@ -510,7 +512,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * Refresh product issues in the merchant issues table.
 	 *
-	 * @param [] $product_issues Array of product issues.
+	 * @param array $product_issues Array of product issues.
+	 * @throws InvalidQuery If an invalid column name is provided.
+	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
+	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
 	protected function refresh_product_issues( array $product_issues ): void {
 		// Alphabetize all product/issue country lists.
@@ -597,8 +602,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * Process product status statistics.
 	 *
-	 * @param array[] $product_view_statuses Product View statuses.
+	 * @param array $product_view_statuses Product View statuses.
 	 * @see MerchantReport::get_product_view_report
+	 *
+	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
+	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
 	public function process_product_statuses( array $product_view_statuses ): void {
 		$product_repository        = $this->container->get( ProductRepository::class );
@@ -798,7 +806,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 *
 	 * @param string $error_message The error message.
 	 */
-	public function handle_failed_mc_statuses_fetching( string $error_message = '' ) {
+	public function handle_failed_mc_statuses_fetching( string $error_message = '' ): void {
 		$this->delete_product_statuses_count_intermediate_data();
 		// Let's remove any issue created during the failed fetch.
 		$this->delete_stale_issues( '=' );

--- a/tests/Unit/API/Google/MerchantReportTest.php
+++ b/tests/Unit/API/Google/MerchantReportTest.php
@@ -152,11 +152,13 @@ class MerchantReportTest extends UnitTest {
 			[
 				'statuses'        => [
 					$wc_product_id_1 => [
+						'mc_id' => 'online:en:ES:gla_' . $wc_product_id_1,
 						'product_id'      => $wc_product_id_1,
 						'status'          => MCStatus::APPROVED,
 						'expiration_date' => $this->convert_shopping_content_date( $product_view_1->getExpirationDate() ),
 					],
 					$wc_product_id_2 => [
+						'mc_id' => 'online:en:ES:gla_' . $wc_product_id_2,
 						'product_id'      => $wc_product_id_2,
 						'status'          => MCStatus::DISAPPROVED,
 						'expiration_date' => $this->convert_shopping_content_date( $product_view_2->getExpirationDate() ),

--- a/tests/Unit/API/Google/MerchantReportTest.php
+++ b/tests/Unit/API/Google/MerchantReportTest.php
@@ -152,13 +152,13 @@ class MerchantReportTest extends UnitTest {
 			[
 				'statuses'        => [
 					$wc_product_id_1 => [
-						'mc_id' => 'online:en:ES:gla_' . $wc_product_id_1,
+						'mc_id'           => 'online:en:ES:gla_' . $wc_product_id_1,
 						'product_id'      => $wc_product_id_1,
 						'status'          => MCStatus::APPROVED,
 						'expiration_date' => $this->convert_shopping_content_date( $product_view_1->getExpirationDate() ),
 					],
 					$wc_product_id_2 => [
-						'mc_id' => 'online:en:ES:gla_' . $wc_product_id_2,
+						'mc_id'           => 'online:en:ES:gla_' . $wc_product_id_2,
 						'product_id'      => $wc_product_id_2,
 						'status'          => MCStatus::DISAPPROVED,
 						'expiration_date' => $this->convert_shopping_content_date( $product_view_2->getExpirationDate() ),

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -205,10 +205,7 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 			->method( 'handle_complete_mc_statuses_fetching' );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
-			->method( 'clear_cache' );
-
-		$this->merchant_statuses->expects( $this->exactly( 1 ) )
-			->method( 'delete_product_statuses_count_intermediate_data' );
+			->method( 'clear_product_statuses_cache' );
 
 		$this->job->schedule();
 	}

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -205,7 +205,7 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 			->method( 'handle_complete_mc_statuses_fetching' );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
-			->method( 'clear_product_statuses_cache' );
+			->method( 'clear_product_statuses_cache_and_issues' );
 
 		$this->job->schedule();
 	}

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -835,6 +835,18 @@ class MerchantStatusesTest extends UnitTest {
 		);
 	}
 
+	protected function test_clear_product_statuses_cache_and_issues() {
+		$this->transients->expects( $this->exactly( 1 ) )
+		->method( 'delete' )
+		->with(
+			TransientsInterface::MC_STATUSES
+		);
+
+		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_stale' )->with( $this->merchant_statuses->get_cache_created_time() );
+		$this->options->expects( $this->once() )->method( 'delete' )->with( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
+		$this->merchant_statuses->clear_product_statuses_cache_and_issues();
+	}
+
 	protected function get_product_status_item( $wc_product_id ): ProductStatus {
 		$product_status = new ProductStatus();
 		$product_status->setProductId( $this->get_mc_id( $wc_product_id ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146 & https://github.com/woocommerce/google-listings-and-ads/issues/2250

This PR fetches the product issues using the same background job used to fetch the product statuses. This allows us to reuse the WC products that were fetched while updating the product statuses.

The logic remains mostly unchanged from before. The main difference is that previously, Google IDs were stored in the database and used to fetch the issues. With the new sync mechanism, since we don't have the Google IDs until we fetch all product statuses, we now use the data from the product statuses to obtain the Google IDs and fetch the issues.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Set your PHP memory limit low so you can catch any heavy process. For example, setting this up to 128MB.
2. Call `GET wp-json/wc/gla/mc/product-statistics/refresh`
3. Go to WooCommerce -> Status -> Action Scheduler -> Search for `gla/jobs/update_merchant_product_statuses/process_item` see how the jobs get completed successfully.
4. See how the table `wp_gla_merchant_issues` gets populated.
5. Once all jobs are completed call `GET wp-json/wc/gla/mc/product-statistics` and see that you get the right stats.


### Additional details:
 - Account and pre-sync issues are not migrated yet.
 - After all the issues logic is refactored, I will remove any legacy code.
 - I wanted to address the scenario where the job fails and some issues are inserted. I used the "created at" field, but it appears that the field will be identical for all batches. Therefore, I'll need to see alternative solutions in a follow-up PR. Any suggestions are welcome too.
 
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
