### PR TITLE
Add support for program types when requesting a review

### DIFF
--- a/js/src/product-feed/review-request/review-request-notice.js
+++ b/js/src/product-feed/review-request/review-request-notice.js
@@ -64,7 +64,8 @@ const ReviewRequestNotice = ( {
 			<FlexItem className="gla-review-request-notice__button">
 				{ accountReviewStatus.requestButton &&
 					( account.cooldown ||
-						account.reviewEligibleRegions.length > 0 ) && (
+						Object.keys( account.reviewEligibleRegions )?.length >
+							0 ) && (
 						<AppButton
 							isPrimary
 							onClick={ onRequestReviewClick }

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -574,7 +574,7 @@ class Middleware implements OptionsAwareInterface {
 			$client = $this->container->get( Client::class );
 
 			// For each region we request a new review
-			foreach ( $regions as $region_code ) {
+			foreach ( $regions as $region_code => $region_types ) {
 				$result = $client->post(
 					$this->get_manager_url( 'account-review-request' ),
 					[
@@ -582,6 +582,7 @@ class Middleware implements OptionsAwareInterface {
 							[
 								'accountId'  => $this->options->get_merchant_id(),
 								'regionCode' => $region_code,
+								'types'      => $region_types,
 							]
 						),
 					]

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -222,7 +222,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				'status'                => RequestReviewStatuses::DISAPPROVED,
 				'issues'                => [ 'one', 'two' ],
 				'cooldown'              => 0,
-				'reviewEligibleRegions' => [ 'US' ],
+				'reviewEligibleRegions' => [ 'US' => [ 'programtypea', 'programtypeb' ] ],
 			],
 			$response->get_data()
 		);
@@ -317,7 +317,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				'status'                => RequestReviewStatuses::DISAPPROVED,
 				'issues'                => [ 'one', 'two' ],
 				'cooldown'              => 0,
-				'reviewEligibleRegions' => [ 'US' ],
+				'reviewEligibleRegions' => [ 'US' => [ 'programtypea' ] ],
 			],
 			$response->get_data()
 		);
@@ -390,7 +390,7 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 				'status'                => RequestReviewStatuses::DISAPPROVED,
 				'issues'                => [ 'one', 'two' ],
 				'cooldown'              => 1651058331000, // 27/04/2022
-				'reviewEligibleRegions' => [ 'US' ],
+				'reviewEligibleRegions' => [ 'US' => [ 'freelistingsprogram' ] ],
 			],
 			$response->get_data()
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, when requesting a review, we merged all the program types (free listings and shopping ads) into one single region. Then we call WCS for requesting the review for both programs Free Listings and Shopping Ads.

This PR adds a "types" param in the request review request with the programs required to review per each region. That way we can request a review in WCS only to the required program types. If both programs are requested, only Free Listings one is processed in WCS


### Screenshots


https://github.com/woocommerce/google-listings-and-ads/assets/5908855/4f7d7308-7563-4c2d-8669-4de3c320faa3



### Related PR

https://github.com/Automattic/woocommerce-connect-server/pull/2404

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Since we are testing a full review Request in https://github.com/Automattic/woocommerce-connect-server/pull/2404  in this PR I advise to alter the types param to have only 'shoppingads' type.

1. Setup WCS and checkout https://github.com/Automattic/woocommerce-connect-server/pull/2404 
2. Alter https://github.com/woocommerce/google-listings-and-ads/pull/2344/files#diff-cc9faaa2c65642115b9c462704152e93ac01760cd0b6338a2e80fb5846382b76R584 to force sending the types as [ 'shoppingadsprogram' ] 
3. Send a request review for an account ready to review
4. See the request is successful


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Exception in request review 
