### PR TITLE
fix php warning due to iterating over null

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -421,6 +421,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 				continue;
 			}
 
+			// Confirm there are issues for this product.
+			if ( empty( $mc_product_status->getItemLevelIssues() ) ) {
+				continue;
+			}
+
 			$product_issue_template = [
 				'product'              => html_entity_decode( $wc_product->get_name() ),
 				'product_id'           => $wc_product_id,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes this PHP warning:
```
Warning: foreach() argument must be of type array|object, null given in /wp-content/plugins/google-listings-and-ads/src/MerchantCenter/MerchantStatuses.php on line 431
```


### Detailed test instructions:

The logic is the same, it just makes sure the results of `$mc_product_status->getItemLevelIssues()` are not empty before trying to iterate over it.

### Changelog entry
* Tweak - Confirm issues are present when retrieving product status.
