### PR TITLE
Add remove partner token section in the Connection Test page

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -889,7 +889,7 @@ class ConnectionTest implements Service, Registerable {
 			$revoke_args = [
 				'method'  => 'DELETE',
 				'timeout' => 30,
-				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/revoke-token/google',
+				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/google/revoke-token',
 				'user_id' => get_current_user_id(),
 			];
 

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -748,6 +748,14 @@ class ConnectionTest implements Service, Registerable {
 								</td>
 							</tr>																																
 						<?php } ?>
+						<tr>
+							<th><label>Revoke WPCOM Partner Access:</label></th>
+							<td>
+								<p>									
+									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'revoke-wpcom-partner-access' ], $url ), 'revoke-wpcom-partner-access' ) ); ?>">Revoke WPCOM Partner Access</a>
+								</p>
+							</td>
+						</tr>
 					</table>
 					<?php wp_nonce_field( 'partner-notification' ); ?>
 					<input name="page" value="connection-test-admin-page" type="hidden" />
@@ -863,7 +871,7 @@ class ConnectionTest implements Service, Registerable {
 			$integration_status_args = [
 				'method'  => 'GET',
 				'timeout' => 30,
-				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/remote-site-status?partner=google',
+				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/remote-site-status?partner=google&XDEBUG_SESSION_START=XDEBUG_OMATTIC',
 				'user_id' => get_current_user_id(),
 			];
 
@@ -873,6 +881,24 @@ class ConnectionTest implements Service, Registerable {
 				$this->integration_status_response['errors']['request_error'] = $integration_remote_request_response->get_error_message();
 			} else {
 				$this->integration_status_response = json_decode( wp_remote_retrieve_body( $integration_remote_request_response ), true ) ?? [];
+			}
+		}
+
+		if ( 'revoke-wpcom-partner-access' === $_GET['action'] && check_admin_referer( 'revoke-wpcom-partner-access' ) ) {
+
+			$revoke_args = [
+				'method'  => 'DELETE',
+				'timeout' => 30,
+				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/revoke-token/google',
+				'user_id' => get_current_user_id(),
+			];
+
+			$revoke_response = Client::remote_request( $revoke_args, null );
+
+			if ( is_wp_error( $revoke_response ) ) {
+				$this->response .= $revoke_response->get_error_message();
+			} else {
+				$this->response .= wp_remote_retrieve_body( $revoke_response );
 			}
 		}
 

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -871,7 +871,7 @@ class ConnectionTest implements Service, Registerable {
 			$integration_status_args = [
 				'method'  => 'GET',
 				'timeout' => 30,
-				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/remote-site-status?partner=google&XDEBUG_SESSION_START=XDEBUG_OMATTIC',
+				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/remote-site-status?partner=google',
 				'user_id' => get_current_user_id(),
 			];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR adds a section to revoke the WPCOM token associated with the Google client.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/6c61d0eb-7b03-4e3c-8614-7723a8c48198)



### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Apply the WPCOM Diff D149792
2. Go to the Connection Test Page
3. Go to https://wordpress.com/me/security/connected-applications and check that you have your application connected there.
4. Click Revoke WPCOM Partner Access
5. Refresh https://wordpress.com/me/security/connected-applications and see that the connection is gone.
6. If there are not tokens associated you will get the following error `{"code":"wpcom_partner_token_not_associated","message":"No token found associated with the client ID and user.","data":null}`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
