### PR TITLE
[API Pull] Tweak Variations Notifications

### DIFF
--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -55,6 +55,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 *
 	 * @param int    $item_id
 	 * @param string $status
+	 * @throws InvalidValue If the given ID doesn't reference a valid product.
 	 */
 	protected function set_status( int $item_id, string $status ): void {
 		$item = $this->get_item( $item_id );
@@ -84,6 +85,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 *
 	 * @param int    $item_id
 	 * @param string $topic
+	 * @throws InvalidValue If the given ID doesn't reference a valid product.
 	 * @return bool
 	 */
 	protected function can_process( int $item_id, string $topic ): bool {
@@ -103,6 +105,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 	 *
 	 * @param string $topic
 	 * @param int    $item
+	 * @throws InvalidValue If the given ID doesn't reference a valid product.
 	 */
 	protected function handle_notified( string $topic, int $item ): void {
 		if ( $this->is_delete_topic( $topic ) ) {

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -48,7 +48,6 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 				__METHOD__
 			);
 		}
-
 	}
 
 	/**

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -55,7 +55,7 @@ class ProductNotificationJob extends AbstractItemNotificationJob {
 	 */
 	protected function process_items( $args ): void {
 		if ( isset( $args['topic'] ) && isset( $args['item_id'] ) && $this->is_delete_topic( $args['topic'] ) ) {
-			$args['data'] = [ 'offer_id' => WCProductAdapter::get_google_product_offer_id( $this->get_slug(), $args['item_id'] ) ];
+			$args['data'] = [ 'offer_id' => $this->helper->get_offer_id( $args['item_id'] ) ];
 		}
 
 		parent::process_items( $args );

--- a/src/Jobs/Notifications/ProductNotificationJob.php
+++ b/src/Jobs/Notifications/ProductNotificationJob.php
@@ -5,10 +5,10 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -65,6 +65,8 @@ class ProductNotificationJob extends AbstractItemNotificationJob {
 	 * Get the product
 	 *
 	 * @param int $item_id
+	 * @throws InvalidValue If the given ID doesn't reference a valid product.
+	 *
 	 * @return \WC_Product
 	 */
 	protected function get_item( int $item_id ) {

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -398,7 +398,7 @@ class ProductHelper implements Service, HelperNotificationInterface {
 			in_array( $product->get_type(), ProductSyncer::get_supported_product_types(), true );
 
 		if ( $is_ready && $product instanceof WC_Product_Variation ) {
-			$parent = $this->maybe_swap_for_parent( $product );
+			$parent   = $this->maybe_swap_for_parent( $product );
 			$is_ready = $this->is_ready_to_notify( $parent );
 		}
 

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -765,7 +765,7 @@ class ProductHelper implements Service, HelperNotificationInterface {
 	 *
 	 * @return string The offer id
 	 */
-	public function get_offer_id( $product_id ) {
+	public function get_offer_id( int $product_id ) {
 		return WCProductAdapter::get_google_product_offer_id( $this->get_slug(), $product_id );
 	}
 }

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -397,6 +397,11 @@ class ProductHelper implements Service, HelperNotificationInterface {
 			$product->get_status() === 'publish' &&
 			in_array( $product->get_type(), ProductSyncer::get_supported_product_types(), true );
 
+		if ( $is_ready && $product instanceof WC_Product_Variation ) {
+			$parent = $this->maybe_swap_for_parent( $product );
+			$is_ready = $this->is_ready_to_notify( $parent );
+		}
+
 		/**
 		 * Allow users to filter if a product is ready to notify.
 		 *
@@ -750,5 +755,17 @@ class ProductHelper implements Service, HelperNotificationInterface {
 	public function get_categories( WC_Product $product ): array {
 		$terms = get_the_terms( $product->get_id(), 'product_cat' );
 		return ( empty( $terms ) || is_wp_error( $terms ) ) ? [] : wp_list_pluck( $terms, 'name' );
+	}
+
+	/**
+	 * Get the offer id for a product
+	 *
+	 * @since x.x.x
+	 * @param int $product_id The product id to get the offer id.
+	 *
+	 * @return string The offer id
+	 */
+	public function get_offer_id( $product_id ) {
+		return WCProductAdapter::get_google_product_offer_id( $this->get_slug(), $product_id );
 	}
 }

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -169,9 +169,7 @@ class SyncerHooks implements Service, Registerable {
 	 */
 	public function update_by_id( int $product_id ) {
 		$product = $this->wc->maybe_get_product( $product_id );
-		if ( $product instanceof WC_Product ) {
-			$this->handle_update_products( [ $product ] );
-		}
+		$this->handle_update_products( [ $product ] );
 	}
 
 	/**
@@ -215,6 +213,11 @@ class SyncerHooks implements Service, Registerable {
 		$products_to_delete = [];
 
 		foreach ( $products as $product ) {
+
+			if ( ! $product instanceof WC_Product ) {
+				continue;
+			}
+
 			$product_id = $product->get_id();
 
 			// Avoid to handle variations directly. We handle them from the parent.

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -216,7 +216,8 @@ class SyncerHooks implements Service, Registerable {
 		foreach ( $products as $product ) {
 			$product_id = $product->get_id();
 
-			if ( $this->notifications_service->is_ready() ) {
+			// Avoid to handle variations directly. We handle them from the parent.
+			if ( $this->notifications_service->is_ready() && ! $product instanceof \WC_Product_Variation ) {
 				$this->handle_update_product_notification( $product );
 			}
 

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -38,13 +38,17 @@ class ProductNotificationJobTest extends AbstractItemNotificationJobTest {
 	}
 
 	public function test_sends_offer_id_on_delete() {
-		$item  = $this->create_item();
-		$id    = $item->get_id();
-		$topic = $this->get_topic_name() . '.delete';
+		$item     = $this->create_item();
+		$id       = $item->get_id();
+		$topic    = $this->get_topic_name() . '.delete';
 
 		$this->job->get_helper()->expects( $this->once() )
 					->method( 'should_trigger_delete_notification' )
 					->willReturn( true );
+
+		$this->job->get_helper()->expects( $this->once() )
+		          ->method( 'get_offer_id' )
+		          ->willReturn( "gla_{$id}" );
 
 		$this->notification_service->expects( $this->once() )->method( 'notify' )->with(
 			$topic,
@@ -57,45 +61,6 @@ class ProductNotificationJobTest extends AbstractItemNotificationJobTest {
 				'item_id' => $id,
 				'topic'   => $topic,
 			]
-		);
-	}
-
-	public function test_sends_filtered_offer_id_on_delete() {
-		$item  = $this->create_item();
-		$id    = $item->get_id();
-		$topic = $this->get_topic_name() . '.delete';
-
-		add_filter(
-			'woocommerce_gla_get_google_product_offer_id',
-			function ( $value, $product_id ) {
-				return "custom_{$product_id}";
-			},
-			10,
-			2
-		);
-
-		$this->job->get_helper()->expects( $this->once() )
-					->method( 'should_trigger_delete_notification' )
-					->willReturn( true );
-
-		$this->notification_service->expects( $this->once() )->method( 'notify' )->with(
-			$topic,
-			$id,
-			[ 'offer_id' => "custom_{$id}" ]
-		)->willReturn( true );
-
-		$this->job->handle_process_items_action(
-			[
-				'item_id' => $id,
-				'topic'   => $topic,
-			]
-		);
-
-		remove_filter(
-			'woocommerce_gla_get_google_product_offer_id',
-			function ( $value, $product_id ) {
-				return "custom_{$product_id}";
-			}
 		);
 	}
 }

--- a/tests/Unit/Jobs/ProductNotificationJobTest.php
+++ b/tests/Unit/Jobs/ProductNotificationJobTest.php
@@ -38,17 +38,17 @@ class ProductNotificationJobTest extends AbstractItemNotificationJobTest {
 	}
 
 	public function test_sends_offer_id_on_delete() {
-		$item     = $this->create_item();
-		$id       = $item->get_id();
-		$topic    = $this->get_topic_name() . '.delete';
+		$item  = $this->create_item();
+		$id    = $item->get_id();
+		$topic = $this->get_topic_name() . '.delete';
 
 		$this->job->get_helper()->expects( $this->once() )
 					->method( 'should_trigger_delete_notification' )
 					->willReturn( true );
 
 		$this->job->get_helper()->expects( $this->once() )
-		          ->method( 'get_offer_id' )
-		          ->willReturn( "gla_{$id}" );
+					->method( 'get_offer_id' )
+					->willReturn( "gla_{$id}" );
 
 		$this->notification_service->expects( $this->once() )->method( 'notify' )->with(
 			$topic,

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -1189,6 +1189,32 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertFalse( $this->product_helper->should_trigger_delete_notification( $product ) );
 	}
 
+
+	public function test_get_offer_id() {
+		$this->assertEquals( $this->product_helper->get_offer_id( 1 ), "gla_1" );
+	}
+
+	public function test_get_filtered_offer_id() {
+
+		add_filter(
+			'woocommerce_gla_get_google_product_offer_id',
+			function ( $value, $product_id ) {
+				return "custom_{$product_id}";
+			},
+			10,
+			2
+		);
+
+		$this->assertEquals( $this->product_helper->get_offer_id( 1 ), "custom_1" );
+
+		remove_filter(
+			'woocommerce_gla_get_google_product_offer_id',
+			function ( $value, $product_id ) {
+				return "custom_{$product_id}";
+			}
+		);
+	}
+
 	/**
 	 * Set and save product to make it Notification Ready
 	 *

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -1191,11 +1191,10 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 
 
 	public function test_get_offer_id() {
-		$this->assertEquals( $this->product_helper->get_offer_id( 1 ), "gla_1" );
+		$this->assertEquals( $this->product_helper->get_offer_id( 1 ), 'gla_1' );
 	}
 
 	public function test_get_filtered_offer_id() {
-
 		add_filter(
 			'woocommerce_gla_get_google_product_offer_id',
 			function ( $value, $product_id ) {
@@ -1205,7 +1204,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 			2
 		);
 
-		$this->assertEquals( $this->product_helper->get_offer_id( 1 ), "custom_1" );
+		$this->assertEquals( $this->product_helper->get_offer_id( 1 ), 'custom_1' );
 
 		remove_filter(
 			'woocommerce_gla_get_google_product_offer_id',

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -430,7 +430,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 
 	public function test_create_variable_product_triggers_notifications_for_variable_and_variations() {
 		$this->set_mc_and_notifications( true, true );
-		$variable_product = $this->create_variation_product(  null, [ 'status' => 'draft' ] );
+		$variable_product = $this->create_variation_product( null, [ 'status' => 'draft' ] );
 		$ids              = array_merge( [ $variable_product->get_id() ], $variable_product->get_children() );
 		$matcher          = $this->exactly( count( $ids ) );
 		$this->product_notification_job->expects( $matcher )
@@ -481,14 +481,14 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'trash' ] );
 
 		$this->product_notification_job->expects( $this->once() )
-		                               ->method( 'schedule' )->with(
-				$this->equalTo(
-					[
-						'item_id' => $product->get_id(),
-						'topic'   => NotificationsService::TOPIC_PRODUCT_CREATED,
-					]
-				)
-			);
+										->method( 'schedule' )->with(
+											$this->equalTo(
+												[
+													'item_id' => $product->get_id(),
+													'topic'   => NotificationsService::TOPIC_PRODUCT_CREATED,
+												]
+											)
+										);
 
 		$product->set_status( 'publish' );
 		$product->save();

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -431,18 +431,19 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	public function test_create_variable_product_triggers_notifications_for_variable_and_variations() {
 		$this->set_mc_and_notifications( true, true );
 		$variable_product = $this->create_variation_product();
-		$ids = array_merge( [ $variable_product->get_id() ], $variable_product->get_children() );
-		$matcher = $this->exactly(count($ids));
+		$ids              = array_merge( [ $variable_product->get_id() ], $variable_product->get_children() );
+		$matcher          = $this->exactly( count( $ids ) );
 		$this->product_notification_job->expects( $matcher )
-		                               ->method( 'schedule' )
-		                               ->with(
-				$this->callback( function($args) use ($ids, $matcher) {
-						$this->assertEquals( $args['item_id'], $ids[$matcher->getInvocationCount() - 1] );
-						$this->assertEquals( $args['topic'], NotificationsService::TOPIC_PRODUCT_CREATED );
-						return true;
-					}
-				)
-			);
+										->method( 'schedule' )
+										->with(
+											$this->callback(
+												function ( $args ) use ( $ids, $matcher ) {
+																$this->assertEquals( $args['item_id'], $ids[ $matcher->getInvocationCount() - 1 ] );
+																$this->assertEquals( $args['topic'], NotificationsService::TOPIC_PRODUCT_CREATED );
+																return true;
+												}
+											)
+										);
 
 		$variable_product->set_status( 'publish' );
 		$variable_product->save();
@@ -451,8 +452,8 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	public function test_update_variable_product_triggers_notifications_for_variable_and_variations() {
 		$this->set_mc_and_notifications( true, true );
 		$variable_product = $this->create_variation_product();
-		$ids = array_merge( [ $variable_product->get_id() ], $variable_product->get_children() );
-		$matcher = $this->exactly(count($ids));
+		$ids              = array_merge( [ $variable_product->get_id() ], $variable_product->get_children() );
+		$matcher          = $this->exactly( count( $ids ) );
 
 		// Set all the variations and the variables as Created
 		foreach ( $ids as $id ) {
@@ -460,15 +461,16 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		}
 
 		$this->product_notification_job->expects( $matcher )
-		                               ->method( 'schedule' )
-		                               ->with(
-			                               $this->callback( function($args) use ($ids, $matcher) {
-				                               $this->assertEquals( $args['item_id'], $ids[$matcher->getInvocationCount() - 1] );
-				                               $this->assertEquals( $args['topic'], NotificationsService::TOPIC_PRODUCT_DELETED );
-				                               return true;
-			                               }
-			                               )
-		                               );
+										->method( 'schedule' )
+										->with(
+											$this->callback(
+												function ( $args ) use ( $ids, $matcher ) {
+													$this->assertEquals( $args['item_id'], $ids[ $matcher->getInvocationCount() - 1 ] );
+													$this->assertEquals( $args['topic'], NotificationsService::TOPIC_PRODUCT_DELETED );
+													return true;
+												}
+											)
+										);
 
 		$variable_product->set_status( 'publish' );
 		// Set the parent variable as DONT_SYNC_AND_SHOW
@@ -479,8 +481,8 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 	public function test_unsync_variable_product_triggers_notifications_for_variable_and_variations() {
 		$this->set_mc_and_notifications( true, true );
 		$variable_product = $this->create_variation_product();
-		$ids = array_merge( [ $variable_product->get_id() ], $variable_product->get_children() );
-		$matcher = $this->exactly(count($ids));
+		$ids              = array_merge( [ $variable_product->get_id() ], $variable_product->get_children() );
+		$matcher          = $this->exactly( count( $ids ) );
 
 		// Set all the variations and the variables as Created
 		foreach ( $ids as $id ) {
@@ -488,15 +490,16 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		}
 
 		$this->product_notification_job->expects( $matcher )
-		                               ->method( 'schedule' )
-		                               ->with(
-			                               $this->callback( function($args) use ($ids, $matcher) {
-				                               $this->assertEquals( $args['item_id'], $ids[$matcher->getInvocationCount() - 1] );
-				                               $this->assertEquals( $args['topic'], NotificationsService::TOPIC_PRODUCT_UPDATED );
-				                               return true;
-			                               }
-			                               )
-		                               );
+										->method( 'schedule' )
+										->with(
+											$this->callback(
+												function ( $args ) use ( $ids, $matcher ) {
+													$this->assertEquals( $args['item_id'], $ids[ $matcher->getInvocationCount() - 1 ] );
+													$this->assertEquals( $args['topic'], NotificationsService::TOPIC_PRODUCT_UPDATED );
+													return true;
+												}
+											)
+										);
 
 		$variable_product->set_status( 'publish' );
 		$variable_product->save();
@@ -508,9 +511,9 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_CREATED );
 
-		$this->notification_service->expects( $this->exactly(1) )
-		                               ->method( 'notify' )
-		                               ->with( NotificationsService::TOPIC_PRODUCT_DELETED, $product->get_id(), [ 'offer_id' => "gla_{$product->get_id()}"] );
+		$this->notification_service->expects( $this->exactly( 1 ) )
+										->method( 'notify' )
+										->with( NotificationsService::TOPIC_PRODUCT_DELETED, $product->get_id(), [ 'offer_id' => "gla_{$product->get_id()}" ] );
 
 		$product->delete();
 	}
@@ -521,9 +524,9 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
 		$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_CREATED );
 
-		$this->notification_service->expects( $this->exactly(1) )
-		                           ->method( 'notify' )
-		                           ->with( NotificationsService::TOPIC_PRODUCT_DELETED, $product->get_id(), [ 'offer_id' => "gla_{$product->get_id()}"] );
+		$this->notification_service->expects( $this->exactly( 1 ) )
+									->method( 'notify' )
+									->with( NotificationsService::TOPIC_PRODUCT_DELETED, $product->get_id(), [ 'offer_id' => "gla_{$product->get_id()}" ] );
 
 		$product->delete( true );
 	}
@@ -533,7 +536,7 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 		/** @var \WC_Product $product */
 		$product = WC_Helper_Product::create_simple_product( true, [ 'status' => 'draft' ] );
 		$this->notification_service->expects( $this->never() )
-		                           ->method( 'notify' );
+									->method( 'notify' );
 
 		$product->delete();
 		$product->delete( true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR tweaks the logic for notifications when handling variations. In particular:

- FIXED: We were sending create notifications for variations when the parent was not published still
- FIXED: We were only sending delete notifications for the parent when a variation was deleted.
- FIXED: SOme unhandled exceptions when we try to access. a product that is not in the database anymore. 

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout PR
2. Test that creation/update/deletion of simple product works as always
3. Create a Variable Product and generate variations for It 
4. Go to Woo - Status - Scheduled actions - That step should not schedule any notifications
5. Asign price to some of the variations and publish the product
6. Go to Woo - Status - Scheduled actions - See scheduled notifications create for the variations with price + the variable product
7. Run the actions and see if they are logged in the gla log under Woo - Status - logs
8. Edit one of the variations without price
9. It doesn't schedule or log anything as it was not created yet
10. Remove one of the variations without price
11.  It doesn't schedule or log anything as it was not created yet
12. Edit one of the variations with price 
13. Go to Woo - Status - Scheduled actions - See scheduled notifications update for the variations with price + the variable product. Run them
14. Remove the variation with price 
15. Go to Woo - Status - Scheduled actions - See scheduled notifications update for the variations with price + the variable product and one delete notification in the logs (directly without schedule) for the one you deleted with offer_id
16. Set the variable product as DONT SYNC AND SHOW
17.  Go to Woo - Status - Scheduled actions - See scheduled notifications delete for the variations with price + the variable product 
18. Before running it. Go back and set the variable product as  SYNC AND SHOW
19. Go to Woo - Status - Scheduled actions - See scheduled notifications update for the variations with price + the variable product 
20. Run the delete notifications of the step 17
21. See in the logs they are not logged (a filter prevented it, because we set is as visible in step 18)
22. Run the tasks from step 19
23. See them logged in the log
24. Try to delete products and variations in different ways to see if everything is handled properly.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> 
