### PR TITLE
Update test proxy port

### DIFF
--- a/tests/proxy/config.js
+++ b/tests/proxy/config.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = {
-	port: 5500,
+	port: process.env.PROXY_PORT || 5555,
 	host: 'localhost',
 	connectServer:
 		process.env.WOOCOMMERCE_CONNECT_SERVER ||

--- a/tests/proxy/proxy.md
+++ b/tests/proxy/proxy.md
@@ -14,7 +14,14 @@ npm run test-proxy
 Or, if you want to use a local connect server:
 
 ```
-WOOCOMMERCE_CONNECT_SERVER=http://localhost:5000 npm run test-proxy
+WOOCOMMERCE_CONNECT_SERVER=http://localhost:5500 npm run test-proxy
+```
+
+### Define port for the proxy
+To run the proxy using a custom port you can start it as follows:
+
+```
+PROXY_PORT=50505 npm run test-proxy
 ```
 
 ### Run the proxy in a specific mode
@@ -40,13 +47,13 @@ PROXY_LOG_RESPONSES=true npm run test-proxy
 On your test site you will need to run a PHP snippet to use the proxy to handle any requests:
 
 ```php
-define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://localhost:5500' );
+define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://localhost:5555' );
 ```
 
 Or, if your test site is running within a docker container, the PHP snippet would be the following instead:
 
 ```php
-define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://host.docker.internal:5500' );
+define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://host.docker.internal:5555' );
 ```
 
 ### Non Mac users


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Now that the WCS runs on port 5500, the proxy will conflict.
Port was changed since MacOS Monterey introduced [AirPlay Receiver](https://en.wikipedia.org/wiki/AirPlay#Receivers) running on port 5000.

This PR changes the default port for the test proxy and allows a custom port number to be used.


### Detailed test instructions:
1. Start proxy `npm run test-proxy`
2. Expect to see it running on port 5555
```
Proxy server running on http://localhost:5555 > https://api-vipgo.woocommerce.com in default mode
```
3. Start it again with a custom port `PROXY_PORT=30303 npm run test-proxy` 
4. Expect to see it running on port 30303
```
Proxy server running on http://localhost:30303 > https://api-vipgo.woocommerce.com in default mode
```

### Changelog entry
* Dev - Update test proxy port.
