### PR TITLE
Enable page size in campaigns endpoint

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -101,7 +101,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 *
 	 * @param bool  $exclude_removed Exclude removed campaigns (default true).
 	 * @param bool  $fetch_criterion Combine the campaign data with criterion data (default true).
-	 * @param array $args Additional arguments.
+	 * @param array $args Arguments for the Ads Campaign Query for example: per_page for limiting the number of results.
 	 *
 	 * @return array
 	 * @throws ExceptionWithResponseData When an ApiException is caught.

--- a/src/API/Google/Query/AdsCampaignQuery.php
+++ b/src/API/Google/Query/AdsCampaignQuery.php
@@ -12,10 +12,15 @@ defined( 'ABSPATH' ) || exit;
  */
 class AdsCampaignQuery extends AdsQuery {
 
+	use ReportQueryTrait;
+
+
 	/**
 	 * Query constructor.
+	 *
+	 * @param array $args Query arguments.
 	 */
-	public function __construct() {
+	public function __construct( $args = [] ) {
 		parent::__construct( 'campaign' );
 		$this->columns(
 			[
@@ -27,5 +32,7 @@ class AdsCampaignQuery extends AdsQuery {
 				'campaign_budget.amount_micros',
 			]
 		);
+
+		$this->handle_query_args( $args );
 	}
 }

--- a/src/API/Google/Query/AdsQuery.php
+++ b/src/API/Google/Query/AdsQuery.php
@@ -91,6 +91,8 @@ abstract class AdsQuery extends Query {
 		}
 
 		$request = new SearchGoogleAdsRequest();
+		// Allow us to get the total number of results for pagination.
+		$request->setReturnTotalResultsCount( true );
 
 		if ( ! empty( $this->search_args['pageSize'] ) ) {
 			$request->setPageSize( $this->search_args['pageSize'] );

--- a/src/API/Google/Query/AdsQuery.php
+++ b/src/API/Google/Query/AdsQuery.php
@@ -91,8 +91,14 @@ abstract class AdsQuery extends Query {
 		}
 
 		$request = new SearchGoogleAdsRequest();
+
+		if ( ! empty( $this->search_args['pageSize'] ) ) {
+			$request->setPageSize( $this->search_args['pageSize'] );
+		}
+
 		$request->setQuery( $this->build_query() );
 		$request->setCustomerId( $this->id );
+
 		$this->results = $this->client->getGoogleAdsServiceClient()->search( $request );
 	}
 }

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -106,7 +106,7 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 						$data = $this->prepare_item_for_response( $campaign, $request );
 						return $this->prepare_response_for_collection( $data );
 					},
-					$this->ads_campaign->get_campaigns( $exclude_removed )
+					$this->ads_campaign->get_campaigns( $exclude_removed, true, $request->get_params() )
 				);
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
@@ -318,6 +318,14 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 				'description'       => __( 'Exclude removed campaigns.', 'google-listings-and-ads' ),
 				'type'              => 'boolean',
 				'default'           => true,
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'per_page'        => [
+				'description'       => __( 'Maximum number of rows to be returned in result data.', 'google-listings-and-ads' ),
+				'type'              => 'integer',
+				'minimum'           => 1,
+				'maximum'           => 1000,
+				'sanitize_callback' => 'absint',
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -99,15 +99,33 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 	protected function get_campaigns_callback(): callable {
 		return function ( Request $request ) {
 			try {
-				$exclude_removed = $request->get_param( 'exclude_removed' );
+				$exclude_removed          = $request->get_param( 'exclude_removed' );
+				$return_pagination_params = true;
+				$campaign_data            = $this->ads_campaign->get_campaigns( $exclude_removed, true, $request->get_params(), $return_pagination_params );
 
-				return array_map(
+				$campaigns = array_map(
 					function ( $campaign ) use ( $request ) {
 						$data = $this->prepare_item_for_response( $campaign, $request );
 						return $this->prepare_response_for_collection( $data );
 					},
-					$this->ads_campaign->get_campaigns( $exclude_removed, true, $request->get_params() )
+					$campaign_data['campaigns']
 				);
+
+				$response = rest_ensure_response( $campaigns );
+
+				$total_campaigns = (int) $campaign_data['total_results'];
+				$response->header( 'X-WP-Total', $total_campaigns );
+				// If per_page is not set, then set it to total number of campaigns.
+				$per_page  = $request->get_param( 'per_page' ) ?: $total_campaigns;
+				$max_pages = $per_page > 0 ? ceil( $total_campaigns / $per_page ) : 1;
+				$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+				if ( ! empty( $campaign_data['next_page_token'] ) ) {
+					$response->header( 'X-GLA-NextPageToken', $campaign_data['next_page_token'] );
+				}
+
+				return $response;
+
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -54,6 +54,7 @@ use Google\Ads\GoogleAds\V16\Services\MutateOperationResponse;
 use Google\Ads\GoogleAds\V16\Services\MutateOperation;
 use Google\Ads\GoogleAds\V16\Services\MutateAssetGroupResult;
 use Google\Ads\GoogleAds\V16\Services\MutateAssetResult;
+use Google\Ads\GoogleAds\V16\Services\SearchGoogleAdsResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\Page;
 use Google\ApiCore\PagedListResponse;
@@ -185,13 +186,22 @@ trait GoogleAdsClientTrait {
 	 *
 	 * @param array $campaigns_responses Set of campaign data to convert.
 	 * @param array $campaign_criterion_responses Set of campaign criterion data to convert.
+	 * @param bool  $assert_pagination Whether to assert pagination.
 	 */
-	protected function generate_ads_campaign_query_mock( array $campaigns_responses, $campaign_criterion_responses ) {
+	protected function generate_ads_campaign_query_mock( array $campaigns_responses, $campaign_criterion_responses, $assert_pagination = false ) {
 		$campaigns_row_mock          = array_map( [ $this, 'generate_campaign_row_mock' ], $campaigns_responses );
 		$campaign_criterion_row_mock = array_map( [ $this, 'generate_campaign_criterion_row_mock' ], $campaign_criterion_responses );
 
 		$list_response = $this->createMock( PagedListResponse::class );
 		$page          = $this->createMock( Page::class );
+
+		if ( $assert_pagination ) {
+			$response_object = $this->createMock( SearchGoogleAdsResponse::class );
+			$response_object->expects( $this->exactly( 1 ) )->method( 'getTotalResultsCount' )->willReturn( count( $campaigns_responses ) );
+			$page->expects( $this->exactly( 1 ) )->method( 'getNextPageToken' )->willReturn( '' );
+			$page->method( 'getResponseObject' )->willReturn( $response_object );
+		}
+
 		$page->method( 'getIterator' )->willReturn(
 			$campaigns_row_mock,
 		);

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -191,10 +191,16 @@ trait GoogleAdsClientTrait {
 		$campaign_criterion_row_mock = array_map( [ $this, 'generate_campaign_criterion_row_mock' ], $campaign_criterion_responses );
 
 		$list_response = $this->createMock( PagedListResponse::class );
-		$list_response->method( 'iterateAllElements' )->willReturnOnConsecutiveCalls(
+		$page          = $this->createMock( Page::class );
+		$page->method( 'getIterator' )->willReturn(
 			$campaigns_row_mock,
+		);
+
+		$list_response->method( 'iterateAllElements' )->willReturn(
 			$campaign_criterion_row_mock
 		);
+
+		$list_response->method( 'getPage' )->willReturn( $page );
 
 		$this->service_client
 			->method( 'search' )->willReturn( $list_response );
@@ -205,7 +211,9 @@ trait GoogleAdsClientTrait {
 	 */
 	protected function generate_ads_campaign_query_mock_with_no_campaigns() {
 		$list_response = $this->createMock( PagedListResponse::class );
-		$list_response->method( 'iterateAllElements' )->willReturn( [] );
+		$page          = $this->createMock( Page::class );
+		$page->method( 'getIterator' )->willReturn( [] );
+		$list_response->method( 'getPage' )->willReturn( $page );
 
 		// Method search() will only being called once by AdsCampaignQuery
 		// since there were no campaigns returned by AdsCampaignQuery, it

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -136,6 +136,63 @@ class AdsCampaignTest extends UnitTest {
 		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns() );
 	}
 
+	public function test_get_campaigns_with_search_args() {
+		$campaign_criterion_data = [
+			[
+				'campaign_id'         => self::TEST_CAMPAIGN_ID,
+				'geo_target_constant' => 'geoTargetConstants/2158',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'geoTargetConstants/2344',
+			],
+			[
+				'campaign_id'         => 5678901234,
+				'geo_target_constant' => 'geoTargetConstants/2826',
+			],
+		];
+
+		$campaigns_data = [
+			[
+				'id'                 => self::TEST_CAMPAIGN_ID,
+				'name'               => 'Campaign One',
+				'status'             => 'paused',
+				'type'               => 'shopping',
+				'amount'             => 10,
+				'country'            => 'US',
+				'targeted_locations' => [ 'TW' ],
+			],
+			[
+				'id'                 => 5678901234,
+				'name'               => 'Campaign Two',
+				'status'             => 'enabled',
+				'type'               => 'performance_max',
+				'amount'             => 20,
+				'country'            => 'UK',
+				'targeted_locations' => [ 'HK', 'GB' ],
+			],
+		];
+
+		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
+
+		$matcher = $this->exactly( 2 );
+		$this->service_client
+		->expects( $matcher )
+		->method( 'search' )
+		->willReturnCallback(
+			function ( $request ) use ( $matcher ) {
+				match ( $matcher->getInvocationCount() ) {
+					1 =>  $this->assertEquals( 2, $request->getPageSize() ), // get_campaigns
+					2 =>  $this->assertEquals( 0, $request->getPageSize() ), // criterion
+				};
+
+				return true;
+			}
+		);
+
+		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns( true, true, [ 'per_page' => 2 ] ) );
+	}
+
 	public function test_get_campaigns_with_nonexist_location_id() {
 		$campaign_criterion_data = [
 			[

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -173,7 +173,7 @@ class AdsCampaignTest extends UnitTest {
 			],
 		];
 
-		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data );
+		$this->generate_ads_campaign_query_mock( $campaigns_data, $campaign_criterion_data, true );
 
 		$matcher = $this->exactly( 2 );
 		$this->service_client
@@ -193,7 +193,14 @@ class AdsCampaignTest extends UnitTest {
 			}
 		);
 
-		$this->assertEquals( $campaigns_data, $this->campaign->get_campaigns( true, true, [ 'per_page' => 2 ] ) );
+		$this->assertEquals(
+			[
+				'campaigns'       => $campaigns_data,
+				'total_results'   => count( $campaigns_data ),
+				'next_page_token' => '',
+			],
+			$this->campaign->get_campaigns( true, true, [ 'per_page' => 2 ], true )
+		);
 	}
 
 	public function test_get_campaigns_with_nonexist_location_id() {

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -181,10 +181,13 @@ class AdsCampaignTest extends UnitTest {
 		->method( 'search' )
 		->willReturnCallback(
 			function ( $request ) use ( $matcher ) {
-				match ( $matcher->getInvocationCount() ) {
-					1 =>  $this->assertEquals( 2, $request->getPageSize() ), // get_campaigns
-					2 =>  $this->assertEquals( 0, $request->getPageSize() ), // criterion
-				};
+				if($matcher->getInvocationCount() === 1 ){
+					$this->assertEquals( 2, $request->getPageSize() ); // Campaigns
+				}
+
+				if($matcher->getInvocationCount() === 2 ){
+					$this->assertEquals( 0, $request->getPageSize() ); // Criterions
+				}				
 
 				return true;
 			}

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -181,13 +181,13 @@ class AdsCampaignTest extends UnitTest {
 		->method( 'search' )
 		->willReturnCallback(
 			function ( $request ) use ( $matcher ) {
-				if($matcher->getInvocationCount() === 1 ){
+				if ( $matcher->getInvocationCount() === 1 ) {
 					$this->assertEquals( 2, $request->getPageSize() ); // Campaigns
 				}
 
-				if($matcher->getInvocationCount() === 2 ){
+				if ( $matcher->getInvocationCount() === 2 ) {
 					$this->assertEquals( 0, $request->getPageSize() ); // Criterions
-				}				
+				}
 
 				return true;
 			}

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -152,6 +152,67 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	public function test_get_campaigns_with_args() {
+		$campaigns_data = [
+			[
+				'id'                 => self::TEST_CAMPAIGN_ID,
+				'name'               => 'Test Campaign',
+				'status'             => 'removed',
+				'type'               => 'shopping',
+				'amount'             => 10,
+				'country'            => 'US',
+				'targeted_locations' => [],
+			],
+			[
+				'id'                 => 5678901234,
+				'name'               => 'PMax: Test Campaign',
+				'status'             => 'enabled',
+				'type'               => 'performance_max',
+				'amount'             => 20,
+				'country'            => 'UK',
+				'targeted_locations' => [],
+			],
+		];
+
+		$expected = [
+			[
+				'id'                 => self::TEST_CAMPAIGN_ID,
+				'name'               => 'Test Campaign',
+				'status'             => 'removed',
+				'type'               => 'shopping',
+				'amount'             => 10,
+				'country'            => 'US',
+				'targeted_locations' => [],
+			],
+			[
+				'id'                 => 5678901234,
+				'name'               => 'PMax: Test Campaign',
+				'status'             => 'enabled',
+				'type'               => 'performance_max',
+				'amount'             => 20,
+				'country'            => 'UK',
+				'targeted_locations' => [],
+			],
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'get_campaigns' )
+			->with(
+				true,
+				true,
+				[
+					'per_page'        => 2,
+					'exclude_removed' => true,
+				]
+			)
+			->willReturn( $campaigns_data );
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'GET', [ 'per_page' => 2 ] );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function test_get_campaigns_with_api_exception() {
 		$this->ads_campaign->expects( $this->once() )
 			->method( 'get_campaigns' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of pcTzPl-2nS-p2

This PR allows setting the per_page parameter in the gla/ads/campaigns endpoint. Previously, we returned all the results, but now it is possible to limit the number of results.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make a request to `GET gla/ads/campaigns?per_page=X` and check that the number of results matches the per_page parameter.
2. Make a request to `GET gla/ads/campaigns` and ensure that you get all the results.

### Additional details:

I had to replace [iterateAllElements()](https://googleapis.github.io/gax-php/master/Google/ApiCore/PagedListResponse.html#method_iterateAllElements) with `getPage()->getIterator()` to avoid iterating through all the pages and retrieving all the results at once.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Enable Page Size Parameter in Campaigns Endpoint