### PR TITLE
API PULL - Fix fatal when sending notifications in Connection test

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -778,7 +778,11 @@ class ConnectionTest implements Service, Registerable {
 			$item  = $_GET['item_id'] ?? null;
 			$topic = $_GET['topic'];
 			$mc    = $this->container->get( MerchantCenterService::class );
+			/** @var OptionsInterface $options */
+			$options = $this->container->get( OptionsInterface::class );
 			$service = new NotificationsService( $mc );
+			$service->set_options_object( $options );
+
 			if ( $service->notify( $topic, $item ) ) {
 				$this->response .= "\n Notification success. Item: " . $item . " - Topic: " . $topic;
 			} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Caused by https://github.com/woocommerce/google-listings-and-ads/pull/2340

This PR fix a fatal when sending a notification from connection test page.



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Without this PR go to COnnection test page
2. Click on Send notification at the end of the page
3. See the fatal
4. Checkout PR
5. Repeat step 2
6. No fatal error

