### PR TITLE
API PULL - Add offer id product deletion notification

### DIFF
--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -77,7 +77,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 *
 	 * @param string   $topic The topic to use in the notification.
 	 * @param int|null $item_id The item ID to notify. It can be null for topics that doesn't need Item ID
-	 * @param array $data Optional data to send in the request.
+	 * @param array    $data Optional data to send in the request.
 	 * @return bool True is the notification is successful. False otherwise.
 	 */
 	public function notify( string $topic, $item_id = null, $data = [] ): bool {

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -116,7 +116,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 
 		do_action(
 			'woocommerce_gla_debug_message',
-			sprintf( 'Notification - Item ID: %s - Topic: %s', $item_id, $topic ),
+			sprintf( 'Notification - Item ID: %s - Topic: %s - Data %s', $item_id, $topic, json_encode( $data ) ),
 			__METHOD__
 		);
 

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -77,9 +77,10 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 *
 	 * @param string   $topic The topic to use in the notification.
 	 * @param int|null $item_id The item ID to notify. It can be null for topics that doesn't need Item ID
+	 * @param array $data Optional data to send in the request.
 	 * @return bool True is the notification is successful. False otherwise.
 	 */
-	public function notify( string $topic, $item_id = null ): bool {
+	public function notify( string $topic, $item_id = null, $data = [] ): bool {
 		/**
 		 * Allow users to disable the notification request.
 		 *
@@ -101,9 +102,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 				'x-woocommerce-topic' => $topic,
 				'Content-Type'        => 'application/json',
 			],
-			'body'    => [
-				'item_id' => $item_id,
-			],
+			'body'    => array_merge( $data, [ 'item_id' => $item_id ] ),
 			'url'     => $this->get_notification_url(),
 		];
 

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\HelperNotificationInterface;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -34,8 +33,9 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 
 		$item  = $args['item_id'];
 		$topic = $args['topic'];
+		$data  = $args['data'] ?? [];
 
-		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item ) ) {
+		if ( $this->can_process( $item, $topic ) && $this->notifications_service->notify( $topic, $item, $data ) ) {
 			$this->set_status( $item, $this->get_after_notification_status( $topic ) );
 			$this->handle_notified( $topic, $item );
 		}
@@ -59,9 +59,9 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 * @return string
 	 */
 	protected function get_after_notification_status( string $topic ): string {
-		if ( str_contains( $topic, '.create' ) ) {
+		if ( $this->is_create_topic( $topic ) ) {
 			return NotificationStatus::NOTIFICATION_CREATED;
-		} elseif ( str_contains( $topic, '.delete' ) ) {
+		} elseif ( $this->is_delete_topic( $topic ) ) {
 			return NotificationStatus::NOTIFICATION_DELETED;
 		} else {
 			return NotificationStatus::NOTIFICATION_UPDATED;
@@ -80,9 +80,9 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	protected function can_process( int $item_id, string $topic ): bool {
 		$item = $this->get_item( $item_id );
 
-		if ( str_contains( $topic, '.create' ) ) {
+		if ( $this->is_create_topic( $topic ) ) {
 			return $this->get_helper()->should_trigger_create_notification( $item );
-		} elseif ( str_contains( $topic, '.delete' ) ) {
+		} elseif ( $this->is_delete_topic( $topic ) ) {
 			return $this->get_helper()->should_trigger_delete_notification( $item );
 		} else {
 			return $this->get_helper()->should_trigger_update_notification( $item );
@@ -96,15 +96,36 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 * @param int    $item
 	 */
 	protected function handle_notified( string $topic, int $item ): void {
-		if ( str_contains( $topic, '.delete' ) ) {
+		if ( $this->is_delete_topic( $topic ) ) {
 			$this->get_helper()->mark_as_unsynced( $this->get_item( $item ) );
 		}
 
-		if ( str_contains( $topic, '.create' ) ) {
+		if ( $this->is_create_topic( $topic ) ) {
 			$this->get_helper()->mark_as_notified( $this->get_item( $item ) );
 		}
 	}
 
+	/**
+	 * If a topic is a delete topic
+	 *
+	 * @param string $topic The topic to check
+	 *
+	 * @return bool
+	 */
+	protected function is_delete_topic( $topic ) {
+		return str_contains( $topic, '.delete' );
+	}
+
+	/**
+	 * If a topic is a create topic
+	 *
+	 * @param string $topic The topic to check
+	 *
+	 * @return bool
+	 */
+	protected function is_create_topic( $topic ) {
+		return str_contains( $topic, '.create' );
+	}
 	/**
 	 * Get the item
 	 *

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -112,7 +112,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 *
 	 * @return bool
 	 */
-	protected function is_delete_topic( $topic ) {
+	protected function is_delete_topic( $topic ): bool {
 		return str_contains( $topic, '.delete' );
 	}
 
@@ -123,7 +123,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 *
 	 * @return bool
 	 */
-	protected function is_create_topic( $topic ) {
+	protected function is_create_topic( $topic ): bool {
 		return str_contains( $topic, '.create' );
 	}
 	/**

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -48,6 +48,8 @@ class ProductNotificationJob extends AbstractItemNotificationJob {
 
 	/**
 	 * Override Product Notification adding Offer ID for deletions.
+	 * The offer_id might match the real offer ID or not, depending on whether the product has been synced by us or not.
+	 * Google should check on their side if the product actually exists.
 	 *
 	 * @param array $args Arguments with the item id and the topic.
 	 */

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\HelperNotificationInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -41,6 +41,20 @@ class ProductNotificationJob extends AbstractItemNotificationJob {
 	) {
 		$this->helper = $helper;
 		parent::__construct( $action_scheduler, $monitor, $notifications_service );
+	}
+
+	/**
+	 * Override Product Notification adding Offer ID for deletions.
+	 * @param $args
+	 *
+	 * @return void
+	 */
+	protected function process_items( $args ): void {
+		if ( isset( $args['topic'] ) && isset( $args['item_id'] ) && $this->is_delete_topic( $args['topic'] ) ) {
+			$args['data'] = [ 'offer_id' => WCProductAdapter::get_google_product_offer_id( 'gla', $args['item_id'] ) ];
+		}
+
+		parent::process_items( $args );
 	}
 
 	/**

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
 
@@ -19,6 +20,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications
  */
 class ProductNotificationJob extends AbstractItemNotificationJob {
+
+	use PluginHelper;
 
 	/**
 	 * @var ProductHelper $helper
@@ -45,13 +48,12 @@ class ProductNotificationJob extends AbstractItemNotificationJob {
 
 	/**
 	 * Override Product Notification adding Offer ID for deletions.
-	 * @param $args
 	 *
-	 * @return void
+	 * @param array $args Arguments with the item id and the topic.
 	 */
 	protected function process_items( $args ): void {
 		if ( isset( $args['topic'] ) && isset( $args['item_id'] ) && $this->is_delete_topic( $args['topic'] ) ) {
-			$args['data'] = [ 'offer_id' => WCProductAdapter::get_google_product_offer_id( 'gla', $args['item_id'] ) ];
+			$args['data'] = [ 'offer_id' => WCProductAdapter::get_google_product_offer_id( $this->get_slug(), $args['item_id'] ) ];
 		}
 
 		parent::process_items( $args );

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -36,4 +36,66 @@ class ProductNotificationJobTest extends AbstractItemNotificationJobTest {
 	public function create_item() {
 		return WC_Helper_Product::create_simple_product();
 	}
+
+	public function test_sends_offer_id_on_delete() {
+		$item  = $this->create_item();
+		$id    = $item->get_id();
+		$topic = $this->get_topic_name() . '.delete';
+
+		$this->job->get_helper()->expects( $this->once() )
+					->method( 'should_trigger_delete_notification' )
+					->willReturn( true );
+
+		$this->notification_service->expects( $this->once() )->method( 'notify' )->with(
+			$topic,
+			$id,
+			[ 'offer_id' => "gla_{$id}" ]
+		)->willReturn( true );
+
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
+	}
+
+	public function test_sends_filtered_offer_id_on_delete() {
+		$item  = $this->create_item();
+		$id    = $item->get_id();
+		$topic = $this->get_topic_name() . '.delete';
+
+		add_filter(
+			'woocommerce_gla_get_google_product_offer_id',
+			function ( $value, $product_id ) {
+				return "custom_{$product_id}";
+			},
+			10,
+			2
+		);
+
+		$this->job->get_helper()->expects( $this->once() )
+					->method( 'should_trigger_delete_notification' )
+					->willReturn( true );
+
+		$this->notification_service->expects( $this->once() )->method( 'notify' )->with(
+			$topic,
+			$id,
+			[ 'offer_id' => "custom_{$id}" ]
+		)->willReturn( true );
+
+		$this->job->handle_process_items_action(
+			[
+				'item_id' => $id,
+				'topic'   => $topic,
+			]
+		);
+
+		remove_filter(
+			'woocommerce_gla_get_google_product_offer_id',
+			function ( $value, $product_id ) {
+				return "custom_{$product_id}";
+			}
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds offer_id when sending a `product.delete` notification.

Slack conversation: p1712250015177139-slack-C02BB3F30TG

### Screenshots:

<img width="1399" alt="Screenshot 2024-04-08 at 10 38 36" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/50afeac5-0ec4-4840-969b-d67380adad5a">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this PR and enable Notifications service. `add_filter( 'woocommerce_gla_notifications_enabled', '__return_true' );`
2. Complete onboarding and enter this URL for authorizing Notifications `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&google_wpcom_app_status=approved`
3. Create or Update a product. Run the `gla/jobs/notifications/products/process_item` job 
4. Delete the product. Run the `gla/jobs/notifications/products/process_item` job.
5. Go to WooCommerce - Status - Logs
6. See the entry in the log with `product.delete` topic and the Offer id "gla_{product_id}".. 
7. Apply a filter to change the Offer ID: 

```php
add_filter(
			'woocommerce_gla_get_google_product_offer_id',
			function ( $value, $product_id ) {
				return "custom_{$product_id}";
			},
			10,
			2
		);
```

8. Repeat steps 3,4 and 5
9. See the entry in the log with `product.delete` topic and the Offer id "custom_{product_id}". 
