### PR TITLE
Add E2E tests for the integration in the classic product editor

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "release/**"
   pull_request:
+    branches:
+      - "release/**"
   workflow_dispatch:
     inputs:
       wp-rc-version:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - "release/**"
   pull_request:
-    branches:
-      - "release/**"
   workflow_dispatch:
     inputs:
       wp-rc-version:

--- a/tests/e2e/bin/test-env-setup.sh
+++ b/tests/e2e/bin/test-env-setup.sh
@@ -22,3 +22,6 @@ wp-env run tests-cli wp wc payment_gateway update cod --enabled=1 --user=admin
 
 echo -e 'Set the tour of product block editor to not display \n'
 wp-env run tests-cli wp option update woocommerce_block_product_tour_shown 'yes'
+
+echo -e 'Set the variable product tour of classic product editor to not display \n'
+wp-env run tests-cli wp user meta update admin woocommerce_admin_variable_product_tour_shown '"yes"'

--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -48,6 +48,7 @@
 		},
 		"variations": [
 			{
+				"menu_order": 1,
 				"regular_price": "19.99",
 				"attributes": [
 					{
@@ -61,6 +62,7 @@
 				]
 			},
 			{
+				"menu_order": 2,
 				"regular_price": "18.99",
 				"attributes": [
 					{
@@ -74,6 +76,7 @@
 				]
 			},
 			{
+				"menu_order": 3,
 				"regular_price": "17.99",
 				"attributes": [
 					{

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -567,45 +567,10 @@ test.describe( 'Product Block Editor integration', () => {
 		await editorUtils.fillProductName();
 		await editorUtils.clickPluginTab();
 
-		const {
-			gtin,
-			mpn,
-			brand,
-			condition,
-			gender,
-			size,
-			sizeSystem,
-			sizeType,
-			color,
-			material,
-			pattern,
-			ageGroup,
-			multipack,
-			isBundle,
-			availabilityDate,
-			availabilityTime,
-			adultContent,
-		} = editorUtils.getAllProductAttributes();
+		const pairs =
+			await editorUtils.getAvailableProductAttributesWithTestValues();
 
-		const pairs = [
-			[ gtin, '3234567890126' ],
-			[ mpn, 'GO12345OOGLE' ],
-			[ brand, 'e2e_test_woocommerce_brands' ],
-			[ condition, 'new' ],
-			[ gender, 'unisex' ],
-			[ size, 'Good for everybody' ],
-			[ sizeSystem, 'JP' ],
-			[ sizeType, 'regular' ],
-			[ color, 'Cherry blossom' ],
-			[ material, 'Titanium alloy' ],
-			[ pattern, 'Cyberpunk' ],
-			[ ageGroup, 'kids' ],
-			[ multipack, '9999' ],
-			[ isBundle, 'no' ],
-			[ availabilityDate, '2024-02-29' ],
-			[ availabilityTime, '23:59' ],
-			[ adultContent, 'no' ],
-		];
+		expect( pairs ).toHaveLength( 17 );
 
 		/*
 		 * Assert:
@@ -639,35 +604,22 @@ test.describe( 'Product Block Editor integration', () => {
 		}
 	} );
 
-	test( 'Save product attributes to variation product', async () => {
+	test( 'Save all product attributes to variation product', async () => {
 		await editorUtils.gotoEditVariableProductPage();
 		await editorUtils.gotoEditVariationProductPage();
 		await editorUtils.clickPluginTab();
 
+		const pairs =
+			await editorUtils.getAvailableProductAttributesWithTestValues();
+
+		expect( pairs ).toHaveLength( 16 );
+
 		/*
-		 * Since the testing of all attributes is already covered in the simple product test case above.
-		 * This case only tests a few key attributes to ensure the data saving works for variation product.
+		 * Assert:
+		 * - All attributes are empty or default
+		 * - Save all attributes
+		 * - After saving, attribute values remain the same
 		 */
-		const {
-			condition,
-			color,
-			multipack,
-			availabilityDate,
-			availabilityTime,
-		} = editorUtils.getAllProductAttributes();
-
-		const pairs = [
-			[ condition, 'new' ],
-			[ color, 'Cherry blossom' ],
-			[ multipack, '9999' ],
-			[ availabilityDate, '2024-02-29' ],
-			[ availabilityTime, '23:59' ],
-		];
-
-		for ( const [ attribute ] of pairs ) {
-			await expect( attribute ).toHaveValue( '' );
-		}
-
 		for ( const [ attribute, value ] of pairs ) {
 			await expect( attribute ).toHaveValue( '' );
 			await editorUtils.setAttributeValue( attribute, value );
@@ -677,6 +629,20 @@ test.describe( 'Product Block Editor integration', () => {
 
 		for ( const [ attribute, value ] of pairs ) {
 			await expect( attribute ).toHaveValue( value );
+		}
+
+		/*
+		 * Assert:
+		 * - It allows to save all attributes to empty or default
+		 */
+		for ( const [ attribute ] of pairs ) {
+			await editorUtils.setAttributeValue( attribute, '' );
+		}
+
+		await editorUtils.save();
+
+		for ( const [ attribute ] of pairs ) {
+			await expect( attribute ).toHaveValue( '' );
 		}
 	} );
 

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -401,6 +401,59 @@ test.describe( 'Classic Product Editor integration', () => {
 		await expect( issues ).toBeHidden();
 	} );
 
+	test( 'Custom input: Select with text input', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+		await editorUtils.clickPluginTab();
+
+		const { selection, input } = editorUtils.getSelectWithTextInput();
+
+		/*
+		 * Assert:
+		 * - The "Default" option is selected and the text field is not shown
+		 */
+		await expect( selection ).toHaveValue( '' );
+		await expect( input ).toBeHidden();
+
+		/*
+		 * Assert:
+		 * - When the "From WooCommerce Brands" option is selected, the text field is not shown
+		 * - After saving, the field value and state remain the same
+		 */
+		await selection.selectOption( 'e2e_test_woocommerce_brands' );
+		await expect( input ).toBeHidden();
+
+		await editorUtils.save();
+		await editorUtils.clickPluginTab();
+
+		await expect( selection ).toHaveValue( 'e2e_test_woocommerce_brands' );
+		await expect( input ).toBeHidden();
+
+		/*
+		 * Assert:
+		 * - When the "Enter a custom value" option is selected, the text field is shown
+		 * - After saving, the field value and state remain the same
+		 */
+		await selection.selectOption( '_gla_custom_value' );
+		await expect( input ).toBeVisible();
+
+		await input.fill( 'Cute Cat' );
+		await editorUtils.save();
+		await editorUtils.clickPluginTab();
+
+		await expect( selection ).toHaveValue( '_gla_custom_value' );
+		await expect( input ).toHaveValue( 'Cute Cat' );
+
+		/*
+		 * Assert:
+		 * - When switching to another value and back, the entered value in the text field is kept
+		 */
+		await selection.selectOption( '' );
+		await expect( input ).toBeHidden();
+		await selection.selectOption( '_gla_custom_value' );
+		await expect( input ).toHaveValue( 'Cute Cat' );
+	} );
+
 	test.afterAll( async () => {
 		await api.clearOnboardedMerchant();
 		await page.close();

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -656,6 +656,50 @@ test.describe( 'Classic Product Editor integration', () => {
 		}
 	} );
 
+	test( 'Save all product attributes to variation product', async () => {
+		await editorUtils.gotoEditVariableProductPage();
+		await editorUtils.gotoEditVariation();
+
+		const pairs = await getAvailableProductAttributesWithTestValues(
+			editorUtils.getPluginVariationMetaBox()
+		);
+
+		expect( pairs ).toHaveLength( 16 );
+
+		/*
+		 * Assert:
+		 * - All attributes are empty or default
+		 * - Save all attributes
+		 * - After saving, attribute values remain the same
+		 */
+		for ( const [ attribute, value ] of pairs ) {
+			await expect( attribute ).toHaveValue( '' );
+			await editorUtils.setAttributeValue( attribute, value );
+		}
+
+		await editorUtils.save();
+		await editorUtils.gotoEditVariation();
+
+		for ( const [ attribute, value ] of pairs ) {
+			await expect( attribute ).toHaveValue( value );
+		}
+
+		/*
+		 * Assert:
+		 * - It allows to save all attributes to empty or default
+		 */
+		for ( const [ attribute ] of pairs ) {
+			await editorUtils.setAttributeValue( attribute, '' );
+		}
+
+		await editorUtils.save();
+		await editorUtils.gotoEditVariation();
+
+		for ( const [ attribute ] of pairs ) {
+			await expect( attribute ).toHaveValue( '' );
+		}
+	} );
+
 	test.afterAll( async () => {
 		await api.clearOnboardedMerchant();
 		await page.close();

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -46,6 +46,34 @@ test.describe( 'Classic Product Editor integration', () => {
 		await api.setOnboardedMerchant();
 	} );
 
+	test( 'Hide plugin tab and meta box for unsupported product types', async () => {
+		await editorUtils.gotoAddProductPage();
+
+		const channelVisibilityMetaBox =
+			editorUtils.getChannelVisibilityMetaBox();
+
+		const pluginTab = editorUtils.getPluginTab();
+
+		await expect( channelVisibilityMetaBox ).toBeVisible();
+		await expect( pluginTab ).toBeVisible();
+
+		await editorUtils.changeToGroupedProduct();
+		await expect( channelVisibilityMetaBox ).toBeHidden();
+		await expect( pluginTab ).toBeHidden();
+
+		await editorUtils.changeToSimpleProduct();
+		await expect( channelVisibilityMetaBox ).toBeVisible();
+		await expect( pluginTab ).toBeVisible();
+
+		await editorUtils.changeToExternalProduct();
+		await expect( channelVisibilityMetaBox ).toBeHidden();
+		await expect( pluginTab ).toBeHidden();
+
+		await editorUtils.changeToVariableProduct();
+		await expect( channelVisibilityMetaBox ).toBeVisible();
+		await expect( pluginTab ).toBeVisible();
+	} );
+
 	test.afterAll( async () => {
 		await api.clearOnboardedMerchant();
 		await page.close();

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -523,6 +523,44 @@ test.describe( 'Classic Product Editor integration', () => {
 		await expect( timeInput ).toHaveValue( '' );
 	} );
 
+	test( 'Custom input: Non-negative integer input', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+		await editorUtils.clickPluginTab();
+
+		const input = editorUtils.getMultipackInput();
+
+		await expect( input ).toHaveValue( '' );
+
+		await input.fill( '-1' );
+		await editorUtils.clickSave();
+
+		expect( await editorUtils.evaluateValidity( input ) ).toBe( false );
+
+		await input.fill( '9.5' );
+		await editorUtils.clickSave();
+
+		expect( await editorUtils.evaluateValidity( input ) ).toBe( false );
+
+		await input.fill( '0' );
+		await editorUtils.save();
+		await editorUtils.clickPluginTab();
+
+		await expect( input ).toHaveValue( '0' );
+
+		await input.fill( '100' );
+		await editorUtils.save();
+		await editorUtils.clickPluginTab();
+
+		await expect( input ).toHaveValue( '100' );
+
+		await input.clear();
+		await editorUtils.save();
+		await editorUtils.clickPluginTab();
+
+		await expect( input ).toHaveValue( '' );
+	} );
+
 	test.afterAll( async () => {
 		await api.clearOnboardedMerchant();
 		await page.close();

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -294,6 +294,36 @@ test.describe( 'Classic Product Editor integration', () => {
 		await expect( variation.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
 	} );
 
+	test( 'Channel visibility is disabled when hiding in product catalog', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+
+		const { selection, help } = editorUtils.getChannelVisibility();
+		const catalogVisibility = page.locator( '#catalog-visibility' );
+
+		await expect( selection ).toBeEnabled();
+		await expect( selection ).toHaveValue( 'sync-and-show' );
+		await expect( help ).toBeHidden();
+
+		await catalogVisibility.getByRole( 'link', { name: 'Edit' } ).click();
+		await catalogVisibility.getByLabel( 'Search results only' ).click();
+		await editorUtils.save();
+
+		await expect( selection ).toBeDisabled();
+		await expect( selection ).toHaveValue( 'dont-sync-and-show' );
+		await expect( help ).toBeVisible();
+		await expect( help ).toContainText(
+			'This product cannot be shown on any channel because it is hidden from your store catalog.'
+		);
+
+		await catalogVisibility.getByRole( 'link', { name: 'Edit' } ).click();
+		await catalogVisibility.getByLabel( 'Shop and search results' ).click();
+		await editorUtils.save();
+
+		await expect( selection ).toBeEnabled();
+		await expect( help ).toBeHidden();
+	} );
+
 	test.afterAll( async () => {
 		await api.clearOnboardedMerchant();
 		await page.close();

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -454,6 +454,75 @@ test.describe( 'Classic Product Editor integration', () => {
 		await expect( input ).toHaveValue( 'Cute Cat' );
 	} );
 
+	test( 'Custom input: Date and time inputs', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.fillProductName();
+		await editorUtils.clickPluginTab();
+
+		const { dateInput, timeInput } = editorUtils.getDateAndTimeInputs();
+
+		/*
+		 * Assert:
+		 * - The default values are empty strings
+		 */
+		await expect( dateInput ).toHaveValue( '' );
+		await expect( timeInput ).toHaveValue( '' );
+
+		/*
+		 * Assert:
+		 * - After entering an invalid date or time value, its validity.valid is false
+		 */
+		await dateInput.pressSequentially( '9' );
+		await editorUtils.clickSave();
+
+		expect( await editorUtils.evaluateValidity( dateInput ) ).toBe( false );
+
+		await dateInput.clear();
+
+		await timeInput.pressSequentially( '9' );
+		await editorUtils.clickSave();
+
+		expect( await editorUtils.evaluateValidity( timeInput ) ).toBe( false );
+
+		await timeInput.clear();
+
+		/*
+		 * Assert:
+		 * - When valid values are entered, it allows to save
+		 * - After saving, the field values remain the same
+		 */
+		await dateInput.fill( '2024-02-29' );
+		await timeInput.fill( '18:30' );
+		await editorUtils.save();
+		await editorUtils.clickPluginTab();
+
+		await expect( dateInput ).toHaveValue( '2024-02-29' );
+		await expect( timeInput ).toHaveValue( '18:30' );
+
+		/*
+		 * Assert:
+		 * - It can enter only the date and leave the time empty
+		 * - After saving, the empty time value is considered as 00:00
+		 */
+		await timeInput.clear();
+		await editorUtils.save();
+		await editorUtils.clickPluginTab();
+
+		await expect( dateInput ).toHaveValue( '2024-02-29' );
+		await expect( timeInput ).toHaveValue( '00:00' );
+
+		/*
+		 * Assert:
+		 * - It allows to save empty values
+		 */
+		await dateInput.clear();
+		await editorUtils.save();
+		await editorUtils.clickPluginTab();
+
+		await expect( dateInput ).toHaveValue( '' );
+		await expect( timeInput ).toHaveValue( '' );
+	} );
+
 	test.afterAll( async () => {
 		await api.clearOnboardedMerchant();
 		await page.close();

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -19,58 +19,6 @@ test.describe( 'Classic Product Editor integration', () => {
 	let page = null;
 	let editorUtils = null;
 
-	async function getAvailableProductAttributesWithTestValues( locator ) {
-		const {
-			gtin,
-			mpn,
-			brand,
-			condition,
-			gender,
-			size,
-			sizeSystem,
-			sizeType,
-			color,
-			material,
-			pattern,
-			ageGroup,
-			multipack,
-			isBundle,
-			availabilityDate,
-			availabilityTime,
-			adultContent,
-		} = editorUtils.getAllProductAttributes( locator );
-
-		const allPairs = [
-			[ gtin, '3234567890126' ],
-			[ mpn, 'GO12345OOGLE' ],
-			[ brand, 'e2e_test_woocommerce_brands' ],
-			[ condition, 'new' ],
-			[ gender, 'unisex' ],
-			[ size, 'Good for everybody' ],
-			[ sizeSystem, 'JP' ],
-			[ sizeType, 'regular' ],
-			[ color, 'Cherry blossom' ],
-			[ material, 'Titanium alloy' ],
-			[ pattern, 'Cyberpunk' ],
-			[ ageGroup, 'kids' ],
-			[ multipack, '9999' ],
-			[ isBundle, 'no' ],
-			[ availabilityDate, '2024-02-29' ],
-			[ availabilityTime, '23:59' ],
-			[ adultContent, 'no' ],
-		];
-
-		const availablePairs = [];
-
-		for ( const pair of allPairs ) {
-			if ( await pair[ 0 ].isVisible() ) {
-				availablePairs.push( pair );
-			}
-		}
-
-		return availablePairs;
-	}
-
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
 		editorUtils = getClassicProductEditorUtils( page );
@@ -618,7 +566,8 @@ test.describe( 'Classic Product Editor integration', () => {
 		await editorUtils.fillProductName();
 		await editorUtils.clickPluginTab();
 
-		const pairs = await getAvailableProductAttributesWithTestValues();
+		const pairs =
+			await editorUtils.getAvailableProductAttributesWithTestValues();
 
 		expect( pairs ).toHaveLength( 17 );
 
@@ -660,9 +609,10 @@ test.describe( 'Classic Product Editor integration', () => {
 		await editorUtils.gotoEditVariableProductPage();
 		await editorUtils.gotoEditVariation();
 
-		const pairs = await getAvailableProductAttributesWithTestValues(
-			editorUtils.getPluginVariationMetaBox()
-		);
+		const pairs =
+			await editorUtils.getAvailableProductAttributesWithTestValues(
+				editorUtils.getPluginVariationMetaBox()
+			);
 
 		expect( pairs ).toHaveLength( 16 );
 

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -74,6 +74,145 @@ test.describe( 'Classic Product Editor integration', () => {
 		await expect( pluginTab ).toBeVisible();
 	} );
 
+	test( 'Check existence and availability of fields for simple product', async () => {
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.clickPluginTab();
+
+		const panel = editorUtils.getPluginPanel();
+
+		/*
+		 * 2 Headings
+		 */
+		await expect( editorUtils.getChannelVisibilityHeading() ).toBeVisible();
+		await expect( editorUtils.getProductAttributesHeading() ).toBeVisible();
+
+		/*
+		 * 1 + 8 <select>:
+		 * - Channel visibility
+		 * - Brand
+		 *   - This is dynamically changed from `Select` to `SelectWithTextInput`.
+		 *   - Code ref: `AttributesForm::init_input`
+		 *   - E2E setup: 'woocommerce_gla_product_attribute_value_options_brand' filter in test-snippets.php
+		 * - Condition
+		 * - Gender
+		 * - Size system
+		 * - Size type
+		 * - Age group
+		 * - Is bundle
+		 * - Adult content
+		 */
+		await expect(
+			editorUtils.getChannelVisibilityMetaBox().getByRole( 'combobox' )
+		).toHaveCount( 1 );
+
+		await expect( panel.getByRole( 'combobox' ) ).toHaveCount( 8 );
+
+		/*
+		 * 8 <input type="text|date|time">:
+		 * - GTIN
+		 * - MPN
+		 * - Size
+		 * - Color
+		 * - Material
+		 * - Pattern
+		 * - Availability date
+		 * - Availability time
+		 */
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 8 );
+
+		/*
+		 * 1 <input type="number">:
+		 * - Multipack
+		 */
+		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
+
+		/*
+		 * 16 pairs of <label> and help icon buttons:
+		 * - GTIN
+		 * - MPN
+		 * - Brand
+		 * - Condition
+		 * - Gender
+		 * - Size
+		 * - Size system
+		 * - Size type
+		 * - Color
+		 * - Material
+		 * - Pattern
+		 * - Age group
+		 * - Multipack
+		 * - Is bundle
+		 * - Availability date and time
+		 * - Adult content
+		 */
+		await expect( panel.locator( 'label:visible' ) ).toHaveCount( 16 );
+		await expect( panel.locator( '.woocommerce-help-tip' ) ).toHaveCount(
+			16
+		);
+
+		/*
+		 * Hover the help icon to view the tooltip and its content for each type of field
+		 * with the tuple of field CSS name and containing text.
+		 */
+		const fields = [
+			// Text
+			[
+				'.gla_attributes_gtin_field',
+				/global trade item number \(gtin\) for your item/i,
+			],
+
+			// Select with text
+			[
+				'.gla_attributes_brand__gla_select_field',
+				/brand of the product/i,
+			],
+
+			// Select
+			[
+				'.gla_attributes_condition_field',
+				/condition or state of the item/i,
+			],
+
+			// Integer
+			[
+				'.gla_attributes_multipack_field',
+				/number of identical products in a multipack/i,
+			],
+
+			// Boolean select
+			[
+				'.gla_attributes_isBundle_field',
+				/whether the item is a bundle of products/i,
+			],
+
+			// Date and time
+			[
+				'.gla_attributes_availabilityDate_field',
+				/date a preordered or backordered product becomes available for delivery/i,
+			],
+		];
+
+		for ( const [ cssName, expectedText ] of fields ) {
+			// Since the testing hovers to the next help icon very quickly
+			// after the Tooltip disappears, which could randomly cause
+			// the next hover not to be triggered, here use `toPass` to
+			// reset the hovering attempt.
+			await expect( async () => {
+				const tooltip = page.locator( '#tiptip_holder' );
+
+				await page.mouse.move( 0, 0 );
+				await expect( tooltip ).toBeHidden();
+
+				await panel
+					.locator( `${ cssName } .woocommerce-help-tip` )
+					.hover();
+
+				await expect( tooltip ).toBeVisible( { timeout: 1000 } );
+				await expect( tooltip ).toContainText( expectedText );
+			} ).toPass();
+		}
+	} );
+
 	test.afterAll( async () => {
 		await api.clearOnboardedMerchant();
 		await page.close();

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -213,6 +213,87 @@ test.describe( 'Classic Product Editor integration', () => {
 		}
 	} );
 
+	test( 'Check existence of fields for variable and variation products', async () => {
+		await editorUtils.gotoEditVariableProductPage();
+		await editorUtils.clickPluginTab();
+
+		const panel = editorUtils.getPluginPanel();
+
+		/*
+		 * 2 Sections for variable product
+		 */
+		await expect( editorUtils.getChannelVisibilityHeading() ).toBeVisible();
+		await expect( editorUtils.getProductAttributesHeading() ).toBeVisible();
+
+		/*
+		 * Description of where to edit attributes for variations
+		 */
+		await expect(
+			panel.getByText(
+				'As this is a variable product, you can add additional product attributes by going to Variations > Select one variation > Google Listings & Ads.'
+			)
+		).toBeVisible();
+
+		/*
+		 * 1 + 2 <select> for variable product:
+		 * - Channel visibility
+		 * - Brand (dynamically changed to `SelectWithTextInput`)
+		 * - Adult content
+		 */
+		await expect(
+			editorUtils.getChannelVisibilityMetaBox().getByRole( 'combobox' )
+		).toHaveCount( 1 );
+		await expect( panel.getByRole( 'combobox' ) ).toHaveCount( 2 );
+
+		/*
+		 * 0 <input type="text|date|time"> for variable product.
+		 */
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 0 );
+
+		/*
+		 * 0 <input type="number"> for variable product.
+		 */
+		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 0 );
+
+		// ===============================
+		// Go to edit the first variation.
+		// ===============================
+		await editorUtils.gotoEditVariation();
+
+		const variation = editorUtils.getPluginVariationMetaBox();
+
+		/*
+		 * 7 <select> for variation product:
+		 * - Condition
+		 * - Gender
+		 * - Size system
+		 * - Size type
+		 * - Age group
+		 * - Is bundle
+		 * - Adult content
+		 */
+		await expect( variation.getByRole( 'combobox' ) ).toHaveCount( 7 );
+
+		/*
+		 * 8 <input type="text|date|time"> for variation product:
+		 * - GTIN
+		 * - MPN
+		 * - Size
+		 * - Color
+		 * - Material
+		 * - Pattern
+		 * - Availability date
+		 * - Availability time
+		 */
+		await expect( variation.getByRole( 'textbox' ) ).toHaveCount( 8 );
+
+		/*
+		 * 1 <input type="number"> for variation product:
+		 * - Multipack
+		 */
+		await expect( variation.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
+	} );
+
 	test.afterAll( async () => {
 		await api.clearOnboardedMerchant();
 		await page.close();

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { expect, test, Page } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import * as api from '../../utils/api';
+import { getClassicProductEditorUtils } from '../../utils/product-editor';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+test.describe.configure( { mode: 'serial' } );
+
+test.describe( 'Classic Product Editor integration', () => {
+	/**
+	 * @type {Page}
+	 */
+	let page = null;
+	let editorUtils = null;
+
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		editorUtils = getClassicProductEditorUtils( page );
+
+		await api.setOnboardedMerchant();
+	} );
+
+	test( 'Prompt to Get Started when not yet finished onboarding', async () => {
+		await api.clearOnboardedMerchant();
+		await editorUtils.gotoAddProductPage();
+
+		await expect( editorUtils.getPluginTab() ).toBeHidden();
+
+		const link = editorUtils
+			.getChannelVisibilityMetaBox()
+			.getByRole( 'link', { name: 'Complete setup' } );
+
+		await expect( link ).toBeVisible();
+		await expect( link ).toHaveAttribute(
+			'href',
+			/\/wp-admin\/admin\.php\?page=wc-admin&path=\/google\/start/
+		);
+
+		// Resume the plugin to onboarded status so that the next test can carry over.
+		await api.setOnboardedMerchant();
+	} );
+
+	test.afterAll( async () => {
+		await api.clearOnboardedMerchant();
+		await page.close();
+	} );
+} );

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -75,6 +75,17 @@ export async function createVariationProducts( productId ) {
 }
 
 /**
+ * Creates a variable product with 3 variation products.
+ *
+ * @return {Promise<number>} Product ID of the created variable product.
+ */
+export async function createVariableWithVariationProducts() {
+	const variableId = await createVariableProduct();
+	await createVariationProducts( variableId );
+	return variableId;
+}
+
+/**
  * Set Test Conversion ID.
  */
 export async function setConversionID() {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -51,6 +51,9 @@ export function getClassicProductEditorUtils( page ) {
 			return {
 				selection: metaBox.getByRole( 'combobox' ),
 				help: metaBox.locator( '.description' ),
+				notice: metaBox.locator( '.sync-status' ),
+				status: metaBox.locator( '.sync-status p' ).nth( 1 ),
+				issues: metaBox.getByRole( 'listitem' ),
 			};
 		},
 	};
@@ -139,9 +142,24 @@ export function getClassicProductEditorUtils( page ) {
 		},
 	};
 
+	const mocks = {
+		async mockChannelVisibility( syncStatus, issues = [] ) {
+			const url = new URL( page.url() );
+			const productId = url.searchParams.get( 'post' );
+
+			await api.api().put( `products/${ productId }`, {
+				meta_data: [
+					{ key: '_wc_gla_sync_status', value: syncStatus },
+					{ key: '_wc_gla_errors', value: issues },
+				],
+			} );
+		},
+	};
+
 	return {
 		...locators,
 		...asyncActions,
+		...mocks,
 	};
 }
 

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -130,8 +130,7 @@ export function getClassicProductEditorUtils( page ) {
 		},
 
 		async gotoEditVariableProductPage() {
-			const variableId = await api.createVariableProduct();
-			await api.createVariationProducts( variableId );
+			const variableId = await api.createVariableWithVariationProducts();
 
 			await page.goto(
 				`/wp-admin/post.php?post=${ variableId }&action=edit`
@@ -383,8 +382,7 @@ export function getProductBlockEditorUtils( page ) {
 		},
 
 		async gotoEditVariableProductPage() {
-			const variableId = await api.createVariableProduct();
-			await api.createVariationProducts( variableId );
+			const variableId = await api.createVariableWithVariationProducts();
 
 			return page.goto(
 				`/wp-admin/admin.php?page=wc-admin&path=%2Fproduct%2F${ variableId }`

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -30,6 +30,26 @@ export function getClassicProductEditorUtils( page ) {
 		gotoAddProductPage() {
 			return page.goto( '/wp-admin/post-new.php?post_type=product' );
 		},
+
+		async changeProductType( type ) {
+			await page.locator( '#product-type' ).selectOption( type );
+		},
+
+		changeToSimpleProduct() {
+			return this.changeProductType( 'simple' );
+		},
+
+		changeToGroupedProduct() {
+			return this.changeProductType( 'grouped' );
+		},
+
+		changeToExternalProduct() {
+			return this.changeProductType( 'external' );
+		},
+
+		changeToVariableProduct() {
+			return this.changeProductType( 'variable' );
+		},
 	};
 
 	return {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -10,6 +10,31 @@ import * as api from './api';
 
 const REGEX_URL_PRODUCTS = /\/wc\/v3\/products\/\d+(\/variations\/\d+)?\?/;
 
+function getAllProductAttributes( locator, funcGetDateAndTime ) {
+	const { dateInput: availabilityDate, timeInput: availabilityTime } =
+		funcGetDateAndTime( locator );
+
+	return {
+		gtin: locator.getByLabel( /\(GTIN\)$/ ),
+		mpn: locator.getByLabel( 'MPN' ),
+		brand: locator.getByLabel( 'Brand', { exact: true } ),
+		condition: locator.getByLabel( 'Condition', { exact: true } ),
+		gender: locator.getByLabel( 'Gender', { exact: true } ),
+		size: locator.getByLabel( 'Size', { exact: true } ),
+		sizeSystem: locator.getByLabel( 'Size system' ),
+		sizeType: locator.getByLabel( 'Size type' ),
+		color: locator.getByLabel( 'Color', { exact: true } ),
+		material: locator.getByLabel( 'Material', { exact: true } ),
+		pattern: locator.getByLabel( 'Pattern', { exact: true } ),
+		ageGroup: locator.getByLabel( 'Age Group', { exact: true } ),
+		multipack: locator.getByLabel( 'Multipack', { exact: true } ),
+		isBundle: locator.getByLabel( 'Is Bundle' ),
+		availabilityDate,
+		availabilityTime,
+		adultContent: locator.getByLabel( 'Adult content' ),
+	};
+}
+
 async function setAttributeValue( locator, value ) {
 	const tagName = await locator.evaluate( ( element ) => element.tagName );
 
@@ -98,28 +123,10 @@ export function getClassicProductEditorUtils( page ) {
 		},
 
 		getAllProductAttributes( locator = page ) {
-			const { dateInput: availabilityDate, timeInput: availabilityTime } =
-				this.getDateAndTimeInputs( locator );
-
-			return {
-				gtin: locator.getByLabel( /\(GTIN\)$/ ),
-				mpn: locator.getByLabel( 'MPN' ),
-				brand: locator.getByLabel( 'Brand', { exact: true } ),
-				condition: locator.getByLabel( 'Condition', { exact: true } ),
-				gender: locator.getByLabel( 'Gender', { exact: true } ),
-				size: locator.getByLabel( 'Size', { exact: true } ),
-				sizeSystem: locator.getByLabel( 'Size system' ),
-				sizeType: locator.getByLabel( 'Size type' ),
-				color: locator.getByLabel( 'Color', { exact: true } ),
-				material: locator.getByLabel( 'Material', { exact: true } ),
-				pattern: locator.getByLabel( 'Pattern', { exact: true } ),
-				ageGroup: locator.getByLabel( 'Age Group', { exact: true } ),
-				multipack: locator.getByLabel( 'Multipack', { exact: true } ),
-				isBundle: locator.getByLabel( 'Is Bundle' ),
-				availabilityDate,
-				availabilityTime,
-				adultContent: locator.getByLabel( 'Adult content' ),
-			};
+			return getAllProductAttributes(
+				locator,
+				this.getDateAndTimeInputs
+			);
 		},
 	};
 
@@ -328,28 +335,7 @@ export function getProductBlockEditorUtils( page ) {
 		},
 
 		getAllProductAttributes() {
-			const { dateInput: availabilityDate, timeInput: availabilityTime } =
-				this.getDateAndTimeFields();
-
-			return {
-				gtin: page.getByLabel( 'GTIN' ),
-				mpn: page.getByLabel( 'MPN' ),
-				brand: page.getByLabel( 'Brand' ),
-				condition: page.getByLabel( 'Condition', { exact: true } ),
-				gender: page.getByLabel( 'Gender' ),
-				size: page.getByLabel( 'Size', { exact: true } ),
-				sizeSystem: page.getByLabel( 'Size system' ),
-				sizeType: page.getByLabel( 'Size type' ),
-				color: page.getByLabel( 'Color' ),
-				material: page.getByLabel( 'Material' ),
-				pattern: page.getByLabel( 'Pattern' ),
-				ageGroup: page.getByLabel( 'Age Group' ),
-				multipack: page.getByLabel( 'Multipack' ),
-				isBundle: page.getByLabel( 'Is Bundle' ),
-				availabilityDate,
-				availabilityTime,
-				adultContent: page.getByLabel( 'Adult content' ),
-			};
+			return getAllProductAttributes( page, this.getDateAndTimeFields );
 		},
 	};
 

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -56,20 +56,31 @@ export function getClassicProductEditorUtils( page ) {
 				issues: metaBox.getByRole( 'listitem' ),
 			};
 		},
+
+		getSelectWithTextInput() {
+			const field = page.locator( '.select-with-text-input' ).first();
+
+			return {
+				selection: field.getByRole( 'combobox' ),
+				input: field.getByRole( 'textbox' ),
+			};
+		},
 	};
 
 	const asyncActions = {
-		gotoAddProductPage() {
-			return page.goto( '/wp-admin/post-new.php?post_type=product' );
+		async gotoAddProductPage() {
+			await page.goto( '/wp-admin/post-new.php?post_type=product' );
+			await this.waitForInteractionReady();
 		},
 
 		async gotoEditVariableProductPage() {
 			const variableId = await api.createVariableProduct();
 			await api.createVariationProducts( variableId );
 
-			return page.goto(
+			await page.goto(
 				`/wp-admin/post.php?post=${ variableId }&action=edit`
 			);
+			await this.waitForInteractionReady();
 		},
 
 		async gotoEditVariation() {
@@ -103,9 +114,18 @@ export function getClassicProductEditorUtils( page ) {
 
 			await this.clickSave();
 			await observer;
+			await this.waitForInteractionReady();
 		},
 
-		clickPluginTab() {
+		waitForInteractionReady() {
+			// Avoiding tests may start to operate the UI before jQuery interactions are initialized,
+			// leading to random failures.
+			return expect(
+				page.locator( '.product_data_tabs li.active' )
+			).toHaveCount( 1 );
+		},
+
+		async clickPluginTab() {
 			return this.getPluginTab().click();
 		},
 

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -65,6 +65,17 @@ export function getClassicProductEditorUtils( page ) {
 				input: field.getByRole( 'textbox' ),
 			};
 		},
+
+		getDateAndTimeInputs() {
+			const field = page.locator(
+				'.gla_attributes_availabilityDate_field'
+			);
+
+			return {
+				dateInput: field.locator( 'input[type=date]' ),
+				timeInput: field.locator( 'input[type=time]' ),
+			};
+		},
 	};
 
 	const asyncActions = {
@@ -159,6 +170,10 @@ export function getClassicProductEditorUtils( page ) {
 			// for these processes to complete to avoid some random race conditions.
 			await input.blur();
 			await expect( page.locator( '#sample-permalink' ) ).toBeVisible();
+		},
+
+		evaluateValidity( input ) {
+			return input.evaluate( ( element ) => element.validity.valid );
 		},
 	};
 

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -10,6 +10,18 @@ import * as api from './api';
 
 const REGEX_URL_PRODUCTS = /\/wc\/v3\/products\/\d+(\/variations\/\d+)?\?/;
 
+async function setAttributeValue( locator, value ) {
+	const tagName = await locator.evaluate( ( element ) => element.tagName );
+
+	if ( tagName === 'SELECT' ) {
+		await locator.selectOption( value );
+	} else {
+		await locator.fill( value );
+	}
+
+	await expect( locator ).toHaveValue( value );
+}
+
 /**
  * Gets E2E test utils for facilitating writing tests for the classic product editor.
  *
@@ -66,8 +78,8 @@ export function getClassicProductEditorUtils( page ) {
 			};
 		},
 
-		getDateAndTimeInputs() {
-			const field = page.locator(
+		getDateAndTimeInputs( locator = page ) {
+			const field = locator.locator(
 				'.gla_attributes_availabilityDate_field'
 			);
 
@@ -79,6 +91,31 @@ export function getClassicProductEditorUtils( page ) {
 
 		getMultipackInput() {
 			return page.locator( '.gla_attributes_multipack_field input' );
+		},
+
+		getAllProductAttributes( locator = page ) {
+			const { dateInput: availabilityDate, timeInput: availabilityTime } =
+				this.getDateAndTimeInputs( locator );
+
+			return {
+				gtin: locator.getByLabel( /\(GTIN\)$/ ),
+				mpn: locator.getByLabel( 'MPN' ),
+				brand: locator.getByLabel( 'Brand', { exact: true } ),
+				condition: locator.getByLabel( 'Condition', { exact: true } ),
+				gender: locator.getByLabel( 'Gender', { exact: true } ),
+				size: locator.getByLabel( 'Size', { exact: true } ),
+				sizeSystem: locator.getByLabel( 'Size system' ),
+				sizeType: locator.getByLabel( 'Size type' ),
+				color: locator.getByLabel( 'Color', { exact: true } ),
+				material: locator.getByLabel( 'Material', { exact: true } ),
+				pattern: locator.getByLabel( 'Pattern', { exact: true } ),
+				ageGroup: locator.getByLabel( 'Age Group', { exact: true } ),
+				multipack: locator.getByLabel( 'Multipack', { exact: true } ),
+				isBundle: locator.getByLabel( 'Is Bundle' ),
+				availabilityDate,
+				availabilityTime,
+				adultContent: locator.getByLabel( 'Adult content' ),
+			};
 		},
 	};
 
@@ -179,6 +216,8 @@ export function getClassicProductEditorUtils( page ) {
 		evaluateValidity( input ) {
 			return input.evaluate( ( element ) => element.validity.valid );
 		},
+
+		setAttributeValue,
 	};
 
 	const mocks = {
@@ -423,19 +462,7 @@ export function getProductBlockEditorUtils( page ) {
 			return input.evaluate( ( element ) => element.validationMessage );
 		},
 
-		async setAttributeValue( locator, value ) {
-			const tagName = await locator.evaluate(
-				( element ) => element.tagName
-			);
-
-			if ( tagName === 'SELECT' ) {
-				await locator.selectOption( value );
-			} else {
-				await locator.fill( value );
-			}
-
-			await expect( locator ).toHaveValue( value );
-		},
+		setAttributeValue,
 	};
 
 	const mocks = {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -25,6 +25,10 @@ export function getClassicProductEditorUtils( page ) {
 			return page.locator( '#gla_attributes' );
 		},
 
+		getPluginVariationMetaBox() {
+			return page.locator( '.gla-metabox:visible' ).first();
+		},
+
 		getChannelVisibilityMetaBox() {
 			return page.locator( '#channel_visibility' );
 		},
@@ -45,6 +49,27 @@ export function getClassicProductEditorUtils( page ) {
 	const asyncActions = {
 		gotoAddProductPage() {
 			return page.goto( '/wp-admin/post-new.php?post_type=product' );
+		},
+
+		async gotoEditVariableProductPage() {
+			const variableId = await api.createVariableProduct();
+			await api.createVariationProducts( variableId );
+
+			return page.goto(
+				`/wp-admin/post.php?post=${ variableId }&action=edit`
+			);
+		},
+
+		async gotoEditVariation() {
+			await page.locator( '.variations_tab' ).click();
+
+			const variation = page.locator( '.woocommerce_variation' ).first();
+
+			await variation.getByRole( 'link', { name: 'Edit' } ).click();
+
+			return variation
+				.getByRole( 'heading', { name: 'Google Listings & Ads' } )
+				.click();
 		},
 
 		clickPluginTab() {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -76,6 +76,10 @@ export function getClassicProductEditorUtils( page ) {
 				timeInput: field.locator( 'input[type=time]' ),
 			};
 		},
+
+		getMultipackInput() {
+			return page.locator( '.gla_attributes_multipack_field input' );
+		},
 	};
 
 	const asyncActions = {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -79,9 +79,13 @@ export function getClassicProductEditorUtils( page ) {
 		},
 
 		getDateAndTimeInputs( locator = page ) {
-			const field = locator.locator(
+			const simple = locator.locator(
 				'.gla_attributes_availabilityDate_field'
 			);
+			const variation = locator.locator(
+				'.gla_variation_attributes\\[0\\]_availabilityDate_field'
+			);
+			const field = simple.or( variation );
 
 			return {
 				dateInput: field.locator( 'input[type=date]' ),
@@ -148,7 +152,9 @@ export function getClassicProductEditorUtils( page ) {
 		},
 
 		clickSave() {
-			return page.getByRole( 'button', { name: 'Save Draft' } ).click();
+			return page
+				.getByRole( 'button', { name: /^(Save Draft|Update)$/ } )
+				.click();
 		},
 
 		async save() {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -10,29 +10,58 @@ import * as api from './api';
 
 const REGEX_URL_PRODUCTS = /\/wc\/v3\/products\/\d+(\/variations\/\d+)?\?/;
 
-function getAllProductAttributes( locator, funcGetDateAndTime ) {
+async function getAvailableProductAttributesWithTestValues(
+	locator,
+	funcGetDateAndTime
+) {
 	const { dateInput: availabilityDate, timeInput: availabilityTime } =
 		funcGetDateAndTime( locator );
 
-	return {
-		gtin: locator.getByLabel( /\(GTIN\)$/ ),
-		mpn: locator.getByLabel( 'MPN' ),
-		brand: locator.getByLabel( 'Brand', { exact: true } ),
-		condition: locator.getByLabel( 'Condition', { exact: true } ),
-		gender: locator.getByLabel( 'Gender', { exact: true } ),
-		size: locator.getByLabel( 'Size', { exact: true } ),
-		sizeSystem: locator.getByLabel( 'Size system' ),
-		sizeType: locator.getByLabel( 'Size type' ),
-		color: locator.getByLabel( 'Color', { exact: true } ),
-		material: locator.getByLabel( 'Material', { exact: true } ),
-		pattern: locator.getByLabel( 'Pattern', { exact: true } ),
-		ageGroup: locator.getByLabel( 'Age Group', { exact: true } ),
-		multipack: locator.getByLabel( 'Multipack', { exact: true } ),
-		isBundle: locator.getByLabel( 'Is Bundle' ),
-		availabilityDate,
-		availabilityTime,
-		adultContent: locator.getByLabel( 'Adult content' ),
-	};
+	const gtin = locator.getByLabel( /\(GTIN\)$/ );
+	const mpn = locator.getByLabel( 'MPN' );
+	const brand = locator.getByLabel( 'Brand', { exact: true } );
+	const condition = locator.getByLabel( 'Condition', { exact: true } );
+	const gender = locator.getByLabel( 'Gender', { exact: true } );
+	const size = locator.getByLabel( 'Size', { exact: true } );
+	const sizeSystem = locator.getByLabel( 'Size system' );
+	const sizeType = locator.getByLabel( 'Size type' );
+	const color = locator.getByLabel( 'Color', { exact: true } );
+	const material = locator.getByLabel( 'Material', { exact: true } );
+	const pattern = locator.getByLabel( 'Pattern', { exact: true } );
+	const ageGroup = locator.getByLabel( 'Age Group', { exact: true } );
+	const multipack = locator.getByLabel( 'Multipack', { exact: true } );
+	const isBundle = locator.getByLabel( 'Is Bundle' );
+	const adultContent = locator.getByLabel( 'Adult content' );
+
+	const allPairs = [
+		[ gtin, '3234567890126' ],
+		[ mpn, 'GO12345OOGLE' ],
+		[ brand, 'e2e_test_woocommerce_brands' ],
+		[ condition, 'new' ],
+		[ gender, 'unisex' ],
+		[ size, 'Good for everybody' ],
+		[ sizeSystem, 'JP' ],
+		[ sizeType, 'regular' ],
+		[ color, 'Cherry blossom' ],
+		[ material, 'Titanium alloy' ],
+		[ pattern, 'Cyberpunk' ],
+		[ ageGroup, 'kids' ],
+		[ multipack, '9999' ],
+		[ isBundle, 'no' ],
+		[ availabilityDate, '2024-02-29' ],
+		[ availabilityTime, '23:59' ],
+		[ adultContent, 'no' ],
+	];
+
+	const availablePairs = [];
+
+	for ( const pair of allPairs ) {
+		if ( await pair[ 0 ].isVisible() ) {
+			availablePairs.push( pair );
+		}
+	}
+
+	return availablePairs;
 }
 
 async function setAttributeValue( locator, value ) {
@@ -122,8 +151,8 @@ export function getClassicProductEditorUtils( page ) {
 			return page.locator( '.gla_attributes_multipack_field input' );
 		},
 
-		getAllProductAttributes( locator = page ) {
-			return getAllProductAttributes(
+		async getAvailableProductAttributesWithTestValues( locator = page ) {
+			return getAvailableProductAttributesWithTestValues(
 				locator,
 				this.getDateAndTimeInputs
 			);
@@ -334,8 +363,11 @@ export function getProductBlockEditorUtils( page ) {
 			};
 		},
 
-		getAllProductAttributes() {
-			return getAllProductAttributes( page, this.getDateAndTimeFields );
+		async getAvailableProductAttributesWithTestValues() {
+			return getAvailableProductAttributesWithTestValues(
+				page,
+				this.getDateAndTimeFields
+			);
 		},
 	};
 

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -21,14 +21,34 @@ export function getClassicProductEditorUtils( page ) {
 			return page.locator( '.gla_attributes_tab' );
 		},
 
+		getPluginPanel() {
+			return page.locator( '#gla_attributes' );
+		},
+
 		getChannelVisibilityMetaBox() {
 			return page.locator( '#channel_visibility' );
+		},
+
+		getChannelVisibilityHeading() {
+			return this.getChannelVisibilityMetaBox().getByRole( 'heading', {
+				name: 'Channel visibility',
+			} );
+		},
+
+		getProductAttributesHeading() {
+			return this.getPluginPanel().getByRole( 'heading', {
+				name: 'Product attributes',
+			} );
 		},
 	};
 
 	const asyncActions = {
 		gotoAddProductPage() {
 			return page.goto( '/wp-admin/post-new.php?post_type=product' );
+		},
+
+		clickPluginTab() {
+			return this.getPluginTab().click();
 		},
 
 		async changeProductType( type ) {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -11,6 +11,34 @@ import * as api from './api';
 const REGEX_URL_PRODUCTS = /\/wc\/v3\/products\/\d+(\/variations\/\d+)?\?/;
 
 /**
+ * Gets E2E test utils for facilitating writing tests for the classic product editor.
+ *
+ * @param {Page} page Playwright page object.
+ */
+export function getClassicProductEditorUtils( page ) {
+	const locators = {
+		getPluginTab() {
+			return page.locator( '.gla_attributes_tab' );
+		},
+
+		getChannelVisibilityMetaBox() {
+			return page.locator( '#channel_visibility' );
+		},
+	};
+
+	const asyncActions = {
+		gotoAddProductPage() {
+			return page.goto( '/wp-admin/post-new.php?post_type=product' );
+		},
+	};
+
+	return {
+		...locators,
+		...asyncActions,
+	};
+}
+
+/**
  * Gets E2E test utils for facilitating writing tests for Product Block Editor.
  *
  * @param {Page} page Playwright page object.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Add `menu_order` properties to the variations data in `tests/e2e/config/default.json` to make them can be updated correctly via the classic product editor.
- Add E2E tests

#### 📌 Checklist (@eason9487)

- [x] Revert 253f16cdb14802ffe47314e62f57eb4381c4ffab before merging this PR

### Detailed test instructions:

1. `npm run dev` to build files
2. `npm run test:e2e` to see if the E2E test in headless mode can pass.
3. (Optional) `npm run test:e2e -- --ui` to inspect the E2E test in UI mode.
4. View the E2E test result on GitHub Actions: https://github.com/woocommerce/google-listings-and-ads/actions/runs/8645102656/job/23701605350?pr=2363

### Changelog entry
