### PR TITLE
Fix exception when response.json() fails

### DIFF
--- a/js/src/hooks/useApiFetchCallback.js
+++ b/js/src/hooks/useApiFetchCallback.js
@@ -173,11 +173,16 @@ const useApiFetchCallback = ( options, initialState = defaultState ) => {
 				}
 
 				const response = e;
+				let error;
 
-				const responseClone = response.clone();
-				const error = responseClone.json
-					? await responseClone.json()
-					: new Error( 'No content body in fetch response.' );
+				try {
+					const responseClone = response.clone();
+					error = responseClone.json
+						? await responseClone.json()
+						: new Error( 'No content body in fetch response.' );
+				} catch ( exception ) {
+					error = new Error( 'Error parsing response.' );
+				}
 
 				dispatch( {
 					type: TYPES.ERROR,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Right now in the extension when creating Ads Account it returns 428 status sometimes. 

We don't block the Account creation in this case.

However, when testing the extension with the Jurassic Ninja site. I got a 428 status but with a wrong response body different from JSON. So when the API Fetch Hook tries to parse the JSON after the exception happens it generates another exception causing the Ads Creation to fail and get blocked.


### Screenshots:

Before:

https://github.com/woocommerce/google-listings-and-ads/assets/5908855/29ac4a74-bad6-4661-9245-5ae881a8edd3



After:

https://github.com/woocommerce/google-listings-and-ads/assets/5908855/26f7d008-c011-49c8-92f1-2c1050d0dc15


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Set up a site in jurassic.ninja
2. Install WC and GLA (archived using this branch)
3. Check that there is no error when creating Ads Account.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Handle parse JSON exception when Creating Ads Account
