### PR TITLE
Disallow tracking enabled check in the extension

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -296,7 +296,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->conditionally_share_with_tags( ProductFeed::class );
 		$this->conditionally_share_with_tags( AttributeMapping::class );
 		$this->conditionally_share_with_tags( Settings::class );
-		$this->conditionally_share_with_tags( TrackerSnapshot::class );
+		$this->share_with_tags( TrackerSnapshot::class );
 		$this->conditionally_share_with_tags( EventTracking::class, ContainerInterface::class );
 		$this->conditionally_share_with_tags( RESTControllers::class, ContainerInterface::class );
 		$this->conditionally_share_with_tags( ConnectionTest::class, ContainerInterface::class );

--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tracking;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
@@ -28,20 +27,12 @@ use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tracking
  */
-class TrackerSnapshot implements Conditional, ContainerAwareInterface, OptionsAwareInterface, Registerable, Service {
+class TrackerSnapshot implements ContainerAwareInterface, OptionsAwareInterface, Registerable, Service {
 
 	use ContainerAwareTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;
 
-	/**
-	 * Not needed if allow_tracking is disabled.
-	 *
-	 * @return bool Whether the object is needed.
-	 */
-	public static function is_needed(): bool {
-		return 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
-	}
 
 	/**
 	 * Hook extension tracker data into the WC tracker data.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WC_Tracks disallows data tracking by itself when the user is not opted-in. This allows us to check the snapshot data in WP-CLI

This PR disables the check for `woocommerce_allow_tracking`

### Screenshots:

<img width="730" alt="Screenshot 2024-05-31 at 11 26 18" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/15cfe65a-478e-47d5-8685-55eee20f3054">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Run `wp option update woocommerce_allow_tracking "no"`
2. Run `wp wc tracker snapshot --format=yaml`
3. See gla extension data in the output


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Show tracking snapshots in WPCLI
