### PR TITLE
[API PULL] E2E TESTS for Notifications schedule

### DIFF
--- a/tests/e2e/specs/notifications/notifications-banner.test.js
+++ b/tests/e2e/specs/notifications/notifications-banner.test.js
@@ -52,7 +52,7 @@ test.describe( 'Notifications Banner', () => {
 
 	test( 'Grant Access button is visible on Settings page when notifications service is enabled', async () => {
 		// Mock Merchant Center as connected
-		settingsPage.mockMCConnected( 1234, true );
+		await settingsPage.mockMCConnected( 1234, true );
 		const button = settingsPage.getGrantAccessBtn();
 
 		await expect( button ).toBeVisible();
@@ -61,8 +61,8 @@ test.describe( 'Notifications Banner', () => {
 	test( 'When click on Grant Access button redirect to Auth page', async () => {
 		const mockAuthURL = 'https://example.com';
 		// Mock Merchant Center as connected
-		settingsPage.mockMCConnected( 1234, true );
-		settingsPage.fulfillRESTApiAuthorize( { auth_url: mockAuthURL } );
+		await settingsPage.mockMCConnected( 1234, true );
+		await settingsPage.fulfillRESTApiAuthorize( { auth_url: mockAuthURL } );
 		const button = settingsPage.getGrantAccessBtn();
 
 		button.click();
@@ -72,8 +72,8 @@ test.describe( 'Notifications Banner', () => {
 	} );
 
 	test( 'When REST API is Approved it shows a success notice in MC and allows to disable it', async () => {
-		settingsPage.goto();
-		settingsPage.mockMCConnected( 1234, true, 'approved' );
+		await settingsPage.goto();
+		await settingsPage.mockMCConnected( 1234, true, 'approved' );
 		const grantedAccessMessage = page
 			.locator( '#woocommerce-layout__primary' )
 			.getByText(
@@ -99,24 +99,24 @@ test.describe( 'Notifications Banner', () => {
 		} );
 
 		await expect( disableDataFetchButton ).toBeVisible();
-		disableDataFetchButton.click();
+		await disableDataFetchButton.click();
 
 		await expect( modalConfirmBtn ).toBeDisabled();
 		await expect( modalDismissBtn ).toBeEnabled();
 		await expect( modalCheck ).toBeVisible();
-		modalCheck.check();
+		await modalCheck.check();
 		await expect( modalConfirmBtn ).toBeEnabled();
-		modalConfirmBtn.click();
+		await modalConfirmBtn.click();
 		await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 		await page.waitForURL( /path=%2Fgoogle%2Fsettings/ );
 		await expect( modalConfirmBtn ).not.toBeVisible();
 	} );
 
 	test( 'When REST API is Error it shows a waring notice in MC and allows to grant access', async () => {
-		settingsPage.goto();
-		settingsPage.mockMCConnected( 1234, true, 'error' );
+		await settingsPage.goto();
+		await settingsPage.mockMCConnected( 1234, true, 'error' );
 		const mockAuthURL = 'https://example.com';
-		settingsPage.fulfillRESTApiAuthorize( { auth_url: mockAuthURL } );
+		await settingsPage.fulfillRESTApiAuthorize( { auth_url: mockAuthURL } );
 		const errorAccessMessage = page
 			.locator( '#woocommerce-layout__primary' )
 			.getByText(
@@ -128,7 +128,7 @@ test.describe( 'Notifications Banner', () => {
 		} );
 		await expect( errorAccessMessage ).toBeVisible();
 		await expect( grantAccessBtn ).toBeVisible();
-		grantAccessBtn.click();
+		await grantAccessBtn.click();
 		await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 		await page.waitForURL( mockAuthURL );
 		expect( page.url() ).toMatch( mockAuthURL );

--- a/tests/e2e/specs/notifications/notifications-banner.test.js
+++ b/tests/e2e/specs/notifications/notifications-banner.test.js
@@ -6,16 +6,16 @@ import { expect, test } from '@playwright/test';
 /**
  * Internal dependencies
  */
-import SettingsPage from '../utils/pages/settings';
-import { clearOnboardedMerchant, setOnboardedMerchant } from '../utils/api';
-import { LOAD_STATE } from '../utils/constants';
+import SettingsPage from '../../utils/pages/settings';
+import { clearOnboardedMerchant, setOnboardedMerchant } from '../../utils/api';
+import { LOAD_STATE } from '../../utils/constants';
 
 test.use( { storageState: process.env.ADMINSTATE } );
 
 test.describe.configure( { mode: 'serial' } );
 
 /**
- * @type {import('../utils/pages/settings.js').default } settingsPage
+ * @type {import('../../utils/pages/settings.js').default } settingsPage
  */
 let settingsPage = null;
 
@@ -24,7 +24,7 @@ let settingsPage = null;
  */
 let page = null;
 
-test.describe( 'Notifications Feature', () => {
+test.describe( 'Notifications Banner', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
 		settingsPage = new SettingsPage( page );

--- a/tests/e2e/specs/notifications/notifications-schedule.test.js
+++ b/tests/e2e/specs/notifications/notifications-schedule.test.js
@@ -12,6 +12,7 @@ import {
 	setNotificationsReady,
 	clearOnboardedMerchant,
 	setOnboardedMerchant,
+	clearNotificationsReady,
 } from '../../utils/api';
 
 test.use( { storageState: process.env.ADMINSTATE } );
@@ -41,24 +42,25 @@ test.describe( 'Notifications Schedule', () => {
 		page = await browser.newPage();
 		productEditor = getClassicProductEditorUtils( page );
 		mockRequests = new MockRequests( page );
-		await mockRequests.mockMCConnected( 1234, true, 'approved' );
 		await setOnboardedMerchant();
+		await setNotificationsReady();
 		await Promise.all( [
 			// Mock Jetpack as connected
 			mockRequests.mockJetpackConnected(),
 
 			// Mock google as connected.
 			mockRequests.mockGoogleConnected(),
+			mockRequests.mockMCConnected( 1234, true, 'approved' ),
 		] );
 	} );
 
 	test.afterAll( async () => {
 		await clearOnboardedMerchant();
+		await clearNotificationsReady();
 		await page.close();
 	} );
 
 	test( 'When access is granted Notifications are scheduled', async () => {
-		await setNotificationsReady();
 		// Create a new fresh product
 		await productEditor.gotoAddProductPage();
 		await productEditor.fillProductName();

--- a/tests/e2e/specs/notifications/notifications-schedule.test.js
+++ b/tests/e2e/specs/notifications/notifications-schedule.test.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { getClassicProductEditorUtils } from '../../utils/product-editor';
+import MockRequests from '../../utils/mock-requests';
+import {
+	setNotificationsReady,
+	clearOnboardedMerchant,
+	setOnboardedMerchant,
+} from '../../utils/api';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/mock-requests.js').default } mockRequests
+ */
+let mockRequests = null;
+
+/**
+ * @type {import('../../utils/product-editor.js').default } productEditor
+ */
+let productEditor = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+const actionSchedulerLink =
+	'wp-admin/admin.php?page=wc-status&tab=action-scheduler&orderby=schedule&order=desc';
+
+test.describe( 'Notifications Schedule', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		productEditor = getClassicProductEditorUtils( page );
+		mockRequests = new MockRequests( page );
+		await mockRequests.mockMCConnected( 1234, true, 'approved' );
+		await setOnboardedMerchant();
+		await Promise.all( [
+			// Mock Jetpack as connected
+			mockRequests.mockJetpackConnected(),
+
+			// Mock google as connected.
+			mockRequests.mockGoogleConnected(),
+		] );
+	} );
+
+	test.afterAll( async () => {
+		await clearOnboardedMerchant();
+		await page.close();
+	} );
+
+	test( 'When access is granted and Product is created - Notifications are scheduled', async () => {
+		await setNotificationsReady();
+		// Create a new fresh product
+		await productEditor.gotoAddProductPage();
+		await productEditor.fillProductName();
+		await productEditor.publish();
+		const id = productEditor.getPostID();
+
+		// Check the product.create job is scheduled.
+		await page.goto( actionSchedulerLink );
+		let row = page.getByRole( 'row', {
+			name: `gla/jobs/notifications/products/process_item Run | Cancel Pending 0 => array ( 'item_id' => ${ id }, 'topic' => 'product.create'`,
+		} );
+		await expect( row ).toBeVisible();
+
+		// Hover the row, so the Run button gets visible
+		await row.hover( { force: true } );
+		await row.getByRole( 'link' ).first().click();
+
+		// Wait for the page to refresh and see that pending job is not there anymore.
+		await page.waitForURL( actionSchedulerLink );
+		await expect( row ).not.toBeVisible();
+
+		// edit the product and set it as notified
+		await productEditor.gotoEditProductPage( id );
+		await productEditor.mockNotificationStatus( 'created' );
+		await productEditor.fillProductName( 'updated product' );
+		await productEditor.save();
+
+		// Check if the product.update job is there.
+		await page.goto( actionSchedulerLink );
+		row = page.getByRole( 'row', {
+			name: `gla/jobs/notifications/products/process_item Run | Cancel Pending 0 => array ( 'item_id' => ${ id }, 'topic' => 'product.update'`,
+		} );
+		await expect( row ).toBeVisible();
+		await row.hover( { force: true } );
+		await row.getByRole( 'link' ).first().click();
+		await page.waitForURL( actionSchedulerLink );
+		await expect( row ).not.toBeVisible();
+
+		// change to external type. It will trigger the product.delete
+		await productEditor.gotoEditProductPage( id );
+		await productEditor.changeToExternalProduct();
+		await productEditor.save();
+		// Check if the product.delete job is there.
+		await page.goto( actionSchedulerLink );
+		row = page.getByRole( 'row', {
+			name: `gla/jobs/notifications/products/process_item Run | Cancel Pending 0 => array ( 'item_id' => ${ id }, 'topic' => 'product.delete'`,
+		} );
+		await expect( row ).toBeVisible();
+		await row.hover( { force: true } );
+		await row.getByRole( 'link' ).first().click();
+		await page.waitForURL( actionSchedulerLink );
+		await expect( row ).not.toBeVisible();
+	} );
+} );

--- a/tests/e2e/specs/notifications/notifications-schedule.test.js
+++ b/tests/e2e/specs/notifications/notifications-schedule.test.js
@@ -57,7 +57,7 @@ test.describe( 'Notifications Schedule', () => {
 		await page.close();
 	} );
 
-	test( 'When access is granted and Product is created - Notifications are scheduled', async () => {
+	test( 'When access is granted Notifications are scheduled', async () => {
 		await setNotificationsReady();
 		// Create a new fresh product
 		await productEditor.gotoAddProductPage();

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
-apply_filters( 'woocommerce_gla_notify', false); // avoid any request to google in the tests
+add_filter( 'woocommerce_gla_notify', '__return_false'); // avoid any request to google in the tests
 
 /**
  * Register routes for setting test data.

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -10,8 +10,10 @@
 namespace Automattic\WooCommerce\GoogleListingsAndAds\TestData;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
+apply_filters( 'woocommerce_gla_notify', false); // avoid any request to google in the tests
 
 /**
  * Register routes for setting test data.
@@ -45,6 +47,22 @@ function register_routes() {
 			[
 				'methods'             => 'DELETE',
 				'callback'            => __NAMESPACE__ . '\clear_onboarded_merchant',
+				'permission_callback' => __NAMESPACE__ . '\permissions',
+			],
+		],
+	);
+	register_rest_route(
+		'wc/v3',
+		'gla-test/notifications-ready',
+		[
+			[
+				'methods'             => 'POST',
+				'callback'            => __NAMESPACE__ . '\set_notifications_ready',
+				'permission_callback' => __NAMESPACE__ . '\permissions',
+			],
+			[
+				'methods'             => 'DELETE',
+				'callback'            => __NAMESPACE__ . '\clear_notifications_ready',
 				'permission_callback' => __NAMESPACE__ . '\permissions',
 			],
 		],
@@ -113,3 +131,27 @@ function clear_conversion_id() {
 function permissions() {
 	return current_user_can( 'manage_woocommerce' );
 }
+
+/**
+ * Set the Notifications Service as ready.
+ */
+function set_notifications_ready() {
+	/** @var OptionsInterface $options */
+	$options    = woogle_get_container()->get( OptionsInterface::class );
+	$transients = woogle_get_container()->get( TransientsInterface::class );
+	$transients->set( TransientsInterface::URL_MATCHES, 'yes' );
+	$options->update(
+		OptionsInterface::WPCOM_REST_API_STATUS, 'approved'
+	);
+}
+/**
+ * Clear the Notifications Service.
+ */
+function clear_notifications_ready() {
+	/** @var OptionsInterface $options */
+	$options    = woogle_get_container()->get( OptionsInterface::class );
+	$transients = woogle_get_container()->get( TransientsInterface::class );
+	$transients->delete( TransientsInterface::URL_MATCHES );
+	$options->delete( OptionsInterface::WPCOM_REST_API_STATUS );
+}
+

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -112,3 +112,17 @@ export async function setOnboardedMerchant() {
 export async function clearOnboardedMerchant() {
 	await api().delete( 'gla-test/onboarded-merchant' );
 }
+
+/**
+ * Set Notifications Ready.
+ */
+export async function setNotificationsReady() {
+	await api().post( 'gla-test/notifications-ready' );
+}
+
+/**
+ * Clear Onboarded Merchant.
+ */
+export async function clearNotificationsReady() {
+	await api().delete( 'gla-test/notifications-ready' );
+}

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -151,6 +151,11 @@ export function getClassicProductEditorUtils( page ) {
 			return page.locator( '.gla_attributes_multipack_field input' );
 		},
 
+		getPostID() {
+			const url = new URL( page.url() );
+			return url.searchParams.get( 'post' );
+		},
+
 		async getAvailableProductAttributesWithTestValues( locator = page ) {
 			return getAvailableProductAttributesWithTestValues(
 				locator,
@@ -162,6 +167,11 @@ export function getClassicProductEditorUtils( page ) {
 	const asyncActions = {
 		async gotoAddProductPage() {
 			await page.goto( '/wp-admin/post-new.php?post_type=product' );
+			await this.waitForInteractionReady();
+		},
+
+		async gotoEditProductPage( id ) {
+			await page.goto( `/wp-admin/post.php?post=${ id }&action=edit` );
 			await this.waitForInteractionReady();
 		},
 
@@ -206,6 +216,30 @@ export function getClassicProductEditorUtils( page ) {
 			} );
 
 			await this.clickSave();
+			await observer;
+			await this.waitForInteractionReady();
+		},
+
+		clickPublish() {
+			return page
+				.getByRole( 'button', { name: 'Publish', exact: true } )
+				.click();
+		},
+
+		async publish() {
+			const observer = page.waitForResponse( ( response ) => {
+				const url = new URL( response.url() );
+
+				return (
+					url.pathname === '/wp-admin/post.php' &&
+					url.searchParams.has( 'post' ) &&
+					url.searchParams.has( 'action', 'edit' ) &&
+					response.ok() &&
+					response.request().method() === 'GET'
+				);
+			} );
+
+			await this.clickPublish();
 			await observer;
 			await this.waitForInteractionReady();
 		},
@@ -270,6 +304,16 @@ export function getClassicProductEditorUtils( page ) {
 				meta_data: [
 					{ key: '_wc_gla_sync_status', value: syncStatus },
 					{ key: '_wc_gla_errors', value: issues },
+				],
+			} );
+		},
+		async mockNotificationStatus( status ) {
+			const url = new URL( page.url() );
+			const productId = url.searchParams.get( 'post' );
+
+			await api.api().put( `products/${ productId }`, {
+				meta_data: [
+					{ key: '_wc_gla_notification_status', value: status },
 				],
 			} );
 		},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adding some E2E tests and useful structure for future cases in the tests.

- Basic schedule (create/update/delete)
- Necessary APIs and methods for future tests
- Refactor location of the notifications test (now inside notifications folder)


### Screenshots:

<img width="1581" alt="Screenshot 2024-07-24 at 19 39 14" src="https://github.com/user-attachments/assets/a77ce473-d75f-4297-96c4-7d884c673385">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. See the tests e2e passing in local environment `npm run test:e2e notifications`
2. [See the tests passing on this branch in the GH actions](https://github.com/woocommerce/google-listings-and-ads/actions/runs/10091712569)

There are some flacky tests failing but doesn't seem to relate to this. as they are failing also in develop branch.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
