### PR TITLE
Fix undefined index for offers_free_shipping  and free_shipping_threshold options

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -54,8 +54,8 @@ class Settings {
 
 		return [
 			'shipping_rate'           => $settings['shipping_rate'] ?? '',
-			'offers_free_shipping'    => (bool) $settings['offers_free_shipping'] ?? false,
-			'free_shipping_threshold' => (float) $settings['free_shipping_threshold'] ?? 0,
+			'offers_free_shipping'    => (bool) ( $settings['offers_free_shipping'] ?? false ),
+			'free_shipping_threshold' => (float) ( $settings['free_shipping_threshold'] ?? 0 ),
 			'shipping_time'           => $settings['shipping_time'] ?? '',
 			'tax_rate'                => $settings['tax_rate'] ?? '',
 			'target_countries'        => join( ',', $this->get_target_countries() ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

When `offers_free_shipping ` or `free_shipping_threshold` is not set in the settings, the following warning is displayed:

```
[Tue Mar 12 19:25:01.441958 2024] [php:warn] [pid 75698] [client ::1:62981] PHP Warning:  Undefined array key "offers_free_shipping" in /opt/homebrew/var/www/wp-content/plugins/google-listings-and-ads/src/API/Google/Settings.php on line 57
[Tue Mar 12 19:25:01.443765 2024] [php:warn] [pid 75698] [client ::1:62981] PHP Warning:  Undefined array key "free_shipping_threshold" in /opt/homebrew/var/www/wp-content/plugins/google-listings-and-ads/src/API/Google/Settings.php on line 58

```

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout develop.
2. Watch your server logs.
3. Disconnect all your accounts, and do the onboarding again.
4. Don't set offers_free_shipping or free_shipping_threshold
5. See the errors mentioned above.
6. Alternatively you can call the following endpoint: `POST wp-json/wc/gla/mc/settings/sync` to see the warnings.
7. Checkout this branch, and see that no warnings are shown.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Undefined keys `offers_free_shipping ` or `free_shipping_threshold`
