### PR TITLE
Add E2E tests for the integration in Product Block Editor

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "release/**"
   pull_request:
+    branches:
+      - "release/**"
   workflow_dispatch:
     inputs:
       wp-rc-version:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - "release/**"
   pull_request:
-    branches:
-      - "release/**"
   workflow_dispatch:
     inputs:
       wp-rc-version:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "google-listings-and-ads",
-			"version": "2.6.2",
+			"version": "2.6.3",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@woocommerce/components": "^10.3.0",
@@ -42,7 +42,7 @@
 			"devDependencies": {
 				"@hapi/h2o2": "^9.1.0",
 				"@hapi/hapi": "^20.2.2",
-				"@playwright/test": "^1.33.0",
+				"@playwright/test": "^1.42.0",
 				"@testing-library/jest-dom": "^5.16.5",
 				"@testing-library/react": "^12.1.5",
 				"@testing-library/react-hooks": "^8.0.1",
@@ -4168,34 +4168,18 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
-			"integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
+			"integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*",
-				"playwright-core": "1.33.0"
+				"playwright": "1.42.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/@playwright/test/node_modules/playwright-core": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
-			"integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
-			"dev": true,
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			}
 		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -23142,6 +23126,36 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/playwright": {
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
+			"integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+			"dev": true,
+			"dependencies": {
+				"playwright-core": "1.42.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
+			"integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+			"dev": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/plur": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -31562,22 +31576,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
-			"integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
+			"integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*",
-				"fsevents": "2.3.2",
-				"playwright-core": "1.33.0"
-			},
-			"dependencies": {
-				"playwright-core": {
-					"version": "1.33.0",
-					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
-					"integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
-					"dev": true
-				}
+				"playwright": "1.42.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -45853,6 +45857,22 @@
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
 			"integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
+			"dev": true
+		},
+		"playwright": {
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
+			"integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+			"dev": true,
+			"requires": {
+				"fsevents": "2.3.2",
+				"playwright-core": "1.42.1"
+			}
+		},
+		"playwright-core": {
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
+			"integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
 			"dev": true
 		},
 		"plur": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	"devDependencies": {
 		"@hapi/h2o2": "^9.1.0",
 		"@hapi/hapi": "^20.2.2",
-		"@playwright/test": "^1.33.0",
+		"@playwright/test": "^1.42.0",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/react": "^12.1.5",
 		"@testing-library/react-hooks": "^8.0.1",

--- a/tests/e2e/bin/test-env-setup.sh
+++ b/tests/e2e/bin/test-env-setup.sh
@@ -22,3 +22,6 @@ wp-env run tests-cli wp option update blogname 'WooCommerce E2E Test Suite'
 
 echo -e 'Adding basic WooCommerce settings... \n'
 wp-env run tests-cli wp wc payment_gateway update cod --enabled=1 --user=admin
+
+echo -e 'Set the tour of product block editor to not display \n'
+wp-env run tests-cli wp option update woocommerce_block_product_tour_shown 'yes'

--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -13,52 +13,42 @@
 	"products": {
 		"simple": {
 			"name": "Simple product",
-			"regularPrice": 9.99
+			"type": "simple",
+			"regular_price": "9.99"
 		},
 		"variable": {
-			"name": "Variable Product with Three Attributes",
-			"defaultAttributes": [
+			"name": "Variable product",
+			"type": "variable",
+			"default_attributes": [
 				{
-					"id": 0,
 					"name": "Size",
 					"option": "Medium"
 				},
 				{
-					"id": 0,
 					"name": "Colour",
 					"option": "Blue"
 				}
 			],
 			"attributes": [
 				{
-					"id": 0,
 					"name": "Colour",
-					"isVisibleOnProductPage": true,
-					"isForVariations": true,
+					"visible": false,
+					"variation": true,
 					"options": [ "Red", "Green", "Blue" ],
-					"sortOrder": 0
+					"position": 0
 				},
 				{
-					"id": 0,
 					"name": "Size",
-					"isVisibleOnProductPage": true,
-					"isForVariations": true,
+					"visible": false,
+					"variation": true,
 					"options": [ "Small", "Medium", "Large" ],
-					"sortOrder": 0
-				},
-				{
-					"id": 0,
-					"name": "Logo",
-					"isVisibleOnProductPage": true,
-					"isForVariations": true,
-					"options": [ "Woo", "WordPress" ],
-					"sortOrder": 0
+					"position": 1
 				}
 			]
 		},
 		"variations": [
 			{
-				"regularPrice": "19.99",
+				"regular_price": "19.99",
 				"attributes": [
 					{
 						"name": "Size",
@@ -71,7 +61,7 @@
 				]
 			},
 			{
-				"regularPrice": "18.99",
+				"regular_price": "18.99",
 				"attributes": [
 					{
 						"name": "Size",
@@ -84,7 +74,7 @@
 				]
 			},
 			{
-				"regularPrice": "17.99",
+				"regular_price": "17.99",
 				"attributes": [
 					{
 						"name": "Size",
@@ -96,30 +86,7 @@
 					}
 				]
 			}
-		],
-		"grouped": {
-			"name": "Grouped Product with Three Children",
-			"groupedProducts": [
-				{
-					"name": "Base Unit",
-					"regularPrice": "29.99"
-				},
-				{
-					"name": "Add-on A",
-					"regularPrice": "11.95"
-				},
-				{
-					"name": "Add-on B",
-					"regularPrice": "18.97"
-				}
-			]
-		},
-		"external": {
-			"name": "External product",
-			"regularPrice": "24.99",
-			"buttonText": "Buy now",
-			"externalUrl": "https://wordpress.org/plugins/woocommerce"
-		}
+		]
 	},
 	"coupons": {
 		"percentage": {

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -21,7 +21,7 @@ import { createBlockShopPage } from '../../utils/block-page';
 import { getEventData, trackGtagEvent } from '../../utils/track-event';
 
 const config = require( '../../config/default' );
-const productPrice = config.products.simple.regularPrice;
+const productPrice = config.products.simple.regular_price;
 
 let simpleProductID;
 
@@ -171,7 +171,7 @@ test.describe( 'GTag events', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request );
-			expect( data.value ).toEqual( String( productPrice ) );
+			expect( data.value ).toEqual( productPrice );
 			expect( data.currency_code ).toEqual( 'USD' );
 		} );
 	} );
@@ -186,7 +186,7 @@ test.describe( 'GTag events', () => {
 
 		await event.then( ( request ) => {
 			const data = getEventData( request );
-			expect( data.value ).toEqual( String( productPrice ) );
+			expect( data.value ).toEqual( productPrice );
 			expect( data.ecomm_pagetype ).toEqual( 'purchase' );
 			expect( data.currency_code ).toEqual( 'USD' );
 			expect( data.country ).toEqual( 'US' );

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -256,6 +256,38 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
 	} );
 
+	test( 'Channel visibility is disabled when hiding in product catalog', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+
+		const { selection, help } = editorUtils.getChannelVisibility();
+
+		await editorUtils.clickPluginTab();
+		await expect( selection ).toBeEnabled();
+		await expect( selection ).toHaveValue( 'sync-and-show' );
+		await expect( help ).toHaveCount( 0 );
+
+		await editorUtils.clickTab( 'Organization' );
+		await page.getByLabel( 'Hide in product catalog' ).setChecked( true );
+		await editorUtils.save();
+
+		await editorUtils.clickPluginTab();
+		await expect( selection ).toBeDisabled();
+		await expect( selection ).toHaveValue( 'dont-sync-and-show' );
+		await expect( help ).toBeVisible();
+		await expect( help ).toContainText(
+			'This product cannot be shown on any channel because it is hidden from your store catalog.'
+		);
+
+		await editorUtils.clickTab( 'Organization' );
+		await page.getByLabel( 'Hide in product catalog' ).setChecked( false );
+		await editorUtils.save();
+
+		await editorUtils.clickPluginTab();
+		await expect( selection ).toBeEnabled();
+		await expect( help ).toHaveCount( 0 );
+	} );
+
 	test.afterAll( async () => {
 		await editorUtils.toggleBlockFeature( page, false );
 		await api.clearOnboardedMerchant();

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -640,6 +640,47 @@ test.describe( 'Product Block Editor integration', () => {
 		}
 	} );
 
+	test( 'Save product attributes to variation product', async () => {
+		await editorUtils.gotoEditVariableProductPage();
+		await editorUtils.gotoEditVariationProductPage();
+		await editorUtils.clickPluginTab();
+
+		/*
+		 * Since the testing of all attributes is already covered in the simple product test case above.
+		 * This case only tests a few key attributes to ensure the data saving works for variation product.
+		 */
+		const {
+			condition,
+			color,
+			multipack,
+			availabilityDate,
+			availabilityTime,
+		} = editorUtils.getAllProductAttributes();
+
+		const pairs = [
+			[ condition, 'new' ],
+			[ color, 'Cherry blossom' ],
+			[ multipack, '9999' ],
+			[ availabilityDate, '2024-02-29' ],
+			[ availabilityTime, '23:59' ],
+		];
+
+		for ( const [ attribute ] of pairs ) {
+			await expect( attribute ).toHaveValue( '' );
+		}
+
+		for ( const [ attribute, value ] of pairs ) {
+			await expect( attribute ).toHaveValue( '' );
+			await editorUtils.setAttributeValue( attribute, value );
+		}
+
+		await editorUtils.save();
+
+		for ( const [ attribute, value ] of pairs ) {
+			await expect( attribute ).toHaveValue( value );
+		}
+	} );
+
 	test.afterEach( async () => {
 		await page.unrouteAll();
 	} );

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -180,6 +180,82 @@ test.describe( 'Product Block Editor integration', () => {
 		}
 	} );
 
+	test( 'Check existence of fields for variable and variation products', async () => {
+		await editorUtils.gotoEditVariableProductPage();
+		await editorUtils.clickPluginTab();
+
+		const panel = page.getByRole( 'tabpanel' );
+
+		/*
+		 * 2 Sections for variable product
+		 */
+		await expect( editorUtils.getChannelVisibilityHeading() ).toBeVisible();
+		await expect( editorUtils.getProductAttributesHeading() ).toBeVisible();
+
+		/*
+		 * 3 <select> for variable product:
+		 * - Channel visibility
+		 * - Brand (dynamically changed to google-listings-and-ads/product-select-with-text-field)
+		 * - Adult content
+		 */
+		await expect( panel.getByRole( 'combobox' ) ).toHaveCount( 3 );
+
+		/*
+		 * 0 <input type="text|date|time"> for variable product.
+		 */
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 0 );
+
+		/*
+		 * 0 <input type="number"> for variable product.
+		 */
+		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 0 );
+
+		// ===============================
+		// Go to edit the first variation.
+		// ===============================
+		await editorUtils.gotoEditVariationProductPage();
+		await editorUtils.clickPluginTab();
+
+		/*
+		 * 1 Section for variation product
+		 */
+		await expect( editorUtils.getProductAttributesHeading() ).toBeVisible();
+		await expect( editorUtils.getChannelVisibilityHeading() ).toHaveCount(
+			0
+		);
+
+		/*
+		 * 7 <select> for variation product:
+		 * - Condition
+		 * - Gender
+		 * - Size system
+		 * - Size type
+		 * - Age group
+		 * - Is bundle
+		 * - Adult content
+		 */
+		await expect( panel.getByRole( 'combobox' ) ).toHaveCount( 7 );
+
+		/*
+		 * 8 <input type="text|date|time"> for variation product:
+		 * - GTIN
+		 * - MPN
+		 * - Size
+		 * - Color
+		 * - Material
+		 * - Pattern
+		 * - Availability date
+		 * - Availability time
+		 */
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 8 );
+
+		/*
+		 * 1 <input type="number"> for variation product:
+		 * - Multipack
+		 */
+		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
+	} );
+
 	test.afterAll( async () => {
 		await editorUtils.toggleBlockFeature( page, false );
 		await api.clearOnboardedMerchant();

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { expect, test, Page } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import * as api from '../../utils/api';
+import { getProductBlockEditorUtils } from '../../utils/product-editor';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+test.describe.configure( { mode: 'serial' } );
+
+test.describe( 'Product Block Editor integration', () => {
+	/**
+	 * @type {Page}
+	 */
+	let page = null;
+	let editorUtils = null;
+
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		editorUtils = getProductBlockEditorUtils( page );
+
+		await editorUtils.toggleBlockFeature( true );
+		await api.setOnboardedMerchant();
+	} );
+
+	test( 'Prompt to Get Started when not yet finished onboarding', async () => {
+		await api.clearOnboardedMerchant();
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.clickPluginTab();
+
+		const link = page.getByRole( 'link', { name: 'Get Started' } );
+
+		await expect( link ).toBeVisible();
+		await link.click();
+
+		await expect( page.getByRole( 'main' ) ).toContainText(
+			/Reach millions of shoppers with product listings on Google/i
+		);
+
+		// Resume the plugin to onboarded status so that the next test can carry over.
+		await api.setOnboardedMerchant();
+	} );
+
+	test.afterAll( async () => {
+		await editorUtils.toggleBlockFeature( page, false );
+		await api.clearOnboardedMerchant();
+		await page.close();
+	} );
+} );

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -427,6 +427,97 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( input ).toHaveValue( 'Cute Cat' );
 	} );
 
+	test( 'Custom block: Product date and time fields', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+		await editorUtils.clickPluginTab();
+
+		const { dateInput, timeInput, dateHelp, timeHelp } =
+			editorUtils.getDateAndTimeFields();
+
+		/*
+		 * Assert:
+		 * - The default values are empty strings
+		 */
+		await expect( dateInput ).toHaveValue( '' );
+		await expect( timeInput ).toHaveValue( '' );
+		await expect( dateHelp ).toHaveCount( 0 );
+		await expect( timeHelp ).toHaveCount( 0 );
+
+		/*
+		 * Assert:
+		 * - After entering an invalid date or time value, the help shows an error message
+		 * - Saving an invalid date or time value shows a failure notice
+		 *
+		 * Please note that this part needs to be run before successfully saving data,
+		 * otherwise it cannot simulate the invalid value status on the date or time input
+		 * via Playwright. It's probably because the React "Controlled Components" runs
+		 * a little differently in Playwright.
+		 */
+		await dateInput.pressSequentially( '9' );
+
+		await editorUtils.assertUnableSave();
+		await expect( dateHelp ).toBeVisible();
+		await expect( dateHelp ).toHaveText(
+			await editorUtils.evaluateValidationMessage( dateInput )
+		);
+
+		await dateInput.clear();
+
+		await timeInput.pressSequentially( '9' );
+
+		await editorUtils.assertUnableSave();
+		await expect( timeHelp ).toBeVisible();
+		await expect( timeHelp ).toHaveText(
+			await editorUtils.evaluateValidationMessage( timeInput )
+		);
+
+		await timeInput.clear();
+
+		/*
+		 * Assert:
+		 * - When valid values are entered, the help messages are not shown
+		 * - After saving, the field values remain the same
+		 */
+		await dateInput.fill( '2024-02-29' );
+		await timeInput.fill( '18:30' );
+
+		await expect( dateInput ).toHaveValue( '2024-02-29' );
+		await expect( timeInput ).toHaveValue( '18:30' );
+		await expect( dateHelp ).toHaveCount( 0 );
+		await expect( timeHelp ).toHaveCount( 0 );
+
+		await editorUtils.save();
+
+		await expect( dateInput ).toHaveValue( '2024-02-29' );
+		await expect( timeInput ).toHaveValue( '18:30' );
+		await expect( dateHelp ).toHaveCount( 0 );
+		await expect( timeHelp ).toHaveCount( 0 );
+
+		/*
+		 * Assert:
+		 * - It can enter only the date and leave the time empty
+		 */
+		await timeInput.clear();
+		await editorUtils.save();
+
+		await expect( dateInput ).toHaveValue( '2024-02-29' );
+		await expect( timeInput ).toHaveValue( '' );
+		await expect( timeHelp ).toHaveCount( 0 );
+
+		/*
+		 * Assert:
+		 * - It allows to save empty values
+		 */
+		await dateInput.clear();
+		await editorUtils.save();
+
+		await expect( dateInput ).toHaveValue( '' );
+		await expect( timeInput ).toHaveValue( '' );
+		await expect( dateHelp ).toHaveCount( 0 );
+		await expect( timeHelp ).toHaveCount( 0 );
+	} );
+
 	test.afterEach( async () => {
 		await page.unrouteAll();
 	} );

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -63,6 +63,123 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( pluginTab ).toHaveCount( 0 );
 	} );
 
+	test( 'Check existence and availability of fields for simple product', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.clickPluginTab();
+
+		const panel = page.getByRole( 'tabpanel' );
+
+		/*
+		 * 2 Sections
+		 */
+		await expect( editorUtils.getChannelVisibilityHeading() ).toBeVisible();
+		await expect( editorUtils.getProductAttributesHeading() ).toBeVisible();
+
+		/*
+		 * 9 <select>:
+		 * - Channel visibility
+		 * - Brand
+		 *   - This is dynamically changed from woocommerce/product-text-field
+		 *     to google-listings-and-ads/product-select-with-text-field.
+		 *   - Code ref: `AttributesForm::init_input`
+		 *   - E2E setup: 'woocommerce_gla_product_attribute_value_options_brand' filter in test-snippets.php
+		 * - Condition
+		 * - Gender
+		 * - Size system
+		 * - Size type
+		 * - Age group
+		 * - Is bundle
+		 * - Adult content
+		 */
+		await expect( panel.getByRole( 'combobox' ) ).toHaveCount( 9 );
+
+		/*
+		 * 8 <input type="text|date|time">:
+		 * - GTIN
+		 * - MPN
+		 * - Size
+		 * - Color
+		 * - Material
+		 * - Pattern
+		 * - Availability date
+		 * - Availability time
+		 */
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 8 );
+
+		/*
+		 * 1 <input type="number">:
+		 * - Multipack
+		 */
+		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
+
+		/*
+		 * 16 pairs of <label> and help icon buttons:
+		 * - GTIN
+		 * - MPN
+		 * - Brand
+		 * - Condition
+		 * - Gender
+		 * - Size
+		 * - Size system
+		 * - Size type
+		 * - Color
+		 * - Material
+		 * - Pattern
+		 * - Age group
+		 * - Multipack
+		 * - Is bundle
+		 * - Availability date
+		 *   Availability time has an invisible pair for layout alignment purpose
+		 * - Adult content
+		 */
+		await expect(
+			panel.locator( 'label' ).filter( { hasText: /\w+/ } )
+		).toHaveCount( 16 );
+
+		await expect(
+			panel.getByRole( 'button', { name: 'help' } )
+		).toHaveCount( 16 );
+
+		/*
+		 * Click the help icon to view the popover and its content for each type of field block
+		 * with the tuple of block name and containing text.
+		 */
+		const blocks = [
+			[
+				'woocommerce/product-text-field',
+				/global trade item number \(gtin\) for your item/i,
+			],
+			[
+				'google-listings-and-ads/product-select-with-text-field',
+				/brand of the product/i,
+			],
+			[
+				'google-listings-and-ads/product-select-field',
+				/condition or state of the item/i,
+			],
+			[
+				'google-listings-and-ads/product-date-time-field',
+				/date a preordered or backordered product becomes available for delivery/i,
+			],
+		];
+
+		for ( const [ name, expectedText ] of blocks ) {
+			await panel
+				.locator( `[data-type="${ name }"]` )
+				.first()
+				.getByRole( 'button', { name: 'help' } )
+				.click();
+
+			const popover = page.locator( '.components-popover:visible' );
+			await expect( popover ).toBeVisible();
+			await expect( popover ).toContainText( expectedText );
+
+			// To close popover
+			await editorUtils.clickPluginTab();
+			await expect( popover ).toHaveCount( 0 );
+		}
+	} );
+
 	test.afterAll( async () => {
 		await editorUtils.toggleBlockFeature( page, false );
 		await api.clearOnboardedMerchant();

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -45,6 +45,24 @@ test.describe( 'Product Block Editor integration', () => {
 		await api.setOnboardedMerchant();
 	} );
 
+	test( 'Hide plugin tab for unsupported product types', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+
+		const pluginTab = editorUtils.getPluginTab();
+
+		await expect( pluginTab ).toHaveCount( 1 );
+
+		await editorUtils.changeToGroupedProduct();
+		await expect( pluginTab ).toHaveCount( 0 );
+
+		await editorUtils.changeToStandardProduct();
+		await expect( pluginTab ).toHaveCount( 1 );
+
+		await editorUtils.changeToAffiliateProduct();
+		await expect( pluginTab ).toHaveCount( 0 );
+	} );
+
 	test.afterAll( async () => {
 		await editorUtils.toggleBlockFeature( page, false );
 		await api.clearOnboardedMerchant();

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -518,6 +518,51 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( timeHelp ).toHaveCount( 0 );
 	} );
 
+	test( 'Generic block transformation: Non-negative integer input field', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+		await editorUtils.clickPluginTab();
+
+		const { input, help } = editorUtils.getMultipackField();
+
+		await expect( input ).toHaveValue( '' );
+		await expect( help ).toHaveCount( 0 );
+
+		await input.fill( '-1' );
+
+		await editorUtils.assertUnableSave();
+		await expect( help ).toBeVisible();
+		await expect( help ).toHaveText(
+			await editorUtils.evaluateValidationMessage( input )
+		);
+
+		await input.fill( '9.5' );
+
+		await editorUtils.assertUnableSave();
+		await expect( help ).toBeVisible();
+		await expect( help ).toHaveText(
+			await editorUtils.evaluateValidationMessage( input )
+		);
+
+		await input.fill( '0' );
+		await editorUtils.save();
+
+		await expect( input ).toHaveValue( '0' );
+		await expect( help ).toHaveCount( 0 );
+
+		await input.fill( '100' );
+		await editorUtils.save();
+
+		await expect( input ).toHaveValue( '100' );
+		await expect( help ).toHaveCount( 0 );
+
+		await input.clear();
+		await editorUtils.save();
+
+		await expect( input ).toHaveValue( '' );
+		await expect( help ).toHaveCount( 0 );
+	} );
+
 	test.afterEach( async () => {
 		await page.unrouteAll();
 	} );

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -35,10 +35,9 @@ test.describe( 'Product Block Editor integration', () => {
 		const link = page.getByRole( 'link', { name: 'Get Started' } );
 
 		await expect( link ).toBeVisible();
-		await link.click();
-
-		await expect( page.getByRole( 'main' ) ).toContainText(
-			/Reach millions of shoppers with product listings on Google/i
+		await expect( link ).toHaveAttribute(
+			'href',
+			/\/wp-admin\/admin\.php\?page=wc-admin&path=\/google\/start/
 		);
 
 		// Resume the plugin to onboarded status so that the next test can carry over.

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -563,6 +563,83 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( help ).toHaveCount( 0 );
 	} );
 
+	test( 'Save all product attributes to simple product', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+		await editorUtils.clickPluginTab();
+
+		const {
+			gtin,
+			mpn,
+			brand,
+			condition,
+			gender,
+			size,
+			sizeSystem,
+			sizeType,
+			color,
+			material,
+			pattern,
+			ageGroup,
+			multipack,
+			isBundle,
+			availabilityDate,
+			availabilityTime,
+			adultContent,
+		} = editorUtils.getAllProductAttributes();
+
+		const pairs = [
+			[ gtin, '3234567890126' ],
+			[ mpn, 'GO12345OOGLE' ],
+			[ brand, 'e2e_test_woocommerce_brands' ],
+			[ condition, 'new' ],
+			[ gender, 'unisex' ],
+			[ size, 'Good for everybody' ],
+			[ sizeSystem, 'JP' ],
+			[ sizeType, 'regular' ],
+			[ color, 'Cherry blossom' ],
+			[ material, 'Titanium alloy' ],
+			[ pattern, 'Cyberpunk' ],
+			[ ageGroup, 'kids' ],
+			[ multipack, '9999' ],
+			[ isBundle, 'no' ],
+			[ availabilityDate, '2024-02-29' ],
+			[ availabilityTime, '23:59' ],
+			[ adultContent, 'no' ],
+		];
+
+		/*
+		 * Assert:
+		 * - All attributes are empty or default
+		 * - Save all attributes
+		 * - After saving, attribute values remain the same
+		 */
+		for ( const [ attribute, value ] of pairs ) {
+			await expect( attribute ).toHaveValue( '' );
+			await editorUtils.setAttributeValue( attribute, value );
+		}
+
+		await editorUtils.save();
+
+		for ( const [ attribute, value ] of pairs ) {
+			await expect( attribute ).toHaveValue( value );
+		}
+
+		/*
+		 * Assert:
+		 * - It allows to save all attributes to empty or default
+		 */
+		for ( const [ attribute ] of pairs ) {
+			await editorUtils.setAttributeValue( attribute, '' );
+		}
+
+		await editorUtils.save();
+
+		for ( const [ attribute ] of pairs ) {
+			await expect( attribute ).toHaveValue( '' );
+		}
+	} );
+
 	test.afterEach( async () => {
 		await page.unrouteAll();
 	} );

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -374,6 +374,59 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( issues ).toHaveCount( 0 );
 	} );
 
+	test( 'Custom block: Product select with text field', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+		await editorUtils.clickPluginTab();
+
+		const { selection, input } = editorUtils.getSelectWithTextField();
+
+		/*
+		 * Assert:
+		 * - The "Default" option is selected and the text field is not shown
+		 */
+		await expect( selection ).toHaveValue( '' );
+		await expect( input ).toHaveCount( 0 );
+
+		/*
+		 * Assert:
+		 * - When the "From WooCommerce Brands" option is selected, the text field is not shown
+		 * - After saving, the field value and state remain the same
+		 */
+		await selection.selectOption( 'e2e_test_woocommerce_brands' );
+		await expect( selection ).toHaveValue( 'e2e_test_woocommerce_brands' );
+		await expect( input ).toHaveCount( 0 );
+
+		await editorUtils.save();
+		await expect( selection ).toHaveValue( 'e2e_test_woocommerce_brands' );
+		await expect( input ).toHaveCount( 0 );
+
+		/*
+		 * Assert:
+		 * - When the "Enter a custom value" option is selected, the text field is shown
+		 * - After saving, the field value and state remain the same
+		 */
+		await selection.selectOption( '_gla_custom_value' );
+		await expect( selection ).toHaveValue( '_gla_custom_value' );
+		await expect( input ).toBeVisible();
+
+		await input.fill( 'Cute Cat' );
+		await editorUtils.save();
+
+		await expect( selection ).toHaveValue( '_gla_custom_value' );
+		await expect( input ).toHaveValue( 'Cute Cat' );
+
+		/*
+		 * Assert:
+		 * - When switching to another value and back, the entered value in the text field is kept
+		 */
+		await selection.selectOption( '' );
+		await expect( input ).toHaveCount( 0 );
+		await selection.selectOption( '_gla_custom_value' );
+		await expect( selection ).toHaveValue( '_gla_custom_value' );
+		await expect( input ).toHaveValue( 'Cute Cat' );
+	} );
+
 	test.afterEach( async () => {
 		await page.unrouteAll();
 	} );

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -25,3 +25,14 @@ add_filter(
 		";
 	}
 );
+
+/*
+ * Mimic the `WooCommerceBrands` class to test plugin integration in product editor.
+ */
+add_filter(
+	'woocommerce_gla_product_attribute_value_options_brand',
+	function ( array $value_options ) {
+		$value_options[ 'e2e_test_woocommerce_brands' ] = 'E2E test: From WooCommerce Brands';
+		return $value_options;
+	}
+);

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -14,14 +14,14 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Snippets;
  * It's a hack to avoid specifying region for E2E environment, but it tests the customization of consent mode.
  */
 add_filter(
-    'woocommerce_gla_gtag_consent',
-    function( $old_config ) {
-        return "gtag( 'consent', 'default', {
-            analytics_storage: 'granted',
-            ad_storage: 'granted',
-            ad_user_data: 'granted',
-            ad_personalization: 'granted',
-        } );
-        ";
-    }
+	'woocommerce_gla_gtag_consent',
+	function( $old_config ) {
+		return "gtag( 'consent', 'default', {
+			analytics_storage: 'granted',
+			ad_storage: 'granted',
+			ad_user_data: 'granted',
+			ad_personalization: 'granted',
+		} );
+		";
+	}
 );

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -34,17 +34,13 @@ export function apiWP() {
 /**
  * Creates a simple product.
  *
- * @return {number} Product ID of the created product.
+ * @return {Promise<number>} Product ID of the created product.
  */
 export async function createSimpleProduct() {
 	const product = config.products.simple;
 
 	return await api()
-		.post( 'products', {
-			name: product.name,
-			type: 'simple',
-			regular_price: String( product.regularPrice ),
-		} )
+		.post( 'products', product )
 		.then( ( response ) => response.data.id );
 }
 

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -45,6 +45,36 @@ export async function createSimpleProduct() {
 }
 
 /**
+ * Creates a variable product.
+ *
+ * @return {Promise<number>} Product ID of the created product.
+ */
+export async function createVariableProduct() {
+	const variableProduct = config.products.variable;
+
+	return await api()
+		.post( 'products', variableProduct )
+		.then( ( response ) => response.data.id );
+}
+
+/**
+ * Creates variation products.
+ *
+ * @param {number|string} productId The product ID to be associated with the variation products to be created.
+ *
+ * @return {Promise<number[]>} Product IDs of the created products.
+ */
+export async function createVariationProducts( productId ) {
+	const variationProducts = config.products.variations;
+
+	return await api()
+		.post( `products/${ productId }/variations/batch`, {
+			create: variationProducts,
+		} )
+		.then( ( response ) => response.data.create.map( ( { id } ) => id ) );
+}
+
+/**
  * Set Test Conversion ID.
  */
 export async function setConversionID() {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -3,6 +3,11 @@
  */
 import { Page } from '@playwright/test';
 
+/**
+ * Internal dependencies
+ */
+import * as api from './api';
+
 const REGEX_URL_PRODUCTS = /\/wc\/v3\/products\/\d+(\/variations\/\d+)?\?/;
 
 /**
@@ -57,6 +62,25 @@ export function getProductBlockEditorUtils( page ) {
 			return page.goto(
 				'/wp-admin/admin.php?page=wc-admin&path=%2Fadd-product'
 			);
+		},
+
+		async gotoEditVariableProductPage() {
+			const variableId = await api.createVariableProduct();
+			await api.createVariationProducts( variableId );
+
+			return page.goto(
+				`/wp-admin/admin.php?page=wc-admin&path=%2Fproduct%2F${ variableId }`
+			);
+		},
+
+		async gotoEditVariationProductPage( index = 0 ) {
+			await this.clickTab( 'Variations' );
+
+			return page
+				.getByRole( 'tabpanel' )
+				.getByRole( 'link', { name: 'Edit' } )
+				.nth( index )
+				.click();
 		},
 
 		waitForSaved() {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -47,6 +47,18 @@ export function getProductBlockEditorUtils( page ) {
 				issues: block.getByRole( 'listitem' ),
 			};
 		},
+
+		getSelectWithTextField() {
+			const block = page
+				.locator(
+					'[data-type="google-listings-and-ads/product-select-with-text-field"]'
+				)
+				.first();
+			return {
+				selection: block.getByRole( 'combobox' ),
+				input: block.getByRole( 'textbox' ),
+			};
+		},
 	};
 
 	const asyncActions = {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { Page } from '@playwright/test';
+
+/**
+ * Gets E2E test utils for facilitating writing tests for Product Block Editor.
+ *
+ * @param {Page} page Playwright page object.
+ */
+export function getProductBlockEditorUtils( page ) {
+	const locators = {
+		getTab( tabName ) {
+			return page
+				.getByRole( 'tablist' )
+				.getByRole( 'button', { name: tabName } );
+		},
+
+		getPluginTab() {
+			return this.getTab( 'Google Listings & Ads' );
+		},
+	};
+
+	const asyncActions = {
+		async toggleBlockFeature( enable ) {
+			await page.goto(
+				'/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features'
+			);
+
+			const checkbox = page.locator(
+				'#woocommerce_feature_product_block_editor_enabled'
+			);
+
+			if ( enable ) {
+				await checkbox.check();
+			} else {
+				await checkbox.uncheck();
+			}
+
+			await page.getByRole( 'button', { name: 'Save changes' } ).click();
+			await page
+				.getByText( 'Your settings have been saved.' )
+				.isVisible();
+		},
+
+		gotoAddProductPage() {
+			return page.goto(
+				'/wp-admin/admin.php?page=wc-admin&path=%2Fadd-product'
+			);
+		},
+
+		clickTab( tabName ) {
+			return this.getTab( tabName ).click();
+		},
+
+		clickPluginTab() {
+			return this.getPluginTab().click();
+		},
+	};
+
+	return {
+		...locators,
+		...asyncActions,
+	};
+}

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -42,6 +42,9 @@ export function getProductBlockEditorUtils( page ) {
 			return {
 				selection: block.getByRole( 'combobox' ),
 				help: block.locator( '.components-base-control__help' ),
+				notice: block.locator( '.components-notice' ),
+				status: block.locator( 'section p' ).first(),
+				issues: block.getByRole( 'listitem' ),
 			};
 		},
 	};
@@ -157,8 +160,28 @@ export function getProductBlockEditorUtils( page ) {
 		},
 	};
 
+	const mocks = {
+		async mockChannelVisibility( syncStatus, issues = [] ) {
+			const key = 'google_listings_and_ads__channel_visibility';
+
+			await page.route( REGEX_URL_PRODUCTS, async ( route ) => {
+				// If the test case has reached the end but there is still any route awaiting fulfillment, it will cause "Request context disposed" errors and further lead to the test case being considered a failure. Therefore, here it catches and ignores errors.
+				try {
+					const response = await route.fetch();
+					const product = await response.json();
+
+					product[ key ].sync_status = syncStatus;
+					product[ key ].issues = issues;
+
+					await route.fulfill( { response, json: product } );
+				} catch ( e ) {}
+			} );
+		},
+	};
+
 	return {
 		...locators,
 		...asyncActions,
+		...mocks,
 	};
 }

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -21,6 +21,14 @@ export function getProductBlockEditorUtils( page ) {
 		getPluginTab() {
 			return this.getTab( 'Google Listings & Ads' );
 		},
+
+		getChannelVisibilityHeading() {
+			return page.getByRole( 'heading', { name: 'Channel visibility' } );
+		},
+
+		getProductAttributesHeading() {
+			return page.getByRole( 'heading', { name: 'Product attributes' } );
+		},
 	};
 
 	const asyncActions = {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -3,6 +3,8 @@
  */
 import { Page } from '@playwright/test';
 
+const REGEX_URL_PRODUCTS = /\/wc\/v3\/products\/\d+(\/variations\/\d+)?\?/;
+
 /**
  * Gets E2E test utils for facilitating writing tests for Product Block Editor.
  *
@@ -49,12 +51,54 @@ export function getProductBlockEditorUtils( page ) {
 			);
 		},
 
+		waitForSaved() {
+			return page.waitForResponse( ( response ) => {
+				return (
+					REGEX_URL_PRODUCTS.test( response.url() ) &&
+					response.ok() &&
+					response.request().method() === 'POST'
+				);
+			} );
+		},
+
 		clickTab( tabName ) {
 			return this.getTab( tabName ).click();
 		},
 
 		clickPluginTab() {
 			return this.getPluginTab().click();
+		},
+
+		async changeProductType( type ) {
+			await page
+				.getByRole( 'button', { name: 'Change product type' } )
+				.click();
+
+			const observer = this.waitForSaved();
+			await page.getByRole( 'menuitemradio', { name: type } ).click();
+
+			// Avoid some random race conditions. Without this wait, subsequent UI operations
+			// or assertions may fail due to re-rendering after data saving is completed or
+			// continuously triggering data saving API requests.
+			await observer;
+		},
+
+		changeToStandardProduct() {
+			return this.changeProductType( /Standard product/ );
+		},
+
+		changeToGroupedProduct() {
+			return this.changeProductType( /Grouped product/ );
+		},
+
+		changeToAffiliateProduct() {
+			return this.changeProductType( /Affiliate product/ );
+		},
+
+		fillProductName( name = 'Cat Teaser' ) {
+			// Timestamp for avoid duplicated SKU errors
+			name += ` - ${ Date.now() }`;
+			return page.getByRole( 'textbox', { name: 'name' } ).fill( name );
 		},
 	};
 

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -80,6 +80,16 @@ export function getProductBlockEditorUtils( page ) {
 					.locator( '.components-base-control__help' ),
 			};
 		},
+
+		getMultipackField() {
+			const block = page.locator(
+				'[data-template-block-id="google-listings-and-ads-product-attributes-multipack"]'
+			);
+			return {
+				input: block.locator( 'input' ),
+				help: block.locator( '.components-base-control__help' ),
+			};
+		},
 	};
 
 	const asyncActions = {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 
 /**
  * Internal dependencies
@@ -57,6 +57,27 @@ export function getProductBlockEditorUtils( page ) {
 			return {
 				selection: block.getByRole( 'combobox' ),
 				input: block.getByRole( 'textbox' ),
+			};
+		},
+
+		getDateAndTimeFields() {
+			const block = page
+				.locator(
+					'[data-type="google-listings-and-ads/product-date-time-field"]'
+				)
+				.first();
+
+			return {
+				dateInput: block.locator( 'input[type=date]' ),
+				timeInput: block.locator( 'input[type=time]' ),
+				dateHelp: block
+					.locator( '.components-input-control' )
+					.nth( 0 )
+					.locator( '.components-base-control__help' ),
+				timeHelp: block
+					.locator( '.components-input-control' )
+					.nth( 1 )
+					.locator( '.components-base-control__help' ),
 			};
 		},
 	};
@@ -170,6 +191,10 @@ export function getProductBlockEditorUtils( page ) {
 			name += ` - ${ Date.now() }`;
 			return page.getByRole( 'textbox', { name: 'name' } ).fill( name );
 		},
+
+		evaluateValidationMessage( input ) {
+			return input.evaluate( ( element ) => element.validationMessage );
+		},
 	};
 
 	const mocks = {
@@ -191,9 +216,26 @@ export function getProductBlockEditorUtils( page ) {
 		},
 	};
 
+	const assertions = {
+		async assertUnableSave() {
+			await this.clickSave();
+
+			const failureNotice = page
+				.getByRole( 'button' )
+				.filter( { hasText: 'Failed to save product' } );
+
+			await expect( failureNotice ).toBeVisible();
+
+			// Dismiss the notice.
+			await failureNotice.click();
+			await expect( failureNotice ).toHaveCount( 0 );
+		},
+	};
+
 	return {
 		...locators,
 		...asyncActions,
 		...mocks,
+		...assertions,
 	};
 }

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -34,6 +34,16 @@ export function getProductBlockEditorUtils( page ) {
 		getProductAttributesHeading() {
 			return page.getByRole( 'heading', { name: 'Product attributes' } );
 		},
+
+		getChannelVisibility() {
+			const block = page.locator(
+				'[data-type="google-listings-and-ads/product-channel-visibility"]'
+			);
+			return {
+				selection: block.getByRole( 'combobox' ),
+				help: block.locator( '.components-base-control__help' ),
+			};
+		},
 	};
 
 	const asyncActions = {
@@ -81,6 +91,19 @@ export function getProductBlockEditorUtils( page ) {
 				.getByRole( 'link', { name: 'Edit' } )
 				.nth( index )
 				.click();
+		},
+
+		clickSave() {
+			return page
+				.getByRole( 'region', { name: 'Header' } )
+				.getByRole( 'button', { name: /^(Save draft|Update)$/ } )
+				.click();
+		},
+
+		async save() {
+			const observer = this.waitForSaved();
+			await this.clickSave();
+			await observer;
 		},
 
 		waitForSaved() {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -90,6 +90,31 @@ export function getProductBlockEditorUtils( page ) {
 				help: block.locator( '.components-base-control__help' ),
 			};
 		},
+
+		getAllProductAttributes() {
+			const { dateInput: availabilityDate, timeInput: availabilityTime } =
+				this.getDateAndTimeFields();
+
+			return {
+				gtin: page.getByLabel( 'GTIN' ),
+				mpn: page.getByLabel( 'MPN' ),
+				brand: page.getByLabel( 'Brand' ),
+				condition: page.getByLabel( 'Condition', { exact: true } ),
+				gender: page.getByLabel( 'Gender' ),
+				size: page.getByLabel( 'Size', { exact: true } ),
+				sizeSystem: page.getByLabel( 'Size system' ),
+				sizeType: page.getByLabel( 'Size type' ),
+				color: page.getByLabel( 'Color' ),
+				material: page.getByLabel( 'Material' ),
+				pattern: page.getByLabel( 'Pattern' ),
+				ageGroup: page.getByLabel( 'Age Group' ),
+				multipack: page.getByLabel( 'Multipack' ),
+				isBundle: page.getByLabel( 'Is Bundle' ),
+				availabilityDate,
+				availabilityTime,
+				adultContent: page.getByLabel( 'Adult content' ),
+			};
+		},
 	};
 
 	const asyncActions = {
@@ -204,6 +229,20 @@ export function getProductBlockEditorUtils( page ) {
 
 		evaluateValidationMessage( input ) {
 			return input.evaluate( ( element ) => element.validationMessage );
+		},
+
+		async setAttributeValue( locator, value ) {
+			const tagName = await locator.evaluate(
+				( element ) => element.tagName
+			);
+
+			if ( tagName === 'SELECT' ) {
+				await locator.selectOption( value );
+			} else {
+				await locator.fill( value );
+			}
+
+			await expect( locator ).toHaveValue( value );
 		},
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Upgrade `@playwright/test` to `^1.42.0` for having the new APIs:
   - https://playwright.dev/docs/api/class-page#page-unroute-all
   - https://playwright.dev/docs/api/class-locator#locator-press-sequentially
- Convert space indentations in `test-snippets.php` to tabs.
- Adjust the product data in `tests/e2e/config/default.json` to fit with WC v3 REST API and remove unused parts.
- Add new E2E API utils for creating variable and variation products.
- Add E2E tests

#### 📌 Checklist (@eason9487)

- [x] Revert 77022c71d358d87a942112c13f9c36b6dca25b33 before merging this PR

### Detailed test instructions:

1. `npm install` to update `@playwright/test` package.
2. `npx playwright install chromium` to update the PlayWright browser as well.
3. `npm run dev` to build files
4. `npm run test:e2e` to see if the E2E test in headless mode can pass.
5. (Optional) `npm run test:e2e -- --ui` to inspect the E2E test in UI mode.
6. View the E2E test result on GitHub Actions: https://github.com/woocommerce/google-listings-and-ads/actions/runs/8376570038/job/22936559491?pr=2327

### Changelog entry
