### PR TITLE
Display body message if error status is 406 during account creation

### DIFF
--- a/js/src/hooks/useUpsertAdsAccount.js
+++ b/js/src/hooks/useUpsertAdsAccount.js
@@ -52,12 +52,13 @@ const useUpsertAdsAccount = () => {
 			// and only display error message and exit this function for non-428 error.
 			if ( e.status !== 428 ) {
 				const body = await e.json();
-				const message = e.status === 406 ?
-					body.message :
-					__(
-						'Unable to create Google Ads account. Please try again later.',
-						'google-listings-and-ads'
-					);
+				const message =
+					e.status === 406
+						? body.message
+						: __(
+								'Unable to create Google Ads account. Please try again later.',
+								'google-listings-and-ads'
+						  );
 
 				createNotice( 'error', message );
 			}

--- a/js/src/hooks/useUpsertAdsAccount.js
+++ b/js/src/hooks/useUpsertAdsAccount.js
@@ -51,13 +51,15 @@ const useUpsertAdsAccount = () => {
 			// so we swallow the error for status code 428,
 			// and only display error message and exit this function for non-428 error.
 			if ( e.status !== 428 ) {
-				createNotice(
-					'error',
+				const body = await e.json();
+				const message = e.status === 406 ?
+					body.message :
 					__(
 						'Unable to create Google Ads account. Please try again later.',
 						'google-listings-and-ads'
-					)
-				);
+					);
+
+				createNotice( 'error', message );
 			}
 		}
 

--- a/js/src/hooks/useUpsertAdsAccount.js
+++ b/js/src/hooks/useUpsertAdsAccount.js
@@ -51,10 +51,12 @@ const useUpsertAdsAccount = () => {
 			// so we swallow the error for status code 428,
 			// and only display error message and exit this function for non-428 error.
 			if ( e.status !== 428 ) {
-				const body = await e.json();
 				const message =
 					e.status === 406
-						? body.message
+						? __(
+								'Error creating account: Account creation limit reached. Contact support for help.',
+								'google-listings-and-ads'
+						  )
 						: __(
 								'Unable to create Google Ads account. Please try again later.',
 								'google-listings-and-ads'


### PR DESCRIPTION
### Changes proposed in this Pull Request:
For merchants who have created more than `20` Ads accounts via the connect server we want to display a more detailed error message and direct them to contact support for help. This PR adjusts the error handling so that if the server returns `406` status then we display the error message as it's received.

### Screenshots:

<img width="1181" alt="Screenshot 2024-08-06 at 21 05 33" src="https://github.com/user-attachments/assets/e5fd93cc-c6ce-402a-9f75-ee7d256972de">

### Detailed test instructions:

---

When reviewing this PR, please review https://github.com/Automattic/woocommerce-connect-server/pull/2554 at the same time.

---

1. Run a local instance of the connect server using the branch in https://github.com/Automattic/woocommerce-connect-server/pull/2554
1. Connect a local GLA test site to that connect server
1. Update the local connect server config and set [the google ads account limit](https://github.com/Automattic/woocommerce-connect-server/blob/da9eb1558182f7a87a64f2cd72db01c610e9b9e4/config/default.js#L223) to `0` 
1. On your local GLA test site, go through onboarding and attempt to create a new Google Ads account
1. Confirm the error message reads `Error creating account: Account creation limit reached. Contact support for help.`

### Changelog entry

> Tweak - Display additional context in error message when Google Ads account limit reached