### PR TITLE
[API Pull] Add Track Events to the Auth API responses

### DIFF
--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -167,8 +167,9 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 				'woocommerce_gla_track_event',
 				'revoke_wpcom_api_auth',
 				[
-					'status' => 'error',
-					'error'  => $request->get_error_message(),
+					'status'  => 'error',
+					'error'   => $request->get_error_message(),
+					'blog_id' => Jetpack_Options::get_option( 'id' ),
 				]
 			);
 
@@ -188,8 +189,9 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 					'woocommerce_gla_track_event',
 					'revoke_wpcom_api_auth',
 					[
-						'status' => $status,
-						'error'  => $message,
+						'status'  => $status,
+						'error'   => $message,
+						'blog_id' => Jetpack_Options::get_option( 'id' ),
 					]
 				);
 
@@ -203,7 +205,8 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 				'woocommerce_gla_track_event',
 				'revoke_wpcom_api_auth',
 				[
-					'status' => 200,
+					'status'  => 200,
+					'blog_id' => Jetpack_Options::get_option( 'id' ),
 				]
 			);
 

--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -164,15 +164,15 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 			 * When the WPCOM token has been revoked with errors.
 			 *
 			 * @event revoke_wpcom_api_authorization
-			 * @property string status The status of the request.
+			 * @property int status The status of the request.
 			 * @property string error The error message.
-			 * @property mixed blog_id The blog ID.
+			 * @property int|null blog_id The blog ID.
 			 */
 			do_action(
 				'woocommerce_gla_track_event',
 				'revoke_wpcom_api_authorization',
 				[
-					'status'  => 'error',
+					'status'  => 400,
 					'error'   => $request->get_error_message(),
 					'blog_id' => Jetpack_Options::get_option( 'id' ),
 				]
@@ -192,9 +192,9 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 				* When the WPCOM token has been revoked with errors.
 				*
 				* @event revoke_wpcom_api_authorization
-				* @property string status The status of the request.
+				* @property int status The status of the request.
 				* @property string error The error message.
-				* @property mixed blog_id The blog ID.
+				* @property int|null blog_id The blog ID.
 				 */
 				do_action(
 					'woocommerce_gla_track_event',
@@ -214,8 +214,7 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 			*
 			* @event revoke_wpcom_api_authorization
 			* @property string status The status of the request.
-			* @property string error The error message.
-			* @property mixed blog_id The blog ID.
+			* @property int|null blog_id The blog ID.
 			 */
 			do_action(
 				'woocommerce_gla_track_event',

--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -161,11 +161,16 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 		if ( is_wp_error( $request ) ) {
 
 			/**
-			 * @event revoke_wpcom_api_auth
+			 * When the WPCOM token has been revoked with errors.
+			 *
+			 * @event revoke_wpcom_api_authorization
+			 * @property string status The status of the request.
+			 * @property string error The error message.
+			 * @property mixed blog_id The blog ID.
 			 */
 			do_action(
 				'woocommerce_gla_track_event',
-				'revoke_wpcom_api_auth',
+				'revoke_wpcom_api_authorization',
 				[
 					'status'  => 'error',
 					'error'   => $request->get_error_message(),
@@ -183,11 +188,17 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 				$message = $data['message'] ?? 'Error revoking access to WPCOM.';
 
 				/**
-				 * @event revoke_wpcom_api_auth
+				*
+				* When the WPCOM token has been revoked with errors.
+				*
+				* @event revoke_wpcom_api_authorization
+				* @property string status The status of the request.
+				* @property string error The error message.
+				* @property mixed blog_id The blog ID.
 				 */
 				do_action(
 					'woocommerce_gla_track_event',
-					'revoke_wpcom_api_auth',
+					'revoke_wpcom_api_authorization',
 					[
 						'status'  => $status,
 						'error'   => $message,
@@ -199,11 +210,16 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 			}
 
 			/**
-			 * @event revoke_wpcom_api_auth
+			* When the WPCOM token has been revoked successfully.
+			*
+			* @event revoke_wpcom_api_authorization
+			* @property string status The status of the request.
+			* @property string error The error message.
+			* @property mixed blog_id The blog ID.
 			 */
 			do_action(
 				'woocommerce_gla_track_event',
-				'revoke_wpcom_api_auth',
+				'revoke_wpcom_api_authorization',
 				[
 					'status'  => 200,
 					'blog_id' => Jetpack_Options::get_option( 'id' ),

--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -213,7 +213,7 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 			* When the WPCOM token has been revoked successfully.
 			*
 			* @event revoke_wpcom_api_authorization
-			* @property string status The status of the request.
+			* @property int status The status of the request.
 			* @property int|null blog_id The blog ID.
 			 */
 			do_action(

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -576,7 +576,11 @@ class AccountService implements OptionsAwareInterface, Service {
 			$this->delete_wpcom_api_auth_nonce();
 
 			/**
+			* When the WPCOM Authorization status has been updated.
+			*
 			* @event update_wpcom_api_authorization
+			* @property string status The status of the request.
+			* @property string blog_id The blog ID.
 			*/
 			do_action(
 				'woocommerce_gla_track_event',
@@ -591,7 +595,11 @@ class AccountService implements OptionsAwareInterface, Service {
 		} catch ( ExceptionWithResponseData $e ) {
 
 			/**
+			* When the WPCOM Authorization status has been updated with errors.
+			*
 			* @event update_wpcom_api_authorization
+			* @property string status The status of the request.
+			* @property string blog_id The blog ID.
 			*/
 			do_action(
 				'woocommerce_gla_track_event',

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Exception;
+use Jetpack_Options;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -581,7 +582,8 @@ class AccountService implements OptionsAwareInterface, Service {
 				'woocommerce_gla_track_event',
 				'update_wpcom_api_authorization',
 				[
-					'status' => $status,
+					'status'  => $status,
+					'blog_id' => Jetpack_Options::get_option( 'id' ),
 				]
 			);
 
@@ -595,7 +597,8 @@ class AccountService implements OptionsAwareInterface, Service {
 				'woocommerce_gla_track_event',
 				'update_wpcom_api_authorization',
 				[
-					'status' => $e->getMessage(),
+					'status'  => $e->getMessage(),
+					'blog_id' => Jetpack_Options::get_option( 'id' ),
 				]
 			);
 

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -580,7 +580,7 @@ class AccountService implements OptionsAwareInterface, Service {
 			*
 			* @event update_wpcom_api_authorization
 			* @property string status The status of the request.
-			* @property string blog_id The blog ID.
+			* @property int|null blog_id The blog ID.
 			*/
 			do_action(
 				'woocommerce_gla_track_event',
@@ -599,7 +599,7 @@ class AccountService implements OptionsAwareInterface, Service {
 			*
 			* @event update_wpcom_api_authorization
 			* @property string status The status of the request.
-			* @property string blog_id The blog ID.
+			* @property int|null blog_id The blog ID.
 			*/
 			do_action(
 				'woocommerce_gla_track_event',

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Containe
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Jetpack;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_Error;
 use Exception;
@@ -25,6 +26,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class OAuthServiceTest extends UnitTest {
 
+	use TrackingTrait;
 	use UtilitiesTrait;
 
 	/**
@@ -201,5 +203,86 @@ class OAuthServiceTest extends UnitTest {
 			$store_url,
 			$parsed_state['store_url']
 		);
+	}
+
+	public function test_revoke_wpcom_api_auth() {
+		$this->jp->expects( $this->once() )
+			->method( 'remote_request' )
+			->willReturn(
+				[
+					'body'     => '{"success":true}',
+					'response' => [ 'code' => 200 ],
+				]
+			);
+
+		$this->account_service->expects( $this->once() )
+			->method( 'reset_wpcom_api_authorization_data' );
+
+		$this->account_service->expects( $this->once() )
+			->method( 'reset_wpcom_api_authorization_data' );
+
+		$this->expect_track_event(
+			'revoke_wpcom_api_auth',
+			[
+				'status' => 200,
+			]
+		);
+
+		$response = $this->service->revoke_wpcom_api_auth();
+
+		$this->assertEquals( '{"success":true}', $response );
+	}
+
+	public function test_revoke_wpcom_api_auth_wp_error() {
+		$this->jp->expects( $this->once() )
+			->method( 'remote_request' )
+			->willReturn(
+				new WP_Error( 'error', 'error message' )
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'error message' );
+		$this->expectExceptionCode( 400 );
+
+		$this->account_service->expects( $this->never() )
+			->method( 'reset_wpcom_api_authorization_data' );
+
+		$this->expect_track_event(
+			'revoke_wpcom_api_auth',
+			[
+				'status' => 'error',
+				'error'  => 'error message',
+			]
+		);
+
+		$this->service->revoke_wpcom_api_auth();
+	}
+
+	public function test_revoke_wpcom_api_auth_status_error() {
+		$this->jp->expects( $this->once() )
+			->method( 'remote_request' )
+			->willReturn(
+				[
+					'body'     => '{"message":"error message"}',
+					'response' => [ 'code' => 400 ],
+				]
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'error message' );
+		$this->expectExceptionCode( 400 );
+
+		$this->account_service->expects( $this->never() )
+			->method( 'reset_wpcom_api_authorization_data' );
+
+		$this->expect_track_event(
+			'revoke_wpcom_api_auth',
+			[
+				'status' => 400,
+				'error'  => 'error message',
+			]
+		);
+
+		$this->service->revoke_wpcom_api_auth();
 	}
 }

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -223,7 +223,7 @@ class OAuthServiceTest extends UnitTest {
 			->method( 'reset_wpcom_api_authorization_data' );
 
 		$this->expect_track_event(
-			'revoke_wpcom_api_auth',
+			'revoke_wpcom_api_authorization',
 			[
 				'status'  => 200,
 				'blog_id' => Jetpack_Options::get_option( 'id' ),
@@ -250,7 +250,7 @@ class OAuthServiceTest extends UnitTest {
 			->method( 'reset_wpcom_api_authorization_data' );
 
 		$this->expect_track_event(
-			'revoke_wpcom_api_auth',
+			'revoke_wpcom_api_authorization',
 			[
 				'status'  => 'error',
 				'error'   => 'error message',
@@ -279,7 +279,7 @@ class OAuthServiceTest extends UnitTest {
 			->method( 'reset_wpcom_api_authorization_data' );
 
 		$this->expect_track_event(
-			'revoke_wpcom_api_auth',
+			'revoke_wpcom_api_authorization',
 			[
 				'status'  => 400,
 				'error'   => 'error message',

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\Tracking
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_Error;
 use Exception;
+use Jetpack_Options;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -224,7 +225,8 @@ class OAuthServiceTest extends UnitTest {
 		$this->expect_track_event(
 			'revoke_wpcom_api_auth',
 			[
-				'status' => 200,
+				'status'  => 200,
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
 			]
 		);
 
@@ -250,8 +252,9 @@ class OAuthServiceTest extends UnitTest {
 		$this->expect_track_event(
 			'revoke_wpcom_api_auth',
 			[
-				'status' => 'error',
-				'error'  => 'error message',
+				'status'  => 'error',
+				'error'   => 'error message',
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
 			]
 		);
 
@@ -278,8 +281,9 @@ class OAuthServiceTest extends UnitTest {
 		$this->expect_track_event(
 			'revoke_wpcom_api_auth',
 			[
-				'status' => 400,
-				'error'  => 'error message',
+				'status'  => 400,
+				'error'   => 'error message',
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
 			]
 		);
 

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -252,7 +252,7 @@ class OAuthServiceTest extends UnitTest {
 		$this->expect_track_event(
 			'revoke_wpcom_api_authorization',
 			[
-				'status'  => 'error',
+				'status'  => 400,
 				'error'   => 'error message',
 				'blog_id' => Jetpack_Options::get_option( 'id' ),
 			]

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -37,6 +38,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class AccountServiceTest extends UnitTest {
 
+	use TrackingTrait;
 	use MerchantTrait;
 
 	/** @var MockObject|Ads $ads */
@@ -877,6 +879,13 @@ class AccountServiceTest extends UnitTest {
 			->method( 'delete' )
 			->with( OptionsInterface::GOOGLE_WPCOM_AUTH_NONCE );
 
+		$this->expect_track_event(
+			'update_wpcom_api_authorization',
+			[
+				'status' => 'approved',
+			]
+		);
+
 		$this->account->update_wpcom_api_authorization( $status, $nonce );
 	}
 
@@ -896,6 +905,13 @@ class AccountServiceTest extends UnitTest {
 
 		$this->expectException( ExceptionWithResponseData::class );
 		$this->expectExceptionMessage( 'Nonce is not provided, skip updating auth status.' );
+
+		$this->expect_track_event(
+			'update_wpcom_api_authorization',
+			[
+				'status' => 'Nonce is not provided, skip updating auth status.',
+			]
+		);
 
 		$this->account->update_wpcom_api_authorization( $status, $nonce );
 	}
@@ -917,6 +933,13 @@ class AccountServiceTest extends UnitTest {
 		$this->expectException( ExceptionWithResponseData::class );
 		$this->expectExceptionMessage( 'No stored nonce found in the database, skip updating auth status.' );
 
+		$this->expect_track_event(
+			'update_wpcom_api_authorization',
+			[
+				'status' => 'No stored nonce found in the database, skip updating auth status.',
+			]
+		);
+
 		$this->account->update_wpcom_api_authorization( $status, $nonce );
 	}
 
@@ -937,6 +960,13 @@ class AccountServiceTest extends UnitTest {
 
 		$this->expectException( ExceptionWithResponseData::class );
 		$this->expectExceptionMessage( 'Nonces mismatch, skip updating auth status.' );
+
+		$this->expect_track_event(
+			'update_wpcom_api_authorization',
+			[
+				'status' => 'Nonces mismatch, skip updating auth status.',
+			]
+		);
 
 		$this->account->update_wpcom_api_authorization( $status, $nonce );
 	}

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -27,6 +27,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Containe
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
+use Jetpack_Options;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -882,7 +883,8 @@ class AccountServiceTest extends UnitTest {
 		$this->expect_track_event(
 			'update_wpcom_api_authorization',
 			[
-				'status' => 'approved',
+				'status'  => 'approved',
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
 			]
 		);
 
@@ -909,7 +911,8 @@ class AccountServiceTest extends UnitTest {
 		$this->expect_track_event(
 			'update_wpcom_api_authorization',
 			[
-				'status' => 'Nonce is not provided, skip updating auth status.',
+				'status'  => 'Nonce is not provided, skip updating auth status.',
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
 			]
 		);
 
@@ -936,7 +939,8 @@ class AccountServiceTest extends UnitTest {
 		$this->expect_track_event(
 			'update_wpcom_api_authorization',
 			[
-				'status' => 'No stored nonce found in the database, skip updating auth status.',
+				'status'  => 'No stored nonce found in the database, skip updating auth status.',
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
 			]
 		);
 
@@ -964,7 +968,8 @@ class AccountServiceTest extends UnitTest {
 		$this->expect_track_event(
 			'update_wpcom_api_authorization',
 			[
-				'status' => 'Nonces mismatch, skip updating auth status.',
+				'status'  => 'Nonces mismatch, skip updating auth status.',
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
 			]
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of #2146 .

Currently, we have two tracking events, `gla_disable_product_sync_click` and `gla_enable_product_sync_click`. However, it would also be useful to track the status of the Auth flow and when merchants revoke access.

This PR adds the following server-side event tracking:

- `revoke_wpcom_api_authorization` -> When the token is revoked, this event will include the status, blog id, and any error if it exists.
- `update_wpcom_api_authorization` -> When the Auth flow is completed, this event will include the status, blog id, and any error if it exists.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm tracking is allowed in WooCommerce > Settings > Advanced > Woo.com
2. To view the tracking, go to Tracks -> History (live tracking doesn't show the properties). Filter by your username and the following events: `wcadmin_gla_update_wpcom_api_authorization` and `wcadmin_gla_revoke_wpcom_api_auth`. It may take some time for the data to appear.
3. Alternatively you can use the following filter to see the events in the error log:

```
add_filter(
	'pre_http_request',
	function ( $pre, $args, $url ) {
		if ( str_starts_with( $url, 'https://pixel.wp.com' ) ) {
			wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_vars );
			error_log( json_encode( $query_vars, JSON_PRETTY_PRINT ) );
		}
		return $pre;
	},
	10,
	3
);
```
Ref: https://github.com/woocommerce/google-listings-and-ads/pull/2207

4. Enable the notification service: `add_filter( 'woocommerce_gla_notifications_enabled','__return_true' )`;
5. Go to GLA -> Settings -> Get Early Access -> follow the steps.
6. Revoke the access by clicking in : `Disable product data fetch`:


![image](https://github.com/woocommerce/google-listings-and-ads/assets/2488994/ba1d4129-2265-45ed-a140-1b0ec9fbfa8d)

 


### Additional details:

- I included the `blog_id` because I thought it might help with debugging issues, but I can't see it in Tracks. I'm not sure why that is.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
