### PR TITLE
Display error message if update_merchant_product_statuses  job throws an error

### DIFF
--- a/js/src/hooks/useMCProductStatistics.js
+++ b/js/src/hooks/useMCProductStatistics.js
@@ -8,6 +8,7 @@ import { useEffect } from '@wordpress/element';
  */
 import useAppSelectDispatch from './useAppSelectDispatch';
 import useCountdown from './useCountdown';
+import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 
 /**
  * Call `useAppSelectDispatch` with `"getMCProductStatistics"`.
@@ -21,6 +22,16 @@ const useMCProductStatistics = () => {
 		useAppSelectDispatch( 'getMCProductStatistics' );
 
 	const isLoading = hasFinishedResolution && data?.loading ? true : false;
+
+	const [ refreshProductStats ] = useApiFetchCallback( {
+		path: `/wc/gla/mc/product-statistics/refresh`,
+		method: 'GET',
+	} );
+
+	const refreshStats = async () => {
+		await refreshProductStats();
+		invalidateResolution( 'getMCProductStatistics', [] );
+	};
 
 	if ( isLoading && callCount === 0 ) {
 		startCountdown( 30 );
@@ -37,6 +48,7 @@ const useMCProductStatistics = () => {
 		data,
 		invalidateResolution,
 		hasFinishedResolution,
+		refreshStats,
 		...rest,
 	};
 };

--- a/js/src/hooks/useMCProductStatistics.js
+++ b/js/src/hooks/useMCProductStatistics.js
@@ -35,7 +35,7 @@ const useMCProductStatistics = () => {
 
 	const refreshStats = async () => {
 		await refreshProductStats();
-		invalidateResolution( 'getMCProductStatistics', [] );
+		invalidateResolution();
 	};
 
 	useEffect( () => {

--- a/js/src/hooks/useMCProductStatistics.js
+++ b/js/src/hooks/useMCProductStatistics.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -33,10 +33,10 @@ const useMCProductStatistics = () => {
 		method: 'GET',
 	} );
 
-	const refreshStats = async () => {
+	const refreshStats = useCallback( async () => {
 		await refreshProductStats();
 		invalidateResolution();
-	};
+	}, [ refreshProductStats, invalidateResolution ] );
 
 	useEffect( () => {
 		// If the job is still processing the data, start the countdown.

--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -22,7 +22,7 @@ import {
 import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
 import ProductStatusHelpPopover from './product-status-help-popover';
 import SyncStatus from '.~/product-feed/product-statistics/status-box/sync-status';
-import SyncMCStatus from '.~/product-feed/product-statistics/status-box/sync-mc-status';
+import SyncProductStatistics from '.~/product-feed/product-statistics/status-box/sync-product-statistics';
 import FeedStatus from '.~/product-feed/product-statistics/status-box/feed-status';
 import AccountStatus from '.~/product-feed/product-statistics/status-box/account-status';
 import Text from '.~/components/app-text';
@@ -107,10 +107,12 @@ const ProductStatistics = () => {
 				<FeedStatus />
 				<SyncStatus />
 				<AccountStatus />
-				<SyncMCStatus
-					refreshStats={ refreshStats }
-					error={ 'My error' }
-				/>
+				{ hasFinishedResolution && data?.error && (
+					<SyncProductStatistics
+						refreshStats={ refreshStats }
+						error={ 'My error' }
+					/>
+				) }
 			</CardFooter>
 		</Card>
 	);

--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -22,6 +22,7 @@ import {
 import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
 import ProductStatusHelpPopover from './product-status-help-popover';
 import SyncStatus from '.~/product-feed/product-statistics/status-box/sync-status';
+import SyncMCStatus from '.~/product-feed/product-statistics/status-box/sync-mc-status';
 import FeedStatus from '.~/product-feed/product-statistics/status-box/feed-status';
 import AccountStatus from '.~/product-feed/product-statistics/status-box/account-status';
 import AppSpinner from '.~/components/app-spinner';
@@ -29,7 +30,8 @@ import Text from '.~/components/app-text';
 import './index.scss';
 
 const ProductStatistics = () => {
-	const { hasFinishedResolution, data } = useMCProductStatistics();
+	const { hasFinishedResolution, data, refreshStats } =
+		useMCProductStatistics();
 
 	if ( hasFinishedResolution && ! data ) {
 		return __(
@@ -125,6 +127,10 @@ const ProductStatistics = () => {
 				<FeedStatus />
 				<SyncStatus />
 				<AccountStatus />
+				<SyncMCStatus
+					refreshStats={ refreshStats }
+					error={ 'My error' }
+				/>
 			</CardFooter>
 		</Card>
 	);

--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -140,7 +140,7 @@ const ProductStatistics = () => {
 				{ hasFinishedResolution && data?.error && (
 					<SyncProductStatistics
 						refreshStats={ refreshStats }
-						error={ 'My error' }
+						error={ data.error }
 					/>
 				) }
 			</CardFooter>

--- a/js/src/product-feed/product-statistics/index.scss
+++ b/js/src/product-feed/product-statistics/index.scss
@@ -96,8 +96,8 @@
 
 		.overview-stats-error-button {
 			height: auto;
-			padding-top: 0px;
-			padding-left: 0px;
+			padding-top: 0;
+			padding-left: 0;
 		}
 	}
 }

--- a/js/src/product-feed/product-statistics/index.scss
+++ b/js/src/product-feed/product-statistics/index.scss
@@ -93,5 +93,11 @@
 		.gridicons-sync {
 			transform: rotateZ(90deg);
 		}
+
+		.overview-stats-error-button {
+			height: auto;
+			padding-top: 0px;
+			padding-left: 0px;
+		}
 	}
 }

--- a/js/src/product-feed/product-statistics/index.test.js
+++ b/js/src/product-feed/product-statistics/index.test.js
@@ -119,4 +119,33 @@ describe( 'Product Statistics', () => {
 			} );
 		} );
 	} );
+	describe( `When there is an error`, () => {
+		it( 'Should render the error', () => {
+			useMCProductStatistics.mockImplementation( () => {
+				return {
+					hasFinishedResolution: true,
+					data: {
+						loading: false,
+						statistics: null,
+						error: 'Error loading stats!',
+					},
+				};
+			} );
+
+			const { getByText, container } = render( <ProductStatistics /> );
+
+			const notAvailableStats = container.querySelectorAll(
+				'.woocommerce-summary__item-value'
+			);
+
+			expect( notAvailableStats.length ).toBe( 5 );
+
+			for ( let i = 0; i < notAvailableStats.length; i++ ) {
+				expect( notAvailableStats[ i ].textContent ).toBe( 'N/A' );
+			}
+
+			expect( getByText( 'Overview Stats:' ) ).toBeInTheDocument();
+			expect( getByText( 'Error loading stats!' ) ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/js/src/product-feed/product-statistics/status-box/sync-mc-status.js
+++ b/js/src/product-feed/product-statistics/status-box/sync-mc-status.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Status from '.~/product-feed/product-statistics/status-box/status';
+import ErrorIcon from '.~/components/error-icon';
+import { Button } from '@wordpress/components';
+
+/**
+ * @typedef {import('.~/data/actions').ProductStatistics } ProductStatistics
+ */
+
+/**
+ * Renders status information for the Product Sync
+ *
+ * @param {Object} props The component props
+ * @param {Function} props.refreshStats
+ * @param {string} props.error
+ * @return {JSX.Element} The status for the Product Sync
+ */
+function SyncMCStatus( { refreshStats, error } ) {
+	return (
+		<Status
+			title={ __( 'Overview Stats:', 'google-listings-and-ads' ) }
+			icon={ <ErrorIcon size={ 24 } /> }
+			label={
+				<Button
+					aria-label={ error }
+					onClick={ refreshStats }
+					className="overview-stats-error-button"
+				>
+					{ __(
+						'There was an error loading the Overview Stats. Click to retry.'
+					) }
+				</Button>
+			}
+			description={ null }
+		/>
+	);
+}
+
+export default SyncMCStatus;

--- a/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
+++ b/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
@@ -22,7 +22,7 @@ import { Button } from '@wordpress/components';
  * @param {string} props.error
  * @return {JSX.Element} The status for the Product Sync
  */
-function SyncMCStatus( { refreshStats, error } ) {
+function SyncProductStatistics( { refreshStats, error } ) {
 	return (
 		<Status
 			title={ __( 'Overview Stats:', 'google-listings-and-ads' ) }
@@ -34,7 +34,8 @@ function SyncMCStatus( { refreshStats, error } ) {
 					className="overview-stats-error-button"
 				>
 					{ __(
-						'There was an error loading the Overview Stats. Click to retry.'
+						'There was an error loading the Overview Stats. Click to retry.',
+						'google-listings-and-ads'
 					) }
 				</Button>
 			}
@@ -43,4 +44,4 @@ function SyncMCStatus( { refreshStats, error } ) {
 	);
 }
 
-export default SyncMCStatus;
+export default SyncProductStatistics;

--- a/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
+++ b/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import Status from '.~/product-feed/product-statistics/status-box/status';
 import ErrorIcon from '.~/components/error-icon';
+import AppButton from '.~/components/app-button';
 
 /**
  * @typedef {import('.~/data/actions').ProductStatistics } ProductStatistics
@@ -28,16 +28,17 @@ function SyncProductStatistics( { refreshStats, error } ) {
 			title={ __( 'Overview Stats:', 'google-listings-and-ads' ) }
 			icon={ <ErrorIcon size={ 24 } /> }
 			label={
-				<Button
+				<AppButton
 					aria-label={ error }
 					onClick={ refreshStats }
 					className="overview-stats-error-button"
+					eventName="gla_retry_loading_product_stats"
 				>
 					{ __(
 						'There was an error loading the Overview Stats. Click to retry.',
 						'google-listings-and-ads'
 					) }
-				</Button>
+				</AppButton>
 			}
 			description={ error }
 		/>

--- a/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
+++ b/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
@@ -39,7 +39,7 @@ function SyncProductStatistics( { refreshStats, error } ) {
 					) }
 				</Button>
 			}
-			description={ null }
+			description={ error }
 		/>
 	);
 }

--- a/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
+++ b/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import Status from '.~/product-feed/product-statistics/status-box/status';
 import ErrorIcon from '.~/components/error-icon';
-import { Button } from '@wordpress/components';
 
 /**
  * @typedef {import('.~/data/actions').ProductStatistics } ProductStatistics

--- a/src/DB/ProductMetaQueryHelper.php
+++ b/src/DB/ProductMetaQueryHelper.php
@@ -62,6 +62,8 @@ class ProductMetaQueryHelper implements Service {
 	/**
 	 * Delete all values for a given meta_key.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param string $meta_key The meta key to delete.
 	 *
 	 * @throws InvalidMeta If the meta key isn't valid.

--- a/src/DB/ProductMetaQueryHelper.php
+++ b/src/DB/ProductMetaQueryHelper.php
@@ -60,6 +60,21 @@ class ProductMetaQueryHelper implements Service {
 	}
 
 	/**
+	 * Delete all values for a given meta_key.
+	 *
+	 * @param string $meta_key The meta key to delete.
+	 *
+	 * @throws InvalidMeta If the meta key isn't valid.
+	 */
+	public function delete_all_values( string $meta_key ) {
+		self::validate_meta_key( $meta_key );
+		$meta_key = $this->prefix_meta_key( $meta_key );
+		$query    = "DELETE FROM {$this->wpdb->postmeta} WHERE meta_key = %s";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$this->wpdb->query( $this->wpdb->prepare( $query, $meta_key ) );
+	}
+
+	/**
 	 * Insert a meta value for multiple posts.
 	 *
 	 * @param string $meta_key The meta value to insert.

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -128,4 +128,17 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 		// We set 'args' to null so it matches any arguments. This is because it's possible to have multiple instances of the job running with different page tokens
 		return $this->is_running( null );
 	}
+
+	/**
+	 * Validate the failure rate of the job.
+	 *
+	 * @return string|null Returns an error message if the failure rate is too high, otherwise null.
+	 */
+	public function get_failure_rate_message() {
+		try {
+			$this->monitor->validate_failure_rate( $this, $this->get_process_item_hook() );
+		} catch ( JobException $e ) {
+			return $e->getMessage();
+		}
+	}
 }

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -132,7 +132,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	/**
 	 * Validate the failure rate of the job.
 	 *
-	 * @return string|null Returns an error message if the failure rate is too high, otherwise null.
+	 * @return string|void Returns an error message if the failure rate is too high, otherwise null.
 	 */
 	public function get_failure_rate_message() {
 		try {

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -289,6 +289,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 		// If force_refresh is true or if not transient, return empty array and scheduled the job to update the statuses.
 		if ( ! $job->is_scheduled() && ( $force_refresh || ( ! $force_refresh && null === $this->mc_statuses ) ) ) {
+			// Delete the transient before scheduling the job because some errors, like the failure rate message, can occur before the job is scheduled.
+			$this->clear_cache();
 			// Schedule job to update the statuses.
 			$job->schedule();
 		}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -58,7 +58,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * The lifetime of the status-related data.
 	 */
-	public const STATUS_LIFETIME = HOUR_IN_SECONDS;
+	public const STATUS_LIFETIME = 12 * HOUR_IN_SECONDS;
 
 	/**
 	 * The types of issues.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -145,7 +145,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 				'timestamp'  => $this->cache_created_time->getTimestamp(),
 				'statistics' => null,
 				'loading'    => false,
-				'error'      => $failure_rate_msg,
+				'error'      => __( 'The scheduled job has been paused due to a high failure rate.', 'google-listings-and-ads' ),
 			];
 		}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -143,7 +143,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		if ( $failure_rate_msg && null === $this->mc_statuses ) {
 			return [
 				'timestamp'  => $this->cache_created_time->getTimestamp(),
-				'statistics' => [],
+				'statistics' => null,
 				'loading'    => false,
 				'error'      => $failure_rate_msg,
 			];
@@ -289,9 +289,9 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 		// If force_refresh is true or if not transient, return empty array and scheduled the job to update the statuses.
 		if ( ! $job->is_scheduled() && ( $force_refresh || ( ! $force_refresh && null === $this->mc_statuses ) ) ) {
-			// Delete the transient before scheduling the job because some errors, like the failure rate message, can occur before the job is scheduled.
+			// Delete the transient before scheduling the job because some errors, like the failure rate message, can occur before the job is executed.
 			$this->clear_cache();
-			// Schedule job to update the statuses.
+			// Schedule job to update the statuses. If the failure rate is too high, the job will not be scheduled.
 			$job->schedule();
 		}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -239,12 +239,23 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
+	 * Delete the stale mc statuses from the database.
+	 *
+	 * @since x.x.x
+	 */
+	protected function delete_stale_mc_statuses(): void {
+		$product_meta_query_helper = $this->container->get( ProductMetaQueryHelper::class );
+		$product_meta_query_helper->delete_all_values( ProductMetaHandler::KEY_MC_STATUS );
+	}
+
+	/**
 	 * Clear the product statuses cache and delete stale issues.
 	 *
 	 * @since x.x.x
 	 */
 	public function clear_product_statuses_cache_and_issues(): void {
 		$this->delete_stale_issues();
+		$this->delete_stale_mc_statuses();
 		$this->delete_product_statuses_count_intermediate_data();
 	}
 

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -248,4 +248,23 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 		do_action( self::PROCESS_ITEM_HOOK, [] );
 	}
+
+	public function test_get_failure_rate_message() {
+		$this->merchant_center_service->method( 'is_connected' )
+		->willReturn( true );
+
+		$this->monitor->expects( $this->exactly( 1 ) )->method( 'validate_failure_rate' )
+		->willThrowException( new JobException( 'The "update_merchant_product_statuses" job was stopped because its failure rate is above the allowed threshold.' ) );
+
+		$this->assertEquals( 'The "update_merchant_product_statuses" job was stopped because its failure rate is above the allowed threshold.', $this->job->get_failure_rate_message() );
+	}
+
+	public function test_get_with_no_failure_rate_message() {
+		$this->merchant_center_service->method( 'is_connected' )
+		->willReturn( true );
+
+		$this->monitor->expects( $this->exactly( 1 ) )->method( 'validate_failure_rate' );
+
+		$this->assertNull( $this->job->get_failure_rate_message() );
+	}
 }

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -334,6 +334,18 @@ class MerchantStatusesTest extends UnitTest {
 		$this->update_merchant_product_statuses_job->expects( $this->exactly( 1 ) )
 		->method( 'schedule' );
 
+		$this->update_all_product_job->expects( $this->exactly( 1 ) )
+		->method( 'can_schedule' )
+		->with( null )
+		->willReturn( true );
+
+		$this->delete_all_product_job->expects( $this->exactly( 1 ) )
+		->method( 'can_schedule' )
+		->with( null )
+		->willReturn( true );
+
+		$this->transients->expects( $this->exactly( 1 ) )->method( 'delete' )->with( Transients::MC_STATUSES );
+
 		$this->update_merchant_product_statuses_job->expects( $this->exactly( 2 ) )
 		->method( 'is_scheduled' );
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -444,6 +444,44 @@ class MerchantStatusesTest extends UnitTest {
 		);
 	}
 
+	public function test_get_product_statistics_with_failure_rate() {
+		$this->merchant_center_service->expects( $this->once() )
+		->method( 'is_connected' )
+		->willReturn( true );
+
+		$this->transients->expects( $this->exactly( 2 ) )
+		->method( 'get' )
+		->willReturn(
+			null
+		);
+
+		$this->update_merchant_product_statuses_job->expects( $this->exactly( 1 ) )
+		->method( 'get_failure_rate_message' )->willReturn( 'Failure rate!' );
+
+		$this->update_merchant_product_statuses_job->expects( $this->exactly( 1 ) )
+		->method( 'schedule' );
+
+		$this->update_merchant_product_statuses_job->expects( $this->exactly( 1 ) )
+		->method( 'is_scheduled' )->willReturn( false );
+
+		$product_statistics = $this->merchant_statuses->get_product_statistics();
+
+		$this->assertEquals(
+			null,
+			$product_statistics['statistics']
+		);
+
+		$this->assertEquals(
+			false,
+			$product_statistics['loading']
+		);
+
+		$this->assertEquals(
+			'Failure rate!',
+			$product_statistics['error']
+		);
+	}
+
 	public function test_process_product_statuses() {
 		$product_1        = WC_Helper_Product::create_simple_product();
 		$product_2        = WC_Helper_Product::create_simple_product();

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -456,7 +456,7 @@ class MerchantStatusesTest extends UnitTest {
 		);
 
 		$this->update_merchant_product_statuses_job->expects( $this->exactly( 1 ) )
-		->method( 'get_failure_rate_message' )->willReturn( 'Failure rate!' );
+		->method( 'get_failure_rate_message' )->willReturn( 'The scheduled job has been paused due to a high failure rate.' );
 
 		$this->update_merchant_product_statuses_job->expects( $this->exactly( 1 ) )
 		->method( 'schedule' );
@@ -477,7 +477,7 @@ class MerchantStatusesTest extends UnitTest {
 		);
 
 		$this->assertEquals(
-			'Failure rate!',
+			'The scheduled job has been paused due to a high failure rate.',
 			$product_statistics['error']
 		);
 	}

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -996,6 +996,7 @@ class MerchantStatusesTest extends UnitTest {
 
 		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_stale' )->with( $this->merchant_statuses->get_cache_created_time() );
 		$this->options->expects( $this->once() )->method( 'delete' )->with( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
+		$this->product_meta_query_helper->expects($this->once())->method('delete_meta_key')->with(ProductMetaHandler::KEY_MC_STATUS);
 		$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 	}
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -987,16 +987,10 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_statuses->clear_cache();
 	}
 
-	protected function test_clear_product_statuses_cache_and_issues() {
-		$this->transients->expects( $this->exactly( 1 ) )
-		->method( 'delete' )
-		->with(
-			TransientsInterface::MC_STATUSES
-		);
-
+	public function test_clear_product_statuses_cache_and_issues() {
 		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_stale' )->with( $this->merchant_statuses->get_cache_created_time() );
 		$this->options->expects( $this->once() )->method( 'delete' )->with( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
-		$this->product_meta_query_helper->expects($this->once())->method('delete_meta_key')->with(ProductMetaHandler::KEY_MC_STATUS);
+		$this->product_meta_query_helper->expects( $this->once() )->method( 'delete_all_values' )->with( ProductMetaHandler::KEY_MC_STATUS );
 		$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146 & https://github.com/woocommerce/google-listings-and-ads/issues/2250

Now that the product statistics are calculated using an AS job, there's a possibility of throwing errors during the calculation process. If an error occurs, we need to notify the merchant and provide them with the option to retry the calculation.

This PR adds:
- The UI to inform the merchant about the error.
- Gives the option to re-try/refresh the stats if an error happens.
- Stops the UI of polling the results if the AS job failure rate is bigger than the threshold.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

### Backend job completed with an error message:

1. Simulate an error, adding the following code:

```
  $this->mc_statuses['error']      = 'My error';
  $this->mc_statuses['statistics'] = null;
  return $this->mc_statuses;
```
After this line: https://github.com/woocommerce/google-listings-and-ads/blob/065ff6dd3ae43beb4eb5118a1d2236c230f66124/src/MerchantCenter/MerchantStatuses.php#L140

2. Go to `admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed` and check that it shows the error.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/015d65eb-72d6-4004-9841-4c7613d9e617)

3. Delete the lines you inserted in step 1, open the Dev console (Netowork tab), then click "Click to retry."
4. Check that it sends a `GET wc/gla/mc/product-statistics/refresh` request.
5. The AppSpinner in the stats will be visible, and every 15 seconds, the UI will attempt to fetch the results. Once the calculation is finished, the stats should be displayed.

### AS Job - Failure rate is bigger than the threshold:

1. Add the following code `throw new \Exception( 'Error');` after this line:

https://github.com/woocommerce/google-listings-and-ads/blob/065ff6dd3ae43beb4eb5118a1d2236c230f66124/src/Jobs/UpdateMerchantProductStatuses.php#L85-L87

2. Make a request to `GET wc/gla/mc/product-statistics/refresh`
3. Go to WC -> Status -> Action Scheduler -> Search for `update_merchant_product_statuses`
4. Wait until it shows `The "update_merchant_product_statuses" job was stopped because its failure rate is above the allowed threshold.`
5. Go to `admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed`, and see that it shows the error:
![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/315d3e6c-37da-465e-bad4-240f4145677b)
6. Clicking "Click to retry" will simply display the error again if the failure rate remains high. For testing purposes, you can change the failure rate timeframe using the below filter and remove the Exception added in step 1.

```
add_filter( 'woocommerce_gla_job_failure_timeframe', function(){
	return 1;
} );
```
Maybe as an improvement, we could consider displaying a message like "Retry after X time." However, this would require additional work to calculate the remaining time based on the average timeframe and threshold and I am not sure about the frequency of this error neither.

7. See that a request is made to `GET wc/gla/mc/product-statistics/refresh` and the stats will be available after the jobs are completed. 


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
