### PR TITLE
Add info about Google Ads API Client Library Legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,15 @@ npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=8.0.0-
 npm run -- wp-env run tests-cli -- wp wc update
 ```
 
+## Google Ads API Client Library 
+
+The new Google Ads API Client Library version is now available with PHP 7.4 support under this "legacy" branch.
+It can be used in composer like this:
+
+`composer require googleads/google-ads-php:dev-legacy-v22.1.0`
+
+Going forward, Google will always add the prefix "legacy-" for the branch supporting PHP 7.4.
+
 ## Docs
 
 - [Usage Tracking](./src/Tracking/README.md)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=8.0.0-
 npm run -- wp-env run tests-cli -- wp wc update
 ```
 
-## Google Ads API Client Library 
+### Google Ads API Client Library 
 
 The new Google Ads API Client Library version is now available with PHP 7.4 support under this "legacy" branch.
 It can be used in composer like this:

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ npm run -- wp-env run tests-cli -- wp wc update
 ### Google Ads API Client Library 
 
 The new Google Ads API Client Library version is now available with PHP 7.4 support under this "legacy" branch.
-It can be used in composer like this:
 
-`composer require googleads/google-ads-php:dev-legacy-v22.1.0`
+We are using it in [composer](https://github.com/woocommerce/google-listings-and-ads/blob/develop/composer.json#L15) 
+in order to support PHP 7.4.
 
 Going forward, Google will always add the prefix "legacy-" for the branch supporting PHP 7.4.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the Readme and add some info regarding the legacy API for Google Ads

PT: pcTzPl-2cX-p2


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add info about  Legacy Google Ads API Client Library  in Readme