### PR TITLE
Add target audiences and shipping times in the settings/general endpoint. 

### DIFF
--- a/src/DB/Query/ShippingTimeQuery.php
+++ b/src/DB/Query/ShippingTimeQuery.php
@@ -47,6 +47,8 @@ class ShippingTimeQuery extends Query {
 	/**
 	 * Get all shipping times.
 	 *
+	 * @since x.x.x
+	 *
 	 * @return array
 	 */
 	public function get_all_shipping_times() {

--- a/src/DB/Query/ShippingTimeQuery.php
+++ b/src/DB/Query/ShippingTimeQuery.php
@@ -43,4 +43,24 @@ class ShippingTimeQuery extends Query {
 
 		return $value;
 	}
+
+	/**
+	 * Get all shipping times.
+	 *
+	 * @return array
+	 */
+	public function get_all_shipping_times() {
+		$times = $this->get_results();
+		$items = [];
+		foreach ( $times as $time ) {
+			$data = [
+				'country_code' => $time['country'],
+				'time'         => $time['time'],
+			];
+
+			$items[ $time['country'] ] = $data;
+		}
+
+		return $items;
+	}
 }

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -20,6 +20,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * Initializes the hooks to filter the data sent to the WPCOM proxy depending on the query parameter gla_syncable.
  *
+ * @since x.x.x
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Integration
  */
 class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -136,12 +136,19 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	protected function register_callbacks() {
 		add_filter(
 			'rest_request_after_callbacks',
-			function ( WP_REST_Response $response, $handler, WP_REST_Request $request ) {
+			/**
+			 * Add the Google Listings and Ads settings to the settings/general response.
+			 *
+			 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response The response object.
+			 * @param mixed                                             $handler  The handler.
+			 * @param WP_REST_Request                                   $request  The request object.
+			 */
+			function ( $response, $handler, $request ) {
 				if ( ! $this->is_gla_request( $request ) ) {
 					return $response;
 				}
 
-				if ( $request->get_route() === '/wc/v3/settings/general' ) {
+				if ( $request->get_route() === '/wc/v3/settings/general' && $response instanceof WP_REST_Response ) {
 					$data   = $response->get_data();
 					$data[] = [
 						'id'    => 'gla_target_audience',

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInitializer;
@@ -48,7 +49,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommercePreOrders::class, ProductHelper::class );
 		$this->conditionally_share_with_tags( JetpackWPCOM::class );
-		$this->share_with_tags( WPCOMProxy::class );
+		$this->share_with_tags( WPCOMProxy::class, ShippingTimeQuery::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPCOMProxy;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use WC_Meta_Data;
 use WP_REST_Response;
 
@@ -391,12 +390,6 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 	public function test_get_settings_with_gla_syncable_param() {
 		global $wpdb;
 
-		$target_audience = [
-			'countries' => [ 'US' ],
-		];
-
-		update_option( 'gla_' . OptionsInterface::TARGET_AUDIENCE, $target_audience );
-
 		// As the shipping time tables are not created in the test environment, we need to suppress the errors.
 		$wpdb->suppress_errors = true;
 
@@ -410,6 +403,5 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 
 		$this->assertArrayHasKey( 'gla_target_audience', $response_mapped );
 		$this->assertArrayHasKey( 'gla_shipping_times', $response_mapped );
-		$this->assertEquals( $target_audience, $response_mapped['gla_target_audience']['value'] );
 	}
 }

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -378,7 +378,6 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_settings_without_gla_syncable_param() {
-
 		$response = $this->do_request( '/wc/v3/settings/general', 'GET' );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -386,18 +385,17 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
 
 		$this->assertArrayNotHasKey( 'gla_target_audience', $response_mapped );
-		$this->assertArrayNotHasKey( 'gla_shipping_times', $response_mapped );			
-	}	
+		$this->assertArrayNotHasKey( 'gla_shipping_times', $response_mapped );
+	}
 
 	public function test_get_settings_with_gla_syncable_param() {
-
 		global $wpdb;
 
 		$target_audience = [
-			'countries' => ['US'],
+			'countries' => [ 'US' ],
 		];
 
-		update_option( "gla_".OptionsInterface::TARGET_AUDIENCE , $target_audience );
+		update_option( 'gla_' . OptionsInterface::TARGET_AUDIENCE, $target_audience );
 
 		// As the shipping time tables are not created in the test environment, we need to suppress the errors.
 		$wpdb->suppress_errors = true;
@@ -411,7 +409,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
 
 		$this->assertArrayHasKey( 'gla_target_audience', $response_mapped );
-		$this->assertArrayHasKey( 'gla_shipping_times', $response_mapped );			
+		$this->assertArrayHasKey( 'gla_shipping_times', $response_mapped );
 		$this->assertEquals( $target_audience, $response_mapped['gla_target_audience']['value'] );
-	}	
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146


As part of the new mechanism for syncing merchant data with Google Merchant Center, we need to make some GLA Options accessible, such as the target audience and shipping times.

This PR adds the target audience and shipping time to the response of `wp-json/wc/v3/settings/general`

Initially, my idea was to use the filter `woocommerce_settings- . $group_id` to add a new group of settings. However, this filter can only be used for Options (which should be fine for the target audience but not for the shipping times). Additionally, the filter `woocommerce_settings-` doesn't provide the Request Object param so I decided to use the filter `rest_request_after_callbacks` which makes it easier to verify if the request is made from the proxied endpoints.

https://github.com/woocommerce/woocommerce/blob/af03815134385c72feb7a70abc597eca57442820/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php#L79

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Get [WC REST API credentials](https://woocommerce.github.io/woocommerce-rest-api-docs/#rest-api-keys), or alternatively, you can use your sandbox and authorize your WPCOM App in WPCOM.
2. Make a request to `GET /wp-json/wc/v3/settings/general?gla_syncable=1`. If using the WPCOM proxy, use `wpcom/v2/sites/YOUR_BLOG_ID/wc/v3/settings/general`.
3. Verify that the response contains two new fields: `gla_target_audience` and `gla_shipping_times`.
4. Check that if the parameter gla_syncable=1 is not included in the URL, for example: `GET /wp-json/wc/v3/settings/general`, it will not add those two fields. Note: If you make the request from WPCOM, it will always add the query parameter.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
