### PR TITLE
Avoid running malicious inputs as shell commands in the GitHub Actions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,14 +50,18 @@ jobs:
 
       - name: Install WP release candidate (optional)
         if: github.event.inputs.wp-rc-version != ''
+        env:
+          INPUT_WP_RC_VERSION: ${{ github.event.inputs.wp-rc-version }}
         run: |
-          npm run -- wp-env run tests-cli -- wp core update --version=${{ github.event.inputs.wp-rc-version }}
+          npm run -- wp-env run tests-cli -- wp core update --version="${INPUT_WP_RC_VERSION}"
           npm run -- wp-env run tests-cli -- wp core update-db
 
       - name: Install WC release candidate (optional)
         if: github.event.inputs.wc-rc-version != ''
+        env:
+          INPUT_WC_RC_VERSION: ${{ github.event.inputs.wc-rc-version }}
         run: |
-          npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=${{ github.event.inputs.wc-rc-version }}
+          npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version="${INPUT_WC_RC_VERSION}"
           npm run -- wp-env run tests-cli -- wp wc update
 
       - name: Download and install Chromium browser.

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -132,7 +132,10 @@ jobs:
         uses: woocommerce/grow/prepare-mysql@actions-v1
 
       - name: Install WP tests
-        run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ inputs.wp-rc-version }} ${{ inputs.wc-rc-version }}
+        env:
+          INPUT_WP_RC_VERSION: ${{ inputs.wp-rc-version }}
+          INPUT_WC_RC_VERSION: ${{ inputs.wc-rc-version }}
+        run: ./bin/install-wp-tests.sh wordpress_test root root localhost "${INPUT_WP_RC_VERSION}" "${INPUT_WC_RC_VERSION}"
 
       - name: Run PHP unit tests
         run: composer test-unit


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR avoids running malicious inputs as shell commands in the GitHub Actions.

Although these input values are entered by devs who have access to this repo, which means it's almost unlikely to be vulnerable to such attacks, it would be better to fix it.

### Detailed test instructions:

#### 📌 E2E Tests workflow

1. View the E2E Tests workflow run that was injected shell commands `ls -la`
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/f2a5f9ae-d48a-4839-97c3-fc4e3379c847)
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/9028825818/job/24809992921
      ![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/a666638d-98cc-4508-bd37-a27c4cb379e5)
      ![2](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/bc521148-2d27-4ff1-8f02-50cf66c620d6)
1. View the E2E Tests workflow run that avoids the shell command injections
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/9029050182/job/24810643369
      ![3](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/61a024fd-9057-435a-ba17-9718e9317d36)
1. Check if the "Install WP release candidate" and "Install WC release candidate" steps can work as before when entering valid versions
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/9029173521/job/24811003759

#### 📌 PHP Unit Tests

1. View the PHP Unit Tests workflow run that was injected shell commands `ls -la` and `cat README.md`
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/a0b2d46b-8f62-44d7-b768-97d0aa8ab996)
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/9029457821/job/24811829608
      ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/af00abfd-8879-4a4b-ba31-fbfa5c7a1640)
      ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/fd11c473-cbbc-4716-947b-3bccafb0ec56)
1. View the PHP Unit Tests workflow run that avoids the shell command injections
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/9029552347/job/24812099947
      ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/ff2bd373-97aa-4c35-9dcf-af4952b7c995)
1. Check if the "Install WP tests" step can work as before when entering valid versions
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/9029679289/job/24812468787#step:5:2

### Changelog entry
