### PR TITLE
Rename `redirect_url` to `store_url` in the state parameter

### DIFF
--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -52,18 +52,18 @@ class OAuthService implements Service, OptionsAwareInterface {
 	 * scope=wc-partner-access&
 	 * state=URL_SAFE_BASE64_ENCODED_STRING
 	 *
-	 * State is an URL safe base64 encoded string.
+	 * State is a URL safe base64 encoded string.
 	 * E.g.
 	 * state=bm9uY2UtMTIzJnJlZGlyZWN0X3VybD1odHRwcyUzQSUyRiUyRm1lcmNoYW50LXNpdGUuZXhhbXBsZS5jb20lMkZ3cC1hZG1pbiUyRmFkbWluLnBocCUzRnBhZ2UlM0R3Yy1hZG1pbiUyNnBhdGglM0QlMkZnb29nbGUlMkZzZXR1cC1tYw
 	 *
-	 * The decoded content of state is an URL query string where the value of its parameter "store_url" is being URL encoded.
+	 * The decoded content of state is a URL query string where the value of its parameter "store_url" is being URL encoded.
 	 * E.g.
 	 * nonce=nonce-123&store_url=https%3A%2F%2Fmerchant-site.example.com%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin%26path%3D%2Fgoogle%2Fsetup-mc
 	 *
 	 * where its URL decoded version is:
 	 * nonce=nonce-123&store_url=https://merchant-site.example.com/wp-admin/admin.php?page=wc-admin&path=/google/setup-mc
 	 *
-	 * @param string $path An URL parameter for the path within GL&A page, which will be added in the merchant redirect URL.
+	 * @param string $path A URL parameter for the path within GL&A page, which will be added in the merchant redirect URL.
 	 *
 	 * @return string Auth URL.
 	 */

--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -56,12 +56,12 @@ class OAuthService implements Service, OptionsAwareInterface {
 	 * E.g.
 	 * state=bm9uY2UtMTIzJnJlZGlyZWN0X3VybD1odHRwcyUzQSUyRiUyRm1lcmNoYW50LXNpdGUuZXhhbXBsZS5jb20lMkZ3cC1hZG1pbiUyRmFkbWluLnBocCUzRnBhZ2UlM0R3Yy1hZG1pbiUyNnBhdGglM0QlMkZnb29nbGUlMkZzZXR1cC1tYw
 	 *
-	 * The decoded content of state is an URL query string where the value of its parameter "redirect_url" is being URL encoded.
+	 * The decoded content of state is an URL query string where the value of its parameter "store_url" is being URL encoded.
 	 * E.g.
-	 * nonce=nonce-123&redirect_url=https%3A%2F%2Fmerchant-site.example.com%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin%26path%3D%2Fgoogle%2Fsetup-mc
+	 * nonce=nonce-123&store_url=https%3A%2F%2Fmerchant-site.example.com%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin%26path%3D%2Fgoogle%2Fsetup-mc
 	 *
 	 * where its URL decoded version is:
-	 * nonce=nonce-123&redirect_url=https://merchant-site.example.com/wp-admin/admin.php?page=wc-admin&path=/google/setup-mc
+	 * nonce=nonce-123&store_url=https://merchant-site.example.com/wp-admin/admin.php?page=wc-admin&path=/google/setup-mc
 	 *
 	 * @param string $path An URL parameter for the path within GL&A page, which will be added in the merchant redirect URL.
 	 *
@@ -70,13 +70,13 @@ class OAuthService implements Service, OptionsAwareInterface {
 	public function get_auth_url( string $path ): string {
 		$google_data = $this->get_data_from_google();
 
-		$merchant_redirect_url = urlencode_deep( admin_url( "admin.php?page=wc-admin&path={$path}" ) );
+		$store_url = urlencode_deep( admin_url( "admin.php?page=wc-admin&path={$path}" ) );
 
 		$state = $this->base64url_encode(
 			build_query(
 				[
 					'nonce'        => $google_data['nonce'],
-					'redirect_url' => $merchant_redirect_url,
+					'store_url' => $store_url,
 				]
 			)
 		);

--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -75,7 +75,7 @@ class OAuthService implements Service, OptionsAwareInterface {
 		$state = $this->base64url_encode(
 			build_query(
 				[
-					'nonce'        => $google_data['nonce'],
+					'nonce'     => $google_data['nonce'],
 					'store_url' => $store_url,
 				]
 			)

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -82,9 +82,9 @@ class OAuthServiceTest extends UnitTest {
 				]
 			);
 
-		$merchant_redirect_url         = "{$admin_url}admin.php?page=wc-admin&path={$path}";
-		$merchant_redirect_url_encoded = urlencode_deep( $merchant_redirect_url );
-		$expected_state_raw            = "nonce={$nonce}&redirect_url={$merchant_redirect_url_encoded}";
+		$store_url         = "{$admin_url}admin.php?page=wc-admin&path={$path}";
+		$store_url_encoded = urlencode_deep( $store_url );
+		$expected_state_raw            = "nonce={$nonce}&store_url={$store_url_encoded}";
 		$state                         = $this->base64url_encode( $expected_state_raw );
 
 		$expected_auth_url  = 'https://public-api.wordpress.com/oauth2/authorize';
@@ -120,8 +120,8 @@ class OAuthServiceTest extends UnitTest {
 			$parsed_state['nonce']
 		);
 		$this->assertEquals(
-			$merchant_redirect_url,
-			$parsed_state['redirect_url']
+			$store_url,
+			$parsed_state['store_url']
 		);
 	}
 }

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -82,10 +82,10 @@ class OAuthServiceTest extends UnitTest {
 				]
 			);
 
-		$store_url         = "{$admin_url}admin.php?page=wc-admin&path={$path}";
-		$store_url_encoded = urlencode_deep( $store_url );
-		$expected_state_raw            = "nonce={$nonce}&store_url={$store_url_encoded}";
-		$state                         = $this->base64url_encode( $expected_state_raw );
+		$store_url          = "{$admin_url}admin.php?page=wc-admin&path={$path}";
+		$store_url_encoded  = urlencode_deep( $store_url );
+		$expected_state_raw = "nonce={$nonce}&store_url={$store_url_encoded}";
+		$state              = $this->base64url_encode( $expected_state_raw );
 
 		$expected_auth_url  = 'https://public-api.wordpress.com/oauth2/authorize';
 		$expected_auth_url .= "?blog={$blog_id}";


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of #2146, this PR renames `redirect_url` to `store_url`, so it will not be confused with `redirect_uri`.

The `store_url` is merchant's store URL, which Google will help redirect to after the OAuth2 flow is completed.

Note that after the PR is merged we also need to update the internal document about the new parameter name.
Internal doc link: PCYsg-Ypu-p2

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Prerequisite

1. Make sure the notification is enabled by setting `add_filter( 'woocommerce_gla_notifications_enabled', '__return_true' )`.
2. Make sure the options `gla_wpcom_rest_api_status` is not in the DB.

#### Test steps

1. Complete the onboarding and go to the settings page.
2. Click `Enable` new product sync from the top-left banner.
3. Complete the OAuth flow.
4. For now you will be redirected to https://woocommerce.com
5. From the URL, copy the value of `state` parameter, which is base64 encoded.
6. Decode the base64 string, make sure the content includes `store_url` param
    ```bash
    echo '<your-base64-string>' | base64 --decode
    ```

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Rename `redirect_url` to `store_url` in the `state` parameter