### PR TITLE
API Pull - Update metadata for Coupons and Product after being notified.

### DIFF
--- a/src/Coupon/CouponHelper.php
+++ b/src/Coupon/CouponHelper.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\HelperNotificationInterface;
 use WC_Coupon;
 defined( 'ABSPATH' ) || exit();
 
@@ -18,7 +19,7 @@ defined( 'ABSPATH' ) || exit();
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
  */
-class CouponHelper implements Service {
+class CouponHelper implements Service, HelperNotificationInterface {
 
 	use PluginHelper;
 
@@ -92,7 +93,7 @@ class CouponHelper implements Service {
 	 *
 	 * @param WC_Coupon $coupon
 	 */
-	public function mark_as_unsynced( WC_Coupon $coupon ) {
+	public function mark_as_unsynced( $coupon ): void {
 		$this->meta_handler->delete_synced_at( $coupon );
 		$this->meta_handler->update_sync_status( $coupon, SyncStatus::NOT_SYNCED );
 		$this->meta_handler->delete_google_ids( $coupon );
@@ -375,7 +376,7 @@ class CouponHelper implements Service {
 	 * @param WC_Coupon $coupon
 	 * @param string    $status
 	 */
-	public function set_notification_status( WC_Coupon $coupon, $status ): void {
+	public function set_notification_status( $coupon, $status ): void {
 		$this->meta_handler->update_notification_status( $coupon, $status );
 	}
 
@@ -387,7 +388,7 @@ class CouponHelper implements Service {
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_create_notification( WC_Coupon $coupon ): bool {
+	public function should_trigger_create_notification( $coupon ): bool {
 		return $this->is_ready_to_notify( $coupon ) && ! $this->has_notified_creation( $coupon );
 	}
 
@@ -399,7 +400,7 @@ class CouponHelper implements Service {
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_update_notification( WC_Coupon $coupon ): bool {
+	public function should_trigger_update_notification( $coupon ): bool {
 		return $this->is_ready_to_notify( $coupon ) && $this->has_notified_creation( $coupon );
 	}
 
@@ -411,7 +412,7 @@ class CouponHelper implements Service {
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_delete_notification( WC_Coupon $coupon ): bool {
+	public function should_trigger_delete_notification( $coupon ): bool {
 		return ! $this->is_ready_to_notify( $coupon ) && $this->has_notified_creation( $coupon );
 	}
 }

--- a/src/Coupon/CouponHelper.php
+++ b/src/Coupon/CouponHelper.php
@@ -59,6 +59,19 @@ class CouponHelper implements Service, HelperNotificationInterface {
 	}
 
 	/**
+	 * Mark the item as notified.
+	 *
+	 * @param WC_Coupon $coupon
+	 *
+	 * @return void
+	 */
+	public function mark_as_notified( $coupon ): void {
+		$this->meta_handler->update_synced_at( $coupon, time() );
+		$this->meta_handler->update_sync_status( $coupon, SyncStatus::SYNCED );
+		$this->update_empty_visibility( $coupon );
+	}
+
+	/**
 	 * Mark a coupon as synced. This function accepts nullable $google_id,
 	 * which guarantees version compatibility for Alpha, Beta and stable verison promtoion APIs.
 	 *

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -3,9 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\HelperNotificationInterface;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -116,7 +115,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	/**
 	 * Get the helper
 	 *
-	 * @return CouponHelper|ProductHelper
+	 * @return HelperNotificationInterface
 	 */
-	abstract public function get_helper();
+	abstract public function get_helper(): HelperNotificationInterface;
 }

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -37,7 +37,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 
 		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
 			$this->set_status( $item, $this->get_after_notification_status( $topic ) );
-			$this->maybe_mark_as_unsynced( $topic, $item );
+			$this->handle_notified( $topic, $item );
 		}
 	}
 
@@ -90,18 +90,19 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	}
 
 	/**
-	 * If there is a valid Item ID and topic is a deletion topic. Mark the item as unsynced.
+	 * Handle the item after the notification.
 	 *
 	 * @param string $topic
 	 * @param int    $item
 	 */
-	protected function maybe_mark_as_unsynced( string $topic, int $item ): void {
-		if ( ! str_contains( $topic, '.delete' ) ) {
-			return;
+	protected function handle_notified( string $topic, int $item ): void {
+		if ( str_contains( $topic, '.delete' ) ) {
+			$this->get_helper()->mark_as_unsynced( $this->get_item( $item ) );
 		}
 
-		$item = $this->get_item( $item );
-		$this->get_helper()->mark_as_unsynced( $item );
+		if ( str_contains( $topic, '.create' ) ) {
+			$this->get_helper()->mark_as_notified( $this->get_item( $item ) );
+		}
 	}
 
 	/**

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -28,10 +28,10 @@ class CouponNotificationJob extends AbstractItemNotificationJob {
 	/**
 	 * Notifications Jobs constructor.
 	 *
-	 * @param ActionSchedulerInterface  $action_scheduler
-	 * @param ActionSchedulerJobMonitor $monitor
-	 * @param NotificationsService      $notifications_service
-	 * @param CouponHelper              $coupon_helper
+	 * @param ActionSchedulerInterface    $action_scheduler
+	 * @param ActionSchedulerJobMonitor   $monitor
+	 * @param NotificationsService        $notifications_service
+	 * @param HelperNotificationInterface $coupon_helper
 	 */
 	public function __construct(
 		ActionSchedulerInterface $action_scheduler,

--- a/src/Jobs/Notifications/CouponNotificationJob.php
+++ b/src/Jobs/Notifications/CouponNotificationJob.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\HelperNotificationInterface;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,7 +37,7 @@ class CouponNotificationJob extends AbstractItemNotificationJob {
 		ActionSchedulerInterface $action_scheduler,
 		ActionSchedulerJobMonitor $monitor,
 		NotificationsService $notifications_service,
-		CouponHelper $coupon_helper
+		HelperNotificationInterface $coupon_helper
 	) {
 		$this->notifications_service = $notifications_service;
 		$this->helper                = $coupon_helper;
@@ -56,9 +57,9 @@ class CouponNotificationJob extends AbstractItemNotificationJob {
 	/**
 	 * Get the Coupon Helper
 	 *
-	 * @return CouponHelper
+	 * @return HelperNotificationInterface
 	 */
-	public function get_helper() {
+	public function get_helper(): HelperNotificationInterface {
 		return $this->helper;
 	}
 

--- a/src/Jobs/Notifications/HelperNotificationInterface.php
+++ b/src/Jobs/Notifications/HelperNotificationInterface.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
  * @since x.x.x
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
  */
-interface  HelperNotificationInterface {
+interface HelperNotificationInterface {
 
 	/**
 	 * Checks if the item can be processed based on the topic.
@@ -39,25 +39,33 @@ interface  HelperNotificationInterface {
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_update_notification( $item ): bool;	
+	public function should_trigger_update_notification( $item ): bool;
 
 	/**
 	 * Marks the item as unsynced.
 	 *
 	 * @param WC_Product|WC_Coupon $item
 	 *
-	 * @return bool
-	 */	
+	 * @return void
+	 */
 	public function mark_as_unsynced( $item ): void;
 
 	/**
 	 * Set the notification status for an item.
 	 *
 	 * @param WC_Product|WC_Coupon $product
-	 * @param string     $status
+	 * @param string               $status
 	 *
-	 * @return bool
-	 */	
-	public function set_notification_status( $item, $status ): void;	
+	 * @return void
+	 */
+	public function set_notification_status( $item, $status ): void;
 
+	/**
+	 * Marks the item as notified.
+	 *
+	 * @param WC_Product|WC_Coupon $item
+	 *
+	 * @return void
+	 */
+	public function mark_as_notified( $item ): void;
 }

--- a/src/Jobs/Notifications/HelperNotificationInterface.php
+++ b/src/Jobs/Notifications/HelperNotificationInterface.php
@@ -1,0 +1,63 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface HelperNotificationInterface
+ *
+ * @since x.x.x
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
+ */
+interface  HelperNotificationInterface {
+
+	/**
+	 * Checks if the item can be processed based on the topic.
+	 *
+	 * @param WC_Product|WC_Coupon $item
+	 *
+	 * @return bool
+	 */
+	public function should_trigger_create_notification( $item ): bool;
+
+
+	/**
+	 * Indicates if the item ready for sending a delete Notification.
+	 *
+	 * @param WC_Product|WC_Coupon $item
+	 *
+	 * @return bool
+	 */
+	public function should_trigger_delete_notification( $item ): bool;
+
+	/**
+	 * Indicates if the item ready for sending an update Notification.
+	 *
+	 * @param WC_Product|WC_Coupon $item
+	 *
+	 * @return bool
+	 */
+	public function should_trigger_update_notification( $item ): bool;	
+
+	/**
+	 * Marks the item as unsynced.
+	 *
+	 * @param WC_Product|WC_Coupon $item
+	 *
+	 * @return bool
+	 */	
+	public function mark_as_unsynced( $item ): void;
+
+	/**
+	 * Set the notification status for an item.
+	 *
+	 * @param WC_Product|WC_Coupon $product
+	 * @param string     $status
+	 *
+	 * @return bool
+	 */	
+	public function set_notification_status( $item, $status ): void;	
+
+}

--- a/src/Jobs/Notifications/HelperNotificationInterface.php
+++ b/src/Jobs/Notifications/HelperNotificationInterface.php
@@ -53,7 +53,7 @@ interface HelperNotificationInterface {
 	/**
 	 * Set the notification status for an item.
 	 *
-	 * @param WC_Product|WC_Coupon $product
+	 * @param WC_Product|WC_Coupon $item
 	 * @param string               $status
 	 *
 	 * @return void

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\HelperNotificationInterface;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,7 +37,7 @@ class ProductNotificationJob extends AbstractItemNotificationJob {
 		ActionSchedulerInterface $action_scheduler,
 		ActionSchedulerJobMonitor $monitor,
 		NotificationsService $notifications_service,
-		ProductHelper $helper
+		HelperNotificationInterface $helper
 	) {
 		$this->notifications_service = $notifications_service;
 		$this->helper                = $helper;
@@ -58,7 +59,7 @@ class ProductNotificationJob extends AbstractItemNotificationJob {
 	 *
 	 * @return ProductHelper
 	 */
-	public function get_helper() {
+	public function get_helper(): HelperNotificationInterface {
 		return $this->helper;
 	}
 

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -28,10 +28,10 @@ class ProductNotificationJob extends AbstractItemNotificationJob {
 	/**
 	 * Notifications Jobs constructor.
 	 *
-	 * @param ActionSchedulerInterface  $action_scheduler
-	 * @param ActionSchedulerJobMonitor $monitor
-	 * @param NotificationsService      $notifications_service
-	 * @param ProductHelper             $helper
+	 * @param ActionSchedulerInterface    $action_scheduler
+	 * @param ActionSchedulerJobMonitor   $monitor
+	 * @param NotificationsService        $notifications_service
+	 * @param HelperNotificationInterface $helper
 	 */
 	public function __construct(
 		ActionSchedulerInterface $action_scheduler,

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product as GoogleProduct;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\HelperNotificationInterface;
 use WC_Product;
 use WC_Product_Variation;
 use WP_Post;
@@ -25,7 +26,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
  */
-class ProductHelper implements Service {
+class ProductHelper implements Service, HelperNotificationInterface {
 
 	use PluginHelper;
 
@@ -103,7 +104,7 @@ class ProductHelper implements Service {
 	/**
 	 * @param WC_Product $product
 	 */
-	public function mark_as_unsynced( WC_Product $product ) {
+	public function mark_as_unsynced( $product ): void {
 		$this->meta_handler->delete_synced_at( $product );
 		if ( ! $this->is_sync_ready( $product ) ) {
 			$this->meta_handler->delete_sync_status( $product );
@@ -390,7 +391,7 @@ class ProductHelper implements Service {
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_create_notification( WC_Product $product ): bool {
+	public function should_trigger_create_notification( $product ): bool {
 		return $this->is_ready_to_notify( $product ) && ! $this->has_notified_creation( $product );
 	}
 
@@ -402,7 +403,7 @@ class ProductHelper implements Service {
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_update_notification( WC_Product $product ): bool {
+	public function should_trigger_update_notification( $product ): bool {
 		return $this->is_ready_to_notify( $product ) && $this->has_notified_creation( $product );
 	}
 
@@ -414,7 +415,7 @@ class ProductHelper implements Service {
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_delete_notification( WC_Product $product ): bool {
+	public function should_trigger_delete_notification( $product ): bool {
 		return ! $this->is_ready_to_notify( $product ) && $this->has_notified_creation( $product );
 	}
 
@@ -447,7 +448,7 @@ class ProductHelper implements Service {
 	 * @param WC_Product $product
 	 * @param string     $status
 	 */
-	public function set_notification_status( WC_Product $product, $status ): void {
+	public function set_notification_status( $product, $status ): void {
 		$this->meta_handler->update_notification_status( $product, $status );
 	}
 

--- a/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
@@ -369,7 +369,7 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 				'topic'   => $this->get_topic_name() . '.create',
 			]
 		);
-	}	
+	}
 
 	public function get_name() {
 		return 'notifications/' . $this->get_job_name();

--- a/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
@@ -147,7 +147,7 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 			->with( $topic, $id )
 			->willReturn( true );
 
-		$this->job->get_helper()->expects( $this->exactly( 2 ) )
+		$this->job->get_helper()->expects( $this->exactly( 3 ) )
 			->method( 'get_wc_' . $this->get_topic_name() )
 			->with( $id )
 			->willReturn( $item );
@@ -218,7 +218,7 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 			->method( 'notify' )
 			->willReturn( true );
 
-		$this->job->get_helper()->expects( $this->exactly( 7 ) )
+		$this->job->get_helper()->expects( $this->exactly( 8 ) )
 			->method( 'get_wc_' . $this->get_topic_name() )
 			->willReturn( $item );
 
@@ -344,6 +344,32 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 			]
 		);
 	}
+
+	public function test_mark_as_notified_when_create() {
+		$item = $this->create_item();
+		$id   = $item->get_id();
+
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'should_trigger_create_notification' )
+			->with( $item )
+			->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->exactly( 3 ) )
+			->method( 'get_wc_' . $this->get_topic_name() )
+			->with( $id )
+			->willReturn( $item );
+
+		$this->notification_service->expects( $this->once() )->method( 'notify' )->willReturn( true );
+		$this->job->get_helper()->expects( $this->once() )
+			->method( 'mark_as_notified' );
+
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $this->get_topic_name() . '.create',
+			]
+		);
+	}	
 
 	public function get_name() {
 		return 'notifications/' . $this->get_job_name();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146

Once the products or coupons are notified, we can still update some metadata as we used to when we were pushing the data. This is particularly useful for coupons, as it allows us to inform the user that the coupon has been sent/notified to Google.

This PR adds the following:

- Once a coupon has been notified, it will update the sync status and sync timestamp.
- A similar approach will be applied to the products.
- I've created a new Interface called `HelperNotificationInterface` for the `ProductHelper` and `CouponHelper`. This is because the `AbstractItemNotificationJob` expects those classes to have certain methods available. By doing this, we can ensure that those methods are indeed available. The catch is that I had to remove some type hints because PHP versions earlier than 8 don't allow multiple types.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

### Coupons
1. Create a new coupon and set the visibility to Show Coupon on Google.
2. Go to WC -> Status -> Action Scheduler -> search for: `gla/jobs/notifications/coupons/process_item`
3. After the job is finished and has been successfully notified, check the postmeta of the coupon you created. It should have `_wc_gla_sync_status` = `synced` and `_wc_gla_synced_at` set.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/d3738479-6359-4043-aa3c-c0603ff16e28)


### Products
1. Create a new product and set the visibility to Sync and Show.
2. Go to WC -> Status -> Action Scheduler -> search for: `gla/jobs/notifications/products/process_item`
3. After the job is finished and has been successfully notified, check the postmeta of the product you created. It should have `_wc_gla_sync_status` = `synced` and `_wc_gla_synced_at` set.




### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
