### PR TITLE
Adjust Review Clicks and Ads Conversions Metrics threshold for Inbox Notes

### DIFF
--- a/src/Notes/ReviewAfterClicks.php
+++ b/src/Notes/ReviewAfterClicks.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class ReviewAfterClicks
  *
- * Note for requesting a review after at 100+ clicks.
+ * Note for requesting a review after 10 clicks.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
@@ -66,8 +66,8 @@ class ReviewAfterClicks extends AbstractNote implements MerchantCenterAwareInter
 	public function get_entry(): NoteEntry {
 		$clicks_count = $this->get_free_listing_clicks_count();
 
-		// Round to nearest 100
-		$clicks_count_rounded = floor( $clicks_count / 100 ) * 100;
+		// Round to nearest 10
+		$clicks_count_rounded = floor( $clicks_count / 10 ) * 10;
 
 		$note = new NoteEntry();
 		$note->set_title(
@@ -92,7 +92,7 @@ class ReviewAfterClicks extends AbstractNote implements MerchantCenterAwareInter
 	/**
 	 * Checks if a note can and should be added.
 	 *
-	 * - checks there is more than 100 clicks
+	 * - checks there are more than 10 clicks
 	 *
 	 * @throws Exception When unable to get clicks data.
 	 *
@@ -104,7 +104,7 @@ class ReviewAfterClicks extends AbstractNote implements MerchantCenterAwareInter
 		}
 
 		$clicks_count = $this->get_free_listing_clicks_count();
-		return $clicks_count > 100;
+		return $clicks_count > 10;
 	}
 
 	/**

--- a/src/Notes/ReviewAfterConversions.php
+++ b/src/Notes/ReviewAfterConversions.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class ReviewAfterConversions
  *
- * Note for requesting a review after at 10+ ad conversions.
+ * Note for requesting a review after one ad conversion.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notes
  */
@@ -77,17 +77,8 @@ class ReviewAfterConversions extends AbstractNote implements AdsAwareInterface {
 	 * @throws Exception When unable to get data.
 	 */
 	public function get_entry(): NoteEntry {
-		// Round to nearest 10
-		$conversions_count_rounded = floor( $this->get_ads_conversions_count() / 10 ) * 10;
-
 		$note = new NoteEntry();
-		$note->set_title(
-			sprintf(
-				/* translators: %s number of conversions */
-				__( 'You’ve gotten %s+ conversions through Google Ads! 🎉', 'google-listings-and-ads' ),
-				$this->wp->number_format_i18n( $conversions_count_rounded )
-			)
-		);
+		$note->set_title( __( 'You got your first conversion on Google Ads! 🎉', 'google-listings-and-ads' ), );
 		$note->set_content(
 			__( 'Congratulations! Tell us what you think about Google Listings & Ads by leaving a review. Your feedback will help us make WooCommerce even better for you.', 'google-listings-and-ads' )
 		);
@@ -103,7 +94,7 @@ class ReviewAfterConversions extends AbstractNote implements AdsAwareInterface {
 	/**
 	 * Checks if a note can and should be added.
 	 *
-	 * - checks there are more than 10 ad conversions
+	 * - checks there is at least one ad conversion
 	 *
 	 * @throws Exception When unable to get data.
 	 *
@@ -118,7 +109,7 @@ class ReviewAfterConversions extends AbstractNote implements AdsAwareInterface {
 			return false;
 		}
 
-		if ( $this->get_ads_conversions_count() <= 10 ) {
+		if ( $this->get_ads_conversions_count() < 1 ) {
 			return false;
 		}
 

--- a/tests/Unit/Notes/ReviewAfterClicksTest.php
+++ b/tests/Unit/Notes/ReviewAfterClicksTest.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReviewAfterClicks;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReviewAfterConversions;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 
@@ -30,7 +29,7 @@ class ReviewAfterClicksTest extends UnitTest {
 	/** @var MockObject|WP $wp */
 	protected $wp;
 
-	/** @var ReviewAfterConversions $note */
+	/** @var ReviewAfterClicks $note */
 	protected $note;
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, we show 2 Inbox Notes in these 2 scenarios:
1. One Note when the clicks on free listings are more than 100
2. One Note when the conversions on Ads are at least 10

This PR adjust those thresholds to: 
1. One Note when the clicks on free listings are more than 10
2. One Note when the conversions on Ads are at least 1

This PR also adjusted the text in the Ads Conversion Note to

"You got your first conversion on Google Ads! 🎉" 

This PR adjusted the tests and also also added some tests for `ReviewAfterClicks`as they were missing


### Screenshots:

<img width="720" alt="Screenshot 2024-03-28 at 12 58 41" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/44befd67-b1fc-4123-8f07-65fdba7f0f2f">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

0. Be sure `gla-review-after-conversions` and `gla-review-after-clicks` are deleted from `wp_wc_admin_notes `
1. Complete Onboarding Setting Up Paid Ads
2. Add the next  transients in WP Options
`_transient_gla_ads_metrics`
`a:3:{s:6:"clicks";i:0;s:11:"conversions";i:0;s:11:"impressions";i:0;}`
and
`_transient_gla_free_listing_metrics `
`a:2:{s:6:"clicks";i:10;s:11:"impressions";i:10;}`
3. Run `wc_gla_cron_daily_notes`
4. Go to WooCommerce - Home
5. Verify the Inbox is NOT showing the notes. 
6. Edit the next  transients in WP Options
`_transient_gla_ads_metrics`
`a:3:{s:6:"clicks";i:1;s:11:"conversions";i:1;s:11:"impressions";i:1;}`
and
`_transient_gla_free_listing_metrics `
`a:2:{s:6:"clicks";i:11;s:11:"impressions";i:11;}`
7. Repeat step 3 and 4
8. Verify the Inbox is showing the notes as in the provided screenshot. 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Show Review Inbox Notices when 11 clicks and 1 Conversion
