### PR TITLE
API PULL - Add Notices inside GMC Card in Settings

### DIFF
--- a/js/src/components/app-notice/index.js
+++ b/js/src/components/app-notice/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
+
+/**
+ * Renders a Notice component with extra props.
+ *
+ * It supports all the props from @wordpress/components - Notice Component
+ *
+ * ## Usage
+ *
+ * ```jsx
+ * <AppNotice >
+ * 		My Notice
+ * </AppButton>
+ * ```
+ *
+ * @param {*} props Props to be forwarded to {@link Notice}.
+ */
+const AppNotice = ( props ) => {
+	const { className, ...rest } = props;
+	const classes = [ 'app-notice', className ];
+	return <Notice className={ classnames( ...classes ) } { ...rest } />;
+};
+
+export default AppNotice;

--- a/js/src/components/app-notice/index.scss
+++ b/js/src/components/app-notice/index.scss
@@ -1,0 +1,6 @@
+.app-notice {
+	border: 0;
+	font-size: $helptext-font-size;
+	margin: 0 var(--large-gap) var(--main-gap);
+	padding: $grid-unit-20;
+}

--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -14,7 +14,7 @@ import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 
 /**
- * Button to initiate auth process for WC Rest API
+ * Button to initiate auth process for WP Rest API
  *
  * @param {Object} params The component params
  * @param {string} params.buttonText The text to show in the enable button

--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -17,12 +17,9 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
  * Button to initiate auth process for WP Rest API
  *
  * @param {Object} params The component params
- * @param {string} params.buttonText The text to show in the enable button
  * @return {JSX.Element} The button.
  */
-const EnableNewProductSyncButton = ( {
-	buttonText = __( 'Enable it', 'google-listings-and-ads' ),
-} ) => {
+const EnableNewProductSyncButton = ( params ) => {
 	const { createNotice } = useDispatchCoreNotices();
 
 	const nextPageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';
@@ -45,9 +42,7 @@ const EnableNewProductSyncButton = ( {
 	};
 
 	return (
-		<AppButton isSecondary onClick={ handleEnableClick }>
-			{ buttonText }
-		</AppButton>
+		<AppButton isSecondary onClick={ handleEnableClick } { ...params } />
 	);
 };
 

--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '.~/components/app-button';
+import { glaData } from '.~/constants';
+import { API_NAMESPACE } from '.~/data/constants';
+import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+
+/**
+ * Button to initiate auth process for WC Rest API
+ *
+ * @param {Object} params The component params
+ * @param {string} params.buttonText The text to show in the enable button
+ * @return {JSX.Element} The button.
+ */
+const EnableNewProductSyncButton = ( {
+	buttonText = __( 'Enable it', 'google-listings-and-ads' ),
+} ) => {
+	const { createNotice } = useDispatchCoreNotices();
+
+	const nextPageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';
+	const query = { next_page_name: nextPageName };
+	const path = addQueryArgs( `${ API_NAMESPACE }/rest-api/authorize`, query );
+	const [ fetchRestAPIAuthorize ] = useApiFetchCallback( { path } );
+	const handleEnableClick = async () => {
+		try {
+			const d = await fetchRestAPIAuthorize();
+			window.location.href = d.auth_url;
+		} catch ( error ) {
+			createNotice(
+				'error',
+				__(
+					'Unable to enable new product sync. Please try again later.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+	};
+
+	return (
+		<AppButton isSecondary onClick={ handleEnableClick }>
+			{ buttonText }
+		</AppButton>
+	);
+};
+
+export default EnableNewProductSyncButton;

--- a/js/src/components/enable-new-product-sync-notice.js
+++ b/js/src/components/enable-new-product-sync-notice.js
@@ -4,17 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import { glaData } from '.~/constants';
-import { API_NAMESPACE } from '.~/data/constants';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
+import EnableNewProductSyncButton from '.~/components/enable-new-product-sync-button';
 
 /**
  * Shows info {@link Notice}
@@ -28,32 +23,10 @@ const EnableNewProductSyncNotice = () => {
 		googleMCAccount,
 	} = useGoogleMCAccount();
 
-	const { createNotice } = useDispatchCoreNotices();
-
-	const nextPageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';
-	const query = { next_page_name: nextPageName };
-	const path = addQueryArgs( `${ API_NAMESPACE }/rest-api/authorize`, query );
-	const [ fetchRestAPIAuthorize ] = useApiFetchCallback( { path } );
-	const handleEnableClick = async () => {
-		try {
-			const d = await fetchRestAPIAuthorize();
-			window.location.href = d.auth_url;
-		} catch ( error ) {
-			createNotice(
-				'error',
-				__(
-					'Unable to enable new product sync. Please try again later.',
-					'google-listings-and-ads'
-				)
-			);
-		}
-	};
-
 	// Do not render if already switch to new product sync.
-	// TODO: also check if the new product sync feature flag is enabled.
 	if (
 		! hasGoogleMCAccountFinishedResolution ||
-		googleMCAccount.wpcom_rest_api_status === 'approved'
+		googleMCAccount.wpcom_rest_api_status
 	) {
 		return null;
 	}
@@ -66,9 +39,7 @@ const EnableNewProductSyncNotice = () => {
 					'google-listings-and-ads'
 				),
 				{
-					enableButton: (
-						<AppButton isTertiary onClick={ handleEnableClick } />
-					),
+					enableButton: <EnableNewProductSyncButton />,
 				}
 			) }
 		</Notice>

--- a/js/src/components/enable-new-product-sync-notice.js
+++ b/js/src/components/enable-new-product-sync-notice.js
@@ -39,7 +39,12 @@ const EnableNewProductSyncNotice = () => {
 					'google-listings-and-ads'
 				),
 				{
-					enableButton: <EnableNewProductSyncButton />,
+					enableButton: (
+						<EnableNewProductSyncButton
+							eventName="gla_enable_product_sync_click"
+							eventProps={ { context: 'banner' } }
+						/>
+					),
 				}
 			) }
 		</Notice>

--- a/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
@@ -17,6 +17,8 @@ import { API_NAMESPACE } from '.~/data/constants';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import { useAppDispatch } from '.~/data';
+import EnableNewProductSyncButton from '.~/components/enable-new-product-sync-button';
+import AppNotice from '.~/components/app-notice';
 
 /**
  * Clicking on the "connect to a different Google Merchant Center account" button.
@@ -32,10 +34,12 @@ import { useAppDispatch } from '.~/data';
  * @param {Object} props React props.
  * @param {{ id: number }} props.googleMCAccount A data payload object containing the user's Google Merchant Center account ID.
  * @param {boolean} [props.hideAccountSwitch=false] Indicate whether hide the account switch block at the card footer.
+ * @param {boolean} [props.hideNotificationService=true] Indicate whether hide the enable Notification service block at the card footer.
  */
 const ConnectedGoogleMCAccountCard = ( {
 	googleMCAccount,
 	hideAccountSwitch = false,
+	hideNotificationService = false,
 } ) => {
 	const { createNotice, removeNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
@@ -45,6 +49,14 @@ const ConnectedGoogleMCAccountCard = ( {
 			path: `${ API_NAMESPACE }/mc/connection`,
 			method: 'DELETE',
 		} );
+
+	const [
+		fetchDisableNotifications,
+		{ loading: loadingDisableNotifications },
+	] = useApiFetchCallback( {
+		path: `${ API_NAMESPACE }/rest-api/authorize`,
+		method: 'DELETE',
+	} );
 
 	const domain = new URL( getSetting( 'homeUrl' ) ).host;
 
@@ -85,6 +97,41 @@ const ConnectedGoogleMCAccountCard = ( {
 		removeNotice( notice.id );
 	};
 
+	const disableNotifications = async () => {
+		const { notice } = await createNotice(
+			'info',
+			__(
+				'Disabling the new Product Sync feature, please wait…',
+				'google-listings-and-ads'
+			)
+		);
+
+		try {
+			await fetchDisableNotifications();
+			invalidateResolution( 'getGoogleMCAccount', [] );
+		} catch ( error ) {
+			createNotice(
+				'error',
+				__(
+					'Unable to disconnect your Google Merchant Center account. Please try again later.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+
+		removeNotice( notice.id );
+	};
+
+	const showDisconnectNotificationsButton =
+		! hideNotificationService &&
+		googleMCAccount.wpcom_rest_api_status === 'approved';
+
+	const showErrorNotificationsNotice =
+		! hideNotificationService &&
+		googleMCAccount.wpcom_rest_api_status === 'error';
+
+	const showFooter = ! hideAccountSwitch || showDisconnectNotificationsButton;
+
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE_MERCHANT_CENTER }
@@ -94,20 +141,64 @@ const ConnectedGoogleMCAccountCard = ( {
 				domain,
 				googleMCAccount.id
 			) }
-			indicator={ <ConnectedIconLabel /> }
-		>
-			{ ! hideAccountSwitch && (
-				<Section.Card.Footer>
-					<AppButton
-						isLink
-						disabled={ loadingGoogleMCDisconnect }
-						text={ __(
-							'Or, connect to a different Google Merchant Center account',
+			indicator={
+				showErrorNotificationsNotice ? (
+					<EnableNewProductSyncButton
+						buttonText={ __(
+							'Grant access',
 							'google-listings-and-ads'
 						) }
-						eventName="gla_mc_account_connect_different_account_button_click"
-						onClick={ handleSwitch }
 					/>
+				) : (
+					<ConnectedIconLabel />
+				)
+			}
+		>
+			{ showDisconnectNotificationsButton && (
+				<AppNotice status="success" isDismissible={ false }>
+					{ __(
+						'Google has been granted access to fetch your product data.',
+						'google-listings-and-ads'
+					) }
+				</AppNotice>
+			) }
+
+			{ showErrorNotificationsNotice && (
+				<AppNotice status="warning" isDismissible={ false }>
+					{ __(
+						'It was a problem granting access to Google for fetching your products.',
+						'google-listings-and-ads'
+					) }
+				</AppNotice>
+			) }
+
+			{ showFooter && (
+				<Section.Card.Footer>
+					{ ! hideAccountSwitch && (
+						<AppButton
+							isLink
+							disabled={ loadingGoogleMCDisconnect }
+							text={ __(
+								'Or, connect to a different Google Merchant Center account',
+								'google-listings-and-ads'
+							) }
+							eventName="gla_mc_account_connect_different_account_button_click"
+							onClick={ handleSwitch }
+						/>
+					) }
+					{ showDisconnectNotificationsButton && (
+						<AppButton
+							isDestructive
+							isLink
+							disabled={ loadingDisableNotifications }
+							text={ __(
+								'Disable product data fetch',
+								'google-listings-and-ads'
+							) }
+							eventName="gla_mc_account_disconnect_wpcom_rest_api"
+							onClick={ disableNotifications }
+						/>
+					) }
 				</Section.Card.Footer>
 			) }
 		</AccountCard>

--- a/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
@@ -147,10 +147,9 @@ const ConnectedGoogleMCAccountCard = ( {
 			indicator={
 				showErrorNotificationsNotice ? (
 					<EnableNewProductSyncButton
-						buttonText={ __(
-							'Grant access',
-							'google-listings-and-ads'
-						) }
+						text={ __( 'Grant access', 'google-listings-and-ads' ) }
+						eventName="gla_enable_product_sync_click"
+						eventProps={ { context: 'mc_card' } }
 					/>
 				) : (
 					<ConnectedIconLabel />

--- a/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
@@ -113,7 +113,7 @@ const ConnectedGoogleMCAccountCard = ( {
 			createNotice(
 				'error',
 				__(
-					'Unable to disconnect your Google Merchant Center account. Please try again later.',
+					'Unable to disable new product sync. Please try again later.',
 					'google-listings-and-ads'
 				)
 			);
@@ -122,13 +122,16 @@ const ConnectedGoogleMCAccountCard = ( {
 		removeNotice( notice.id );
 	};
 
+	// Show the button if the status is "approved" and the Notification Service is not hidden.
 	const showDisconnectNotificationsButton =
 		! hideNotificationService &&
 		googleMCAccount.wpcom_rest_api_status === 'approved';
 
+	// Show the error if the status is set but is not "approved" and the Notification Service is not hidden.
 	const showErrorNotificationsNotice =
 		! hideNotificationService &&
-		googleMCAccount.wpcom_rest_api_status === 'error';
+		googleMCAccount.wpcom_rest_api_status &&
+		googleMCAccount.wpcom_rest_api_status !== 'approved';
 
 	const showFooter = ! hideAccountSwitch || showDisconnectNotificationsButton;
 
@@ -166,7 +169,7 @@ const ConnectedGoogleMCAccountCard = ( {
 			{ showErrorNotificationsNotice && (
 				<AppNotice status="warning" isDismissible={ false }>
 					{ __(
-						'It was a problem granting access to Google for fetching your products.',
+						'There was an issue granting access to Google for fetching your products.',
 						'google-listings-and-ads'
 					) }
 				</AppNotice>

--- a/js/src/components/google-mc-account-card/google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/google-mc-account-card.js
@@ -23,7 +23,12 @@ const GoogleMCAccountCard = () => {
 		return <NonConnected />;
 	}
 
-	return <ConnectedGoogleMCAccountCard googleMCAccount={ googleMCAccount } />;
+	return (
+		<ConnectedGoogleMCAccountCard
+			hideNotificationService
+			googleMCAccount={ googleMCAccount }
+		/>
+	);
 };
 
 export default GoogleMCAccountCard;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "google-listings-and-ads",
-			"version": "2.6.2",
+			"version": "2.5.18",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@woocommerce/components": "^10.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "google-listings-and-ads",
-			"version": "2.5.18",
+			"version": "2.6.2",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@woocommerce/components": "^10.3.0",

--- a/src/API/Site/Controllers/DisconnectController.php
+++ b/src/API/Site/Controllers/DisconnectController.php
@@ -46,6 +46,7 @@ class DisconnectController extends BaseController {
 				'mc/connection',
 				'google/connect',
 				'jetpack/connect',
+				'rest-api/authorize',
 			];
 
 			$errors    = [];

--- a/src/API/Site/Controllers/RestAPI/AuthController.php
+++ b/src/API/Site/Controllers/RestAPI/AuthController.php
@@ -45,13 +45,13 @@ class AuthController extends BaseController {
 	/**
 	 * AuthController constructor.
 	 *
-	 * @param RESTServer   $server
-	 * @param OAuthService $oauth_service
+	 * @param RESTServer     $server
+	 * @param OAuthService   $oauth_service
 	 * @param AccountService $account_service
 	 */
 	public function __construct( RESTServer $server, OAuthService $oauth_service, AccountService $account_service ) {
 		parent::__construct( $server );
-		$this->oauth_service = $oauth_service;
+		$this->oauth_service   = $oauth_service;
 		$this->account_service = $account_service;
 	}
 

--- a/src/API/Site/Controllers/RestAPI/AuthController.php
+++ b/src/API/Site/Controllers/RestAPI/AuthController.php
@@ -68,12 +68,6 @@ class AuthController extends BaseController {
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_auth_params(),
 				],
-			]
-		);
-
-		$this->register_route(
-			'rest-api/authorize',
-			[
 				[
 					'methods'             => TransportMethods::DELETABLE,
 					'callback'            => $this->delete_authorize_callback(),

--- a/src/API/Site/Controllers/RestAPI/AuthController.php
+++ b/src/API/Site/Controllers/RestAPI/AuthController.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestA
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use WP_REST_Request as Request;
@@ -25,6 +26,11 @@ class AuthController extends BaseController {
 	protected $oauth_service;
 
 	/**
+	 * @var AccountService
+	 */
+	protected $account_service;
+
+	/**
 	 * Mapping between the client page name and its path.
 	 * The first value is also used as a default,
 	 * and changing the order of keys/values may affect things below.
@@ -41,10 +47,12 @@ class AuthController extends BaseController {
 	 *
 	 * @param RESTServer   $server
 	 * @param OAuthService $oauth_service
+	 * @param AccountService $account_service
 	 */
-	public function __construct( RESTServer $server, OAuthService $oauth_service ) {
+	public function __construct( RESTServer $server, OAuthService $oauth_service, AccountService $account_service ) {
 		parent::__construct( $server );
 		$this->oauth_service = $oauth_service;
+		$this->account_service = $account_service;
 	}
 
 	/**
@@ -59,6 +67,17 @@ class AuthController extends BaseController {
 					'callback'            => $this->get_authorize_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_auth_params(),
+				],
+			]
+		);
+
+		$this->register_route(
+			'rest-api/authorize',
+			[
+				[
+					'methods'             => TransportMethods::DELETABLE,
+					'callback'            => $this->delete_authorize_callback(),
+					'permission_callback' => $this->get_permission_callback(),
 				],
 			]
 		);
@@ -81,6 +100,22 @@ class AuthController extends BaseController {
 				];
 
 				return $this->prepare_item_for_response( $response, $request );
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function for the delete authorization request.
+	 *
+	 * @return callable
+	 */
+	protected function delete_authorize_callback(): callable {
+		return function ( Request $request ) {
+			try {
+				$this->account_service->reset_wpcom_api_authorization();
+				return $this->prepare_item_for_response( [], $request );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -669,6 +669,14 @@ class ConnectionTest implements Service, Registerable {
 								</p>
 							</td>
 						</tr>
+						<tr>
+							<th>Disconnect WP API Product SYNC:</th>
+							<td>
+								<p>
+									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'disconnect-wp-api' ), $url ), 'disconnect-wp-api' ) ); ?>">Disconnect</a>
+								</p>
+							</td>
+						</tr>
 					</table>
 					<?php wp_nonce_field( 'partner-notification' ); ?>
 					<input name="page" value="connection-test-admin-page" type="hidden" />
@@ -773,6 +781,11 @@ class ConnectionTest implements Service, Registerable {
 			}
 
 			return;
+		}
+
+		if ( 'disconnect-wp-api' === $_GET['action'] && check_admin_referer( 'disconnect-wp-api' ) ) {
+			$request = new Request( 'DELETE', '/wc/gla/rest-api/authorize' );
+			$this->send_rest_request( $request );
 		}
 
 		if ( 'wcs-auth-test' === $_GET['action'] && check_admin_referer( 'wcs-auth-test' ) ) {

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -640,9 +640,21 @@ class ConnectionTest implements Service, Registerable {
 			<hr />
 
 			<?php if ( $blog_token ) { ?>
+				<?php
+				  $wp_api_status = $this->container->get( OptionsInterface::class )->get( OptionsInterface::WPCOM_REST_API_STATUS );
+				?>
 				<h2 class="title">Partner API Pull Integration</h2>
 				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
 					<table class="form-table" role="presentation">
+						<tr>
+							<th><label>WPCOM REST API Status:</label></th>
+							<td>
+								<p>
+									<code><?php echo $wp_api_status ?? 'NOT SET'; ?></code>
+									<?php if ( $wp_api_status === 'approved' ) { ?> <a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'disconnect-wp-api' ), $url ), 'disconnect-wp-api' ) ); ?>">Disconnect</a> <?php }  ?>
+								</p>
+							</td>
+						</tr>
 						<tr>
 							<th>Send partner notification request to WPCOM:</th>
 							<td>
@@ -666,14 +678,6 @@ class ConnectionTest implements Service, Registerable {
 										</select>
 									</label>
 									<button class="button">Send Notification</button>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<th>Disconnect WP API Product SYNC:</th>
-							<td>
-								<p>
-									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'disconnect-wp-api' ), $url ), 'disconnect-wp-api' ) ); ?>">Disconnect</a>
 								</p>
 							</td>
 						</tr>

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -140,7 +140,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( AttributeMappingCategoriesController::class );
 		$this->share( AttributeMappingSyncerController::class, ProductSyncStats::class );
 		$this->share( TourController::class );
-		$this->share( RestAPIAuthController::class, OAuthService::class );
+		$this->share( RestAPIAuthController::class, OAuthService::class, MerchantAccountService::class );
 	}
 
 	/**

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -222,7 +222,7 @@ class AccountService implements OptionsAwareInterface, Service {
 		$status = [
 			'id'                    => $id,
 			'status'                => $id ? 'connected' : 'disconnected',
-			'wpcom_rest_api_status' => $wpcom_rest_api_status === 'approved' ? 'approved' : 'disapproved',
+			'wpcom_rest_api_status' => $wpcom_rest_api_status,
 		];
 
 		$incomplete = $this->state->last_incomplete_step();
@@ -491,5 +491,14 @@ class AccountService implements OptionsAwareInterface, Service {
 		}
 
 		return new ExceptionWithResponseData( $message, $code ?: 400, null, $data );
+	}
+
+	/**
+	 * Delete the option regarding WPCOM authorization
+	 *
+	 * @return bool
+	 */
+	public function reset_wpcom_api_authorization(): bool {
+		return $this->options->delete( OptionsInterface::WPCOM_REST_API_STATUS );
 	}
 }

--- a/tests/Unit/API/Site/Controllers/RestAPI/AuthControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/RestAPI/AuthControllerTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\AuthController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
@@ -19,6 +20,9 @@ class AuthControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|OAuthService $oauth_service */
 	protected $oauth_service;
 
+	/** @var MockObject|AccountService $oauth_service */
+	protected $account_service;
+
 	/** @var AuthController $controller */
 	protected $controller;
 
@@ -27,8 +31,9 @@ class AuthControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->oauth_service = $this->createMock( OAuthService::class );
-		$this->controller    = new AuthController( $this->server, $this->oauth_service );
+		$this->oauth_service   = $this->createMock( OAuthService::class );
+		$this->account_service = $this->createMock( AccountService::class );
+		$this->controller      = new AuthController( $this->server, $this->oauth_service, $this->account_service );
 		$this->controller->register();
 	}
 
@@ -40,13 +45,12 @@ class AuthControllerTest extends RESTControllerUnitTest {
 		$expected_auth_url .= '&response_type=code';
 		$expected_auth_url .= '&scope=wc-partner-access';
 		$expected_auth_url .= '&state=base64_encoded_string';
-		$expected_auth_url  = $expected_auth_url;
 
 		$this->oauth_service->expects( $this->once() )
 			->method( 'get_auth_url' )
 			->willReturn( $expected_auth_url );
 
-		$response = $this->do_request( self::ROUTE_AUTHORIZE, 'GET' );
+		$response = $this->do_request( self::ROUTE_AUTHORIZE );
 		$data     = $response->get_data();
 
 		$this->assertEquals(
@@ -71,7 +75,7 @@ class AuthControllerTest extends RESTControllerUnitTest {
 			->method( 'get_auth_url' )
 			->willThrowException( new Exception( 'error', 400 ) );
 
-		$response = $this->do_request( self::ROUTE_AUTHORIZE, 'GET' );
+		$response = $this->do_request( self::ROUTE_AUTHORIZE );
 
 		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
 		$this->assertEquals( 400, $response->get_status() );

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -686,7 +686,7 @@ class AccountServiceTest extends UnitTest {
 				'id'                    => self::TEST_ACCOUNT_ID,
 				'status'                => 'incomplete',
 				'step'                  => 'verify',
-				'wpcom_rest_api_status' => 'disapproved',
+				'wpcom_rest_api_status' => null,
 			],
 			$this->account->get_connected_status()
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR enables some info Notices inside the GMC card under settings depending on the status of WP API Auth Grant 

This PR does some adjustments as:

- Create a component for the Button for initialize the Auth process
- Create a  success notice and a disable link in the GMC Card when the status is "approved" 
- Create a warning notice and a button to initialize the auth process when the status is "error"
- Adapt some Notice styles creating a component (I used the 10Up styles in https://github.com/woocommerce/google-listings-and-ads/pull/2270/files#diff-3034ade2c4e48a4e528de03c43bc15f68606bf48b4fc7e0537668f3eedb49633)

### Screenshots:

When status saved in `gla_wpcom_rest_api_status`  is empty

https://github.com/woocommerce/google-listings-and-ads/assets/5908855/431e521f-58ba-4c60-91e4-3fbcdb1afdea

When status saved in `gla_wpcom_rest_api_status`  is "approved"

https://github.com/woocommerce/google-listings-and-ads/assets/5908855/c998deef-d20d-420b-93db-005ba32f7c4d

When status saved in `gla_wpcom_rest_api_status`  is "error"

https://github.com/woocommerce/google-listings-and-ads/assets/5908855/99307909-f704-4512-8f14-787b719be2fd

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this PR and be sure `gla_wpcom_rest_api_status` is empty
2. Go to Settings and see the banner at the top (this banner was not touched, its for the parent PR)
3. Check the GMC card is as always
4. Go to the database and add the `gla_wpcom_rest_api_status`  option with the value "approved"
5. Go to Settings and see there is NO banner at the top 
6. Check the GMC card and see a success message and a link for disable the feature
7. Click on that link
8. See a loading message at the bottom
9. When it finishes see the card as always and the banner at the top
10. Go to the database and add the `gla_wpcom_rest_api_status`  option with the value "error"
11. Go to Settings and see there is NO banner at the top 
12. Check the GMC card and see a warning message and a button for grant access
13. Click to the button, it does the same as the banner button


