### PR TITLE
Update version of bcmath_compat and phpseclib packages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1671,16 +1671,16 @@
         },
         {
             "name": "phpseclib/bcmath_compat",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/bcmath_compat.git",
-                "reference": "2ffea8bfe1702b4535a7b3c2649c4301968e9a3c"
+                "reference": "29bbf07a7039ff65ce7daa44502ba34baf1512ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/bcmath_compat/zipball/2ffea8bfe1702b4535a7b3c2649c4301968e9a3c",
-                "reference": "2ffea8bfe1702b4535a7b3c2649c4301968e9a3c",
+                "url": "https://api.github.com/repos/phpseclib/bcmath_compat/zipball/29bbf07a7039ff65ce7daa44502ba34baf1512ec",
+                "reference": "29bbf07a7039ff65ce7daa44502ba34baf1512ec",
                 "shasum": ""
             },
             "require": {
@@ -1729,20 +1729,20 @@
                 "issues": "https://github.com/phpseclib/bcmath_compat/issues",
                 "source": "https://github.com/phpseclib/bcmath_compat"
             },
-            "time": "2021-12-16T02:35:52+00:00"
+            "time": "2024-02-21T10:30:36+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.35",
+            "version": "3.0.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "4b1827beabce71953ca479485c0ae9c51287f2fe"
+                "reference": "cfa2013d0f68c062055180dd4328cc8b9d1f30b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/4b1827beabce71953ca479485c0ae9c51287f2fe",
-                "reference": "4b1827beabce71953ca479485c0ae9c51287f2fe",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/cfa2013d0f68c062055180dd4328cc8b9d1f30b8",
+                "reference": "cfa2013d0f68c062055180dd4328cc8b9d1f30b8",
                 "shasum": ""
             },
             "require": {
@@ -1823,7 +1823,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.35"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.37"
             },
             "funding": [
                 {
@@ -1839,7 +1839,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-29T01:59:53+00:00"
+            "time": "2024-03-03T02:14:58+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the bcmath_compat and phpseclib packages to the following versions:

`composer update phpseclib/bcmath_compat --with-all-dependencies`
```
- Upgrading phpseclib/bcmath_compat (2.0.1 => 2.0.2)
- Upgrading phpseclib/phpseclib (3.0.35 => 3.0.37)
```

I have confirmed that these changes work locally and don't conflict with any other packages.

This resolves the following Dependabot reports:
- https://github.com/woocommerce/google-listings-and-ads/security/dependabot/87
- https://github.com/woocommerce/google-listings-and-ads/security/dependabot/88
- Supersedes #2293

### Detailed test instructions:

1. Run `composer update` to get new dependencies
2. Rebuild assets `nvm use && npm ci && npm start`
3. Run several smoke tests
4. Monitor error/warnings from PHP

### Changelog entry
* Update - Newer version of bcmath_compat and phpseclib packages.