### PR TITLE
Avoid a possible error when linking accounts due to the delay between Google APIs

### DIFF
--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -129,7 +129,7 @@ class Ads implements OptionsAwareInterface {
 	 * @throws Exception When a link is unavailable.
 	 */
 	public function accept_merchant_link( int $merchant_id ) {
-		$link        = $this->get_merchant_link( $merchant_id );
+		$link        = $this->get_merchant_link( $merchant_id, 3 );
 		$link_status = $link->getStatus();
 		if ( $link_status === ProductLinkInvitationStatus::ACCEPTED ) {
 			return;
@@ -325,12 +325,17 @@ class Ads implements OptionsAwareInterface {
 	/**
 	 * Get the link from a merchant account.
 	 *
+	 * The invitation link may not be available in Google Ads immediately after
+	 * the invitation is sent from Google Merchant Center, so this method offers
+	 * a parameter to specify the number of retries.
+	 *
 	 * @param int $merchant_id Merchant Center account id.
+	 * @param int $attempts_left The number of attempts left to get the link.
 	 *
 	 * @return ProductLinkInvitation
 	 * @throws Exception When the merchant link hasn't been created.
 	 */
-	private function get_merchant_link( int $merchant_id ): ProductLinkInvitation {
+	private function get_merchant_link( int $merchant_id, int $attempts_left = 0 ): ProductLinkInvitation {
 		$res = ( new AdsProductLinkInvitationQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
 			->where( 'product_link_invitation.status', [ ProductLinkInvitationStatus::name( ProductLinkInvitationStatus::ACCEPTED ), ProductLinkInvitationStatus::name( ProductLinkInvitationStatus::PENDING_APPROVAL ) ], 'IN' )
@@ -343,6 +348,10 @@ class Ads implements OptionsAwareInterface {
 			if ( absint( $mc_id ) === $merchant_id ) {
 				return $link;
 			}
+		}
+
+		if ( $attempts_left > 0 ) {
+			return $this->get_merchant_link( $merchant_id, $attempts_left - 1 );
 		}
 
 		throw new Exception( __( 'Merchant link is not available to accept', 'google-listings-and-ads' ) );

--- a/tests/Unit/API/Google/AdsTest.php
+++ b/tests/Unit/API/Google/AdsTest.php
@@ -179,6 +179,30 @@ class AdsTest extends UnitTest {
 		$this->ads->accept_merchant_link( self::TEST_MERCHANT_ID );
 	}
 
+	public function test_accept_merchant_link_with_retry_get_merchant_link() {
+		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
+		$link = new ProductLinkInvitation();
+		$mc   = $this->createMock( MerchantCenterLinkInvitationIdentifier::class );
+
+		$mc
+			->expects( $this->exactly( 4 ) )
+			->method( 'getMerchantCenterId' )
+			->willReturnOnConsecutiveCalls(
+				self::TEST_MERCHANT_ID + 3,
+				self::TEST_MERCHANT_ID + 2,
+				self::TEST_MERCHANT_ID + 1,
+				self::TEST_MERCHANT_ID
+			);
+
+		$link->setStatus( ProductLinkInvitationStatus::PENDING_APPROVAL );
+		$link->setMerchantCenter( $mc );
+
+		$service = $this->generate_mc_link_mock( [ $link ] );
+		$service->expects( $this->once() )->method( 'updateProductLinkInvitation' );
+
+		$this->ads->accept_merchant_link( self::TEST_MERCHANT_ID );
+	}
+
 	public function test_accept_merchant_link() {
 		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
 		$link = new ProductLinkInvitation();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PT: pcTzPl-2iK-p2

It's an additional fix for a bug found while testing #2215.

This PR avoids a possible error when linking accounts due to the delay between Google APIs of Google Merchant Center and Google Ads. Please refer to the **Additional details** section for the issue details.

- Add a retry mechanism to the `API\Google\Ads::get_merchant_link` method.

💡 After a few rounds of testing, I could get an invitation link on the first retry in my dev environment, so I set the number of retries to 3.

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/e7e52c1d-cfaf-4ed7-88f3-53417c6259e5

### Detailed test instructions:

1. Disconnect Google Ads account if there is a connected one.
2. Go to step 1 of the onboarding flow.
3. Connect a Google Merchant Center account first.
4. Create a new Google Ads account and claim it.
5. Check if the “Merchant link is not available to accept” error doesn't occur.

### Additional details:

Looks like after updating Google API to v16 (#2386), the invitation link may not be available in Google Ads immediately after the invitation is sent from Google Merchant Center. This may result in a “Merchant link is not available to accept” error when linking to a newly created Google Ads account.

#### The error when linking accounts

![1](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/9ee1bc75-6a35-4bd7-bbeb-eac0b7db01f7)

#### An invitation was sent but left as pending approval

![2](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/9525debb-fd08-4d58-9cdf-a92a86a5a7f1)

#### The way to reproduce the issue

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/bc6b21ca-fdd7-4b8c-9238-aee4dd16fe7f

### Changelog entry

