### PR TITLE
Add Integration Status Report for the partner integration. 

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -863,7 +863,7 @@ class ConnectionTest implements Service, Registerable {
 			$integration_status_args = [
 				'method'  => 'GET',
 				'timeout' => 30,
-				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/remote-site-status?partner=google&XDEBUG_SESSION_START=XDEBUG_OMATTIC',
+				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/remote-site-status?partner=google',
 				'user_id' => get_current_user_id(),
 			];
 

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -863,17 +863,22 @@ class ConnectionTest implements Service, Registerable {
 			$integration_status_args = [
 				'method'  => 'GET',
 				'timeout' => 30,
-				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/remote-site-status?partner=google',
+				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/google/remote-site-status',
 				'user_id' => get_current_user_id(),
 			];
 
 			$integration_remote_request_response = Client::remote_request( $integration_status_args, null );
 
-			if ( is_wp_error( $this->integration_status_response ) ) {
-				$this->integration_status_response['errors']['request_error'] = $integration_remote_request_response->get_error_message();
+			if ( is_wp_error( $integration_remote_request_response ) ) {
+				$this->response .= $integration_remote_request_response->get_error_message();
 			} else {
 				$this->integration_status_response = json_decode( wp_remote_retrieve_body( $integration_remote_request_response ), true ) ?? [];
+
+				if ( json_last_error() || ! isset( $this->integration_status_response['site'] ) ) {
+					$this->response .= wp_remote_retrieve_body( $integration_remote_request_response );
+				}
 			}
+
 		}
 
 		if ( 'disconnect-wp-api' === $_GET['action'] && check_admin_referer( 'disconnect-wp-api' ) ) {

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
@@ -81,6 +82,13 @@ class ConnectionTest implements Service, Registerable {
 	 * @var string
 	 */
 	protected $response = '';
+
+	/**
+	 * Store response from the integration status API request.
+	 *
+	 * @var string
+	 */
+	protected $integration_status_response = [];
 
 	/**
 	 * Add menu entries
@@ -682,6 +690,64 @@ class ConnectionTest implements Service, Registerable {
 								</p>
 							</td>
 						</tr>
+						<tr>
+							<th><label>API Pull Integration Status:</label></th>
+							<td>
+								<p>									
+									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'partner-integration-status' ], $url ), 'partner-integration-status' ) ); ?>">Get API Pull Integration Status</a>
+								</p>
+							</td>
+						</tr>
+						<?php if ( isset( $this->integration_status_response['site'] ) || isset( $this->integration_status_response['errors'] ) ) { ?>
+							<tr>
+								<th><label>Site:</label></th>
+								<td>
+									<p>
+										<code><?php echo $this->integration_status_response['site'] ?? ''; ?></code>
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<th><label>Jetpack Connection Health:</label></th>
+								<td>
+									<p>
+										<code><?php echo isset( $this->integration_status_response['is_healthy'] ) && $this->integration_status_response['is_healthy'] === true ? 'Healthy' : 'Unhealthy'; ?></code>
+									</p>
+								</td>
+							</tr>	
+							<tr>
+								<th><label>Last Jetpack Contact:</label></th>
+								<td>
+									<p>
+										<code><?php echo isset( $this->integration_status_response['last_jetpack_contact'] ) ? date( 'Y-m-d H:i:s', $this->integration_status_response['last_jetpack_contact'] ) : '-'; ?></code>
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<th><label>WC REST API Health:</label></th>
+								<td>
+									<p>
+										<code><?php echo isset( $this->integration_status_response['is_wc_rest_api_healthy'] ) && $this->integration_status_response['is_wc_rest_api_healthy'] === true ? 'Healthy' : 'Unhealthy'; ?></code>
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<th><label>Google token health:</label></th>
+								<td>
+									<p>
+										<code><?php echo isset( $this->integration_status_response['is_partner_token_healthy'] ) && $this->integration_status_response['is_partner_token_healthy'] === true ? 'Connected' : 'Disconnected'; ?></code>
+									</p>
+								</td>
+							</tr>
+							<tr>
+								<th><label>Errors:</label></th>
+								<td>
+									<p>
+										<code><?php echo isset( $this->integration_status_response['errors'] ) ? wp_kses_post( json_encode( $this->integration_status_response['errors'] ) ) ?? '' : '-'; ?></code>
+									</p>
+								</td>
+							</tr>																																
+						<?php } ?>
 					</table>
 					<?php wp_nonce_field( 'partner-notification' ); ?>
 					<input name="page" value="connection-test-admin-page" type="hidden" />
@@ -790,6 +856,24 @@ class ConnectionTest implements Service, Registerable {
 			}
 
 			return;
+		}
+
+		if ( 'partner-integration-status' === $_GET['action'] && check_admin_referer( 'partner-integration-status' ) ) {
+
+			$integration_status_args = [
+				'method'  => 'GET',
+				'timeout' => 30,
+				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/remote-site-status?partner=google&XDEBUG_SESSION_START=XDEBUG_OMATTIC',
+				'user_id' => get_current_user_id(),
+			];
+
+			$integration_remote_request_response = Client::remote_request( $integration_status_args, null );
+
+			if ( is_wp_error( $this->integration_status_response ) ) {
+				$this->integration_status_response['errors']['request_error'] = $integration_remote_request_response->get_error_message();
+			} else {
+				$this->integration_status_response = json_decode( wp_remote_retrieve_body( $integration_remote_request_response ), true ) ?? [];
+			}
 		}
 
 		if ( 'disconnect-wp-api' === $_GET['action'] && check_admin_referer( 'disconnect-wp-api' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR adds a section to the connection test page that displays the status of the following points:

- **Jetpack Connection Health**: Indicates whether the Jetpack connection between WPCOM and the remote site is healthy. This involves a series of checks, such as communicating with the blog via XML-RPC and REST, and verifying that the blog owner exists and is a site member.
- **Last Jetpack Contact**: Shows the last time Jetpack was in contact with the remote site.
- **WC REST API Health**: Tests if WPCOM can access the WC REST API. Currently, it checks the /wc/v3/products endpoint, with the possibility of testing other endpoints in the future.
- **Google Token Health**: Displays whether there is a valid WPCOM token with the correct access scope linked to the Google WPCOM client ID and the user connected to the Jetpack token.
-  **Errors**: Shows the errors returned by WPCOM.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/0f288cc7-5d71-4368-afd5-e58d77f84910)


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Apply the WPCOM Diff `D149450`
2. Go to the Connection Test Page
3. Click "Get API Pull Integration Status"
4. Check the results align with your current setup. For instance:
 -  Changing the Google Client ID in Diff `D149450`,
 -  Make your site unreachable by disconnecting Ngrok.
 -  Make WC REST API Products unreachable by changing the endpoint here: 

https://github.com/woocommerce/woocommerce/blob/42f693d8b2ca848a0e62b8ac3bed569db3995283/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php#L64
- Throw an error in the following method: 

https://github.com/woocommerce/google-listings-and-ads/blob/d6898e0ee7be7f3fb6007551ea71cc501730e403/src/Integration/WPCOMProxy.php#L300-L302


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
