### PR TITLE
Add snippet to bypass plugin dependency to fix e2e tests

### DIFF
--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -36,3 +36,18 @@ add_filter(
 		return $value_options;
 	}
 );
+
+/**
+ * Snippet to bypass the WooCommerce dependency in Google Listings & Ads because
+ * in wp-env WooCommerce is installed in the directory woocommerce-trunk-nightly
+ */
+add_action(
+	'wp_plugin_dependencies_slug',
+	function( $slug ) {
+		if ( 'woocommerce' === $slug ) {
+			$slug = '';
+		}
+
+		return $slug;
+	}
+);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2348

The WooCommerce plugin dependency listed in Google Listings & Ads is causing problems with the E2E environment setup because if WooCommerce is not activated first then GLA won't be activated at all.

This PR adds a snippet to bypass the dependency so that the environment can be setup.

Ref: pcShBQ-1yd-p2#comment-2990

### Changelog entry

> Dev - Add snippet to bypass WooCommerce dependency in E2E tests