### PR TITLE
[API Pull] Add language param in settings endpoint

### DIFF
--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -184,8 +184,8 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 					];
 
 					$data[] = [
-						'id'    => 'language',
-						'label' => 'Store language',
+						'id'    => 'gla_language',
+						'label' => 'Google Listings and Ads: Store language',
 						'value' => get_locale(),
 					];
 

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -183,6 +183,12 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 						'value' => $this->shipping_time_query->get_all_shipping_times(),
 					];
 
+					$data[] = [
+						'id'    => 'language',
+						'label' => 'Store language',
+						'value' => get_locale(),
+					];
+
 					$response->set_data( array_values( $data ) );
 				}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the site language as param when requesting `GET /wp-json/wc/v3/settings/general?gla_syncable=1`


### Screenshots:

<img width="455" alt="Screenshot 2024-06-18 at 19 22 09" src="https://github.com/woocommerce/google-listings-and-ads/assets/5908855/d24ea573-d210-41bf-b8a9-79d3a6cb22c1">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Request GET /wp-json/wc/v3/settings/general?gla_syncable=1
2. See the language param appears with your site language



