### PR TITLE
Restrict product types to be limited to only 10 when converting from categories.

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -210,6 +210,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 				),
 				__METHOD__
 			);
+			$google_product_types = array_slice( $google_product_types, 0, 10 );
 			$this->setProductTypes( $google_product_types );
 		}
 		return $this;

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -571,6 +571,48 @@ DESCRIPTION;
 		$this->assertNotContains( 'Delta Category', $adapted_product->getProductTypes() );
 	}
 
+	public function test_product_types_are_limited_to_five_categories() {
+		$product     = WC_Helper_Product::create_simple_product();
+		$category_1  = wp_insert_term( 'Zulu Category', 'product_cat' );
+		$category_2  = wp_insert_term( 'Alpha Category', 'product_cat' );
+		$category_3  = wp_insert_term( 'Beta Category', 'product_cat' );
+		$category_4  = wp_insert_term( 'Charlie Category', 'product_cat' );
+		$category_5  = wp_insert_term( 'Delta Category', 'product_cat' );
+		$category_6  = wp_insert_term( 'Echo Category', 'product_cat' );
+		$category_7  = wp_insert_term( 'Foxtrot Category', 'product_cat' );
+		$category_8  = wp_insert_term( 'Golf Category', 'product_cat' );
+		$category_9  = wp_insert_term( 'Hotel Category', 'product_cat' );
+		$category_10 = wp_insert_term( 'India Category', 'product_cat' );
+		$category_11 = wp_insert_term( 'Juliet Category', 'product_cat' );
+
+		$product->set_category_ids(
+			[
+				$category_1['term_id'], // Zulu
+				$category_2['term_id'], // Alpha
+				$category_3['term_id'], // Beta
+				$category_4['term_id'], // Charlie
+				$category_5['term_id'], // Delta
+				$category_6['term_id'], // Echo
+				$category_7['term_id'], // Foxtrot
+				$category_8['term_id'], // Golf
+				$category_9['term_id'], // Hotel
+				$category_10['term_id'], // India
+				$category_11['term_id'], // Juliet
+			]
+		);
+		$product->save();
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		// Confirm only 10 categories are included.
+		$this->assertCount( 10, $adapted_product->getProductTypes() );
+	}
+
 	public function test_images_are_set() {
 		$product = WC_Helper_Product::create_simple_product();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Restrict product types to be limited to only 10 when converting from categories

If you give more than 10 then Google will give a warning of: Too many values [product type]

Pre-edited description:

~~Restrict product types to be limited to only 5 when converting from categories.~~

~~From the Google Documentation: https://support.google.com/merchants/answer/6324406?hl=en~~

~~Repeated field: Submit up to 5 times, but keep in mind that only the first value will be used to organize bidding and reporting in Google Ads Shopping campaigns.~~

~~If you give more than 5 then Google will give a warning of: Too many values [product type]~~

### Screenshots:

![2024-04-12_378x194](https://github.com/woocommerce/google-listings-and-ads/assets/664294/b335c301-3865-4e52-93c0-218bee15a97f)

![2024-04-12_721x566](https://github.com/woocommerce/google-listings-and-ads/assets/664294/1cc498e9-7720-41e1-b552-824d5266f23d)




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

PHP Unit test added as well to make sure it is restricted to 10.


### Changelog entry

> Update - Restrict product types to be limited to only 10 when converting from categories.
