### PR TITLE
Add a manual workflow run for PHP unit tests

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -16,13 +16,25 @@ on:
       - composer.json
       - composer.lock
       - .github/workflows/php-unit-tests.yml
-
+  workflow_dispatch:
+    inputs:
+      php-version:
+        description: 'PHP Version'
+        default: '8.2'
+      wp-rc-version:
+        description: 'WordPress version for Release Candidate (ex. 6.5-RC3)'
+        default: 'latest'
+      wc-rc-version:
+        description: 'WooCommerce version for Release Candidate (ex. 8.7.0-rc.1)'
+        default: 'latest'
+    
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   GetMatrix:
+    if: github.event_name != 'workflow_dispatch'
     name: Get WP and WC version Matrix
     runs-on: ubuntu-latest
     outputs:
@@ -42,12 +54,14 @@ jobs:
           slug: woocommerce
 
   UnitTests:
+    if: github.event_name != 'workflow_dispatch'
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     needs: GetMatrix
     runs-on: ubuntu-latest
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
+      generate_coverage: 'false'
     strategy:
       matrix:
         php: [ 8.2 ]
@@ -96,3 +110,30 @@ jobs:
           files: tests/php-coverage/report.xml
           flags: php-unit-tests
           name: php-coverage-report
+
+  ReleaseCandidateUnitTests:
+    if: github.event_name == 'workflow_dispatch'
+    name: PHP unit tests - PHP ${{ inputs.php-version }}, WP ${{ inputs.wp-rc-version }}, WC ${{ inputs.wc-rc-version }}
+    runs-on: ubuntu-latest
+    env:
+      WP_CORE_DIR: "/tmp/wordpress/src"
+      WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@actions-v1
+        with:
+          php-version: "${{ inputs.php-version }}"
+
+      - name: Prepare MySQL
+        uses: woocommerce/grow/prepare-mysql@actions-v1
+
+      - name: Install WP tests
+        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ inputs.wp-rc-version }} ${{ inputs.wc-rc-version }}
+
+      - name: Run PHP unit tests
+        run: composer test-unit
+        

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -113,7 +113,7 @@ jobs:
 
   ReleaseCandidateUnitTests:
     if: github.event_name == 'workflow_dispatch'
-    name: PHP unit tests - PHP ${{ inputs.php-version }}, WP ${{ inputs.wp-rc-version }}, WC ${{ inputs.wc-rc-version }}
+    name: PHP unit tests (for Release Candidates)
     runs-on: ubuntu-latest
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
@@ -136,4 +136,4 @@ jobs:
 
       - name: Run PHP unit tests
         run: composer test-unit
-        
+     


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR allows us to run the PHP unit tests manually for any version of PHP / WP / WC. This makes it easier to test release candidates / beta versions without needing to setup the environment locally. The intention is for this to be used during compatibility testing, once this PR is approved we can do the same for other extension we manage.

### Detailed test instructions:

A manual workflow can't be triggered until this branch is merged. So testing will need to be done on a fork.

1. Create a fork of this repo
2. Merge the corresponding branch (with a PR or directly)
3. Run the manual workflow using release candidate versions of WP and WC
4. Confirm the single job `PHP unit tests (for Release Candidates)` completed successfully
![image](https://github.com/woocommerce/google-listings-and-ads/assets/11388669/eed203f1-17b3-46b0-9603-5abaa7d76d21)

### Changelog entry
* Dev - Add a manual workflow run for PHP unit tests.
