### PR TITLE
The Product Block Editor feature should be disabled after an E2E test run

### DIFF
--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -685,7 +685,7 @@ test.describe( 'Product Block Editor integration', () => {
 	} );
 
 	test.afterAll( async () => {
-		await editorUtils.toggleBlockFeature( page, false );
+		await editorUtils.toggleBlockFeature( false );
 		await api.clearOnboardedMerchant();
 		await page.close();
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This RP fixes an issue that the Product Block Editor feature is not correctly disabled after an E2E test run.

The `toggleBlockFeature` function has only one parameter:

https://github.com/woocommerce/google-listings-and-ads/blob/a345951899bfd319603bc48b8fb4bc09415c3a33/tests/e2e/utils/product-editor.js#L121-L134

But it's incorrectly called with two parameters and this causes the Product Block Editor feature to still be enabled after an E2E test run:

https://github.com/woocommerce/google-listings-and-ads/blob/a345951899bfd319603bc48b8fb4bc09415c3a33/tests/e2e/specs/product-editor/block-integration.test.js#L687-L688

### Detailed test instructions:

1. Run E2E test locally.
2. Go to http://localhost:8889/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
3. The **New product editor** option should not be enabled.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/5eb39ee4-9212-4fee-97af-bbb07189cde3)

### Changelog entry
