### PR TITLE
Remove deprecated event properties marked as removable after Q1 2024 from the onboarding event tracking

### DIFF
--- a/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
+++ b/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
@@ -14,13 +14,6 @@ jest.mock( '.~/hooks/useGoogleAdsAccount', () =>
 	jest.fn().mockName( 'useGoogleAdsAccount' ).mockReturnValue( {} )
 );
 
-jest.mock( '.~/hooks/useDispatchCoreNotices', () =>
-	jest
-		.fn()
-		.mockName( 'useDispatchCoreNotices' )
-		.mockReturnValue( { createNotice: () => {} } )
-);
-
 jest.mock( '.~/hooks/useWindowFocus', () =>
 	jest.fn().mockName( 'useWindowFocus' ).mockReturnValue( true )
 );

--- a/js/src/get-started-page/get-started-card/index.js
+++ b/js/src/get-started-page/get-started-card/index.js
@@ -17,7 +17,7 @@ import AppButton from '.~/components/app-button';
 import { getSetupMCUrl } from '.~/utils/urls';
 
 /**
- * @fires gla_setup_mc with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started', target: 'set_up_free_listings', trigger: 'click' }`.
+ * @fires gla_setup_mc with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started' }`.
  * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
  */
 const GetStartedCard = () => {
@@ -55,9 +55,6 @@ const GetStartedCard = () => {
 						triggered_by: 'start-onboarding-button',
 						action: 'go-to-onboarding',
 						context: 'get-started',
-						// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
-						target: 'set_up_free_listings',
-						trigger: 'click',
 					} }
 				>
 					{ __(

--- a/js/src/get-started-page/get-started-with-video-card/index.js
+++ b/js/src/get-started-page/get-started-with-video-card/index.js
@@ -17,7 +17,7 @@ import { getSetupMCUrl } from '.~/utils/urls';
 import './index.scss';
 
 /**
- * @fires gla_setup_mc with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started-with-video', target: 'set_up_free_listings', trigger: 'click' }`.
+ * @fires gla_setup_mc with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started-with-video' }`.
  * @fires gla_documentation_link_click with `{ context: 'get-started-with-video', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
  */
 const GetStartedWithVideoCard = () => {
@@ -70,9 +70,6 @@ const GetStartedWithVideoCard = () => {
 						triggered_by: 'start-onboarding-button',
 						action: 'go-to-onboarding',
 						context: 'get-started-with-video',
-						// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
-						target: 'set_up_free_listings',
-						trigger: 'click',
 					} }
 				>
 					{ __(

--- a/js/src/product-feed/index.test.js
+++ b/js/src/product-feed/index.test.js
@@ -27,18 +27,6 @@ jest.mock( '.~/utils/localStorage', () => {
 	};
 } );
 
-jest.mock( '.~/hooks/useDispatchCoreNotices', () => ( {
-	__esModule: true,
-	default: jest
-		.fn()
-		.mockName( 'useDispatchCoreNotices' )
-		.mockImplementation( () => {
-			return {
-				createNotice: jest.fn(),
-			};
-		} ),
-} ) );
-
 jest.mock( '.~/utils/isWCTracksEnabled', () => jest.fn() );
 
 const SUBMISSION_SUCCESS_GUIDE_TEXT =

--- a/js/src/product-feed/review-request/index.test.js
+++ b/js/src/product-feed/review-request/index.test.js
@@ -16,13 +16,6 @@ jest.mock( '.~/utils/tracks', () => {
 	};
 } );
 
-jest.mock( '.~/hooks/useDispatchCoreNotices', () => ( {
-	__esModule: true,
-	default: jest.fn().mockName( 'useDispatchCoreNotices' ).mockReturnValue( {
-		createNotice: jest.fn(),
-	} ),
-} ) );
-
 /**
  * External dependencies
  */

--- a/js/src/product-feed/review-request/review-request-modal.test.js
+++ b/js/src/product-feed/review-request/review-request-modal.test.js
@@ -4,18 +4,6 @@ jest.mock( '.~/utils/tracks', () => {
 	};
 } );
 
-jest.mock( '.~/hooks/useDispatchCoreNotices', () => ( {
-	__esModule: true,
-	default: jest
-		.fn()
-		.mockName( 'useDispatchCoreNotices' )
-		.mockImplementation( () => {
-			return {
-				createNotice: jest.fn(),
-			};
-		} ),
-} ) );
-
 jest.mock( '.~/data', () => ( {
 	__esModule: true,
 	useAppDispatch: jest.fn( () => {

--- a/js/src/setup-ads/ads-stepper/index.js
+++ b/js/src/setup-ads/ads-stepper/index.js
@@ -11,7 +11,10 @@ import { useState } from '@wordpress/element';
 import SetupAccounts from './setup-accounts';
 import AdsCampaign from '.~/components/paid-ads/ads-campaign';
 import SetupBilling from './setup-billing';
-import { recordGlaEvent } from '.~/utils/tracks';
+import {
+	recordStepperChangeEvent,
+	recordStepContinueEvent,
+} from '.~/utils/tracks';
 
 /**
  * @param {Object} props React props
@@ -26,10 +29,7 @@ const AdsStepper = ( { formProps } ) => {
 	// Users can only go forward by clicking on the Continue button.
 	const handleStepClick = ( value ) => {
 		if ( value < step ) {
-			recordGlaEvent( 'gla_setup_ads', {
-				triggered_by: `stepper-step${ value }-button`,
-				action: `go-to-step${ value }`,
-			} );
+			recordStepperChangeEvent( 'gla_setup_ads', value );
 			setStep( value );
 		}
 	};
@@ -42,10 +42,7 @@ const AdsStepper = ( { formProps } ) => {
 	const continueStep = ( to ) => {
 		const from = step;
 
-		recordGlaEvent( 'gla_setup_ads', {
-			triggered_by: `step${ from }-continue-button`,
-			action: `go-to-step${ to }`,
-		} );
+		recordStepContinueEvent( 'gla_setup_ads', from, to );
 		setStep( to );
 	};
 

--- a/js/src/setup-ads/ads-stepper/index.test.js
+++ b/js/src/setup-ads/ads-stepper/index.test.js
@@ -1,0 +1,131 @@
+jest.mock( '@woocommerce/tracks', () => {
+	return {
+		recordEvent: jest.fn().mockName( 'recordEvent' ),
+	};
+} );
+
+jest.mock( './setup-accounts', () => jest.fn().mockName( 'SetupAccounts' ) );
+jest.mock( '.~/components/paid-ads/ads-campaign', () =>
+	jest.fn().mockName( 'AdsCampaign' )
+);
+jest.mock( './setup-billing', () => jest.fn().mockName( 'SetupBilling' ) );
+
+/**
+ * External dependencies
+ */
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import AdsStepper from './';
+import { addBaseEventProperties as withBaseProperties } from '.~/utils/tracks';
+import SetupAccounts from './setup-accounts';
+import AdsCampaign from '.~/components/paid-ads/ads-campaign';
+import SetupBilling from './setup-billing';
+
+describe( 'AdsStepper', () => {
+	let continueToStep2;
+	let continueToStep3;
+
+	beforeEach( () => {
+		SetupAccounts.mockImplementation( ( { onContinue } ) => {
+			continueToStep2 = onContinue;
+			return null;
+		} );
+
+		AdsCampaign.mockImplementation( ( { onContinue } ) => {
+			continueToStep3 = onContinue;
+			return null;
+		} );
+
+		SetupBilling.mockReturnValue( null );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	function continueUntilStep3() {
+		continueToStep2();
+		continueToStep3();
+	}
+
+	describe( 'tracks', () => {
+		it( 'Should record events after calling back to `onContinue`', () => {
+			render( <AdsStepper /> );
+
+			continueUntilStep3();
+
+			expect( recordEvent ).toHaveBeenCalledTimes( 2 );
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				1,
+				'gla_setup_ads',
+				withBaseProperties( {
+					action: 'go-to-step2',
+					triggered_by: 'step1-continue-button',
+				} )
+			);
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				2,
+				'gla_setup_ads',
+				withBaseProperties( {
+					action: 'go-to-step3',
+					triggered_by: 'step2-continue-button',
+				} )
+			);
+		} );
+
+		it( 'Should record events after clicking step navigation buttons', async () => {
+			render( <AdsStepper /> );
+
+			const step1 = screen.getByRole( 'button', { name: /accounts/ } );
+			const step2 = screen.getByRole( 'button', { name: /campaign/ } );
+
+			// Step 3 -> Step 2 -> Step 1
+			continueUntilStep3();
+			recordEvent.mockClear();
+			expect( recordEvent ).toHaveBeenCalledTimes( 0 );
+
+			await userEvent.click( step2 );
+			await userEvent.click( step1 );
+
+			expect( recordEvent ).toHaveBeenCalledTimes( 2 );
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				1,
+				'gla_setup_ads',
+				withBaseProperties( {
+					action: 'go-to-step2',
+					triggered_by: 'stepper-step2-button',
+				} )
+			);
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				2,
+				'gla_setup_ads',
+				withBaseProperties( {
+					action: 'go-to-step1',
+					triggered_by: 'stepper-step1-button',
+				} )
+			);
+
+			// Step 3 -> Step 1
+			continueUntilStep3();
+			recordEvent.mockClear();
+			expect( recordEvent ).toHaveBeenCalledTimes( 0 );
+
+			await userEvent.click( step1 );
+
+			expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				1,
+				'gla_setup_ads',
+				withBaseProperties( {
+					action: 'go-to-step1',
+					triggered_by: 'stepper-step1-button',
+				} )
+			);
+		} );
+	} );
+} );

--- a/js/src/setup-ads/top-bar/index.js
+++ b/js/src/setup-ads/top-bar/index.js
@@ -12,7 +12,7 @@ import HelpIconButton from '.~/components/help-icon-button';
 import { recordGlaEvent } from '.~/utils/tracks';
 
 /**
- * @fires gla_setup_ads with given `{ triggered_by: 'back-button', action: 'leave', target: 'back', trigger: 'click' }` when back button is clicked.
+ * @fires gla_setup_ads with given `{ triggered_by: 'back-button', action: 'leave' }` when back button is clicked.
  */
 const SetupAdsTopBar = () => {
 	// We record the intent to go back or to help - clicking buttons.
@@ -22,9 +22,6 @@ const SetupAdsTopBar = () => {
 		recordGlaEvent( 'gla_setup_ads', {
 			triggered_by: 'back-button',
 			action: 'leave',
-			// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
-			target: 'back',
-			trigger: 'click',
 		} );
 	};
 

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -22,7 +22,10 @@ import SetupFreeListings from '.~/components/free-listings/setup-free-listings';
 import StoreRequirements from './store-requirements';
 import SetupPaidAds from './setup-paid-ads';
 import stepNameKeyMap from './stepNameKeyMap';
-import { recordGlaEvent } from '.~/utils/tracks';
+import {
+	recordStepperChangeEvent,
+	recordStepContinueEvent,
+} from '.~/utils/tracks';
 
 /**
  * @param {Object} props React props
@@ -82,10 +85,7 @@ const SavedSetupStepper = ( { savedStep } ) => {
 	const continueStep = ( to ) => {
 		const from = step;
 
-		recordGlaEvent( 'gla_setup_mc', {
-			triggered_by: `step${ from }-continue-button`,
-			action: `go-to-step${ to }`,
-		} );
+		recordStepContinueEvent( 'gla_setup_mc', from, to );
 		setStep( to );
 	};
 
@@ -104,10 +104,7 @@ const SavedSetupStepper = ( { savedStep } ) => {
 	const handleStepClick = ( stepKey ) => {
 		// Only allow going back to the previous steps.
 		if ( Number( stepKey ) < Number( step ) ) {
-			recordGlaEvent( 'gla_setup_mc', {
-				triggered_by: `stepper-step${ stepKey }-button`,
-				action: `go-to-step${ stepKey }`,
-			} );
+			recordStepperChangeEvent( 'gla_setup_mc', stepKey );
 			setStep( stepKey );
 		}
 	};

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -27,7 +27,7 @@ import { recordGlaEvent } from '.~/utils/tracks';
 /**
  * @param {Object} props React props
  * @param {string} [props.savedStep] A saved step overriding the current step
- * @fires gla_setup_mc with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button', 'step3-continue-button', action: 'go-to-step2' | 'go-to-step3' | 'go-to-step4', target: 'step1_continue' | 'step2_continue' | 'step3_continue', trigger: 'click' }`.
+ * @fires gla_setup_mc with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button', 'step3-continue-button', action: 'go-to-step2' | 'go-to-step3' | 'go-to-step4' }`.
  * @fires gla_setup_mc with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button' | 'stepper-step3-button', action: 'go-to-step1' | 'go-to-step2' | 'go-to-step3' }`.
  */
 const SavedSetupStepper = ( { savedStep } ) => {
@@ -85,9 +85,6 @@ const SavedSetupStepper = ( { savedStep } ) => {
 		recordGlaEvent( 'gla_setup_mc', {
 			triggered_by: `step${ from }-continue-button`,
 			action: `go-to-step${ to }`,
-			// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
-			target: `step${ from }_continue`,
-			trigger: 'click',
 		} );
 		setStep( to );
 	};

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.test.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.test.js
@@ -1,0 +1,188 @@
+jest.mock( '@woocommerce/tracks', () => {
+	return {
+		recordEvent: jest.fn().mockName( 'recordEvent' ),
+	};
+} );
+
+jest.mock( './useTargetAudienceWithSuggestions', () =>
+	jest
+		.fn()
+		.mockName( 'useTargetAudienceWithSuggestions' )
+		.mockReturnValue( {} )
+);
+jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
+	jest
+		.fn()
+		.mockName( 'useTargetAudienceFinalCountryCodes' )
+		.mockReturnValue( {} )
+);
+jest.mock(
+	'.~/components/free-listings/configure-product-listings/useSettings',
+	() => jest.fn().mockName( 'useSettings' ).mockReturnValue( {} )
+);
+jest.mock( '.~/hooks/useShippingRates', () =>
+	jest.fn().mockName( 'useShippingRates' ).mockReturnValue( {} )
+);
+jest.mock( '.~/hooks/useShippingTimes', () =>
+	jest.fn().mockName( 'useShippingTimes' ).mockReturnValue( {} )
+);
+
+jest.mock( './setup-accounts', () => jest.fn().mockName( 'SetupAccounts' ) );
+jest.mock( '.~/components/free-listings/setup-free-listings', () =>
+	jest.fn().mockName( 'SetupFreeListings' )
+);
+jest.mock( './store-requirements', () =>
+	jest.fn().mockName( 'StoreRequirements' )
+);
+jest.mock( './setup-paid-ads', () => jest.fn().mockName( 'SetupPaidAds' ) );
+
+/**
+ * External dependencies
+ */
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import SavedSetupStepper from './saved-setup-stepper';
+import { addBaseEventProperties as withBaseProperties } from '.~/utils/tracks';
+import SetupAccounts from './setup-accounts';
+import SetupFreeListings from '.~/components/free-listings/setup-free-listings';
+import StoreRequirements from './store-requirements';
+import SetupPaidAds from './setup-paid-ads';
+
+describe( 'SavedSetupStepper', () => {
+	let continueToStep2;
+	let continueToStep3;
+	let continueToStep4;
+
+	beforeEach( () => {
+		SetupAccounts.mockImplementation( ( { onContinue } ) => {
+			continueToStep2 = onContinue;
+			return null;
+		} );
+
+		SetupFreeListings.mockImplementation( ( { onContinue } ) => {
+			continueToStep3 = onContinue;
+			return null;
+		} );
+
+		StoreRequirements.mockImplementation( ( { onContinue } ) => {
+			continueToStep4 = onContinue;
+			return null;
+		} );
+
+		SetupPaidAds.mockReturnValue( null );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	function continueUntilStep4() {
+		continueToStep2();
+		continueToStep3();
+		continueToStep4();
+	}
+
+	describe( 'tracks', () => {
+		it( 'Should record events after calling back to `onContinue`', () => {
+			render( <SavedSetupStepper savedStep="1" /> );
+
+			continueUntilStep4();
+
+			expect( recordEvent ).toHaveBeenCalledTimes( 3 );
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				1,
+				'gla_setup_mc',
+				withBaseProperties( {
+					action: 'go-to-step2',
+					triggered_by: 'step1-continue-button',
+					// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
+					target: 'step1_continue',
+					trigger: 'click',
+				} )
+			);
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				2,
+				'gla_setup_mc',
+				withBaseProperties( {
+					action: 'go-to-step3',
+					triggered_by: 'step2-continue-button',
+					// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
+					target: 'step2_continue',
+					trigger: 'click',
+				} )
+			);
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				3,
+				'gla_setup_mc',
+				withBaseProperties( {
+					action: 'go-to-step4',
+					triggered_by: 'step3-continue-button',
+					// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
+					target: 'step3_continue',
+					trigger: 'click',
+				} )
+			);
+		} );
+
+		it( 'Should record events after clicking step navigation buttons', async () => {
+			render( <SavedSetupStepper savedStep="4" /> );
+
+			const step1 = screen.getByRole( 'button', { name: /accounts/ } );
+			const step2 = screen.getByRole( 'button', { name: /listings/ } );
+			const step3 = screen.getByRole( 'button', { name: /store/ } );
+
+			// Step 4 -> Step 3 -> Step 2 -> Step 1
+			await userEvent.click( step3 );
+			await userEvent.click( step2 );
+			await userEvent.click( step1 );
+
+			expect( recordEvent ).toHaveBeenCalledTimes( 3 );
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				1,
+				'gla_setup_mc',
+				withBaseProperties( {
+					action: 'go-to-step3',
+					triggered_by: 'stepper-step3-button',
+				} )
+			);
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				2,
+				'gla_setup_mc',
+				withBaseProperties( {
+					action: 'go-to-step2',
+					triggered_by: 'stepper-step2-button',
+				} )
+			);
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				3,
+				'gla_setup_mc',
+				withBaseProperties( {
+					action: 'go-to-step1',
+					triggered_by: 'stepper-step1-button',
+				} )
+			);
+
+			// Step 4 -> Step 2
+			continueUntilStep4();
+			recordEvent.mockClear();
+			expect( recordEvent ).toHaveBeenCalledTimes( 0 );
+
+			await userEvent.click( step2 );
+
+			expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+			expect( recordEvent ).toHaveBeenNthCalledWith(
+				1,
+				'gla_setup_mc',
+				withBaseProperties( {
+					action: 'go-to-step2',
+					triggered_by: 'stepper-step2-button',
+				} )
+			);
+		} );
+	} );
+} );

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.test.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.test.js
@@ -100,9 +100,6 @@ describe( 'SavedSetupStepper', () => {
 				withBaseProperties( {
 					action: 'go-to-step2',
 					triggered_by: 'step1-continue-button',
-					// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
-					target: 'step1_continue',
-					trigger: 'click',
 				} )
 			);
 			expect( recordEvent ).toHaveBeenNthCalledWith(
@@ -111,9 +108,6 @@ describe( 'SavedSetupStepper', () => {
 				withBaseProperties( {
 					action: 'go-to-step3',
 					triggered_by: 'step2-continue-button',
-					// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
-					target: 'step2_continue',
-					trigger: 'click',
 				} )
 			);
 			expect( recordEvent ).toHaveBeenNthCalledWith(
@@ -122,9 +116,6 @@ describe( 'SavedSetupStepper', () => {
 				withBaseProperties( {
 					action: 'go-to-step4',
 					triggered_by: 'step3-continue-button',
-					// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
-					target: 'step3_continue',
-					trigger: 'click',
 				} )
 			);
 		} );

--- a/js/src/setup-mc/top-bar/index.js
+++ b/js/src/setup-mc/top-bar/index.js
@@ -12,16 +12,13 @@ import HelpIconButton from '.~/components/help-icon-button';
 import { recordGlaEvent } from '.~/utils/tracks';
 
 /**
- * @fires gla_setup_mc with `{ triggered_by: 'back-button', action: 'leave', target: 'back', trigger: 'click' }`.
+ * @fires gla_setup_mc with `{ triggered_by: 'back-button', action: 'leave' }`.
  */
 const SetupMCTopBar = () => {
 	const handleBackButtonClick = () => {
 		recordGlaEvent( 'gla_setup_mc', {
 			triggered_by: 'back-button',
 			action: 'leave',
-			// 'target' and 'trigger' were deprecated and can be removed after Q1 2024.
-			target: 'back',
-			trigger: 'click',
 		} );
 	};
 

--- a/js/src/tests/jest-unit.setup.js
+++ b/js/src/tests/jest-unit.setup.js
@@ -20,3 +20,15 @@ global.ResizeObserver = jest
 	} ) );
 
 global.wpNavMenuClassChange = jest.fn().mockName( 'wpNavMenuClassChange' );
+
+// The data store of 'core/notices' namespace is registered by the `@wordpress/notices`
+// in WordPress Core in runtime. It's always unavailable when running jest so here it's
+// mocked globally.
+//
+// Ref: https://github.com/WordPress/gutenberg/tree/trunk/packages/notices#usage
+jest.mock( '.~/hooks/useDispatchCoreNotices', () =>
+	jest
+		.fn()
+		.mockName( 'useDispatchCoreNotices' )
+		.mockReturnValue( { createNotice: () => {} } )
+);

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -137,8 +137,6 @@ export const recordTablePageEvent = ( context, page, direction ) => {
  * @property {string} triggered_by Indicates which button triggered this event
  * @property {string} action User's action or/and objective (e.g. `leave`, `go-to-step-2`)
  * @property {string | undefined} context Indicates which CTA is clicked
- * @property {string | undefined} target (**Deprecated: this property should not be used after Q1 2024**) Button ID
- * @property {string | undefined} trigger (**Deprecated: this property should not be used after Q1 2024**) Action (e.g. `click`)
  */
 
 /**
@@ -173,8 +171,6 @@ export const recordTablePageEvent = ( context, page, direction ) => {
  * @event gla_setup_ads
  * @property {string} triggered_by Indicates which button triggered this event
  * @property {string} action User's action or/and objective (e.g. `leave`, `go-to-step-2`)
- * @property {string | undefined} target (**Deprecated: this property should not be used after Q1 2024**) Button ID
- * @property {string | undefined} trigger (**Deprecated: this property should not be used after Q1 2024**) Action (e.g. `click`)
  */
 
 /**

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -459,7 +459,7 @@ Saving changes to the free campaign.
 #### Emitters
 - [`EditFreeCampaign`](../../js/src/edit-free-campaign/index.js#L46)
 
-### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L152)
+### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L150)
 Clicking on the button to connect Google account.
 #### Properties
 | name | type | description |
@@ -491,7 +491,7 @@ Clicking on a Google Ads account text link.
 #### Emitters
 - [`BillingSavedCard`](../../js/src/setup-ads/ads-stepper/setup-billing/billing-saved-card/index.js#L31) with `{ context: 'setup-ads', link_id: 'google-ads-account' }`
 
-### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L162)
+### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L160)
 Clicking on a Google Merchant Center link.
 #### Properties
 | name | type | description |
@@ -520,7 +520,7 @@ Clicking on the "Scan for assets" button.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/assets-loader.js#L96)
 
-### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L144)
+### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L142)
 Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign in the Google Ads setup flow.
 #### Properties
 | name | type | description |
@@ -594,7 +594,7 @@ Clicking on the Merchant Center phone number edit button.
 #### Emitters
 - [`PhoneNumberCard`](../../js/src/components/contact-information/phone-number-card/phone-number-card.js#L127)
 
-### [`gla_modal_closed`](../../js/src/utils/tracks.js#L220)
+### [`gla_modal_closed`](../../js/src/utils/tracks.js#L216)
 A modal is closed.
 #### Properties
 | name | type | description |
@@ -617,7 +617,7 @@ Clicking on a text link within the modal content
 #### Emitters
 - [`ContentLink`](../../js/src/components/guide-page-content/index.js#L46) with given `context, href`
 
-### [`gla_modal_open`](../../js/src/utils/tracks.js#L233)
+### [`gla_modal_open`](../../js/src/utils/tracks.js#L229)
 A modal is open
 #### Properties
 | name | type | description |
@@ -659,7 +659,7 @@ Clicking on the "Create a paid ad campaign" button to open the paid ads setup in
 #### Emitters
 - [`exports`](../../js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js#L71)
 
-### [`gla_paid_campaign_step`](../../js/src/utils/tracks.js#L180)
+### [`gla_paid_campaign_step`](../../js/src/utils/tracks.js#L176)
 Triggered when moving to another step during creating/editing a campaign.
 #### Properties
 | name | type | description |
@@ -704,20 +704,18 @@ Clicking on the "Or, select another page" button.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/final-url-card.js#L39)
 
-### [`gla_setup_ads`](../../js/src/utils/tracks.js#L170)
+### [`gla_setup_ads`](../../js/src/utils/tracks.js#L168)
 Triggered on events during ads onboarding
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `triggered_by` | `string` | Indicates which button triggered this event
 `action` | `string` | User's action or/and objective (e.g. `leave`, `go-to-step-2`)
-`target` | `string \| undefined` | (**Deprecated: this property should not be used after Q1 2024**) Button ID
-`trigger` | `string \| undefined` | (**Deprecated: this property should not be used after Q1 2024**) Action (e.g. `click`)
 #### Emitters
-- [`AdsStepper`](../../js/src/setup-ads/ads-stepper/index.js#L22)
+- [`AdsStepper`](../../js/src/setup-ads/ads-stepper/index.js#L25)
 	- with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button' , action: 'go-to-step2' | 'go-to-step3' }`.
 	- with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button', action: 'go-to-step1' | 'go-to-step2' }`.
-- [`SetupAdsTopBar`](../../js/src/setup-ads/top-bar/index.js#L17) with given `{ triggered_by: 'back-button', action: 'leave', target: 'back', trigger: 'click' }` when back button is clicked.
+- [`SetupAdsTopBar`](../../js/src/setup-ads/top-bar/index.js#L17) with given `{ triggered_by: 'back-button', action: 'leave' }` when back button is clicked.
 
 ### [`gla_setup_ads_faq`](../../js/src/components/paid-ads/faqs-section.js#L76)
 Clicking on faq items to collapse or expand it in the Onboarding Flow or creating/editing a campaign
@@ -737,15 +735,13 @@ Setup Merchant Center
 `triggered_by` | `string` | Indicates which button triggered this event
 `action` | `string` | User's action or/and objective (e.g. `leave`, `go-to-step-2`)
 `context` | `string \| undefined` | Indicates which CTA is clicked
-`target` | `string \| undefined` | (**Deprecated: this property should not be used after Q1 2024**) Button ID
-`trigger` | `string \| undefined` | (**Deprecated: this property should not be used after Q1 2024**) Action (e.g. `click`)
 #### Emitters
-- [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started', target: 'set_up_free_listings', trigger: 'click' }`.
-- [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started-with-video', target: 'set_up_free_listings', trigger: 'click' }`.
-- [`SavedSetupStepper`](../../js/src/setup-mc/setup-stepper/saved-setup-stepper.js#L33)
-	- with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button', 'step3-continue-button', action: 'go-to-step2' | 'go-to-step3' | 'go-to-step4', target: 'step1_continue' | 'step2_continue' | 'step3_continue', trigger: 'click' }`.
+- [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started' }`.
+- [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started-with-video' }`.
+- [`SavedSetupStepper`](../../js/src/setup-mc/setup-stepper/saved-setup-stepper.js#L36)
+	- with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button', 'step3-continue-button', action: 'go-to-step2' | 'go-to-step3' | 'go-to-step4' }`.
 	- with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button' | 'stepper-step3-button', action: 'go-to-step1' | 'go-to-step2' | 'go-to-step3' }`.
-- [`SetupMCTopBar`](../../js/src/setup-mc/top-bar/index.js#L17) with `{ triggered_by: 'back-button', action: 'leave', target: 'back', trigger: 'click' }`.
+- [`SetupMCTopBar`](../../js/src/setup-mc/top-bar/index.js#L17) with `{ triggered_by: 'back-button', action: 'leave' }`.
 
 ### [`gla_submit_campaign_button_click`](../../js/src/components/paid-ads/asset-group/asset-group.js#L26)
 Clicking on the submit button on the campaign creation or editing page.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2141

This PR:

- Handle deprecated event properties marked as removable after Q1 2024.
- Change to use `recordStepperChangeEvent` and `recordStepContinueEvent` to reduce a bit of code duplications.
- Update *src/Tracking/README.md*.
- To facilitate writing JS tests, change to globally mock the `useDispatchCoreNotices` hook when running jest.

### Detailed test instructions:

1. `git checkout 58f1a667964e380edab7f16073471771011a6e8a` (Ref: 58f1a667964e380edab7f16073471771011a6e8a)
2. `npm run test:js` to see if the JS tests can pass before the d4944c10eed9705e09328b69880dbb51bae95ddd change
3. `git checkout tweak/2141-remove-deprecated-event-properties`
4. `npm run test:js` to see if the JS tests can pass as well after the d4944c10eed9705e09328b69880dbb51bae95ddd change
5. Globally search the codebase to check if all deprecated event properties mentioned in #2141 have been cleaned up

### Changelog entry

> Tweak - Remove deprecated event properties marked as removable after Q1 2024 from the onboarding event tracking.
