### PR TITLE
API Pull - Expose Attribute mapping Rules Values

### DIFF
--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -132,7 +132,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		add_filter(
 			'woocommerce_rest_prepare_' . $object_type . '_object',
 			[ $this, 'filter_response_by_syncable_item' ],
-			9,
+			1000, // Run this filter last.
 			3
 		);
 

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -132,7 +132,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		add_filter(
 			'woocommerce_rest_prepare_' . $object_type . '_object',
 			[ $this, 'filter_response_by_syncable_item' ],
-			1000, // Run this filter last.
+			1000, // Run this filter last to override any other response.
 			3
 		);
 

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use WC_Product;
 use WP_REST_Response;
 use WP_REST_Request;
 
@@ -36,12 +38,29 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	protected $shipping_time_query;
 
 	/**
+	 * The AttributeManager object.
+	 *
+	 * @var AttributeManager
+	 */
+	protected $attribute_manager;
+
+	/**
+	 * The protected resources. Only items with visibility set to sync-and-show will be returned.
+	 */
+	protected const PROTECTED_RESOURCES = [
+		'products',
+		'coupons',
+	];
+
+	/**
 	 * WPCOMProxy constructor.
 	 *
 	 * @param ShippingTimeQuery $shipping_time_query The ShippingTimeQuery object.
+	 * @param AttributeManager  $attribute_manager   The AttributeManager object.
 	 */
-	public function __construct( ShippingTimeQuery $shipping_time_query ) {
+	public function __construct( ShippingTimeQuery $shipping_time_query, AttributeManager $attribute_manager ) {
 		$this->shipping_time_query = $shipping_time_query;
+		$this->attribute_manager   = $attribute_manager;
 	}
 
 	/**
@@ -119,7 +138,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 
 		add_filter(
 			'woocommerce_rest_prepare_' . $object_type . '_object',
-			[ $this, 'filter_metadata' ],
+			[ $this, 'prepare_response' ],
 			10,
 			3
 		);
@@ -187,6 +206,21 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	}
 
 	/**
+	 * Get the resource endpoint.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return string The resource endpoint.
+	 */
+	protected function get_resource_endpoint( WP_REST_Request $request ): string {
+		$route   = $request->get_route();
+		$pattern = '/(?P<resource>[\w]+)\/(?P<id>[\d]+$)/';
+		preg_match( $pattern, $route, $matches );
+
+		return $matches['resource'] ?? '';
+	}
+
+	/**
 	 * Filter response by syncable item.
 	 *
 	 * @param WP_REST_Response $response The response object.
@@ -200,15 +234,9 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 			return $response;
 		}
 
-		$route               = $request->get_route();
-		$pattern             = '/(?P<resource>[\w]+)\/(?P<id>[\d]+$)/';
-		$protected_resources = [
-			'products',
-			'coupons',
-		];
-		preg_match( $pattern, $route, $matches );
+		$resource = $this->get_resource_endpoint( $request );
 
-		if ( ! isset( $matches['id'] ) || ! isset( $matches['resource'] ) || ! in_array( $matches['resource'], $protected_resources, true ) ) {
+		if ( ! isset( $matches['id'] ) || ! $resource || ! in_array( $resource, self::PROTECTED_RESOURCES, true ) ) {
 			return $response;
 		}
 
@@ -258,7 +286,10 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	}
 
 	/**
-	 * Filter the response metadata returning all public metadata and those prefixed with _wc_gla
+	 * Prepares the response when the request is coming from the WPCOM proxy:
+	 *
+	 * Filter all the private metadata and returns only the public metadata and those prefixed with _wc_gla
+	 * For WooCommerce products, it will add the attribute values.
 	 *
 	 * @param WP_REST_Response $response The response object.
 	 * @param mixed            $item     The item.
@@ -266,18 +297,19 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	 *
 	 * @return WP_REST_Response The response object updated.
 	 */
-	public function filter_metadata( WP_REST_Response $response, $item, WP_REST_Request $request ): WP_REST_Response {
+	public function prepare_response( WP_REST_Response $response, $item, WP_REST_Request $request ): WP_REST_Response {
 		if ( ! $this->is_gla_request( $request ) ) {
 			return $response;
 		}
 
 		$data = $response->get_data();
 
-		if ( ! isset( $data['meta_data'] ) ) {
-			return $response;
+		if ( $item instanceof WC_Product && $this->get_resource_endpoint( $request ) === 'products' ) {
+			$attr                   = $this->attribute_manager->get_all_aggregated_values( $item );
+			$data['gla_attributes'] = $attr;
 		}
 
-		foreach ( $data['meta_data'] as $key => $meta ) {
+		foreach ( $data['meta_data'] ?? [] as $key => $meta ) {
 			if ( str_starts_with( $meta->key, '_' ) && ! str_starts_with( $meta->key, '_wc_gla' ) ) {
 				unset( $data['meta_data'][ $key ] );
 			}

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -289,7 +289,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	 * Prepares the response when the request is coming from the WPCOM proxy:
 	 *
 	 * Filter all the private metadata and returns only the public metadata and those prefixed with _wc_gla
-	 * For WooCommerce products, it will add the attribute values.
+	 * For WooCommerce products, it will add the attribute mapping values.
 	 *
 	 * @param WP_REST_Response $response The response object.
 	 * @param mixed            $item     The item.

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -331,7 +331,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( NoteInitializer::class, ActionScheduler::class );
 
 		// Product attributes
-		$this->conditionally_share_with_tags( AttributeManager::class, AttributeMappingRulesQuery::class );
+		$this->conditionally_share_with_tags( AttributeManager::class, AttributeMappingRulesQuery::class, WC::class );
 		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -331,7 +331,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( NoteInitializer::class, ActionScheduler::class );
 
 		// Product attributes
-		$this->conditionally_share_with_tags( AttributeManager::class );
+		$this->conditionally_share_with_tags( AttributeManager::class, AttributeMappingRulesQuery::class );
 		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -49,7 +49,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommercePreOrders::class, ProductHelper::class );
 		$this->conditionally_share_with_tags( JetpackWPCOM::class );
-		$this->share_with_tags( WPCOMProxy::class, ShippingTimeQuery::class );
+		$this->share_with_tags( WPCOMProxy::class, ShippingTimeQuery::class, AttributeManager::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -176,6 +176,8 @@ class AttributeManager implements Service {
 	/**
 	 * Return all attribute values for the given product, including the ones from the attribute mapping rules
 	 *
+	 * @since x.x.x
+	 *
 	 * @param WC_Product $product
 	 *
 	 * @return array of attribute values
@@ -197,6 +199,8 @@ class AttributeManager implements Service {
 
 	/**
 	 * Get the values for the attribute mapping rules
+	 *
+	 * @since x.x.x
 	 *
 	 * @param WC_Product $product
 	 * @param array      $mapping_rules
@@ -225,6 +229,8 @@ class AttributeManager implements Service {
 	/**
 	 * Get a source value for attribute mapping
 	 *
+	 * @since x.x.x
+	 *
 	 * @param WC_Product $product The product to get the value from
 	 * @param string     $source The source to get the value
 	 * @return string The source value for this product
@@ -242,7 +248,7 @@ class AttributeManager implements Service {
 		// Detect if the source_type is kind of product, taxonomy or attribute. Otherwise, we take it the full source as a static value.
 		switch ( $source_type ) {
 			case 'product':
-				return $this->get_product_field( $source_value, $product );
+				return $this->get_product_field( $product, $source_value );
 			case 'taxonomy':
 				return $this->get_product_taxonomy( $product, $source_value );
 			case 'attribute':
@@ -254,6 +260,8 @@ class AttributeManager implements Service {
 
 	/**
 	 * Gets a custom attribute from a product
+	 *
+	 * @since x.x.x
 	 *
 	 * @param WC_Product $product - The product to get the attribute from.
 	 * @param string     $attribute_name - The attribute name to get.
@@ -280,6 +288,8 @@ class AttributeManager implements Service {
 	 * Get product source type  for attribute mapping.
 	 * Those are fields belonging to the product core data. Like title, weight, SKU...
 	 *
+	 * @since x.x.x
+	 *
 	 * @param WC_Product $product The product to get the value from
 	 * @param string     $field The field to get
 	 * @return string|null The field value (null if data is not available)
@@ -301,6 +311,8 @@ class AttributeManager implements Service {
 	/**
 	 * Get taxonomy source type for attribute mapping
 	 *
+	 * @since x.x.x
+	 *
 	 * @param WC_Product $product The product to get the taxonomy from
 	 * @param string     $taxonomy The taxonomy to get
 	 * @return string The taxonomy value
@@ -314,7 +326,7 @@ class AttributeManager implements Service {
 			}
 
 			if ( ! $values ) { // if the value is still not available at this point, we try to get it from the parent
-				$parent = wc_get_product( $product->get_parent_id() );
+				$parent = $this->wc->get_product( $product->get_parent_id() );
 				$values = $parent->get_attribute( $taxonomy );
 
 				if ( ! $values ) {
@@ -339,6 +351,8 @@ class AttributeManager implements Service {
 	/**
 	 * Get a taxonomy term names from a product using
 	 *
+	 * @since x.x.x
+	 *
 	 * @param int    $product_id - The product ID to get the taxonomy term
 	 * @param string $taxonomy - The taxonomy to get.
 	 * @return string[] An array of term names.
@@ -352,6 +366,8 @@ class AttributeManager implements Service {
 	/**
 	 *
 	 * Formats the attribute for sending it via Google API
+	 *
+	 * @since x.x.x
 	 *
 	 * @param string $value The value to format
 	 * @param string $attribute_id The attribute ID for which this value belongs
@@ -374,6 +390,8 @@ class AttributeManager implements Service {
 	/**
 	 * Check if the current product match the conditions for applying the Attribute mapping rule.
 	 * For now the conditions are just matching with the product category conditions.
+	 *
+	 * @since x.x.x
 	 *
 	 * @param WC_Product $product The product to check
 	 * @param array      $rule The attribute mapping rule

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -157,7 +157,6 @@ class AttributeManager implements Service {
 	 * Return all attribute values for the given product
 	 *
 	 * @param WC_Product $product
-	 * @param bool       $apply_rules Whether to apply attribute mapping rules
 	 *
 	 * @return array of attribute values
 	 */
@@ -174,7 +173,8 @@ class AttributeManager implements Service {
 	}
 
 	/**
-	 * Return all attribute values for the given product, including the ones from the attribute mapping rules
+	 * Return all attribute values for the given product, including the ones from the attribute mapping rules.
+	 * GLA Attributes has priority over the product attributes.
 	 *
 	 * @since x.x.x
 	 *
@@ -406,7 +406,7 @@ class AttributeManager implements Service {
 		}
 
 		// size is not the real attribute, the real attribute is sizes
-		if ( ! in_array( $attribute, $this->get_attribute_ids() ) && $attribute !== 'size' ) {
+		if ( ! in_array( $attribute, $this->get_attribute_ids(), true ) && $attribute !== 'size' ) {
 			return false;
 		}
 
@@ -431,13 +431,12 @@ class AttributeManager implements Service {
 		$attributes = [];
 		foreach ( self::ATTRIBUTES as $attribute_type ) {
 			if ( method_exists( $attribute_type, 'get_id' ) ) {
-				$attribute_id                = call_user_func( [ $attribute_type, 'get_id' ] );
+				$attribute_id = call_user_func( [ $attribute_type, 'get_id' ] );
 				$attributes[] = $attribute_id;
 			}
 		}
 
 		return $attributes;
-	
 	}
 
 	/**

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -194,7 +194,7 @@ class AttributeManager implements Service {
 
 		$mapping_rules        = $this->attribute_mapping_rules_query->get_results();
 		$mapping_rules_values = $this->get_attribute_mapping_rules_values( $product, $mapping_rules );
-		return array_merge( $attributes, $mapping_rules_values );
+		return array_merge( $mapping_rules_values, $attributes );
 	}
 
 	/**
@@ -406,7 +406,7 @@ class AttributeManager implements Service {
 		}
 
 		// size is not the real attribute, the real attribute is sizes
-		if ( ! property_exists( $this, $attribute ) && $attribute !== 'size' ) {
+		if ( ! in_array( $attribute, $this->get_attribute_ids() ) && $attribute !== 'size' ) {
 			return false;
 		}
 
@@ -420,6 +420,24 @@ class AttributeManager implements Service {
 		}
 
 		return ! $contains_rules_categories;
+	}
+
+	/**
+	 * Get attribute IDs
+	 *
+	 * @return array Attribute IDs
+	 */
+	protected function get_attribute_ids(): array {
+		$attributes = [];
+		foreach ( self::ATTRIBUTES as $attribute_type ) {
+			if ( method_exists( $attribute_type, 'get_id' ) ) {
+				$attribute_id                = call_user_func( [ $attribute_type, 'get_id' ] );
+				$attributes[] = $attribute_id;
+			}
+		}
+
+		return $attributes;
+	
 	}
 
 	/**

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -549,4 +549,61 @@ trait ProductTrait {
 			]
 		);
 	}
+
+	/**
+	 * Creates a simple product ready for being tested in Attribute Mapping
+	 *
+	 * @param array $categories The Categories attached to this product.
+	 * @return WC_Product The simple product.
+	 */
+	protected function generate_attribute_mapping_simple_product( $categories = [] ) {
+		$product = WC_Helper_Product::create_simple_product( false );
+
+		$attributes = [
+			WC_Helper_Product::create_product_attribute_object( 'size', [ 's', 'xs' ] ),
+		];
+
+		$product->set_attributes( $attributes );
+		$product->add_meta_data( 'custom', 'test' );
+		$product->add_meta_data( 'array', [ 'foo' => 'bar' ] );
+		$product->add_meta_data( 'multiple', 'Value1 | Value 2' );
+
+		if ( ! empty( $categories ) ) {
+			$product->set_category_ids( $categories );
+		}
+
+		$product->set_stock_quantity( 1 );
+		$product->set_tax_class( 'mytax' );
+
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * Creates a variant with variations ready for being tested in Attribute Mapping
+	 *
+	 * @param array $categories The Categories attached to the variation parent.
+	 * @return array The variation and the parent product.
+	 */
+	protected function generate_attribute_mapping_variant_product( $categories = [] ) {
+		$variable = WC_Helper_Product::create_variation_product();
+		if ( ! empty( $categories ) ) {
+			$variable->set_category_ids( $categories );
+		}
+		$variable->save();
+
+		$variation = wc_get_product( $variable->get_children()[ count( $variable->get_children() ) - 1 ] );
+		$variation->set_stock_quantity( 1 );
+		$variation->set_weight( 1.2 );
+		$variation->set_tax_class( 'mytax' );
+		$variation->add_meta_data( 'custom', 'test' );
+		$variation->add_meta_data( 'array', [ 'foo' => 'bar' ] );
+		$variation->add_meta_data( 'multiple', 'Value1 | Value 2' );
+
+		return [
+			'parent'    => $variable,
+			'variation' => $variation,
+		];
+	}
 }

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -557,10 +557,11 @@ trait ProductTrait {
 	 * @return WC_Product The simple product.
 	 */
 	protected function generate_attribute_mapping_simple_product( $categories = [] ) {
-		$product = WC_Helper_Product::create_simple_product( false );
+		$product = WC_Helper_Product::create_simple_product();
 
 		$attributes = [
 			WC_Helper_Product::create_product_attribute_object( 'size', [ 's', 'xs' ] ),
+			WC_Helper_Product::create_product_attribute_object( 'gender', [ 'man' ] ),
 		];
 
 		$product->set_attributes( $attributes );
@@ -572,10 +573,10 @@ trait ProductTrait {
 			$product->set_category_ids( $categories );
 		}
 
+		$product->save();
+
 		$product->set_stock_quantity( 1 );
 		$product->set_tax_class( 'mytax' );
-
-		$product->save();
 
 		return $product;
 	}

--- a/tests/Unit/Product/Attributes/AttributeManagerTest.php
+++ b/tests/Unit/Product/Attributes/AttributeManagerTest.php
@@ -452,8 +452,6 @@ class AttributeManagerTest extends ContainerAwareUnitTest {
 	public function test_gla_attribute_has_priority_over_attribute_mapping_rules() {
 		$rules = $this->get_sample_rules();
 
-		// 'gla_attributes' => [ 'gender' => 'man' ],
-
 		$product = $this->generate_attribute_mapping_simple_product();
 
 		$product->add_meta_data( $this->prefix_meta_key( Gender::get_id() ), 'man' );

--- a/tests/Unit/Product/Attributes/AttributeManagerTest.php
+++ b/tests/Unit/Product/Attributes/AttributeManagerTest.php
@@ -13,6 +13,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Brand;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\GTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\IsBundle;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use WC_Helper_Product;
 
 /**
@@ -26,6 +28,12 @@ class AttributeManagerTest extends ContainerAwareUnitTest {
 
 	/** @var AttributeManager $attribute_manager */
 	protected $attribute_manager;
+
+	/** @var MockObject|AttributeMappingRulesQuery $attribute_mapping_rules_query */
+	protected $attribute_mapping_rules_query;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
 
 	public function test_update_throws_exception_if_attribute_inapplicable_to_product() {
 		$variable  = WC_Helper_Product::create_variation_product();
@@ -185,7 +193,7 @@ class AttributeManagerTest extends ContainerAwareUnitTest {
 		// We need a new instance of AttributeManager because the attribute map created by `AttributeManager:map_attribute_types`
 		// is cached when called previously, which mean that it can not be modified by filters.
 		// Since we can not place the filters to run before `AttributeManager:map_attribute_types`, it's best to create a new instance of our class.
-		$attribute_manager = new AttributeManager();
+		$attribute_manager = new AttributeManager( $this->attribute_mapping_rules_query, $this->wc);
 
 		$brand_id = Brand::get_id();
 		add_filter(
@@ -213,7 +221,7 @@ class AttributeManagerTest extends ContainerAwareUnitTest {
 		// We need a new instance of AttributeManager because the attribute map created by `AttributeManager:map_attribute_types`
 		// is cached when called previously, which mean that it can not be modified by filters.
 		// Since we can not place the filters to run before `AttributeManager:map_attribute_types`, it's best to create a new instance of our class.
-		$attribute_manager = new AttributeManager();
+		$attribute_manager = new AttributeManager( $this->attribute_mapping_rules_query, $this->wc);
 
 		add_filter(
 			'woocommerce_gla_product_attribute_types',
@@ -228,7 +236,7 @@ class AttributeManagerTest extends ContainerAwareUnitTest {
 		// We need a new instance of AttributeManager because the attribute map created by `AttributeManager:map_attribute_types`
 		// is cached when called previously, which mean that it can not be modified by filters.
 		// Since we can not place the filters to run before `AttributeManager:map_attribute_types`, it's best to create a new instance of our class.
-		$attribute_manager = new AttributeManager();
+		$attribute_manager = new AttributeManager( $this->attribute_mapping_rules_query, $this->wc);
 
 		add_filter(
 			'woocommerce_gla_product_attribute_types',
@@ -248,6 +256,11 @@ class AttributeManagerTest extends ContainerAwareUnitTest {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->attribute_mapping_rules_query   = $this->createMock( AttributeMappingRulesQuery::class );
+		$this->wc = $this->createMock( WC::class );
+
+
 		$this->attribute_manager = $this->container->get( AttributeManager::class );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146

As we move to a new approach for fetching products using the WC REST API, we need to make product's attribute mapping values accessible. Hence, this PR introduces a new property to the `wc/v3/products` endpoint, named `gla_attributes`. This property will contain the attribute values after applying all GLA Mapping Attribute rules, with GLA attributes taking precedence over mapping rules.

Also, I realized that most of the logic for mapping attribute rules resides within `WCProductAdapter`. In my view, moving this logic to the `AttributeManager` class would be more logical, given its existing handling of GLA attributes. Therefore, I've moved and adjusted most of the logic from the `WCProductAdapter` to the `AttributeManager` class. This adjustment will enable us to independently retrieve attributes from a product, without needing to create an instance of `WCProductAdapter`.

I was thinking of refactoring `WCProductAdapter` to use the new methods in the `AttributeManager` class, however, as we are not going to sync the attributes anymore I believe it's unnecessary to refactor that section as we will delete that part of the code in the next stages.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to GLA -> Attribute -> Create some rules.
2. Make the following request `GET wc/v3/products?gla_syncable=1` or `GET wc/v3/products/YOUR_PRODUCT_ID?gla_syncable=1`
3. See that the response contains a new property named: `gla_attributes` with the correct values.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/ac985dcb-4feb-4250-938b-14e8c37d3f6b)


4. Update the products by adding a GLA Attribute. This attribute should take precedence over any mapping rule applied to the same attribute.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/d6819f86-c696-4601-ad1b-3a6a7843dace)

5. Remove the query parameter `gla_syncable=1` and the response should not contain `gla_attributes`.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
