### PR TITLE
Fix: jumping to wrong step in onboarding

### DIFF
--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -18,7 +18,6 @@ use Google\Ads\GoogleAds\V14\Enums\AccessRoleEnum\AccessRole;
 use Google\Ads\GoogleAds\V14\Enums\MerchantCenterLinkStatusEnum\MerchantCenterLinkStatus;
 use Google\Ads\GoogleAds\V14\Resources\MerchantCenterLink;
 use Google\Ads\GoogleAds\V14\Services\MerchantCenterLinkOperation;
-use Google\Ads\GoogleAds\V14\Resources\ConversionTrackingSetting;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;
 
@@ -332,9 +331,12 @@ class Ads implements OptionsAwareInterface {
 	 * @return boolean
 	 */
 	public function get_accepted_customer_data_terms(): bool {
-		$ads_id = $this->options->get_ads_id();
+		if ( ! $this->options->get_ads_id() ) {
+			return false;
+		}
 
 		try {
+			$ads_id         = $this->options->get_ads_id();
 			$accepted_terms = $this->options->get( OptionsInterface::ADS_CUSTOMER_DATA_TERMS, null );
 
 			// Retrieve the terms acceptance data from options.

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -215,9 +215,10 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		}
 
 		// Check if user is connected to google account.
+		$ads_id                 = $this->options->get_ads_id();
 		$connection_status      = $this->container->get( Connection::class )->get_status();
 		$email                  = $connection_status['email'] ?? null;
-		$has_ads_account_access = $email ? $this->container->get( Ads::class )->has_access( $email ) : false;
+		$has_ads_account_access = ( $ads_id && $email ) ? $this->container->get( Ads::class )->has_access( $email ) : false;
 		$step                   = 'accounts';
 
 		if ( $this->connected_account() && $has_ads_account_access ) {

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -93,6 +93,8 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	protected const TEST_SETUP_COMPLETED = 1641038400;
 
+	protected const TST_ADS_ACCOUNT_ID = 12345678;
+
 	/**
 	 * Runs before each test is executed.
 	 */
@@ -404,6 +406,10 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_step_accounts() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
 			->willReturn( [ 'email' => 'test@gmail.com' ] );
@@ -423,6 +429,10 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_step_product_listings() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
 			->willReturn( [ 'email' => 'test@gmail.com' ] );
@@ -457,6 +467,10 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_step_store_requirements() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
 			->willReturn( [ 'email' => 'test@gmail.com' ] );
@@ -495,6 +509,10 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_shipping_selected_rates() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
 			->willReturn( [ 'email' => 'test@gmail.com' ] );
@@ -547,6 +565,10 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_step_paid_ads() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
 			->willReturn( [ 'email' => 'test@gmail.com' ] );

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -408,7 +408,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_step_accounts() {
 		$this->options->expects( $this->once() )
 			->method( 'get_ads_id' )
-			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+			->willReturn( self::TST_ADS_ACCOUNT_ID );
 
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
@@ -431,7 +431,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_step_product_listings() {
 		$this->options->expects( $this->once() )
 			->method( 'get_ads_id' )
-			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+			->willReturn( self::TST_ADS_ACCOUNT_ID );
 
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
@@ -469,7 +469,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_step_store_requirements() {
 		$this->options->expects( $this->once() )
 			->method( 'get_ads_id' )
-			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+			->willReturn( self::TST_ADS_ACCOUNT_ID );
 
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
@@ -511,7 +511,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_shipping_selected_rates() {
 		$this->options->expects( $this->once() )
 			->method( 'get_ads_id' )
-			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+			->willReturn( self::TST_ADS_ACCOUNT_ID );
 
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
@@ -567,7 +567,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_step_paid_ads() {
 		$this->options->expects( $this->once() )
 			->method( 'get_ads_id' )
-			->willReturn( SELF::TST_ADS_ACCOUNT_ID );
+			->willReturn( self::TST_ADS_ACCOUNT_ID );
 
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
@@ -38,8 +40,14 @@ class MerchantCenterServiceTest extends UnitTest {
 	/** @var MockObject|AddressUtility $address_utility */
 	protected $address_utility;
 
+	/** @var MockObject|Ads $ads */
+	protected $ads;
+
 	/** @var MockObject|ContactInformation $contact_information */
 	protected $contact_information;
+
+	/** @var MockObject|Connection $connection */
+	protected $connection;
 
 	/** @var MockObject|GoogleHelper $google_helper */
 	protected $google_helper;
@@ -91,6 +99,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->address_utility        = $this->createMock( AddressUtility::class );
+		$this->ads                    = $this->createMock( Ads::class );
 		$this->contact_information    = $this->createMock( ContactInformation::class );
 		$this->google_helper          = $this->createMock( GoogleHelper::class );
 		$this->merchant               = $this->createMock( Merchant::class );
@@ -104,9 +113,11 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->wc                     = $this->createMock( WC::class );
 		$this->wp                     = $this->createMock( WP::class );
 		$this->options                = $this->createMock( OptionsInterface::class );
+		$this->connection             = $this->createMock( Connection::class );
 
 		$this->container = new Container();
 		$this->container->share( AddressUtility::class, $this->address_utility );
+		$this->container->share( Ads::class, $this->ads );
 		$this->container->share( ContactInformation::class, $this->contact_information );
 		$this->container->share( GoogleHelper::class, $this->google_helper );
 		$this->container->share( Merchant::class, $this->merchant );
@@ -117,6 +128,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->container->share( ShippingTimeQuery::class, $this->shipping_time_query );
 		$this->container->share( TargetAudience::class, $this->target_audience );
 		$this->container->share( TransientsInterface::class, $this->transients );
+		$this->container->share( Connection::class, $this->connection );
 		$this->container->share( WC::class, $this->wc );
 		$this->container->share( WP::class, $this->wp );
 
@@ -392,6 +404,15 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_step_accounts() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( [ 'email' => 'test@gmail.com' ] );
+
+		$this->ads->expects( $this->once() )
+			->method( 'has_access' )
+			->with( 'test@gmail.com' )
+			->willReturn( false );
+
 		$this->assertEquals(
 			[
 				'status' => 'incomplete',
@@ -402,6 +423,15 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_step_product_listings() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( [ 'email' => 'test@gmail.com' ] );
+
+		$this->ads->expects( $this->once() )
+			->method( 'has_access' )
+			->with( 'test@gmail.com' )
+			->willReturn( true );
+
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->options->method( 'get' )
@@ -427,6 +457,15 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_step_store_requirements() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( [ 'email' => 'test@gmail.com' ] );
+
+		$this->ads->expects( $this->once() )
+			->method( 'has_access' )
+			->with( 'test@gmail.com' )
+			->willReturn( true );
+
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->options->method( 'get' )
@@ -456,6 +495,15 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_shipping_selected_rates() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( [ 'email' => 'test@gmail.com' ] );
+
+		$this->ads->expects( $this->once() )
+			->method( 'has_access' )
+			->with( 'test@gmail.com' )
+			->willReturn( true );
+
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->options->method( 'get' )
@@ -499,6 +547,15 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_get_setup_status_step_paid_ads() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( [ 'email' => 'test@gmail.com' ] );
+
+		$this->ads->expects( $this->once() )
+			->method( 'has_access' )
+			->with( 'test@gmail.com' )
+			->willReturn( true );
+
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->options->method( 'get' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

If the user has not accepted ads account invite, do not proceed to step 2 when revisiting the onboarding journey.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
