### PR TITLE
[API Pull] Enable notifications by default

### DIFF
--- a/js/src/components/enable-new-product-sync-notice.js
+++ b/js/src/components/enable-new-product-sync-notice.js
@@ -26,6 +26,7 @@ const EnableNewProductSyncNotice = () => {
 	// Do not render if already switch to new product sync.
 	if (
 		! hasGoogleMCAccountFinishedResolution ||
+		! googleMCAccount.notification_service_enabled ||
 		googleMCAccount.wpcom_rest_api_status
 	) {
 		return null;

--- a/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
+++ b/js/src/components/google-mc-account-card/connected-google-mc-account-card.js
@@ -146,10 +146,9 @@ const ConnectedGoogleMCAccountCard = ( {
 	const showErrorNotificationsNotice =
 		! hideNotificationService &&
 		googleMCAccount.wpcom_rest_api_status &&
+		googleMCAccount.notification_service_enabled &&
 		googleMCAccount.wpcom_rest_api_status !==
-			GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED &&
-		googleMCAccount.wpcom_rest_api_status !==
-			GOOGLE_WPCOM_APP_CONNECTED_STATUS.DISABLED;
+			GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
 
 	const showFooter = ! hideAccountSwitch || showDisconnectNotificationsButton;
 

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -173,6 +173,6 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 * @return bool
 	 */
 	public function is_enabled(): bool {
-		return apply_filters( 'woocommerce_gla_notifications_enabled', false );
+		return apply_filters( 'woocommerce_gla_notifications_enabled', true );
 	}
 }

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -650,11 +650,30 @@ class ConnectionTest implements Service, Registerable {
 
 			<?php if ( $blog_token ) { ?>
 				<?php
-				  $wp_api_status = $this->container->get( OptionsInterface::class )->get( OptionsInterface::WPCOM_REST_API_STATUS );
+				  $options = $this->container->get( OptionsInterface::class );
+				  $wp_api_status = $options->get( OptionsInterface::WPCOM_REST_API_STATUS );
+				  $notification_service = new NotificationsService( $this->container->get( MerchantCenterService::class ) );
+				  $notification_service->set_options_object( $options );
 				?>
 				<h2 class="title">Partner API Pull Integration</h2>
 				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
 					<table class="form-table" role="presentation">
+						<tr>
+							<th><label>Notification Service Enabled:</label></th>
+							<td>
+								<p>
+									<code><?php echo $notification_service->is_enabled() ? 'yes' : 'no' ?></code>
+								</p>
+							</td>
+						</tr>
+						<tr>
+							<th><label>Notification Service Ready:</label></th>
+							<td>
+								<p>
+									<code><?php echo $notification_service->is_ready() ? 'yes' : 'no' ?></code>
+								</p>
+							</td>
+						</tr>
 						<tr>
 							<th><label>WPCOM REST API Status:</label></th>
 							<td>
@@ -693,7 +712,7 @@ class ConnectionTest implements Service, Registerable {
 						<tr>
 							<th><label>API Pull Integration Status:</label></th>
 							<td>
-								<p>									
+								<p>
 									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'partner-integration-status' ], $url ), 'partner-integration-status' ) ); ?>">Get API Pull Integration Status</a>
 								</p>
 							</td>
@@ -714,7 +733,7 @@ class ConnectionTest implements Service, Registerable {
 										<code><?php echo isset( $this->integration_status_response['is_healthy'] ) && $this->integration_status_response['is_healthy'] === true ? 'Healthy' : 'Unhealthy'; ?></code>
 									</p>
 								</td>
-							</tr>	
+							</tr>
 							<tr>
 								<th><label>Last Jetpack Contact:</label></th>
 								<td>
@@ -746,12 +765,12 @@ class ConnectionTest implements Service, Registerable {
 										<code><?php echo isset( $this->integration_status_response['errors'] ) ? wp_kses_post( json_encode( $this->integration_status_response['errors'] ) ) ?? '' : '-'; ?></code>
 									</p>
 								</td>
-							</tr>																																
+							</tr>
 						<?php } ?>
 						<tr>
 							<th><label>Revoke WPCOM Partner Access:</label></th>
 							<td>
-								<p>									
+								<p>
 									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'revoke-wpcom-partner-access' ], $url ), 'revoke-wpcom-partner-access' ) ); ?>">Revoke WPCOM Partner Access</a>
 								</p>
 							</td>

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -227,9 +227,10 @@ class AccountService implements OptionsAwareInterface, Service {
 		$wpcom_rest_api_status = $this->options->get( OptionsInterface::WPCOM_REST_API_STATUS );
 
 		$status = [
-			'id'                    => $id,
-			'status'                => $id ? 'connected' : 'disconnected',
-			'wpcom_rest_api_status' => $notifications_service->is_enabled() ? $wpcom_rest_api_status : 'disabled',
+			'id'                           => $id,
+			'status'                       => $id ? 'connected' : 'disconnected',
+			'notification_service_enabled' => $notifications_service->is_enabled(),
+			'wpcom_rest_api_status'        => $wpcom_rest_api_status,
 		];
 
 		$incomplete = $this->state->last_incomplete_step();

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -765,9 +765,10 @@ class AccountServiceTest extends UnitTest {
 
 		$this->assertEquals(
 			[
-				'id'                    => self::TEST_ACCOUNT_ID,
-				'status'                => 'connected',
-				'wpcom_rest_api_status' => 'approved',
+				'id'                           => self::TEST_ACCOUNT_ID,
+				'status'                       => 'connected',
+				'notification_service_enabled' => true,
+				'wpcom_rest_api_status'        => 'approved',
 			],
 			$this->account->get_connected_status()
 		);
@@ -788,9 +789,10 @@ class AccountServiceTest extends UnitTest {
 
 		$this->assertEquals(
 			[
-				'id'                    => self::TEST_ACCOUNT_ID,
-				'status'                => 'connected',
-				'wpcom_rest_api_status' => 'disabled',
+				'id'                           => self::TEST_ACCOUNT_ID,
+				'status'                       => 'connected',
+				'notification_service_enabled' => false,
+				'wpcom_rest_api_status'        => 'approved',
 			],
 			$this->account->get_connected_status()
 		);
@@ -811,10 +813,11 @@ class AccountServiceTest extends UnitTest {
 
 		$this->assertEquals(
 			[
-				'id'                    => self::TEST_ACCOUNT_ID,
-				'status'                => 'incomplete',
-				'step'                  => 'verify',
-				'wpcom_rest_api_status' => null,
+				'id'                           => self::TEST_ACCOUNT_ID,
+				'status'                       => 'incomplete',
+				'step'                         => 'verify',
+				'notification_service_enabled' => true,
+				'wpcom_rest_api_status'        => null,
 			],
 			$this->account->get_connected_status()
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up from this conversation p1719565119808809-slack-C02BB3F30TG

The PR enables Notifications feature by default

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Checkout this PR
2.  Complete setup
3.  Grant access to Data fetch in Settings
4.  Go to the connection test page
5.  Send a notification and verify it works
6. Add this filter `add_filter( 'woocommerce_gla_notifications_enabled', '__return_false' );`
7.  Send a notification and verify it fails 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>