### PR TITLE
Expose OCID via REST

### DIFF
--- a/src/API/Site/Controllers/Ads/AccountController.php
+++ b/src/API/Site/Controllers/Ads/AccountController.php
@@ -122,6 +122,17 @@ class AccountController extends BaseController {
 				],
 			]
 		);
+
+		$this->register_route(
+			'ads/ocid',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_ocid(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
 	}
 
 	/**
@@ -238,6 +249,17 @@ class AccountController extends BaseController {
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}
+		};
+	}
+
+	/**
+	 * Get the callback function for retrieving OCID for ads account.
+	 *
+	 * @return callable
+	 */
+	protected function get_ocid() {
+		return function ( Request $request ) {
+			return $this->account->get_ocid();
 		};
 	}
 

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -320,4 +320,13 @@ class AccountService implements OptionsAwareInterface, Service {
 			'status' => $status,
 		];
 	}
+
+	/**
+	 * Get the OCID for account.
+	 *
+	 * @return string
+	 */
+	public function get_ocid() {
+		return $this->options->get( OptionsInterface::ADS_ACCOUNT_OCID, '' );
+	}
 }

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\PositiveInteger;
 interface OptionsInterface {
 
 	public const ADS_ACCOUNT_CURRENCY                      = 'ads_account_currency';
+	public const ADS_ACCOUNT_OCID                          = 'ads_account_ocid';
 	public const ADS_ACCOUNT_STATE                         = 'ads_account_state';
 	public const ADS_BILLING_URL                           = 'ads_billing_url';
 	public const ADS_CUSTOMER_DATA_TERMS                   = 'ads_customer_data_terms';

--- a/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AccountControllerTest.php
@@ -29,6 +29,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	protected const ROUTE_ACCEPTED_DATA_TERMS = '/wc/gla/ads/accepted-customer-data-terms';
 	protected const ROUTE_UPDATED_EC_STATUS   = '/wc/gla/ads/enhanced-conversion-status';
 	protected const ROUTE_GET_EC_STATUS       = '/wc/gla/ads/enhanced-conversion-status';
+	protected const ROUTE_GET_ADS_OCID        = '/wc/gla/ads/ocid';
 	protected const TEST_ACCOUNT_ID           = 1234567890;
 	protected const TEST_BILLING_URL          = 'https://domain.test/billing/setup/';
 	protected const TEST_BILLING_STATUS       = 'pending';
@@ -68,6 +69,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		'status'      => self::TEST_BILLING_STATUS,
 		'billing_url' => self::TEST_BILLING_URL,
 	];
+	protected const TEST_ADS_OCID             = '123456789';
 
 	public function setUp(): void {
 		parent::setUp();
@@ -206,6 +208,19 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			$response->get_data()
 		);
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * @group ocid
+	 */
+	public function test_get_ocid() {
+		$this->account->expects( $this->once() )
+			->method( 'get_ocid' )
+			->willReturn( self::TEST_ADS_OCID );
+
+		$response = $this->do_request( self::ROUTE_GET_ADS_OCID, 'GET' );
+
+		$this->assertEquals( self::TEST_ADS_OCID, $response->get_data() );
 	}
 
 	public function test_get_billing_status() {

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -55,6 +55,7 @@ class AccountServiceTest extends UnitTest {
 	protected $options;
 
 	protected const TEST_ACCOUNT_ID        = 1234567890;
+	protected const TEST_ACCOUNT_OCID      = '9876565656';
 	protected const TEST_OLD_ACCOUNT_ID    = 2345678901;
 	protected const TEST_MERCHANT_ID       = 78123456;
 	protected const TEST_BILLING_URL       = 'https://domain.test/billing/setup/';
@@ -482,5 +483,16 @@ class AccountServiceTest extends UnitTest {
 			);
 
 		$this->account->disconnect();
+	}
+
+	public function test_get_ocid() {
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::ADS_ACCOUNT_OCID, '' )
+			->willReturn( self::TEST_ACCOUNT_OCID );
+
+		$ocid = $this->account->get_ocid();
+
+		$this->assertEquals( self::TEST_ACCOUNT_OCID, $ocid );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

Expose the ads account OCID via REST API endpoint in order to form the deeplink in FE components.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
