### PR TITLE
Avoid running untrusted input as shell commands in the GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,10 @@ jobs:
 
       - name: Prepare BundleWatch env values - pull request
         if: ${{ github.event_name == 'pull_request' }}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "CI_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+          echo "CI_BRANCH=${HEAD_REF}" >> $GITHUB_ENV
           echo "CI_BRANCH_BASE=${{ github.base_ref }}" >> $GITHUB_ENV
           echo "CI_COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -31,6 +31,8 @@ jobs:
           source-directories: src/,views/,google-listings-and-ads.php,uninstall.php
 
       - name: Commit hook documentation
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         shell: bash
         # Use the github-actions bot account to commit.
         # https://api.github.com/users/github-actions%5Bbot%5D
@@ -43,6 +45,6 @@ jobs:
             echo "*No documentation changes to commit.*" >> $GITHUB_STEP_SUMMARY
           else
             echo "*Committing documentation changes.*" >> $GITHUB_STEP_SUMMARY
-            git commit -q -m "Update hooks documentation from ${{ github.head_ref }} branch."
+            git commit -q -m "Update hooks documentation from ${HEAD_REF} branch."
             git push
           fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR avoids running untrusted inputs as shell command in the GitHub Actions.

Ref: https://securitylab.github.com/research/github-actions-untrusted-input/

### Detailed test instructions:

1. View the workflow that simulates the same uses of `${{ github.head_ref }}` in this repo
   - https://github.com/eason9487/gha-playground/blob/test/vulnerability/.github/workflows/untrusted-input.yml
1. View a test PR trying to inject command `ls -la` via branch name `zzz";ls${IFS}-la;#`
   - https://github.com/eason9487/gha-playground/pull/4
1. View the workflow run that was injected shell command `ls -la` from a forked repo
   - https://github.com/eason9487/gha-playground/actions/runs/9011882305/job/24760188266
      <img width="1031" alt="1" src="https://github.com/woocommerce/google-listings-and-ads/assets/17420811/43088ab9-c129-4fc6-a892-adb6210561ba">
1. View the fix commit
   - https://github.com/eason9487/gha-playground/commit/957a051da206b1d4e980678f5b19fa85f4994514
1. View the workflow run that avoids the shell command injections
   - https://github.com/eason9487/gha-playground/actions/runs/9012011241/job/24760504989
      <img width="1067" alt="2" src="https://github.com/woocommerce/google-listings-and-ads/assets/17420811/6cc7023b-cfdd-457e-9a8b-b4e6f4e7d243">
1. Check if the "Build" workflow run in this repo is successful
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/9012343327/job/24761392142?pr=2394

### Changelog entry
