### PR TITLE
API PULL - Add Coupons Notification

### DIFF
--- a/src/Coupon/CouponHelper.php
+++ b/src/Coupon/CouponHelper.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterSer
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use WC_Coupon;
 defined( 'ABSPATH' ) || exit();
@@ -320,5 +321,97 @@ class CouponHelper implements Service {
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * Indicates if a coupon is ready for sending Notifications.
+	 * A coupon is ready to send notifications if its sync ready and the post status is publish.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return bool
+	 */
+	public function is_ready_to_notify( WC_Coupon $coupon ): bool {
+		$is_ready = $this->is_sync_ready( $coupon ) && $coupon->get_status() === 'publish';
+
+		/**
+		 * Allow users to filter if a coupon is ready to notify.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool $value The current filter value.
+		 * @param WC_Coupon $coupon The coupon for the notification.
+		 */
+		return apply_filters( 'woocommerce_gla_coupon_is_ready_to_notify', $is_ready, $coupon );
+	}
+
+
+	/**
+	 * Indicates if a coupon was already notified about its creation.
+	 * Notice we consider synced coupons in MC as notified for creation.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return bool
+	 */
+	public function has_notified_creation( WC_Coupon $coupon ): bool {
+		$valid_has_notified_creation_statuses = [
+			NotificationStatus::NOTIFICATION_CREATED,
+			NotificationStatus::NOTIFICATION_UPDATED,
+			NotificationStatus::NOTIFICATION_PENDING_UPDATE,
+			NotificationStatus::NOTIFICATION_PENDING_DELETE,
+		];
+
+		return in_array(
+			$this->meta_handler->get_notification_status( $coupon ),
+			$valid_has_notified_creation_statuses,
+			true
+		) || $this->is_coupon_synced( $coupon );
+	}
+
+	/**
+	 * Set the notification status for a WooCommerce coupon.
+	 *
+	 * @param WC_Coupon $coupon
+	 * @param string    $status
+	 */
+	public function set_notification_status( WC_Coupon $coupon, $status ): void {
+		$this->meta_handler->update_notification_status( $coupon, $status );
+	}
+
+	/**
+	 * Indicates if a coupon is ready for sending a create Notification.
+	 * A coupon is ready to send create notifications if is ready to notify and has not sent create notification yet.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return bool
+	 */
+	public function should_trigger_create_notification( WC_Coupon $coupon ): bool {
+		return $this->is_ready_to_notify( $coupon ) && ! $this->has_notified_creation( $coupon );
+	}
+
+	/**
+	 * Indicates if a coupon is ready for sending an update Notification.
+	 * A coupon is ready to send update notifications if is ready to notify and has sent create notification already.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return bool
+	 */
+	public function should_trigger_update_notification( WC_Coupon $coupon ): bool {
+		return $this->is_ready_to_notify( $coupon ) && $this->has_notified_creation( $coupon );
+	}
+
+	/**
+	 * Indicates if a coupon is ready for sending a delete Notification.
+	 * A coupon is ready to send delete notifications if it is not ready to notify and has sent create notification already.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return bool
+	 */
+	public function should_trigger_delete_notification( WC_Coupon $coupon ): bool {
+		return ! $this->is_ready_to_notify( $coupon ) && $this->has_notified_creation( $coupon );
 	}
 }

--- a/src/Coupon/CouponMetaHandler.php
+++ b/src/Coupon/CouponMetaHandler.php
@@ -38,6 +38,9 @@ defined( 'ABSPATH' ) || exit();
  * @method update_mc_status( WC_Coupon $coupon, string $value )
  * @method delete_mc_status( WC_Coupon $coupon )
  * @method get_mc_status( WC_Coupon $coupon ): string|null
+ * @method update_notification_status( WC_Coupon $coupon, string $value )
+ * @method delete_notification_status( WC_Coupon $coupon )
+ * @method get_notification_status( WC_Coupon $coupon ): string|null
  */
 class CouponMetaHandler implements Service {
 
@@ -59,6 +62,9 @@ class CouponMetaHandler implements Service {
 
 	public const KEY_MC_STATUS = 'mc_status';
 
+	public const KEY_NOTIFICATION_STATUS = 'notification_status';
+
+
 	protected const TYPES = [
 		self::KEY_SYNCED_AT            => 'int',
 		self::KEY_GOOGLE_IDS           => 'array',
@@ -68,6 +74,7 @@ class CouponMetaHandler implements Service {
 		self::KEY_SYNC_FAILED_AT       => 'int',
 		self::KEY_SYNC_STATUS          => 'string',
 		self::KEY_MC_STATUS            => 'string',
+		self::KEY_NOTIFICATION_STATUS  => 'string',
 	];
 
 	/**

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -355,7 +355,7 @@ class SyncerHooks implements Service, Registerable {
 	}
 
 	/**
-	 * Schedules notifications for an updated product
+	 * Schedules notifications for an updated coupon
 	 *
 	 * @param WC_Coupon $coupon
 	 */

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -259,7 +259,12 @@ class SyncerHooks implements Service, Registerable {
 
 		if ( $coupon instanceof WC_Coupon && $this->notifications_service->is_enabled() && $this->coupon_helper->should_trigger_delete_notification( $coupon ) ) {
 			$this->coupon_helper->set_notification_status( $coupon, NotificationStatus::NOTIFICATION_PENDING_DELETE );
-			$this->coupon_notification_job->schedule( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_DELETED ] );
+			$this->coupon_notification_job->schedule(
+				[
+					'item_id' => $coupon->get_id(),
+					'topic'   => NotificationsService::TOPIC_COUPON_DELETED,
+				]
+			);
 			return;
 		}
 
@@ -362,13 +367,28 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_update_coupon_notification( WC_Coupon $coupon ) {
 		if ( $this->coupon_helper->should_trigger_create_notification( $coupon ) ) {
 			$this->coupon_helper->set_notification_status( $coupon, NotificationStatus::NOTIFICATION_PENDING_CREATE );
-			$this->coupon_notification_job->schedule( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_CREATED ] );
+			$this->coupon_notification_job->schedule(
+				[
+					'item_id' => $coupon->get_id(),
+					'topic'   => NotificationsService::TOPIC_COUPON_CREATED,
+				]
+			);
 		} elseif ( $this->coupon_helper->should_trigger_update_notification( $coupon ) ) {
 			$this->coupon_helper->set_notification_status( $coupon, NotificationStatus::NOTIFICATION_PENDING_UPDATE );
-			$this->coupon_notification_job->schedule( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_UPDATED ] );
+			$this->coupon_notification_job->schedule(
+				[
+					'item_id' => $coupon->get_id(),
+					'topic'   => NotificationsService::TOPIC_COUPON_UPDATED,
+				]
+			);
 		} elseif ( $this->coupon_helper->should_trigger_delete_notification( $coupon ) ) {
 			$this->coupon_helper->set_notification_status( $coupon, NotificationStatus::NOTIFICATION_PENDING_DELETE );
-			$this->coupon_notification_job->schedule( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_DELETED ] );
+			$this->coupon_notification_job->schedule(
+				[
+					'item_id' => $coupon->get_id(),
+					'topic'   => NotificationsService::TOPIC_COUPON_DELETED,
+				]
+			);
 		}
 	}
 }

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -23,6 +23,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\CouponNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ProductNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ShippingNotificationJob;
@@ -117,6 +118,13 @@ class JobServiceProvider extends AbstractServiceProvider {
 			ProductHelper::class
 		);
 
+		// share coupon notifications job
+		$this->share_action_scheduler_job(
+			CouponNotificationJob::class,
+			NotificationsService::class,
+			CouponHelper::class
+		);
+
 		$this->share_with_tags(
 			JobRepository::class,
 			JobInterface::class
@@ -142,6 +150,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 			CouponHelper::class,
 			JobRepository::class,
 			MerchantCenterService::class,
+			NotificationsService::class,
 			WC::class
 		);
 

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -152,19 +152,15 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 	 * If there is a valid Item ID and topic is a deletion topic. Mark the coupon as unsynced.
 	 *
 	 * @param string   $topic
-	 * @param int|null $item
+	 * @param int $item
 	 */
-	protected function maybe_mark_as_unsynced( string $topic, $item = null ): void {
-		if ( is_null( $item ) || ! str_contains( $topic, '.delete' ) ) {
+	protected function maybe_mark_as_unsynced( string $topic, int $item ): void {
+		if ( ! str_contains( $topic, '.delete' ) ) {
 			return;
 		}
 
-		try {
-			$coupon = $this->coupon_helper->get_wc_coupon( $item );
-			$this->coupon_helper->mark_as_unsynced( $coupon );
-		} catch ( InvalidValue $e ) {
-			return;
-		}
+		$coupon = $this->coupon_helper->get_wc_coupon( $item );
+		$this->coupon_helper->mark_as_unsynced( $coupon );
 	}
 
 	/**

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -71,7 +71,7 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 		if ( ! isset( $args[0] ) || ! isset( $args[1] ) ) {
 			do_action(
 				'woocommerce_gla_error',
-				'Error sending Coupon Notification. Topic and Items are mandatory',
+				'Error sending Coupon Notification. Topic and Coupon ID are mandatory',
 				__METHOD__
 			);
 			return;

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -69,7 +69,7 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 	 * @param array $args Arguments with the item id and the topic
 	 */
 	protected function process_items( array $args ): void {
-		if ( ! isset( $args[0] ) || ! isset( $args[1] ) ) {
+		if ( ! isset( $args['item_id'] ) || ! $args['topic']  ) {
 			do_action(
 				'woocommerce_gla_error',
 				'Error sending Coupon Notification. Topic and Coupon ID are mandatory',
@@ -78,8 +78,8 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 			return;
 		}
 
-		$item  = $args[0];
-		$topic = $args[1];
+		$item  = $args['item_id'];
+		$topic = $args['topic'];
 
 		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
 			$this->set_status( $item, $this->get_after_notification_status( $topic ) );

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -69,7 +69,7 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 	 * @param array $args Arguments with the item id and the topic
 	 */
 	protected function process_items( array $args ): void {
-		if ( ! isset( $args['item_id'] ) || ! $args['topic']  ) {
+		if ( ! isset( $args['item_id'] ) || ! isset( $args['topic'] ) ) {
 			do_action(
 				'woocommerce_gla_error',
 				'Error sending Coupon Notification. Topic and Coupon ID are mandatory',

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -151,8 +151,8 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 	/**
 	 * If there is a valid Item ID and topic is a deletion topic. Mark the coupon as unsynced.
 	 *
-	 * @param string   $topic
-	 * @param int $item
+	 * @param string $topic
+	 * @param int    $item
 	 */
 	protected function maybe_mark_as_unsynced( string $topic, int $item ): void {
 		if ( ! str_contains( $topic, '.delete' ) ) {

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -69,6 +69,11 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 	 */
 	protected function process_items( array $args ): void {
 		if ( ! isset( $args[0] ) || ! isset( $args[1] ) ) {
+			do_action(
+				'woocommerce_gla_error',
+				'Error sending Coupon Notification. Topic and Items are mandatory',
+				__METHOD__
+			);
 			return;
 		}
 

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -151,11 +151,11 @@ class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInt
 	/**
 	 * If there is a valid Item ID and topic is a deletion topic. Mark the coupon as unsynced.
 	 *
-	 * @param string $topic
+	 * @param string   $topic
 	 * @param int|null $item
 	 */
 	protected function maybe_mark_as_unsynced( string $topic, $item = null ): void {
-		if ( is_null( $item ) || !  str_contains( $topic, '.delete' ) ) {
+		if ( is_null( $item ) || ! str_contains( $topic, '.delete' ) ) {
 			return;
 		}
 

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractActionSchedulerJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
+
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CouponNotificationJob
+ * Class for all the Coupons Notifications Jobs
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
+ */
+class CouponNotificationJob extends AbstractActionSchedulerJob implements JobInterface {
+
+	/**
+	 * @var NotificationsService $notifications_service
+	 */
+	protected $notifications_service;
+
+	/**
+	 * @var CouponHelper $coupon_helper
+	 */
+	protected $coupon_helper;
+
+	/**
+	 * Notifications Jobs constructor.
+	 *
+	 * @param ActionSchedulerInterface  $action_scheduler
+	 * @param ActionSchedulerJobMonitor $monitor
+	 * @param NotificationsService      $notifications_service
+	 * @param CouponHelper              $coupon_helper
+	 */
+	public function __construct(
+		ActionSchedulerInterface $action_scheduler,
+		ActionSchedulerJobMonitor $monitor,
+		NotificationsService $notifications_service,
+		CouponHelper $coupon_helper
+	) {
+		$this->notifications_service = $notifications_service;
+		$this->coupon_helper         = $coupon_helper;
+		parent::__construct( $action_scheduler, $monitor );
+	}
+
+	/**
+	 * Get the job name
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'notifications/coupons';
+	}
+
+
+	/**
+	 * Logic when processing the items
+	 *
+	 * @param array $args Arguments with the item id and the topic
+	 */
+	protected function process_items( array $args ): void {
+		if ( ! isset( $args[0] ) || ! isset( $args[1] ) ) {
+			return;
+		}
+
+		$item  = $args[0];
+		$topic = $args[1];
+
+		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
+			$this->set_status( $item, $this->get_after_notification_status( $topic ) );
+		}
+	}
+
+	/**
+	 * Schedule the Coupon Notification Job
+	 *
+	 * @param array $args
+	 */
+	public function schedule( array $args = [] ): void {
+		if ( $this->can_schedule( [ $args ] ) ) {
+			$this->action_scheduler->schedule_immediate(
+				$this->get_process_item_hook(),
+				[ $args ]
+			);
+		}
+	}
+
+	/**
+	 * Set the notification status for a coupon.
+	 *
+	 * @param int    $coupon_id
+	 * @param string $status
+	 */
+	protected function set_status( int $coupon_id, string $status ): void {
+		$coupon = $this->coupon_helper->get_wc_coupon( $coupon_id );
+		$this->coupon_helper->set_notification_status( $coupon, $status );
+	}
+
+	/**
+	 * Get the Notification Status after the notification happens
+	 *
+	 * @param string $topic
+	 * @return string
+	 */
+	protected function get_after_notification_status( string $topic ): string {
+		if ( str_contains( $topic, '.create' ) ) {
+			return NotificationStatus::NOTIFICATION_CREATED;
+		} elseif ( str_contains( $topic, '.delete' ) ) {
+			return NotificationStatus::NOTIFICATION_DELETED;
+		} else {
+			return NotificationStatus::NOTIFICATION_UPDATED;
+		}
+	}
+
+	/**
+	 * Checks if the item can be processed based on the topic.
+	 * This is needed because the coupon can change the Notification Status before
+	 * the Job process the item.
+	 *
+	 * @param int    $coupon_id
+	 * @param string $topic
+	 * @return bool
+	 */
+	protected function can_process( int $coupon_id, string $topic ): bool {
+		$coupon = $this->coupon_helper->get_wc_coupon( $coupon_id );
+		if ( str_contains( $topic, '.create' ) ) {
+			return $this->coupon_helper->should_trigger_create_notification( $coupon );
+		} elseif ( str_contains( $topic, '.delete' ) ) {
+			return $this->coupon_helper->should_trigger_delete_notification( $coupon );
+		} else {
+			return $this->coupon_helper->should_trigger_update_notification( $coupon );
+		}
+	}
+
+	/**
+	 * Can the job be scheduled.
+	 *
+	 * @param array|null $args
+	 *
+	 * @return bool Returns true if the job can be scheduled.
+	 */
+	public function can_schedule( $args = [] ): bool {
+		/**
+		 * Allow users to disable the notification job schedule.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool $value The current filter value. By default, it is the result of `$this->can_schedule` function.
+		 * @param array $args The arguments for the schedule function with the item id and the topic.
+		 */
+		return apply_filters( 'woocommerce_gla_coupon_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $args );
+	}
+}

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -354,7 +354,7 @@ class ProductHelper implements Service {
 		 * @param bool $value The current filter value.
 		 * @param WC_Product $product The product for the notification.
 		 */
-		return apply_filters( 'woocommerce_gla_is_ready_to_notify', $is_ready, $product );
+		return apply_filters( 'woocommerce_gla_product_is_ready_to_notify', $is_ready, $product );
 	}
 
 	/**

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -121,7 +121,6 @@ class SyncerHooks implements Service, Registerable {
 	 */
 	public function register(): void {
 		// only register the hooks if Merchant Center is connected and ready for syncing data.
-		// TODO: Potentially change this after API Pull is implemented as we don't need MC to be connected for the API Pull
 		if ( ! $this->merchant_center->is_ready_for_syncing() ) {
 			return;
 		}

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -178,7 +178,14 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$coupon = WC_Helper_Coupon::create_coupon( uniqid(), [ 'status' => 'draft' ] );
 		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->coupon_notification_job->expects( $this->once() )
-			->method( 'schedule' )->with( $this->equalTo( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_CREATED ] ) );
+			->method( 'schedule' )->with(
+				$this->equalTo(
+					[
+						'item_id' => $coupon->get_id(),
+						'topic'   => NotificationsService::TOPIC_COUPON_CREATED,
+					]
+				)
+			);
 		$coupon->set_status( 'publish' );
 		$coupon->add_meta_data( '_wc_gla_visibility', ChannelVisibility::SYNC_AND_SHOW, true );
 		$coupon->save();
@@ -191,7 +198,14 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$coupon = WC_Helper_Coupon::create_coupon( uniqid() );
 		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->coupon_notification_job->expects( $this->once() )
-			->method( 'schedule' )->with( $this->equalTo( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_UPDATED ] ) );
+			->method( 'schedule' )->with(
+				$this->equalTo(
+					[
+						'item_id' => $coupon->get_id(),
+						'topic'   => NotificationsService::TOPIC_COUPON_UPDATED,
+					]
+				)
+			);
 		$this->coupon_helper->set_notification_status( $coupon, NotificationStatus::NOTIFICATION_CREATED );
 		$coupon->set_status( 'publish' );
 		$coupon->add_meta_data( '_wc_gla_visibility', ChannelVisibility::SYNC_AND_SHOW, true );
@@ -205,7 +219,14 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$coupon = WC_Helper_Coupon::create_coupon( uniqid() );
 		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
 		$this->coupon_notification_job->expects( $this->once() )
-			->method( 'schedule' )->with( $this->equalTo( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_DELETED ] ) );
+			->method( 'schedule' )->with(
+				$this->equalTo(
+					[
+						'item_id' => $coupon->get_id(),
+						'topic'   => NotificationsService::TOPIC_COUPON_DELETED,
+					]
+				)
+			);
 		$coupon->set_status( 'publish' );
 		$coupon->add_meta_data( '_wc_gla_visibility', ChannelVisibility::DONT_SYNC_AND_SHOW, true );
 		$this->coupon_helper->set_notification_status( $coupon, NotificationStatus::NOTIFICATION_UPDATED );

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -6,20 +6,25 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\SyncerHooks;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\WCCouponAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\DeleteCouponEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteCoupon;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\CouponNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateCoupon;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\CouponTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Coupon;
+use WC_Helper_Coupon;
 
 /**
  * Class SyncerHooksTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon
  */
 class SyncerHooksTest extends ContainerAwareUnitTest {
 
@@ -36,6 +41,12 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 	/** @var MockObject|UpdateCoupon $update_coupon_job */
 	protected $update_coupon_job;
+
+	/** @var MockObject|CouponNotificationJob $coupon_notification_job */
+	protected $coupon_notification_job;
+
+	/** @var MockObject|NotificationsService $notification_service */
+	protected $notification_service;
 
 	/** @var CouponHelper $coupon_helper */
 	protected $coupon_helper;
@@ -160,6 +171,47 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		wp_untrash_post( $post->ID );
 	}
 
+	public function test_create_coupon_triggers_notification_created() {
+		/**
+		 * @var WC_Coupon $coupon
+		 */
+		$coupon = WC_Helper_Coupon::create_coupon( uniqid(), [ 'status' => 'draft' ] );
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+		$this->coupon_notification_job->expects( $this->once() )
+			->method( 'schedule' )->with( $this->equalTo( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_CREATED ] ) );
+		$coupon->set_status( 'publish' );
+		$coupon->add_meta_data( '_wc_gla_visibility', ChannelVisibility::SYNC_AND_SHOW, true );
+		$coupon->save();
+	}
+
+	public function test_update_coupon_triggers_notification_updated() {
+		/**
+		 * @var WC_Coupon $coupon
+		 */
+		$coupon = WC_Helper_Coupon::create_coupon( uniqid() );
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+		$this->coupon_notification_job->expects( $this->once() )
+			->method( 'schedule' )->with( $this->equalTo( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_UPDATED ] ) );
+		$this->coupon_helper->set_notification_status( $coupon, NotificationStatus::NOTIFICATION_CREATED );
+		$coupon->set_status( 'publish' );
+		$coupon->add_meta_data( '_wc_gla_visibility', ChannelVisibility::SYNC_AND_SHOW, true );
+		$coupon->save();
+	}
+
+	public function test_delete_coupon_triggers_notification_delete() {
+		/**
+		 * @var WC_Coupon $coupon
+		 */
+		$coupon = WC_Helper_Coupon::create_coupon( uniqid() );
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+		$this->coupon_notification_job->expects( $this->once() )
+			->method( 'schedule' )->with( $this->equalTo( [ $coupon->get_id(), NotificationsService::TOPIC_COUPON_DELETED ] ) );
+		$coupon->set_status( 'publish' );
+		$coupon->add_meta_data( '_wc_gla_visibility', ChannelVisibility::DONT_SYNC_AND_SHOW, true );
+		$this->coupon_helper->set_notification_status( $coupon, NotificationStatus::NOTIFICATION_UPDATED );
+		$coupon->save();
+	}
+
 	/**
 	 * Runs before each test is executed.
 	 */
@@ -177,6 +229,10 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 		$this->update_coupon_job = $this->createMock( UpdateCoupon::class );
 		$this->delete_coupon_job = $this->createMock( DeleteCoupon::class );
+		$this->delete_coupon_job = $this->createMock( DeleteCoupon::class );
+		$this->coupon_notification_job = $this->createMock( CouponNotificationJob::class );
+		$this->notification_service = $this->createMock( NotificationsService::class );
+
 		$this->job_repository    = $this->createMock( JobRepository::class );
 		$this->job_repository->expects( $this->any() )
 			->method( 'get' )
@@ -184,6 +240,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 				[
 					[ DeleteCoupon::class, $this->delete_coupon_job ],
 					[ UpdateCoupon::class, $this->update_coupon_job ],
+					[ CouponNotificationJob::class, $this->coupon_notification_job ],
 				]
 			);
 
@@ -193,9 +250,11 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 			$this->coupon_helper,
 			$this->job_repository,
 			$this->merchant_center,
+			$this->notification_service,
 			$this->wc
 		);
 
+		add_filter( 'woocommerce_gla_notifications_enabled', '__return_false' );
 		$this->syncer_hooks->register();
 	}
 }

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -227,13 +227,13 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 			->method( 'is_ready_for_syncing' )
 			->willReturn( true );
 
-		$this->update_coupon_job = $this->createMock( UpdateCoupon::class );
-		$this->delete_coupon_job = $this->createMock( DeleteCoupon::class );
-		$this->delete_coupon_job = $this->createMock( DeleteCoupon::class );
+		$this->update_coupon_job       = $this->createMock( UpdateCoupon::class );
+		$this->delete_coupon_job       = $this->createMock( DeleteCoupon::class );
+		$this->delete_coupon_job       = $this->createMock( DeleteCoupon::class );
 		$this->coupon_notification_job = $this->createMock( CouponNotificationJob::class );
-		$this->notification_service = $this->createMock( NotificationsService::class );
+		$this->notification_service    = $this->createMock( NotificationsService::class );
 
-		$this->job_repository    = $this->createMock( JobRepository::class );
+		$this->job_repository = $this->createMock( JobRepository::class );
 		$this->job_repository->expects( $this->any() )
 			->method( 'get' )
 			->willReturnMap(

--- a/tests/Unit/Jobs/CouponNotificationJobTest.php
+++ b/tests/Unit/Jobs/CouponNotificationJobTest.php
@@ -187,7 +187,7 @@ class CouponNotificationJobTest extends UnitTest {
 			->method( 'notify' )
 			->willReturn( true );
 
-		$this->coupon_helper->expects( $this->exactly( 6 ) )
+		$this->coupon_helper->expects( $this->exactly( 7 ) )
 			->method( 'get_wc_coupon' )
 			->willReturn( $coupon );
 
@@ -256,5 +256,28 @@ class CouponNotificationJobTest extends UnitTest {
 		$this->job->handle_process_items_action( [ $id, 'coupon.create' ] );
 		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
 		$this->job->handle_process_items_action( [ $id, 'coupon.update' ] );
+	}
+
+	public function test_mark_as_unsynced_when_delete() {
+		/** @var \WC_Coupon $coupon */
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$id     = $coupon->get_id();
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_delete_notification' )
+			->with( $coupon )
+			->willReturn( true );
+
+		$this->coupon_helper->expects( $this->exactly( 3 ) )
+			->method( 'get_wc_coupon' )
+			->with( $id )
+			->willReturn( $coupon );
+
+		$this->notification_service->expects( $this->once() )->method( 'notify' )->willReturn( true );
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'mark_as_unsynced' );
+
+
+		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
 	}
 }

--- a/tests/Unit/Jobs/CouponNotificationJobTest.php
+++ b/tests/Unit/Jobs/CouponNotificationJobTest.php
@@ -277,7 +277,6 @@ class CouponNotificationJobTest extends UnitTest {
 		$this->coupon_helper->expects( $this->once() )
 			->method( 'mark_as_unsynced' );
 
-
 		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
 	}
 }

--- a/tests/Unit/Jobs/CouponNotificationJobTest.php
+++ b/tests/Unit/Jobs/CouponNotificationJobTest.php
@@ -140,7 +140,12 @@ class CouponNotificationJobTest extends UnitTest {
 			->method( 'set_notification_status' )
 			->with( $coupon, NotificationStatus::NOTIFICATION_CREATED );
 
-		$this->job->handle_process_items_action( [ $id, $topic ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
 	}
 
 	public function test_process_items_doesnt_calls_notify_when_no_args() {
@@ -175,7 +180,12 @@ class CouponNotificationJobTest extends UnitTest {
 		$this->coupon_helper->expects( $this->never() )
 			->method( 'set_notification_status' );
 
-		$this->job->handle_process_items_action( [ $id, $topic ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
 	}
 
 	public function test_get_after_notification_status() {
@@ -220,9 +230,24 @@ class CouponNotificationJobTest extends UnitTest {
 				}
 			);
 
-		$this->job->handle_process_items_action( [ $id, 'coupon.create' ] );
-		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
-		$this->job->handle_process_items_action( [ $id, 'coupon.update' ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => 'coupon.create',
+			]
+		);
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => 'coupon.delete',
+			]
+		);
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => 'coupon.update',
+			]
+		);
 	}
 
 	public function test_dont_process_item_if_status_changed() {
@@ -253,9 +278,24 @@ class CouponNotificationJobTest extends UnitTest {
 
 		$this->coupon_helper->expects( $this->never() )->method( 'set_notification_status' );
 
-		$this->job->handle_process_items_action( [ $id, 'coupon.create' ] );
-		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
-		$this->job->handle_process_items_action( [ $id, 'coupon.update' ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => 'coupon.create',
+			]
+		);
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => 'coupon.delete',
+			]
+		);
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => 'coupon.update',
+			]
+		);
 	}
 
 	public function test_mark_as_unsynced_when_delete() {
@@ -277,6 +317,11 @@ class CouponNotificationJobTest extends UnitTest {
 		$this->coupon_helper->expects( $this->once() )
 			->method( 'mark_as_unsynced' );
 
-		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => 'coupon.delete',
+			]
+		);
 	}
 }

--- a/tests/Unit/Jobs/CouponNotificationJobTest.php
+++ b/tests/Unit/Jobs/CouponNotificationJobTest.php
@@ -1,0 +1,260 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\CouponNotificationJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Helper_Coupon;
+
+/**
+ * Class CouponNotificationJobTest
+ *
+ * @group Notifications
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+class CouponNotificationJobTest extends UnitTest {
+
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|NotificationsService $notification_service */
+	protected $notification_service;
+
+	/** @var MockObject|CouponHelper $coupon_helper */
+	protected $coupon_helper;
+
+	/** @var CouponNotificationJob $job */
+	protected $job;
+
+	protected const JOB_NAME          = 'notifications/coupons';
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->notification_service = $this->createMock( NotificationsService::class );
+		$this->coupon_helper        = $this->createMock( CouponHelper::class );
+		$this->job                  = new CouponNotificationJob(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->notification_service,
+			$this->coupon_helper
+		);
+
+		$this->job->init();
+	}
+
+	public function test_job_name() {
+		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
+	}
+
+	public function test_schedule_schedules_immediate_job() {
+		$topic = 'coupon.create';
+		$id    = 1;
+
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
+			->willReturn( false );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with(
+				self::PROCESS_ITEM_HOOK,
+				[ [ $id, $topic ] ]
+			);
+
+		$this->job->schedule( [ $id, $topic ] );
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
+		$id    = 1;
+		$topic = 'coupon.create';
+
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'has_scheduled_action' )
+			->with( self::PROCESS_ITEM_HOOK, [ [ $id, $topic ] ] )
+			->willReturn( true );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule( [ $id, $topic ] );
+	}
+
+	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
+		$id    = 1;
+		$topic = 'coupon.create';
+
+		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
+
+		$this->action_scheduler->expects( $this->never() )
+			->method( 'has_scheduled_action' );
+
+		$this->action_scheduler->expects( $this->never() )->method( 'schedule_immediate' );
+
+		$this->job->schedule( [ $id, $topic ] );
+	}
+
+	public function test_process_items_calls_notify_and_set_status_on_success() {
+		/** @var \WC_Coupon $coupon */
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$id     = $coupon->get_id();
+		$topic  = 'coupon.create';
+
+		$this->notification_service->expects( $this->once() )
+			->method( 'notify' )
+			->with( $topic, $id )
+			->willReturn( true );
+
+		$this->coupon_helper->expects( $this->exactly( 2 ) )
+		->method( 'get_wc_coupon' )
+		->with( $id )
+		->willReturn( $coupon );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $coupon )
+			->willReturn( true );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'set_notification_status' )
+			->with( $coupon, NotificationStatus::NOTIFICATION_CREATED );
+
+		$this->job->handle_process_items_action( [ $id, $topic ] );
+	}
+
+	public function test_process_items_doesnt_calls_notify_when_no_args() {
+		$this->notification_service->expects( $this->never() )
+			->method( 'notify' );
+
+		$this->job->handle_process_items_action( [] );
+		$this->job->handle_process_items_action( [ 1 ] );
+	}
+
+	public function test_process_items_doesnt_calls_set_status_on_failure() {
+		/** @var \WC_Coupon $coupon */
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$id     = $coupon->get_id();
+		$topic  = 'coupon.create';
+
+		$this->notification_service->expects( $this->once() )
+			->method( 'notify' )
+			->with( $topic, $id )
+			->willReturn( false );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'get_wc_coupon' )
+			->with( $id )
+			->willReturn( $coupon );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $coupon )
+			->willReturn( true );
+
+		$this->coupon_helper->expects( $this->never() )
+			->method( 'set_notification_status' );
+
+		$this->job->handle_process_items_action( [ $id, $topic ] );
+	}
+
+	public function test_get_after_notification_status() {
+		/** @var \WC_Coupon $coupon */
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$id     = $coupon->get_id();
+
+		$this->notification_service->expects( $this->exactly( 3 ) )
+			->method( 'notify' )
+			->willReturn( true );
+
+		$this->coupon_helper->expects( $this->exactly( 6 ) )
+			->method( 'get_wc_coupon' )
+			->willReturn( $coupon );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $coupon )
+			->willReturn( true );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_update_notification' )
+			->with( $coupon )
+			->willReturn( true );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_delete_notification' )
+			->with( $coupon )
+			->willReturn( true );
+
+		$this->coupon_helper->expects( $this->exactly( 3 ) )
+			->method( 'set_notification_status' )
+			->willReturnCallback(
+				function ( $id, $topic ) {
+					if ( $topic === 'coupon.create' ) {
+							return NotificationStatus::NOTIFICATION_CREATED;
+					} elseif ( $topic === 'coupon.delete' ) {
+						return NotificationStatus::NOTIFICATION_DELETED;
+					} else {
+						return NotificationStatus::NOTIFICATION_UPDATED;
+					}
+				}
+			);
+
+		$this->job->handle_process_items_action( [ $id, 'coupon.create' ] );
+		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
+		$this->job->handle_process_items_action( [ $id, 'coupon.update' ] );
+	}
+
+	public function test_dont_process_item_if_status_changed() {
+		/** @var \WC_Coupon $coupon */
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$id     = $coupon->get_id();
+
+		$this->notification_service->expects( $this->never() )->method( 'notify' );
+
+		$this->coupon_helper->expects( $this->exactly( 3 ) )
+			->method( 'get_wc_coupon' )
+			->willReturn( $coupon );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $coupon )
+			->willReturn( false );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_update_notification' )
+			->with( $coupon )
+			->willReturn( false );
+
+		$this->coupon_helper->expects( $this->once() )
+			->method( 'should_trigger_delete_notification' )
+			->with( $coupon )
+			->willReturn( false );
+
+		$this->coupon_helper->expects( $this->never() )->method( 'set_notification_status' );
+
+		$this->job->handle_process_items_action( [ $id, 'coupon.create' ] );
+		$this->job->handle_process_items_action( [ $id, 'coupon.delete' ] );
+		$this->job->handle_process_items_action( [ $id, 'coupon.update' ] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -60,6 +60,7 @@ if ( file_exists( $wc_dir . '/tests/legacy/bootstrap.php' ) ) {
 	$wc_tests_dir .= '/legacy';
 }
 
+require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-coupon.php';
 require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-product.php';
 require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-shipping.php';
 require_once $wc_tests_dir . '/framework/helpers/class-wc-helper-customer.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the logic for adding Cupon Notifications in the API PULL Project.

⚠️  It follows the same structure as Product Notifications. Hence a lot of code can be refactored reducing duplications. This will be done in further PRs.

⚠️  IF your domain is not authorized for using the sandbox, this PR wont work as a successful notification it's needed to update the statuses. So one option is to hardcode the next line so the notification is always successful.

`NotificationsService.php`
```php
public function notify( string $topic, $item_id = null ): bool {
     return true;
}
```

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. With the Onboarding finished, crate a coupon with the status "DRAFT" and Channel Visibility "Dont show coupon on Google"
2. Check the Action Scheduler and see there is NO action `gla/jobs/notifications/coupons/process_item`
3. Change the status to Publish but still "Dont show coupon on Google". 
4. Check the Action Scheduler and see there is NO action `gla/jobs/notifications/coupons/process_item`
5. Change the channel visibility to  "Show coupon on Google"
6. Check the Action Scheduler and see that there is an action `gla/jobs/notifications/coupons/process_item` with `coupon.create` topic.
7. Run the action 
8. Update the coupon description
9. Check the Action Scheduler and see that there is an action `gla/jobs/notifications/coupons/process_item` with `coupon.update` topic.
10. Change the channel visibility again to  "Don't Show coupon on Google"
11.  Check the Action Scheduler and see that there is an action `gla/jobs/notifications/coupons/process_item` with `coupon.delete` topic.
12. Update the coupon description
13. Check the Action Scheduler and see there is NO action `gla/jobs/notifications/coupons/process_item`
14. Change the channel visibility to  "Show coupon on Google"
15. Check the Action Scheduler and see that there is an action `gla/jobs/notifications/coupons/process_item` with `coupon.create` topic.
16. Test other scenarios to verify that the notifications are being sent correctly. 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
