### PR TITLE
Fix issue with inconsistent metadata format

### DIFF
--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -322,6 +322,8 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 			}
 		}
 
+		$data['meta_data'] = array_values( $data['meta_data'] );
+
 		$response->set_data( $data );
 
 		return $response;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of #2146 

When filtering the private metadata, we use the unset function to remove the private metadata from the response. However, this alters the final response format, changing it from an array of objects to a single object. For example:

Incorrect:
```
"meta_data": {
            "1": {
                "id": 241,
                "key": "_wc_gla_visibility",
                "value": "sync-and-show"
            },
}
```
Correct:
```
"meta_data": [
          {
                "id": 241,
                "key": "_wc_gla_visibility",
                "value": "sync-and-show"
            },
]
```

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Choose one product and set the channel visibility to "Sync & Show". Add some private metadata to the product (private metadata = metadata starting with `_`, for example `_my_private_data`).
2. Create some WC REST API credentials and do the following request GET `wp-json/wc/v3/products/YOUR_PRODUCT_ID?gla_syncable=1`
3. Without checking this PR, see how the metadata format is incorrect.
4. Checkout this PR and see the expected response.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
