### PR TITLE
Fix - Handle null value for getAdsLinks response

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -314,7 +314,7 @@ class Merchant implements OptionsAwareInterface {
 	 */
 	public function link_ads_id( int $ads_id ): bool {
 		$account   = $this->get_account();
-		$ads_links = $account->getAdsLinks();
+		$ads_links = $account->getAdsLinks() ?? [];
 
 		// Stop early if we already have a link setup.
 		foreach ( $ads_links as $link ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

In https://github.com/woocommerce/google-listings-and-ads/issues/2251, it was mentioned that `getAdsLinks` can return a `null` value instead of the expected array, leading to a fatal error. The fix was done in https://github.com/woocommerce/google-listings-and-ads/pull/2205#discussion_r1489476259, however, it hasn't been merged into the develop branch yet. This PR brings the fix to the develop branch to prevent the fatal error.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. I haven't been able to reproduce the issue, but the fatal error mentioned https://github.com/woocommerce/google-listings-and-ads/issues/2251 makes it clear that `getAdsLinks` returns a null value in some cases.
2. Simulate the getAdsLinks returns a `null` value.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fatal error when getAdsLinks response is null