### PR TITLE
API PULL - Add confirmation modal for disabling the feature

### DIFF
--- a/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { sprintf, __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
@@ -19,6 +20,10 @@ import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
 import { useAppDispatch } from '.~/data';
 import EnableNewProductSyncButton from '.~/components/enable-new-product-sync-button';
 import AppNotice from '.~/components/app-notice';
+import DisconnectModal, {
+	API_DATA_FETCH_FEATURE,
+} from '.~/settings/disconnect-modal';
+import { getSettingsUrl } from '.~/utils/urls';
 
 /**
  * Clicking on the "connect to a different Google Merchant Center account" button.
@@ -57,6 +62,14 @@ const ConnectedGoogleMCAccountCard = ( {
 		path: `${ API_NAMESPACE }/rest-api/authorize`,
 		method: 'DELETE',
 	} );
+
+	/**
+	 * Temporary code for disabling the API PULL Beta Feature from the GMC Card
+	 */
+	const [ openedModal, setOpenedModal ] = useState( null );
+	const dismissModal = () => setOpenedModal( null );
+	const openDisableDataFetchModal = () =>
+		setOpenedModal( API_DATA_FETCH_FEATURE );
 
 	const domain = new URL( getSetting( 'homeUrl' ) ).host;
 
@@ -174,6 +187,17 @@ const ConnectedGoogleMCAccountCard = ( {
 				</AppNotice>
 			) }
 
+			{ openedModal && (
+				<DisconnectModal
+					onRequestClose={ dismissModal }
+					onDisconnected={ () => {
+						window.location.href = getSettingsUrl();
+					} }
+					disconnectTarget={ openedModal }
+					disconnectAction={ disableNotifications }
+				/>
+			) }
+
 			{ showFooter && (
 				<Section.Card.Footer>
 					{ ! hideAccountSwitch && (
@@ -198,7 +222,7 @@ const ConnectedGoogleMCAccountCard = ( {
 								'google-listings-and-ads'
 							) }
 							eventName="gla_mc_account_disconnect_wpcom_rest_api"
-							onClick={ disableNotifications }
+							onClick={ openDisableDataFetchModal }
 						/>
 					) }
 				</Section.Card.Footer>

--- a/js/src/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/settings/disconnect-modal/confirm-modal.js
@@ -12,7 +12,7 @@ import AppModal from '.~/components/app-modal';
 import AppButton from '.~/components/app-button';
 import WarningIcon from '.~/components/warning-icon';
 import { useAppDispatch } from '.~/data';
-import { ALL_ACCOUNTS, ADS_ACCOUNT } from './constants';
+import { ALL_ACCOUNTS, ADS_ACCOUNT, API_DATA_FETCH_FEATURE } from './constants';
 
 const textDict = {
 	[ ALL_ACCOUNTS ]: {
@@ -66,12 +66,31 @@ const textDict = {
 			),
 		],
 	},
+	[ API_DATA_FETCH_FEATURE ]: {
+		title: __( 'Disable data fetching', 'google-listings-and-ads' ),
+		confirmButton: __( 'Disable data fetching', 'google-listings-and-ads' ),
+		confirmation: __(
+			'Yes, I want to disable the data fetching feature.',
+			'google-listings-and-ads'
+		),
+		contents: [
+			__(
+				'I understand that I am disabling the data fetching feature from this WooCommerce extension.',
+				'google-listings-and-ads'
+			),
+			__(
+				'Any ongoing campaigns and configuration will continue to run. They will be pushed to Google as in the previous versions of this extension.',
+				'google-listings-and-ads'
+			),
+		],
+	},
 };
 
 export default function ConfirmModal( {
 	disconnectTarget,
 	onRequestClose,
 	onDisconnected,
+	disconnectAction,
 } ) {
 	const [ isAgreed, setAgreed ] = useState( false );
 	const [ isDisconnecting, setDisconnecting ] = useState( false );
@@ -88,10 +107,14 @@ export default function ConfirmModal( {
 	};
 
 	const handleConfirmClick = () => {
-		const disconnect =
+		let disconnect =
 			disconnectTarget === ALL_ACCOUNTS
 				? dispatcher.disconnectAllAccounts
 				: dispatcher.disconnectGoogleAdsAccount;
+
+		if ( disconnectAction ) {
+			disconnect = disconnectAction;
+		}
 
 		setDisconnecting( true );
 		disconnect()

--- a/js/src/settings/disconnect-modal/constants.js
+++ b/js/src/settings/disconnect-modal/constants.js
@@ -1,2 +1,3 @@
 export const ALL_ACCOUNTS = 'all-accounts';
 export const ADS_ACCOUNT = 'ads-account';
+export const API_DATA_FETCH_FEATURE = 'api-data-fetch-feature';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a follow-up from the last changes in https://github.com/woocommerce/google-listings-and-ads/pull/2325

The PR adds a confirmation Modal before disabling the feature.


### Screenshots:
<img width="804" alt="Screenshot 2024-03-27 at 18 44 05" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/17e66f3a-7d64-41ca-9c63-4d41fa791385">




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Complete Onboarding (check GMC card stays the same)
2. Go to `/wp-admin/admin.php?page=wc-admin&path=/google/settings&google_wpcom_app_status=approved`
3. See the "Disable data fetching" link in GMC card
4. Click on it
5. See the modal
6. Dismiss it. 
7. Open it again
8. Check the checkbox and confirm
9. Feature is disabled.
10. You're redirected to Settings

