### PR TITLE
Enable labeling of Ads campaigns

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -82,18 +82,25 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	protected $google_helper;
 
 	/**
+	 * @var AdsCampaignLabel $campaign_label
+	 */
+	protected $campaign_label;
+
+	/**
 	 * AdsCampaign constructor.
 	 *
 	 * @param GoogleAdsClient      $client
 	 * @param AdsCampaignBudget    $budget
 	 * @param AdsCampaignCriterion $criterion
 	 * @param GoogleHelper         $google_helper
+	 * @param AdsCampaignLabel     $campaign_label
 	 */
-	public function __construct( GoogleAdsClient $client, AdsCampaignBudget $budget, AdsCampaignCriterion $criterion, GoogleHelper $google_helper ) {
-		$this->client        = $client;
-		$this->budget        = $budget;
-		$this->criterion     = $criterion;
-		$this->google_helper = $google_helper;
+	public function __construct( GoogleAdsClient $client, AdsCampaignBudget $budget, AdsCampaignCriterion $criterion, GoogleHelper $google_helper, AdsCampaignLabel $campaign_label ) {
+		$this->client         = $client;
+		$this->budget         = $budget;
+		$this->criterion      = $criterion;
+		$this->google_helper  = $google_helper;
+		$this->campaign_label = $campaign_label;
 	}
 
 	/**
@@ -233,6 +240,10 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			);
 
 			$campaign_id = $this->mutate( $operations );
+
+			if ( isset( $params['label'] ) ) {
+				$this->campaign_label->assign_label_to_campaign_by_label_name( $campaign_id, $params['label'] );
+			}
 
 			// Clear cached campaign count.
 			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_CAMPAIGN_COUNT );

--- a/src/API/Google/AdsCampaignLabel.php
+++ b/src/API/Google/AdsCampaignLabel.php
@@ -44,7 +44,7 @@ class AdsCampaignLabel implements OptionsAwareInterface {
 
 
 	/**
-	 * AdsCampaign constructor.
+	 * AdsCampaignLabel constructor.
 	 *
 	 * @param GoogleAdsClient $client
 	 */
@@ -80,6 +80,8 @@ class AdsCampaignLabel implements OptionsAwareInterface {
 	 *
 	 * @param int    $campaign_id The campaign ID.
 	 * @param string $label_name  The label name.
+	 *
+	 * @throws ApiException If searching for the label fails.
 	 */
 	public function assign_label_to_campaign_by_label_name( int $campaign_id, string $label_name ) {
 		$label_id   = $this->get_label_id_by_name( $label_name );
@@ -148,6 +150,8 @@ class AdsCampaignLabel implements OptionsAwareInterface {
 	 * Mutate the operations.
 	 *
 	 * @param array $operations The operations to mutate.
+	 *
+	 * @throws ApiException — Thrown if the API call fails.
 	 */
 	protected function mutate( array $operations ) {
 		$request = new MutateGoogleAdsRequest();

--- a/src/API/Google/AdsCampaignLabel.php
+++ b/src/API/Google/AdsCampaignLabel.php
@@ -1,0 +1,177 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCampaignLabelQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Google\Ads\GoogleAds\Util\V16\ResourceNames;
+use Google\Ads\GoogleAds\V16\Resources\Label;
+use Google\Ads\GoogleAds\V16\Resources\CampaignLabel;
+use Google\Ads\GoogleAds\V16\Services\LabelOperation;
+use Google\Ads\GoogleAds\V16\Services\CampaignLabelOperation;
+use Google\Ads\GoogleAds\V16\Services\MutateOperation;
+use Google\Ads\GoogleAds\V16\Services\MutateGoogleAdsRequest;
+use Google\ApiCore\ApiException;
+
+
+/**
+ * Class AdsCampaignLabel
+ * https://developers.google.com/google-ads/api/docs/reporting/labels
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class AdsCampaignLabel implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+	use ExceptionTrait;
+
+	/**
+	 * Temporary ID to use within a batch job.
+	 * A negative number which is unique for all the created resources.
+	 *
+	 * @var int
+	 */
+	protected const TEMPORARY_ID = -1;
+
+	/**
+	 * The Google Ads Client.
+	 *
+	 * @var GoogleAdsClient
+	 */
+	protected $client;
+
+
+	/**
+	 * AdsCampaign constructor.
+	 *
+	 * @param GoogleAdsClient $client
+	 */
+	public function __construct( GoogleAdsClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Get the label ID by name.
+	 *
+	 * @param string $name The label name.
+	 *
+	 * @return null|int The label ID.
+	 * @throws ExceptionWithResponseData When an ApiException is caught.
+	 */
+	protected function get_label_id_by_name( string $name ) {
+		try {
+			$query = new AdsCampaignLabelQuery();
+			$query->set_client( $this->client, $this->options->get_ads_id() );
+			$query->where( 'label.name', $name, '=' );
+			$label_results = $query->get_results();
+			$label_id      = null;
+
+			foreach ( $label_results->iterateAllElements() as $row ) {
+				return $row->getLabel()->getId();
+			}
+
+			return $label_id;
+		} catch ( ApiException $e ) {
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
+
+			$errors = $this->get_exception_errors( $e );
+			throw new ExceptionWithResponseData(
+				/* translators: %s Error message */
+				sprintf( __( 'Error retrieving label: %s', 'google-listings-and-ads' ), reset( $errors ) ),
+				$this->map_grpc_code_to_http_status_code( $e ),
+				null,
+				[
+					'errors' => $errors,
+					'name'   => $name,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Assign a label to a campaign by label name.
+	 *
+	 * @param int    $campaign_id The campaign ID.
+	 * @param string $label_name  The label name.
+	 */
+	public function assign_label_to_campaign_by_label_name( int $campaign_id, string $label_name ) {
+		$label_id   = $this->get_label_id_by_name( $label_name );
+		$operations = [];
+
+		if ( ! $label_id ) {
+			$operations[] = $this->create_operation( $label_name );
+			$label_id     = self::TEMPORARY_ID;
+		}
+
+		$operations[] = $this->assign_label_to_campaign_operation( $campaign_id, $label_id );
+		$this->mutate( $operations );
+	}
+
+	/**
+	 * Create a label operation.
+	 *
+	 * @param string $name The label name.
+	 *
+	 * @return MutateOperation
+	 */
+	protected function create_operation( string $name ): MutateOperation {
+		$label = new Label(
+			[
+				'name'          => $name,
+				'resource_name' => $this->temporary_resource_name(),
+			]
+		);
+
+		$operation = ( new LabelOperation() )->setCreate( $label );
+		return ( new MutateOperation() )->setLabelOperation( $operation );
+	}
+
+	/**
+	 * Return a temporary resource name for the label.
+	 *
+	 * @return string
+	 */
+	protected function temporary_resource_name() {
+		return ResourceNames::forLabel( $this->options->get_ads_id(), self::TEMPORARY_ID );
+	}
+
+	/**
+	 * Creates a campaign label operation.
+	 *
+	 * @param int $campaign_id The campaign ID.
+	 * @param int $label_id    The label ID.
+	 *
+	 * @return MutateOperation
+	 */
+	protected function assign_label_to_campaign_operation( int $campaign_id, int $label_id ): MutateOperation {
+		$label_resource_name = ResourceNames::forLabel( $this->options->get_ads_id(), $label_id );
+
+		$campaign_label = new CampaignLabel(
+			[
+				'campaign' => ResourceNames::forCampaign( $this->options->get_ads_id(), $campaign_id ),
+				'label'    => $label_resource_name,
+			]
+		);
+
+		$operation = ( new CampaignLabelOperation() )->setCreate( $campaign_label );
+		return ( new MutateOperation() )->setCampaignLabelOperation( $operation );
+	}
+
+	/**
+	 * Mutate the operations.
+	 *
+	 * @param array $operations The operations to mutate.
+	 */
+	protected function mutate( array $operations ) {
+		$request = new MutateGoogleAdsRequest();
+		$request->setCustomerId( $this->options->get_ads_id() );
+		$request->setMutateOperations( $operations );
+		$this->client->getGoogleAdsServiceClient()->mutate( $request );
+	}
+}

--- a/src/API/Google/AdsCampaignLabel.php
+++ b/src/API/Google/AdsCampaignLabel.php
@@ -59,7 +59,7 @@ class AdsCampaignLabel implements OptionsAwareInterface {
 	 *
 	 * @return null|int The label ID.
 	 *
-	 * @throws ApiException When no results returned or an error occurs.
+	 * @throws ApiException If the search call fails.
 	 */
 	protected function get_label_id_by_name( string $name ) {
 		$query = new AdsCampaignLabelQuery();

--- a/src/API/Google/AdsCampaignLabel.php
+++ b/src/API/Google/AdsCampaignLabel.php
@@ -66,13 +66,12 @@ class AdsCampaignLabel implements OptionsAwareInterface {
 		$query->set_client( $this->client, $this->options->get_ads_id() );
 		$query->where( 'label.name', $name, '=' );
 		$label_results = $query->get_results();
-		$label_id      = null;
 
 		foreach ( $label_results->iterateAllElements() as $row ) {
 			return $row->getLabel()->getId();
 		}
 
-		return $label_id;
+		return null;
 	}
 
 	/**

--- a/src/API/Google/Query/AdsCampaignLabelQuery.php
+++ b/src/API/Google/Query/AdsCampaignLabelQuery.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class AdsCampaignQuery
+ * Class AdsCampaignLabelQuery
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
  */
@@ -14,10 +14,8 @@ class AdsCampaignLabelQuery extends AdsQuery {
 
 	/**
 	 * Query constructor.
-	 *
-	 * @param array $args Query arguments.
 	 */
-	public function __construct( $args = [] ) {
+	public function __construct() {
 		parent::__construct( 'label' );
 		$this->columns(
 			[

--- a/src/API/Google/Query/AdsCampaignLabelQuery.php
+++ b/src/API/Google/Query/AdsCampaignLabelQuery.php
@@ -1,0 +1,28 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsCampaignQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
+class AdsCampaignLabelQuery extends AdsQuery {
+
+	/**
+	 * Query constructor.
+	 *
+	 * @param array $args Query arguments.
+	 */
+	public function __construct( $args = [] ) {
+		parent::__construct( 'label' );
+		$this->columns(
+			[
+				'label.id',
+			]
+		);
+	}
+}

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -384,6 +384,14 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 					'type' => 'string',
 				],
 			],
+			'label'              => [
+				'type'              => 'string',
+				'description'       => __( 'The name of the label to assign to the campaign.', 'google-listings-and-ads' ),
+				'context'           => [ 'edit' ],
+				'validate_callback' => 'rest_validate_request_arg',
+				'required'          => false,
+
+			],
 		];
 	}
 

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignBudget;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignCriterion;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignLabel;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroupAsset;
@@ -80,6 +81,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		AdsAssetGroup::class          => true,
 		AdsCampaign::class            => true,
 		AdsCampaignBudget::class      => true,
+		AdsCampaignLabel::class       => true,
 		AdsConversionAction::class    => true,
 		AdsReport::class              => true,
 		AdsAssetGroupAsset::class     => true,
@@ -109,11 +111,12 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 		$this->share( Ads::class, GoogleAdsClient::class );
 		$this->share( AdsAssetGroup::class, GoogleAdsClient::class, AdsAssetGroupAsset::class );
-		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class, AdsCampaignCriterion::class, GoogleHelper::class );
+		$this->share( AdsCampaign::class, GoogleAdsClient::class, AdsCampaignBudget::class, AdsCampaignCriterion::class, GoogleHelper::class, AdsCampaignLabel::class );
 		$this->share( AdsCampaignBudget::class, GoogleAdsClient::class );
 		$this->share( AdsAssetGroupAsset::class, GoogleAdsClient::class, AdsAsset::class );
 		$this->share( AdsAsset::class, GoogleAdsClient::class, WP::class );
 		$this->share( AdsCampaignCriterion::class );
+		$this->share( AdsCampaignLabel::class, GoogleAdsClient::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );
 

--- a/tests/Unit/API/Google/AdsCampaignLabelTest.php
+++ b/tests/Unit/API/Google/AdsCampaignLabelTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
 use PHPUnit\Framework\MockObject\MockObject;
+use Google\ApiCore\ApiException;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -27,7 +28,6 @@ class AdsCampaignLabelTest extends UnitTest {
 	protected $campaign_label;
 
 	protected const TEST_CAMPAIGN_ID = 1234567890;
-	protected const BASE_COUNTRY     = 'US';
 
 	/**
 	 * Runs before each test is executed.
@@ -65,5 +65,18 @@ class AdsCampaignLabelTest extends UnitTest {
 		);
 		$this->generate_campaign_label_mutate_mock( self::TEST_CAMPAIGN_ID, $label_id );
 		$this->campaign_label->assign_label_to_campaign_by_label_name( self::TEST_CAMPAIGN_ID, $name );
+	}
+
+	public function test_query_labels_exception() {
+		$name = 'wc-gla';
+		$this->generate_ads_query_mock_exception( new ApiException( 'No labels', 14, 'UNAVAILABLE' ) );
+
+		try {
+			$this->campaign_label->assign_label_to_campaign_by_label_name( self::TEST_CAMPAIGN_ID, $name );
+		} catch ( ApiException $e ) {
+
+			$this->assertEquals( 14, $e->getCode() );
+			$this->assertEquals( 'No labels', $e->getMessage() );
+		}
 	}
 }

--- a/tests/Unit/API/Google/AdsCampaignLabelTest.php
+++ b/tests/Unit/API/Google/AdsCampaignLabelTest.php
@@ -1,0 +1,69 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignLabel;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsCampaignLabelTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class AdsCampaignLabelTest extends UnitTest {
+
+	use GoogleAdsClientTrait;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var AdsCampaignLabel $campaign_label */
+	protected $campaign_label;
+
+	protected const TEST_CAMPAIGN_ID = 1234567890;
+	protected const BASE_COUNTRY     = 'US';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->ads_client_setup();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+
+		$this->campaign_label = new AdsCampaignLabel( $this->client );
+		$this->campaign_label->set_options_object( $this->options );
+
+		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+	}
+
+	public function test_assign_new_label() {
+		$label_id = -1;
+		$this->generate_mock_label_query_with_no_existing_labels();
+		$this->generate_campaign_label_mutate_mock( self::TEST_CAMPAIGN_ID, $label_id );
+		$this->campaign_label->assign_label_to_campaign_by_label_name( self::TEST_CAMPAIGN_ID, 'new-label' );
+	}
+
+	public function test_assign_existing_label() {
+		$label_id = 1234567890;
+		$name     = 'wc-gla';
+		$this->generate_label_query_mock(
+			[
+				[
+					'id'   => $label_id,
+					'name' => $name,
+				],
+			]
+		);
+		$this->generate_campaign_label_mutate_mock( self::TEST_CAMPAIGN_ID, $label_id );
+		$this->campaign_label->assign_label_to_campaign_by_label_name( self::TEST_CAMPAIGN_ID, $name );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of pcTzPl-2nS-p2

We would like to track where campaigns are created from by labeling them with their source of creation. For example, use `wc-gla` for the web version, and for the mobile versions, something like `wc-gla-android` or `wc-gla-ios`.

This PR allows the creation of a new campaign with a specific label. Note that I haven't updated the frontend to send the label query parameter yet, as I would first like to define the label names we'll be using.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

 1. Make the following call `POST wp-json/wc/gla/ads/campaigns` with this body: 
```
{
    "amount": 0.01,
    "targeted_locations": ["ES"],
    "label": "wc-gla"
}
```
3. The campaign should be created successfully.
4. Go to https://ads.google.com/
5. Filter your campaign by label:

![image](https://github.com/user-attachments/assets/09433042-a0fd-4146-ad9e-6d07c5808f37)

You should see the campaign that you just created.
6. Alternatively, you can customize the campaigns table to display the labels:

![image](https://github.com/user-attachments/assets/0eadfd8f-66fc-4c68-b1c8-62061ebb6318)

![image](https://github.com/user-attachments/assets/b8814f46-efa8-4318-bcbe-f55a0b145675)

![image](https://github.com/user-attachments/assets/1db47049-364e-485e-aa91-879c17a8196f)



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Enable labeling of Ads campaigns