### PR TITLE
Update e2e test environment to install WooCommerce earlier

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,7 @@
 {
 	"phpVersion": "8.0",
 	"plugins": [
+		"https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip",
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"./tests/e2e/test-data",
 		"./tests/e2e/test-snippets",

--- a/tests/e2e/bin/test-env-setup.sh
+++ b/tests/e2e/bin/test-env-setup.sh
@@ -3,9 +3,6 @@
 echo -e 'Activate twentytwentytwo theme \n'
 wp-env run tests-cli wp theme activate twentytwentytwo
 
-echo -e 'Install WooCommerce \n'
-wp-env run tests-cli -- wp plugin install woocommerce --activate
-
 echo -e 'Update URL structure \n'
 wp-env run tests-cli -- wp rewrite structure '/%postname%/' --hard
 

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -36,18 +36,3 @@ add_filter(
 		return $value_options;
 	}
 );
-
-/**
- * Snippet to bypass the WooCommerce dependency in Google Listings & Ads because
- * in wp-env WooCommerce is installed in the directory woocommerce-trunk-nightly
- */
-add_action(
-	'wp_plugin_dependencies_slug',
-	function( $slug ) {
-		if ( 'woocommerce' === $slug ) {
-			$slug = '';
-		}
-
-		return $slug;
-	}
-);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Copied from https://github.com/woocommerce/automatewoo/pull/1731

Removes the snippet to bypass the WooCommerce dependency in the E2E environment and instead installs WooCommerce by setting it as a plugin option in the `.wp-env.json` file.

### Screenshots:

<img width="653" alt="Screenshot 2024-04-10 at 11 35 07" src="https://github.com/woocommerce/google-listings-and-ads/assets/40762232/6e2b666b-9c01-4404-a996-4235725d5278">

### Detailed test instructions:

1. Checkout `update/e2e-test-environment`
2. Run `npm run wp-env:down && npm run wp-env:up` to setup a new test environment
3. Run `npm run test:e2e`
4. Confirm tests pass