### PR TITLE
Expose attribute mapping rule values using WCProductAdapter

### DIFF
--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -305,7 +305,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		$data     = $response->get_data();
 		$resource = $this->get_route_pieces( $request )['resource'] ?? null;
 
-		if ( $item instanceof WC_Product && $resource === 'products' ) {
+		if ( $item instanceof WC_Product && ( $resource === 'products' || $resource === 'variations' ) ) {
 			$attr                   = $this->attribute_manager->get_all_aggregated_values( $item );
 			$data['gla_attributes'] = $attr;
 		}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -331,7 +331,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( NoteInitializer::class, ActionScheduler::class );
 
 		// Product attributes
-		$this->conditionally_share_with_tags( AttributeManager::class );
+		$this->conditionally_share_with_tags( AttributeManager::class, AttributeMappingRulesQuery::class, WC::class );
 		$this->conditionally_share_with_tags( AttributesTab::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 		$this->conditionally_share_with_tags( VariationsAttributes::class, Admin::class, AttributeManager::class, MerchantCenterService::class );
 

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -49,7 +49,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommercePreOrders::class, ProductHelper::class );
 		$this->conditionally_share_with_tags( JetpackWPCOM::class );
-		$this->share_with_tags( WPCOMProxy::class, ShippingTimeQuery::class );
+		$this->share_with_tags( WPCOMProxy::class, ShippingTimeQuery::class, AttributeManager::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -26,7 +26,7 @@ class AttributeManager implements Service {
 	use PluginHelper;
 	use ValidateInterface;
 
-	public const ATTRIBUTES = [
+	protected const ATTRIBUTES = [
 		GTIN::class,
 		MPN::class,
 		Brand::class,
@@ -127,6 +127,7 @@ class AttributeManager implements Service {
 	 * @param WC_Product $product
 	 *
 	 * @return array of attribute values
+	 * @throws InvalidValue When the product does not exist.
 	 */
 	public function get_all_aggregated_values( WC_Product $product ) {
 		$attributes = $this->get_all_values( $product );
@@ -145,7 +146,7 @@ class AttributeManager implements Service {
 			[
 				'wc_product'        => $product,
 				'parent_wc_product' => $parent_product,
-				'targetCountry'     => 'US',
+				'targetCountry'     => 'US', // targetCountry is required to create a new WCProductAdapter instance, but it's not used in the attributes context.
 				'gla_attributes'    => $attributes,
 				'mapping_rules'     => $mapping_rules,
 			]
@@ -153,6 +154,10 @@ class AttributeManager implements Service {
 
 		foreach ( self::ATTRIBUTES as $attribute_class ) {
 			$attribute_id = $attribute_class::get_id();
+			if ( $attribute_id === 'size' ) {
+				$attribute_id = 'sizes';
+			}
+
 			if ( isset( $adapted_product->$attribute_id ) ) {
 				$attributes[ $attribute_id ] = $adapted_product->$attribute_id;
 			}

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -3,12 +3,16 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use WC_Product;
+use WC_Product_Variation;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -22,7 +26,7 @@ class AttributeManager implements Service {
 	use PluginHelper;
 	use ValidateInterface;
 
-	protected const ATTRIBUTES = [
+	public const ATTRIBUTES = [
 		GTIN::class,
 		MPN::class,
 		Brand::class,
@@ -45,6 +49,27 @@ class AttributeManager implements Service {
 	 * @var array Attribute types mapped to product types
 	 */
 	protected $attribute_types_map;
+
+	/**
+	 * @var AttributeMappingRulesQuery
+	 */
+	protected $attribute_mapping_rules_query;
+
+	/**
+	 * @var WC
+	 */
+	protected $wc;
+
+	/**
+	 * AttributeManager constructor.
+	 *
+	 * @param AttributeMappingRulesQuery $attribute_mapping_rules_query
+	 * @param WC                         $wc
+	 */
+	public function __construct( AttributeMappingRulesQuery $attribute_mapping_rules_query, WC $wc ) {
+		$this->attribute_mapping_rules_query = $attribute_mapping_rules_query;
+		$this->wc                            = $wc;
+	}
 
 	/**
 	 * @param WC_Product         $product
@@ -91,6 +116,49 @@ class AttributeManager implements Service {
 
 		$attribute_class = $this->get_attribute_types_for_product( $product )[ $attribute_id ];
 		return new $attribute_class( $value );
+	}
+
+	/**
+	 * Return all attribute values for the given product, after the mapping rules, GLA attributes, and filters have been applied.
+	 * GLA Attributes has priority over the product attributes.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param WC_Product $product
+	 *
+	 * @return array of attribute values
+	 */
+	public function get_all_aggregated_values( WC_Product $product ) {
+		$attributes = $this->get_all_values( $product );
+
+		$parent_product = null;
+		// merge with parent's attributes if it's a variation product
+		if ( $product instanceof WC_Product_Variation ) {
+			$parent_product    = $this->wc->get_product( $product->get_parent_id() );
+			$parent_attributes = $this->get_all_values( $parent_product );
+			$attributes        = array_merge( $parent_attributes, $attributes );
+		}
+
+		$mapping_rules = $this->attribute_mapping_rules_query->get_results();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'parent_wc_product' => $parent_product,
+				'targetCountry'     => 'US',
+				'gla_attributes'    => $attributes,
+				'mapping_rules'     => $mapping_rules,
+			]
+		);
+
+		foreach ( self::ATTRIBUTES as $attribute_class ) {
+			$attribute_id = $attribute_class::get_id();
+			if ( isset( $adapted_product->$attribute_id ) ) {
+				$attributes[ $attribute_id ] = $adapted_product->$attribute_id;
+			}
+		}
+
+		return $attributes;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146

This is an alternative for https://github.com/woocommerce/google-listings-and-ads/pull/2351.

Rather than moving the attribute logic from `WCProductAdapter` into the AttributeManager, we're now crating an instance of `WCProductAdapter` to retrieve all aggregated attribute values from particular products. Similar to the other PR, we'll use these attribute values to expose them in the WC REST Product endpoints. For additional context, refer to https://github.com/woocommerce/google-listings-and-ads/pull/2351.



### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to GLA -> Attribute -> Create some rules.
2. Make the following request `GET wc/v3/products?gla_syncable=1` or `GET wc/v3/products/YOUR_PRODUCT_ID?gla_syncable=1`
3. See that the response contains a new property named: `gla_attributes` with the correct values.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/ac985dcb-4feb-4250-938b-14e8c37d3f6b)


4. Update the products by adding a GLA Attribute. This attribute should take precedence over any mapping rule applied to the same attribute.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/d6819f86-c696-4601-ad1b-3a6a7843dace)

5. Remove the query parameter `gla_syncable=1` and the response should not contain `gla_attributes`.
7. Repeat the steps for a variation product using the following endpoint: `wc/v3/products/PARENT_ID/variations/VARIATION_ID?gla_syncable=1`

### Additional details:
- PHP unit tests are failing because of this issue: https://github.com/woocommerce/grow/issues/101 but you can run the tests locally.
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
