### PR TITLE
[R-1.3] Fix onboarding flow skipping to step 2

### DIFF
--- a/src/Ads/AdsService.php
+++ b/src/Ads/AdsService.php
@@ -62,4 +62,15 @@ class AdsService implements OptionsAwareInterface, Service {
 		$google_connected = boolval( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) );
 		return $google_connected && $this->is_setup_complete();
 	}
+
+	/**
+	 * Determine whether the Ads account is connected, even when pending billing.
+	 *
+	 * @return bool
+	 */
+	public function connected_account(): bool {
+		$id        = $this->options->get_ads_id();
+		$last_step = $this->account_state->last_incomplete_step();
+		return $id && ( $last_step === '' || $last_step === 'billing' );
+	}
 }

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
@@ -32,6 +33,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * ContainerAware used to access:
  * - AddressUtility
+ * - AdsService
  * - ContactInformation
  * - Merchant
  * - MerchantAccountState
@@ -211,7 +213,11 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		}
 
 		$step = 'accounts';
-		if ( $this->connected_account() ) {
+
+		if (
+			$this->connected_account() &&
+			$this->container->get( AdsService::class )->connected_account()
+		) {
 			$step = 'product_listings';
 
 			if ( $this->saved_target_audience() && $this->saved_shipping_and_tax_options() ) {

--- a/tests/Unit/Ads/AdsServiceTest.php
+++ b/tests/Unit/Ads/AdsServiceTest.php
@@ -65,4 +65,31 @@ class AdsServiceTest extends UnitTest {
 
 		$this->assertFalse( $this->ads_service->is_setup_started() );
 	}
+
+	public function test_connected_account_without_ads_id() {
+		$this->options->method( 'get_ads_id' )->willReturn( 0 );
+
+		$this->assertFalse( $this->ads_service->connected_account() );
+	}
+
+	public function test_connected_account_without_ads_fully_connected() {
+		$this->options->method( 'get_ads_id' )->willReturn( 123 );
+		$this->state->method( 'last_incomplete_step' )->willReturn( 'conversion_action' );
+
+		$this->assertFalse( $this->ads_service->connected_account() );
+	}
+
+	public function test_connected_account_with_setup_complete() {
+		$this->options->method( 'get_ads_id' )->willReturn( 123 );
+		$this->state->method( 'last_incomplete_step' )->willReturn( '' );
+
+		$this->assertTrue( $this->ads_service->connected_account() );
+	}
+
+	public function test_connected_account_pending_billing() {
+		$this->options->method( 'get_ads_id' )->willReturn( 123 );
+		$this->state->method( 'last_incomplete_step' )->willReturn( 'billing' );
+
+		$this->assertTrue( $this->ads_service->connected_account() );
+	}
 }

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
@@ -37,6 +38,9 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	/** @var MockObject|AddressUtility $address_utility */
 	protected $address_utility;
+
+	/** @var MockObject|AdsService $ads_service */
+	protected $ads_service;
 
 	/** @var MockObject|ContactInformation $contact_information */
 	protected $contact_information;
@@ -91,6 +95,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->address_utility        = $this->createMock( AddressUtility::class );
+		$this->ads_service            = $this->createMock( AdsService::class );
 		$this->contact_information    = $this->createMock( ContactInformation::class );
 		$this->google_helper          = $this->createMock( GoogleHelper::class );
 		$this->merchant               = $this->createMock( Merchant::class );
@@ -107,6 +112,7 @@ class MerchantCenterServiceTest extends UnitTest {
 
 		$this->container = new Container();
 		$this->container->share( AddressUtility::class, $this->address_utility );
+		$this->container->share( AdsService::class, $this->ads_service );
 		$this->container->share( ContactInformation::class, $this->contact_information );
 		$this->container->share( GoogleHelper::class, $this->google_helper );
 		$this->container->share( Merchant::class, $this->merchant );
@@ -404,6 +410,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_step_product_listings() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
 			->withConsecutive(
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
@@ -429,6 +436,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_step_store_requirements() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
 			->withConsecutive(
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
@@ -458,6 +466,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_shipping_selected_rates() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
 			->withConsecutive(
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
@@ -501,6 +510,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	public function test_get_setup_status_step_paid_ads() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
 			->withConsecutive(
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This fixes an issue where a the setup flow could load in step 2 if the Ads account is switched after initially setting up MC by checking that both Ads and MC are connected prior to moving to step 2.

This adds a new method to the AdsService to check if the Ads account is connected. It does so by making sure that there is an Ads ID and that the last incomplete step is either empty, or pending 'billing', which can optionally be skipped.

See #2270. Replaces #2316.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->


1. Connect both and Ads and and MC account in step one
2. Refresh the page and see that it will skip to step 2
3. Move back to step one and disconnect the Ads account
4. Refresh the page again and ensure that the setup is loading in step one

### Changelog entry
