### PR TITLE
Grant consent before checking the gtag events

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,8 +2,8 @@
 	"phpVersion": "8.0",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
-		"./tests/e2e/disable-consent-mode",
 		"./tests/e2e/test-data",
+		"./tests/e2e/test-snippets",
 		"."
 	],
 	"mappings": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,6 +2,7 @@
 	"phpVersion": "8.0",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
+		"./tests/e2e/disable-consent-mode",
 		"./tests/e2e/test-data",
 		"."
 	],

--- a/tests/e2e/disable-consent-mode/disable-consent-mode.php
+++ b/tests/e2e/disable-consent-mode/disable-consent-mode.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin name: Custom Consent Mode
+ * Description: A plugin to customize/disable the gtag consent mode, to make testing esier by granting everything by default.
+ *
+ * Intended to function as a plugin while tests are running.
+ * It hopefully goes without saying, this should not be used in a production environment.
+ * It's a hack to avoid specifying region for E2E environment, but it tests the customization of consent mode.
+ */
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Snippets;
+
+add_filter(
+    'woocommerce_gla_gtag_consent',
+    function( $old_config ) {
+        return "gtag( 'consent', 'default', {
+            analytics_storage: 'granted',
+            ad_storage: 'granted',
+            ad_user_data: 'granted',
+            ad_personalization: 'granted',
+        } );
+        ";
+    }
+);

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -9,8 +9,10 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Snippets;
 
-// Customize/disable the gtag consent mode, to make testing easier by granting everything by default.
-// It's a hack to avoid specifying region for E2E environment, but it tests the customization of consent mode.
+/*
+ * Customize/disable the gtag consent mode, to make testing easier by granting everything by default.
+ * It's a hack to avoid specifying region for E2E environment, but it tests the customization of consent mode.
+ */
 add_filter(
     'woocommerce_gla_gtag_consent',
     function( $old_config ) {

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * Plugin name: Custom Consent Mode
- * Description: A plugin to customize/disable the gtag consent mode, to make testing esier by granting everything by default.
+ * Plugin name: E2E test snippets
+ * Description: A plugin to provide some PHP snippets used in E2E tests.
  *
  * Intended to function as a plugin while tests are running.
  * It hopefully goes without saying, this should not be used in a production environment.
- * It's a hack to avoid specifying region for E2E environment, but it tests the customization of consent mode.
  */
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Snippets;
 
+// Customize/disable the gtag consent mode, to make testing easier by granting everything by default.
+// It's a hack to avoid specifying region for E2E environment, but it tests the customization of consent mode.
 add_filter(
     'woocommerce_gla_gtag_consent',
     function( $old_config ) {

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin name: E2E test snippets
+ * Plugin name: GLA Test Snippets
  * Description: A plugin to provide some PHP snippets used in E2E tests.
  *
  * Intended to function as a plugin while tests are running.

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -23,7 +23,7 @@ export function trackGtagEvent( page, eventName, urlPath = null ) {
 
 		return (
 			url.includes( eventPath ) &&
-			params.get( 'data' ).includes( match ) &&
+			params.get( 'data' )?.includes( match ) &&
 			( urlPath
 				? params
 						.get( 'url' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Fixes tests for gtag after consent mode was added.

Adds a plugin with a PHP snippet to grant all params for consent mode, so the E2E tests will have permissions to track events regardless of the environment's region.

As we're planning further improvements to `gtag` implementation (making it closer to GA4W), right now, we'll use this workaround, then we'll add tests suite for `gtag` and consent mode, once the implementation and feature set will be in the final shape.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. checkout, build
2. run E2Es:
```
npm run wp-env:up
npm run test:e2e
```


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix E2E tests for gtags consent mode
