### PR TITLE
Add require plugins header

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -11,7 +11,7 @@
  * Tested up to: 6.5
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits
- *
+ * Requires Plugins: woocommerce
  * WC requires at least: 6.9
  * WC tested up to: 8.7
  * Woo:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2313 

This PR enables the new Requires Plugins header available in WP 6.5

See --> https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/

### Screenshots:

<img width="1311" alt="Screenshot 2024-03-14 at 19 30 20" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/c21f036e-5c80-4c21-ab76-4398d4612517">
<img width="1567" alt="Screenshot 2024-03-14 at 19 30 36" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/b287a741-e323-4417-a532-28ff5c26b74c">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install WP 6.5 (RC2) --> https://wordpress.org/wordpress-6.5-RC2.zip 
2. Install Woo Commerce and GLA (checkout this PR)
3. If WC is activated, GLA can be activated
4. If WC is not activated, GLA button for activate is disabled. A notice "This plugin cannot be activated because required plugins are missing or inactive." is shown.
5. If GLA is activated and WC is activated. WC cannot be deactivated. And it shows info like "Required by: Google Listings and Ads" 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Add WP 6.5 Require plugins header
