### PR TITLE
Update is_gtag_page to support Google Analytics for WooCommerce version 2.0.0+

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -217,7 +217,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	 */
 	public function activate_global_site_tag( string $ads_conversion_id ) {
 		if ( $this->gtag_js->is_adding_framework() ) {
-			if ( version_compare( \WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION, '2.0.0', '>=' ) ) {
+			if ( $this->gtag_js->ga4w_v2 ) {
 				wp_add_inline_script(
 					'woocommerce-google-analytics-integration',
 					$this->get_gtag_config( $ads_conversion_id )

--- a/src/Proxies/GoogleGtagJs.php
+++ b/src/Proxies/GoogleGtagJs.php
@@ -14,7 +14,7 @@ class GoogleGtagJs {
 	private $wcga_settings;
 
 	/** @var bool $ga4c_v2 True if Google Analytics for WooCommerce version 2 or higher is installed */
-	private $ga4w_v2;
+	public $ga4w_v2;
 
 	/**
 	 * GoogleGtagJs constructor.

--- a/src/Proxies/GoogleGtagJs.php
+++ b/src/Proxies/GoogleGtagJs.php
@@ -13,6 +13,9 @@ class GoogleGtagJs {
 	/** @var array */
 	private $wcga_settings;
 
+	/** @var bool $ga4c_v2 True if Google Analytics for WooCommerce version 2 or higher is installed */
+	private $ga4w_v2;
+
 	/**
 	 * GoogleGtagJs constructor.
 	 *
@@ -20,9 +23,10 @@ class GoogleGtagJs {
 	 */
 	public function __construct() {
 		$this->wcga_settings = get_option( 'woocommerce_google_analytics_settings', [] );
+		$this->ga4w_v2       = defined( '\WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION' ) && version_compare( \WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION, '2.0.0', '>=' );
 
 		// Prime some values.
-		if ( defined( '\WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION' ) && version_compare( \WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION, '2.0.0', '>=' ) ) {
+		if ( $this->ga4w_v2 ) {
 			$this->wcga_settings['ga_gtag_enabled'] = 'yes';
 		} elseif ( empty( $this->wcga_settings['ga_gtag_enabled'] ) ) {
 			$this->wcga_settings['ga_gtag_enabled'] = 'no';
@@ -57,7 +61,7 @@ class GoogleGtagJs {
 		$standard_tracking_enabled = 'yes' === $this->wcga_settings['ga_standard_tracking_enabled'];
 		$is_wc_page                = is_order_received_page() || is_woocommerce() || is_cart() || is_checkout();
 
-		return $standard_tracking_enabled || $is_wc_page;
+		return $this->ga4w_v2 || $standard_tracking_enabled || $is_wc_page;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In Google Analytics for WooCommerce version `2.0.0`, the `Standard Tracking` option is removed (See: https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/365).

This PR adjusts `is_gtag_page()` to check either the standard tracking option for backwards compatibility or the version of Google Analytics for WooCommerce.

### Detailed test instructions:

1. Checkout `tweak/support-for-ga4w-version-2` on a test site with GLA setup
2. With Google Analytics for WooCommerce installed, edit the `WC_GOOGLE_ANALYTICS_INTEGRATION_VERSION` constant to `2.0.0` (Found in `woocommerce-google-analytics-integration.php`)
3. Visit site pages and confirm the Google Ads conversion config is included on the page

### Additional details:

Follow-up to #2287