### PR TITLE
Upgrade the workflows in GitHub Actions to use Node.js v20

### DIFF
--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -5,20 +5,19 @@ on:
     types:
       - opened
       - transferred
-  pull_request:
+  pull_request_target:
     types:
       - opened
-
-# Leverage project write access for dependabot.
-permissions:
-  repository-projects: write
 
 jobs:
   add-to-project:
     name: Add issue/PR to project
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.4.0
+      - uses: actions/add-to-project@v1.0.1
         with:
           project-url: https://github.com/orgs/woocommerce/projects/119
           github-token: ${{ secrets.BOT_GH_TOKEN }}

--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v2
+        uses: eason9487/grow/branch-label@actions-v2

--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -1,11 +1,15 @@
 name: Set PR Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types: opened
+
 jobs:
   SetLabels:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v1
+        uses: woocommerce/grow/branch-label@actions-v2

--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: eason9487/grow/branch-label@actions-v2
+        uses: woocommerce/grow/branch-label@actions-v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,15 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -69,13 +69,13 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v1
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v2
         with:
           extension-asset-path: google-listings-and-ads.zip
 
       - name: Publish build artifact
         if: ${{ ! ( github.event_name == 'push' && github.ref_name == 'develop' ) }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: google-listings-and-ads.zip
           path: ${{ github.workspace }}/google-listings-and-ads.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: eason9487/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: eason9487/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -69,7 +69,7 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-        uses: eason9487/grow/publish-extension-dev-build@actions-v2
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v2
         with:
           extension-asset-path: google-listings-and-ads.zip
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: eason9487/grow/prepare-php@actions-v2
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: eason9487/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -69,7 +69,7 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v2
+        uses: eason9487/grow/publish-extension-dev-build@actions-v2
         with:
           extension-asset-path: google-listings-and-ads.zip
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: eason9487/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: eason9487/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,15 +26,15 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -72,7 +72,7 @@ jobs:
 
       - name: Archive e2e failure screenshots
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: e2e-screenshots
             path: tests/e2e/test-results/report/**/*.png

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: eason9487/grow/prepare-php@actions-v2
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: eason9487/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: eason9487/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v2
+        uses: eason9487/grow/eslint-annotation@actions-v2
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js -- --quiet --format ./eslintFormatter.cjs
@@ -49,12 +49,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: eason9487/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/stylelint-annotation@actions-v2
+        uses: eason9487/grow/stylelint-annotation@actions-v2
 
       - name: Lint CSS and annotate linting errors
         run: npm run lint:css -- --custom-formatter ./stylelintFormatter.cjs

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -28,15 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v1
+        uses: woocommerce/grow/eslint-annotation@actions-v2
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js -- --quiet --format ./eslintFormatter.cjs
@@ -46,15 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/stylelint-annotation@actions-v1
+        uses: woocommerce/grow/stylelint-annotation@actions-v2
 
       - name: Lint CSS and annotate linting errors
         run: npm run lint:css -- --custom-formatter ./stylelintFormatter.cjs

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: eason9487/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: eason9487/grow/eslint-annotation@actions-v2
+        uses: woocommerce/grow/eslint-annotation@actions-v2
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js -- --quiet --format ./eslintFormatter.cjs
@@ -49,12 +49,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: eason9487/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: eason9487/grow/stylelint-annotation@actions-v2
+        uses: woocommerce/grow/stylelint-annotation@actions-v2
 
       - name: Lint CSS and annotate linting errors
         run: npm run lint:css -- --custom-formatter ./stylelintFormatter.cjs

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: eason9487/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: eason9487/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -29,10 +29,10 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: ".nvmrc"
 
@@ -40,8 +40,9 @@ jobs:
         run: npm run test:js
 
       - name: Upload JS unit coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/clover.xml
           flags: js-unit-tests
           name: js-coverage-report

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           tools: cs2pr
 

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: eason9487/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           tools: cs2pr
 

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: eason9487/grow/prepare-php@actions-v2
         with:
           tools: cs2pr
 

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -26,7 +26,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: eason9487/grow/hook-documentation@actions-v2
+        uses: woocommerce/grow/hook-documentation@actions-v2
         with:
           source-directories: src/,views/,google-listings-and-ads.php,uninstall.php
 

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Checks out a branch instead of a commit in detached HEAD state
           ref: ${{ github.head_ref }}
@@ -26,7 +26,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: woocommerce/grow/hook-documentation@actions-v1
+        uses: woocommerce/grow/hook-documentation@actions-v2
         with:
           source-directories: src/,views/,google-listings-and-ads.php,uninstall.php
 

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -26,7 +26,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: woocommerce/grow/hook-documentation@actions-v2
+        uses: eason9487/grow/hook-documentation@actions-v2
         with:
           source-directories: src/,views/,google-listings-and-ads.php,uninstall.php
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,12 +44,12 @@ jobs:
     steps:
       - name: Get Release versions from Wordpress
         id: wp
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: eason9487/grow/get-plugin-releases@actions-v2
         with:
           slug: wordpress
       - name: Get Release versions from WooCommerce
         id: wc
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: eason9487/grow/get-plugin-releases@actions-v2
         with:
           slug: woocommerce
 
@@ -84,13 +84,13 @@ jobs:
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: eason9487/grow/prepare-php@actions-v2
         with:
           php-version: "${{ matrix.php }}"
           coverage: "${{ env.generate_coverage == 'true' && 'xdebug' || 'none' }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v2
+        uses: eason9487/grow/prepare-mysql@actions-v2
 
       - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
@@ -125,12 +125,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: eason9487/grow/prepare-php@actions-v2
         with:
           php-version: "${{ inputs.php-version }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v2
+        uses: eason9487/grow/prepare-mysql@actions-v2
 
       - name: Install WP tests
         env:

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,12 +44,12 @@ jobs:
     steps:
       - name: Get Release versions from Wordpress
         id: wp
-        uses: eason9487/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: wordpress
       - name: Get Release versions from WooCommerce
         id: wc
-        uses: eason9487/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: woocommerce
 
@@ -84,13 +84,13 @@ jobs:
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 
       - name: Prepare PHP
-        uses: eason9487/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           php-version: "${{ matrix.php }}"
           coverage: "${{ env.generate_coverage == 'true' && 'xdebug' || 'none' }}"
 
       - name: Prepare MySQL
-        uses: eason9487/grow/prepare-mysql@actions-v2
+        uses: woocommerce/grow/prepare-mysql@actions-v2
 
       - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
@@ -125,12 +125,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: eason9487/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           php-version: "${{ inputs.php-version }}"
 
       - name: Prepare MySQL
-        uses: eason9487/grow/prepare-mysql@actions-v2
+        uses: woocommerce/grow/prepare-mysql@actions-v2
 
       - name: Install WP tests
         env:

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,12 +44,12 @@ jobs:
     steps:
       - name: Get Release versions from Wordpress
         id: wp
-        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: wordpress
       - name: Get Release versions from WooCommerce
         id: wc
-        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: woocommerce
 
@@ -77,20 +77,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - if: matrix.wc-versions == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.2
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           php-version: "${{ matrix.php }}"
           coverage: "${{ env.generate_coverage == 'true' && 'xdebug' || 'none' }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v1
+        uses: woocommerce/grow/prepare-mysql@actions-v2
 
       - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }} ${{ matrix.wc-versions }}
@@ -105,8 +105,9 @@ jobs:
 
       - if: env.generate_coverage == 'true'
         name: Upload PHP unit coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/php-coverage/report.xml
           flags: php-unit-tests
           name: php-coverage-report
@@ -121,15 +122,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           php-version: "${{ inputs.php-version }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v1
+        uses: woocommerce/grow/prepare-mysql@actions-v2
 
       - name: Install WP tests
         env:

--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -15,4 +15,4 @@ jobs:
   MergeTrunkDevelopPR:
     runs-on: ubuntu-latest
     steps:
-      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v1
+      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v2

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@actions-v1
+        uses: woocommerce/grow/prepare-extension-release@actions-v2
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -58,12 +58,12 @@ jobs:
     needs: build
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: google-listings-and-ads.zip
       - name: Run QIT Tests
         # Update it with more stable path once merged.
-        uses: woocommerce/grow/run-qit-extension@actions-v1
+        uses: woocommerce/grow/run-qit-extension@actions-v2
         with:
           qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
           qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -63,7 +63,7 @@ jobs:
           name: google-listings-and-ads.zip
       - name: Run QIT Tests
         # Update it with more stable path once merged.
-        uses: eason9487/grow/run-qit-extension@actions-v2
+        uses: woocommerce/grow/run-qit-extension@actions-v2
         with:
           qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
           qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -63,7 +63,7 @@ jobs:
           name: google-listings-and-ads.zip
       - name: Run QIT Tests
         # Update it with more stable path once merged.
-        uses: woocommerce/grow/run-qit-extension@actions-v2
+        uses: eason9487/grow/run-qit-extension@actions-v2
         with:
           qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
           qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}

--- a/src/Hooks/README.md
+++ b/src/Hooks/README.md
@@ -8,7 +8,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
+- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
 
 ## woocommerce_admin_disabled
 
@@ -16,7 +16,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Internal/Requirements/WCAdminValidator.php#L38)
+- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Internal/Requirements/WCAdminValidator.php#L38)
 
 ## woocommerce_gla_ads_billing_setup_status
 
@@ -24,8 +24,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Ads.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L113)
-- [Ads.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L122)
+- [Ads.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L113)
+- [Ads.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L122)
 
 ## woocommerce_gla_ads_client_exception
 
@@ -33,24 +33,24 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsCampaign.php#L141](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L141)
-- [AdsCampaign.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L184)
-- [AdsCampaign.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L247)
-- [AdsCampaign.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L302)
-- [AdsCampaign.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L339)
-- [AdsReport.php#L105](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsReport.php#L105)
-- [Ads.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L74)
-- [Ads.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L118)
-- [Ads.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L167)
-- [Ads.php#L209](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L209)
-- [Ads.php#L293](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L293)
-- [AdsConversionAction.php#L100](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsConversionAction.php#L100)
-- [AdsConversionAction.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsConversionAction.php#L146)
-- [AdsAssetGroupAsset.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroupAsset.php#L135)
-- [AdsAssetGroupAsset.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroupAsset.php#L201)
-- [AdsAssetGroup.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroup.php#L113)
-- [AdsAssetGroup.php#L261](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroup.php#L261)
-- [AdsAssetGroup.php#L325](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroup.php#L325)
+- [AdsReport.php#L105](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsReport.php#L105)
+- [AdsConversionAction.php#L100](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsConversionAction.php#L100)
+- [AdsConversionAction.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsConversionAction.php#L146)
+- [AdsAssetGroupAsset.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroupAsset.php#L135)
+- [AdsAssetGroupAsset.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroupAsset.php#L201)
+- [Ads.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L74)
+- [Ads.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L118)
+- [Ads.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L167)
+- [Ads.php#L209](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L209)
+- [Ads.php#L293](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L293)
+- [AdsCampaign.php#L141](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L141)
+- [AdsCampaign.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L184)
+- [AdsCampaign.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L247)
+- [AdsCampaign.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L302)
+- [AdsCampaign.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L339)
+- [AdsAssetGroup.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroup.php#L113)
+- [AdsAssetGroup.php#L261](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroup.php#L261)
+- [AdsAssetGroup.php#L325](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroup.php#L325)
 
 ## woocommerce_gla_ads_setup_completed
 
@@ -58,7 +58,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SetupCompleteController.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/SetupCompleteController.php#L66)
+- [SetupCompleteController.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/SetupCompleteController.php#L66)
 
 ## woocommerce_gla_attribute_applicable_product_types_
 
@@ -66,8 +66,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L98](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Product/Attributes/AttributesForm.php#L98)
-- [AttributeManager.php#L295](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/Attributes/AttributeManager.php#L295)
+- [AttributeManager.php#L295](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/Attributes/AttributeManager.php#L295)
+- [AttributesForm.php#L98](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Product/Attributes/AttributesForm.php#L98)
 
 ## woocommerce_gla_attribute_hidden_product_types_
 
@@ -75,7 +75,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Product/Attributes/AttributesForm.php#L103)
+- [AttributesForm.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Product/Attributes/AttributesForm.php#L103)
 
 ## woocommerce_gla_attribute_mapping_sources
 
@@ -83,7 +83,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
+- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
 
 ## woocommerce_gla_attribute_mapping_sources_custom_attributes
 
@@ -91,7 +91,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
+- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
 
 ## woocommerce_gla_attribute_mapping_sources_global_attributes
 
@@ -99,7 +99,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
+- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
 
 ## woocommerce_gla_attribute_mapping_sources_product_fields
 
@@ -107,7 +107,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
+- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
 
 ## woocommerce_gla_attribute_mapping_sources_taxonomies
 
@@ -115,7 +115,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
+- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
 
 ## woocommerce_gla_attributes_tab_applicable_product_types
 
@@ -123,7 +123,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesTrait.php#L18](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Product/Attributes/AttributesTrait.php#L18)
+- [AttributesTrait.php#L18](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Product/Attributes/AttributesTrait.php#L18)
 
 ## woocommerce_gla_batch_deleted_products
 
@@ -131,7 +131,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L229)
+- [ProductSyncer.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L229)
 
 ## woocommerce_gla_batch_retry_delete_products
 
@@ -139,7 +139,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L343](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L343)
+- [ProductSyncer.php#L343](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L343)
 
 ## woocommerce_gla_batch_retry_update_products
 
@@ -147,7 +147,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L287](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L287)
+- [ProductSyncer.php#L287](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L287)
 
 ## woocommerce_gla_batch_updated_products
 
@@ -155,7 +155,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L143)
+- [ProductSyncer.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L143)
 
 ## woocommerce_gla_batched_job_size
 
@@ -163,8 +163,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/UpdateSyncableProductsCount.php#L74)
-- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
+- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
+- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/UpdateSyncableProductsCount.php#L74)
 
 ## woocommerce_gla_bulk_update_coupon
 
@@ -172,7 +172,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponBulkEdit.php#L133](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/BulkEdit/CouponBulkEdit.php#L133)
+- [CouponBulkEdit.php#L133](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/BulkEdit/CouponBulkEdit.php#L133)
 
 ## woocommerce_gla_conversion_action_name
 
@@ -180,7 +180,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsConversionAction.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsConversionAction.php#L67)
+- [AdsConversionAction.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsConversionAction.php#L67)
 
 ## woocommerce_gla_coupon_destinations
 
@@ -188,7 +188,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCCouponAdapter.php#L391](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/WCCouponAdapter.php#L391)
+- [WCCouponAdapter.php#L391](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/WCCouponAdapter.php#L391)
 
 ## woocommerce_gla_coupons_delete_retry_on_failure
 
@@ -196,7 +196,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L438](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L438)
+- [CouponSyncer.php#L438](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L438)
 
 ## woocommerce_gla_coupons_update_retry_on_failure
 
@@ -204,7 +204,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L400](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L400)
+- [CouponSyncer.php#L400](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L400)
 
 ## woocommerce_gla_custom_merchant_issues
 
@@ -212,7 +212,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L538](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L538)
+- [MerchantStatuses.php#L538](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L538)
 
 ## woocommerce_gla_debug_message
 
@@ -220,39 +220,39 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SyncerHooks.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/SyncerHooks.php#L178)
-- [CouponHelper.php#L257](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponHelper.php#L257)
-- [CouponHelper.php#L294](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponHelper.php#L294)
-- [CouponSyncer.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L103)
-- [CouponSyncer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L116)
-- [CouponSyncer.php#L141](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L141)
-- [CouponSyncer.php#L155](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L155)
-- [CouponSyncer.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L172)
-- [CouponSyncer.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L195)
-- [CouponSyncer.php#L260](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L260)
-- [CouponSyncer.php#L309](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L309)
-- [CouponSyncer.php#L328](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L328)
-- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/ActionSchedulerJobMonitor.php#L117)
-- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/ActionSchedulerJobMonitor.php#L126)
-- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/CleanupSyncedProducts.php#L74)
-- [ProductMetaQueryHelper.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/DB/ProductMetaQueryHelper.php#L109)
-- [ProductMetaQueryHelper.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/DB/ProductMetaQueryHelper.php#L140)
-- [IssuesController.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L95)
-- [MerchantCenterService.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantCenterService.php#L305)
-- [MerchantStatuses.php#L413](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L413)
-- [MerchantStatuses.php#L667](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L667)
-- [MerchantStatuses.php#L916](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L916)
-- [BatchProductHelper.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/BatchProductHelper.php#L208)
-- [BatchProductHelper.php#L231](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/BatchProductHelper.php#L231)
-- [ProductSyncer.php#L149](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L149)
-- [ProductSyncer.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L159)
-- [ProductSyncer.php#L235](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L235)
-- [ProductSyncer.php#L245](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L245)
-- [ProductRepository.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductRepository.php#L315)
-- [WCProductAdapter.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L205)
-- [SyncerHooks.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/SyncerHooks.php#L197)
-- [ProductHelper.php#L483](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L483)
-- [ProductHelper.php#L516](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L516)
+- [ProductSyncer.php#L149](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L149)
+- [ProductSyncer.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L159)
+- [ProductSyncer.php#L235](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L235)
+- [ProductSyncer.php#L245](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L245)
+- [BatchProductHelper.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/BatchProductHelper.php#L208)
+- [BatchProductHelper.php#L231](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/BatchProductHelper.php#L231)
+- [SyncerHooks.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/SyncerHooks.php#L197)
+- [ProductRepository.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductRepository.php#L315)
+- [WCProductAdapter.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L205)
+- [ProductHelper.php#L483](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L483)
+- [ProductHelper.php#L516](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L516)
+- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/CleanupSyncedProducts.php#L74)
+- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/ActionSchedulerJobMonitor.php#L117)
+- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/ActionSchedulerJobMonitor.php#L126)
+- [SyncerHooks.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/SyncerHooks.php#L178)
+- [CouponHelper.php#L257](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponHelper.php#L257)
+- [CouponHelper.php#L294](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponHelper.php#L294)
+- [CouponSyncer.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L103)
+- [CouponSyncer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L116)
+- [CouponSyncer.php#L141](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L141)
+- [CouponSyncer.php#L155](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L155)
+- [CouponSyncer.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L172)
+- [CouponSyncer.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L195)
+- [CouponSyncer.php#L260](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L260)
+- [CouponSyncer.php#L309](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L309)
+- [CouponSyncer.php#L328](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L328)
+- [IssuesController.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L95)
+- [ProductMetaQueryHelper.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/DB/ProductMetaQueryHelper.php#L109)
+- [ProductMetaQueryHelper.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/DB/ProductMetaQueryHelper.php#L140)
+- [MerchantCenterService.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantCenterService.php#L305)
+- [MerchantStatuses.php#L413](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L413)
+- [MerchantStatuses.php#L667](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L667)
+- [MerchantStatuses.php#L916](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L916)
 
 ## woocommerce_gla_deleted_promotions
 
@@ -260,7 +260,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L322](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L322)
+- [CouponSyncer.php#L322](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L322)
 
 ## woocommerce_gla_dimension_unit
 
@@ -268,7 +268,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L431](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L431)
+- [WCProductAdapter.php#L431](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L431)
 
 ## woocommerce_gla_disable_gtag_tracking
 
@@ -276,7 +276,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L526](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Google/GlobalSiteTag.php#L526)
+- [GlobalSiteTag.php#L526](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Google/GlobalSiteTag.php#L526)
 
 ## woocommerce_gla_enable_connection_test
 
@@ -284,7 +284,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ConnectionTest.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/ConnectionTest.php#L87)
+- [ConnectionTest.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/ConnectionTest.php#L87)
 
 ## woocommerce_gla_enable_debug_logging
 
@@ -292,7 +292,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Logging/DebugLogger.php#L33)
+- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Logging/DebugLogger.php#L33)
 
 ## woocommerce_gla_enable_mcm
 
@@ -300,7 +300,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GLAChannel.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MultichannelMarketing/GLAChannel.php#L75)
+- [GLAChannel.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MultichannelMarketing/GLAChannel.php#L75)
 
 ## woocommerce_gla_enable_reports
 
@@ -308,7 +308,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Admin.php#L271](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Admin.php#L271)
+- [Admin.php#L271](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Admin.php#L271)
 
 ## woocommerce_gla_error
 
@@ -316,23 +316,23 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponMetaHandler.php#L220)
-- [CouponSyncer.php#L410](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L410)
-- [CouponSyncer.php#L448](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L448)
-- [CouponSyncer.php#L466](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L466)
-- [ProductMetaQueryHelper.php#L156](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/DB/ProductMetaQueryHelper.php#L156)
-- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/View/PHPView.php#L136)
-- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/View/PHPView.php#L164)
-- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/View/PHPView.php#L208)
-- [BatchProductHelper.php#L248](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/BatchProductHelper.php#L248)
-- [ProductSyncer.php#L290](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L290)
-- [ProductSyncer.php#L313](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L313)
-- [ProductSyncer.php#L346](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L346)
-- [ProductSyncer.php#L361](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L361)
-- [ProductMetaHandler.php#L173](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductMetaHandler.php#L173)
-- [AttributeManager.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/Attributes/AttributeManager.php#L269)
-- [ProductHelper.php#L375](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L375)
-- [ProductHelper.php#L592](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L592)
+- [ProductSyncer.php#L290](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L290)
+- [ProductSyncer.php#L313](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L313)
+- [ProductSyncer.php#L346](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L346)
+- [ProductSyncer.php#L361](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L361)
+- [BatchProductHelper.php#L248](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/BatchProductHelper.php#L248)
+- [ProductMetaHandler.php#L173](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductMetaHandler.php#L173)
+- [AttributeManager.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/Attributes/AttributeManager.php#L269)
+- [ProductHelper.php#L375](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L375)
+- [ProductHelper.php#L592](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L592)
+- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponMetaHandler.php#L220)
+- [CouponSyncer.php#L410](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L410)
+- [CouponSyncer.php#L448](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L448)
+- [CouponSyncer.php#L466](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L466)
+- [ProductMetaQueryHelper.php#L156](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/DB/ProductMetaQueryHelper.php#L156)
+- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/View/PHPView.php#L136)
+- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/View/PHPView.php#L164)
+- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/View/PHPView.php#L208)
 
 ## woocommerce_gla_exception
 
@@ -340,30 +340,30 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GoogleServiceProvider.php#L234](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Internal/DependencyManagement/GoogleServiceProvider.php#L234)
-- [GoogleServiceProvider.php#L244](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Internal/DependencyManagement/GoogleServiceProvider.php#L244)
-- [CouponSyncer.php#L203](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L203)
-- [CouponSyncer.php#L293](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L293)
-- [PluginUpdate.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/Update/PluginUpdate.php#L75)
-- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Event/ClearProductStatsCache.php#L61)
-- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Input/DateTime.php#L44)
-- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Input/DateTime.php#L80)
-- [CouponChannelVisibilityMetaBox.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197)
-- [ChannelVisibilityMetaBox.php#L176](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L176)
-- [SettingsSyncController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L96)
-- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
-- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
-- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L95)
-- [Middleware.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L455)
-- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/View/PHPView.php#L87)
-- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Notes/NoteInitializer.php#L74)
-- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Notes/NoteInitializer.php#L116)
-- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
-- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Integration/WooCommercePreOrders.php#L111)
-- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Integration/WooCommercePreOrders.php#L131)
-- [ProductSyncer.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L134)
-- [ProductSyncer.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L220)
-- [ProductHelper.php#L257](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L257)
+- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
+- [ProductSyncer.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L134)
+- [ProductSyncer.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L220)
+- [ProductHelper.php#L257](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L257)
+- [PluginUpdate.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/Update/PluginUpdate.php#L75)
+- [CouponSyncer.php#L203](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L203)
+- [CouponSyncer.php#L293](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L293)
+- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
+- [SettingsSyncController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L96)
+- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
+- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L95)
+- [Middleware.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L455)
+- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Input/DateTime.php#L44)
+- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Input/DateTime.php#L80)
+- [CouponChannelVisibilityMetaBox.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197)
+- [ChannelVisibilityMetaBox.php#L176](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L176)
+- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/View/PHPView.php#L87)
+- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Integration/WooCommercePreOrders.php#L111)
+- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Integration/WooCommercePreOrders.php#L131)
+- [GoogleServiceProvider.php#L234](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Internal/DependencyManagement/GoogleServiceProvider.php#L234)
+- [GoogleServiceProvider.php#L244](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Internal/DependencyManagement/GoogleServiceProvider.php#L244)
+- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Event/ClearProductStatsCache.php#L61)
+- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Notes/NoteInitializer.php#L74)
+- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Notes/NoteInitializer.php#L116)
 
 ## woocommerce_gla_force_run_install
 
@@ -371,7 +371,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Installer.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Installer.php#L82)
+- [Installer.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Installer.php#L82)
 
 ## woocommerce_gla_get_google_product_offer_id
 
@@ -379,7 +379,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L284)
+- [WCProductAdapter.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L284)
 
 ## woocommerce_gla_get_sync_ready_products_filter
 
@@ -387,7 +387,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductFilter.php#L61)
+- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductFilter.php#L61)
 
 ## woocommerce_gla_get_sync_ready_products_pre_filter
 
@@ -395,7 +395,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductFilter.php#L47)
+- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductFilter.php#L47)
 
 ## woocommerce_gla_get_wc_product_id
 
@@ -403,7 +403,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L302)
+- [ProductHelper.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L302)
 
 ## woocommerce_gla_gtag_consent
 
@@ -411,7 +411,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Google/GlobalSiteTag.php#L302)
+- [GlobalSiteTag.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Google/GlobalSiteTag.php#L302)
 
 ## woocommerce_gla_guzzle_client_exception
 
@@ -419,20 +419,20 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GoogleServiceProvider.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Internal/DependencyManagement/GoogleServiceProvider.php#L263)
-- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L70)
-- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L91)
-- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L126)
-- [Middleware.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L80)
-- [Middleware.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L178)
-- [Middleware.php#L228](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L228)
-- [Middleware.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L273)
-- [Middleware.php#L344](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L344)
-- [Middleware.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L394)
-- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L418)
-- [Middleware.php#L452](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L452)
-- [Middleware.php#L554](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L554)
-- [Middleware.php#L614](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L614)
+- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L70)
+- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L91)
+- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L126)
+- [Middleware.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L80)
+- [Middleware.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L178)
+- [Middleware.php#L228](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L228)
+- [Middleware.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L273)
+- [Middleware.php#L344](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L344)
+- [Middleware.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L394)
+- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L418)
+- [Middleware.php#L452](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L452)
+- [Middleware.php#L554](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L554)
+- [Middleware.php#L614](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L614)
+- [GoogleServiceProvider.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Internal/DependencyManagement/GoogleServiceProvider.php#L263)
 
 ## woocommerce_gla_guzzle_invalid_response
 
@@ -440,15 +440,15 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L66)
-- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L121)
-- [Middleware.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L159)
-- [Middleware.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L223)
-- [Middleware.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L267)
-- [Middleware.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L339)
-- [Middleware.php#L389](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L389)
-- [Middleware.php#L550](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L550)
-- [Middleware.php#L602](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L602)
+- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L66)
+- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L121)
+- [Middleware.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L159)
+- [Middleware.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L223)
+- [Middleware.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L267)
+- [Middleware.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L339)
+- [Middleware.php#L389](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L389)
+- [Middleware.php#L550](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L550)
+- [Middleware.php#L602](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L602)
 
 ## woocommerce_gla_handle_shipping_method_to_rates
 
@@ -456,7 +456,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ZoneMethodsParser.php#L106](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Shipping/ZoneMethodsParser.php#L106)
+- [ZoneMethodsParser.php#L106](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Shipping/ZoneMethodsParser.php#L106)
 
 ## woocommerce_gla_hidden_coupon_types
 
@@ -464,7 +464,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L379](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L379)
+- [CouponSyncer.php#L379](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L379)
 
 ## woocommerce_gla_job_failure_rate_threshold
 
@@ -472,7 +472,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/ActionSchedulerJobMonitor.php#L186)
+- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/ActionSchedulerJobMonitor.php#L186)
 
 ## woocommerce_gla_job_failure_timeframe
 
@@ -480,7 +480,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/ActionSchedulerJobMonitor.php#L195)
+- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/ActionSchedulerJobMonitor.php#L195)
 
 ## woocommerce_gla_mapping_rules_change
 
@@ -488,9 +488,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
-- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
-- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
+- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
+- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
+- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
 
 ## woocommerce_gla_mc_account_review_lifetime
 
@@ -498,7 +498,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewStatuses.php#L156](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Google/RequestReviewStatuses.php#L156)
+- [RequestReviewStatuses.php#L156](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Google/RequestReviewStatuses.php#L156)
 
 ## woocommerce_gla_mc_client_exception
 
@@ -506,15 +506,15 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L92)
-- [Merchant.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L140)
-- [Merchant.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L172)
-- [Merchant.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L191)
-- [Merchant.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L247)
-- [Merchant.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L292)
-- [Merchant.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L354)
-- [MerchantReport.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/MerchantReport.php#L115)
-- [MerchantReport.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/MerchantReport.php#L183)
+- [MerchantReport.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/MerchantReport.php#L115)
+- [MerchantReport.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/MerchantReport.php#L183)
+- [Merchant.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L92)
+- [Merchant.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L140)
+- [Merchant.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L172)
+- [Merchant.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L191)
+- [Merchant.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L247)
+- [Merchant.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L292)
+- [Merchant.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L354)
 
 ## woocommerce_gla_mc_settings_sync
 
@@ -522,7 +522,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
+- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
 
 ## woocommerce_gla_mc_status_lifetime
 
@@ -530,7 +530,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L935](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L935)
+- [MerchantStatuses.php#L935](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L935)
 
 ## woocommerce_gla_merchant_issue_override
 
@@ -538,7 +538,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IssuesController.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L85)
+- [IssuesController.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L85)
 
 ## woocommerce_gla_merchant_status_presync_issues_chunk
 
@@ -546,7 +546,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L596](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L596)
+- [MerchantStatuses.php#L596](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L596)
 
 ## woocommerce_gla_options_deleted_
 
@@ -554,7 +554,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Options/Options.php#L103)
+- [Options.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Options/Options.php#L103)
 
 ## woocommerce_gla_options_updated_
 
@@ -562,8 +562,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Options/Options.php#L65)
-- [Options.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Options/Options.php#L85)
+- [Options.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Options/Options.php#L65)
+- [Options.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Options/Options.php#L85)
 
 ## woocommerce_gla_prepared_response_->GET_ROUTE_NAME
 
@@ -571,7 +571,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BaseController.php#L160](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/BaseController.php#L160)
+- [BaseController.php#L160](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/BaseController.php#L160)
 
 ## woocommerce_gla_product_attribute_types
 
@@ -579,7 +579,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/Attributes/AttributeManager.php#L243)
+- [AttributeManager.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/Attributes/AttributeManager.php#L243)
 
 ## woocommerce_gla_product_attribute_value_
 
@@ -587,8 +587,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L916](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L916)
-- [WCProductAdapter.php#L967](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L967)
+- [WCProductAdapter.php#L916](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L916)
+- [WCProductAdapter.php#L967](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L967)
 
 ## woocommerce_gla_product_attribute_value_description
 
@@ -596,7 +596,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L352](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L352)
+- [WCProductAdapter.php#L352](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L352)
 
 ## woocommerce_gla_product_attribute_value_options_::get_id
 
@@ -604,7 +604,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Product/Attributes/AttributesForm.php#L127)
+- [AttributesForm.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Product/Attributes/AttributesForm.php#L127)
 
 ## woocommerce_gla_product_attribute_value_price
 
@@ -612,7 +612,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L640](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L640)
+- [WCProductAdapter.php#L640](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L640)
 
 ## woocommerce_gla_product_attribute_value_sale_price
 
@@ -620,7 +620,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L692](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L692)
+- [WCProductAdapter.php#L692](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L692)
 
 ## woocommerce_gla_product_attribute_values
 
@@ -628,7 +628,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L166)
+- [WCProductAdapter.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L166)
 
 ## woocommerce_gla_product_description_apply_shortcodes
 
@@ -636,7 +636,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L321)
+- [WCProductAdapter.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L321)
 
 ## woocommerce_gla_product_property_value_is_virtual
 
@@ -644,7 +644,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L782](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L782)
+- [WCProductAdapter.php#L782](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L782)
 
 ## woocommerce_gla_product_query_args
 
@@ -652,7 +652,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductRepository.php#L376](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductRepository.php#L376)
+- [ProductRepository.php#L376](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductRepository.php#L376)
 
 ## woocommerce_gla_product_view_report_page_size
 
@@ -660,7 +660,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantReport.php#L68](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/MerchantReport.php#L68)
+- [MerchantReport.php#L68](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/MerchantReport.php#L68)
 
 ## woocommerce_gla_products_delete_retry_on_failure
 
@@ -668,7 +668,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L342](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L342)
+- [ProductSyncer.php#L342](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L342)
 
 ## woocommerce_gla_products_update_retry_on_failure
 
@@ -676,7 +676,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L286](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L286)
+- [ProductSyncer.php#L286](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L286)
 
 ## woocommerce_gla_ready_for_syncing
 
@@ -684,7 +684,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantCenterService.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantCenterService.php#L118)
+- [MerchantCenterService.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantCenterService.php#L118)
 
 ## woocommerce_gla_request_review_failure
 
@@ -692,9 +692,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewController.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110)
-- [RequestReviewController.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122)
-- [Middleware.php#L595](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L595)
+- [RequestReviewController.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110)
+- [RequestReviewController.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122)
+- [Middleware.php#L595](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L595)
 
 ## woocommerce_gla_request_review_response
 
@@ -702,7 +702,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Middleware.php#L547](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L547)
+- [Middleware.php#L547](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L547)
 
 ## woocommerce_gla_retry_delete_coupons
 
@@ -710,7 +710,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L443](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L443)
+- [CouponSyncer.php#L443](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L443)
 
 ## woocommerce_gla_retry_update_coupons
 
@@ -718,7 +718,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L405](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L405)
+- [CouponSyncer.php#L405](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L405)
 
 ## woocommerce_gla_site_claim_failure
 
@@ -726,10 +726,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L93)
-- [Middleware.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L268)
-- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L274)
-- [AccountService.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/AccountService.php#L365)
+- [Merchant.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L93)
+- [Middleware.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L268)
+- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L274)
+- [AccountService.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/AccountService.php#L365)
 
 ## woocommerce_gla_site_claim_overwrite_required
 
@@ -737,7 +737,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/AccountService.php#L360)
+- [AccountService.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/AccountService.php#L360)
 
 ## woocommerce_gla_site_claim_success
 
@@ -745,8 +745,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L90)
-- [Middleware.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L263)
+- [Merchant.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L90)
+- [Middleware.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L263)
 
 ## woocommerce_gla_site_url
 
@@ -754,7 +754,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/PluginHelper.php#L188)
+- [PluginHelper.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/PluginHelper.php#L188)
 
 ## woocommerce_gla_site_verify_failure
 
@@ -762,9 +762,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L58)
-- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L66)
-- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L87)
+- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L58)
+- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L66)
+- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L87)
 
 ## woocommerce_gla_site_verify_success
 
@@ -772,7 +772,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L85)
+- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L85)
 
 ## woocommerce_gla_supported_coupon_types
 
@@ -780,7 +780,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L366](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L366)
+- [CouponSyncer.php#L366](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L366)
 
 ## woocommerce_gla_supported_product_types
 
@@ -788,7 +788,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L264](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L264)
+- [ProductSyncer.php#L264](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L264)
 
 ## woocommerce_gla_sv_client_exception
 
@@ -796,8 +796,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L120)
-- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L162)
+- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L120)
+- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L162)
 
 ## woocommerce_gla_tax_excluded
 
@@ -805,7 +805,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L601](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L601)
+- [WCProductAdapter.php#L601](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L601)
 
 ## woocommerce_gla_track_event
 
@@ -813,11 +813,11 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SetupCompleteController.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/SetupCompleteController.php#L75)
-- [CampaignController.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/CampaignController.php#L151)
-- [CampaignController.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/CampaignController.php#L229)
-- [CampaignController.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/CampaignController.php#L267)
-- [SettingsSyncController.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L83)
+- [SetupCompleteController.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/SetupCompleteController.php#L75)
+- [CampaignController.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/CampaignController.php#L151)
+- [CampaignController.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/CampaignController.php#L229)
+- [CampaignController.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/CampaignController.php#L267)
+- [SettingsSyncController.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L83)
 
 ## woocommerce_gla_updated_coupon
 
@@ -825,7 +825,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L169)
+- [CouponSyncer.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L169)
 
 ## woocommerce_gla_url_switch_required
 
@@ -833,7 +833,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/AccountService.php#L445)
+- [AccountService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/AccountService.php#L445)
 
 ## woocommerce_gla_url_switch_success
 
@@ -841,7 +841,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L468](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/AccountService.php#L468)
+- [AccountService.php#L468](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/AccountService.php#L468)
 
 ## woocommerce_gla_use_short_description
 
@@ -849,7 +849,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L298)
+- [WCProductAdapter.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L298)
 
 ## woocommerce_gla_wcs_url
 
@@ -857,8 +857,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/PluginHelper.php#L174)
-- [PluginHelper.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/PluginHelper.php#L177)
+- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/PluginHelper.php#L174)
+- [PluginHelper.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/PluginHelper.php#L177)
 
 ## woocommerce_gla_weight_unit
 
@@ -866,7 +866,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L432)
+- [WCProductAdapter.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L432)
 
 ## woocommerce_hide_invisible_variations
 
@@ -874,5 +874,5 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L390](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L390)
+- [ProductHelper.php#L390](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L390)
 

--- a/src/Hooks/README.md
+++ b/src/Hooks/README.md
@@ -8,7 +8,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
+- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
 
 ## woocommerce_admin_disabled
 
@@ -16,7 +16,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Internal/Requirements/WCAdminValidator.php#L38)
+- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Internal/Requirements/WCAdminValidator.php#L38)
 
 ## woocommerce_gla_ads_billing_setup_status
 
@@ -24,8 +24,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Ads.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L113)
-- [Ads.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L122)
+- [Ads.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L113)
+- [Ads.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L122)
 
 ## woocommerce_gla_ads_client_exception
 
@@ -33,24 +33,24 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsReport.php#L105](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsReport.php#L105)
-- [AdsConversionAction.php#L100](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsConversionAction.php#L100)
-- [AdsConversionAction.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsConversionAction.php#L146)
-- [AdsAssetGroupAsset.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroupAsset.php#L135)
-- [AdsAssetGroupAsset.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroupAsset.php#L201)
-- [Ads.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L74)
-- [Ads.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L118)
-- [Ads.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L167)
-- [Ads.php#L209](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L209)
-- [Ads.php#L293](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Ads.php#L293)
-- [AdsCampaign.php#L141](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L141)
-- [AdsCampaign.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L184)
-- [AdsCampaign.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L247)
-- [AdsCampaign.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L302)
-- [AdsCampaign.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsCampaign.php#L339)
-- [AdsAssetGroup.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroup.php#L113)
-- [AdsAssetGroup.php#L261](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroup.php#L261)
-- [AdsAssetGroup.php#L325](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsAssetGroup.php#L325)
+- [AdsCampaign.php#L141](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L141)
+- [AdsCampaign.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L184)
+- [AdsCampaign.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L247)
+- [AdsCampaign.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L302)
+- [AdsCampaign.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsCampaign.php#L339)
+- [AdsReport.php#L105](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsReport.php#L105)
+- [Ads.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L74)
+- [Ads.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L118)
+- [Ads.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L167)
+- [Ads.php#L209](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L209)
+- [Ads.php#L293](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Ads.php#L293)
+- [AdsConversionAction.php#L100](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsConversionAction.php#L100)
+- [AdsConversionAction.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsConversionAction.php#L146)
+- [AdsAssetGroupAsset.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroupAsset.php#L135)
+- [AdsAssetGroupAsset.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroupAsset.php#L201)
+- [AdsAssetGroup.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroup.php#L113)
+- [AdsAssetGroup.php#L261](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroup.php#L261)
+- [AdsAssetGroup.php#L325](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsAssetGroup.php#L325)
 
 ## woocommerce_gla_ads_setup_completed
 
@@ -58,7 +58,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SetupCompleteController.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/SetupCompleteController.php#L66)
+- [SetupCompleteController.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/SetupCompleteController.php#L66)
 
 ## woocommerce_gla_attribute_applicable_product_types_
 
@@ -66,8 +66,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L295](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/Attributes/AttributeManager.php#L295)
-- [AttributesForm.php#L98](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Product/Attributes/AttributesForm.php#L98)
+- [AttributesForm.php#L98](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Product/Attributes/AttributesForm.php#L98)
+- [AttributeManager.php#L295](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/Attributes/AttributeManager.php#L295)
 
 ## woocommerce_gla_attribute_hidden_product_types_
 
@@ -75,7 +75,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Product/Attributes/AttributesForm.php#L103)
+- [AttributesForm.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Product/Attributes/AttributesForm.php#L103)
 
 ## woocommerce_gla_attribute_mapping_sources
 
@@ -83,7 +83,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
+- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
 
 ## woocommerce_gla_attribute_mapping_sources_custom_attributes
 
@@ -91,7 +91,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
+- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
 
 ## woocommerce_gla_attribute_mapping_sources_global_attributes
 
@@ -99,7 +99,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
+- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
 
 ## woocommerce_gla_attribute_mapping_sources_product_fields
 
@@ -107,7 +107,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
+- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
 
 ## woocommerce_gla_attribute_mapping_sources_taxonomies
 
@@ -115,7 +115,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
+- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
 
 ## woocommerce_gla_attributes_tab_applicable_product_types
 
@@ -123,7 +123,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesTrait.php#L18](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Product/Attributes/AttributesTrait.php#L18)
+- [AttributesTrait.php#L18](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Product/Attributes/AttributesTrait.php#L18)
 
 ## woocommerce_gla_batch_deleted_products
 
@@ -131,7 +131,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L229)
+- [ProductSyncer.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L229)
 
 ## woocommerce_gla_batch_retry_delete_products
 
@@ -139,7 +139,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L343](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L343)
+- [ProductSyncer.php#L343](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L343)
 
 ## woocommerce_gla_batch_retry_update_products
 
@@ -147,7 +147,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L287](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L287)
+- [ProductSyncer.php#L287](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L287)
 
 ## woocommerce_gla_batch_updated_products
 
@@ -155,7 +155,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L143)
+- [ProductSyncer.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L143)
 
 ## woocommerce_gla_batched_job_size
 
@@ -163,8 +163,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
-- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/UpdateSyncableProductsCount.php#L74)
+- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/UpdateSyncableProductsCount.php#L74)
+- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
 
 ## woocommerce_gla_bulk_update_coupon
 
@@ -172,7 +172,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponBulkEdit.php#L133](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/BulkEdit/CouponBulkEdit.php#L133)
+- [CouponBulkEdit.php#L133](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/BulkEdit/CouponBulkEdit.php#L133)
 
 ## woocommerce_gla_conversion_action_name
 
@@ -180,7 +180,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsConversionAction.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/AdsConversionAction.php#L67)
+- [AdsConversionAction.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/AdsConversionAction.php#L67)
 
 ## woocommerce_gla_coupon_destinations
 
@@ -188,7 +188,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCCouponAdapter.php#L391](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/WCCouponAdapter.php#L391)
+- [WCCouponAdapter.php#L391](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/WCCouponAdapter.php#L391)
 
 ## woocommerce_gla_coupons_delete_retry_on_failure
 
@@ -196,7 +196,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L438](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L438)
+- [CouponSyncer.php#L438](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L438)
 
 ## woocommerce_gla_coupons_update_retry_on_failure
 
@@ -204,7 +204,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L400](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L400)
+- [CouponSyncer.php#L400](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L400)
 
 ## woocommerce_gla_custom_merchant_issues
 
@@ -212,7 +212,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L538](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L538)
+- [MerchantStatuses.php#L538](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L538)
 
 ## woocommerce_gla_debug_message
 
@@ -220,39 +220,39 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L149](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L149)
-- [ProductSyncer.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L159)
-- [ProductSyncer.php#L235](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L235)
-- [ProductSyncer.php#L245](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L245)
-- [BatchProductHelper.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/BatchProductHelper.php#L208)
-- [BatchProductHelper.php#L231](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/BatchProductHelper.php#L231)
-- [SyncerHooks.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/SyncerHooks.php#L197)
-- [ProductRepository.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductRepository.php#L315)
-- [WCProductAdapter.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L205)
-- [ProductHelper.php#L483](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L483)
-- [ProductHelper.php#L516](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L516)
-- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/CleanupSyncedProducts.php#L74)
-- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/ActionSchedulerJobMonitor.php#L117)
-- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/ActionSchedulerJobMonitor.php#L126)
-- [SyncerHooks.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/SyncerHooks.php#L178)
-- [CouponHelper.php#L257](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponHelper.php#L257)
-- [CouponHelper.php#L294](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponHelper.php#L294)
-- [CouponSyncer.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L103)
-- [CouponSyncer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L116)
-- [CouponSyncer.php#L141](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L141)
-- [CouponSyncer.php#L155](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L155)
-- [CouponSyncer.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L172)
-- [CouponSyncer.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L195)
-- [CouponSyncer.php#L260](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L260)
-- [CouponSyncer.php#L309](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L309)
-- [CouponSyncer.php#L328](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L328)
-- [IssuesController.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L95)
-- [ProductMetaQueryHelper.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/DB/ProductMetaQueryHelper.php#L109)
-- [ProductMetaQueryHelper.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/DB/ProductMetaQueryHelper.php#L140)
-- [MerchantCenterService.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantCenterService.php#L305)
-- [MerchantStatuses.php#L413](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L413)
-- [MerchantStatuses.php#L667](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L667)
-- [MerchantStatuses.php#L916](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L916)
+- [SyncerHooks.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/SyncerHooks.php#L178)
+- [CouponHelper.php#L257](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponHelper.php#L257)
+- [CouponHelper.php#L294](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponHelper.php#L294)
+- [CouponSyncer.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L103)
+- [CouponSyncer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L116)
+- [CouponSyncer.php#L141](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L141)
+- [CouponSyncer.php#L155](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L155)
+- [CouponSyncer.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L172)
+- [CouponSyncer.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L195)
+- [CouponSyncer.php#L260](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L260)
+- [CouponSyncer.php#L309](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L309)
+- [CouponSyncer.php#L328](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L328)
+- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/ActionSchedulerJobMonitor.php#L117)
+- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/ActionSchedulerJobMonitor.php#L126)
+- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/CleanupSyncedProducts.php#L74)
+- [ProductMetaQueryHelper.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/DB/ProductMetaQueryHelper.php#L109)
+- [ProductMetaQueryHelper.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/DB/ProductMetaQueryHelper.php#L140)
+- [IssuesController.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L95)
+- [MerchantCenterService.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantCenterService.php#L305)
+- [MerchantStatuses.php#L413](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L413)
+- [MerchantStatuses.php#L667](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L667)
+- [MerchantStatuses.php#L916](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L916)
+- [BatchProductHelper.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/BatchProductHelper.php#L208)
+- [BatchProductHelper.php#L231](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/BatchProductHelper.php#L231)
+- [ProductSyncer.php#L149](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L149)
+- [ProductSyncer.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L159)
+- [ProductSyncer.php#L235](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L235)
+- [ProductSyncer.php#L245](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L245)
+- [ProductRepository.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductRepository.php#L315)
+- [WCProductAdapter.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L205)
+- [SyncerHooks.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/SyncerHooks.php#L197)
+- [ProductHelper.php#L483](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L483)
+- [ProductHelper.php#L516](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L516)
 
 ## woocommerce_gla_deleted_promotions
 
@@ -260,7 +260,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L322](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L322)
+- [CouponSyncer.php#L322](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L322)
 
 ## woocommerce_gla_dimension_unit
 
@@ -268,7 +268,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L431](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L431)
+- [WCProductAdapter.php#L431](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L431)
 
 ## woocommerce_gla_disable_gtag_tracking
 
@@ -276,7 +276,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L526](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Google/GlobalSiteTag.php#L526)
+- [GlobalSiteTag.php#L526](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Google/GlobalSiteTag.php#L526)
 
 ## woocommerce_gla_enable_connection_test
 
@@ -284,7 +284,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ConnectionTest.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/ConnectionTest.php#L87)
+- [ConnectionTest.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/ConnectionTest.php#L87)
 
 ## woocommerce_gla_enable_debug_logging
 
@@ -292,7 +292,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Logging/DebugLogger.php#L33)
+- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Logging/DebugLogger.php#L33)
 
 ## woocommerce_gla_enable_mcm
 
@@ -300,7 +300,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GLAChannel.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MultichannelMarketing/GLAChannel.php#L75)
+- [GLAChannel.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MultichannelMarketing/GLAChannel.php#L75)
 
 ## woocommerce_gla_enable_reports
 
@@ -308,7 +308,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Admin.php#L271](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Admin.php#L271)
+- [Admin.php#L271](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Admin.php#L271)
 
 ## woocommerce_gla_error
 
@@ -316,23 +316,23 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L290](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L290)
-- [ProductSyncer.php#L313](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L313)
-- [ProductSyncer.php#L346](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L346)
-- [ProductSyncer.php#L361](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L361)
-- [BatchProductHelper.php#L248](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/BatchProductHelper.php#L248)
-- [ProductMetaHandler.php#L173](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductMetaHandler.php#L173)
-- [AttributeManager.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/Attributes/AttributeManager.php#L269)
-- [ProductHelper.php#L375](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L375)
-- [ProductHelper.php#L592](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L592)
-- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponMetaHandler.php#L220)
-- [CouponSyncer.php#L410](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L410)
-- [CouponSyncer.php#L448](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L448)
-- [CouponSyncer.php#L466](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L466)
-- [ProductMetaQueryHelper.php#L156](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/DB/ProductMetaQueryHelper.php#L156)
-- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/View/PHPView.php#L136)
-- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/View/PHPView.php#L164)
-- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/View/PHPView.php#L208)
+- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponMetaHandler.php#L220)
+- [CouponSyncer.php#L410](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L410)
+- [CouponSyncer.php#L448](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L448)
+- [CouponSyncer.php#L466](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L466)
+- [ProductMetaQueryHelper.php#L156](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/DB/ProductMetaQueryHelper.php#L156)
+- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/View/PHPView.php#L136)
+- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/View/PHPView.php#L164)
+- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/View/PHPView.php#L208)
+- [BatchProductHelper.php#L248](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/BatchProductHelper.php#L248)
+- [ProductSyncer.php#L290](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L290)
+- [ProductSyncer.php#L313](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L313)
+- [ProductSyncer.php#L346](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L346)
+- [ProductSyncer.php#L361](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L361)
+- [ProductMetaHandler.php#L173](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductMetaHandler.php#L173)
+- [AttributeManager.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/Attributes/AttributeManager.php#L269)
+- [ProductHelper.php#L375](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L375)
+- [ProductHelper.php#L592](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L592)
 
 ## woocommerce_gla_exception
 
@@ -340,30 +340,30 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
-- [ProductSyncer.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L134)
-- [ProductSyncer.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L220)
-- [ProductHelper.php#L257](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L257)
-- [PluginUpdate.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/Update/PluginUpdate.php#L75)
-- [CouponSyncer.php#L203](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L203)
-- [CouponSyncer.php#L293](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L293)
-- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
-- [SettingsSyncController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L96)
-- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
-- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L95)
-- [Middleware.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L455)
-- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Input/DateTime.php#L44)
-- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Input/DateTime.php#L80)
-- [CouponChannelVisibilityMetaBox.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197)
-- [ChannelVisibilityMetaBox.php#L176](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L176)
-- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/View/PHPView.php#L87)
-- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Integration/WooCommercePreOrders.php#L111)
-- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Integration/WooCommercePreOrders.php#L131)
-- [GoogleServiceProvider.php#L234](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Internal/DependencyManagement/GoogleServiceProvider.php#L234)
-- [GoogleServiceProvider.php#L244](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Internal/DependencyManagement/GoogleServiceProvider.php#L244)
-- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Event/ClearProductStatsCache.php#L61)
-- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Notes/NoteInitializer.php#L74)
-- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Notes/NoteInitializer.php#L116)
+- [GoogleServiceProvider.php#L234](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Internal/DependencyManagement/GoogleServiceProvider.php#L234)
+- [GoogleServiceProvider.php#L244](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Internal/DependencyManagement/GoogleServiceProvider.php#L244)
+- [CouponSyncer.php#L203](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L203)
+- [CouponSyncer.php#L293](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L293)
+- [PluginUpdate.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/Update/PluginUpdate.php#L75)
+- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Event/ClearProductStatsCache.php#L61)
+- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Input/DateTime.php#L44)
+- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Input/DateTime.php#L80)
+- [CouponChannelVisibilityMetaBox.php#L197](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L197)
+- [ChannelVisibilityMetaBox.php#L176](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L176)
+- [SettingsSyncController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L96)
+- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
+- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
+- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L95)
+- [Middleware.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L455)
+- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/View/PHPView.php#L87)
+- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Notes/NoteInitializer.php#L74)
+- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Notes/NoteInitializer.php#L116)
+- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
+- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Integration/WooCommercePreOrders.php#L111)
+- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Integration/WooCommercePreOrders.php#L131)
+- [ProductSyncer.php#L134](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L134)
+- [ProductSyncer.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L220)
+- [ProductHelper.php#L257](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L257)
 
 ## woocommerce_gla_force_run_install
 
@@ -371,7 +371,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Installer.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Installer.php#L82)
+- [Installer.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Installer.php#L82)
 
 ## woocommerce_gla_get_google_product_offer_id
 
@@ -379,7 +379,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L284)
+- [WCProductAdapter.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L284)
 
 ## woocommerce_gla_get_sync_ready_products_filter
 
@@ -387,7 +387,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductFilter.php#L61)
+- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductFilter.php#L61)
 
 ## woocommerce_gla_get_sync_ready_products_pre_filter
 
@@ -395,7 +395,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductFilter.php#L47)
+- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductFilter.php#L47)
 
 ## woocommerce_gla_get_wc_product_id
 
@@ -403,7 +403,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L302)
+- [ProductHelper.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L302)
 
 ## woocommerce_gla_gtag_consent
 
@@ -411,7 +411,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Google/GlobalSiteTag.php#L302)
+- [GlobalSiteTag.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Google/GlobalSiteTag.php#L302)
 
 ## woocommerce_gla_guzzle_client_exception
 
@@ -419,20 +419,20 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L70)
-- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L91)
-- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L126)
-- [Middleware.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L80)
-- [Middleware.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L178)
-- [Middleware.php#L228](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L228)
-- [Middleware.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L273)
-- [Middleware.php#L344](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L344)
-- [Middleware.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L394)
-- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L418)
-- [Middleware.php#L452](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L452)
-- [Middleware.php#L554](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L554)
-- [Middleware.php#L614](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L614)
-- [GoogleServiceProvider.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Internal/DependencyManagement/GoogleServiceProvider.php#L263)
+- [GoogleServiceProvider.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Internal/DependencyManagement/GoogleServiceProvider.php#L263)
+- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L70)
+- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L91)
+- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L126)
+- [Middleware.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L80)
+- [Middleware.php#L178](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L178)
+- [Middleware.php#L228](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L228)
+- [Middleware.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L273)
+- [Middleware.php#L344](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L344)
+- [Middleware.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L394)
+- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L418)
+- [Middleware.php#L452](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L452)
+- [Middleware.php#L554](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L554)
+- [Middleware.php#L614](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L614)
 
 ## woocommerce_gla_guzzle_invalid_response
 
@@ -440,15 +440,15 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L66)
-- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Connection.php#L121)
-- [Middleware.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L159)
-- [Middleware.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L223)
-- [Middleware.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L267)
-- [Middleware.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L339)
-- [Middleware.php#L389](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L389)
-- [Middleware.php#L550](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L550)
-- [Middleware.php#L602](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L602)
+- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L66)
+- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Connection.php#L121)
+- [Middleware.php#L159](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L159)
+- [Middleware.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L223)
+- [Middleware.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L267)
+- [Middleware.php#L339](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L339)
+- [Middleware.php#L389](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L389)
+- [Middleware.php#L550](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L550)
+- [Middleware.php#L602](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L602)
 
 ## woocommerce_gla_handle_shipping_method_to_rates
 
@@ -456,7 +456,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ZoneMethodsParser.php#L106](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Shipping/ZoneMethodsParser.php#L106)
+- [ZoneMethodsParser.php#L106](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Shipping/ZoneMethodsParser.php#L106)
 
 ## woocommerce_gla_hidden_coupon_types
 
@@ -464,7 +464,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L379](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L379)
+- [CouponSyncer.php#L379](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L379)
 
 ## woocommerce_gla_job_failure_rate_threshold
 
@@ -472,7 +472,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/ActionSchedulerJobMonitor.php#L186)
+- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/ActionSchedulerJobMonitor.php#L186)
 
 ## woocommerce_gla_job_failure_timeframe
 
@@ -480,7 +480,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Jobs/ActionSchedulerJobMonitor.php#L195)
+- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Jobs/ActionSchedulerJobMonitor.php#L195)
 
 ## woocommerce_gla_mapping_rules_change
 
@@ -488,9 +488,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
-- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
-- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
+- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
+- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
+- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
 
 ## woocommerce_gla_mc_account_review_lifetime
 
@@ -498,7 +498,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewStatuses.php#L156](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Google/RequestReviewStatuses.php#L156)
+- [RequestReviewStatuses.php#L156](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Google/RequestReviewStatuses.php#L156)
 
 ## woocommerce_gla_mc_client_exception
 
@@ -506,15 +506,15 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantReport.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/MerchantReport.php#L115)
-- [MerchantReport.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/MerchantReport.php#L183)
-- [Merchant.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L92)
-- [Merchant.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L140)
-- [Merchant.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L172)
-- [Merchant.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L191)
-- [Merchant.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L247)
-- [Merchant.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L292)
-- [Merchant.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L354)
+- [Merchant.php#L92](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L92)
+- [Merchant.php#L140](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L140)
+- [Merchant.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L172)
+- [Merchant.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L191)
+- [Merchant.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L247)
+- [Merchant.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L292)
+- [Merchant.php#L354](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L354)
+- [MerchantReport.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/MerchantReport.php#L115)
+- [MerchantReport.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/MerchantReport.php#L183)
 
 ## woocommerce_gla_mc_settings_sync
 
@@ -522,7 +522,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
+- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
 
 ## woocommerce_gla_mc_status_lifetime
 
@@ -530,7 +530,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L935](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L935)
+- [MerchantStatuses.php#L935](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L935)
 
 ## woocommerce_gla_merchant_issue_override
 
@@ -538,7 +538,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IssuesController.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L85)
+- [IssuesController.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L85)
 
 ## woocommerce_gla_merchant_status_presync_issues_chunk
 
@@ -546,7 +546,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L596](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantStatuses.php#L596)
+- [MerchantStatuses.php#L596](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantStatuses.php#L596)
 
 ## woocommerce_gla_options_deleted_
 
@@ -554,7 +554,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Options/Options.php#L103)
+- [Options.php#L103](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Options/Options.php#L103)
 
 ## woocommerce_gla_options_updated_
 
@@ -562,8 +562,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Options/Options.php#L65)
-- [Options.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Options/Options.php#L85)
+- [Options.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Options/Options.php#L65)
+- [Options.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Options/Options.php#L85)
 
 ## woocommerce_gla_prepared_response_->GET_ROUTE_NAME
 
@@ -571,7 +571,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BaseController.php#L160](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/BaseController.php#L160)
+- [BaseController.php#L160](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/BaseController.php#L160)
 
 ## woocommerce_gla_product_attribute_types
 
@@ -579,7 +579,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/Attributes/AttributeManager.php#L243)
+- [AttributeManager.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/Attributes/AttributeManager.php#L243)
 
 ## woocommerce_gla_product_attribute_value_
 
@@ -587,8 +587,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L916](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L916)
-- [WCProductAdapter.php#L967](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L967)
+- [WCProductAdapter.php#L916](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L916)
+- [WCProductAdapter.php#L967](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L967)
 
 ## woocommerce_gla_product_attribute_value_description
 
@@ -596,7 +596,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L352](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L352)
+- [WCProductAdapter.php#L352](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L352)
 
 ## woocommerce_gla_product_attribute_value_options_::get_id
 
@@ -604,7 +604,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Admin/Product/Attributes/AttributesForm.php#L127)
+- [AttributesForm.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Admin/Product/Attributes/AttributesForm.php#L127)
 
 ## woocommerce_gla_product_attribute_value_price
 
@@ -612,7 +612,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L640](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L640)
+- [WCProductAdapter.php#L640](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L640)
 
 ## woocommerce_gla_product_attribute_value_sale_price
 
@@ -620,7 +620,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L692](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L692)
+- [WCProductAdapter.php#L692](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L692)
 
 ## woocommerce_gla_product_attribute_values
 
@@ -628,7 +628,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L166)
+- [WCProductAdapter.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L166)
 
 ## woocommerce_gla_product_description_apply_shortcodes
 
@@ -636,7 +636,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L321)
+- [WCProductAdapter.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L321)
 
 ## woocommerce_gla_product_property_value_is_virtual
 
@@ -644,7 +644,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L782](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L782)
+- [WCProductAdapter.php#L782](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L782)
 
 ## woocommerce_gla_product_query_args
 
@@ -652,7 +652,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductRepository.php#L376](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductRepository.php#L376)
+- [ProductRepository.php#L376](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductRepository.php#L376)
 
 ## woocommerce_gla_product_view_report_page_size
 
@@ -660,7 +660,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantReport.php#L68](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/MerchantReport.php#L68)
+- [MerchantReport.php#L68](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/MerchantReport.php#L68)
 
 ## woocommerce_gla_products_delete_retry_on_failure
 
@@ -668,7 +668,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L342](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L342)
+- [ProductSyncer.php#L342](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L342)
 
 ## woocommerce_gla_products_update_retry_on_failure
 
@@ -676,7 +676,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L286](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L286)
+- [ProductSyncer.php#L286](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L286)
 
 ## woocommerce_gla_ready_for_syncing
 
@@ -684,7 +684,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantCenterService.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/MerchantCenterService.php#L118)
+- [MerchantCenterService.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/MerchantCenterService.php#L118)
 
 ## woocommerce_gla_request_review_failure
 
@@ -692,9 +692,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewController.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110)
-- [RequestReviewController.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122)
-- [Middleware.php#L595](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L595)
+- [RequestReviewController.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L110)
+- [RequestReviewController.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L122)
+- [Middleware.php#L595](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L595)
 
 ## woocommerce_gla_request_review_response
 
@@ -702,7 +702,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Middleware.php#L547](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L547)
+- [Middleware.php#L547](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L547)
 
 ## woocommerce_gla_retry_delete_coupons
 
@@ -710,7 +710,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L443](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L443)
+- [CouponSyncer.php#L443](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L443)
 
 ## woocommerce_gla_retry_update_coupons
 
@@ -718,7 +718,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L405](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L405)
+- [CouponSyncer.php#L405](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L405)
 
 ## woocommerce_gla_site_claim_failure
 
@@ -726,10 +726,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L93)
-- [Middleware.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L268)
-- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L274)
-- [AccountService.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/AccountService.php#L365)
+- [Merchant.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L93)
+- [Middleware.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L268)
+- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L274)
+- [AccountService.php#L365](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/AccountService.php#L365)
 
 ## woocommerce_gla_site_claim_overwrite_required
 
@@ -737,7 +737,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/AccountService.php#L360)
+- [AccountService.php#L360](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/AccountService.php#L360)
 
 ## woocommerce_gla_site_claim_success
 
@@ -745,8 +745,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Merchant.php#L90)
-- [Middleware.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/Middleware.php#L263)
+- [Merchant.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Merchant.php#L90)
+- [Middleware.php#L263](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/Middleware.php#L263)
 
 ## woocommerce_gla_site_url
 
@@ -754,7 +754,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/PluginHelper.php#L188)
+- [PluginHelper.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/PluginHelper.php#L188)
 
 ## woocommerce_gla_site_verify_failure
 
@@ -762,9 +762,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L58)
-- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L66)
-- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L87)
+- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L58)
+- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L66)
+- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L87)
 
 ## woocommerce_gla_site_verify_success
 
@@ -772,7 +772,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L85)
+- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L85)
 
 ## woocommerce_gla_supported_coupon_types
 
@@ -780,7 +780,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L366](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L366)
+- [CouponSyncer.php#L366](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L366)
 
 ## woocommerce_gla_supported_product_types
 
@@ -788,7 +788,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L264](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductSyncer.php#L264)
+- [ProductSyncer.php#L264](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductSyncer.php#L264)
 
 ## woocommerce_gla_sv_client_exception
 
@@ -796,8 +796,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L120)
-- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Google/SiteVerification.php#L162)
+- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L120)
+- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Google/SiteVerification.php#L162)
 
 ## woocommerce_gla_tax_excluded
 
@@ -805,7 +805,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L601](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L601)
+- [WCProductAdapter.php#L601](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L601)
 
 ## woocommerce_gla_track_event
 
@@ -813,11 +813,11 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SetupCompleteController.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/SetupCompleteController.php#L75)
-- [CampaignController.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/CampaignController.php#L151)
-- [CampaignController.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/CampaignController.php#L229)
-- [CampaignController.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/Ads/CampaignController.php#L267)
-- [SettingsSyncController.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L83)
+- [SetupCompleteController.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/SetupCompleteController.php#L75)
+- [CampaignController.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/CampaignController.php#L151)
+- [CampaignController.php#L229](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/CampaignController.php#L229)
+- [CampaignController.php#L267](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/Ads/CampaignController.php#L267)
+- [SettingsSyncController.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L83)
 
 ## woocommerce_gla_updated_coupon
 
@@ -825,7 +825,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Coupon/CouponSyncer.php#L169)
+- [CouponSyncer.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Coupon/CouponSyncer.php#L169)
 
 ## woocommerce_gla_url_switch_required
 
@@ -833,7 +833,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/AccountService.php#L445)
+- [AccountService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/AccountService.php#L445)
 
 ## woocommerce_gla_url_switch_success
 
@@ -841,7 +841,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L468](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/MerchantCenter/AccountService.php#L468)
+- [AccountService.php#L468](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/MerchantCenter/AccountService.php#L468)
 
 ## woocommerce_gla_use_short_description
 
@@ -849,7 +849,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L298)
+- [WCProductAdapter.php#L298](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L298)
 
 ## woocommerce_gla_wcs_url
 
@@ -857,8 +857,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/PluginHelper.php#L174)
-- [PluginHelper.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/PluginHelper.php#L177)
+- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/PluginHelper.php#L174)
+- [PluginHelper.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/PluginHelper.php#L177)
 
 ## woocommerce_gla_weight_unit
 
@@ -866,7 +866,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductAdapter.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/WCProductAdapter.php#L432)
+- [WCProductAdapter.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/WCProductAdapter.php#L432)
 
 ## woocommerce_hide_invisible_variations
 
@@ -874,5 +874,5 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L390](https://github.com/woocommerce/google-listings-and-ads/blob/718b8cfc612f2dd94e0390c79856326bbed44616/src/Product/ProductHelper.php#L390)
+- [ProductHelper.php#L390](https://github.com/woocommerce/google-listings-and-ads/blob/e92dba1129d0538d26b7cb459d6c2f147c9e17ad/src/Product/ProductHelper.php#L390)
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2218 

This PR upgrades the workflows in GitHub Actions to use Node.js v20.

### Detailed test instructions:

1. View the [Checks](https://github.com/woocommerce/google-listings-and-ads/pull/2404/checks) tab to check if all checks have passed and if there are no longer deprecated warnings about Node.js <= 16
2. View the [E2E Tests result](https://github.com/woocommerce/google-listings-and-ads/actions/runs/9110477176) that is not listed in the Checks tab
3. The rest of workflows that can't be viewed in this PR have basically been verified during development, if one wants to view them, please find the corresponding development RP in https://github.com/woocommerce/grow/issues/108

### Changelog entry
