### PR TITLE
Add Tracking snapshot

### DIFF
--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -106,7 +106,7 @@ class TrackerSnapshot implements Conditional, ContainerAwareInterface, OptionsAw
 			'ads_setup_started'               => $ads_service->is_setup_started() ? 'yes' : 'no',
 			'ads_customer_id'                 => $this->options->get_ads_id(),
 			'ads_campaign_count'              => $merchant_metrics->get_campaign_count(),
-			'wpcom_api_authorized'       => $this->options->is_wpcom_api_authorized(),
+			'wpcom_api_authorized'            => $this->options->is_wpcom_api_authorized(),
 		];
 	}
 

--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -106,6 +106,7 @@ class TrackerSnapshot implements Conditional, ContainerAwareInterface, OptionsAw
 			'ads_setup_started'               => $ads_service->is_setup_started() ? 'yes' : 'no',
 			'ads_customer_id'                 => $this->options->get_ads_id(),
 			'ads_campaign_count'              => $merchant_metrics->get_campaign_count(),
+			'wpcom_api_authorized'       => $this->options->is_wpcom_api_authorized(),
 		];
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR add a tracking snapshot to track the current WPCOM API REST Authorization

### Screenshots:

<img width="452" alt="Screenshot 2024-05-30 at 12 10 04" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/ad6e978e-cf1d-41f7-b6ef-582af77e2d43">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Set `woocommerce_allow_tracking` entry in wp_options as "yes"
2. Set or create `gla_wpcom_rest_api_status` option as "approved"
3. Run `wp wc tracker snapshot --format=yaml` in your wp cli
4. See the new `wpcom_api_authorized` entry in gla as `True`
5. Set `gla_wpcom_rest_api_status` option as "error"
6. Run `wp wc tracker snapshot --format=yaml` in your wp cli
7.  See the new `wpcom_api_authorized` entry in gla as `false`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Tracking snapshots for WPCOM REST API authorization
