### PR TITLE
[API PULL] Disable create and update notifications for variations

### DIFF
--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -422,7 +422,7 @@ class ProductHelper implements Service, HelperNotificationInterface {
 	 * @return bool
 	 */
 	public function should_trigger_create_notification( $product ): bool {
-		return $this->is_ready_to_notify( $product ) && ! $this->has_notified_creation( $product );
+		return ! $product instanceof WC_Product_Variation && $this->is_ready_to_notify( $product ) && ! $this->has_notified_creation( $product );
 	}
 
 	/**
@@ -434,7 +434,7 @@ class ProductHelper implements Service, HelperNotificationInterface {
 	 * @return bool
 	 */
 	public function should_trigger_update_notification( $product ): bool {
-		return $this->is_ready_to_notify( $product ) && $this->has_notified_creation( $product );
+		return ! $product instanceof WC_Product_Variation && $this->is_ready_to_notify( $product ) && $this->has_notified_creation( $product );
 	}
 
 	/**
@@ -458,6 +458,10 @@ class ProductHelper implements Service, HelperNotificationInterface {
 	 * @return bool
 	 */
 	public function has_notified_creation( WC_Product $product ): bool {
+		if ( $product instanceof WC_Product_Variation ) {
+			return $this->has_notified_creation( $this->maybe_swap_for_parent( $product ) );
+		}
+
 		$valid_has_notified_creation_statuses = [
 			NotificationStatus::NOTIFICATION_CREATED,
 			NotificationStatus::NOTIFICATION_UPDATED,

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -281,13 +281,6 @@ class SyncerHooks implements Service, Registerable {
 					'topic'   => NotificationsService::TOPIC_PRODUCT_CREATED,
 				]
 			);
-
-			// Variations are not handled when the parent is created.
-			if ( $product instanceof WC_Product_Variable ) {
-				foreach ( $product->get_available_variations( 'objects' ) as $variation ) {
-					$this->handle_update_product_notification( $variation );
-				}
-			}
 		} elseif ( $this->product_helper->should_trigger_update_notification( $product ) ) {
 			$this->product_helper->set_notification_status( $product, NotificationStatus::NOTIFICATION_PENDING_UPDATE );
 			$this->product_notification_job->schedule(
@@ -298,6 +291,12 @@ class SyncerHooks implements Service, Registerable {
 			);
 		} elseif ( $this->product_helper->should_trigger_delete_notification( $product ) ) {
 			$this->schedule_delete_notification( $product );
+			// Schedule variation deletion when the parent is deleted.
+			if ( $product instanceof WC_Product_Variable ) {
+				foreach ( $product->get_available_variations( 'objects' ) as $variation ) {
+					$this->handle_update_product_notification( $variation );
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Disable Create notification if the product is a variation
- Disable Update notification if the product is a variation
- Schedules delete notifications when the parent product is (DONT_SYNC_AND_SHOW, unpublished etc...) 
- Tweak tests

Slack ref: p1720458122308169/1719561677.366209-slack-C02BB3F30TG

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a variable product
2. Set the variables for the product and prices
3. Publish the product
4. See the Notification Create Job is scheduled for the parent. Run it
5. Update the product description 
6. See the Notification Update Job is scheduled for the parent. Run it
7.  Update a variation price
8. See the Notification Update Job is scheduled for the parent. Run it
9. Delete a variation
10. See the Notification Update Job is scheduled for the parent. Run it
11. See in the logs the delete notification has been sent for the variable 
12. Set the parent product as "DONT SYNC AND SHOW" 
13. See the Notification Delete Job is scheduled for the parent and variations


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>