### PR TITLE
Simplify and enhance the loading state control during the Google Ads account creation and claiming

### DIFF
--- a/js/src/components/google-ads-account-card/claim-account-button.js
+++ b/js/src/components/google-ads-account-card/claim-account-button.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { noop } from 'lodash';
 import { useCallback } from '@wordpress/element';
 
 /**
@@ -10,36 +9,25 @@ import { useCallback } from '@wordpress/element';
  */
 import AppButton from '.~/components/app-button';
 import getWindowFeatures from '.~/utils/getWindowFeatures';
-import LoadingLabel from '.~/components/loading-label';
 import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
 
-const ClaimAccountButton = ( { loading = false, onClaimClick = noop } ) => {
+const ClaimAccountButton = () => {
 	const { inviteLink } = useGoogleAdsAccountStatus();
 
 	const handleClaimAccountClick = useCallback(
 		( event ) => {
-			onClaimClick();
-
 			const { defaultView } = event.target.ownerDocument;
 			const features = getWindowFeatures( defaultView, 600, 800 );
 
 			defaultView.open( inviteLink, '_blank', features );
 		},
-		[ inviteLink, onClaimClick ]
+		[ inviteLink ]
 	);
 
 	return (
-		<>
-			{ loading ? (
-				<LoadingLabel
-					text={ __( 'Waiting…', 'google-listings-and-ads' ) }
-				/>
-			) : (
-				<AppButton isSecondary onClick={ handleClaimAccountClick }>
-					{ __( 'Claim Account', 'google-listings-and-ads' ) }
-				</AppButton>
-			) }
-		</>
+		<AppButton isSecondary onClick={ handleClaimAccountClick }>
+			{ __( 'Claim Account', 'google-listings-and-ads' ) }
+		</AppButton>
 	);
 };
 

--- a/js/src/components/google-ads-account-card/claim-account/index.js
+++ b/js/src/components/google-ads-account-card/claim-account/index.js
@@ -7,11 +7,16 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { useAppDispatch } from '.~/data';
 import Section from '.~/wcdl/section';
+import useWindowFocusCallbackIntervalEffect from '.~/hooks/useWindowFocusCallbackIntervalEffect';
 import DisconnectAccount from '../disconnect-account';
 import './index.scss';
 
 const ClaimAccount = () => {
+	const { fetchGoogleAdsAccountStatus } = useAppDispatch();
+	useWindowFocusCallbackIntervalEffect( fetchGoogleAdsAccountStatus, 30 );
+
 	return (
 		<Fragment>
 			<p className="gla-ads-claim-account-notice">

--- a/js/src/components/google-ads-account-card/create-account-button.js
+++ b/js/src/components/google-ads-account-card/create-account-button.js
@@ -9,7 +9,6 @@ import { useState } from '@wordpress/element';
  */
 import TermsModal from './terms-modal';
 import AppButton from '.~/components/app-button';
-import LoadingLabel from '.~/components/loading-label';
 
 /**
  * Renders a Google Ads account creaton button.
@@ -18,8 +17,7 @@ import LoadingLabel from '.~/components/loading-label';
  * @param {Object} props React props.
  * @param {Function} [props.onCreateAccount] Called after the user accept the terms agreement.
  */
-const CreateAccountButton = ( props ) => {
-	const { onCreateAccount, ...rest } = props;
+const CreateAccountButton = ( { onCreateAccount } ) => {
 	const [ isOpen, setOpen ] = useState( false );
 
 	const handleButtonClick = () => {
@@ -32,18 +30,11 @@ const CreateAccountButton = ( props ) => {
 
 	return (
 		<>
-			{ rest.loading ? (
-				<LoadingLabel
-					text={ __( 'Creating…', 'google-listings-and-ads' ) }
-				/>
-			) : (
-				<AppButton
-					isSecondary
-					{ ...rest }
-					text={ __( 'Create account', 'google-listings-and-ads' ) }
-					onClick={ handleButtonClick }
-				/>
-			) }
+			<AppButton
+				isSecondary
+				text={ __( 'Create account', 'google-listings-and-ads' ) }
+				onClick={ handleButtonClick }
+			/>
 			{ isOpen && (
 				<TermsModal
 					onCreateAccount={ onCreateAccount }

--- a/js/src/components/google-ads-account-card/create-account.js
+++ b/js/src/components/google-ads-account-card/create-account.js
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useCallback, Fragment } from '@wordpress/element';
+import { useState, useEffect, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
 import AccountCard, { APPEARANCE } from '.~/components/account-card';
 import AppButton from '.~/components/app-button';
 import ClaimAccount from './claim-account';
@@ -18,75 +17,50 @@ import Section from '.~/wcdl/section';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
 import useUpsertAdsAccount from '.~/hooks/useUpsertAdsAccount';
-import useWindowFocusCallbackIntervalEffect from '.~/hooks/useWindowFocusCallbackIntervalEffect';
-import LoadingLabel from '../loading-label/loading-label';
 
 const CreateAccount = ( props ) => {
 	const { allowShowExisting, onShowExisting } = props;
 	const [ showClaimModal, setShowClaimModal ] = useState( false );
-	const [ isClaiming, setIsClaiming ] = useState( false );
 	const { googleAdsAccount } = useGoogleAdsAccount();
 	const { hasAccess, step } = useGoogleAdsAccountStatus();
-	const [ upsertAdsAccount, { loading: isUpsertAdsAccountLoading } ] =
-		useUpsertAdsAccount();
+	const [ upsertAdsAccount, { loading, action } ] = useUpsertAdsAccount();
+
 	const shouldClaimGoogleAdsAccount = Boolean(
 		googleAdsAccount.id && hasAccess === false
 	);
 
 	const handleOnRequestClose = () => {
 		setShowClaimModal( false );
-		setIsClaiming( false );
 	};
 
 	const handleOnCreateAccount = async () => {
-		setIsClaiming( true );
 		await upsertAdsAccount();
 		setShowClaimModal( true );
 	};
 
-	const handleOnClaimClick = () => {
-		setIsClaiming( true );
-	};
-
-	const { fetchGoogleAdsAccountStatus } = useAppDispatch();
-
-	const refreshAdsStatus = useCallback( async () => {
-		if ( ! shouldClaimGoogleAdsAccount ) {
-			return false;
-		}
-
-		await fetchGoogleAdsAccountStatus();
-	}, [ fetchGoogleAdsAccountStatus, shouldClaimGoogleAdsAccount ] );
-
-	useWindowFocusCallbackIntervalEffect( refreshAdsStatus, 30 );
-
 	// Update the Ads account once we have access.
 	useEffect( () => {
 		if ( hasAccess === true && step === 'conversion_action' ) {
-			setIsClaiming( false );
 			upsertAdsAccount();
 		}
 	}, [ hasAccess, upsertAdsAccount, step ] );
 
 	const getIndicator = () => {
-		if ( shouldClaimGoogleAdsAccount ) {
-			return (
-				<ClaimAccountButton
-					loading={ isClaiming || showClaimModal }
-					onClaimClick={ handleOnClaimClick }
-				/>
-			);
+		if ( loading ) {
+			const text =
+				action === 'create'
+					? __( 'Creating…', 'google-listings-and-ads' )
+					: __( 'Updating…', 'google-listings-and-ads' );
+
+			return <AppButton loading text={ text } />;
 		}
 
-		return googleAdsAccount.id && isUpsertAdsAccountLoading ? (
-			<LoadingLabel
-				text={ __( 'Updating…', 'google-listings-and-ads' ) }
-			/>
-		) : (
-			<CreateAccountButton
-				onCreateAccount={ handleOnCreateAccount }
-				loading={ isUpsertAdsAccountLoading }
-			/>
+		if ( shouldClaimGoogleAdsAccount ) {
+			return <ClaimAccountButton />;
+		}
+
+		return (
+			<CreateAccountButton onCreateAccount={ handleOnCreateAccount } />
 		);
 	};
 

--- a/js/src/components/google-ads-account-card/create-account.js
+++ b/js/src/components/google-ads-account-card/create-account.js
@@ -72,7 +72,11 @@ const CreateAccount = ( props ) => {
 		>
 			{ allowShowExisting && ! shouldClaimGoogleAdsAccount && (
 				<Section.Card.Footer>
-					<AppButton isLink onClick={ onShowExisting }>
+					<AppButton
+						isLink
+						disabled={ loading }
+						onClick={ onShowExisting }
+					>
 						{ __(
 							'Or, use your existing Google Ads account',
 							'google-listings-and-ads'

--- a/js/src/hooks/useUpsertAdsAccount.js
+++ b/js/src/hooks/useUpsertAdsAccount.js
@@ -62,8 +62,10 @@ const useUpsertAdsAccount = () => {
 		}
 
 		// Update Google Ads data in the data store after posting an account update.
-		await fetchGoogleAdsAccount();
-		await fetchGoogleAdsAccountStatus();
+		await Promise.all( [
+			fetchGoogleAdsAccount(),
+			fetchGoogleAdsAccountStatus(),
+		] );
 
 		setCurrentAction( null );
 	}, [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a pre-processing PR for event tracking to be added for #2215. In this way, the position and timing of adding event tracking could be made more explicit.

- Simplify the loading state control during the Google Ads account creation and claiming.
   - The reason for removing the "Waiting…" state is that once the user closes all pop-up windows, there is no button to open the invitation window again from the onboarding page unless they refresh the webpage.
- Parallel fetches Google Ads account and its status in the `useUpsertAdsAccount` hook to reduce the waiting time a bit.
- Disable the "Or, use your existing Google Ads account" button while upserting Google Ads account.
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/0e530699-88cb-46fd-a66d-7292164c8c75)

### Screenshots:

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/24ec49f0-187f-4471-a0a5-c6d3f961d8ac

### Detailed test instructions:

1. Disconnect Google Ads account if there is a connected one.
2. Go to step 1 of the onboarding flow.
3. Connect a Google Merchant Center account first.
4. Create a new Google Ads account and claim it.
5. During Google Ads account creation and claiming, inspect the loading state to see if it's correct and not flashing other unexpected stuff.
6. Make sure it doesn't have issues like the following video:
   1. The "Or, use your existing Google Ads account" button is enabled while upserting Google Ads account.
   2. There is no way to open the pop-up window again from the page after closing the pop-up window opened by clicking on the "Claim Account"

https://github.com/woocommerce/google-listings-and-ads/assets/17420811/8c19ef28-1fa5-48a3-892d-daac8ef304ef

### Changelog entry
