### PR TITLE
Fix fatal error when fetching marketing campaigns for Marketing Channel

### DIFF
--- a/src/MultichannelMarketing/GLAChannel.php
+++ b/src/MultichannelMarketing/GLAChannel.php
@@ -78,11 +78,11 @@ class GLAChannel implements MarketingChannelInterface {
 	}
 
 	/**
-	 * Determines if the marketing channel campaigns is enabled.
+	 * Determines if the marketing channel campaigns types are enabled.
 	 *
 	 * @return bool
 	 */
-	protected function is_enable_campaign_types() {
+	protected function is_enable_campaign_types(): bool {
 		return apply_filters( 'woocommerce_gla_enable_mcm', false ) === true;
 	}
 

--- a/src/MultichannelMarketing/GLAChannel.php
+++ b/src/MultichannelMarketing/GLAChannel.php
@@ -72,17 +72,17 @@ class GLAChannel implements MarketingChannelInterface {
 		$this->product_sync_stats = $product_sync_stats;
 		$this->campaign_types     = [];
 
-		if ( $this->is_enable_campaign_types() ) {
+		if ( $this->is_mcm_enabled() ) {
 			$this->campaign_types = $this->generate_campaign_types();
 		}
 	}
 
 	/**
-	 * Determines if the marketing channel campaigns types are enabled.
+	 * Determines if the multichannel marketing is enabled.
 	 *
 	 * @return bool
 	 */
-	protected function is_enable_campaign_types(): bool {
+	protected function is_mcm_enabled(): bool {
 		return apply_filters( 'woocommerce_gla_enable_mcm', false ) === true;
 	}
 
@@ -185,7 +185,7 @@ class GLAChannel implements MarketingChannelInterface {
 	 * @return MarketingCampaign[]
 	 */
 	public function get_campaigns(): array {
-		if ( ! $this->ads->ads_id_exists() || ! $this->is_enable_campaign_types() ) {
+		if ( ! $this->ads->ads_id_exists() || ! $this->is_mcm_enabled() ) {
 			return [];
 		}
 

--- a/src/MultichannelMarketing/GLAChannel.php
+++ b/src/MultichannelMarketing/GLAChannel.php
@@ -72,9 +72,18 @@ class GLAChannel implements MarketingChannelInterface {
 		$this->product_sync_stats = $product_sync_stats;
 		$this->campaign_types     = [];
 
-		if ( apply_filters( 'woocommerce_gla_enable_mcm', false ) === true ) {
+		if ( $this->is_enable_campaign_types() ) {
 			$this->campaign_types = $this->generate_campaign_types();
 		}
+	}
+
+	/**
+	 * Determines if the marketing channel campaigns is enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_enable_campaign_types() {
+		return apply_filters( 'woocommerce_gla_enable_mcm', false ) === true;
 	}
 
 	/**
@@ -176,7 +185,7 @@ class GLAChannel implements MarketingChannelInterface {
 	 * @return MarketingCampaign[]
 	 */
 	public function get_campaigns(): array {
-		if ( ! $this->ads->ads_id_exists() ) {
+		if ( ! $this->ads->ads_id_exists() || ! $this->is_enable_campaign_types() ) {
 			return [];
 		}
 

--- a/tests/Unit/MultichannelMarketing/GLAChannelTest.php
+++ b/tests/Unit/MultichannelMarketing/GLAChannelTest.php
@@ -204,6 +204,16 @@ class GLAChannelTest extends UnitTest {
 		$this->assertEquals( [], $channel->get_supported_campaign_types() );
 	}
 
+	public function test_get_campaigns_returns_empty_if_filter_is_disabled() {
+		remove_filter( 'woocommerce_gla_enable_mcm', '__return_true' );
+		$this->ads->expects( $this->once() )->method( 'ads_id_exists' )->willReturn( true );
+		$this->ads_campaign
+			->expects( $this->never() )
+			->method( 'get_campaigns' );
+
+		$this->assertEmpty( $this->gla_channel->get_campaigns() );
+	}
+
 	/**
 	 * Runs before each test is executed.
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

When loading the Marketing -> Overview section, there is a request to fetch the campaigns, but it currently fails because the campaign types are not loaded. The campaign types are only loaded if the filter `woocommerce_gla_enable_mcm` returns true.

The fatal error is the below:

```
undefined array key "google-ads" in /opt/homebrew/var/www/wp-content/plugins/google-listings-and-ads/src/MultichannelMarketing/GLAChannel.php on line 195, referer: https://civet-pleasing-internally.ngrok-free.app/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing
[Thu Jun 06 16:19:22.787147 2024] [php:error] [pid 2819] [client ::1:56339] PHP Fatal error:  Uncaught TypeError: Automattic\\WooCommerce\\Admin\\Marketing\\MarketingCampaign::__construct(): Argument #2 ($type) must be of type Automattic\\WooCommerce\\Admin\\Marketing\\MarketingCampaignType, null given, called in /opt/homebrew/var/www/wp-content/plugins/google-listings-and-ads/src/MultichannelMarketing/GLAChannel.php on line 194 and defined in /opt/homebrew/var/www/wp-content/plugins/woocommerce-dev/plugins/woocommerce/src/Admin/Marketing/MarketingCampaign.php:68\nStack trace:\n#0 /opt/homebrew/var/www/wp-content/plugins/google-listings-and-ads/src/MultichannelMarketing/GLAChannel.php(194): Automattic\\WooCommerce\\Admin\\Marketing\\MarketingCampaign->__construct('21359526875', NULL, 'Campaign 2024-0...', 'https://civet-p...', Object(Automattic\\WooCommerce\\Admin\\Marketing\\Price))\
```
### Screenshots:

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/4499c65d-5da6-4b3d-98e7-f72aacf01556)

This PR prevents the error by checking if the campaign types have been enabled before fetching the campaigns.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout `develop`.
2. Go to Marketing -> Overview.
3. Check your PHP errors or open the console and see how the campaign request fails.
4. Checkout this branch.
5. Refresh the Marketing -> Overview page.
6. See that we prevent the fatal error.
7. Add the following filter: add_filter( 'woocommerce_gla_enable_mcm', '__return_true' );
8 Refresh and see that now the campaigns are loaded. 

### Additional details:

Tests are failing because of this issue: https://github.com/woocommerce/google-listings-and-ads/pull/2415#issuecomment-2149368962 however you can run the tests locally and see if everything is OK

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fatal error when loading campaign in the marketing overview section.
