### PR TITLE
Add docs note about WP Consent API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Going forward, Google will always add the prefix "legacy-" for the branch suppor
 
 - [Usage Tracking](./src/Tracking/README.md)
 - [Hooks defined or used in GLA](./src/Hooks/README.md)
-- [gtag consent mode](./docs/gtag-consent-mode.md)
+- [gtag consent mode & cookie banners](./docs/gtag-consent-mode.md)
 
 <p align="center">
 	<br/><br/>

--- a/docs/gtag-consent-mode.md
+++ b/docs/gtag-consent-mode.md
@@ -1,9 +1,15 @@
-## Googla Analytics (gtag) Consent Mode
+## Google Analytics (gtag) Consent Mode
 
 Unless you're running the [Google Analytics for WooCommerce](https://woo.com/products/woocommerce-google-analytics/) extension for a more sophisticated configuration, Google Listings and Ads will add Google's `gtag` to help you track some customer behavior.
 
-To respect your customers' privacy, we set up the default state of [consent mode](https://support.google.com/analytics/answer/9976101). We set it to deny all the parameters for visitors from the EEA region. You can add an extension or CMP that delivers a banner or any other UI to let visitors update their consent in runtime.
+To respect your customers' privacy, we set up the default state of [consent mode](https://support.google.com/analytics/answer/9976101). We set it to deny all the parameters for visitors from the EEA region.
 
 You can also customize your own default state configuration using the `woocommerce_gla_gtag_consent` filter providing any snippet that uses [Google's `gtag('consent', 'default', {…})` API ](https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced).
 
 After the page loads, the consent for particular parameters can be updated by other plugins or custom code implementing UI for customer-facing configuration using [Google's consent API](https://developers.google.com/tag-platform/security/guides/consent?hl=en&consentmode=advanced#update-consent) (`gtag('consent', 'update', {…})`).
+
+## Cookie banners & WP Consent API
+
+The extension does not provide any UI, like a cookie banner, to let your visitors grant consent for tracking. However, it's integrated with [WP Consent API](https://wordpress.org/plugins/wp-consent-api/), so you can pick another extension that provides a banner that meets your needs.
+
+Each of those extensions may require additional setup or registration. Usually, the basic default setup works out of the box, but there may be some integration caveats.


### PR DESCRIPTION
_This is a follow-up for https://github.com/woocommerce/google-listings-and-ads/pull/2425_
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Add developer-facing notes regarding WP Consent API integration and cookie banner extensions.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Reade the README and `docs/gtag-consent-mode.md`
2. Check if the notes are clear and descriptive enough.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Add docs note about WP Consent API integration
