### PR TITLE
Set woocommerce_gla_wcs_url to api.woocommerce.com

### DIFF
--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -174,8 +174,7 @@ trait PluginHelper {
 			return apply_filters( 'woocommerce_gla_wcs_url', WOOCOMMERCE_GLA_CONNECT_SERVER_URL );
 		}
 
-		// TODO: Change to api.woocommerce.com when we are no longer in test phase.
-		return apply_filters( 'woocommerce_gla_wcs_url', 'https://api-vipgo.woocommerce.com' );
+		return apply_filters( 'woocommerce_gla_wcs_url', 'https://api.woocommerce.com' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The connect server has now been migrated and we're redirecting traffic from `api-vipgo.woocommerce.com` to `api.woocommerce.com`.

This PR updates the default `woocommerce_gla_wcs_url` value to `api.woocommerce.com`.

### Detailed test instructions:

1. Confirm existing connections work as expected after updating to this branch
2. Confirm that new connections can be established

### Changelog entry

> Update - Set default connect server URL to api.woocommerce.com