### PR TITLE
API PULL - Overview Stats - delete stale mc statuses

### DIFF
--- a/src/DB/ProductMetaQueryHelper.php
+++ b/src/DB/ProductMetaQueryHelper.php
@@ -62,6 +62,8 @@ class ProductMetaQueryHelper implements Service {
 	/**
 	 * Delete all values for a given meta_key.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param string $meta_key The meta key to delete.
 	 *
 	 * @throws InvalidMeta If the meta key isn't valid.

--- a/src/DB/ProductMetaQueryHelper.php
+++ b/src/DB/ProductMetaQueryHelper.php
@@ -60,6 +60,21 @@ class ProductMetaQueryHelper implements Service {
 	}
 
 	/**
+	 * Delete all values for a given meta_key.
+	 *
+	 * @param string $meta_key The meta key to delete.
+	 *
+	 * @throws InvalidMeta If the meta key isn't valid.
+	 */
+	public function delete_all_values( string $meta_key ) {
+		self::validate_meta_key( $meta_key );
+		$meta_key = $this->prefix_meta_key( $meta_key );
+		$query    = "DELETE FROM {$this->wpdb->postmeta} WHERE meta_key = %s";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$this->wpdb->query( $this->wpdb->prepare( $query, $meta_key ) );
+	}
+
+	/**
 	 * Insert a meta value for multiple posts.
 	 *
 	 * @param string $meta_key The meta value to insert.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -58,7 +58,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * The lifetime of the status-related data.
 	 */
-	public const STATUS_LIFETIME = HOUR_IN_SECONDS;
+	public const STATUS_LIFETIME = 12 * HOUR_IN_SECONDS;
 
 	/**
 	 * The types of issues.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -239,12 +239,23 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
+	 * Delete the stale mc statuses from the database.
+	 *
+	 * @since x.x.x
+	 */
+	protected function delete_stale_mc_statuses(): void {
+		$product_meta_query_helper = $this->container->get( ProductMetaQueryHelper::class );
+		$product_meta_query_helper->delete_all_values( ProductMetaHandler::KEY_MC_STATUS );
+	}
+
+	/**
 	 * Clear the product statuses cache and delete stale issues.
 	 *
 	 * @since x.x.x
 	 */
 	public function clear_product_statuses_cache_and_issues(): void {
 		$this->delete_stale_issues();
+		$this->delete_stale_mc_statuses();
 		$this->delete_product_statuses_count_intermediate_data();
 	}
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -996,6 +996,7 @@ class MerchantStatusesTest extends UnitTest {
 
 		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_stale' )->with( $this->merchant_statuses->get_cache_created_time() );
 		$this->options->expects( $this->once() )->method( 'delete' )->with( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
+		$this->product_meta_query_helper->expects($this->once())->method('delete_meta_key')->with(ProductMetaHandler::KEY_MC_STATUS);
 		$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 	}
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -987,16 +987,10 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_statuses->clear_cache();
 	}
 
-	protected function test_clear_product_statuses_cache_and_issues() {
-		$this->transients->expects( $this->exactly( 1 ) )
-		->method( 'delete' )
-		->with(
-			TransientsInterface::MC_STATUSES
-		);
-
+	public function test_clear_product_statuses_cache_and_issues() {
 		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_stale' )->with( $this->merchant_statuses->get_cache_created_time() );
 		$this->options->expects( $this->once() )->method( 'delete' )->with( OptionsInterface::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA );
-		$this->product_meta_query_helper->expects($this->once())->method('delete_meta_key')->with(ProductMetaHandler::KEY_MC_STATUS);
+		$this->product_meta_query_helper->expects( $this->once() )->method( 'delete_all_values' )->with( ProductMetaHandler::KEY_MC_STATUS );
 		$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146 & https://github.com/woocommerce/google-listings-and-ads/issues/2250

Since the product's MC status depends on the status in Google Merchant Center, if the product no longer exists in the MC, the local MC status will never be deleted. Hence, this PR will clear all the MC statuses, allowing us to start fresh when pulling the product MC statuses.

In the previous https://github.com/woocommerce/google-listings-and-ads/pull/2257, we refactor some code to use WC Crud classes instead of directly querying the database. However, in this scenario, I think deleting all the product's post meta `_wc_gla_mc_status` with a single query would be much more efficient than using the CRUD classes and loading all the products.

I increased the transient expiration time to 12 hours. Because currently, whenever a product is created, updated, or deleted, the transient cache is cleared because it calls the hooks (`woocommerce_gla_batch_updated_products` and `woocommerce_gla_batch_deleted_products`). Therefore, I believe it's unnecessary to remove the transient cache every hour if no changes to products have occurred.

https://github.com/woocommerce/google-listings-and-ads/blob/8ebe1ecaf902ea114ae426d2abd86aebc960b560/src/Event/ClearProductStatsCache.php#L39-L50

With the new approach of notifications, we could do something similar, once a product has been notified to Google we could clear the cache.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Call `wc/gla/mc/product-statistics/refresh`
2. Go to WC -> Status -> Action Scheduler and see that the `gla/jobs/update_merchant_product_statuses/process_item` is scheduled.
3. Go to `page=wc-admin&path=%2Fgoogle%2Fproduct-feed` and wait until the stats are fetched.
4. If you want to check whether the postmeta has been deleted and then reinserted, you can check if the postmeta IDs in the database have changed.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>