### PR TITLE
Refactor Account and Presync issues

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -179,6 +179,12 @@ class IssuesController extends BaseOptionsController {
 				'context'  => [ 'view' ],
 				'readonly' => true,
 			],
+			'loading'        => [
+				'type'        => 'boolean',
+				'description' => __( 'Whether the product issues are loading.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],			
 		];
 	}
 

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use WP_REST_Request as Request;
-use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/API/Site/Controllers/MerchantCenter/IssuesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/IssuesController.php
@@ -113,7 +113,7 @@ class IssuesController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'issues' => [
+			'issues'  => [
 				'type'        => 'array',
 				'description' => __( 'The issues related to the Merchant Center account.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
@@ -169,22 +169,22 @@ class IssuesController extends BaseOptionsController {
 					],
 				],
 			],
-			'total'  => [
+			'total'   => [
 				'type'     => 'numeric',
 				'context'  => [ 'view' ],
 				'readonly' => true,
 			],
-			'page'   => [
+			'page'    => [
 				'type'     => 'numeric',
 				'context'  => [ 'view' ],
 				'readonly' => true,
 			],
-			'loading'        => [
+			'loading' => [
 				'type'        => 'boolean',
 				'description' => __( 'Whether the product issues are loading.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
-			],			
+			],
 		];
 	}
 

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -78,14 +78,15 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 	 * @throws Exception If the status data can't be retrieved from Google.
 	 */
 	public function get( WP_REST_Request $request ): array {
-		$this->request          = $request;
-		$products               = [];
-		$args                   = $this->prepare_query_args();
-		list( $limit, $offset ) = $this->prepare_query_pagination();
+		$this->request           = $request;
+		$products                = [];
+		$args                    = $this->prepare_query_args();
+		$refresh_status_data_job = null;
+		list( $limit, $offset )  = $this->prepare_query_pagination();
 
 		$mc_service = $this->container->get( MerchantCenterService::class );
 		if ( $mc_service->is_connected() ) {
-			$this->container->get( MerchantStatuses::class )->maybe_refresh_status_data();
+			$refresh_status_data_job = $this->container->get( MerchantStatuses::class )->maybe_refresh_status_data();
 		}
 
 		/** @var ProductHelper $product_helper */
@@ -94,14 +95,20 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 		add_filter( 'posts_where', [ $this, 'title_filter' ], 10, 2 );
 
 		foreach ( $this->product_repository->find( $args, $limit, $offset ) as $product ) {
-			$id     = $product->get_id();
-			$errors = $product_helper->get_validation_errors( $product );
+			$id        = $product->get_id();
+			$errors    = $product_helper->get_validation_errors( $product );
+			$mc_status = $product_helper->get_mc_status( $product ) ?: $product_helper->get_sync_status( $product );
+
+			// If the refresh_status_data_job is scheduled, we don't know the status yet as it is being refreshed.
+			if ( $refresh_status_data_job && $refresh_status_data_job->is_scheduled() ) {
+				$mc_status = '-';
+			}
 
 			$products[ $id ] = [
 				'id'        => $id,
 				'title'     => $product->get_name(),
 				'visible'   => $product_helper->get_channel_visibility( $product ) !== ChannelVisibility::DONT_SYNC_AND_SHOW,
-				'status'    => $product_helper->get_mc_status( $product ) ?: $product_helper->get_sync_status( $product ),
+				'status'    => $mc_status,
 				'image_url' => wp_get_attachment_image_url( $product->get_image_id(), 'full' ),
 				'price'     => $product->get_price(),
 				'errors'    => array_values( $errors ),

--- a/src/DB/ProductFeedQueryHelper.php
+++ b/src/DB/ProductFeedQueryHelper.php
@@ -101,7 +101,7 @@ class ProductFeedQueryHelper implements ContainerAwareInterface, Service {
 
 			// If the refresh_status_data_job is scheduled, we don't know the status yet as it is being refreshed.
 			if ( $refresh_status_data_job && $refresh_status_data_job->is_scheduled() ) {
-				$mc_status = '-';
+				$mc_status = null;
 			}
 
 			$products[ $id ] = [

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -89,6 +89,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 			// Clear the cache if we're starting from the beginning.
 			if ( ! $next_page_token ) {
 				$this->merchant_statuses->clear_product_statuses_cache_and_issues();
+				$this->merchant_statuses->refresh_account_and_presync_issues();
 			}
 
 			$results         = $this->merchant_report->get_product_view_report( $next_page_token );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -165,12 +165,12 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		// Get only error issues
 		$severity_error_issues = $this->fetch_issues( $type, $per_page, $page, true );
 
-		if ( $job->is_scheduled() ) {
-			$severity_error_issues['loading'] = true;
-		}
-
 		// In case there are error issues we show only those, otherwise we show all the issues.
-		return $severity_error_issues['total'] > 0 ? $severity_error_issues : $this->fetch_issues( $type, $per_page, $page );
+		$issues = $severity_error_issues['total'] > 0 ? $severity_error_issues : $this->fetch_issues( $type, $per_page, $page );
+		$issues['loading'] = $job->is_scheduled();
+
+		return $issues;
+
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -117,13 +117,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$this->check_mc_is_connected();
 
 		$this->mc_statuses = $this->container->get( TransientsInterface::class )->get( Transients::MC_STATUSES );
-		$job               = $this->container->get( UpdateMerchantProductStatuses::class );
-
-		// If force_refresh is true or if not transient, return empty array and scheduled the job to update the statuses.
-		if ( ! $job->is_scheduled() && ( $force_refresh || ( ! $force_refresh && null === $this->mc_statuses ) ) ) {
-			// Schedule job to update the statuses.
-			$job->schedule();
-		}
+		$job               = $this->maybe_refresh_status_data( $force_refresh );
 
 		if ( $job->is_scheduled() || null === $this->mc_statuses ) {
 			return [
@@ -168,10 +162,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @throws Exception If the account state can't be retrieved from Google.
 	 */
 	public function get_issues( string $type = null, int $per_page = 0, int $page = 1, bool $force_refresh = false ): array {
-		$this->maybe_refresh_status_data( $force_refresh );
+		$job = $this->maybe_refresh_status_data( $force_refresh );
 
 		// Get only error issues
 		$severity_error_issues = $this->fetch_issues( $type, $per_page, $page, true );
+
+		if ( $job->is_scheduled() ) {
+			$severity_error_issues['loading'] = true;
+		}
 
 		// In case there are error issues we show only those, otherwise we show all the issues.
 		return $severity_error_issues['total'] > 0 ? $severity_error_issues : $this->fetch_issues( $type, $per_page, $page );
@@ -237,33 +235,30 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
-	 * Update stale status-related data - account issues.
+	 * Maybe start the job to refresh the status and issues data.
 	 *
 	 * @param bool $force_refresh Force refresh of all status-related data.
 	 *
+	 * @return UpdateMerchantProductStatuses The job to update the statuses.
+	 *
 	 * @throws Exception If no Merchant Center account is connected, or account status is not retrievable.
+	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
+	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
-	public function maybe_refresh_status_data( bool $force_refresh = false ): void {
-		// Only refresh if the current data has expired.
-		$this->mc_statuses = $this->container->get( TransientsInterface::class )->get( Transients::MC_STATUSES );
-		if ( ! $force_refresh && null !== $this->mc_statuses ) {
-			return;
-		}
-
-		// Save a request if accounts are not connected.
+	public function maybe_refresh_status_data( bool $force_refresh = false ): UpdateMerchantProductStatuses {
 		$this->check_mc_is_connected();
 
-		// Update account-level issues.
-		$this->refresh_account_issues();
+		// Only refresh if the current data has expired.
+		$this->mc_statuses = $this->container->get( TransientsInterface::class )->get( Transients::MC_STATUSES );
+		$job               = $this->container->get( UpdateMerchantProductStatuses::class );
 
-		// Update pre-sync product validation issues.
-		$this->refresh_presync_product_issues();
+		// If force_refresh is true or if not transient, return empty array and scheduled the job to update the statuses.
+		if ( ! $job->is_scheduled() && ( $force_refresh || ( ! $force_refresh && null === $this->mc_statuses ) ) ) {
+			// Schedule job to update the statuses.
+			$job->schedule();
+		}
 
-		// Include any custom merchant issues.
-		$this->refresh_custom_merchant_issues();
-
-		// Delete stale issues.
-		$this->container->get( MerchantIssueTable::class )->delete_stale( $this->cache_created_time );
+		return $job;
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -166,11 +166,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$severity_error_issues = $this->fetch_issues( $type, $per_page, $page, true );
 
 		// In case there are error issues we show only those, otherwise we show all the issues.
-		$issues = $severity_error_issues['total'] > 0 ? $severity_error_issues : $this->fetch_issues( $type, $per_page, $page );
+		$issues            = $severity_error_issues['total'] > 0 ? $severity_error_issues : $this->fetch_issues( $type, $per_page, $page );
 		$issues['loading'] = $job->is_scheduled();
 
 		return $issues;
-
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -433,6 +433,22 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
+	 * Refresh the account , pre-sync product validation and custom merchant issues.
+	 *
+	 * @throws Exception  If the account state can't be retrieved from Google.
+	 */
+	public function refresh_account_and_presync_issues(): void {
+		// Update account-level issues.
+		$this->refresh_account_issues();
+
+		// Update pre-sync product validation issues.
+		$this->refresh_presync_product_issues();
+
+		// Include any custom merchant issues.
+		$this->refresh_custom_merchant_issues();
+	}
+
+	/**
 	 * Retrieve all account-level issues and store them in the database.
 	 *
 	 * @throws Exception If the account state can't be retrieved from Google.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -156,7 +156,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @param int         $page The page to start on (1-indexed).
 	 * @param bool        $force_refresh Force refresh of all product status data.
 	 *
-	 * @return array With two indices, results (may be paged) and count (considers type).
+	 * @return array With two indices, results (may be paged), count (considers type) and loading (indicating whether the data is loading).
 	 * @throws Exception If the account state can't be retrieved from Google.
 	 */
 	public function get_issues( string $type = null, int $per_page = 0, int $page = 1, bool $force_refresh = false ): array {
@@ -431,6 +431,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 	/**
 	 * Refresh the account , pre-sync product validation and custom merchant issues.
+	 *
+	 * @since x.x.x
 	 *
 	 * @throws Exception  If the account state can't be retrieved from Google.
 	 */

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -114,10 +114,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @throws Exception If no Merchant Center account is connected, or account status is not retrievable.
 	 */
 	public function get_product_statistics( bool $force_refresh = false ): array {
-		$this->check_mc_is_connected();
-
-		$this->mc_statuses = $this->container->get( TransientsInterface::class )->get( Transients::MC_STATUSES );
 		$job               = $this->maybe_refresh_status_data( $force_refresh );
+		$this->mc_statuses = $this->container->get( TransientsInterface::class )->get( Transients::MC_STATUSES );
 
 		if ( $job->is_scheduled() || null === $this->mc_statuses ) {
 			return [

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product as GoogleProduct;
 use WC_Product;
@@ -484,7 +485,8 @@ class ProductHelper implements Service {
 	 */
 	public function get_mc_status( WC_Product $wc_product ): ?string {
 		try {
-			return $this->meta_handler->get_mc_status( $this->maybe_swap_for_parent( $wc_product ) );
+			// If the mc_status is not set, return NOT_SYNCED.
+			return $this->meta_handler->get_mc_status( $this->maybe_swap_for_parent( $wc_product ) ) ?: MCStatus::NOT_SYNCED;
 		} catch ( InvalidValue $exception ) {
 			do_action(
 				'woocommerce_gla_debug_message',

--- a/tests/Unit/DB/ProductFeedQueryHelperTest.php
+++ b/tests/Unit/DB/ProductFeedQueryHelperTest.php
@@ -48,7 +48,6 @@ class ProductFeedQueryHelperTest extends UnitTest {
 	/** @var ProductFeedQueryHelper $product_feed_query_helper */
 	protected $product_feed_query_helper;
 
-
 	/**
 	 * Runs before each test is executed.
 	 */

--- a/tests/Unit/DB/ProductFeedQueryHelperTest.php
+++ b/tests/Unit/DB/ProductFeedQueryHelperTest.php
@@ -4,14 +4,16 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateMerchantProductStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use PHPUnit\Framework\MockObject\MockObject;
-
+use WC_Helper_Product;
 use WP_REST_Request;
 use wpdb;
 
@@ -40,8 +42,12 @@ class ProductFeedQueryHelperTest extends UnitTest {
 	/** @var MockObject|WP_REST_Request $request */
 	protected $request;
 
+	/** @var MockObject|UpdateMerchantProductStatuses $job */
+	protected $job;
+
 	/** @var ProductFeedQueryHelper $product_feed_query_helper */
 	protected $product_feed_query_helper;
+
 
 	/**
 	 * Runs before each test is executed.
@@ -55,6 +61,7 @@ class ProductFeedQueryHelperTest extends UnitTest {
 		$this->merchant_statuses  = $this->createMock( MerchantStatuses::class );
 		$this->product_helper     = $this->createMock( ProductHelper::class );
 		$this->request            = $this->createMock( WP_REST_Request::class );
+		$this->job                = $this->createMock( UpdateMerchantProductStatuses::class );
 
 		$container = new Container();
 		$container->share( MerchantCenterService::class, $this->mc_service );
@@ -66,14 +73,87 @@ class ProductFeedQueryHelperTest extends UnitTest {
 	}
 
 	public function test_get_product_feed_merchant_center_is_connected() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->job->expects( $this->exactly( 1 ) )
+			->method( 'is_scheduled' )
+			->willReturn( false );
+
 		$this->mc_service->expects( $this->any() )
 			->method( 'is_connected' )
 			->willReturn( true );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
-			->method( 'maybe_refresh_status_data' );
+			->method( 'maybe_refresh_status_data' )
+			->willReturn( $this->job );
 
-		$this->product_feed_query_helper->get( $this->request );
+		$this->product_repository->expects( $this->exactly( 1 ) )
+			->method( 'find' )
+			->willReturn( [ $product ] );
+
+			$this->product_helper->expects( $this->exactly( 1 ) )
+			->method( 'get_mc_status' )
+			->with( $product )
+			->willReturn( MCStatus::APPROVED );
+
+		$response = $this->product_feed_query_helper->get( $this->request );
+
+		$this->assertEquals(
+			[
+				[
+					'id'        => $product->get_id(),
+					'title'     => $product->get_name(),
+					'visible'   => true,
+					'status'    => MCStatus::APPROVED,
+					'image_url' => wp_get_attachment_image_url( $product->get_image_id(), 'full' ),
+					'price'     => $product->get_price(),
+					'errors'    => [],
+				],
+			],
+			$response
+		);
+	}
+
+	public function test_get_product_feed_merchant_center_while_the_job_is_scheduled() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->mc_service->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->job->expects( $this->exactly( 1 ) )
+			->method( 'is_scheduled' )
+			->willReturn( true );
+
+		$this->merchant_statuses->expects( $this->exactly( 1 ) )
+			->method( 'maybe_refresh_status_data' )
+			->willReturn( $this->job );
+
+		$this->product_repository->expects( $this->exactly( 1 ) )
+			->method( 'find' )
+			->willReturn( [ $product ] );
+
+		$this->product_helper->expects( $this->exactly( 1 ) )
+			->method( 'get_mc_status' )
+			->with( $product )
+			->willReturn( MCStatus::APPROVED );
+
+		$response = $this->product_feed_query_helper->get( $this->request );
+
+		$this->assertEquals(
+			[
+				[
+					'id'        => $product->get_id(),
+					'title'     => $product->get_name(),
+					'visible'   => true,
+					'status'    => '-',
+					'image_url' => wp_get_attachment_image_url( $product->get_image_id(), 'full' ),
+					'price'     => $product->get_price(),
+					'errors'    => [],
+				],
+			],
+			$response
+		);
 	}
 
 	public function test_get_product_feed_merchant_center_is_not_connected() {

--- a/tests/Unit/DB/ProductFeedQueryHelperTest.php
+++ b/tests/Unit/DB/ProductFeedQueryHelperTest.php
@@ -145,7 +145,7 @@ class ProductFeedQueryHelperTest extends UnitTest {
 					'id'        => $product->get_id(),
 					'title'     => $product->get_name(),
 					'visible'   => true,
-					'status'    => '-',
+					'status'    => null,
 					'image_url' => wp_get_attachment_image_url( $product->get_image_id(), 'full' ),
 					'price'     => $product->get_price(),
 					'errors'    => [],

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -207,6 +207,9 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
 			->method( 'clear_product_statuses_cache_and_issues' );
 
+		$this->merchant_statuses->expects( $this->exactly( 1 ) )
+			->method( 'refresh_account_and_presync_issues' );
+
 		$this->job->schedule();
 	}
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -201,7 +201,7 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_issue_query->expects( $this->exactly( 2 ) )
 		->method( 'update_or_insert' )
 		->withConsecutive( [ $issues ], [] );
-		$this->merchant_statuses->maybe_refresh_status_data( true );
+		$this->merchant_statuses->refresh_account_and_presync_issues();
 	}
 
 
@@ -210,7 +210,7 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'is_connected' )
 			->willReturn( false );
 
-			$this->merchant_center_service->expects( $this->once() )
+		$this->merchant_center_service->expects( $this->once() )
 			->method( 'is_google_connected' )
 			->willReturn( false );
 
@@ -232,7 +232,7 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'is_connected' )
 			->willReturn( true );
 
-		$this->transients->expects( $this->once() )
+		$this->transients->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->willReturn(
 				[
@@ -279,7 +279,7 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'is_connected' )
 			->willReturn( true );
 
-		$this->transients->expects( $this->once() )
+		$this->transients->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->willReturn(
 				[
@@ -313,7 +313,7 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'is_connected' )
 			->willReturn( true );
 
-		$this->transients->expects( $this->once() )
+		$this->transients->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->willReturn(
 				null
@@ -343,7 +343,7 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'is_connected' )
 			->willReturn( true );
 
-		$this->transients->expects( $this->once() )
+		$this->transients->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->willReturn(
 				[
@@ -384,7 +384,7 @@ class MerchantStatusesTest extends UnitTest {
 			->method( 'is_connected' )
 			->willReturn( true );
 
-		$this->transients->expects( $this->once() )
+		$this->transients->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->willReturn(
 				[

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -835,6 +835,48 @@ class MerchantStatusesTest extends UnitTest {
 		);
 	}
 
+	public function test_get_issues_when_job_is_scheduled() {
+		$this->merchant_center_service->expects( $this->any() )
+		->method( 'is_connected' )
+		->willReturn( true );
+
+		$this->update_merchant_product_statuses_job->expects( $this->any() )->method( 'is_scheduled' )->willReturn( true );
+
+		$this->merchant_issue_query->expects( $this->exactly( 2 ) )->method( 'get_results' )->willReturn( [] );
+
+		$response = $this->merchant_statuses->get_issues();
+
+		$this->assertEquals(
+			[
+				'loading' => true,
+				'total'   => 0,
+				'issues'  => [],
+			],
+			$response
+		);
+	}
+
+	public function test_get_issues_when_job_is_not_scheduled() {
+		$this->merchant_center_service->expects( $this->any() )
+		->method( 'is_connected' )
+		->willReturn( true );
+
+		$this->update_merchant_product_statuses_job->expects( $this->any() )->method( 'is_scheduled' )->willReturn( false );
+
+		$this->merchant_issue_query->expects( $this->exactly( 2 ) )->method( 'get_results' )->willReturn( [] );
+
+		$response = $this->merchant_statuses->get_issues();
+
+		$this->assertEquals(
+			[
+				'loading' => false,
+				'total'   => 0,
+				'issues'  => [],
+			],
+			$response
+		);
+	}
+
 	protected function get_product_status_item( $wc_product_id ): ProductStatus {
 		$product_status = new ProductStatus();
 		$product_status->setProductId( $this->get_mc_id( $wc_product_id ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146 & https://github.com/woocommerce/google-listings-and-ads/issues/2250

This PR fetches the account and presync issues using the same background job used to fetch the product statuses. The issues will be fetched in the first batch. The logic remains mostly unchanged from before, the main difference is the addition of a new property `loading when retrieving the issues. This indicates whether the job is scheduled or running and if the process to fetch the issues is in progress. I'll create a follow-up PR to update the UI to reflect the loading status of the issues.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Set your PHP memory limit low so you can catch any heavy process. For example, setting this up to 128MB.
2. Call GET `wp-json/wc/gla/mc/product-statistics/refresh`
3. Go to WooCommerce -> Status -> Action Scheduler -> Search for `gla/jobs/update_merchant_product_statuses/process_item` see how the jobs get completed successfully.
4. See how the table wp_gla_merchant_issues gets populated with presync and account issues.

### Additional details:
- I refactor `maybe_refresh_status_data` so it returns the AS job, so it is easier to determine if the process of updating the status and issues is scheduled or in progress.
- If the mc_statuses is not set for the product, we will consider that product is not synced in the MC. See here: https://github.com/woocommerce/google-listings-and-ads/pull/2255#issuecomment-1941282154
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
