### PR TITLE
[API Pull] Ensure empty GLA attributes are returned as an object instead of an empty array in the responses.

### DIFF
--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -312,8 +312,9 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		$resource = $this->get_route_pieces( $request )['resource'] ?? null;
 
 		if ( $item instanceof WC_Product && ( $resource === 'products' || $resource === 'variations' ) ) {
-			$attr                   = $this->attribute_manager->get_all_aggregated_values( $item );
-			$data['gla_attributes'] = $attr;
+			$attr = $this->attribute_manager->get_all_aggregated_values( $item );
+			// In case of empty array, convert to object to keep the response consistent.
+			$data['gla_attributes'] = (object) $attr;
 		}
 
 		foreach ( $data['meta_data'] ?? [] as $key => $meta ) {

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -123,6 +123,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$this->assertEquals( $product_1->get_id(), $response->get_data()[0]['id'] );
 		$this->assertEquals( $expected_metadata, $this->format_metadata( $response->get_data()[0]['meta_data'] ) );
 		$this->assertArrayHasKey( 'gla_attributes', $response->get_data()[0] );
+		$this->assertEquals( 'object', gettype( $response->get_data()[0]['gla_attributes'] ) );
 	}
 
 	public function test_get_products_with_gla_syncable_false() {
@@ -167,6 +168,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$this->assertEquals( $product_2->get_id(), $response->get_data()[0]['id'] );
 		$this->assertEquals( $expected_metadata, $this->format_metadata( $response->get_data()[0]['meta_data'] ) );
 		$this->assertArrayHasKey( 'gla_attributes', $response->get_data()[0] );
+		$this->assertEquals( 'object', gettype( $response->get_data()[0]['gla_attributes'] ) );
 	}
 
 	public function test_get_product_without_gla_visibility_metadata() {
@@ -248,6 +250,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 			$this->assertArrayHasKey( $variation['variation_id'], $response_mapped );
 			$this->assertEquals( $expected_metadata, $this->format_metadata( $response_mapped[ $variation['variation_id'] ]['meta_data'] ) );
 			$this->assertArrayHasKey( 'gla_attributes', $response->get_data()[0] );
+			$this->assertEquals( 'object', gettype( $response->get_data()[0]['gla_attributes'] ) );
 		}
 	}
 
@@ -295,6 +298,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( $expected_metadata, $this->format_metadata( $response->get_data()['meta_data'] ) );
 		$this->assertArrayHasKey( 'gla_attributes', $response->get_data() );
+		$this->assertEquals( 'object', gettype( $response->get_data()['gla_attributes'] ) );
 	}
 
 	public function test_get_specific_variation_without_gla_syncable() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of #2146 

This PR ensures that empty GLA attributes are returned as an empty object instead of an empty array, maintaining consistency in the responses.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Remove any attribute mapping set.
2. Make a request to `GET wp-json/wc/v3/products/PRODUCT_ID?gla_syncable=1`
3. Check that `gla_attributes` is returned as an empty object instead of an empty array.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
