### PR TITLE
WordPress 6.4 Compatibility: Fix the problem that the modal closed event is not sent when clicking on its overlay

### DIFF
--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -135,8 +135,12 @@ const handleGuideFinish = ( e ) => {
 
 	// Since there is no built-in way to distinguish the modal/guide is closed by what action,
 	// here is a workaround by identifying the close button's data-aciton attribute.
-	const target = e.currentTarget || e.target;
-	const action = target.dataset.action || 'dismiss';
+	let action = 'dismiss';
+
+	if ( e ) {
+		const target = e.currentTarget || e.target;
+		action = target.dataset.action || action;
+	}
 	recordGlaEvent( EVENT_NAME, {
 		context: GUIDE_NAMES.SUBMISSION_SUCCESS,
 		action,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Noticed this uncaught error when reviewing #2242.

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/59194cd7-e86a-4b91-ab56-237ee376ec95

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/2dba88b4-e560-49a1-a8aa-163cba5dd4e6)

There is a breaking change about the `Modal` component's `onRequestClose` callback when clicking on its overlay.

- With WordPress < 6.4, it uses [`useFocusOutside`](https://github.com/WordPress/gutenberg/blob/wp/6.3/packages/components/src/modal/index.tsx#L80) to [call back with an event object](https://github.com/WordPress/gutenberg/blob/wp/6.3/packages/compose/src/hooks/use-focus-outside/index.ts#L182).
- With WordPress >= 6.4, [it's no longer calling back with an event object](https://github.com/WordPress/gutenberg/blob/wp/6.4/packages/components/src/modal/index.tsx#L194-L210).

This PR adjusts the logic to make it compatible with both WordPress versions.

### Detailed test instructions:

1. Set up WordPress with a version **< 6.4**
2. Open browser's DevTool and switch to Console tab
   - Run `localStorage.setItem( 'debug', 'wc-admin:*' )` to enable event tracks debugger
   - Tick the "Verbose" level
3. Go to admin page with this path: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed&guide=submission-success`
4. Click on the overlay to see if it can record *gla_modal_closed* event with `'dismiss'` action
   ![2](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/2ccf85ab-548b-4e46-b748-653205517eee)
5. Go to the page in step 3 again. Click on the X icon button to check if the same event with `'dismiss'` action is recorded
6. Go to the page in step 3 again. Press ESC key to check if the same event with `'dismiss'` action is recorded
7. Go to the page in step 3 again. Click the button in the modal footer, e.g. "View product feed" button, and check if the 
corresponding action `'view-product-feed'` is recorded
   ![3](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/375544a9-471a-4abc-95dc-92e1900b98d8)
8. Set up WordPress with a version **>= 6.4**
9. Repeat steps 3-7

### Changelog entry

> Fix - WordPress 6.4 Compatibility: The modal closed event is not sent when clicking on its overlay.
