### PR TITLE
API PULL - Add a filter for enabling the feature

### DIFF
--- a/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
@@ -134,7 +134,9 @@ const ConnectedGoogleMCAccountCard = ( {
 		! hideNotificationService &&
 		googleMCAccount.wpcom_rest_api_status &&
 		googleMCAccount.wpcom_rest_api_status !==
-			GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
+			GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED &&
+		googleMCAccount.wpcom_rest_api_status !==
+			GOOGLE_WPCOM_APP_CONNECTED_STATUS.DISABLED;
 
 	const showFooter = ! hideAccountSwitch || showDisconnectNotificationsButton;
 

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -116,4 +116,5 @@ export const GOOGLE_WPCOM_APP_CONNECTED_STATUS = {
 	APPROVED: 'approved',
 	DISAPPROVED: 'disapproved',
 	ERROR: 'error',
+	DISABLED: 'disabled',
 };

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -147,11 +147,21 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	}
 
 	/**
+	 * If the Notifications are ready
+	 * This happens when the WPCOM API is Authorized and the feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public function is_ready(): bool {
+		return $this->options->is_wpcom_api_authorized() && $this->is_enabled();
+	}
+
+	/**
 	 * If the Notifications are enabled
 	 *
 	 * @return bool
 	 */
 	public function is_enabled(): bool {
-		return $this->options->notifications_enabled();
+		return apply_filters( 'woocommerce_gla_notifications_enabled', false );
 	}
 }

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -181,7 +181,7 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_update_coupon( WC_Coupon $coupon ) {
 		$coupon_id = $coupon->get_id();
 
-		if ( $this->notifications_service->is_enabled() ) {
+		if ( $this->notifications_service->is_ready() ) {
 			$this->handle_update_coupon_notification( $coupon );
 			return;
 		}
@@ -227,7 +227,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $coupon_id
 	 */
 	protected function handle_pre_delete_coupon( int $coupon_id ) {
-		if ( $this->notifications_service->is_enabled() ) {
+		if ( $this->notifications_service->is_ready() ) {
 			return;
 		}
 
@@ -269,7 +269,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $coupon_id
 	 */
 	protected function handle_delete_coupon( int $coupon_id ) {
-		if ( $this->notifications_service->is_enabled() ) {
+		if ( $this->notifications_service->is_ready() ) {
 			$this->maybe_send_delete_notification( $coupon_id );
 			return;
 		}

--- a/src/Jobs/Notifications/AbstractNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractNotificationJob.php
@@ -85,7 +85,7 @@ abstract class AbstractNotificationJob extends AbstractActionSchedulerJob implem
 		 * @param string $job_name The current Job name.
 		 * @param array $args The arguments for the schedule function with the item id and the topic.
 		 */
-		return apply_filters( 'woocommerce_gla_notification_job_can_schedule', $this->notifications_service->is_enabled() && parent::can_schedule( $args ), $this->get_job_name(), $args );
+		return apply_filters( 'woocommerce_gla_notification_job_can_schedule', $this->notifications_service->is_ready() && parent::can_schedule( $args ), $this->get_job_name(), $args );
 	}
 
 	/**

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
@@ -216,13 +217,16 @@ class AccountService implements OptionsAwareInterface, Service {
 	 * @return array
 	 */
 	public function get_connected_status(): array {
+		/** @var NotificationsService $notifications_service */
+		$notifications_service = $this->container->get( NotificationsService::class );
+
 		$id                    = $this->options->get_merchant_id();
 		$wpcom_rest_api_status = $this->options->get( OptionsInterface::WPCOM_REST_API_STATUS );
 
 		$status = [
 			'id'                    => $id,
 			'status'                => $id ? 'connected' : 'disconnected',
-			'wpcom_rest_api_status' => $wpcom_rest_api_status,
+			'wpcom_rest_api_status' => $notifications_service->is_enabled() ? $wpcom_rest_api_status : 'disabled',
 		];
 
 		$incomplete = $this->state->last_incomplete_step();

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
@@ -131,7 +132,9 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * @since x.x.x
 	 */
 	public function should_push(): bool {
-		return $this->is_ready_for_syncing() && ! $this->options->notifications_enabled();
+		/** @var NotificationsService $notifications_service */
+		$notifications_service = $this->container->get( NotificationsService::class );
+		return $this->is_ready_for_syncing() && ! $notifications_service->is_ready();
 	}
 
 

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -208,11 +208,11 @@ final class Options implements OptionsInterface, Service {
 	}
 
 	/**
-	 * Checks if Notifications are enabled.
+	 * Checks if WPCOM API is Authorized.
 	 *
 	 * @return bool
 	 */
-	public function notifications_enabled(): bool {
-		return apply_filters( 'woocommerce_gla_notifications_enabled', $this->get( self::WPCOM_REST_API_STATUS ) === 'approved' );
+	public function is_wpcom_api_authorized(): bool {
+		return $this->get( self::WPCOM_REST_API_STATUS ) === 'approved';
 	}
 }

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -144,9 +144,9 @@ interface OptionsInterface {
 	public function get_ads_id(): int;
 
 	/**
-	 * If the Notifications are enabled
+	 * If the WPCOM API is authorized
 	 *
 	 * @return bool
 	 */
-	public function notifications_enabled(): bool;
+	public function is_wpcom_api_authorized(): bool;
 }

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -213,7 +213,7 @@ class SyncerHooks implements Service, Registerable {
 		$products_to_update = [];
 		$products_to_delete = [];
 
-		if ( $this->notifications_service->is_enabled() ) {
+		if ( $this->notifications_service->is_ready() ) {
 			$this->handle_update_product_notification( $products[0] );
 			return;
 		}
@@ -302,7 +302,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_delete_product( int $product_id ) {
-		if ( $this->notifications_service->is_enabled() ) {
+		if ( $this->notifications_service->is_ready() ) {
 			$this->maybe_send_delete_notification( $product_id );
 			return;
 		}
@@ -342,7 +342,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_pre_delete_product( int $product_id ) {
-		if ( $this->notifications_service->is_enabled() ) {
+		if ( $this->notifications_service->is_ready() ) {
 			return;
 		}
 

--- a/src/Settings/SyncerHooks.php
+++ b/src/Settings/SyncerHooks.php
@@ -80,7 +80,7 @@ class SyncerHooks implements Service, Registerable {
 	 * Register the service.
 	 */
 	public function register(): void {
-		if ( ! $this->notifications_service->is_enabled() ) {
+		if ( ! $this->notifications_service->is_ready() ) {
 			return;
 		}
 

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -144,7 +144,7 @@ class SyncerHooks implements Service, Registerable {
 			return;
 		}
 
-		if ( $this->notifications_service->is_enabled() ) {
+		if ( $this->notifications_service->is_ready() ) {
 			$this->shipping_notification_job->schedule();
 		} else {
 			$this->update_shipping_job->schedule();

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -297,7 +297,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	 * Set the SyncerHooks class with specific features.
 	 *
 	 * @param bool $mc_status True if MC is ready. { @see MerchantCenterService::is_ready_for_syncing() }
-	 * @param bool $notifications_status True if NotificationsService is enabled. { @see NotificationsService::is_enabled() }
+	 * @param bool $notifications_status True if NotificationsService is enabled. { @see NotificationsService::is_ready() }
 	 */
 	public function set_mc_and_notifications( bool $mc_status = true, bool $notifications_status = false ) {
 		$this->merchant_center->expects( $this->any() )
@@ -305,7 +305,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 			->willReturn( $mc_status );
 
 		$this->notification_service->expects( $this->any() )
-			->method( 'is_enabled' )
+			->method( 'is_ready' )
 			->willReturn( $notifications_status );
 
 		$this->syncer_hooks = new SyncerHooks(

--- a/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
@@ -53,7 +53,7 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 		$topic = $this->get_topic_name() . '.create';
 		$id    = 1;
 
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+		$this->notification_service->expects( $this->once() )->method( 'is_ready' )->willReturn( true );
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
@@ -92,7 +92,7 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 		$topic = $this->get_topic_name() . '.create';
 		$id    = 1;
 
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+		$this->notification_service->expects( $this->once() )->method( 'is_ready' )->willReturn( true );
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
@@ -121,7 +121,7 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 		$topic = $this->get_topic_name() . '.create';
 		$id    = 1;
 
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
+		$this->notification_service->expects( $this->once() )->method( 'is_ready' )->willReturn( false );
 
 		$this->action_scheduler->expects( $this->never() )
 			->method( 'has_scheduled_action' );

--- a/tests/Unit/Jobs/AbstractNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractNotificationJobTest.php
@@ -48,7 +48,7 @@ abstract class AbstractNotificationJobTest extends UnitTest {
 	}
 
 	public function test_schedule_schedules_immediate_job() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+		$this->notification_service->expects( $this->once() )->method( 'is_ready' )->willReturn( true );
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
@@ -63,7 +63,7 @@ abstract class AbstractNotificationJobTest extends UnitTest {
 	}
 
 	public function test_schedule_doesnt_schedules_immediate_job_if_already_scheduled() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
+		$this->notification_service->expects( $this->once() )->method( 'is_ready' )->willReturn( true );
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'has_scheduled_action' )
@@ -76,7 +76,7 @@ abstract class AbstractNotificationJobTest extends UnitTest {
 	}
 
 	public function test_schedule_doesnt_schedules_immediate_job_if_not_enabled() {
-		$this->notification_service->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
+		$this->notification_service->expects( $this->once() )->method( 'is_ready' )->willReturn( false );
 
 		$this->action_scheduler->expects( $this->never() )
 			->method( 'has_scheduled_action' );

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -441,7 +441,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	 * Set the SyncerHooks class with specific features.
 	 *
 	 * @param bool $mc_status True if MC is ready. { @see MerchantCenterService::is_ready_for_syncing() }
-	 * @param bool $notifications_status True if NotificationsService is enabled. { @see NotificationsService::is_enabled() }
+	 * @param bool $notifications_status True if NotificationsService is enabled. { @see NotificationsService::is_ready() }
 	 */
 	public function set_mc_and_notifications( bool $mc_status = true, bool $notifications_status = false ) {
 		$this->merchant_center->expects( $this->any() )
@@ -449,7 +449,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 			->willReturn( $mc_status );
 
 		$this->notification_service->expects( $this->any() )
-			->method( 'is_enabled' )
+			->method( 'is_ready' )
 			->willReturn( $notifications_status );
 
 		$this->syncer_hooks = new SyncerHooks( $this->batch_helper, $this->product_helper, $this->job_repository, $this->merchant_center, $this->notification_service, $this->wc );

--- a/tests/Unit/Settings/SyncerHooksTest.php
+++ b/tests/Unit/Settings/SyncerHooksTest.php
@@ -69,7 +69,7 @@ class SyncerHooksTest extends UnitTest {
 
 	public function test_saving_woocommerce_general_settings_schedules_notification_job() {
 		$this->notification_service->expects( $this->once() )
-			->method( 'is_enabled' )
+			->method( 'is_ready' )
 			->willReturn( true );
 
 		$this->settings_notification_job->expects( $this->exactly( count( self::ALLOWED_SETTINGS ) ) )
@@ -83,7 +83,7 @@ class SyncerHooksTest extends UnitTest {
 
 	public function test_saving_other_settings_dont_schedules_notification_job() {
 		$this->notification_service->expects( $this->once() )
-			->method( 'is_enabled' )
+			->method( 'is_ready' )
 			->willReturn( true );
 
 		$this->settings_notification_job->expects( $this->never() )
@@ -95,7 +95,7 @@ class SyncerHooksTest extends UnitTest {
 
 	public function test_dont_register_if_notifications_disabled() {
 		$this->notification_service->expects( $this->once() )
-			->method( 'is_enabled' )
+			->method( 'is_ready' )
 			->willReturn( false );
 
 		$this->settings_notification_job->expects( $this->never() )

--- a/tests/Unit/Shipping/SyncerHooksTest.php
+++ b/tests/Unit/Shipping/SyncerHooksTest.php
@@ -197,7 +197,7 @@ class SyncerHooksTest extends UnitTest {
 		$this->mock_sync_ready_flags_and_register_hooks( true, true );
 
 		$this->notification_service->expects( $this->once() )
-			->method( 'is_enabled' );
+			->method( 'is_ready' );
 
 		$this->shipping_notification_job->expects( $this->never() )
 			->method( 'schedule' );
@@ -212,7 +212,7 @@ class SyncerHooksTest extends UnitTest {
 		$this->mock_sync_ready_flags_and_register_hooks( true, true );
 
 		$this->notification_service->expects( $this->once() )
-			->method( 'is_enabled' )->willReturn( true );
+			->method( 'is_ready' )->willReturn( true );
 
 		$this->shipping_notification_job->expects( $this->once() )
 			->method( 'schedule' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR enables a filter for enabling the full Notifications feature:

If the `woocommerce_gla_notifications_enabled` is false

- The enable feature banner and the info in the settings page cards won't show in the UI
- `wpcom_rest_api_status` will return `disabled` -- Even setting the `gla_wpcom_rest_api_status` Option as `approved`, `error` or `disapproved` 
- The Notification service won't trigger notifications (This will be done when https://github.com/woocommerce/google-listings-and-ads/pull/2336/ gets merged)
- The Syncer Hooks won't schedule any notification job
- MC will sync products and coupons as usual. (old strategy)

The PR does some naming changes

NotificationsService::is_enabled() -> Just checks the filter. 
Options::notifications_enabled() -> Renamed to `Options::is_wpcom_api_authorized()`
NotificationsService::is_ready() -> Check if NotificationsService::is_enabled() and if Options::is_wpcom_api_authorized()

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this PR ( `woocommerce_gla_notifications_enabled` is false by default) 
2. Complete the onboarding
3. Go to settings, no banner is shown
4. Set `gla_wpcom_rest_api_status` as `approved` 
5. No info in GMC Card is shown
6. Set `gla_wpcom_rest_api_status` as `error` 
7. No info in GMC Card is shown
8. Change some product 
9. See the notification jobs are not scheduled
10. Set `woocommerce_gla_notifications_enabled`  filter as true 
11. Delete `gla_wpcom_rest_api_status` option
12. Banner is shown
13. Set `gla_wpcom_rest_api_status` as `approved`
14. Info is shown in the card
15.  Change some product 
16.  See the notification jobs is scheduled


