### PR TITLE
Add gtag consent mode v0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ npm run -- wp-env run tests-cli -- wp wc update
 
 - [Usage Tracking](./src/Tracking/README.md)
 - [Hooks defined or used in GLA](./src/Hooks/README.md)
+- [gtag consent mode](./docs/gtag-consent-mode.md)
 
 <p align="center">
 	<br/><br/>

--- a/docs/gtag-consent-mode.md
+++ b/docs/gtag-consent-mode.md
@@ -5,3 +5,5 @@ Unless you're running the [Google Analytics Integration](https://woo.com/product
 To respect your customers' privacy, we set up the default state of [consent mode](https://support.google.com/analytics/answer/9976101). We set it to deny all the parameters for visitors from the EEA region. You can add an extension or CMP that delivers a banner or any other UI to let visitors update their consent in runtime.
 
 You can also customize your own default state configuration using the `woocommerce_gla_gtag_consent` filter providing any snippet that uses [Google's `gtag('consent', 'default', {…})` API ](https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced).
+
+After the page loads, the consent for particular parameters can be updated by other plugins or custom code implementing UI for customer-facing configuration using [Google's consent API](https://developers.google.com/tag-platform/security/guides/consent?hl=en&consentmode=advanced#update-consent) (`gtag('consent', 'update', {…})`).

--- a/docs/gtag-consent-mode.md
+++ b/docs/gtag-consent-mode.md
@@ -1,0 +1,7 @@
+## Googla Analytics (gtag) Consent Mode
+
+Unless you're running the [Google Analytics Integration](https://woo.com/products/woocommerce-google-analytics/) extension for a more sophisticated configuration, Google Listings and Ads will add Google's `gtag` to help you track some customer behavior.
+
+To respect your customers' privacy, we set up the default state of [consent mode](https://support.google.com/analytics/answer/9976101). We set it to deny all the parameters for visitors from the EEA region. You can add an extension or CMP that delivers a banner or any other UI to let visitors update their consent in runtime.
+
+You can also customize your own default state configuration using the `woocommerce_gla_gtag_consent` filter providing any snippet that uses [Google's `gtag('consent', 'default', {…})` API ](https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced).

--- a/docs/gtag-consent-mode.md
+++ b/docs/gtag-consent-mode.md
@@ -1,6 +1,6 @@
 ## Googla Analytics (gtag) Consent Mode
 
-Unless you're running the [Google Analytics Integration](https://woo.com/products/woocommerce-google-analytics/) extension for a more sophisticated configuration, Google Listings and Ads will add Google's `gtag` to help you track some customer behavior.
+Unless you're running the [Google Analytics for WooCommerce](https://woo.com/products/woocommerce-google-analytics/) extension for a more sophisticated configuration, Google Listings and Ads will add Google's `gtag` to help you track some customer behavior.
 
 To respect your customers' privacy, we set up the default state of [consent mode](https://support.google.com/analytics/answer/9976101). We set it to deny all the parameters for visitors from the EEA region. You can add an extension or CMP that delivers a banner or any other UI to let visitors update their consent in runtime.
 

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -211,7 +211,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	/**
 	 * Activate the Global Site Tag framework:
 	 * - Insert GST code, or
-	 * - Include the Google Ads conversion ID in WooCommerce Google Analytics Integration output, if available
+	 * - Include the Google Ads conversion ID in WooCommerce Google Analytics for WooCommerce output, if available
 	 *
 	 * @param string $ads_conversion_id Google Ads account conversion ID.
 	 */

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -254,6 +254,10 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		<script>
 			window.dataLayer = window.dataLayer || [];
 			function gtag() { dataLayer.push(arguments); }
+			<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $this->get_consent_mode_config();
+			?>
 
 			gtag('js', new Date());
 			gtag('set', 'developer_id.<?php echo esc_js( self::DEVELOPER_ID ); ?>', true);
@@ -277,6 +281,25 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			'gtag("config", "%1$s", { "groups": "GLA", "send_page_view": false });',
 			esc_js( $ads_conversion_id )
 		);
+	}
+
+	/**
+	 * Get the default consent mode configuration.
+	 */
+	protected function get_consent_mode_config() {
+		$consent_mode_snippet = "gtag( 'consent', 'default', {
+				analytics_storage: 'denied',
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+				region: ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU', 'IS', 'IE', 'IT', 'LV', 'LI', 'LT', 'LU', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'GB', 'CH'],
+			} );";
+		/**
+		 * Filters the default gtag consent mode configuration.
+		 *
+		 * @param string $consent_mode_snippet Default configuration with all the parameters `denied` for the EEA region.
+		 */
+		return apply_filters( 'woocommerce_gla_gtag_consent', $consent_mode_snippet );
 	}
 
 	/**

--- a/src/Proxies/GoogleGtagJs.php
+++ b/src/Proxies/GoogleGtagJs.php
@@ -16,7 +16,7 @@ class GoogleGtagJs {
 	/**
 	 * GoogleGtagJs constructor.
 	 *
-	 * Load the WooCommerce Google Analytics Integration extension settings.
+	 * Load the WooCommerce Google Analytics for WooCommerce extension settings.
 	 */
 	public function __construct() {
 		$this->wcga_settings = get_option( 'woocommerce_google_analytics_settings', [] );
@@ -36,20 +36,20 @@ class GoogleGtagJs {
 	}
 
 	/**
-	 * Determine whether WooCommerce Google Analytics Integration is already
+	 * Determine whether WooCommerce Google Analytics for WooCommerce is already
 	 * injecting the gtag <script> code.
 	 *
 	 * @return bool True if the <script> code is present.
 	 */
 	public function is_adding_framework() {
-		// WooCommerce Google Analytics Integration is disabled for admin users.
+		// WooCommerce Google Analytics for WooCommerce is disabled for admin users.
 		$is_admin = is_admin() || current_user_can( 'manage_options' );
 
 		return ! $is_admin && class_exists( '\WC_Google_Gtag_JS' ) && $this->is_gtag_page() && $this->has_required_settings();
 	}
 
 	/**
-	 * Determine whether the current page has WooCommerce Google Analytics Integration enabled.
+	 * Determine whether the current page has WooCommerce Google Analytics for WooCommerce enabled.
 	 *
 	 * @return bool If the page is a Analytics-enabled page.
 	 */
@@ -61,7 +61,7 @@ class GoogleGtagJs {
 	}
 
 	/**
-	 * In order for WooCommerce Google Analytics Integration to include the Global Site Tag
+	 * In order for WooCommerce Google Analytics for WooCommerce to include the Global Site Tag
 	 * framework, it needs to be enabled in the settings and a Measurement ID must be provided.
 	 *
 	 * @return bool True if Global Site Tag is enabled and a Measurement ID is provided.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


Add the minimalistic implementation to add support for [Google Consent mode](https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced)

We want to add MVP ASAP before Google starts penalizing merchants without this setup. (pcTzPl-25o-p2)

This PR adds a basic default and documents how to customize/extend it.


### Screenshots:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17435/81dadd01-38fe-4565-aff1-a6aed5614fde)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Build, install, activate the extension
2. Deactivate Google Analytics Integration extension
3. Open [Tag assistant](https://tagassistant.google.com/)
4. Visit shop page
5. You should see consent mode set up
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17435/7342e3dc-53ab-48be-846a-44d8fd58ba6c)
7. Read the docs, check if they are explanatory enough
8. Try the following snippet
```php
add_filter(
    'woocommerce_gla_gtag_consent',
    function( $old_config ) {
        $additional_config = "
        gtag( 'consent', 'default', {
            analytics_storage: 'granted',
            ad_storage: 'granted',
            ad_user_data: 'denied',
            ad_personalization: 'denied',
            region: ['PL'], // <--------- SET IT TO YOUR REGION
        } );
        ";
        return $old_config . $additional_config;
    }
);
```
9. You should see another consent entry  specified
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17435/3c629c52-cd25-4f4b-9a26-b4be49ad7a17)




### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Google Analytics consent mode support.
