### PR TITLE
[Revert] Update docs domain name to Woo.com 

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please see [SECURITY.md](./SECURITY.md).
 
 ## Feature Requests
 
-Feature requests can be submitted to our [feature requests page](https://woo.com/feature-requests/google-listings-and-ads/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+Feature requests can be submitted to our [feature requests page](https://woocommerce.com/feature-requests/google-listings-and-ads/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@
 
 A native integration with Google offering free listings and Performance Max ads to WooCommerce merchants.
 
--   [Woo.com product page](https://woo.com/products/google-listings-and-ads/)
+-   [WooCommerce.com product page](https://woocommerce.com/products/google-listings-and-ads/)
 -   [WordPress.org plugin page](https://wordpress.org/plugins/google-listings-and-ads/)
--   [User documentation](https://woo.com/document/google-listings-and-ads/)
--   [Feature requests](https://woo.com/feature-requests/google-listings-and-ads/)
+-   [User documentation](https://woocommerce.com/document/google-listings-and-ads/)
+-   [Feature requests](https://woocommerce.com/feature-requests/google-listings-and-ads/)
 
 ## Support
 
 This repository is not suitable for support. Please don't use our issue tracker for support requests.
 
-For self help, start with our [user documentation](https://woo.com/document/google-listings-and-ads/).
+For self help, start with our [user documentation](https://woocommerce.com/document/google-listings-and-ads/).
 
 The best place to get support is the [WordPress.org Google Listings and Ads forum](https://wordpress.org/support/plugin/google-listings-and-ads/).
 
-If you have a Woo.com account, you can [start a chat or open a ticket on Woo.com](https://woo.com/my-account/contact-support/).
+If you have a WooCommerce.com account, you can [start a chat or open a ticket on WooCommerce.com](https://woocommerce.com/my-account/contact-support/).
 
 ## Prerequisites
 
@@ -197,6 +197,6 @@ Going forward, Google will always add the prefix "legacy-" for the branch suppor
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
-	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woocommerce.com/">Woo</a>.<br/>
+	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/docs/gtag-consent-mode.md
+++ b/docs/gtag-consent-mode.md
@@ -1,6 +1,6 @@
 ## Googla Analytics (gtag) Consent Mode
 
-Unless you're running the [Google Analytics for WooCommerce](https://woo.com/products/woocommerce-google-analytics/) extension for a more sophisticated configuration, Google Listings and Ads will add Google's `gtag` to help you track some customer behavior.
+Unless you're running the [Google Analytics for WooCommerce](https://woocommerce.com/products/woocommerce-google-analytics/) extension for a more sophisticated configuration, Google Listings and Ads will add Google's `gtag` to help you track some customer behavior.
 
 To respect your customers' privacy, we set up the default state of [consent mode](https://support.google.com/analytics/answer/9976101). We set it to deny all the parameters for visitors from the EEA region. You can add an extension or CMP that delivers a banner or any other UI to let visitors update their consent in runtime.
 

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -5,7 +5,7 @@
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
  * Version: 2.7.2
  * Author: WooCommerce
- * Author URI: https://woo.com/
+ * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
  * Requires at least: 5.9
  * Tested up to: 6.5

--- a/js/src/components/contact-information/index.js
+++ b/js/src/components/contact-information/index.js
@@ -20,7 +20,7 @@ import usePhoneNumberCheckTrackEventEffect from './usePhoneNumberCheckTrackEvent
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
-	'https://woo.com/document/google-listings-and-ads/#contact-information';
+	'https://woocommerce.com/document/google-listings-and-ads/#contact-information';
 
 const description = (
 	<>
@@ -84,9 +84,9 @@ export function ContactInformationPreview() {
  *
  * @param {Object} props React props.
  * @param {Function} [props.onPhoneNumberVerified] Called when the phone number is verified or has been verified.
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
- * @fires gla_documentation_link_click with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
- * @fires gla_documentation_link_click with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+ * @fires gla_documentation_link_click with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#contact-information' }`
  */
 const ContactInformation = ( { onPhoneNumberVerified } ) => {
 	const { adapter } = useAdaptiveFormContext();

--- a/js/src/components/google-account-card/connect-google-account-card.js
+++ b/js/src/components/google-account-card/connect-google-account-card.js
@@ -18,7 +18,7 @@ import useGoogleConnectFlow from './use-google-connect-flow';
  * @param {boolean} props.disabled
  * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'reconnect' }`
  * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'setup-mc' }`
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
 const ConnectGoogleAccountCard = ( { disabled } ) => {
 	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';

--- a/js/src/components/google-account-card/read-more-link.js
+++ b/js/src/components/google-account-card/read-more-link.js
@@ -7,7 +7,7 @@ const readMoreLink = (
 	<AppDocumentationLink
 		context="setup-mc-accounts"
 		linkId="required-google-permissions"
-		href="https://woo.com/document/google-listings-and-ads/#required-google-permissions"
+		href="https://woocommerce.com/document/google-listings-and-ads/#required-google-permissions"
 	/>
 );
 

--- a/js/src/components/google-account-card/request-full-access-google-account-card.js
+++ b/js/src/components/google-account-card/request-full-access-google-account-card.js
@@ -21,7 +21,7 @@ import './request-full-access-google-account-card.scss';
  * @param {string} props.additionalScopeEmail Specify the email to be requested additional permission scopes to Google.
  * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'reconnect' }`
  * @fires gla_google_account_connect_button_click with `{ action: 'scope', context: 'setup-mc' }`
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
  */
 const RequestFullAccessGoogleAccountCard = ( { additionalScopeEmail } ) => {
 	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';

--- a/js/src/components/help-icon-button.js
+++ b/js/src/components/help-icon-button.js
@@ -34,7 +34,7 @@ const HelpIconButton = ( props ) => {
 		<AppIconButton
 			icon={ <GridiconHelpOutline /> }
 			text={ __( 'Help', 'google-listings-and-ads' ) }
-			href="https://woo.com/document/google-listings-and-ads/"
+			href="https://woocommerce.com/document/google-listings-and-ads/"
 			target="_blank"
 			eventName="gla_help_click"
 			eventProps={ {

--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -30,7 +30,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="general-requirements"
-								href="https://woo.com/document/google-listings-and-ads/#general-requirements"
+								href="https://woocommerce.com/document/google-listings-and-ads/#general-requirements"
 							/>
 						),
 					}
@@ -96,7 +96,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="google-merchant-center-requirements"
-								href="https://woo.com/document/google-listings-and-ads/#google-merchant-center-requirements"
+								href="https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements"
 							/>
 						),
 					}
@@ -122,7 +122,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="performance-max"
-								href="https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns"
+								href="https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns"
 							/>
 						),
 					}
@@ -145,7 +145,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="free-listings"
-								href="https://woo.com/document/google-listings-and-ads/#free-listings-on-google"
+								href="https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google"
 							/>
 						),
 					}
@@ -172,7 +172,7 @@ const faqItems = [
 							<AppDocumentationLink
 								context="faqs"
 								linkId="campaign-analytics"
-								href="https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics"
+								href="https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics"
 							/>
 						),
 					}
@@ -265,12 +265,12 @@ const faqItems = [
  * @fires gla_faq with `{ context: 'get-started', id: 'can-i-run-both-shopping-ads-and-free-listings-campaigns', action: 'collapse' }`.
  * @fires gla_faq with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'expand' }`.
  * @fires gla_faq with `{ context: 'get-started', id: 'how-can-i-get-the-ad-credit-offer', action: 'collapse' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woo.com/document/google-listings-and-ads/#general-requirements' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woo.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woo.com/document/google-listings-and-ads/#free-listings-on-google' }`.
- * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+ * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
  * @fires gla_documentation_link_click with `{ context: 'faqs', linkId: 'terms-and-conditions-of-google-ads-coupons', href: 'https://www.google.com/ads/coupons/terms/' }`.
  */
 const Faqs = () => {

--- a/js/src/get-started-page/features-card/index.js
+++ b/js/src/get-started-page/features-card/index.js
@@ -38,9 +38,9 @@ const LearnMoreLink = ( { linkId, href } ) => {
 };
 
 /*
- * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-free-listing-learn-more', href: 'https://woo.com/document/google-listings-and-ads/#free-listings-on-google' }`.
- * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-google-ads-learn-more', href: 'https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
- * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-dashboard-learn-more', href: 'https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-free-listing-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-google-ads-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+ * @fires gla_documentation_link_click with `{ context: 'get-started', linkId: 'get-started-features-dashboard-learn-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
  */
 const FeaturesCard = () => {
 	return (
@@ -96,7 +96,7 @@ const FeaturesCard = () => {
 					</Text>
 					<LearnMoreLink
 						linkId="get-started-features-free-listing-learn-more"
-						href="https://woo.com/document/google-listings-and-ads/#free-listings-on-google"
+						href="https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google"
 					/>
 				</FlexBlock>
 				<FlexBlock>
@@ -129,7 +129,7 @@ const FeaturesCard = () => {
 					</Text>
 					<LearnMoreLink
 						linkId="get-started-features-google-ads-learn-more"
-						href="https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns"
+						href="https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns"
 					/>
 				</FlexBlock>
 				<FlexBlock>
@@ -162,7 +162,7 @@ const FeaturesCard = () => {
 					</Text>
 					<LearnMoreLink
 						linkId="get-started-features-dashboard-learn-more"
-						href="https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics"
+						href="https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics"
 					/>
 				</FlexBlock>
 			</Flex>

--- a/js/src/settings/edit-phone-number.js
+++ b/js/src/settings/edit-phone-number.js
@@ -18,13 +18,13 @@ import usePhoneNumberCheckTrackEventEffect from '.~/components/contact-informati
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
-	'https://woo.com/document/google-listings-and-ads/#contact-information';
+	'https://woocommerce.com/document/google-listings-and-ads/#contact-information';
 
 /**
  * Renders the phone number settings page.
  *
  * @see PhoneNumberCard
- * @fires gla_documentation_link_click with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
+ * @fires gla_documentation_link_click with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woocommerce.com/document/google-listings-and-ads/#contact-information" }`
  */
 const EditPhoneNumber = () => {
 	const phone = useGoogleMCPhoneNumber();

--- a/js/src/settings/edit-store-address.js
+++ b/js/src/settings/edit-store-address.js
@@ -23,7 +23,7 @@ import StoreAddressCard from '.~/components/contact-information/store-address-ca
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =
-	'https://woo.com/document/google-listings-and-ads/#contact-information';
+	'https://woocommerce.com/document/google-listings-and-ads/#contact-information';
 
 /**
  * Triggered when the save button in contact information page is clicked.
@@ -36,7 +36,7 @@ const learnMoreUrl =
  *
  * @see StoreAddressCard
  * @fires gla_contact_information_save_button_click
- * @fires gla_documentation_link_click with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
+ * @fires gla_documentation_link_click with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woocommerce.com/document/google-listings-and-ads/#contact-information" }`
  */
 const EditStoreAddress = () => {
 	useLayout( 'full-content' );

--- a/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
+++ b/js/src/setup-mc/setup-stepper/store-requirements/pre-launch-checklist/index.js
@@ -39,7 +39,7 @@ const PreLaunchChecklist = () => {
 							<AppDocumentationLink
 								context="setup-mc-checklist"
 								linkId="checklist-requirements"
-								href="https://woo.com/document/google-listings-and-ads/compliance-policy"
+								href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy"
 							>
 								{ __(
 									'Read Google Merchant Center requirements',
@@ -72,7 +72,7 @@ const PreLaunchChecklist = () => {
 									context="setup-mc-checklist"
 									linkId="check-website-is-live"
 									type="external"
-									href="https://woo.com/document/google-listings-and-ads/compliance-policy/#store-is-live"
+									href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#store-is-live"
 								>
 									{ __(
 										'Learn more about common landing page issues and how to fix them',
@@ -99,7 +99,7 @@ const PreLaunchChecklist = () => {
 									context="setup-mc-checklist"
 									linkId="check-payment-methods-visible"
 									type="external"
-									href="https://woo.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
+									href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
 								>
 									{ __(
 										"Learn more about Google's checkout requirements & best practices",
@@ -131,7 +131,7 @@ const PreLaunchChecklist = () => {
 									context="setup-mc-checklist"
 									linkId="check-checkout-process-secure"
 									type="external"
-									href="https://woo.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
+									href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout"
 								>
 									{ __(
 										'Learn to set up SSL on your website',
@@ -158,7 +158,7 @@ const PreLaunchChecklist = () => {
 									context="setup-mc-checklist"
 									linkId="check-refund-tos-visible"
 									type="external"
-									href="https://woo.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms"
+									href="https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms"
 								>
 									{ __(
 										"Learn more about Google's refund policy requirements",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"WooCommerce",
 		"Google"
 	],
-	"homepage": "https://woo.com/products/google-listings-and-ads/",
+	"homepage": "https://woocommerce.com/products/google-listings-and-ads/",
 	"repository": {
 		"type": "git",
 		"url": "git@github.com:woocommerce/google-listings-and-ads.git"

--- a/readme.txt
+++ b/readme.txt
@@ -60,7 +60,7 @@ Create a new Google Ads account through Google Listings & Ads and a promotional 
 * PHP Architecture 64 bits
 * MySQL version 5.6 or greater
 
-Visit the [WooCommerce server requirements documentation](https://woo.com/document/server-requirements/) for a detailed list of server requirements.
+Visit the [WooCommerce server requirements documentation](https://woocommerce.com/document/server-requirements/) for a detailed list of server requirements.
 
 = Automatic installation =
 

--- a/src/Integration/WooCommercePreOrders.php
+++ b/src/Integration/WooCommercePreOrders.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Integration
  *
- * @link https://woo.com/products/woocommerce-pre-orders/
+ * @link https://woocommerce.com/products/woocommerce-pre-orders/
  *
  * @since 1.5.0
  */

--- a/src/Menu/MenuFixesTrait.php
+++ b/src/Menu/MenuFixesTrait.php
@@ -28,7 +28,7 @@ trait MenuFixesTrait {
 	 *
 	 * There is a guide with a few examples showing how to add a page to WooCommerce Admin.
 	 *
-	 * @link https://developer.woo.com/extension-developer-guide/working-with-woocommerce-admin-pages/
+	 * @link https://developer.woocommerce.com/extension-developer-guide/working-with-woocommerce-admin-pages/
 	 *
 	 * Originally, a React-powered page is expected to be registered by WC core function
 	 * `wc_admin_register_page`, and the function also handles the registration of wp-admin

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -1040,7 +1040,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		 */
 		if ( 'home_page_issue' === $issue['code'] ) {
 			$issue['issue']      = 'Website claim is lost, need to re verify and claim your website. Please reference the support link';
-			$issue['action_url'] = 'https://woo.com/document/google-listings-and-ads-faqs/#reverify-website';
+			$issue['action_url'] = 'https://woocommerce.com/document/google-listings-and-ads-faqs/#reverify-website';
 		}
 
 		return $issue;

--- a/src/MultichannelMarketing/GLAChannel.php
+++ b/src/MultichannelMarketing/GLAChannel.php
@@ -119,7 +119,7 @@ class GLAChannel implements MarketingChannelInterface {
 	 * @return string
 	 */
 	public function get_icon_url(): string {
-		return 'https://woo.com/wp-content/uploads/2021/06/woo-GoogleListingsAds-jworee.png';
+		return 'https://woocommerce.com/wp-content/uploads/2021/06/woo-GoogleListingsAds-jworee.png';
 	}
 
 	/**

--- a/src/Notes/LeaveReviewActionTrait.php
+++ b/src/Notes/LeaveReviewActionTrait.php
@@ -23,7 +23,7 @@ trait LeaveReviewActionTrait {
 	 */
 	protected function add_leave_review_note_action( NoteEntry $note ) {
 		$wp_link = 'https://wordpress.org/support/plugin/google-listings-and-ads/reviews/#new-post';
-		$wc_link = 'https://woo.com/products/google-listings-and-ads/#reviews';
+		$wc_link = 'https://woocommerce.com/products/google-listings-and-ads/#reviews';
 
 		$note->add_action(
 			'leave-review',

--- a/src/Notes/SetupCampaign.php
+++ b/src/Notes/SetupCampaign.php
@@ -79,7 +79,7 @@ class SetupCampaign extends AbstractSetupCampaign {
 		$note->add_action(
 			'setup-campaign-learn-more',
 			__( 'Learn more', 'google-listings-and-ads' ),
-			'https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns'
+			'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns'
 		);
 	}
 }

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -152,7 +152,7 @@ trait PluginHelper {
 	 * @return string
 	 */
 	protected function get_documentation_url(): string {
-		return 'https://woo.com/document/google-listings-and-ads/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=google-listings-and-ads';
+		return 'https://woocommerce.com/document/google-listings-and-ads/?utm_source=wordpress&utm_medium=all-plugins-page&utm_campaign=doc-link&utm_content=google-listings-and-ads';
 	}
 
 	/**

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -1,6 +1,6 @@
 # Usage Tracking
 
-_Google Listings & Ads_ implements usage tracking, based on the native [WooCommerce Usage Tracking](https://woo.com/usage-tracking/), and is only enabled when WooCommerce Tracking is enabled.
+_Google Listings & Ads_ implements usage tracking, based on the native [WooCommerce Usage Tracking](https://woocommerce.com/usage-tracking/), and is only enabled when WooCommerce Tracking is enabled.
 
 When a store opts in to WooCommerce usage tracking and uses _Google Listings & Ads_, they will also be opted in to the tracking added by _Google Listings & Ads_.
 
@@ -324,24 +324,24 @@ When a documentation link is clicked.
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
 - [`ChooseAudienceSection`](../../js/src/components/free-listings/choose-audience-section/choose-audience-section.js#L29) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
 - [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L42) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
-- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
 - [`ContactInformation`](../../js/src/components/contact-information/index.js#L91)
-	- with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
-	- with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
-	- with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://woo.com/document/google-listings-and-ads/#contact-information' }`
+	- with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+	- with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#contact-information' }`
+	- with `{ context: 'settings-no-store-address-notice', link_id: 'contact-information-read-more', href: 'https://woocommerce.com/document/google-listings-and-ads/#contact-information' }`
 - [`DifferentCurrencyNotice`](../../js/src/components/different-currency-notice.js#L28)
 	- with `{ context: "dashboard", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-products", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
-- [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
-- [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woo.com/document/google-listings-and-ads/#contact-information" }`
+- [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woocommerce.com/document/google-listings-and-ads/#contact-information" }`
+- [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woocommerce.com/document/google-listings-and-ads/#contact-information" }`
 - [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
-	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woo.com/document/google-listings-and-ads/#general-requirements' }`.
+	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#general-requirements' }`.
 	- with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
-	- with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woo.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
-	- with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woo.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
-	- with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woo.com/document/google-listings-and-ads/#free-listings-on-google' }`.
-	- with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woo.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
+	- with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-merchant-center-requirements' }`.
+	- with `{ context: 'faqs', linkId: 'performance-max', href: 'https://woocommerce.com/document/google-listings-and-ads/#google-performance-max-campaigns' }`.
+	- with `{ context: 'faqs', linkId: 'free-listings', href: 'https://woocommerce.com/document/google-listings-and-ads/#free-listings-on-google' }`.
+	- with `{ context: 'faqs', linkId: 'campaign-analytics', href: 'https://woocommerce.com/document/google-listings-and-ads/#getting-started-with-campaign-analytics' }`.
 	- with `{ context: 'faqs', linkId: 'terms-and-conditions-of-google-ads-coupons', href: 'https://www.google.com/ads/coupons/terms/' }`.
 - [`Faqs`](../../js/src/setup-mc/setup-stepper/setup-accounts/faqs.js#L68) with `{ context: 'faqs', link_id: 'find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
 - [`FaqsSection`](../../js/src/components/paid-ads/asset-group/faqs-section.js#L73) with `{ context: 'assets-faq', linkId: 'assets-faq-about-ad-formats-available-in-different-campaign-types', href: 'https://support.google.com/google-ads/answer/1722124' }`.
@@ -354,7 +354,7 @@ When a documentation link is clicked.
 - [`IssuesTableDataModal`](../../js/src/product-feed/issues-table-card/issues-table-data-modal.js#L21) with { context: 'issues-data-table-modal' }
 - [`ProductStatusHelpPopover`](../../js/src/product-feed/product-statistics/product-status-help-popover/index.js#L16) with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`
 - [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L41) with `{ context: 'setup-mc', link_id: 'claim-url', href: 'https://support.google.com/merchants/answer/176793' }`
-- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woo.com/document/google-listings-and-ads/#required-google-permissions' }`
+- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
 - [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L23)
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`

--- a/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-confirm-store-requirements.test.js
@@ -219,7 +219,7 @@ test.describe( 'Confirm store requirements', () => {
 			await expect( link ).toBeVisible();
 			await expect( link ).toHaveAttribute(
 				'href',
-				'https://woo.com/document/google-listings-and-ads/#contact-information'
+				'https://woocommerce.com/document/google-listings-and-ads/#contact-information'
 			);
 		} );
 
@@ -229,7 +229,7 @@ test.describe( 'Confirm store requirements', () => {
 			await expect( link ).toBeVisible();
 			await expect( link ).toHaveAttribute(
 				'href',
-				'https://woo.com/document/google-listings-and-ads/compliance-policy'
+				'https://woocommerce.com/document/google-listings-and-ads/compliance-policy'
 			);
 		} );
 
@@ -321,7 +321,7 @@ test.describe( 'Confirm store requirements', () => {
 					await expect( link1 ).toBeVisible();
 					await expect( link1 ).toHaveAttribute(
 						'href',
-						'https://woo.com/document/google-listings-and-ads/compliance-policy/#store-is-live'
+						'https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#store-is-live'
 					);
 
 					const panel2 = await panels.nth( 1 );
@@ -329,7 +329,7 @@ test.describe( 'Confirm store requirements', () => {
 					await expect( link2 ).toBeVisible();
 					await expect( link2 ).toHaveAttribute(
 						'href',
-						'https://woo.com/document/google-listings-and-ads/compliance-policy/#complete-checkout'
+						'https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout'
 					);
 
 					const panel3 = await panels.nth( 2 );
@@ -337,7 +337,7 @@ test.describe( 'Confirm store requirements', () => {
 					await expect( link3 ).toBeVisible();
 					await expect( link3 ).toHaveAttribute(
 						'href',
-						'https://woo.com/document/google-listings-and-ads/compliance-policy/#complete-checkout'
+						'https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#complete-checkout'
 					);
 
 					const panel4 = await panels.nth( 3 );
@@ -345,7 +345,7 @@ test.describe( 'Confirm store requirements', () => {
 					await expect( link4 ).toBeVisible();
 					await expect( link4 ).toHaveAttribute(
 						'href',
-						'https://woo.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms'
+						'https://woocommerce.com/document/google-listings-and-ads/compliance-policy/#refund-and-terms'
 					);
 				} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project: peeuvX-1zs-p2

This PR reverts all the changes in https://github.com/woocommerce/google-listings-and-ads/pull/2189 and https://github.com/woocommerce/google-listings-and-ads/pull/2144
that replaced woocommerce.com references with woo.com references.

So this PR will put back woocommerce.com as the domain.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm all changed URLs work.
2. Verify no woo.com references are left in the repo


### Additional details:


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak -  Replace woo.com references with woocommerce.com.