### PR TITLE
Update tags in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Google Listings & Ads ===
 Contributors: automattic, google, woocommerce
-Tags: woocommerce, google, listings, ads
+Tags: woocommerce, google, product feed, ads, listings
 Requires at least: 5.9
 Tested up to: 6.5
 Requires PHP: 7.4


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the tags in readme.txt to:
`woocommerce, google, product feed, ads, listings`

Closes #2376

### Changelog entry
* Tweak - Update tags in readme.txt.
