### PR TITLE
Update connect server URL in test proxy configuration

### DIFF
--- a/tests/proxy/config.js
+++ b/tests/proxy/config.js
@@ -3,8 +3,7 @@ module.exports = {
 	port: process.env.PROXY_PORT || 5555,
 	host: 'localhost',
 	connectServer:
-		process.env.WOOCOMMERCE_CONNECT_SERVER ||
-		'https://api.woocommerce.com',
+		process.env.WOOCOMMERCE_CONNECT_SERVER || 'https://api.woocommerce.com',
 	proxyMode: process.env.PROXY_MODE || 'default',
 	logResponses: process.env.PROXY_LOG_RESPONSES || false,
 };

--- a/tests/proxy/config.js
+++ b/tests/proxy/config.js
@@ -4,7 +4,7 @@ module.exports = {
 	host: 'localhost',
 	connectServer:
 		process.env.WOOCOMMERCE_CONNECT_SERVER ||
-		'https://api-vipgo.woocommerce.com',
+		'https://api.woocommerce.com',
 	proxyMode: process.env.PROXY_MODE || 'default',
 	logResponses: process.env.PROXY_LOG_RESPONSES || false,
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2446 

Updates the test proxy configuration to set the connect server URL to `https://api.woocommerce.com` as this was missed when the service was originally migrated.

<img width="943" alt="Screenshot 2024-06-27 at 07 23 57" src="https://github.com/woocommerce/google-listings-and-ads/assets/40762232/591d7c7f-6908-483f-b436-22190bab1572">

### Detailed test instructions:

1. Run `npm run test-proxy`
2. Confirm the correct connect server URL is displayed in the output
    - `Proxy server running on http://localhost:5555 > https://api.woocommerce.com in default mode`
3. Confirm the test data is displayed when viewing reports in `Marketing > Google Listings & Ads`

### Changelog entry

> Dev - Update connect server URL in test proxy configuration