### PR TITLE
API PULL - Prevent notification errors for deleted products

### DIFF
--- a/src/Coupon/CouponHelper.php
+++ b/src/Coupon/CouponHelper.php
@@ -378,7 +378,7 @@ class CouponHelper implements Service, HelperNotificationInterface {
 		try {
 			$coupon = $this->get_wc_coupon( $coupon_id );
 		} catch ( InvalidValue $e ) {
-			return true; // Sent true for forcing delete notification as the product doesn't exist anymore.
+			return true; // Sent true for forcing delete notification as the coupon doesn't exist anymore.
 		}
 
 		$valid_has_notified_creation_statuses = [

--- a/src/Coupon/CouponHelper.php
+++ b/src/Coupon/CouponHelper.php
@@ -341,11 +341,17 @@ class CouponHelper implements Service, HelperNotificationInterface {
 	 * Indicates if a coupon is ready for sending Notifications.
 	 * A coupon is ready to send notifications if its sync ready and the post status is publish.
 	 *
-	 * @param WC_Coupon $coupon
+	 * @param int $coupon_id
 	 *
 	 * @return bool
 	 */
-	public function is_ready_to_notify( WC_Coupon $coupon ): bool {
+	public function is_ready_to_notify( int $coupon_id ): bool {
+		try {
+			$coupon = $this->get_wc_coupon( $coupon_id );
+		} catch ( InvalidValue $e ) {
+			return false;
+		}
+
 		$is_ready = $this->is_sync_ready( $coupon ) && $coupon->get_status() === 'publish';
 
 		/**
@@ -364,11 +370,17 @@ class CouponHelper implements Service, HelperNotificationInterface {
 	 * Indicates if a coupon was already notified about its creation.
 	 * Notice we consider synced coupons in MC as notified for creation.
 	 *
-	 * @param WC_Coupon $coupon
+	 * @param int $coupon_id
 	 *
 	 * @return bool
 	 */
-	public function has_notified_creation( WC_Coupon $coupon ): bool {
+	public function has_notified_creation( int $coupon_id ): bool {
+		try {
+			$coupon = $this->get_wc_coupon( $coupon_id );
+		} catch ( InvalidValue $e ) {
+			return true; // Sent true for forcing delete notification as the product doesn't exist anymore.
+		}
+
 		$valid_has_notified_creation_statuses = [
 			NotificationStatus::NOTIFICATION_CREATED,
 			NotificationStatus::NOTIFICATION_UPDATED,
@@ -397,35 +409,35 @@ class CouponHelper implements Service, HelperNotificationInterface {
 	 * Indicates if a coupon is ready for sending a create Notification.
 	 * A coupon is ready to send create notifications if is ready to notify and has not sent create notification yet.
 	 *
-	 * @param WC_Coupon $coupon
+	 * @param int $coupon_id
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_create_notification( $coupon ): bool {
-		return $this->is_ready_to_notify( $coupon ) && ! $this->has_notified_creation( $coupon );
+	public function should_trigger_create_notification( int $coupon_id ): bool {
+		return $this->is_ready_to_notify( $coupon_id ) && ! $this->has_notified_creation( $coupon_id );
 	}
 
 	/**
 	 * Indicates if a coupon is ready for sending an update Notification.
 	 * A coupon is ready to send update notifications if is ready to notify and has sent create notification already.
 	 *
-	 * @param WC_Coupon $coupon
+	 * @param int $coupon_id
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_update_notification( $coupon ): bool {
-		return $this->is_ready_to_notify( $coupon ) && $this->has_notified_creation( $coupon );
+	public function should_trigger_update_notification( int $coupon_id ): bool {
+		return $this->is_ready_to_notify( $coupon_id ) && $this->has_notified_creation( $coupon_id );
 	}
 
 	/**
 	 * Indicates if a coupon is ready for sending a delete Notification.
 	 * A coupon is ready to send delete notifications if it is not ready to notify and has sent create notification already.
 	 *
-	 * @param WC_Coupon $coupon
+	 * @param int $coupon_id
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_delete_notification( $coupon ): bool {
-		return ! $this->is_ready_to_notify( $coupon ) && $this->has_notified_creation( $coupon );
+	public function should_trigger_delete_notification( int $coupon_id ): bool {
+		return ! $this->is_ready_to_notify( $coupon_id ) && $this->has_notified_creation( $coupon_id );
 	}
 }

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -186,7 +186,7 @@ class SyncerHooks implements Service, Registerable {
 			return;
 		}
 
-		// Schedule an update job if product sync is enabled.
+		// Schedule an update job if coupon sync is enabled.
 		if ( $this->coupon_helper->is_sync_ready( $coupon ) ) {
 			$this->coupon_helper->mark_as_pending( $coupon );
 			$this->update_coupon_job->schedule(
@@ -300,7 +300,7 @@ class SyncerHooks implements Service, Registerable {
 		$coupon = $this->wc->maybe_get_coupon( $coupon_id );
 
 		if ( is_null( $coupon ) ) {
-			// In case product is not anymore in DB we send the notification directly.
+			// In case coupon is not anymore in DB we send the notification directly.
 			$this->notifications_service->notify( NotificationsService::TOPIC_COUPON_DELETED, $coupon_id );
 			return;
 		}

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\NotificationStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\HelperNotificationInterface;
 
@@ -48,7 +49,12 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 * @param string $status
 	 */
 	protected function set_status( int $item_id, string $status ): void {
-		$item = $this->get_item( $item_id );
+		try {
+			$item = $this->get_item( $item_id );
+		} catch ( InvalidValue $e ) {
+			return;
+		}
+
 		$this->get_helper()->set_notification_status( $item, $status );
 	}
 
@@ -78,14 +84,12 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 * @return bool
 	 */
 	protected function can_process( int $item_id, string $topic ): bool {
-		$item = $this->get_item( $item_id );
-
 		if ( str_contains( $topic, '.create' ) ) {
-			return $this->get_helper()->should_trigger_create_notification( $item );
+			return $this->get_helper()->should_trigger_create_notification( $item_id );
 		} elseif ( str_contains( $topic, '.delete' ) ) {
-			return $this->get_helper()->should_trigger_delete_notification( $item );
+			return $this->get_helper()->should_trigger_delete_notification( $item_id );
 		} else {
-			return $this->get_helper()->should_trigger_update_notification( $item );
+			return $this->get_helper()->should_trigger_update_notification( $item_id );
 		}
 	}
 
@@ -93,15 +97,21 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 * Handle the item after the notification.
 	 *
 	 * @param string $topic
-	 * @param int    $item
+	 * @param int    $item_id
 	 */
-	protected function handle_notified( string $topic, int $item ): void {
+	protected function handle_notified( string $topic, int $item_id ): void {
+		try {
+			$item = $this->get_item( $item_id );
+		} catch ( InvalidValue $e ) {
+			return;
+		}
+
 		if ( str_contains( $topic, '.delete' ) ) {
-			$this->get_helper()->mark_as_unsynced( $this->get_item( $item ) );
+			$this->get_helper()->mark_as_unsynced( $item );
 		}
 
 		if ( str_contains( $topic, '.create' ) ) {
-			$this->get_helper()->mark_as_notified( $this->get_item( $item ) );
+			$this->get_helper()->mark_as_notified( $item );
 		}
 	}
 

--- a/src/Jobs/Notifications/HelperNotificationInterface.php
+++ b/src/Jobs/Notifications/HelperNotificationInterface.php
@@ -16,30 +16,30 @@ interface HelperNotificationInterface {
 	/**
 	 * Checks if the item can be processed based on the topic.
 	 *
-	 * @param WC_Product|WC_Coupon $item
+	 * @param int $item_id
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_create_notification( $item ): bool;
+	public function should_trigger_create_notification( int $item_id ): bool;
 
 
 	/**
 	 * Indicates if the item ready for sending a delete Notification.
 	 *
-	 * @param WC_Product|WC_Coupon $item
+	 * @param int $item_id
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_delete_notification( $item ): bool;
+	public function should_trigger_delete_notification( int $item_id ): bool;
 
 	/**
 	 * Indicates if the item ready for sending an update Notification.
 	 *
-	 * @param WC_Product|WC_Coupon $item
+	 * @param int $item_id
 	 *
 	 * @return bool
 	 */
-	public function should_trigger_update_notification( $item ): bool;
+	public function should_trigger_update_notification( int $item_id ): bool;
 
 	/**
 	 * Marks the item as unsynced.

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -327,7 +327,11 @@ class SyncerHooks implements Service, Registerable {
 		$product = $this->wc->maybe_get_product( $product_id );
 		if ( is_null( $product ) ) {
 			// In case product is not anymore in DB we send the notification directly.
-			$this->notifications_service->notify( NotificationsService::TOPIC_PRODUCT_DELETED, $product_id );
+			$this->notifications_service->notify(
+				NotificationsService::TOPIC_PRODUCT_DELETED,
+				$product_id,
+				[ 'offer_id' => WCProductAdapter::get_google_product_offer_id( $this->get_slug(), $product_id ) ]
+			);
 			return;
 		}
 

--- a/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
+++ b/tests/Unit/Jobs/AbstractItemNotificationJobTest.php
@@ -147,14 +147,14 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 			->with( $topic, $id )
 			->willReturn( true );
 
-		$this->job->get_helper()->expects( $this->exactly( 3 ) )
+		$this->job->get_helper()->expects( $this->any() )
 			->method( 'get_wc_' . $this->get_topic_name() )
 			->with( $id )
 			->willReturn( $item );
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_create_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( true );
 
 		$this->job->get_helper()->expects( $this->once() )
@@ -188,14 +188,14 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 			->with( $topic, $id )
 			->willReturn( false );
 
-		$this->job->get_helper()->expects( $this->once() )
+		$this->job->get_helper()->expects( $this->any() )
 			->method( 'get_wc_' . $this->get_topic_name() )
 			->with( $id )
 			->willReturn( $item );
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_create_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( true );
 
 		$this->job->get_helper()->expects( $this->never() )
@@ -218,23 +218,23 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 			->method( 'notify' )
 			->willReturn( true );
 
-		$this->job->get_helper()->expects( $this->exactly( 8 ) )
+		$this->job->get_helper()->expects( $this->any() )
 			->method( 'get_wc_' . $this->get_topic_name() )
 			->willReturn( $item );
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_create_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( true );
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_update_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( true );
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_delete_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( true );
 
 		$this->job->get_helper()->expects( $this->exactly( 3 ) )
@@ -278,23 +278,23 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 
 		$this->notification_service->expects( $this->never() )->method( 'notify' );
 
-		$this->job->get_helper()->expects( $this->exactly( 3 ) )
+		$this->job->get_helper()->expects( $this->any() )
 			->method( 'get_wc_' . $this->get_topic_name() )
 			->willReturn( $item );
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_create_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( false );
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_update_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( false );
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_delete_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( false );
 
 		$this->job->get_helper()->expects( $this->never() )->method( 'set_notification_status' );
@@ -325,10 +325,10 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_delete_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( true );
 
-		$this->job->get_helper()->expects( $this->exactly( 3 ) )
+		$this->job->get_helper()->expects( $this->any() )
 			->method( 'get_wc_' . $this->get_topic_name() )
 			->with( $id )
 			->willReturn( $item );
@@ -351,10 +351,10 @@ abstract class AbstractItemNotificationJobTest extends UnitTest {
 
 		$this->job->get_helper()->expects( $this->once() )
 			->method( 'should_trigger_create_notification' )
-			->with( $item )
+			->with( $id )
 			->willReturn( true );
 
-		$this->job->get_helper()->expects( $this->exactly( 3 ) )
+		$this->job->get_helper()->expects( $this->any() )
 			->method( 'get_wc_' . $this->get_topic_name() )
 			->with( $id )
 			->willReturn( $item );

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -1127,66 +1127,76 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		/**
 		 * @var WC_Product $product
 		 */
-		$product = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
-		$this->assertTrue( $this->product_helper->is_ready_to_notify( $product ) );
+		$product    = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product_id = $product->get_id();
+
+		$this->assertTrue( $this->product_helper->is_ready_to_notify( $product_id ) );
 
 		$product->set_status( 'draft' );
 		$product->save();
-		$this->assertFalse( $this->product_helper->is_ready_to_notify( $product ) );
+		$this->assertFalse( $this->product_helper->is_ready_to_notify( $product_id ) );
 
 		$product->set_status( 'publish' );
 		$product->add_meta_data( '_wc_gla_visibility', ChannelVisibility::DONT_SYNC_AND_SHOW, true );
 		$product->save();
-		$this->assertFalse( $this->product_helper->is_ready_to_notify( $product ) );
+		$this->assertFalse( $this->product_helper->is_ready_to_notify( $product_id ) );
 	}
 
 	public function test_should_trigger_create_notification() {
 		/**
 		 * @var WC_Product $product
 		 */
-		$product = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
-		$this->assertTrue( $this->product_helper->should_trigger_create_notification( $product ) );
+		$product    = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product_id = $product->get_id();
+
+		$this->assertTrue( $this->product_helper->should_trigger_create_notification( $product_id ) );
 
 		$product->set_status( 'draft' );
 		$product->save();
-		$this->assertFalse( $this->product_helper->should_trigger_create_notification( $product ) );
+		$this->assertFalse( $this->product_helper->should_trigger_create_notification( $product_id ) );
 
-		$product = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product    = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product_id = $product->get_id();
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_CREATED );
-		$this->assertFalse( $this->product_helper->should_trigger_create_notification( $product ) );
+		$this->assertFalse( $this->product_helper->should_trigger_create_notification( $product_id ) );
 	}
 
 	public function test_should_trigger_update_notification() {
 		/**
 		 * @var WC_Product $product
 		 */
-		$product = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product    = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product_id = $product->get_id();
+
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_CREATED );
-		$this->assertTrue( $this->product_helper->should_trigger_update_notification( $product ) );
+		$this->assertTrue( $this->product_helper->should_trigger_update_notification( $product_id ) );
 
 		$product->set_status( 'draft' );
 		$product->save();
-		$this->assertFalse( $this->product_helper->should_trigger_update_notification( $product ) );
+		$this->assertFalse( $this->product_helper->should_trigger_update_notification( $product_id ) );
 
-		$product = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product    = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product_id = $product->get_id();
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_DELETED );
-		$this->assertFalse( $this->product_helper->should_trigger_update_notification( $product ) );
+		$this->assertFalse( $this->product_helper->should_trigger_update_notification( $product_id ) );
 	}
 
 	public function test_should_trigger_delete_notification() {
 		/**
 		 * @var WC_Product $product
 		 */
-		$product = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product    = $this->get_notification_ready_product( WC_Helper_Product::create_simple_product() );
+		$product_id = $product->get_id();
+
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_CREATED );
-		$this->assertFalse( $this->product_helper->should_trigger_delete_notification( $product ) );
+		$this->assertFalse( $this->product_helper->should_trigger_delete_notification( $product_id ) );
 
 		$product->set_status( 'draft' );
 		$product->save();
-		$this->assertTrue( $this->product_helper->should_trigger_delete_notification( $product ) );
+		$this->assertTrue( $this->product_helper->should_trigger_delete_notification( $product_id ) );
 
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_DELETED );
-		$this->assertFalse( $this->product_helper->should_trigger_delete_notification( $product ) );
+		$this->assertFalse( $this->product_helper->should_trigger_delete_notification( $product_id ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When we send notifications we take as granted that the product or coupon are available in DB when handling its metas. This is not always true as the Job and some intermediate functions can run after the Product or Coupon is permanently deleted. 

When this happens, the notifications meta handler or some other functions will throw some exceptions. 

This PR fixes that ensuring that the item is available. Introducing the next changes:

- Check the item is available on Update and Create Topics. Boil in case it isn't. 
- Run the delete Notification right away (without AS job) when the product doesn't exist.
- Consider NON-existent products as already Notified products. This could trigger (very rarely, I wasn't able to reproduce it yet) unnecessarily DELETE notifications when we permanently delete a product that was never notified. But I think even if this may happen it would be better than missing a needed notification. 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow the steps in https://github.com/woocommerce/google-listings-and-ads/wiki/API-PULL-Feature-(Beta)#enabling-the-feature and https://github.com/woocommerce/google-listings-and-ads/wiki/API-PULL-Feature-(Beta)#enabling-the-feature for enabling and granting access to Notifications feature.
2. Create a Product - See the `gla/jobs/notifications/products/process_item` job is scheduled with CREATE topic. 
3. Run it. See the Notification happens in the Logs
4. Update the product - See the `gla/jobs/notifications/products/process_item` job is scheduled with UPDATE topic.
5. Run it. See the Notification happens in the Logs
6. Trash the product - See the `gla/jobs/notifications/products/process_item` job is scheduled with DELETE topic.
7. Run it. See the Notification happens in the Logs
8. Create a Product - See the `gla/jobs/notifications/products/process_item` job is scheduled with CREATE topic. 
9. Don't run it.
10. Delete the product via `wp_delete_post( {post_id}, true );`
11. Run the job from step 8. See the Notification DOESNT happen in the Logs. NO exception happens.
12. Repeat steps 2-4. Don't run the UPDATE topic Job
13. Delete the product via `wp_delete_post( {post_id}, true );`
14. Run the update job from step. See the Notification DOESNT happen in the Logs. NO exception happens.
15. Repeat steps 2-3 and 6. Don't run the DELETE topic Job
16. Delete the product via `wp_delete_post( {post_id}, true );`
17. Now run the job. See the Notification YES happens in the Logs. NO exception happens.
18. Repeat all the steps for Coupons. 

### Additional details

I considered as well having some kind of table/options to keep the Notification metas so we don't depend anymore on the item itself. But that would require a big re-structure of the Notifications so this may be discussed for phase 2. 