### PR TITLE
Remove esc_js from add_inline_event_script

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -314,7 +314,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		if ( class_exists( '\WC_Google_Gtag_JS' ) ) {
 			wp_add_inline_script(
 				'woocommerce-google-analytics-integration',
-				esc_js( $inline_script )
+				$inline_script
 			);
 		} else {
 			wp_print_inline_script_tag( $inline_script );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When Google Analytics for WooCommerce version > `2.0.0` is installed, inline Javascript is being incorrectly escaped for GLA events. This PR removes the `esc_js` call so that the code is output correctly and how it previously was.

### Screenshots:

<img width="1214" alt="Screenshot 2024-03-14 at 16 13 24" src="https://github.com/woocommerce/google-listings-and-ads/assets/40762232/8d434327-9a1e-4d1a-909c-b8fb5e24ea75">

### Detailed test instructions:

1. Checkout `fix/escaping-inline-javascript` on a test site with Google Analytics for WooCommerce version `2.0.3` installed and active
2. View page source and look for `send_to`
3. Confirm the inline JS for GLA is correct

### Changelog entry

> Fix - Inline Javascript encoding for gtag events