### PR TITLE
Update `woocommerce-grow-jsdoc` to use `jsdoc` v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
 				"stylelint-config-standard-scss": "^3.0.0",
-				"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?update/jsdoc-deps"
+				"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca"
 			},
 			"engines": {
 				"node": "^16 || ^18",
@@ -28251,8 +28251,8 @@
 		},
 		"node_modules/woocommerce-grow-jsdoc": {
 			"version": "0.0.2",
-			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?update/jsdoc-deps",
-			"integrity": "sha512-VxoM6P3pKVr8FPBhlXoeI+uoVrXomG4IEKlcD288IInVXlr7BbtZifPdqCV/K0TcrnwVrALbgFX7RVry5ZUxRA==",
+			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca",
+			"integrity": "sha512-r8yvGjSD7DSEfg6OsuEFnjIcsR8kZ8NRWclNAbTssgnSoZzwRU0hzGnGTHHa3wfrK5M8KjPtZvmZfofQbCQPqw==",
 			"dev": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
@@ -28261,7 +28261,7 @@
 				"jsdoc-plugin-intersection": "^1.0.4",
 				"jsdoc-plugin-typescript": "^2.2.1",
 				"shelljs": "^0.8.5",
-				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?update/tracking-jsdoc-deps"
+				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba"
 			},
 			"bin": {
 				"woocommerce-grow-jsdoc": "bin/jsdoc.mjs"
@@ -28269,8 +28269,8 @@
 		},
 		"node_modules/woocommerce-grow-tracking-jsdoc": {
 			"version": "0.0.2",
-			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?update/tracking-jsdoc-deps",
-			"integrity": "sha512-YrtZKYry5BAkrch81Hd6jZmI1OoX8WxQ6rGm+3ujfLifowrvDEOXQnYwMf7X5Nvkf7HiPORAEmEkaF54kE3pMw==",
+			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba",
+			"integrity": "sha512-RMZecq3RbgutjnmAbrO0dLBQ/MX3i/kQXyHGeYITocOIDZIabUX6mvEEK2uHu2frtvAVn154u3upEMk7X8JZnw==",
 			"dev": true,
 			"license": "GPL-3.0-or-later",
 			"peerDependencies": {
@@ -49663,8 +49663,8 @@
 			"dev": true
 		},
 		"woocommerce-grow-jsdoc": {
-			"version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?update/jsdoc-deps",
-			"integrity": "sha512-VxoM6P3pKVr8FPBhlXoeI+uoVrXomG4IEKlcD288IInVXlr7BbtZifPdqCV/K0TcrnwVrALbgFX7RVry5ZUxRA==",
+			"version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca",
+			"integrity": "sha512-r8yvGjSD7DSEfg6OsuEFnjIcsR8kZ8NRWclNAbTssgnSoZzwRU0hzGnGTHHa3wfrK5M8KjPtZvmZfofQbCQPqw==",
 			"dev": true,
 			"requires": {
 				"jsdoc": "^4.0.2",
@@ -49672,12 +49672,12 @@
 				"jsdoc-plugin-intersection": "^1.0.4",
 				"jsdoc-plugin-typescript": "^2.2.1",
 				"shelljs": "^0.8.5",
-				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?update/tracking-jsdoc-deps"
+				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba"
 			}
 		},
 		"woocommerce-grow-tracking-jsdoc": {
-			"version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?update/tracking-jsdoc-deps",
-			"integrity": "sha512-YrtZKYry5BAkrch81Hd6jZmI1OoX8WxQ6rGm+3ujfLifowrvDEOXQnYwMf7X5Nvkf7HiPORAEmEkaF54kE3pMw==",
+			"version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba",
+			"integrity": "sha512-RMZecq3RbgutjnmAbrO0dLBQ/MX3i/kQXyHGeYITocOIDZIabUX6mvEEK2uHu2frtvAVn154u3upEMk7X8JZnw==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
 				"stylelint-config-standard-scss": "^3.0.0",
-				"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?9eb10353728dc915bf5f7bdd4b8e218c625355a9"
+				"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?update/jsdoc-deps"
 			},
 			"engines": {
 				"node": "^16 || ^18",
@@ -4044,6 +4044,18 @@
 				"@jridgewell/sourcemap-codec": "1.4.14"
 			}
 		},
+		"node_modules/@jsdoc/salty": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+			"integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+			"dev": true,
+			"dependencies": {
+				"lodash": "^4.17.21"
+			},
+			"engines": {
+				"node": ">=v12.0.0"
+			}
+		},
 		"node_modules/@kwsites/file-exists": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -5206,9 +5218,9 @@
 			}
 		},
 		"node_modules/@types/linkify-it": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+			"integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
 			"dev": true
 		},
 		"node_modules/@types/markdown-it": {
@@ -5222,9 +5234,9 @@
 			}
 		},
 		"node_modules/@types/mdurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+			"integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
 			"dev": true
 		},
 		"node_modules/@types/mime": {
@@ -20740,12 +20752,13 @@
 			}
 		},
 		"node_modules/jsdoc": {
-			"version": "3.6.11",
-			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
-			"integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
+			"integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/parser": "^7.9.4",
+				"@babel/parser": "^7.20.15",
+				"@jsdoc/salty": "^0.2.1",
 				"@types/markdown-it": "^12.2.3",
 				"bluebird": "^3.7.2",
 				"catharsis": "^0.9.0",
@@ -20758,7 +20771,6 @@
 				"mkdirp": "^1.0.4",
 				"requizzle": "^0.2.3",
 				"strip-json-comments": "^3.1.0",
-				"taffydb": "2.6.2",
 				"underscore": "~1.13.2"
 			},
 			"bin": {
@@ -20782,9 +20794,9 @@
 			"dev": true
 		},
 		"node_modules/jsdoc-plugin-typescript": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.2.0.tgz",
-			"integrity": "sha512-lYkuHBitTWDjvzBENiPUzpUM6i9aqfxUvg5H7pS2F1eYAMgxsSEBc6W9TN8I10eXD66tdkHbCU2qkKZV9f5wvA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.2.1.tgz",
+			"integrity": "sha512-xxuiqJ1O5+KIoOd8G8+iIZ89ns/ZvuzerrhCQhLPmeSIVsv5Ra42D9/YOHPi2DndUJbbkEpJCB95i7EXIOmhnA==",
 			"dev": true,
 			"dependencies": {
 				"string.prototype.matchall": "^4.0.0"
@@ -21396,9 +21408,9 @@
 			}
 		},
 		"node_modules/markdown-it-anchor": {
-			"version": "8.6.5",
-			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
-			"integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
+			"version": "8.6.7",
+			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+			"integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
 			"dev": true,
 			"peerDependencies": {
 				"@types/markdown-it": "*",
@@ -21511,9 +21523,9 @@
 			"dev": true
 		},
 		"node_modules/marked": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.2.tgz",
-			"integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked.js"
@@ -24797,12 +24809,12 @@
 			"dev": true
 		},
 		"node_modules/requizzle": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+			"integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
 			"dev": true,
 			"dependencies": {
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.21"
 			}
 		},
 		"node_modules/resolve": {
@@ -26676,12 +26688,6 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
-		"node_modules/taffydb": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA==",
-			"dev": true
-		},
 		"node_modules/tannin": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
@@ -28244,31 +28250,31 @@
 			"dev": true
 		},
 		"node_modules/woocommerce-grow-jsdoc": {
-			"version": "0.0.1",
-			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?9eb10353728dc915bf5f7bdd4b8e218c625355a9",
-			"integrity": "sha512-ksRpzDDkKtk43cUqTRw04829SoKWpnGtSLqQMkgpKc9+XqLsmo9zvz0izGDHeSxqkzg8Ze1PBQul14vegt25Bg==",
+			"version": "0.0.2",
+			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?update/jsdoc-deps",
+			"integrity": "sha512-VxoM6P3pKVr8FPBhlXoeI+uoVrXomG4IEKlcD288IInVXlr7BbtZifPdqCV/K0TcrnwVrALbgFX7RVry5ZUxRA==",
 			"dev": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"jsdoc": "^3.6.10",
+				"jsdoc": "^4.0.2",
 				"jsdoc-advanced-types-plugin": "git+https://github.com/tomalec/jsdoc-advanced-types-plugin#add/return-support",
 				"jsdoc-plugin-intersection": "^1.0.4",
-				"jsdoc-plugin-typescript": "^2.0.6",
+				"jsdoc-plugin-typescript": "^2.2.1",
 				"shelljs": "^0.8.5",
-				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?fecfad52db350afd3550842e2374dee8dbc587ea"
+				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?update/tracking-jsdoc-deps"
 			},
 			"bin": {
 				"woocommerce-grow-jsdoc": "bin/jsdoc.mjs"
 			}
 		},
 		"node_modules/woocommerce-grow-tracking-jsdoc": {
-			"version": "0.0.1",
-			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?fecfad52db350afd3550842e2374dee8dbc587ea",
-			"integrity": "sha512-032SZfhnkPW/DWJ/yCpLdouQDRwpcKC+Llu1SHmkv4bmwWhIYXeQJ4c33Oc3VlmhzwxKknH/nkpG150C5g7xHg==",
+			"version": "0.0.2",
+			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?update/tracking-jsdoc-deps",
+			"integrity": "sha512-YrtZKYry5BAkrch81Hd6jZmI1OoX8WxQ6rGm+3ujfLifowrvDEOXQnYwMf7X5Nvkf7HiPORAEmEkaF54kE3pMw==",
 			"dev": true,
 			"license": "GPL-3.0-or-later",
 			"peerDependencies": {
-				"jsdoc": "^3.6.10"
+				"jsdoc": "^4.0.2"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -31471,6 +31477,15 @@
 				"@jridgewell/sourcemap-codec": "1.4.14"
 			}
 		},
+		"@jsdoc/salty": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+			"integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.21"
+			}
+		},
 		"@kwsites/file-exists": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -32333,9 +32348,9 @@
 			}
 		},
 		"@types/linkify-it": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+			"integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
 			"dev": true
 		},
 		"@types/markdown-it": {
@@ -32349,9 +32364,9 @@
 			}
 		},
 		"@types/mdurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+			"integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
 			"dev": true
 		},
 		"@types/mime": {
@@ -44017,12 +44032,13 @@
 			}
 		},
 		"jsdoc": {
-			"version": "3.6.11",
-			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
-			"integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
+			"integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
 			"dev": true,
 			"requires": {
-				"@babel/parser": "^7.9.4",
+				"@babel/parser": "^7.20.15",
+				"@jsdoc/salty": "^0.2.1",
 				"@types/markdown-it": "^12.2.3",
 				"bluebird": "^3.7.2",
 				"catharsis": "^0.9.0",
@@ -44035,7 +44051,6 @@
 				"mkdirp": "^1.0.4",
 				"requizzle": "^0.2.3",
 				"strip-json-comments": "^3.1.0",
-				"taffydb": "2.6.2",
 				"underscore": "~1.13.2"
 			},
 			"dependencies": {
@@ -44066,9 +44081,9 @@
 			"dev": true
 		},
 		"jsdoc-plugin-typescript": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.2.0.tgz",
-			"integrity": "sha512-lYkuHBitTWDjvzBENiPUzpUM6i9aqfxUvg5H7pS2F1eYAMgxsSEBc6W9TN8I10eXD66tdkHbCU2qkKZV9f5wvA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.2.1.tgz",
+			"integrity": "sha512-xxuiqJ1O5+KIoOd8G8+iIZ89ns/ZvuzerrhCQhLPmeSIVsv5Ra42D9/YOHPi2DndUJbbkEpJCB95i7EXIOmhnA==",
 			"dev": true,
 			"requires": {
 				"string.prototype.matchall": "^4.0.0"
@@ -44567,9 +44582,9 @@
 			}
 		},
 		"markdown-it-anchor": {
-			"version": "8.6.5",
-			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
-			"integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
+			"version": "8.6.7",
+			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+			"integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -44645,9 +44660,9 @@
 			"dev": true
 		},
 		"marked": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.2.tgz",
-			"integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
 			"dev": true
 		},
 		"match-sorter": {
@@ -47024,12 +47039,12 @@
 			"dev": true
 		},
 		"requizzle": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+			"integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.21"
 			}
 		},
 		"resolve": {
@@ -48492,12 +48507,6 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
-		"taffydb": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA==",
-			"dev": true
-		},
 		"tannin": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
@@ -49654,21 +49663,21 @@
 			"dev": true
 		},
 		"woocommerce-grow-jsdoc": {
-			"version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?9eb10353728dc915bf5f7bdd4b8e218c625355a9",
-			"integrity": "sha512-ksRpzDDkKtk43cUqTRw04829SoKWpnGtSLqQMkgpKc9+XqLsmo9zvz0izGDHeSxqkzg8Ze1PBQul14vegt25Bg==",
+			"version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?update/jsdoc-deps",
+			"integrity": "sha512-VxoM6P3pKVr8FPBhlXoeI+uoVrXomG4IEKlcD288IInVXlr7BbtZifPdqCV/K0TcrnwVrALbgFX7RVry5ZUxRA==",
 			"dev": true,
 			"requires": {
-				"jsdoc": "^3.6.10",
+				"jsdoc": "^4.0.2",
 				"jsdoc-advanced-types-plugin": "git+https://github.com/tomalec/jsdoc-advanced-types-plugin#add/return-support",
 				"jsdoc-plugin-intersection": "^1.0.4",
-				"jsdoc-plugin-typescript": "^2.0.6",
+				"jsdoc-plugin-typescript": "^2.2.1",
 				"shelljs": "^0.8.5",
-				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?fecfad52db350afd3550842e2374dee8dbc587ea"
+				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?update/tracking-jsdoc-deps"
 			}
 		},
 		"woocommerce-grow-tracking-jsdoc": {
-			"version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?fecfad52db350afd3550842e2374dee8dbc587ea",
-			"integrity": "sha512-032SZfhnkPW/DWJ/yCpLdouQDRwpcKC+Llu1SHmkv4bmwWhIYXeQJ4c33Oc3VlmhzwxKknH/nkpG150C5g7xHg==",
+			"version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?update/tracking-jsdoc-deps",
+			"integrity": "sha512-YrtZKYry5BAkrch81Hd6jZmI1OoX8WxQ6rGm+3ujfLifowrvDEOXQnYwMf7X5Nvkf7HiPORAEmEkaF54kE3pMw==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"stylelint-config-standard-scss": "^3.0.0",
-		"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?9eb10353728dc915bf5f7bdd4b8e218c625355a9"
+		"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?update/jsdoc-deps"
 	},
 	"overrides": {
 		"engine.io-client": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"stylelint-config-standard-scss": "^3.0.0",
-		"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?update/jsdoc-deps"
+		"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca"
 	},
 	"overrides": {
 		"engine.io-client": {

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -605,7 +605,7 @@ A modal is closed.
 - [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
 - [`Dashboard`](../../js/src/dashboard/index.js#L33) when CES modal is closed.
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
-- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
+- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L159) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
 
 ### [`gla_modal_content_link_click`](../../js/src/components/guide-page-content/index.js#L28)
 Clicking on a text link within the modal content
@@ -626,7 +626,7 @@ A modal is open
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
-- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
+- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L159) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
 ### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L49)
 Clicking on the skip paid ads button to complete the onboarding flow.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -296,6 +296,9 @@ When a documentation link is clicked.
 `href` | `string` | link's URL
 #### Emitters
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
+- [`ChooseAudienceSection`](../../js/src/components/free-listings/choose-audience-section/choose-audience-section.js#L29) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
+- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L37) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
 - [`ContactInformation`](../../js/src/components/contact-information/index.js#L91)
 	- with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
 	- with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
@@ -304,24 +307,8 @@ When a documentation link is clicked.
 	- with `{ context: "dashboard", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-products", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
-- [`ChooseAudienceSection`](../../js/src/components/free-listings/choose-audience-section/choose-audience-section.js#L29) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
-- [`ShippingTimeSection`](../../js/src/components/free-listings/configure-product-listings/shipping-time-section.js#L17) with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
-- [`TaxRate`](../../js/src/components/free-listings/configure-product-listings/tax-rate.js#L22)
-	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-read-more', href: 'https://support.google.com/merchants/answer/160162' }`
-	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
-- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
-- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
-- [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L37) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
-- [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L32)
-	- with `{ context: 'setup-ads', link_id: 'shopping-ads-policies', href: 'https://support.google.com/merchants/answer/6149970' }`
-	- with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
-- [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L41) with `{ context: 'setup-mc', link_id: 'claim-url', href: 'https://support.google.com/merchants/answer/176793' }`
-- [`TermsModal`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L29) with `{ context: 'setup-mc', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
-- [`exports`](../../js/src/components/paid-ads/ads-campaign.js#L38) with `{ context: 'create-ads' | 'edit-ads' | 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
-- [`FaqsSection`](../../js/src/components/paid-ads/asset-group/faqs-section.js#L73) with `{ context: 'assets-faq', linkId: 'assets-faq-about-ad-formats-available-in-different-campaign-types', href: 'https://support.google.com/google-ads/answer/1722124' }`.
-- [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L23)
-	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
-	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
+- [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
+- [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
 - [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
 	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woo.com/document/google-listings-and-ads/#general-requirements' }`.
 	- with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
@@ -330,19 +317,32 @@ When a documentation link is clicked.
 	- with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woo.com/document/google-listings-and-ads/#free-listings-on-google' }`.
 	- with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
 	- with `{ context: 'faqs', linkId: 'terms-and-conditions-of-google-ads-coupons', href: 'https://www.google.com/ads/coupons/terms/' }`.
+- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L68) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
+- [`FaqsSection`](../../js/src/components/paid-ads/asset-group/faqs-section.js#L73) with `{ context: 'assets-faq', linkId: 'assets-faq-about-ad-formats-available-in-different-campaign-types', href: 'https://support.google.com/google-ads/answer/1722124' }`.
+- [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27) with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
 - [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L23) with `{ context: 'get-started', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
 - [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L23) with `{ context: 'get-started-with-video', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
-- [`UnsupportedLanguage`](../../js/src/get-started-page/unsupported-notices/index.js#L30) with `{ context: 'get-started', link_id: 'supported-languages', href: 'https://support.google.com/merchants/answer/160637' }`
-- [`UnsupportedCountry`](../../js/src/get-started-page/unsupported-notices/index.js#L73) with `{ context: "get-started", link_id: "supported-countries" }`
-- [`IssuesTableDataModal`](../../js/src/product-feed/issues-table-card/issues-table-data-modal.js#L21) with { context: 'issues-data-table-modal' }
-- [`ProductStatusHelpPopover`](../../js/src/product-feed/product-statistics/product-status-help-popover/index.js#L16) with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`
-- [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
-- [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
-- [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27) with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
-- [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L68) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
 - [`GoogleMCDisclaimer`](../../js/src/setup-mc/setup-stepper/setup-accounts/index.js#L33)
 	- with `{ context: 'setup-mc-accounts', link_id: 'comparison-shopping-services', href: 'https://support.google.com/merchants/topic/9080307' }`
 	- with `{ context: 'setup-mc-accounts', link_id: 'comparison-shopping-partners-find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
+- [`IssuesTableDataModal`](../../js/src/product-feed/issues-table-card/issues-table-data-modal.js#L21) with { context: 'issues-data-table-modal' }
+- [`ProductStatusHelpPopover`](../../js/src/product-feed/product-statistics/product-status-help-popover/index.js#L16) with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`
+- [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L41) with `{ context: 'setup-mc', link_id: 'claim-url', href: 'https://support.google.com/merchants/answer/176793' }`
+- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L23)
+	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
+	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
+- [`ShippingTimeSection`](../../js/src/components/free-listings/configure-product-listings/shipping-time-section.js#L17) with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
+- [`TaxRate`](../../js/src/components/free-listings/configure-product-listings/tax-rate.js#L22)
+	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-read-more', href: 'https://support.google.com/merchants/answer/160162' }`
+	- with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
+- [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L32)
+	- with `{ context: 'setup-ads', link_id: 'shopping-ads-policies', href: 'https://support.google.com/merchants/answer/6149970' }`
+	- with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
+- [`TermsModal`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L29) with `{ context: 'setup-mc', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
+- [`UnsupportedCountry`](../../js/src/get-started-page/unsupported-notices/index.js#L73) with `{ context: "get-started", link_id: "supported-countries" }`
+- [`UnsupportedLanguage`](../../js/src/get-started-page/unsupported-notices/index.js#L30) with `{ context: 'get-started', link_id: 'supported-languages', href: 'https://support.google.com/merchants/answer/160637' }`
+- [`exports`](../../js/src/components/paid-ads/ads-campaign.js#L38) with `{ context: 'create-ads' | 'edit-ads' | 'setup-ads', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
 
 ### [`gla_edit_mc_phone_number`](../../js/src/components/contact-information/phone-number-card/phone-number-card-preview.js#L14)
 Triggered when phone number edit button is clicked.
@@ -403,9 +403,6 @@ Clicking on faq item to collapse or expand it.
 `action` | `string` | (`expand`\|`collapse`)
 `context` | `string` | Indicates which page / module the FAQ is in
 #### Emitters
-- [`FaqsSection`](../../js/src/components/paid-ads/asset-group/faqs-section.js#L73)
-	- with `{ context: 'campaign-management', id: 'what-will-my-ads-look-like', action: 'expand' | 'collapse' }`.
-	- with `{ context: 'campaign-management', id: 'what-makes-these-ads-different-from-product-ads', action: 'expand' | 'collapse' }`.
 - [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
 	- with `{ context: 'get-started', id: 'what-do-i-need-to-get-started', action: 'expand' }`.
 	- with `{ context: 'get-started', id: 'what-do-i-need-to-get-started', action: 'collapse' }`.
@@ -430,6 +427,9 @@ Clicking on faq item to collapse or expand it.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-wp-account', action: 'collapse' }`.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'expand' }`.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'collapse' }`.
+- [`FaqsSection`](../../js/src/components/paid-ads/asset-group/faqs-section.js#L73)
+	- with `{ context: 'campaign-management', id: 'what-will-my-ads-look-like', action: 'expand' | 'collapse' }`.
+	- with `{ context: 'campaign-management', id: 'what-makes-these-ads-different-from-product-ads', action: 'expand' | 'collapse' }`.
 
 ### [`gla_filter`](../../js/src/utils/tracks.js#L122)
 Triggered when changing products & variations filter,
@@ -467,13 +467,13 @@ Clicking on the button to connect Google account.
 `context` | `string` | (`setup-mc`\|`setup-ads`\|`reconnect`) - indicate the button is clicked from which page.
 `action` | `string` | (`authorization`\|`scope`) 	- `authorization` is used when the plugin has not been authorized yet and requests Google account access and permission scopes from users.   - `scope` is used when requesting required permission scopes from users in order to proceed with more plugin functions. Added with the Partial OAuth feature (aka Incremental Authorization).
 #### Emitters
+- [`AuthorizeAds`](../../js/src/components/google-ads-account-card/authorize-ads.js#L20) with `{ action: 'scope', context: 'setup-ads' }`
 - [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23)
 	- with `{ action: 'authorization', context: 'reconnect' }`
 	- with `{ action: 'authorization', context: 'setup-mc' }`
 - [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26)
 	- with `{ action: 'scope', context: 'reconnect' }`
 	- with `{ action: 'scope', context: 'setup-mc' }`
-- [`AuthorizeAds`](../../js/src/components/google-ads-account-card/authorize-ads.js#L20) with `{ action: 'scope', context: 'setup-ads' }`
 
 ### [`gla_google_account_connect_different_account_button_click`](../../js/src/components/google-account-card/connected-google-account-card.js#L15)
 Clicking on the "connect to a different Google account" button.
@@ -792,8 +792,8 @@ Toggling display of table columns
 `column` | `string` | Name of the column
 `status` | `'on' \| 'off'` | Indicates if the column was toggled on or off.
 #### Emitters
-- [`recordColumnToggleEvent`](../../js/src/components/app-table-card/index.js#L29) with given `report: trackEventReportId, column: toggled`
 - [`AppTableCard`](../../js/src/components/app-table-card/index.js#L74) upon toggling column visibility
+- [`recordColumnToggleEvent`](../../js/src/components/app-table-card/index.js#L29) with given `report: trackEventReportId, column: toggled`
 
 ### [`gla_table_page_click`](../../js/src/utils/tracks.js#L25)
 When table pagination is clicked
@@ -815,8 +815,8 @@ Sorting table
 `column` | `string` | Name of the column
 `direction` | `string` | (`asc`\|`desc`)
 #### Emitters
-- [`recordTableSortEvent`](../../js/src/components/app-table-card/index.js#L55) with given props.
 - [`AppTableCard`](../../js/src/components/app-table-card/index.js#L74) upon sorting table by column
+- [`recordTableSortEvent`](../../js/src/components/app-table-card/index.js#L55) with given props.
 
 ### [`gla_tooltip_viewed`](../../js/src/components/help-popover/index.js#L16)
 Viewing tooltip


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates `jsdoc` to use v4 to resolve a high-severity vulnerability introduced by TaffyDB.

#### 📌 Checklist before merging (@eason9487)

- [x] Wait for https://github.com/woocommerce/grow/pull/104 getting merged
- [x] Change to use the above merged revision
      https://github.com/woocommerce/google-listings-and-ads/blob/103a4f4f7f7a1ab084a1b33bec879ed680db5ef2/package.json#L79

### Detailed test instructions:

1. Set `node` to use v16
2. Checkout this PR
3. `npm install`
4. `npm ls jsdoc` to check if the current `jsdoc` is v4
5. `npm run doc:tracking` to see if the script can be run without errors
6. View the generated content in [src/Tracking/README.md](https://github.com/woocommerce/google-listings-and-ads/blob/103a4f4f7f7a1ab084a1b33bec879ed680db5ef2/src/Tracking/README.md)

### Changelog entry
