### PR TITLE
Fix e2e tests failed with WC 9.1

### DIFF
--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -529,7 +529,9 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await input.fill( '-1' );
 
-		await editorUtils.assertUnableSave( 'The minimum value of the field is 0' );
+		await editorUtils.assertUnableSave(
+			'The minimum value of the field is 0'
+		);
 		await expect( help ).toBeVisible();
 		await expect( help ).toHaveText(
 			await editorUtils.evaluateValidationMessage( input )

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -529,7 +529,7 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await input.fill( '-1' );
 
-		await editorUtils.assertUnableSave();
+		await editorUtils.assertUnableSave( 'The minimum value of the field is 0' );
 		await expect( help ).toBeVisible();
 		await expect( help ).toHaveText(
 			await editorUtils.evaluateValidationMessage( input )

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -46,7 +46,7 @@ export default class MockRequests {
 	 */
 	async fulfillWCDefaultCountry( payload ) {
 		await this.fulfillRequest(
-			/wc-admin\/options\?options=woocommerce_default_country\b/,
+			/wc-admin\/options\?options=.*woocommerce_default_country\b/,
 			payload
 		);
 	}

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -507,17 +507,20 @@ export function getProductBlockEditorUtils( page ) {
 	};
 
 	const assertions = {
-		async assertUnableSave() {
+		async assertUnableSave( message = 'Please enter a valid value.' ) {
 			await this.clickSave();
 
 			const failureNotice = page
-				.getByRole( 'button' )
-				.filter( { hasText: 'Failed to save product' } );
+				.locator( '.components-snackbar__content' )
+				.filter( { hasText: new RegExp( message ) } );
+
+			const failureNoticeDismissButton = failureNotice
+				.getByRole( 'button' );
 
 			await expect( failureNotice ).toBeVisible();
 
 			// Dismiss the notice.
-			await failureNotice.click();
+			await failureNoticeDismissButton.click();
 			await expect( failureNotice ).toHaveCount( 0 );
 		},
 	};

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -291,8 +291,8 @@ export function getProductBlockEditorUtils( page ) {
 	const locators = {
 		getTab( tabName ) {
 			return page
-				.getByRole( 'tablist' )
-				.getByRole( 'button', { name: tabName } );
+				.locator( '.woocommerce-product-tabs' )
+				.getByRole( 'tab', { name: tabName } );
 		},
 
 		getPluginTab() {

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -514,8 +514,8 @@ export function getProductBlockEditorUtils( page ) {
 				.locator( '.components-snackbar__content' )
 				.filter( { hasText: new RegExp( message ) } );
 
-			const failureNoticeDismissButton = failureNotice
-				.getByRole( 'button' );
+			const failureNoticeDismissButton =
+				failureNotice.getByRole( 'button' );
 
 			await expect( failureNotice ).toBeVisible();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2453.

This PR fixes three part of the E2E tests:

The first one is related to woocommerce/woocommerce#47860, where the tabs (`<button>` elements) on the product edit block has been added `role="tab"` attribute. So we should rewrite the Playwright query from `getByRole( 'button' )` to `getByRole( 'tab' )`.

The second one is related to woocommerce/woocommerce#48192, where the error messages of the failure notice on the product edit block has been modified from always showing `Failed to save product` to different messages based on the error type. E.g.

**Date error:**

<img width="928" alt="Screenshot 2024-07-08 at 17 42 55" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/3fb8160c-f02f-449c-bdd6-4f84e0435211">
.

**Multipack error:**

<img width="955" alt="Screenshot 2024-07-08 at 17 44 10" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/f72046e7-1b0b-408a-a409-9c948617d87d">

<img width="982" alt="Screenshot 2024-07-08 at 17 44 25" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/09bdacbd-0640-4d80-ab85-ad6bc7f8ff4d">

<img width="969" alt="Screenshot 2024-07-08 at 17 43 48" src="https://github.com/woocommerce/google-listings-and-ads/assets/914406/01af5c52-803d-4747-b3ba-2dd9e0c4a72f">
.

Also, the behaviour of dismissing the error notice has been changed. Instead of clicking anywhere on the notice to dismiss it, now we need to click a specific `X` button.

The third one is not related to the compatibility of WC 9.1. It's in the onboarding step 2 when we want to overwrite the default WC country by fulfilling the request `/wc-admin/options?options=woocommerce_default_country`. Now that there are more options being added into the `options` query parameter, so we need to rewrite the URL matching pattern from `/wc-admin\/options\?options=woocommerce_default_country\b/` to `/wc-admin\/options\?options=.*woocommerce_default_country\b/`.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check out the branch of this PR
2. [Set up E2E test](https://github.com/woocommerce/google-listings-and-ads?tab=readme-ov-file#e2e-testing)
3. Upgrade WP to 6.6-RC2
    ```bash
    npm run -- wp-env run tests-cli -- wp core update --version=6.6-RC2
    npm run -- wp-env run tests-cli -- wp core update-db
    ````
4. Upgrade WC to 9.1.0-rc.1
    ```bash
    npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.1.0-rc.1
    npm run -- wp-env run tests-cli -- wp wc update
    ````
5. Run E2E test: `npm run test:e2e`
6. See the E2E test passed


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix E2E tests failed with WC 9.1
