### PR TITLE
[API Pull] Handle exception when deactivating the plugin and the WPCOM token does not exist.

### DIFF
--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -180,6 +180,11 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 	 * Revoke token on deactivation.
 	 */
 	public function deactivate(): void {
-		$this->revoke_wpcom_api_auth();
+		// Try to revoke the token on deactivation. If no token is available, it will throw an exception which we can ignore.
+		try {
+			$this->revoke_wpcom_api_auth();
+		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Do nothing.
+		}
 	}
 }

--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -183,8 +183,12 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 		// Try to revoke the token on deactivation. If no token is available, it will throw an exception which we can ignore.
 		try {
 			$this->revoke_wpcom_api_auth();
-		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Do nothing.
+		} catch ( Exception $e ) {
+			do_action(
+				'woocommerce_gla_error',
+				sprintf( 'Error revoking the WPCOM token: %s', $e->getMessage() ),
+				__METHOD__
+			);
 		}
 	}
 }

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -748,14 +748,6 @@ class ConnectionTest implements Service, Registerable {
 								</td>
 							</tr>																																
 						<?php } ?>
-						<tr>
-							<th><label>Revoke WPCOM Partner Access:</label></th>
-							<td>
-								<p>									
-									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'revoke-wpcom-partner-access' ], $url ), 'revoke-wpcom-partner-access' ) ); ?>">Revoke WPCOM Partner Access</a>
-								</p>
-							</td>
-						</tr>
 					</table>
 					<?php wp_nonce_field( 'partner-notification' ); ?>
 					<input name="page" value="connection-test-admin-page" type="hidden" />
@@ -887,24 +879,6 @@ class ConnectionTest implements Service, Registerable {
 				}
 			}
 
-		}
-
-		if ( 'revoke-wpcom-partner-access' === $_GET['action'] && check_admin_referer( 'revoke-wpcom-partner-access' ) ) {
-
-			$revoke_args = [
-				'method'  => 'DELETE',
-				'timeout' => 30,
-				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/google/revoke-token',
-				'user_id' => get_current_user_id(),
-			];
-
-			$revoke_response = Client::remote_request( $revoke_args, null );
-
-			if ( is_wp_error( $revoke_response ) ) {
-				$this->response .= $revoke_response->get_error_message();
-			} else {
-				$this->response .= wp_remote_retrieve_body( $revoke_response );
-			}
 		}
 
 		if ( 'disconnect-wp-api' === $_GET['action'] && check_admin_referer( 'disconnect-wp-api' ) ) {

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -132,6 +132,8 @@ class OAuthServiceTest extends UnitTest {
 
 		// The exception should be caught and ignored.
 		$this->service->deactivate();
+
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_error' ) );
 	}
 
 	/**

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -123,8 +123,6 @@ class OAuthServiceTest extends UnitTest {
 
 	public function test_deactivation_with_wp_error() {
 		$this->assertInstanceOf( Deactivateable::class, $this->service );
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'error message' );
 
 		$this->jp->expects( $this->once() )
 			->method( 'remote_request' )->willReturn( new WP_Error( 'error', 'error message' ) );
@@ -132,6 +130,7 @@ class OAuthServiceTest extends UnitTest {
 		$this->account_service->expects( $this->never() )
 			->method( 'reset_wpcom_api_authorization_data' );
 
+		// The exception should be caught and ignored.
 		$this->service->deactivate();
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of #2146 .

Currently, we throw an exception if the request to revoke the token fails, such as when the WPCOM token is not found and therefore can't be deleted. This can lead to a fatal error when deactivating the plugin, preventing its deactivation. Since not all merchants will opt into the new mechanism, the scenario where the WPCOM token is missing is possible. To prevent this fatal error, I think it's better to catch the exception and log the error.

Additionally, I've removed the "Revoke WPCOM Access token" option from the Connection Test page. We now have a similar option, "WPCOM REST API Status" -> "Disconnect," which has the same purpose, making the option redundant.

![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/16f670c5-4f0f-40f8-907c-18bf9661f817)



### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Revoke any WPCOM token, you can use the connection test page if you already have one WPCOM token.
2. Deactivate the plugin.
3. See that we prevent the fatal error and log the error. 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
