### PR TITLE
API Pull - Enable pull and push mechanism to work together

### DIFF
--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -226,7 +226,6 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $coupon_id
 	 */
 	protected function handle_pre_delete_coupon( int $coupon_id ) {
-
 		$coupon = $this->wc->maybe_get_coupon( $coupon_id );
 
 		if ( $coupon instanceof WC_Coupon &&

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -183,7 +183,6 @@ class SyncerHooks implements Service, Registerable {
 
 		if ( $this->notifications_service->is_ready() ) {
 			$this->handle_update_coupon_notification( $coupon );
-			return;
 		}
 
 		// Schedule an update job if product sync is enabled.
@@ -227,9 +226,6 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $coupon_id
 	 */
 	protected function handle_pre_delete_coupon( int $coupon_id ) {
-		if ( $this->notifications_service->is_ready() ) {
-			return;
-		}
 
 		$coupon = $this->wc->maybe_get_coupon( $coupon_id );
 
@@ -271,7 +267,6 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_delete_coupon( int $coupon_id ) {
 		if ( $this->notifications_service->is_ready() ) {
 			$this->maybe_send_delete_notification( $coupon_id );
-			return;
 		}
 
 		if ( ! isset( $this->delete_requests_map[ $coupon_id ] ) ) {

--- a/src/Jobs/Notifications/ShippingNotificationJob.php
+++ b/src/Jobs/Notifications/ShippingNotificationJob.php
@@ -30,6 +30,6 @@ class ShippingNotificationJob extends AbstractNotificationJob {
 	 * @param array $args Arguments for the notification
 	 */
 	protected function process_items( array $args ): void {
-		$this->notifications_service->notify( $this->notifications_service::TOPIC_SHIPPING_UPDATED );
+		$this->notifications_service->notify( $this->notifications_service::TOPIC_SHIPPING_UPDATED, null, $args );
 	}
 }

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -132,9 +132,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * @since x.x.x
 	 */
 	public function should_push(): bool {
-		/** @var NotificationsService $notifications_service */
-		$notifications_service = $this->container->get( NotificationsService::class );
-		return $this->is_ready_for_syncing() && ! $notifications_service->is_ready();
+		return $this->is_ready_for_syncing();
 	}
 
 

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -340,7 +340,6 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_pre_delete_product( int $product_id ) {
-
 		$product = $this->wc->maybe_get_product( $product_id );
 
 		// each variation is passed to this method separately so we don't need to delete the variable product

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -215,7 +215,6 @@ class SyncerHooks implements Service, Registerable {
 
 		if ( $this->notifications_service->is_ready() ) {
 			$this->handle_update_product_notification( $products[0] );
-			return;
 		}
 
 		foreach ( $products as $product ) {
@@ -304,7 +303,6 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_delete_product( int $product_id ) {
 		if ( $this->notifications_service->is_ready() ) {
 			$this->maybe_send_delete_notification( $product_id );
-			return;
 		}
 
 		if ( isset( $this->delete_requests_map[ $product_id ] ) ) {
@@ -342,9 +340,6 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_pre_delete_product( int $product_id ) {
-		if ( $this->notifications_service->is_ready() ) {
-			return;
-		}
 
 		$product = $this->wc->maybe_get_product( $product_id );
 

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -145,10 +145,10 @@ class SyncerHooks implements Service, Registerable {
 		}
 
 		if ( $this->notifications_service->is_ready() ) {
-			$this->shipping_notification_job->schedule();
-		} else {
-			$this->update_shipping_job->schedule();
+			$this->shipping_notification_job->schedule( [ 'topic' => NotificationsService::TOPIC_SHIPPING_UPDATED ] );
 		}
+
+		$this->update_shipping_job->schedule();
 
 		$this->already_scheduled = true;
 	}

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -197,7 +197,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 	public function test_create_coupon_triggers_notification_created() {
 		$this->set_mc_and_notifications( true, true );
-		$this->update_coupon_job->expects( $this->never() )
+		$this->update_coupon_job->expects( $this->exactly( 1 ) )
 			->method( 'schedule' );
 
 		/**
@@ -220,7 +220,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 	public function test_update_coupon_triggers_notification_updated() {
 		$this->set_mc_and_notifications( true, true );
-		$this->update_coupon_job->expects( $this->never() )
+		$this->update_coupon_job->expects( $this->exactly( 1 ) )
 			->method( 'schedule' );
 		/**
 		 * @var WC_Coupon $coupon

--- a/tests/Unit/Shipping/SyncerHooksTest.php
+++ b/tests/Unit/Shipping/SyncerHooksTest.php
@@ -217,7 +217,7 @@ class SyncerHooksTest extends UnitTest {
 		$this->shipping_notification_job->expects( $this->once() )
 			->method( 'schedule' );
 
-		$this->update_shipping_job->expects( $this->never() )
+		$this->update_shipping_job->expects( $this->once() )
 			->method( 'schedule' );
 
 		$zone = new WC_Shipping_Zone();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://github.com/woocommerce/google-listings-and-ads/issues/2146

For the initial launch, we want to keep both the pull and push mechanisms working together. This PR enables sending the notification  (pull mechanism) and the usual job to push the data.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Enable the Pull mechanism with the following filter: `add_filter( 'woocommerce_gla_notifications_enabled', '__return_true' );` and run this command `wp option update gla_wpcom_rest_api_status "approved"`

### Create Product
1. Create a product with the visibility "Sync and Show"
2. Go to WC -> Status -> Scheduled jobs
3. See that there is a job `gla/jobs/update_products/process_item` with the product that you created
4. See that there is a job `gla/jobs/notifications/products/process_item` with the itemID = the product ID that you created and the topic `product.create`

### Update Product
1. Update a product
3. See that there is a job `gla/jobs/update_products/process_item` with the product that you updated
4. See that there is a job `gla/jobs/notifications/products/process_item` with the itemID = the product ID that you updated and the topic `product.update`

### Delete Product
1. Delete a product
3. See that there is a job `gla/jobs/delete_products/process_item` with the product that you deleted.
4. See that there is a job `gla/jobs/notifications/products/process_item` with the itemID  = the product ID that you deleted and the topic `product.delete`


### Create Coupon
1. Create a coupon with the visibility "Show Coupon on Google"
3. See that there is a job `gla/jobs/update_coupon/process_item` with the coupon that you created
4. See that there is a job `gla/jobs/notifications/coupons/process_item` with the itemID  = the coupon ID that you created and the topic `coupon.create`

### Update Coupon
1. Update a coupon
3. See that there is a job `gla/jobs/update_coupon/process_item` with the coupon that you updated
4. See that there is a job `gla/jobs/notifications/coupons/process_item` with the itemID = the coupon ID that you updated and the topic `product.update`

### Delete Coupon
1. Delete a product
3. See that there is a job `gla/jobs/delete_coupon/process_item` with the coupon that you deleted.
4. See that there is a job `gla/jobs/notifications/coupons/process_item` with the itemID = the coupon ID that you deleted and the topic `coupon.delete`
 

### Update Shipping Settings
1. Go to WC -> Settings -> Shippings and edit one of the shipping methods
3. See that there is a job gla/jobs/update_shipping_settings/process_item` scheduled
4. See that there is a job `gla/jobs/notifications/shipping/process_item` with the topic `shipping.update`

### Additional details:

Currently, for shipping notifications, we haven't included the topic in the body, only in the header. For consistency, I think it's better to include it in the body as well, so I added it here.: https://github.com/woocommerce/google-listings-and-ads/pull/2428/files#diff-f9aaeb6620028c10c8ce8c3178abf2f6db34168939ba33c4d8bcef410a5125b5R148 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
