### PR TITLE
Fix failing E2E tests

### DIFF
--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -42,8 +42,8 @@ export async function singleProductAddToCart( page, productID ) {
  */
 export async function relatedProductAddToCart( page ) {
 	const addToCart = ( await page.locator( '.related.products' ).isVisible() )
-		? '.related.products .add_to_cart_button'
-		: '.wp-block-woocommerce-related-products .add_to_cart_button';
+		? '.related.products .add_to_cart_button.product_type_simple'
+		: '.wp-block-woocommerce-related-products .add_to_cart_button.product_type_simple';
 
 	const addToCartButton = await page.locator( addToCart ).first();
 	await addToCartButton.click();

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -35,7 +35,7 @@ export async function singleProductAddToCart( page, productID ) {
 }
 
 /**
- * Adds a related product to the cart.
+ * Adds a related single product to the cart.
  *
  * @param {Page} page
  * @return {number} Product ID of the added product.

--- a/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
+++ b/tests/e2e/utils/pages/setup-mc/step-3-confirm-store-requirements.js
@@ -38,21 +38,12 @@ export default class StoreRequirements extends MockRequests {
 	}
 
 	/**
-	 * Get components-card class.
-	 *
-	 * @return {import('@playwright/test').Locator} Get components-card class.
-	 */
-	getComponentsCard() {
-		return this.page.locator( '.components-card' );
-	}
-
-	/**
 	 * Get phone verification card.
 	 *
 	 * @return {import('@playwright/test').Locator} Get phone verification card.
 	 */
 	getPhoneVerificationCard() {
-		return this.getComponentsCard().first();
+		return this.page.locator( '.gla-phone-number-card' );
 	}
 
 	/**
@@ -61,7 +52,7 @@ export default class StoreRequirements extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get store address card.
 	 */
 	getStoreAddressCard() {
-		return this.getComponentsCard().nth( 1 );
+		return this.page.locator( '.gla-store-address-card' );
 	}
 
 	/**
@@ -70,7 +61,7 @@ export default class StoreRequirements extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get checklist card.
 	 */
 	getChecklistCard() {
-		return this.getComponentsCard().nth( 2 );
+		return this.page.locator( '.gla-pre-launch-checklist' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some tests in GLA are failing because the classes are not defined correctly. This PR addresses that.

### Screenshots:

<img width="748" alt="Screenshot 2024-05-09 at 11 48 53" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/fe37a567-62ff-4348-b48c-b44e4b445cbc">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this PR
2. E2E tests pass
3. See E2E test passing in the GH WF https://github.com/woocommerce/google-listings-and-ads/actions/runs/9014174756

### Additional details:

- One of the errors is because the variable product is located on first place so the add to cart fails.
<img width="469" alt="Screenshot 2024-05-09 at 11 27 09" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/3cb40e2d-86a1-4009-8c37-7f9b99929017">


- The other one is because of the classes used in selecting the different cards in the last step. .components-card matches a totally unrelated div in the page. So the selector won't work.
- 
<img width="784" alt="Screenshot 2024-05-09 at 11 41 33" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/ebba5a99-0297-45d6-b7ab-ff7bdb26ecc2">


⚠️  If you test this PR use the latest WC not the RC (it will fail if you do so, fixed here https://github.com/woocommerce/google-listings-and-ads/pull/2393 )
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - E2E tests
