### PR TITLE
API Pull - Grant access to Google WPCOM app in onboarding flow

### DIFF
--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -1,17 +1,8 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
-
-/**
  * Internal dependencies
  */
 import AppButton from '.~/components/app-button';
-import { glaData } from '.~/constants';
-import { API_NAMESPACE } from '.~/data/constants';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import useRestAPIAuthURLRedirect from '.~/hooks/useRestAPIAuthURLRedirect';
 
 /**
  * Button to initiate auth process for WP Rest API
@@ -20,29 +11,14 @@ import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
  * @return {JSX.Element} The button.
  */
 const EnableNewProductSyncButton = ( params ) => {
-	const { createNotice } = useDispatchCoreNotices();
-
-	const nextPageName = glaData.mcSetupComplete ? 'settings' : 'setup-mc';
-	const query = { next_page_name: nextPageName };
-	const path = addQueryArgs( `${ API_NAMESPACE }/rest-api/authorize`, query );
-	const [ fetchRestAPIAuthorize ] = useApiFetchCallback( { path } );
-	const handleEnableClick = async () => {
-		try {
-			const d = await fetchRestAPIAuthorize();
-			window.location.href = d.auth_url;
-		} catch ( error ) {
-			createNotice(
-				'error',
-				__(
-					'Unable to enable new product sync. Please try again later.',
-					'google-listings-and-ads'
-				)
-			);
-		}
-	};
+	const [ handleRestAPIAuthURLRedirect ] = useRestAPIAuthURLRedirect();
 
 	return (
-		<AppButton isSecondary onClick={ handleEnableClick } { ...params } />
+		<AppButton
+			isSecondary
+			onClick={ handleRestAPIAuthURLRedirect }
+			{ ...params }
+		/>
 	);
 };
 

--- a/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
@@ -35,12 +35,12 @@ import AppNotice from '.~/components/app-notice';
  * @param {Object} props React props.
  * @param {{ id: number }} props.googleMCAccount A data payload object containing the user's Google Merchant Center account ID.
  * @param {boolean} [props.hideAccountSwitch=false] Indicate whether hide the account switch block at the card footer.
- * @param {boolean} [props.hideNotificationService=true] Indicate whether hide the enable Notification service block at the card footer.
+ * @param {boolean} [props.hideDisableProductFetch=true] Indicate whether hide the disable product fetch block at the card footer.
  */
 const ConnectedGoogleMCAccountCard = ( {
 	googleMCAccount,
 	hideAccountSwitch = false,
-	hideNotificationService = false,
+	hideDisableProductFetch = false,
 } ) => {
 	const { createNotice, removeNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
@@ -123,18 +123,17 @@ const ConnectedGoogleMCAccountCard = ( {
 		removeNotice( notice.id );
 	};
 
-	// Show the button if the status is "approved" and the Notification Service is not hidden.
-	const showDisconnectNotificationsButton =
-		! hideNotificationService &&
+	const isGoogleWPCOMAppApproved =
 		googleMCAccount.wpcom_rest_api_status ===
-			GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
+		GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
 
-	// Show the error if the status is set but is not "approved" and the Notification Service is not hidden.
+	// Show the button if the status is "approved" and the "disable product fetch" is not hidden.
+	const showDisconnectNotificationsButton =
+		! hideDisableProductFetch && isGoogleWPCOMAppApproved;
+
+	// Show the error if the status is set but is not "approved".
 	const showErrorNotificationsNotice =
-		! hideNotificationService &&
-		googleMCAccount.wpcom_rest_api_status &&
-		googleMCAccount.wpcom_rest_api_status !==
-			GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
+		googleMCAccount.wpcom_rest_api_status && ! isGoogleWPCOMAppApproved;
 
 	const showFooter = ! hideAccountSwitch || showDisconnectNotificationsButton;
 
@@ -159,7 +158,7 @@ const ConnectedGoogleMCAccountCard = ( {
 				)
 			}
 		>
-			{ showDisconnectNotificationsButton && (
+			{ isGoogleWPCOMAppApproved && (
 				<AppNotice status="success" isDismissible={ false }>
 					{ __(
 						'Google has been granted access to fetch your product data.',

--- a/js/src/components/google-mc-account-card/google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/google-mc-account-card.js
@@ -26,7 +26,7 @@ const GoogleMCAccountCard = () => {
 		return <NonConnected />;
 	}
 
-	if ( googleMCAccount.wpcom_rest_api_status !== 'approved' ) {
+	if ( ! googleMCAccount.wpcom_rest_api_status ) {
 		handleRestAPIAuthURLRedirect();
 		return <SpinnerCard />;
 	}

--- a/js/src/components/google-mc-account-card/google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/google-mc-account-card.js
@@ -3,6 +3,7 @@
  */
 import SpinnerCard from '.~/components/spinner-card';
 import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
+import useRestAPIAuthURLRedirect from '.~/hooks/useRestAPIAuthURLRedirect';
 import ConnectedGoogleMCAccountCard from './connected-google-mc-account-card';
 import DisabledCard from './disabled-card';
 import NonConnected from './non-connected';
@@ -10,6 +11,8 @@ import NonConnected from './non-connected';
 const GoogleMCAccountCard = () => {
 	const { hasFinishedResolution, isPreconditionReady, googleMCAccount } =
 		useGoogleMCAccount();
+
+	const [ handleRestAPIAuthURLRedirect ] = useRestAPIAuthURLRedirect();
 
 	if ( ! hasFinishedResolution ) {
 		return <SpinnerCard />;
@@ -21,6 +24,11 @@ const GoogleMCAccountCard = () => {
 
 	if ( googleMCAccount.id === 0 || googleMCAccount.status !== 'connected' ) {
 		return <NonConnected />;
+	}
+
+	if ( googleMCAccount.wpcom_rest_api_status !== 'approved' ) {
+		handleRestAPIAuthURLRedirect();
+		return <SpinnerCard />;
 	}
 
 	return (

--- a/js/src/components/google-mc-account-card/google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/google-mc-account-card.js
@@ -31,12 +31,7 @@ const GoogleMCAccountCard = () => {
 		return <SpinnerCard />;
 	}
 
-	return (
-		<ConnectedGoogleMCAccountCard
-			hideNotificationService
-			googleMCAccount={ googleMCAccount }
-		/>
-	);
+	return <ConnectedGoogleMCAccountCard googleMCAccount={ googleMCAccount } />;
 };
 
 export default GoogleMCAccountCard;

--- a/js/src/components/google-mc-account-card/google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/google-mc-account-card.js
@@ -31,7 +31,12 @@ const GoogleMCAccountCard = () => {
 		return <SpinnerCard />;
 	}
 
-	return <ConnectedGoogleMCAccountCard googleMCAccount={ googleMCAccount } />;
+	return (
+		<ConnectedGoogleMCAccountCard
+			googleMCAccount={ googleMCAccount }
+			hideDisableProductFetch
+		/>
+	);
 };
 
 export default GoogleMCAccountCard;

--- a/js/src/hooks/useRestAPIAuthURLRedirect.js
+++ b/js/src/hooks/useRestAPIAuthURLRedirect.js
@@ -19,12 +19,16 @@ const useRestAPIAuthURLRedirect = () => {
 	const nextPageName = glaData.mcSetupComplete ? 'settings' : 'setup-mc';
 	const query = { next_page_name: nextPageName };
 	const path = addQueryArgs( `${ API_NAMESPACE }/rest-api/authorize`, query );
-	const [ fetchRestAPIAuthorize ] = useApiFetchCallback( { path } );
+	const [ fetchRestAPIAuthorize, { loading } ] = useApiFetchCallback( {
+		path,
+	} );
 
 	const handleRestAPIAuthURLRedirect = useCallback( async () => {
 		try {
-			const d = await fetchRestAPIAuthorize();
-			window.location.href = d.auth_url;
+			if ( ! loading ) {
+				const d = await fetchRestAPIAuthorize();
+				window.location.href = d.auth_url;
+			}
 		} catch ( error ) {
 			createNotice(
 				'error',
@@ -34,7 +38,7 @@ const useRestAPIAuthURLRedirect = () => {
 				)
 			);
 		}
-	}, [ fetchRestAPIAuthorize, createNotice ] );
+	}, [ fetchRestAPIAuthorize, createNotice, loading ] );
 
 	return [ handleRestAPIAuthURLRedirect ];
 };

--- a/js/src/hooks/useRestAPIAuthURLRedirect.js
+++ b/js/src/hooks/useRestAPIAuthURLRedirect.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { glaData } from '.~/constants';
+import { API_NAMESPACE } from '.~/data/constants';
+import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+
+const useRestAPIAuthURLRedirect = () => {
+	const { createNotice } = useDispatchCoreNotices();
+
+	const nextPageName = glaData.mcSetupComplete ? 'settings' : 'setup-mc';
+	const query = { next_page_name: nextPageName };
+	const path = addQueryArgs( `${ API_NAMESPACE }/rest-api/authorize`, query );
+	const [ fetchRestAPIAuthorize ] = useApiFetchCallback( { path } );
+
+	const handleRestAPIAuthURLRedirect = useCallback( async () => {
+		try {
+			const d = await fetchRestAPIAuthorize();
+			window.location.href = d.auth_url;
+		} catch ( error ) {
+			createNotice(
+				'error',
+				__(
+					'Unable to enable new product sync. Please try again later.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+	}, [ fetchRestAPIAuthorize, createNotice ] );
+
+	return [ handleRestAPIAuthURLRedirect ];
+};
+
+export default useRestAPIAuthURLRedirect;

--- a/js/src/setup-mc/index.js
+++ b/js/src/setup-mc/index.js
@@ -2,11 +2,13 @@
  * Internal dependencies
  */
 import useLayout from '.~/hooks/useLayout';
+import useUpdateRestAPIAuthorizeStatusByUrlQuery from '.~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery';
 import SetupMCTopBar from './top-bar';
 import SetupStepper from './setup-stepper';
 
 const SetupMC = () => {
 	useLayout( 'full-page' );
+	useUpdateRestAPIAuthorizeStatusByUrlQuery();
 
 	return (
 		<>

--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getHistory, getNewPath, getQuery } from '@woocommerce/navigation';
+import { getHistory, getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -24,17 +24,11 @@ const SetupStepper = () => {
 		return null;
 	}
 
-	let { status, step } = mcSetup;
+	const { status, step } = mcSetup;
 
 	if ( status === 'complete' ) {
 		getHistory().replace( getNewPath( {}, '/google/dashboard' ) );
 		return null;
-	}
-
-	const queries = getQuery();
-
-	if ( queries.step && stepNameKeyMap[ queries.step ] ) {
-		step = queries.step;
 	}
 
 	return <SavedSetupStepper savedStep={ stepNameKeyMap[ step ] } />;

--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { getHistory, getNewPath, getQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -24,11 +24,17 @@ const SetupStepper = () => {
 		return null;
 	}
 
-	const { status, step } = mcSetup;
+	let { status, step } = mcSetup;
 
 	if ( status === 'complete' ) {
 		getHistory().replace( getNewPath( {}, '/google/dashboard' ) );
 		return null;
+	}
+
+	const queries = getQuery();
+
+	if ( queries.step && stepNameKeyMap[ queries.step ] ) {
+		step = queries.step;
 	}
 
 	return <SavedSetupStepper savedStep={ stepNameKeyMap[ step ] } />;

--- a/js/src/setup-mc/setup-stepper/stepNameKeyMap.js
+++ b/js/src/setup-mc/setup-stepper/stepNameKeyMap.js
@@ -1,5 +1,6 @@
 const stepNameKeyMap = {
 	accounts: '1',
+	grant_rest_api_access: '1',
 	product_listings: '2',
 	store_requirements: '3',
 	paid_ads: '4',

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -231,7 +231,9 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		if ( $this->connected_account() ) {
 			$step = 'grant_rest_api_access';
 
-			if ( $this->is_rest_api_granted() ) {
+			$notifications_enabled = $this->container->get( NotificationsService::class )->is_enabled();
+
+			if ( ! $notifications_enabled || $this->is_rest_api_granted() ) {
 				$step = 'product_listings';
 
 				if ( $this->saved_target_audience() && $this->saved_shipping_and_tax_options() ) {

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
@@ -225,13 +226,17 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 		$step = 'accounts';
 		if ( $this->connected_account() ) {
-			$step = 'product_listings';
+			$step = 'grant_rest_api_access';
 
-			if ( $this->saved_target_audience() && $this->saved_shipping_and_tax_options() ) {
-				$step = 'store_requirements';
+			if ( $this->is_rest_api_granted() ) {
+				$step = 'product_listings';
 
-				if ( $this->is_mc_contact_information_setup() && $this->checked_pre_launch_checklist() ) {
-					$step = 'paid_ads';
+				if ( $this->saved_target_audience() && $this->saved_shipping_and_tax_options() ) {
+					$step = 'store_requirements';
+
+					if ( $this->is_mc_contact_information_setup() && $this->checked_pre_launch_checklist() ) {
+						$step = 'paid_ads';
+					}
 				}
 			}
 		}
@@ -447,5 +452,16 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		$statuses = $this->container->get( MerchantStatuses::class )->get_product_statistics();
 
 		return $statuses['statistics']['active'] >= 1;
+	}
+
+	/**
+	 * Check if REST API has been granted.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	public function is_rest_api_granted(): bool {
+		$wpcom_rest_api_status = $this->options->get( OptionsInterface::WPCOM_REST_API_STATUS );
+		return $wpcom_rest_api_status === OAuthService::STATUS_APPROVED;
 	}
 }

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -401,15 +401,38 @@ class MerchantCenterServiceTest extends UnitTest {
 		);
 	}
 
+	public function test_get_setup_status_step_grant_rest_api_access() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::WPCOM_REST_API_STATUS ],
+			)->willReturnOnConsecutiveCalls(
+				false,
+				''
+			);
+
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'grant_rest_api_access',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
 	public function test_get_setup_status_step_product_listings() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->options->method( 'get' )
 			->withConsecutive(
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::WPCOM_REST_API_STATUS ],
 				[ OptionsInterface::TARGET_AUDIENCE ]
 			)->willReturnOnConsecutiveCalls(
 				false,
+				'approved',
 				[
 					'location'  => 'selected',
 					'countries' => [ 'US' ],
@@ -432,10 +455,12 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->options->method( 'get' )
 			->withConsecutive(
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::WPCOM_REST_API_STATUS ],
 				[ OptionsInterface::TARGET_AUDIENCE ],
 				[ OptionsInterface::MERCHANT_CENTER, [] ]
 			)->willReturnOnConsecutiveCalls(
 				false,
+				'approved',
 				[
 					'location'  => 'selected',
 					'countries' => [ 'US' ],
@@ -461,9 +486,11 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->options->method( 'get' )
 			->withConsecutive(
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::WPCOM_REST_API_STATUS ],
 				[ OptionsInterface::TARGET_AUDIENCE ]
 			)->willReturnOnConsecutiveCalls(
 				false,
+				'approved',
 				[
 					'location'  => 'selected',
 					'countries' => [ 'US' ],
@@ -504,11 +531,13 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->options->method( 'get' )
 			->withConsecutive(
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ],
+				[ OptionsInterface::WPCOM_REST_API_STATUS ],
 				[ OptionsInterface::TARGET_AUDIENCE ],
 				[ OptionsInterface::MERCHANT_CENTER, [] ],
 				[ OptionsInterface::MERCHANT_CENTER, [] ]
 			)->willReturnOnConsecutiveCalls(
 				false,
+				'approved',
 				[
 					'location'  => 'selected',
 					'countries' => [ 'GB' ],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Project: pcTzPl-1SM-p2
Figma: JjJwsuOziVFv6eP1HNFhU8-fi-18069-355

Part of #2146 and similar to #2311. This PR adds the granting access to Google WPCOM app flow in the onboarding flow.

What has been changed:

- Add a shared hook to handle REST API auth URL redirect, both settings page and onboarding can use this hook.
- Add a new setup mc step `grant_rest_api_access`. Like the step `accounts`, its index is also `1` as we want the UI stays on the set up accounts page when the step `grant_rest_api_access` is still incomplete.
  - This step is only valid when notification service is enabled (by setting the filter `woocommerce_gla_notifications_enabled` to true)
- Remove a prop `hideNotificationService` in the component `ConnectedGoogleMCAccountCard` as we would always show it on both settings and onboarding pages.
- Add a prop `hideDisableProductFetch` in the component `ConnectedGoogleMCAccountCard` as we are not showing `Disable product data fetch` in the onboarding flow when the granting access is approved.
    - This is open for discussion, whether we'd want to show it in the onboarding flow.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Approved

1. Checkout this branch
2. Set the filter `woocommerce_gla_notifications_enabled` to `true`
3. Make sure the option `gla_wpcom_rest_api_status` is not set
4. Delete all connected accounts, go to the onboarding flow by going to `/wp-admin/admin.php?page=wc-admin&path=/google/setup-mc`
5. Connect Google account
6. Connect MC account
7. After MC account is connected, it will automatically be redirect to the WPCOM app granting access page
    - <img width="567" alt="Screenshot 2024-03-26 at 21 36 09" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/610fd175-cca5-4bcb-8c91-20e6de00fe81">
8. Finish the auth step, it will eventually be redirect to https://woo.com
    - Because currently we are using a test WPCOM app, in the future this will the Google's WPCOM app and they will help us to redirect back to the merchant site.
9. Go back to setup mc page with an extra query parameter `google_wpcom_app_status=approved`. E.g.
    - `/wp-admin/admin.php?page=wc-admin&path=/google/setup-mc&google_wpcom_app_status=approved`
10. The UI shows MC account connected and also `Google has been granted access to fetch your product data.`
    - <img width="1150" alt="Screenshot 2024-04-02 at 17 38 42" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/6e286614-0857-49bc-88af-b78530bc047e">
11. The UI **_does not_** show `Disable product data fetch` like that in the settings page. #2311 
    - <img width="1096" alt="Screenshot 2024-04-02 at 17 08 42" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/84b09a3e-0c6f-4f79-b5fc-4d30aaa9034a">

#### Disapproved or Error

1. Disconnect MC account by calling `DELETE /wc/gla/mc/connection`, and delete the option `gla_wpcom_rest_api_status`
2. Go to setup mc page
3. Reconnect MC account, and finish the granting access flow
4. Go back to setup mc page with an extra query parameter `google_wpcom_app_status=error` or `google_wpcom_app_status=disapproved`. E.g.
    - `/wp-admin/admin.php?page=wc-admin&path=/google/setup-mc&google_wpcom_app_status=disapproved`
5. The UI shows MC account connected but `There was an issue granting access to Google for fetching your products.`
    - <img width="1148" alt="Screenshot 2024-04-02 at 17 47 53" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/b5026cd3-a169-4cc4-a66f-2725cb0cab08">
6. Click `Grant access` will redirect to WPCOM app granting access page

#### Notifications Service is not Enabled

1. Set the filter `woocommerce_gla_notifications_enabled` to `false`
2. Delete all accounts and delete the option `gla_wpcom_rest_api_status`
3. Connect MC account, it will not be redirected to WPCOM granting access page
4. Set the option `gla_wpcom_rest_api_status` to `approved`, `disapproved`, or `error`
5. The MC card will not display new product data fetch notice.

### Additional details

Verifying who can set the REST API status by setting a query parameter `google_wpcom_app_status` will be implemented in another PR.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
