### PR TITLE
Prevent PHP Warning when Statistics is null

### DIFF
--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -433,6 +433,6 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	public function has_at_least_one_synced_product(): bool {
 		$statuses = $this->container->get( MerchantStatuses::class )->get_product_statistics();
 
-		return $statuses['statistics']['active'] >= 1;
+		return isset( $statuses['statistics']['active'] ) && $statuses['statistics']['active'] >= 1;
 	}
 }

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -627,26 +627,26 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	public function test_has_at_least_one_synced_product_when_no_actives() {
 		$this->merchant_statuses->method( 'get_product_statistics' )
-		                        ->willReturn(
-			                        [
-				                        'statistics' => [
-					                        'active'     => 0,
-					                        'pending'    => 4,
-					                        'not_synced' => 5,
-				                        ],
-			                        ]
-		                        );
+								->willReturn(
+									[
+										'statistics' => [
+											'active'     => 0,
+											'pending'    => 4,
+											'not_synced' => 5,
+										],
+									]
+								);
 
 		$this->assertFalse( $this->mc_service->has_at_least_one_synced_product() );
 	}
 
 	public function test_has_at_least_one_synced_product_when_null_statistics() {
 		$this->merchant_statuses->method( 'get_product_statistics' )
-		                        ->willReturn(
-			                        [
-				                        'statistics' => null
-			                        ]
-		                        );
+								->willReturn(
+									[
+										'statistics' => null,
+									]
+								);
 
 		$this->assertFalse( $this->mc_service->has_at_least_one_synced_product() );
 	}

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -624,4 +624,30 @@ class MerchantCenterServiceTest extends UnitTest {
 
 		$this->assertTrue( $this->mc_service->has_at_least_one_synced_product() );
 	}
+
+	public function test_has_at_least_one_synced_product_when_no_actives() {
+		$this->merchant_statuses->method( 'get_product_statistics' )
+		                        ->willReturn(
+			                        [
+				                        'statistics' => [
+					                        'active'     => 0,
+					                        'pending'    => 4,
+					                        'not_synced' => 5,
+				                        ],
+			                        ]
+		                        );
+
+		$this->assertFalse( $this->mc_service->has_at_least_one_synced_product() );
+	}
+
+	public function test_has_at_least_one_synced_product_when_null_statistics() {
+		$this->merchant_statuses->method( 'get_product_statistics' )
+		                        ->willReturn(
+			                        [
+				                        'statistics' => null
+			                        ]
+		                        );
+
+		$this->assertFalse( $this->mc_service->has_at_least_one_synced_product() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes part of #2398 

This PR prevents a PHP warning when `statistics` is null as we try to access ['statistics']['active`] in some parts of the code without checking if it's set.

### Detailed test instructions:

1. Enable debug logging to see PHP warnings
2. Clear statistics cache
3. Trigger the scheduled action to run notification ( `wc_gla_cron_daily_notes` )
4. Confirm that the PHP warning is not generated and note is not created

Notice that some conditions are required for this Note to be triggered. For testing this I recommend commenting off some checks under `AbstractSetupCampaign::should_be_added` or be sure you pass all those checks.

So we can focus on the problematic method `$this->merchant_center_service->has_at_least_one_synced_product()`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent PHP Warning when Statistics is null
