### PR TITLE
Change connection test page capabilities to manage_woocommerce

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -98,7 +98,7 @@ class ConnectionTest implements Service, Registerable {
 			add_menu_page(
 				'Connection Test',
 				'Connection Test',
-				'manage_options',
+				'manage_woocommerce',
 				'connection-test-admin-page',
 				function() {
 					$this->render_admin_page();
@@ -109,7 +109,7 @@ class ConnectionTest implements Service, Registerable {
 				'',
 				'Connection Test',
 				'Connection Test',
-				'manage_options',
+				'manage_woocommerce',
 				'connection-test-admin-page',
 				function() {
 					$this->render_admin_page();

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -100,7 +100,7 @@ class ConnectionTest implements Service, Registerable {
 				'Connection Test',
 				'manage_woocommerce',
 				'connection-test-admin-page',
-				function() {
+				function () {
 					$this->render_admin_page();
 				}
 			);
@@ -111,7 +111,7 @@ class ConnectionTest implements Service, Registerable {
 				'Connection Test',
 				'manage_woocommerce',
 				'connection-test-admin-page',
-				function() {
+				function () {
 					$this->render_admin_page();
 				}
 			);

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -118,20 +118,20 @@ class AccountServiceTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->ads               = $this->createMock( Ads::class );
-		$this->cleanup_synced    = $this->createMock( CleanupSyncedProducts::class );
-		$this->merchant          = $this->createMock( Merchant::class );
-		$this->mc_service        = $this->createMock( MerchantCenterService::class );
-		$this->issue_table       = $this->createMock( MerchantIssueTable::class );
-		$this->merchant_statuses = $this->createMock( MerchantStatuses::class );
-		$this->middleware        = $this->createMock( Middleware::class );
-		$this->site_verification = $this->createMock( SiteVerification::class );
-		$this->rate_table        = $this->createMock( ShippingRateTable::class );
-		$this->time_table        = $this->createMock( ShippingTimeTable::class );
-		$this->state             = $this->createMock( MerchantAccountState::class );
-		$this->ads_state         = $this->createMock( AdsAccountState::class );
-		$this->options           = $this->createMock( OptionsInterface::class );
-		$this->transients        = $this->createMock( TransientsInterface::class );
+		$this->ads                   = $this->createMock( Ads::class );
+		$this->cleanup_synced        = $this->createMock( CleanupSyncedProducts::class );
+		$this->merchant              = $this->createMock( Merchant::class );
+		$this->mc_service            = $this->createMock( MerchantCenterService::class );
+		$this->issue_table           = $this->createMock( MerchantIssueTable::class );
+		$this->merchant_statuses     = $this->createMock( MerchantStatuses::class );
+		$this->middleware            = $this->createMock( Middleware::class );
+		$this->site_verification     = $this->createMock( SiteVerification::class );
+		$this->rate_table            = $this->createMock( ShippingRateTable::class );
+		$this->time_table            = $this->createMock( ShippingTimeTable::class );
+		$this->state                 = $this->createMock( MerchantAccountState::class );
+		$this->ads_state             = $this->createMock( AdsAccountState::class );
+		$this->options               = $this->createMock( OptionsInterface::class );
+		$this->transients            = $this->createMock( TransientsInterface::class );
 		$this->notifications_service = $this->createMock( NotificationsService::class );
 
 		$this->container = new Container();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of #2146 

Currently, the connection test page is only available to the administrator because it is registered with the `manage_options` capability. However, all our endpoints are checking the `manage_woocommerce` capability.

https://github.com/woocommerce/google-listings-and-ads/blob/cbcff08cf1270def397a0317d55316c991c5efd2/src/API/PermissionsTrait.php#L20-L22

This makes it harder for a Shop Manager to debug any issues with the new approach as the connection test page is not available. Therefore, this PR updates the capability to `manage_woocommerce`. Since all actions available on the connection test page are also accessible through the UI for users with `manage_woocommerce` capability I don't think we are giving new privileges to the Shop Manager role.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Log in to wp-admin with a Shop Manager user role.
2. Add this filter `add_filter('woocommerce_gla_enable_connection_test','__return_true');` or navigate to `wp-admin/admin.php?page=connection-test-admin-page`
3. Check that you can access the Connection Test Page.


### Additional details:
Not sure why but the phpcs were failing for the account services test, so I fixed it in this PR. 
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
