### PR TITLE
API PULL - Unsync product when delete Notification happens

### DIFF
--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -77,6 +77,7 @@ class ProductNotificationJob extends AbstractActionSchedulerJob implements JobIn
 
 		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
 			$this->set_status( $item, $this->get_after_notification_status( $topic ) );
+			$this->maybe_mark_as_unsynced( $topic, $item );
 		}
 	}
 
@@ -119,6 +120,21 @@ class ProductNotificationJob extends AbstractActionSchedulerJob implements JobIn
 		} else {
 			return NotificationStatus::NOTIFICATION_UPDATED;
 		}
+	}
+
+	/**
+	 * If there is a valid Item ID and topic is a deletion topic. Mark the coupon as unsynced.
+	 *
+	 * @param string $topic
+	 * @param int    $item
+	 */
+	protected function maybe_mark_as_unsynced( string $topic, int $item ): void {
+		if ( ! str_contains( $topic, '.delete' ) ) {
+			return;
+		}
+
+		$product = $this->product_helper->get_wc_product( $item );
+		$this->product_helper->mark_as_unsynced( $product );
 	}
 
 	/**

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -257,4 +257,26 @@ class ProductNotificationJobTest extends UnitTest {
 		$this->job->handle_process_items_action( [ $id, 'product.delete' ] );
 		$this->job->handle_process_items_action( [ $id, 'product.update' ] );
 	}
+
+	public function test_mark_as_unsynced_when_delete() {
+		/** @var \WC_Product $product */
+		$product = WC_Helper_Product::create_simple_product();
+		$id     = $product->get_id();
+
+		$this->product_helper->expects( $this->once() )
+			->method( 'should_trigger_delete_notification' )
+			->with( $product )
+			->willReturn( true );
+
+		$this->product_helper->expects( $this->exactly( 3 ) )
+			->method( 'get_wc_product' )
+			->with( $id )
+			->willReturn( $product );
+
+		$this->notification_service->expects( $this->once() )->method( 'notify' )->willReturn( true );
+		$this->product_helper->expects( $this->once() )
+			->method( 'mark_as_unsynced' );
+
+		$this->job->handle_process_items_action( [ $id, 'product.delete' ] );
+	}
 }

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -187,7 +187,7 @@ class ProductNotificationJobTest extends UnitTest {
 			->method( 'notify' )
 			->willReturn( true );
 
-		$this->product_helper->expects( $this->exactly( 6 ) )
+		$this->product_helper->expects( $this->exactly( 7 ) )
 			->method( 'get_wc_product' )
 			->willReturn( $product );
 
@@ -261,7 +261,7 @@ class ProductNotificationJobTest extends UnitTest {
 	public function test_mark_as_unsynced_when_delete() {
 		/** @var \WC_Product $product */
 		$product = WC_Helper_Product::create_simple_product();
-		$id     = $product->get_id();
+		$id      = $product->get_id();
 
 		$this->product_helper->expects( $this->once() )
 			->method( 'should_trigger_delete_notification' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR will mark the product as unsynced in MC when a delete notification happens.

ℹ️  This was discussed in p1708720809845579-slack-C0410KV3YLW

⚠️  IF your domain is not authorized for using the sandbox, this PR wont work as a successful notification it's needed to update the statuses. So one option is to hardcode the next line so the notification is always successful.

`NotificationsService.php`
```php
public function notify( string $topic, $item_id = null ): bool {
     return true;
}
```

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Sync a Product to Google MC
2. Delete that product
3. Go to action Scheduler and see the action `gla/jobs/notifications/products/process_item` with the product and the `product.delete` topic.
4. Run it
5. See the product is unsynced. 
