### PR TITLE
Improve WordPress.com account handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
 	"require": {
 		"php": ">=7.4",
 		"ext-json": "*",
-		"automattic/jetpack-autoloader": "^2.4",
-		"automattic/jetpack-config": "^1.4",
-		"automattic/jetpack-connection": "^1.40",
+		"automattic/jetpack-autoloader": "^3.0",
+		"automattic/jetpack-config": "^2.0",
+		"automattic/jetpack-connection": "^2.3",
 		"google/apiclient": "^2.15",
 		"google/apiclient-services": "~0.312",
 		"googleads/google-ads-php": "^19.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44d590a9ed062f32ccca8e0708ef9350",
+    "content-hash": "f5d792942004e9483018be005ffee7e9",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
-            "version": "v1.4.22",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-a8c-mc-stats.git",
-                "reference": "d7fdf2fc7ae33d75e24e82d81269e33ec718446f"
+                "reference": "6ce7a1e1eba796643d7d32dc49057c7bb8e3233c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/d7fdf2fc7ae33d75e24e82d81269e33ec718446f",
-                "reference": "d7fdf2fc7ae33d75e24e82d81269e33ec718446f",
+                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/6ce7a1e1eba796643d7d32dc49057c7bb8e3233c",
+                "reference": "6ce7a1e1eba796643d7d32dc49057c7bb8e3233c",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=7.0"
+            },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.9",
+                "automattic/jetpack-changelogger": "^4.0.0",
                 "yoast/phpunit-polyfills": "1.1.0"
             },
             "suggest": {
@@ -35,7 +38,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -49,27 +52,30 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/v1.4.22"
+                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/v2.0.0"
             },
-            "time": "2023-09-19T18:18:33+00:00"
+            "time": "2023-11-20T20:02:34+00:00"
         },
         {
             "name": "automattic/jetpack-admin-ui",
-            "version": "v0.2.24",
+            "version": "v0.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-admin-ui.git",
-                "reference": "334858057237be51aa916352c7573fc4c06bbd6c"
+                "reference": "22c381953ce293529202cda959218d6256a3ef7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-admin-ui/zipball/334858057237be51aa916352c7573fc4c06bbd6c",
-                "reference": "334858057237be51aa916352c7573fc4c06bbd6c",
+                "url": "https://api.github.com/repos/Automattic/jetpack-admin-ui/zipball/22c381953ce293529202cda959218d6256a3ef7c",
+                "reference": "22c381953ce293529202cda959218d6256a3ef7c",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=7.0"
+            },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.11",
-                "automattic/jetpack-logo": "^1.6.3",
+                "automattic/jetpack-changelogger": "^4.1.0",
+                "automattic/jetpack-logo": "^2.0.0",
                 "automattic/wordbless": "dev-master",
                 "yoast/phpunit-polyfills": "1.1.0"
             },
@@ -85,7 +91,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-admin-menu.php"
@@ -102,29 +108,30 @@
             ],
             "description": "Generic Jetpack wp-admin UI elements",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-admin-ui/tree/v0.2.24"
+                "source": "https://github.com/Automattic/jetpack-admin-ui/tree/v0.3.2"
             },
-            "time": "2023-10-30T08:37:02+00:00"
+            "time": "2024-01-29T19:37:58+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.12.0",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "632b69cfc73ed5505f2b03165e7f68d414d0da12"
+                "reference": "bbf43988d1538a9f2678809b0868dc42111d0b12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/632b69cfc73ed5505f2b03165e7f68d414d0da12",
-                "reference": "632b69cfc73ed5505f2b03165e7f68d414d0da12",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/bbf43988d1538a9f2678809b0868dc42111d0b12",
+                "reference": "bbf43988d1538a9f2678809b0868dc42111d0b12",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1 || ^2.0"
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": ">=7.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.11",
+                "automattic/jetpack-changelogger": "^4.0.2",
                 "yoast/phpunit-polyfills": "1.1.0"
             },
             "type": "composer-plugin",
@@ -139,7 +146,7 @@
                     "::VERSION": "src/AutoloadGenerator.php"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -164,26 +171,29 @@
                 "wordpress"
             ],
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.12.0"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v3.0.2"
             },
-            "time": "2023-09-28T18:33:34+00:00"
+            "time": "2023-11-21T18:59:10+00:00"
         },
         {
             "name": "automattic/jetpack-config",
-            "version": "v1.15.4",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-config.git",
-                "reference": "6cf8d61a972530322c9b62f7375fff83342c38f9"
+                "reference": "1e34ef5f598abc1e5ee9100aa5a1a1f51b62681d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/6cf8d61a972530322c9b62f7375fff83342c38f9",
-                "reference": "6cf8d61a972530322c9b62f7375fff83342c38f9",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/1e34ef5f598abc1e5ee9100aa5a1a1f51b62681d",
+                "reference": "1e34ef5f598abc1e5ee9100aa5a1a1f51b62681d",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=7.0"
+            },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.9"
+                "automattic/jetpack-changelogger": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -197,7 +207,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -211,34 +221,35 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-config/tree/v1.15.4"
+                "source": "https://github.com/Automattic/jetpack-config/tree/v2.0.0"
             },
-            "time": "2023-09-19T18:18:30+00:00"
+            "time": "2023-11-20T20:02:25+00:00"
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "v1.59.0",
+            "version": "v2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "eb55a554fe9cbb0d0b7ade54ea6ff965a508b05e"
+                "reference": "0d43e67354dfd6f39a0b1cbb070ba24a64377f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/eb55a554fe9cbb0d0b7ade54ea6ff965a508b05e",
-                "reference": "eb55a554fe9cbb0d0b7ade54ea6ff965a508b05e",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/0d43e67354dfd6f39a0b1cbb070ba24a64377f41",
+                "reference": "0d43e67354dfd6f39a0b1cbb070ba24a64377f41",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-a8c-mc-stats": "^1.4.22",
-                "automattic/jetpack-admin-ui": "^0.2.24",
-                "automattic/jetpack-constants": "^1.6.23",
-                "automattic/jetpack-redirect": "^1.7.27",
-                "automattic/jetpack-roles": "^1.4.25",
-                "automattic/jetpack-status": "^1.18.5"
+                "automattic/jetpack-a8c-mc-stats": "^2.0.0",
+                "automattic/jetpack-admin-ui": "^0.3.2",
+                "automattic/jetpack-constants": "^2.0.0",
+                "automattic/jetpack-redirect": "^2.0.0",
+                "automattic/jetpack-roles": "^2.0.0",
+                "automattic/jetpack-status": "^2.1.0",
+                "php": ">=7.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.11",
+                "automattic/jetpack-changelogger": "^4.1.0",
                 "automattic/wordbless": "@dev",
                 "brain/monkey": "2.6.1",
                 "yoast/phpunit-polyfills": "1.1.0"
@@ -258,7 +269,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -274,26 +285,29 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-connection/tree/v1.59.0"
+                "source": "https://github.com/Automattic/jetpack-connection/tree/v2.3.2"
             },
-            "time": "2023-11-08T09:11:43+00:00"
+            "time": "2024-02-26T17:42:33+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "v1.6.23",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "0825fb1fa94956f26adebc01be0d716a0fd3ade0"
+                "reference": "d4244e33d2d18902951af05ca5dbb689a23c9cdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/0825fb1fa94956f26adebc01be0d716a0fd3ade0",
-                "reference": "0825fb1fa94956f26adebc01be0d716a0fd3ade0",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/d4244e33d2d18902951af05ca5dbb689a23c9cdc",
+                "reference": "d4244e33d2d18902951af05ca5dbb689a23c9cdc",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=7.0"
+            },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.8",
+                "automattic/jetpack-changelogger": "^4.0.0",
                 "brain/monkey": "2.6.1",
                 "yoast/phpunit-polyfills": "1.1.0"
             },
@@ -308,7 +322,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-constants/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.6.x-dev"
+                    "dev-trunk": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -322,29 +336,30 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.6.23"
+                "source": "https://github.com/Automattic/jetpack-constants/tree/v2.0.0"
             },
-            "time": "2023-08-23T17:56:35+00:00"
+            "time": "2023-11-20T20:02:28+00:00"
         },
         {
             "name": "automattic/jetpack-redirect",
-            "version": "v1.7.27",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-redirect.git",
-                "reference": "43dd3ae2bef71281fe70f62733bfaa44c988f1b1"
+                "reference": "8f1bbfd4b046b8a0ae7b156007c2ef56a0ddbf76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-redirect/zipball/43dd3ae2bef71281fe70f62733bfaa44c988f1b1",
-                "reference": "43dd3ae2bef71281fe70f62733bfaa44c988f1b1",
+                "url": "https://api.github.com/repos/Automattic/jetpack-redirect/zipball/8f1bbfd4b046b8a0ae7b156007c2ef56a0ddbf76",
+                "reference": "8f1bbfd4b046b8a0ae7b156007c2ef56a0ddbf76",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-status": "^1.18.4"
+                "automattic/jetpack-status": "^2.0.0",
+                "php": ">=7.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.9",
+                "automattic/jetpack-changelogger": "^4.0.0",
                 "brain/monkey": "2.6.1",
                 "yoast/phpunit-polyfills": "1.1.0"
             },
@@ -359,7 +374,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-redirect/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.7.x-dev"
+                    "dev-trunk": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -373,26 +388,29 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-redirect/tree/v1.7.27"
+                "source": "https://github.com/Automattic/jetpack-redirect/tree/v2.0.0"
             },
-            "time": "2023-09-19T18:19:22+00:00"
+            "time": "2023-11-20T20:03:01+00:00"
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "v1.4.25",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-roles.git",
-                "reference": "708b33f16a879fc2ab5939a972c968c9aeefbe38"
+                "reference": "967e52052a17123a23f4112da3d8e7e995467cb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/708b33f16a879fc2ab5939a972c968c9aeefbe38",
-                "reference": "708b33f16a879fc2ab5939a972c968c9aeefbe38",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/967e52052a17123a23f4112da3d8e7e995467cb2",
+                "reference": "967e52052a17123a23f4112da3d8e7e995467cb2",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=7.0"
+            },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.9",
+                "automattic/jetpack-changelogger": "^4.0.0",
                 "brain/monkey": "2.6.1",
                 "yoast/phpunit-polyfills": "1.1.0"
             },
@@ -407,7 +425,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-roles/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -421,30 +439,31 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-roles/tree/v1.4.25"
+                "source": "https://github.com/Automattic/jetpack-roles/tree/v2.0.0"
             },
-            "time": "2023-09-19T18:18:38+00:00"
+            "time": "2023-11-20T20:02:32+00:00"
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "v1.18.5",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-status.git",
-                "reference": "fe08772e2005b8cd78ec5e0d416b73a04ae57c10"
+                "reference": "badaae2ef5345629f5333938e32a649bf946d688"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/fe08772e2005b8cd78ec5e0d416b73a04ae57c10",
-                "reference": "fe08772e2005b8cd78ec5e0d416b73a04ae57c10",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/badaae2ef5345629f5333938e32a649bf946d688",
+                "reference": "badaae2ef5345629f5333938e32a649bf946d688",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-constants": "^1.6.23"
+                "automattic/jetpack-constants": "^2.0.0",
+                "php": ">=7.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.10",
-                "automattic/jetpack-ip": "^0.1.6",
+                "automattic/jetpack-changelogger": "^4.0.5",
+                "automattic/jetpack-ip": "^0.2.1",
                 "brain/monkey": "2.6.1",
                 "yoast/phpunit-polyfills": "1.1.0"
             },
@@ -459,7 +478,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.18.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -473,9 +492,9 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-status/tree/v1.18.5"
+                "source": "https://github.com/Automattic/jetpack-status/tree/v2.1.0"
             },
-            "time": "2023-09-25T19:07:29+00:00"
+            "time": "2024-01-18T21:49:55+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -5689,5 +5708,5 @@
     "platform-overrides": {
         "php": "7.4.30"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -450,7 +450,9 @@ class Middleware implements OptionsAwareInterface {
 			);
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
-
+			return new TosAccepted( false, $e->getMessage() );
+		} catch ( Exception $e ) {
+			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
 			return new TosAccepted( false, $e->getMessage() );
 		}
 	}

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -104,19 +104,21 @@ class AccountController extends BaseOptionsController {
 	 */
 	protected function get_connect_callback(): callable {
 		return function ( Request $request ) {
-			// Register the site to wp.com.
-			if ( ! $this->manager->is_connected() ) {
+			// Register the site to WPCOM.
+			if ( $this->manager->is_connected() ) {
+				$result = $this->manager->reconnect();
+			} else {
 				$result = $this->manager->register();
+			}
 
-				if ( is_wp_error( $result ) ) {
-					return new Response(
-						[
-							'status'  => 'error',
-							'message' => $result->get_error_message(),
-						],
-						400
-					);
-				}
+			if ( is_wp_error( $result ) ) {
+				return new Response(
+					[
+						'status'  => 'error',
+						'message' => $result->get_error_message(),
+					],
+					400
+				);
 			}
 
 			// Get an authorization URL which will redirect back to our page.

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -182,6 +182,9 @@ class AccountController extends BaseOptionsController {
 				$this->log_wp_tos_accepted();
 			}
 
+			// Update connection status.
+			$this->options->update( OptionsInterface::JETPACK_CONNECTED, $this->is_jetpack_connected );
+
 			$user_data = $this->get_jetpack_user_data();
 			return [
 				'active'      => $this->display_boolean( $this->is_jetpack_connected() ),

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -36,7 +36,7 @@ class AccountController extends BaseOptionsController {
 	 *
 	 * @var bool
 	 */
-	private $connected;
+	private $jetpack_connected_state;
 
 	/**
 	 * Mapping between the client page name and its path.
@@ -202,18 +202,18 @@ class AccountController extends BaseOptionsController {
 	 * @return bool
 	 */
 	protected function is_jetpack_connected(): bool {
-		if ( null !== $this->connected ) {
-			return $this->connected;
+		if ( null !== $this->jetpack_connected_state ) {
+			return $this->jetpack_connected_state;
 		}
 
 		if ( ! $this->manager->has_connected_owner() || ! $this->manager->is_connected() ) {
-			$this->connected = false;
+			$this->jetpack_connected_state = false;
 			return false;
 		}
 
 		// Send an external request to validate the token.
-		$this->connected = $this->manager->get_tokens()->validate_blog_token();
-		return $this->connected;
+		$this->jetpack_connected_state = $this->manager->get_tokens()->validate_blog_token();
+		return $this->jetpack_connected_state;
 	}
 
 	/**

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -183,7 +183,7 @@ class AccountController extends BaseOptionsController {
 			}
 
 			// Update connection status.
-			$this->options->update( OptionsInterface::JETPACK_CONNECTED, $this->is_jetpack_connected );
+			$this->options->update( OptionsInterface::JETPACK_CONNECTED, $this->is_jetpack_connected() );
 
 			$user_data = $this->get_jetpack_user_data();
 			return [

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -219,12 +219,12 @@ class ConnectionTest implements Service, Registerable {
 				<?php } ?>
 
 				<tr>
-					<th>Toggle Connection:</th>
+					<th>Connection Status:</th>
 					<td>
 						<?php if ( ! $blog_token ) { ?>
 							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'connect' ], $url ), 'connect' ) ); ?>">Connect to WordPress.com</a></p>
 						<?php } else { ?>
-							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'disconnect' ], $url ), 'disconnect' ) ); ?>">Disconnect from WordPress.com</a></p>
+							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'wp-status' ], $url ), 'wp-status' ) ); ?>">WordPress.com Connection Status</a></p>
 						<?php } ?>
 					</td>
 				</tr>
@@ -681,6 +681,15 @@ class ConnectionTest implements Service, Registerable {
 				wp_safe_redirect( $redirect );
 				exit;
 			}
+		}
+
+		if ( 'wp-status' === $_GET['action'] && check_admin_referer( 'wp-status' ) ) {
+			$request = new Request( 'GET', '/wc/gla/jetpack/connected' );
+			$this->send_rest_request( $request );
+
+			/** @var OptionsInterface $options */
+			$options = $this->container->get( OptionsInterface::class );
+			$this->response .= "\n\n" . 'Saved Connection option = ' . ( $options->get( OptionsInterface::JETPACK_CONNECTED ) ? 'connected' : 'disconnected' );
 		}
 
 		if ( 'wcs-test' === $_GET['action'] && check_admin_referer( 'wcs-test' ) ) {

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -176,7 +176,7 @@ class ConnectionTest implements Service, Registerable {
 
 			<hr />
 
-			<h2 class="title">Jetpack</h2>
+			<h2 class="title">WordPress.com</h2>
 
 			<table class="form-table" role="presentation">
 
@@ -222,9 +222,9 @@ class ConnectionTest implements Service, Registerable {
 					<th>Toggle Connection:</th>
 					<td>
 						<?php if ( ! $blog_token ) { ?>
-							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'connect' ], $url ), 'connect' ) ); ?>">Connect to Jetpack</a></p>
+							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'connect' ], $url ), 'connect' ) ); ?>">Connect to WordPress.com</a></p>
 						<?php } else { ?>
-							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'disconnect' ], $url ), 'disconnect' ) ); ?>">Disconnect Jetpack</a></p>
+							<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'disconnect' ], $url ), 'disconnect' ) ); ?>">Disconnect from WordPress.com</a></p>
 						<?php } ?>
 					</td>
 				</tr>
@@ -672,9 +672,9 @@ class ConnectionTest implements Service, Registerable {
 
 			if ( $plugin && ! $plugin->is_only() ) {
 				$connected_plugins = $manager->get_connected_plugins();
-				$this->response    = 'Cannot disconnect Jetpack connection as there are other plugins using it: ';
+				$this->response    = 'Cannot disconnect WordPress.com connection as there are other plugins using it: ';
 				$this->response   .= implode( ', ', array_keys( $connected_plugins ) ) . "\n";
-				$this->response   .= 'Please disconnect the connection using My Jetpack.';
+				$this->response   .= 'Please disconnect the connection using the Jetpack plugin.';
 				return;
 			} else {
 				$redirect = admin_url( 'admin.php?page=connection-test-admin-page' );

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -112,6 +112,8 @@ class ConnectionTest implements Service, Registerable {
 	 * Render the admin page.
 	 */
 	protected function render_admin_page() {
+		/** @var OptionsInterface $options */
+		$options = $this->container->get( OptionsInterface::class );
 		/** @var Manager $manager */
 		$manager    = $this->container->get( Manager::class );
 		$blog_token = $manager->get_tokens()->get_access_token();
@@ -172,6 +174,17 @@ class ConnectionTest implements Service, Registerable {
 					</td>
 				</tr>
 
+				<?php if ( $blog_token ) { ?>
+				<tr>
+					<th>Test Authenticated WCS Request:</th>
+					<td>
+						<p>
+							<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'wcs-auth-test' ], $url ), 'wcs-auth-test' ) ); ?>">Test Authenticated Request</a>
+						</p>
+					</td>
+				</tr>
+				<?php } ?>
+
 			</table>
 
 			<hr />
@@ -207,17 +220,6 @@ class ConnectionTest implements Service, Registerable {
 					</tr>
 				<?php } ?>
 
-				<?php if ( $blog_token ) { ?>
-				<tr>
-					<th>Test Authenticated WCS Request:</th>
-					<td>
-						<p>
-							<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'wcs-auth-test' ], $url ), 'wcs-auth-test' ) ); ?>">Test Authenticated Request</a>
-						</p>
-					</td>
-				</tr>
-				<?php } ?>
-
 				<tr>
 					<th>Connection Status:</th>
 					<td>
@@ -228,6 +230,15 @@ class ConnectionTest implements Service, Registerable {
 						<?php } ?>
 					</td>
 				</tr>
+
+				<?php if ( ! $options->get( OptionsInterface::JETPACK_CONNECTED ) ) { ?>
+				<tr>
+					<th>Reconnect WordPress.com:</th>
+					<td>
+						<p><a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'connect' ], $url ), 'connect' ) ); ?>">Reconnect to WordPress.com</a></p>
+					</td>
+				</tr>
+				<?php } ?>
 
 			</table>
 

--- a/tests/Tools/HelperTrait/GuzzleClientTrait.php
+++ b/tests/Tools/HelperTrait/GuzzleClientTrait.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\BadResponseException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
@@ -120,6 +121,25 @@ trait GuzzleClientTrait {
 		$response->method( 'getStatusCode' )->willReturn( $code );
 
 		$exception = new RequestException( $message, $request, $response );
+		$this->client->method( $type )->willThrowException( $exception );
+	}
+
+	/**
+	 * Generates an account reconnect exception when a get_request is sent.
+	 *
+	 * @param string $reconnect_type Type of reconnect 'google' or 'jetpack'.
+	 * @param string $type           Request type get|post.
+	 */
+	protected function generate_account_reconnect_exception( string $reconnect_type, string $type = 'get' ) {
+		switch ( $reconnect_type ) {
+			case 'google':
+				$exception = AccountReconnect::google_disconnected();
+				break;
+			case 'jetpack':
+			default:
+				$exception = AccountReconnect::jetpack_disconnected();
+				break;
+		}
 		$this->client->method( $type )->willThrowException( $exception );
 	}
 

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -375,6 +375,20 @@ class MiddlewareTest extends UnitTest {
 		$this->assertEquals( 'error', $tos->message() );
 	}
 
+	public function test_mark_tos_accepted_exception() {
+		$this->generate_request_mock_exception( 'error', 'post' );
+		$tos = $this->middleware->mark_tos_accepted( 'google-mc', 'user@email.test' );
+		$this->assertFalse( $tos->accepted() );
+		$this->assertEquals( 'error', $tos->message() );
+	}
+
+	public function test_mark_tos_accepted_account_reconnect_exception() {
+		$this->generate_account_reconnect_exception( 'jetpack', 'post' );
+		$tos = $this->middleware->mark_tos_accepted( 'google-mc', 'user@email.test' );
+		$this->assertFalse( $tos->accepted() );
+		$this->assertEquals( 'Please reconnect your Jetpack account.', $tos->message() );
+	}
+
 	public function test_get_account_review_status() {
 		$this->options->expects( $this->exactly( 2 ) )->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
 

--- a/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
@@ -115,10 +115,11 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			'email'        => $email,
 		];
 
-		$this->tokens->method( 'get_access_token' )->willReturn( 'abcd' );
 		$this->manager->method( 'has_connected_owner' )->willReturn( true );
-		$this->manager->method( 'is_connection_owner' )->willReturn( true );
+		$this->manager->method( 'is_connected' )->willReturn( true );
+		$this->tokens->method( 'validate_blog_token' )->willReturn( true );
 		$this->manager->method( 'get_tokens' )->willReturn( $this->tokens );
+		$this->manager->method( 'is_connection_owner' )->willReturn( true );
 
 		// Confirm the WP TOS is marked as accepted for the current user.
 		$this->middleware->expects( $this->once() )
@@ -143,10 +144,37 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	/**
+	 * Tests an invalid token stored locally.
+	 */
 	public function test_connected_invalid_token() {
-		$this->tokens->method( 'get_access_token' )->willReturn( false );
 		$this->manager->method( 'has_connected_owner' )->willReturn( true );
+		$this->manager->method( 'is_connected' )->willReturn( false );
 		$this->manager->method( 'is_connection_owner' )->willReturn( true );
+
+		$response = $this->do_request( self::ROUTE_CONNECTED, 'GET' );
+
+		$this->assertEquals(
+			[
+				'active'      => 'no',
+				'owner'       => 'yes',
+				'displayName' => '',
+				'email'       => '',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Tests a valid token stored locally, but invalid once checked externally.
+	 * The Jetpack connection package handles the external check through `validate_blog_token`.
+	 */
+	public function test_connected_token_does_not_validate() {
+		$this->manager->method( 'has_connected_owner' )->willReturn( true );
+		$this->manager->method( 'is_connected' )->willReturn( true );
+		$this->manager->method( 'is_connection_owner' )->willReturn( true );
+		$this->tokens->method( 'validate_blog_token' )->willReturn( false );
 		$this->manager->method( 'get_tokens' )->willReturn( $this->tokens );
 
 		$response = $this->do_request( self::ROUTE_CONNECTED, 'GET' );

--- a/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Jetpack/AccountControllerTest.php
@@ -54,6 +54,14 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$expected_auth_url = $auth_url . '&from=google-listings-and-ads';
 
 		$this->manager->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( false );
+
+		$this->manager->expects( $this->once() )
+			->method( 'register' )
+			->willReturn( true );
+
+		$this->manager->expects( $this->once() )
 			->method( 'get_authorization_url' )
 			->willReturn( $auth_url );
 
@@ -70,6 +78,10 @@ class AccountControllerTest extends RESTControllerUnitTest {
 
 	public function test_connect_with_error() {
 		$this->manager->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( false );
+
+		$this->manager->expects( $this->once() )
 			->method( 'register' )
 			->willReturn( new WP_Error( 'error', 'Error message' ) );
 
@@ -83,6 +95,33 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			$response->get_data()
 		);
 		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_reconnect() {
+		$auth_url          = 'https://domain.test?auth=1';
+		$expected_auth_url = $auth_url . '&from=google-listings-and-ads';
+
+		$this->manager->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->manager->expects( $this->once() )
+			->method( 'reconnect' )
+			->willReturn( true );
+
+		$this->manager->expects( $this->once() )
+			->method( 'get_authorization_url' )
+			->willReturn( $auth_url );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals(
+			[
+				'url' => $expected_auth_url,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_disconnect() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is intended to improve the handling of the WordPress.com connection status. There are several fixes within this PR that handled various scenarios.

#### Uncaught Fatal Error
When we reset all the plugin data using the snippet `define( 'WC_GLA_REMOVE_ALL_DATA', true );`
And at the same time disconnect the WordPress.com connection externally. We end up with a scenario where it assumes the connection is still intact but it hasn't accepted the TOS conditions yet. This triggers a request to WCS which fails because the token is no longer valid, and in turn triggers a ReconnectAccount exception. In this PR we make sure this exception is caught and handled.

Closes #2285 

#### Disconnect during onboarding
If we trigger an external disconnect during onboarding, we end up with a situation where the local token in the DB is still valid but once an external request is sent it returns a response which triggers a ReconnectAccount exception.
The UI tries to resolve this by checking if the WordPress.com account is still connected. Since this only checks the local token it assumes it's connected.

In this PR we resolve that scenario by doing a more extensive check with the token. We both confirm it's available and send a request to a token endpoint to validate the token hasn't been invalidated externally. This ensures the UI gets a response that the account is no longer connected and can once again show the connect button.

Closes #2284

#### Disconnected after onboarding
If we trigger an external disconnect after onboarding, we end up with the same situation where the local token in the DB is still valid but once an external request is sent it returns a response which triggers a ReconnectAccount exception.

In this PR we again resolve that both by doing an external request to validate the token, and by updating the option `JETPACK_CONNECTED` to reflect the actual status. This allows the UI to catch the error and stay on the reconnect page without assuming it's connected.

Closes #1972

#### Remove disconnect button
This PR also removes the disconnect button on the Connection Test page, as it can only perform a "soft connect", which will always show WooCommerce is connected so we are unable to disconnect.
The intention is to handle this better within WooCommerce or some other higher level, at the moment the Jetpack plugin can be installed to disconnect fully.

Closes #2118

#### Jetpack packages update
To ensure we are working with the latest version of the Jetpack connect I also updated the composer packages. According to the changelogs there are mostly minor fixes. The major version bump is for dropping PHP < 7. Since we have a minimum of PHP 7.4 those changes don't affect anything.
`composer update automattic/jetpack* --with-all-dependencies`
```
- Upgrading automattic/jetpack-a8c-mc-stats (v1.4.22 => v2.0.0)
- Upgrading automattic/jetpack-admin-ui (v0.2.24 => v0.3.2)
- Upgrading automattic/jetpack-autoloader (v2.12.0 => v3.0.2)
- Upgrading automattic/jetpack-config (v1.15.4 => v2.0.0)
- Upgrading automattic/jetpack-connection (v1.59.0 => v2.3.2)
- Upgrading automattic/jetpack-constants (v1.6.23 => v2.0.0)
- Upgrading automattic/jetpack-redirect (v1.7.27 => v2.0.0)
- Upgrading automattic/jetpack-roles (v1.4.25 => v2.0.0)
- Upgrading automattic/jetpack-status (v1.18.5 => v2.1.0)
```

### Detailed test instructions:

#### Uncaught Fatal Error
1. Go through the onboarding steps to connect at least the accounts in step 1
2. Abort onboarding
3. Visit the page /wp-admin/options.php (or directly in the DB) and set the option `gla_wp_tos_accepted` to 0
4. Go to the URL `jptools.wordpress.com/debug/` and find your site
5. Scroll down to the section Blog Details and click Disconnect Jetpack
6. Restart onboarding from the beginning
7. Confirm we are able to connect a WordPress.com account and continue onboarding without issues

#### Disconnect during onboarding
1. Go through the onboarding steps to connect at least the accounts in step 1
2. Abort onboarding
3. Go to the URL `jptools.wordpress.com/debug/` and find your site
4. Scroll down to the section Blog Details and click Disconnect Jetpack
5. Restart onboarding from the beginning
6. Confirm that we see a request to `/wc/gla/jetpack/connected` with a response similar to:
```json
{
    "active": "no",
    "owner": "yes",
    "displayName": "User",
    "email": "user@email.test"
}
```

#### Disconnect after onboarding
1. Go through all the onboarding steps
2. Go to the URL `jptools.wordpress.com/debug/` and find your site
3. Scroll down to the section Blog Details and click Disconnect Jetpack
4. Refresh one of the GLA pages like Dashboard or Settings
5. Confirm that we are redirected to a reconnect page
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/6c70a5b3-83e4-40dd-95b5-b5c6c05aff3b)
6. Confirm that we see a request to `/wc/gla/jetpack/connected` with a response similar to:
```json
{
    "active": "no",
    "owner": "yes",
    "displayName": "User",
    "email": "user@email.test"
}
```
7. Try the connect button on the Reconnect Page and confirm that all the pages work again after this is successful.

#### Test Connection Test page
1. Simulate the same scenario as one of the previous where we disconnect the WordPress.com account externally
2. Visit the Connection Test page and expect to see a section with a reconnect button (similar as is done through the UI). Reconnect button should only be visible in cases where we still have a local connection token, but the token is no longer valid.
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/7fac72b8-bcbf-4b24-b505-b23d7c4b5199)
3. Try the status button and expect a response like:
```json
{
    "active": "no",
    "owner": "yes",
    "displayName": "User",
    "email": "user@email.test"
}
```
4. Try the reconnect button and confirm that we can correctly connect again (same as in the UI)

### Changelog entry
* Fix - Improve WordPress.com account handling.