### PR TITLE
Add support for Google Analytics for WooCommerce version 2.0.0

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -257,7 +257,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 
 			gtag('js', new Date());
 			gtag('set', 'developer_id.<?php echo esc_js( self::DEVELOPER_ID ); ?>', true);
-			<?php echo $this->get_gtag_config( $ads_conversion_id ); ?>
+			<?php echo esc_js( $this->get_gtag_config( $ads_conversion_id ) ); ?>
 		</script>
 
 		<?php
@@ -288,7 +288,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		if ( class_exists( '\WC_Google_Gtag_JS' ) ) {
 			wp_add_inline_script(
 				'woocommerce-google-analytics-integration',
-				$inline_script
+				esc_js( $inline_script )
 			);
 		} else {
 			wp_print_inline_script_tag( $inline_script );

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -257,7 +257,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 
 			gtag('js', new Date());
 			gtag('set', 'developer_id.<?php echo esc_js( self::DEVELOPER_ID ); ?>', true);
-			<?php echo esc_js( $this->get_gtag_config( $ads_conversion_id ) ); ?>
+			<?php echo $this->get_gtag_config( $ads_conversion_id ); ?>
 		</script>
 
 		<?php

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -217,16 +217,24 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	 */
 	public function activate_global_site_tag( string $ads_conversion_id ) {
 		if ( $this->gtag_js->is_adding_framework() ) {
-			add_filter(
-				'woocommerce_gtag_snippet',
-				function ( $gtag_snippet ) use ( $ads_conversion_id ) {
-					return preg_replace(
-						'~(\s)</script>~',
-						"\tgtag('config', '" . $ads_conversion_id . "', { 'groups': 'GLA', 'send_page_view': false });\n$1</script>",
-						$gtag_snippet
-					);
-				}
-			);
+			if ( version_compare( \WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION, '2.0.0', '>=' ) ) {
+				wp_add_inline_script(
+					'woocommerce-google-analytics-integration',
+					$this->get_gtag_config( $ads_conversion_id )
+				);
+			} else {
+				// Legacy code to support Google Analytics for WooCommerce version < 2.0.0.
+				add_filter(
+					'woocommerce_gtag_snippet',
+					function ( $gtag_snippet ) use ( $ads_conversion_id ) {
+						return preg_replace(
+							'~(\s)</script>~',
+							"\tgtag('config', '" . $ads_conversion_id . "', { 'groups': 'GLA', 'send_page_view': false });\n$1</script>",
+							$gtag_snippet
+						);
+					}
+				);
+			}
 		} else {
 			$this->display_global_site_tag( $ads_conversion_id );
 		}
@@ -249,14 +257,42 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 
 			gtag('js', new Date());
 			gtag('set', 'developer_id.<?php echo esc_js( self::DEVELOPER_ID ); ?>', true);
-			gtag('config', '<?php echo esc_js( $ads_conversion_id ); ?>', {
-				'groups': 'GLA',
-				'send_page_view': false
-			});
+			<?php echo $this->get_gtag_config( $ads_conversion_id ); ?>
 		</script>
 
 		<?php
 		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	}
+
+	/**
+	 * Get the ads conversion configuration for the Global Site Tag
+	 *
+	 * @param string $ads_conversion_id Google Ads account conversion ID.
+	 */
+	protected function get_gtag_config( string $ads_conversion_id ) {
+		return sprintf(
+			'gtag("config", "%1$s", { "groups": "GLA", "send_page_view": false });',
+			esc_js( $ads_conversion_id )
+		);
+	}
+
+	/**
+	 * Add inline JavaScript to the page either as a standalone script or
+	 * attach it to Google Analytics for WooCommerce if it's installed
+	 *
+	 * @param string $inline_script The JavaScript code to display
+	 *
+	 * @return void
+	 */
+	public function add_inline_event_script( string $inline_script ) {
+		if ( class_exists( '\WC_Google_Gtag_JS' ) ) {
+			wp_add_inline_script(
+				'woocommerce-google-analytics-integration',
+				$inline_script
+			);
+		} else {
+			wp_print_inline_script_tag( $inline_script );
+		}
 	}
 
 	/**
@@ -294,7 +330,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $order->get_currency() ),
 			esc_js( $order->get_id() ),
 		);
-		wp_print_inline_script_tag( $conversion_gtag_info );
+		$this->add_inline_event_script( $conversion_gtag_info );
 
 		// Get the item info in the order
 		$item_info = [];
@@ -355,7 +391,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $language ),
 			join( ',', $item_info ),
 		);
-		wp_print_inline_script_tag( $purchase_page_gtag );
+		$this->add_inline_event_script( $purchase_page_gtag );
 	}
 
 	/**
@@ -387,7 +423,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( $product->get_name() ),
 			esc_js( join( ' & ', $this->product_helper->get_categories( $product ) ) ),
 		);
-		wp_print_inline_script_tag( $view_item_gtag );
+		$this->add_inline_event_script( $view_item_gtag );
 	}
 
 	/**
@@ -395,7 +431,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	 */
 	private function display_page_view_event_snippet(): void {
 		if ( ! is_cart() ) {
-			wp_print_inline_script_tag(
+			$this->add_inline_event_script(
 				'gtag("event", "page_view", {send_to: "GLA"});'
 			);
 			return;
@@ -438,7 +474,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			$value,
 			join( ',', $item_info ),
 		);
-		wp_print_inline_script_tag( $page_view_gtag );
+		$this->add_inline_event_script( $page_view_gtag );
 	}
 
 	/**

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -257,7 +257,10 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 
 			gtag('js', new Date());
 			gtag('set', 'developer_id.<?php echo esc_js( self::DEVELOPER_ID ); ?>', true);
-			<?php echo $this->get_gtag_config( $ads_conversion_id ); ?>
+			<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $this->get_gtag_config( $ads_conversion_id );
+			?>
 		</script>
 
 		<?php

--- a/src/Proxies/GoogleGtagJs.php
+++ b/src/Proxies/GoogleGtagJs.php
@@ -22,7 +22,9 @@ class GoogleGtagJs {
 		$this->wcga_settings = get_option( 'woocommerce_google_analytics_settings', [] );
 
 		// Prime some values.
-		if ( empty( $this->wcga_settings['ga_gtag_enabled'] ) ) {
+		if ( defined( '\WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION' ) && version_compare( \WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION, '2.0.0', '>=' ) ) {
+			$this->wcga_settings['ga_gtag_enabled'] = 'yes';
+		} elseif ( empty( $this->wcga_settings['ga_gtag_enabled'] ) ) {
 			$this->wcga_settings['ga_gtag_enabled'] = 'no';
 		}
 		if ( empty( $this->wcga_settings['ga_standard_tracking_enabled'] ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

⚠️ **Requires:** https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/322

Google Analytics for WooCommerce updates how the Global Site Tag is loaded so this PR updates the integration in GLA to support version `2.0.0` and above while maintaining backwards compatibility.

The main difference is that instead of simply adding a script to the page with a call to `gtag`, we now use `wp_add_inline_script` and the Google Analytics for WooCommerce script handle where applicable.

### Detailed test instructions:

1. Build Google Analytics for WooCommerce from [#322](https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/322)
2. Complete onboarding if needed
3. Debug a GLA test site via [TagAssistant](https://tagassistant.google.com/)
4. Confirm the GLA tag is found
5. Confirm that the GLA events are sent:
    - `page_view`
    - `view_item`
    - `purchase`
    - `conversion`

### Changelog entry

> Add - Support for Google Analytics for WooCommerce version 2.0.0 and above