### PR TITLE
Add a query param `campaign=saved` to the dashboard URL when campaign was successfully created and saved

### DIFF
--- a/js/src/pages/create-paid-ads-campaign/index.js
+++ b/js/src/pages/create-paid-ads-campaign/index.js
@@ -109,7 +109,8 @@ const CreatePaidAdsCampaign = () => {
 			return;
 		}
 
-		getHistory().push( getDashboardUrl() );
+		// Add a query param `campaign=saved` to the dashboard URL to indicate that the campaign was successfully created and saved.
+		getHistory().push( getDashboardUrl( { campaign: 'saved' } ) );
 	};
 
 	if ( ! initialCountryCodes ) {

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -64,8 +64,8 @@ export const getSetupMCUrl = () => {
 	return getNewPath( null, setupMCPath, null );
 };
 
-export const getDashboardUrl = () => {
-	return getNewPath( null, dashboardPath, null );
+export const getDashboardUrl = ( query = null ) => {
+	return getNewPath( query, dashboardPath, null );
 };
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2439.

This PR adds an extra query parameter `campaign=saved` to the dashboard URL to indicate that the campaign was successfully created and saved.

### Screenshots:

<img width="1485" alt="Screenshot 2024-06-25 at 16 10 14" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/6a978b98-5d03-4d6b-bdf5-f44d4ce38f83">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout the branch `add/query-param-when-campaign-created`
2. Go to the dashboard page, click `Add paid campaign`, and create a campaign.
3. After the campaign was created successfully, it will redirect back to the dashboard page.
4. Confirm the URL contains a parameter `campaign=saved`.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Add an query parameter `campaign=saved` to the dashboard URL after the campaign was created
