### PR TITLE
Convert `lbs` to `lb` when mapping WC products to Google products

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -572,6 +572,12 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		}
 
 		$weight = wc_get_weight( $this->wc_product->get_weight(), $unit );
+
+		// Use lb if the unit is lbs, since GMC uses lb.
+		if ( 'lbs' === $unit ) {
+			$unit = 'lb';
+		}
+
 		$this->setShippingWeight(
 			new GoogleProductShippingWeight(
 				[

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -930,6 +930,28 @@ DESCRIPTION;
 		$this->assertEquals( 1000, $adapted_product->getShippingWeight()->getValue() );
 	}
 
+	public function test_shipping_weight_unit_uses_lb_if_wc_option_is_lbs() {
+		update_option( 'woocommerce_weight_unit', 'lbs' );
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'height' => '3',
+				'length' => '4',
+				'width'  => '5',
+				'weight' => '1',
+			]
+		);
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+		$this->assertEquals( 'lb', $adapted_product->getShippingWeight()->getUnit() );
+	}
+
 	/**
 	 * @param array $shipping_dimensions
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2388. This PR converts `lbs` to `lb` when mapping WC products to Google products, since in GMC it uses the unit `lb` while in WC is uses `lbs`.

### Screenshots:

<img width="1017" alt="Screenshot 2024-05-06 at 15 52 09" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/a3cd513e-c12d-489f-ab82-ba11043b5e45">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to `WooCommerce -> Settings -> Products`, change `Weight unit` to `lbs`.
2. Go editing a simple product, in the `Shipping` section update the `Weight` to any value, click `Update` after finished.
3. Go to GMC and locate the product you just updated (this may take a while to see the updated value)
4. Click the product and edit it by clicking the pencil icon
5. In the section `Shipping, tax, and returns`, you should see the unit `lb` is set correctly.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Convert `lbs` to `lb` when mapping WC products to Google products
