### PR TITLE
Make campaign preview card responsive

### DIFF
--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -58,10 +58,14 @@ const BudgetSection = ( { formProps, disabled = false, children } ) => {
 			<Section
 				disabled={ disabled }
 				title={ __( 'Set your budget', 'google-listings-and-ads' ) }
-				description={ __(
-					'With Performance Max campaigns, you can set your own budget and Google’s Smart Bidding technology will serve the most appropriate ad, with the optimal bid, to maximize campaign performance. You only pay when people click on your ads, and you can start or stop your campaign whenever you want.',
-					'google-listings-and-ads'
-				) }
+				description={
+					<p>
+						{ __(
+							'With Performance Max campaigns, you can set your own budget and Google’s Smart Bidding technology will serve the most appropriate ad, with the optimal bid, to maximize campaign performance. You only pay when people click on your ads, and you can start or stop your campaign whenever you want.',
+							'google-listings-and-ads'
+						) }
+					</p>
+				}
 			>
 				<Section.Card>
 					<Section.Card.Body className="gla-budget-section__card-body">

--- a/js/src/components/paid-ads/campaign-preview/campaign-preview-card.js
+++ b/js/src/components/paid-ads/campaign-preview/campaign-preview-card.js
@@ -36,7 +36,7 @@ export default function CampaignPreviewCard() {
 	return (
 		<Section.Card className="gla-campaign-preview-card">
 			<Section.Card.Body>
-				<Flex align="start" gap={ 9 }>
+				<Flex align="start" gap={ 9 } direction={ [ 'column', 'row' ] }>
 					<FlexBlock>
 						<Section.Card.Title>
 							{ __(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2461.

This PR tweaks the campaign preview card to be responsive.

### Before

![image](https://github.com/user-attachments/assets/f4919275-62db-45f3-9cc0-7b586f5a1019)


### After

![image](https://github.com/user-attachments/assets/de2d86f3-9e09-4b05-9825-15cff7724179)



### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check out this branch and build the assets.
2. Go to Add Campaign.
3. Now, the first step of creating a campaign is functional. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak -   Make campaign preview card responsive
